### PR TITLE
SchedulerController: receive_completed before scheduling

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -105,8 +105,8 @@ impl<C: LikeClusterInfo, R: ReceiveAndBuffer> SchedulerController<C, R> {
             self.timing_metrics
                 .maybe_report_and_reset_slot(new_leader_slot);
 
-            self.process_transactions(&decision)?;
             self.receive_completed()?;
+            self.process_transactions(&decision)?;
             if !self.receive_and_buffer_packets(&decision) {
                 break;
             }


### PR DESCRIPTION
#### Problem
- `receive_completed` is called immediately after scheduling...when it is very likely **nothing** (that was just scheduled) has completed.
- It is better to to call `receive_completed` sometime **after** the (potentially) long call to `receive_and_buffer` and before the next `schedule`.

#### Summary of Changes
Flip-flop the lines so that we `receive_completed` before scheduling (after `receive_and_buffer`)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
