### PR TITLE
v2.0: hardcode rust version for publish-crate

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,6 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
+export RUST_STABLE_VERSION=1.81.0
 source ci/rust-version.sh stable
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
#### Problem

<img width="464" alt="Screenshot 2024-12-31 at 16 29 05" src="https://github.com/user-attachments/assets/2b614252-e58d-4ce6-885e-c2634a3a04bd" />

#### Summary of Changes

hardcode a higher rust version for crate publishing (the same workaround as in https://github.com/solana-labs/solana/pull/34552)