### PR TITLE
accounts-db: Improve the account size weights

### DIFF
--- a/accounts-db/benches/read_only_accounts_cache.rs
+++ b/accounts-db/benches/read_only_accounts_cache.rs
@@ -4,7 +4,6 @@ use {
     solana_accounts_db::{
         accounts_db::AccountsDb, read_only_accounts_cache::ReadOnlyAccountsCache,
     },
-    solana_sdk::system_instruction::MAX_PERMITTED_DATA_LENGTH,
     std::{
         hint::black_box,
         sync::{
@@ -22,15 +21,15 @@ mod utils;
 /// - No data.
 /// - 165 bytes (a token account).
 /// - 200 bytes (a stake account).
-/// - 10 mebibytes (the max size for an account).
-const DATA_SIZES: &[usize] = &[0, 165, 200, MAX_PERMITTED_DATA_LENGTH as usize];
+/// - 300 kibibytes (an account with data).
+const DATA_SIZES: &[usize] = &[0, 165, 200, 300 * 1024];
 /// Distribution of the account sizes:
 ///
-/// - 3% of accounts have no data.
+/// - 4% of accounts have no data.
 /// - 75% of accounts are 165 bytes (a token account).
 /// - 20% of accounts are 200 bytes (a stake account).
-/// - 2% of accounts are 10 mebibytes (the max size for an account).
-const WEIGHTS: &[usize] = &[3, 75, 20, 2];
+/// - 1% of accounts are 300 kibibytes (an account with data).
+const WEIGHTS: &[usize] = &[4, 75, 20, 1];
 /// Numbers of reader and writer threads to bench.
 const NUM_READERS_WRITERS: &[usize] = &[
     8, 16,


### PR DESCRIPTION
#### Problem

The previous weights, which were assuming that 1% of accounts have 10MiB of data, were filling up the whole cache with just 2369 accounts. That's very far away from the amount of cache entries on mainnet beta validators, which with default cache limits, hold around 50-60K accounts.

#### Summary of Changes

To keep the benchmarked caches closer to the reality, assume that the 1% accounts have 300 KiB of data. With that assumption, 64356 accounts are needed to fill the cache.
