### PR TITLE
consensus: add fork choice weight to threshold check metrics

### DIFF
--- a/core/src/consensus/fork_choice.rs
+++ b/core/src/consensus/fork_choice.rs
@@ -355,13 +355,16 @@ fn can_vote_on_candidate_bank(
     // Check if we failed any of the vote thresholds.
     let mut threshold_passed = true;
     for threshold_failure in vote_thresholds {
-        let &ThresholdDecision::FailedThreshold(vote_depth, fork_stake) = threshold_failure else {
+        let &ThresholdDecision::FailedThreshold(vote_depth, fork_stake, fork_choice_stake) =
+            threshold_failure
+        else {
             continue;
         };
         failure_reasons.push(HeaviestForkFailures::FailedThreshold(
             candidate_vote_bank_slot,
             vote_depth,
             fork_stake,
+            fork_choice_stake,
             total_threshold_stake,
         ));
         // Ignore shallow checks for voting purposes


### PR DESCRIPTION
#### Problem
I plan to make an argument to remove `VotedStakes` and the accompanying legacy logic in favor of just using fork choice in all vote checks. 

As part of this argument I would like to point to scenarios where the threshold check currently fails with `VotedStakes`, but would have allowed a validator to vote if we used fork choice.

#### Summary of Changes
Augment the failure metrics with the stake observed by fork choice. This change is not intended to change any consensus behavior.
