### PR TITLE
skips (redundant) signature verification for recovered Merkle shreds

### DIFF
--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -30,7 +30,6 @@ pub struct BlockstoreInsertionMetrics {
     pub num_recovered: usize,
     pub num_recovered_blockstore_error: usize,
     pub num_recovered_inserted: usize,
-    pub num_recovered_failed_sig: usize,
     pub num_recovered_failed_invalid: usize,
     pub num_recovered_exists: usize,
     pub num_repaired_data_shreds_exists: usize,
@@ -81,11 +80,6 @@ impl BlockstoreInsertionMetrics {
             (
                 "num_recovered_inserted",
                 self.num_recovered_inserted as i64,
-                i64
-            ),
-            (
-                "num_recovered_failed_sig",
-                self.num_recovered_failed_sig as i64,
                 i64
             ),
             (

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -787,31 +787,34 @@ pub(super) fn recover(
     // Incoming shreds are resigned immediately after signature verification,
     // so we can just grab the retransmitter signature from one of the
     // available shreds and attach it to the recovered shreds.
-    let (common_header, coding_header, chained_merkle_root, retransmitter_signature) = shreds
-        .iter()
-        .find_map(|shred| {
-            let Shred::ShredCode(shred) = shred else {
-                return None;
-            };
-            let chained_merkle_root = shred.chained_merkle_root().ok();
-            let retransmitter_signature = shred.retransmitter_signature().ok();
-            let position = u32::from(shred.coding_header.position);
-            let common_header = ShredCommonHeader {
-                index: shred.common_header.index.checked_sub(position)?,
-                ..shred.common_header
-            };
-            let coding_header = CodingShredHeader {
-                position: 0u16,
-                ..shred.coding_header
-            };
-            Some((
-                common_header,
-                coding_header,
-                chained_merkle_root,
-                retransmitter_signature,
-            ))
-        })
-        .ok_or(TooFewParityShards)?;
+    let (common_header, coding_header, merkle_root, chained_merkle_root, retransmitter_signature) =
+        shreds
+            .iter()
+            .find_map(|shred| {
+                let Shred::ShredCode(shred) = shred else {
+                    return None;
+                };
+                let merkle_root = shred.merkle_root().ok()?;
+                let chained_merkle_root = shred.chained_merkle_root().ok();
+                let retransmitter_signature = shred.retransmitter_signature().ok();
+                let position = u32::from(shred.coding_header.position);
+                let common_header = ShredCommonHeader {
+                    index: shred.common_header.index.checked_sub(position)?,
+                    ..shred.common_header
+                };
+                let coding_header = CodingShredHeader {
+                    position: 0u16,
+                    ..shred.coding_header
+                };
+                Some((
+                    common_header,
+                    coding_header,
+                    merkle_root,
+                    chained_merkle_root,
+                    retransmitter_signature,
+                ))
+            })
+            .ok_or(TooFewParityShards)?;
     debug_assert_matches!(common_header.shred_variant, ShredVariant::MerkleCode { .. });
     let (proof_size, chained, resigned) = match common_header.shred_variant {
         ShredVariant::MerkleCode {
@@ -953,6 +956,9 @@ pub(super) fn recover(
         .map(Shred::merkle_node)
         .collect::<Result<_, _>>()?;
     let tree = make_merkle_tree(nodes);
+    if tree.last() != Some(&merkle_root) {
+        return Err(Error::InvalidMerkleRoot);
+    }
     for (index, (shred, mask)) in shreds.iter_mut().zip(&mask).enumerate() {
         let proof = make_merkle_proof(index, num_shards, &tree).ok_or(Error::InvalidMerkleProof)?;
         if proof.len() != usize::from(proof_size) {


### PR DESCRIPTION

#### Problem
With Merkle shreds, leader signs the Merkle root of the erasure batch and all shreds within the same erasure batch have the same signature.
For recovered shreds, the (unique) signature is copied from shreds which were received from turbine (or repair) and are already sig-verified.
The same signature also verifies for recovered shreds because when reconstructing the Merkle tree for the erasure batch, we will obtain the same Merkle root.


#### Summary of Changes
The commit skips (redundant) signature verification for recovered Merkle shreds.