### PR TITLE
Uses anyhow in accounts-hash-cache-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ name = "agave-accounts-hash-cache-tool"
 version = "2.2.0"
 dependencies = [
  "ahash 0.8.11",
+ "anyhow",
  "bytemuck",
  "clap 2.33.3",
  "memmap2",

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 ahash = { workspace = true }
+anyhow = { workspace = true }
 bytemuck = { workspace = true }
 clap = { workspace = true }
 memmap2 = { workspace = true }


### PR DESCRIPTION
#### Problem

The agave-hash-cache-tool provides displays messages on errors. This could be even more helpful by using [`anyhow`](https://docs.rs/anyhow/latest/anyhow/index.html).

Additionally, this reduces developer burden to manually handle displaying error messages correctly.


#### Summary of Changes

Use `anyhow::Result<_>` instead of `std::result::Result<_, String>`.

Here's an example of the output:

```
$ agave-accounts-hash-cache-tool diff files bad-file1 bad-file2
Error: 'diff files' failed

Caused by:
    0: failed to extract entries from file 1
    1: failed to open accounts hash cache file 'bad-file1'
    2: No such file or directory (os error 2)
```