### PR TITLE
reduces intermediate vector allocations when recovering shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1138,7 +1138,6 @@ pub(crate) fn recover(
             // when reconstructing the Merkle tree for the erasure batch, we
             // will obtain the same Merkle root.
             Ok(merkle::recover(shreds, reed_solomon_cache)?
-                .into_iter()
                 .map(|shred| {
                     let shred = Shred::from(shred);
                     debug_assert!(get_slot_leader(shred.slot())


### PR DESCRIPTION
#### Problem
When recovering shreds, below two `.collect::<Vec<_>>()`  are unnecessarily allocating a vector and can be skipped by using iterators:
https://github.com/anza-xyz/agave/blob/40be9b6d1/ledger/src/shred/merkle.rs#L987
https://github.com/anza-xyz/agave/blob/40be9b6d1/ledger/src/blockstore.rs#L1089

Also we can reduce allocations by collecting a `Vec<Vec<Shred>>` instead of below `append`:
https://github.com/anza-xyz/agave/blob/40be9b6d1/ledger/src/blockstore.rs#L844

#### Summary of Changes
The commit reduces intermediate vector allocations when recovering shreds.
