### PR TITLE
simplifies ContactInfo::get_socket return type to Option<SocketAddr>

### DIFF
--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -25,7 +25,7 @@ const MAX_CONNECTIONS: usize = 1024;
 /// Default connection pool size per remote address
 pub const DEFAULT_CONNECTION_POOL_SIZE: usize = 2;
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Protocol {
     UDP,
     QUIC,

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -29,9 +29,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .into_iter()
         .dedup()
         .filter_map(|leader_pubkey| {
-            cluster_info
-                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
-                .ok()
+            cluster_info.lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
         })
         // dedup again since leaders could potentially share the same tpu vote socket
         .dedup()
@@ -47,13 +45,13 @@ pub(crate) fn next_leader_tpu_vote(
     })
 }
 
-pub(crate) fn next_leader<F, E>(
+pub(crate) fn next_leader<F>(
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
     port_selector: F,
 ) -> Option<(Pubkey, SocketAddr)>
 where
-    F: FnOnce(&ContactInfo) -> Result<SocketAddr, E>,
+    F: FnOnce(&ContactInfo) -> Option<SocketAddr>,
 {
     let leader_pubkey = poh_recorder
         .read()
@@ -62,5 +60,4 @@ where
     cluster_info
         .lookup_contact_info(&leader_pubkey, port_selector)?
         .map(|addr| (leader_pubkey, addr))
-        .ok()
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1011,8 +1011,8 @@ impl Validator {
                     &identity_keypair,
                     node.info
                         .tpu(Protocol::UDP)
-                        .map_err(|err| {
-                            ValidatorError::Other(format!("Invalid TPU address: {err:?}"))
+                        .ok_or_else(|| {
+                            ValidatorError::Other(String::from("Invalid UDP address for TPU"))
                         })?
                         .ip(),
                 )),
@@ -1035,8 +1035,8 @@ impl Validator {
                     &identity_keypair,
                     node.info
                         .tpu_vote(Protocol::QUIC)
-                        .map_err(|err| {
-                            ValidatorError::Other(format!("Invalid TPU Vote address: {err:?}"))
+                        .ok_or_else(|| {
+                            ValidatorError::Other(String::from("Invalid QUIC address for TPU Vote"))
                         })?
                         .ip(),
                 )),
@@ -1062,14 +1062,10 @@ impl Validator {
             bank_notification_sender,
         ) = if let Some((rpc_addr, rpc_pubsub_addr)) = config.rpc_addrs {
             assert_eq!(
-                node.info
-                    .rpc()
-                    .map(|addr| socket_addr_space.check(&addr))
-                    .ok(),
+                node.info.rpc().map(|addr| socket_addr_space.check(&addr)),
                 node.info
                     .rpc_pubsub()
                     .map(|addr| socket_addr_space.check(&addr))
-                    .ok()
             );
             let (bank_notification_sender, bank_notification_receiver) = unbounded();
             let confirmed_bank_subscribers = if !bank_notification_senders.is_empty() {

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -5,10 +5,7 @@ use {
     rand::{thread_rng, Rng},
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_connection_cache::client_connection::ClientConnection as TpuConnection,
-    solana_gossip::{
-        cluster_info::ClusterInfo,
-        contact_info::{ContactInfo, Error},
-    },
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_poh::poh_recorder::PohRecorder,
     solana_pubkey::Pubkey,
     std::{
@@ -35,11 +32,11 @@ impl WarmQuicCacheService {
         cache: Option<&ConnectionCache>,
         cluster_info: &ClusterInfo,
         leader_pubkey: &Pubkey,
-        contact_info_selector: impl Fn(&ContactInfo) -> Result<SocketAddr, Error>,
+        contact_info_selector: impl Fn(&ContactInfo) -> Option<SocketAddr>,
         log_context: &str,
     ) {
         if let Some(connection_cache) = cache {
-            if let Some(Ok(addr)) =
+            if let Some(Some(addr)) =
                 cluster_info.lookup_contact_info(leader_pubkey, contact_info_selector)
             {
                 let conn = connection_cache.get_connection(&addr);

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -442,7 +442,7 @@ fn get_target(
         info!("ADDR = {}", entrypoint_addr);
 
         for node in nodes {
-            if node.gossip().ok() == Some(entrypoint_addr) {
+            if node.gossip() == Some(entrypoint_addr) {
                 info!("{:?}", node.gossip());
                 target = match mode {
                     Mode::Gossip => Some((*node.pubkey(), node.gossip().unwrap())),
@@ -475,7 +475,7 @@ fn get_rpc_client(
 
     // find target node
     for node in nodes {
-        if node.gossip().ok() == Some(entrypoint_addr) {
+        if node.gossip() == Some(entrypoint_addr) {
             info!("{:?}", node.gossip());
             return Ok(RpcClient::new_socket(node.rpc().unwrap()));
         }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -315,7 +315,7 @@ impl ClusterInfo {
                 .read()
                 .unwrap()
                 .iter()
-                .filter_map(|node| node.gossip().ok())
+                .filter_map(ContactInfo::gossip)
                 .collect::<HashSet<_>>();
             let self_pubkey = self.id();
             let gossip_crds = self.gossip.crds.read().unwrap();
@@ -479,7 +479,7 @@ impl ClusterInfo {
         let gossip_crds = self.gossip.crds.read().unwrap();
         let mut nodes = gossip_crds.get_nodes_contact_info();
         nodes
-            .find(|node| node.gossip().ok() == Some(*gossip_addr))
+            .find(|node| node.gossip() == Some(*gossip_addr))
             .cloned()
     }
 
@@ -524,7 +524,6 @@ impl ClusterInfo {
             .filter_map(|(node, last_updated)| {
                 let node_rpc = node
                     .rpc()
-                    .ok()
                     .filter(|addr| self.socket_addr_space.check(addr))?;
                 let node_version = self.get_node_version(node.pubkey());
                 if my_shred_version != 0
@@ -548,8 +547,8 @@ impl ClusterInfo {
                     } else {
                         "-".to_string()
                     },
-                    self.addr_to_string(&Some(rpc_addr), &node.rpc().ok()),
-                    self.addr_to_string(&Some(rpc_addr), &node.rpc_pubsub().ok()),
+                    self.addr_to_string(&Some(rpc_addr), &node.rpc()),
+                    self.addr_to_string(&Some(rpc_addr), &node.rpc_pubsub()),
                     node.shred_version(),
                 ))
             })
@@ -591,11 +590,10 @@ impl ClusterInfo {
                     if is_spy_node {
                         shred_spy_nodes = shred_spy_nodes.saturating_add(1);
                     }
-                    let ip_addr = node.gossip().as_ref().map(SocketAddr::ip).ok();
+                    let ip_addr = node.gossip().as_ref().map(SocketAddr::ip);
                     Some(format!(
                         "{:15} {:2}| {:5} | {:44} |{:^9}| {:5}|  {:5}| {:5}| {:5}| {:5}| {:5}| {:5}| {}\n",
                         node.gossip()
-                            .ok()
                             .filter(|addr| self.socket_addr_space.check(addr))
                             .as_ref()
                             .map(SocketAddr::ip)
@@ -610,13 +608,13 @@ impl ClusterInfo {
                         } else {
                             "-".to_string()
                         },
-                        self.addr_to_string(&ip_addr, &node.gossip().ok()),
-                        self.addr_to_string(&ip_addr, &node.tpu_vote(contact_info::Protocol::UDP).ok()),
-                        self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::UDP).ok()),
-                        self.addr_to_string(&ip_addr, &node.tpu_forwards(contact_info::Protocol::UDP).ok()),
-                        self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::UDP).ok()),
-                        self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::QUIC).ok()),
-                        self.addr_to_string(&ip_addr, &node.serve_repair(contact_info::Protocol::UDP).ok()),
+                        self.addr_to_string(&ip_addr, &node.gossip()),
+                        self.addr_to_string(&ip_addr, &node.tpu_vote(contact_info::Protocol::UDP)),
+                        self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::UDP)),
+                        self.addr_to_string(&ip_addr, &node.tpu_forwards(contact_info::Protocol::UDP)),
+                        self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::UDP)),
+                        self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::QUIC)),
+                        self.addr_to_string(&ip_addr, &node.serve_repair(contact_info::Protocol::UDP)),
                         node.shred_version(),
                     ))
                 }
@@ -1061,7 +1059,7 @@ impl ClusterInfo {
             .cloned()
     }
 
-    fn check_socket_addr_space<E>(&self, addr: &Result<SocketAddr, E>) -> bool {
+    fn check_socket_addr_space(&self, addr: &Option<SocketAddr>) -> bool {
         addr.as_ref()
             .map(|addr| self.socket_addr_space.check(addr))
             .unwrap_or_default()
@@ -1222,11 +1220,11 @@ impl ClusterInfo {
                     return;
                 }
                 entrypoint.set_wallclock(now);
-                if let Ok(entrypoint_gossip) = entrypoint.gossip() {
+                if let Some(entrypoint_gossip) = entrypoint.gossip() {
                     if self
                         .time_gossip_read_lock("entrypoint", &self.stats.entrypoint)
                         .get_nodes_contact_info()
-                        .any(|node| node.gossip().ok() == Some(entrypoint_gossip))
+                        .any(|node| node.gossip() == Some(entrypoint_gossip))
                     {
                         return; // Found the entrypoint, no need to pull from it
                     }
@@ -1294,7 +1292,7 @@ impl ClusterInfo {
         self.stats.new_pull_requests_count.add_relaxed(num_requests);
         let pulls = pulls
             .into_iter()
-            .filter_map(|(peer, filters)| Some((peer.gossip().ok()?, filters)))
+            .filter_map(|(peer, filters)| Some((peer.gossip()?, filters)))
             .flat_map(|(addr, filters)| repeat(addr).zip(filters))
             .map(|(gossip_addr, filter)| {
                 let request = Protocol::PullRequest(filter, self_info.clone());
@@ -1343,7 +1341,7 @@ impl ClusterInfo {
                 .into_iter()
                 .filter_map(|(pubkey, messages)| {
                     let peer: &ContactInfo = gossip_crds.get(pubkey)?;
-                    Some((peer.gossip().ok()?, messages))
+                    Some((peer.gossip()?, messages))
                 })
                 .collect()
         };
@@ -1437,7 +1435,6 @@ impl ClusterInfo {
                 // If a pull from the entrypoint was successful it should exist in the CRDS table
                 if let Some(entrypoint_from_gossip) = entrypoint
                     .gossip()
-                    .ok()
                     .and_then(|addr| self.lookup_contact_info_by_gossip_addr(&addr))
                 {
                     // Update the entrypoint's id so future entrypoint pulls correctly reference it
@@ -2084,7 +2081,7 @@ impl ClusterInfo {
                 prunes
                     .into_par_iter()
                     .filter_map(|(pubkey, prunes)| {
-                        let addr = gossip_crds.get::<&ContactInfo>(pubkey)?.gossip().ok()?;
+                        let addr = gossip_crds.get::<&ContactInfo>(pubkey)?.gossip()?;
                         Some((pubkey, addr, prunes))
                     })
                     .collect()
@@ -3107,7 +3104,7 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
         return true;
     }
     // Invalid addresses are not verifiable.
-    let Some(addr) = addr.ok().filter(|addr| socket_addr_space.check(addr)) else {
+    let Some(addr) = addr.filter(|addr| socket_addr_space.check(addr)) else {
         return false;
     };
     let (out, ping) = {

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -363,7 +363,7 @@ pub(crate) fn dedup_gossip_addresses(
 ) -> HashMap</*gossip:*/ SocketAddr, (/*stake:*/ u64, ContactInfo)> {
     nodes
         .into_iter()
-        .filter_map(|node| Some((node.gossip().ok()?, node)))
+        .filter_map(|node| Some((node.gossip()?, node)))
         .into_grouping_map()
         .aggregate(|acc, _node_gossip, node| {
             let stake = stakes.get(node.pubkey()).copied().unwrap_or_default();
@@ -389,7 +389,7 @@ pub(crate) fn maybe_ping_gossip_addresses<R: Rng + CryptoRng>(
     nodes
         .into_iter()
         .filter(|node| {
-            let Ok(node_gossip) = node.gossip() else {
+            let Some(node_gossip) = node.gossip() else {
                 return false;
             };
             let (check, ping) = {

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -275,7 +275,7 @@ fn spy(
         let found_node_by_gossip_addr = if let Some(gossip_addr) = find_node_by_gossip_addr {
             all_peers
                 .iter()
-                .any(|node| node.gossip().ok() == Some(*gossip_addr))
+                .any(|node| node.gossip() == Some(*gossip_addr))
         } else {
             false
         };

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -330,7 +330,7 @@ fn process_rpc_url(
                     .map(|addr| Some(addr) == entrypoint_addr)
                     .unwrap_or_default()
         })
-        .filter_map(|node| node.rpc().ok())
+        .filter_map(ContactInfo::rpc)
         .filter(|addr| socket_addr_space.check(addr))
         .collect();
 

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -129,13 +129,13 @@ fn retransmit_to(
     let dests: Vec<_> = if forwarded {
         peers
             .iter()
-            .filter_map(|peer| peer.tvu(Protocol::UDP).ok())
+            .filter_map(|peer| peer.tvu(Protocol::UDP))
             .filter(|addr| socket_addr_space.check(addr))
             .collect()
     } else {
         peers
             .iter()
-            .filter_map(|peer| peer.tvu(Protocol::UDP).ok())
+            .filter_map(|peer| peer.tvu(Protocol::UDP))
             .filter(|addr| socket_addr_space.check(addr))
             .collect()
     };

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -38,10 +38,7 @@ impl TpuInfo for ClusterTpuInfo {
             .filter_map(|node| {
                 Some((
                     *node.pubkey(),
-                    (
-                        node.tpu(Protocol::UDP).ok()?,
-                        node.tpu(Protocol::QUIC).ok()?,
-                    ),
+                    (node.tpu(Protocol::UDP)?, node.tpu(Protocol::QUIC)?),
                 ))
             })
             .collect();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3704,42 +3704,33 @@ pub mod rpc_full {
                         };
                         Some(RpcContactInfo {
                             pubkey: contact_info.pubkey().to_string(),
-                            gossip: contact_info.gossip().ok(),
+                            gossip: contact_info.gossip(),
                             tvu: contact_info
                                 .tvu(Protocol::UDP)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu: contact_info
                                 .tpu(Protocol::UDP)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu_quic: contact_info
                                 .tpu(Protocol::QUIC)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu_forwards: contact_info
                                 .tpu_forwards(Protocol::UDP)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu_forwards_quic: contact_info
                                 .tpu_forwards(Protocol::QUIC)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             tpu_vote: contact_info
                                 .tpu_vote(Protocol::UDP)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             serve_repair: contact_info
                                 .serve_repair(Protocol::UDP)
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             rpc: contact_info
                                 .rpc()
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             pubsub: contact_info
                                 .rpc_pubsub()
-                                .ok()
                                 .filter(|addr| socket_addr_space.check(addr)),
                             version,
                             feature_set,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -380,7 +380,12 @@ impl JsonRpcService {
         let tpu_address = cluster_info
             .my_contact_info()
             .tpu(connection_cache.protocol())
-            .map_err(|err| format!("{err}"))?;
+            .ok_or_else(|| {
+                format!(
+                    "Invalid {:?} socket address for TPU",
+                    connection_cache.protocol()
+                )
+            })?;
 
         let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -461,7 +461,6 @@ pub fn broadcast_shreds(
                 cluster_nodes
                     .get_broadcast_peer(&key)?
                     .tvu(protocol)
-                    .ok()
                     .filter(|addr| socket_addr_space.check(addr))
                     .map(|addr| {
                         (match protocol {

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -341,7 +341,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             .iter()
             .filter_map(|shred| {
                 let node = cluster_nodes.get_broadcast_peer(&shred.id())?;
-                if !socket_addr_space.check(&node.tvu(Protocol::UDP).ok()?) {
+                if !socket_addr_space.check(&node.tvu(Protocol::UDP)?) {
                     return None;
                 }
                 if self
@@ -380,15 +380,14 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                                     pubkey,
                                 );
                                 let tvu = cluster_info
-                                    .lookup_contact_info(pubkey, |node| node.tvu(Protocol::UDP))?
-                                    .ok()?;
+                                    .lookup_contact_info(pubkey, |node| node.tvu(Protocol::UDP))??;
                                 Some((shred.payload(), tvu))
                             })
                             .collect(),
                     );
                 }
 
-                Some(vec![(shred.payload(), node.tvu(Protocol::UDP).ok()?)])
+                Some(vec![(shred.payload(), node.tvu(Protocol::UDP)?)])
             })
             .flatten()
             .collect();

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -157,7 +157,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             peers.iter().enumerate().for_each(|(i, peer)| {
                 if fake == (i <= self.partition) {
                     // Send fake shreds to the first N peers
-                    if let Ok(addr) = peer.tvu(Protocol::UDP) {
+                    if let Some(addr) = peer.tvu(Protocol::UDP) {
                         data_shreds.iter().for_each(|b| {
                             sock.send_to(b.payload(), addr).unwrap();
                         });

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -189,7 +189,7 @@ impl ClusterNodes<RetransmitStage> {
                 let node = &self.nodes[index];
                 let addr: Option<SocketAddr> = node
                     .contact_info()
-                    .and_then(|node| node.tvu(protocol).ok())
+                    .and_then(|node| node.tvu(protocol))
                     .filter(|&addr| addrs.insert(addr));
                 (node, addr)
             })
@@ -313,7 +313,7 @@ fn get_nodes(
         if !should_dedup_addrs
             || node
                 .contact_info()
-                .and_then(|node| node.tvu(Protocol::UDP).ok())
+                .and_then(|node| node.tvu(Protocol::UDP))
                 .map(|addr| {
                     *counts
                         .entry(addr.ip())

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -618,11 +618,11 @@ impl AdminRpc for AdminRpcImpl {
                 .cluster_info
                 .my_contact_info()
                 .tpu(Protocol::UDP)
-                .map_err(|err| {
+                .ok_or_else(|| {
                     error!(
                         "The public TPU address isn't being published. The node is likely in \
                          repair mode. See help for --restricted-repair-only-mode for more \
-                         information. {err}"
+                         information."
                     );
                     jsonrpc_core::error::Error::internal_error()
                 })?;
@@ -655,11 +655,11 @@ impl AdminRpc for AdminRpcImpl {
                 .cluster_info
                 .my_contact_info()
                 .tpu_forwards(Protocol::UDP)
-                .map_err(|err| {
+                .ok_or_else(|| {
                     error!(
                         "The public TPU Forwards address isn't being published. The node is \
                          likely in repair mode. See help for --restricted-repair-only-mode for \
-                         more information. {err}"
+                         more information."
                     );
                     jsonrpc_core::error::Error::internal_error()
                 })?;


### PR DESCRIPTION

#### Problem
`ContactInfo::get_socket` returns `Result<SocketAddr, Error>` but the error value is not really used.
Simplifying the return type to `Option<SocketAddr>` would allow to simplify `ContactInfo.cache` and reduce the overhead.


#### Summary of Changes
The commit simplifies `ContactInfo::get_socket` return type to `Option<SocketAddr>`.