### PR TITLE
move Signable trait to solana-keypair

### DIFF
--- a/sdk/keypair/Cargo.toml
+++ b/sdk/keypair/Cargo.toml
@@ -18,7 +18,7 @@ solana-derivation-path = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, features = ["verify"] }
 solana-signer = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/keypair/src/lib.rs
+++ b/sdk/keypair/src/lib.rs
@@ -18,6 +18,7 @@ use {
 
 #[cfg(feature = "seed-derivable")]
 pub mod seed_derivable;
+pub mod signable;
 
 /// A vanilla Ed25519 key pair
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]

--- a/sdk/keypair/src/signable.rs
+++ b/sdk/keypair/src/signable.rs
@@ -1,0 +1,23 @@
+use {
+    crate::Keypair,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::Signer,
+    std::borrow::{Borrow, Cow},
+};
+
+pub trait Signable {
+    fn sign(&mut self, keypair: &Keypair) {
+        let signature = keypair.sign_message(self.signable_data().borrow());
+        self.set_signature(signature);
+    }
+    fn verify(&self) -> bool {
+        self.get_signature()
+            .verify(self.pubkey().as_ref(), self.signable_data().borrow())
+    }
+
+    fn pubkey(&self) -> Pubkey;
+    fn signable_data(&self) -> Cow<[u8]>;
+    fn get_signature(&self) -> Signature;
+    fn set_signature(&mut self, signature: Signature);
+}

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -2,30 +2,15 @@
 #![cfg(feature = "full")]
 
 // legacy module paths
-use {
-    crate::pubkey::Pubkey,
-    std::borrow::{Borrow, Cow},
-};
+#[deprecated(
+    since = "2.2.0",
+    note = "Use solana_keypair::signable::Signable instead."
+)]
+pub use solana_keypair::signable::Signable;
 pub use {
     crate::signer::{keypair::*, null_signer::*, presigner::*, *},
     solana_signature::{ParseSignatureError, Signature, SIGNATURE_BYTES},
 };
-
-pub trait Signable {
-    fn sign(&mut self, keypair: &Keypair) {
-        let signature = keypair.sign_message(self.signable_data().borrow());
-        self.set_signature(signature);
-    }
-    fn verify(&self) -> bool {
-        self.get_signature()
-            .verify(self.pubkey().as_ref(), self.signable_data().borrow())
-    }
-
-    fn pubkey(&self) -> Pubkey;
-    fn signable_data(&self) -> Cow<[u8]>;
-    fn get_signature(&self) -> Signature;
-    fn set_signature(&mut self, signature: Signature);
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Problem
This trait imposes a solana-sdk dependency in multiple places.

#### Summary of Changes
Move it to a new file in solana-keypair. This crate already has the required deps for the trait definition