### PR TITLE
Fix missing dependency in solana-curve25519's Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6957,6 +6957,7 @@ dependencies = [
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-define-syscall",
+ "subtle",
  "thiserror 2.0.9",
 ]
 

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -15,6 +15,8 @@ bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
 # this crate uses `subtle::CtOption<Scalar>::into_option` via curve25519-dalek,
 # which requires subtle v2.6.1, but curve25519-dalek only requires v2.3.0
+# The line below help users of this crate obtain correct subtle version. 
+# (that is, the version specified by our workspace or greater minor version, not the version specified by curve25519-dalek)
 subtle = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -13,6 +13,8 @@ edition = { workspace = true }
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
+# this crate uses `subtle::CtOption<Scalar>::into_option` via curve25519-dalek,
+# which requires subtle v2.6.1, but curve25519-dalek only requires v2.3.0
 subtle = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
+subtle = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -12,12 +12,12 @@ edition = { workspace = true }
 [dependencies]
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
-thiserror = { workspace = true }
 # this crate uses `subtle::CtOption<Scalar>::into_option` via curve25519-dalek,
 # which requires subtle v2.6.1, but curve25519-dalek only requires v2.3.0
 # The line below help users of this crate obtain correct subtle version.
 # (that is, the version specified by our workspace or greater minor version, not the version specified by curve25519-dalek)
 subtle = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -15,7 +15,7 @@ bytemuck_derive = { workspace = true }
 thiserror = { workspace = true }
 # this crate uses `subtle::CtOption<Scalar>::into_option` via curve25519-dalek,
 # which requires subtle v2.6.1, but curve25519-dalek only requires v2.3.0
-# The line below help users of this crate obtain correct subtle version. 
+# The line below help users of this crate obtain correct subtle version.
 # (that is, the version specified by our workspace or greater minor version, not the version specified by curve25519-dalek)
 subtle = { workspace = true }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5583,6 +5583,7 @@ dependencies = [
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-define-syscall",
+ "subtle",
  "thiserror 2.0.9",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5434,6 +5434,7 @@ dependencies = [
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "solana-define-syscall",
+ "subtle",
  "thiserror 2.0.9",
 ]
 


### PR DESCRIPTION
#### Problem
Currently, `solana-curve25519` indirectly depends on crate `subtle` through `curve25519-dalek`.

here,  `solana-curve25519` uses `into_option` provided by crate `subtle` (provided in `subtle` >=2.6)

https://github.com/anza-xyz/agave/blob/aaee37d1307aa0a0dec2ff70552549e5b9af191b/curves/curve25519/src/scalar.rs#L22
https://github.com/anza-xyz/agave/blob/aaee37d1307aa0a0dec2ff70552549e5b9af191b/curves/curve25519/src/scalar.rs#L38

but dependency `curve25519-dalek` only require `subtle` version >=2.3. (https://docs.rs/crate/curve25519-dalek/4.1.3/source/Cargo.toml)

---

Currently, we specify subtle version 2.6.1 in agave workspace Cargo.toml.
That's why the compilation of validator can succeed.

https://github.com/anza-xyz/agave/blob/b6a3aa022388cfc14e20a41e7cba33d7d3deb69e/Cargo.toml#L640


But there is no one in `solana-curve25519`'s Cargo.toml

---

For users who only use the crate `solana-curve25519`,
this will cause Cargo to resolve the lower version of `subtle` and report `into_option` cannot be found.

#### Summary of Changes


Fixes # add it in  `solana-curve25519`'s Cargo.toml to fix potential compile error
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

