### PR TITLE
Uses swap to check if append vec is dirty and should be flushed

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -417,15 +417,22 @@ impl AppendVec {
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap_only) => {
                 // Check to see if the mmap is actually dirty before flushing.
-                if mmap_only.is_dirty.load(Ordering::Acquire) {
+                let should_flush = mmap_only.is_dirty.compare_exchange(
+                    true,
+                    false,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) == Ok(true);
+                if should_flush {
                     mmap_only.mmap.flush()?;
-                    mmap_only.is_dirty.store(false, Ordering::Release);
                     APPEND_VEC_MMAPPED_FILES_DIRTY.fetch_sub(1, Ordering::Relaxed);
                 }
                 Ok(())
             }
-            // File also means read only, so nothing to flush.
-            AppendVecFileBacking::File(_file) => Ok(()),
+            AppendVecFileBacking::File(_file) => {
+                // File also means read only, so nothing to flush.
+                Ok(())
+            }
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -417,12 +417,7 @@ impl AppendVec {
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap_only) => {
                 // Check to see if the mmap is actually dirty before flushing.
-                let should_flush = mmap_only.is_dirty.compare_exchange(
-                    true,
-                    false,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) == Ok(true);
+                let should_flush = mmap_only.is_dirty.swap(false, Ordering::AcqRel);
                 if should_flush {
                     mmap_only.mmap.flush()?;
                     APPEND_VEC_MMAPPED_FILES_DIRTY.fetch_sub(1, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

`AppendVec::flush()` conditionally flushes the underlying mmap if it is dirty. However, there's a race in the current implementation. If this flush is called in multiple threads, both may see `dirty == true`, which will flush the mmap twice. This is not a correctness issue luckily. However, the `APPEND_VEC_MMAPPED_FILES_DIRTY` counter would be incorrect in this case.

The current implementation flushes the append vecs sequentially in a single thread, so we're safe. However, it's best to fix the `AppendVec::flush()` impl to prevent this from being an issue in the first place.


#### Summary of Changes

Replace the separate atomic load and atomic store with an atomic swap.