### PR TITLE
Cli: fix inflation rewards effective slot, block time

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1025,9 +1025,15 @@ pub struct CliKeyedEpochReward {
 #[serde(rename_all = "camelCase")]
 pub struct CliEpochRewardsMetadata {
     pub epoch: Epoch,
-    // Deprecated
+    #[deprecated(
+        since = "2.2.0",
+        note = "Please use CliEpochReward::effective_slot per reward"
+    )]
     pub effective_slot: Slot,
-    // Deprecated
+    #[deprecated(
+        since = "2.2.0",
+        note = "Please use CliEpochReward::block_time per reward"
+    )]
     pub block_time: UnixTimestamp,
 }
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1021,7 +1021,7 @@ pub struct CliKeyedEpochReward {
     pub reward: Option<CliEpochReward>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CliEpochRewardsMetadata {
     pub epoch: Epoch,

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1025,7 +1025,9 @@ pub struct CliKeyedEpochReward {
 #[serde(rename_all = "camelCase")]
 pub struct CliEpochRewardsMetadata {
     pub epoch: Epoch,
+    // Deprecated
     pub effective_slot: Slot,
+    // Deprecated
     pub block_time: UnixTimestamp,
 }
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1053,7 +1053,7 @@ impl VerboseDisplay for CliKeyedEpochRewards {
         writeln!(w, "Epoch Rewards:")?;
         writeln!(
             w,
-            "  {:<44}  {:<11}  {:<23}  {:<18}  {:<18}  {:>14}  {:>7}  {:>10}",
+            "  {:<44}  {:<11}  {:<23}  {:<18}  {:<20}  {:>14}  {:>7}  {:>10}",
             "Address",
             "Reward Slot",
             "Time",
@@ -1068,7 +1068,7 @@ impl VerboseDisplay for CliKeyedEpochRewards {
                 Some(reward) => {
                     writeln!(
                         w,
-                        "  {:<44}  {:<11}  {:<23}  ◎{:<17.9}  ◎{:<17.9}  {:>13.9}%  {:>7}  {:>10}",
+                        "  {:<44}  {:<11}  {:<23}  ◎{:<17.9}  ◎{:<19.9}  {:>13.9}%  {:>7}  {:>10}",
                         keyed_reward.address,
                         reward.effective_slot,
                         Utc.timestamp_opt(reward.block_time, 0).unwrap(),

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1049,9 +1049,6 @@ impl fmt::Display for CliKeyedEpochRewards {
 
         if let Some(metadata) = &self.epoch_metadata {
             writeln!(f, "Epoch: {}", metadata.epoch)?;
-            writeln!(f, "Reward Slot: {}", metadata.effective_slot)?;
-            let timestamp = metadata.block_time;
-            writeln!(f, "Block Time: {}", unix_timestamp_to_string(timestamp))?;
         }
         writeln!(f, "Epoch Rewards:")?;
         writeln!(

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -141,8 +141,7 @@ fn process_rewards(
         }
         Some(CliEpochRewardsMetadata {
             epoch: first_reward.epoch,
-            effective_slot: 0, // Deprecated
-            block_time: 0,     // Deprecated
+            ..CliEpochRewardsMetadata::default()
         })
     } else {
         None

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -11,8 +11,11 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_sdk::{clock::Epoch, pubkey::Pubkey},
-    std::rc::Rc,
+    solana_sdk::{
+        clock::{Epoch, Slot, UnixTimestamp},
+        pubkey::Pubkey,
+    },
+    std::{collections::HashMap, rc::Rc},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -114,13 +117,23 @@ fn process_rewards(
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
 
     let mut epoch_rewards: Vec<CliKeyedEpochReward> = vec![];
+    let mut block_times: HashMap<Slot, UnixTimestamp> = HashMap::new();
     let epoch_metadata = if let Some(Some(first_reward)) = rewards.iter().find(|&v| v.is_some()) {
         let (epoch_start_time, epoch_end_time) =
             crate::stake::get_epoch_boundary_timestamps(rpc_client, first_reward, &epoch_schedule)?;
         for (reward, address) in rewards.iter().zip(addresses) {
-            let cli_reward = reward.as_ref().and_then(|reward| {
-                crate::stake::make_cli_reward(reward, epoch_start_time, epoch_end_time)
-            });
+            let cli_reward = if let Some(reward) = reward {
+                let block_time = if let Some(block_time) = block_times.get(&reward.effective_slot) {
+                    *block_time
+                } else {
+                    let block_time = rpc_client.get_block_time(reward.effective_slot)?;
+                    block_times.insert(reward.effective_slot, block_time);
+                    block_time
+                };
+                crate::stake::make_cli_reward(reward, block_time, epoch_start_time, epoch_end_time)
+            } else {
+                None
+            };
             epoch_rewards.push(CliKeyedEpochReward {
                 address: address.to_string(),
                 reward: cli_reward,

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -139,11 +139,10 @@ fn process_rewards(
                 reward: cli_reward,
             });
         }
-        let block_time = rpc_client.get_block_time(first_reward.effective_slot)?;
         Some(CliEpochRewardsMetadata {
             epoch: first_reward.epoch,
-            effective_slot: first_reward.effective_slot,
-            block_time,
+            effective_slot: 0, // Deprecated
+            block_time: 0,     // Deprecated
         })
     } else {
         None

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2544,6 +2544,7 @@ pub fn get_epoch_boundary_timestamps(
 
 pub fn make_cli_reward(
     reward: &RpcInflationReward,
+    block_time: UnixTimestamp,
     epoch_start_time: UnixTimestamp,
     epoch_end_time: UnixTimestamp,
 ) -> Option<CliEpochReward> {
@@ -2564,7 +2565,7 @@ pub fn make_cli_reward(
             percent_change: rate_change * 100.0,
             apr: Some(apr * 100.0),
             commission: reward.commission,
-            block_time: epoch_end_time,
+            block_time,
         })
     } else {
         None
@@ -2593,7 +2594,9 @@ pub(crate) fn fetch_epoch_rewards(
             if let Some(reward) = reward {
                 let (epoch_start_time, epoch_end_time) =
                     get_epoch_boundary_timestamps(rpc_client, reward, &epoch_schedule)?;
-                if let Some(cli_reward) = make_cli_reward(reward, epoch_start_time, epoch_end_time)
+                let block_time = rpc_client.get_block_time(reward.effective_slot)?;
+                if let Some(cli_reward) =
+                    make_cli_reward(reward, block_time, epoch_start_time, epoch_end_time)
                 {
                     all_epoch_rewards.push(cli_reward);
                 }


### PR DESCRIPTION
#### Problem
As of partitioned epoch rewards activation, the effective slots and block times returned from `solana inflation reward` that are incorrect, since the cli assumes that all rewards have been delivered in the same slot.

#### Summary of Changes
- Remove general effective slot and block time from human-readable output
- Deprecate these fields in `CliEpochRewardsMetadata` and populate with 0 for json output
- Add verbose display that includes effective slot and blocktime for every reward
- Query for correct block time for all reward slots

Fixes #3984 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
