### PR TITLE
Uses iter::once() when scanning candidates in clean_accounts()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -104,6 +104,7 @@ use {
         fs,
         hash::{Hash as StdHash, Hasher as StdHasher},
         io::Result as IoResult,
+        iter,
         num::{NonZeroUsize, Saturating},
         ops::{Range, RangeBounds},
         path::{Path, PathBuf},
@@ -2839,7 +2840,7 @@ impl AccountsDb {
                 candidates_bin.retain(|candidate_pubkey, candidate_info| {
                     let mut should_collect_reclaims = false;
                     self.accounts_index.scan(
-                        [*candidate_pubkey].iter(),
+                        iter::once(candidate_pubkey),
                         |_candidate_pubkey, slot_list_and_ref_count, _entry| {
                             let mut useless = true;
                             if let Some((slot_list, ref_count)) = slot_list_and_ref_count {


### PR DESCRIPTION
#### Problem

When scanning the candidates in `clean`, we call AccountsIndex::scan() on each candidate one at a time. So we need to turn each candidate into a single element iterator. The impl is done manually, and creates a one element array of `Pubkey` (note, *not* `&Pubkey`), which then has `.iter()` called on it. This is verbose, and potentially copies each candidate pubkey each time unnecessarily.


#### Summary of Changes

Use `std::iter::once()`, which is made for turning a single element into an iterator.