### PR TITLE
Updates last_update_time when storing into an occupied accounts read cache entry

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -202,6 +202,9 @@ impl ReadOnlyAccountsCache {
                 self.data_size.fetch_sub(account_size, Ordering::Relaxed);
                 entry.account = account;
                 entry.slot = slot;
+                entry
+                    .last_update_time
+                    .store(ReadOnlyAccountCacheEntry::timestamp(), Ordering::Release);
                 // Move the entry to the end of the queue.
                 let mut queue = self.queue.lock().unwrap();
                 queue.remove(entry.index());


### PR DESCRIPTION
#### Problem

When storing an entry into the accounts read cache, if we are *updating* an existing entry, we currently do not update the entry's `last_update_time`. Note that we *do* update the last_update_time when inserting a new entry during` store()` though. This mismatch in behavior seems wrong.

Additionally, https://github.com/anza-xyz/agave/pull/3943 will remove the separate LRU queue from the read cache, and the last_update_time will be the source of truth for which entries to evict. This means that the last_update_time needs to be correct.


#### Summary of Changes

Storing into the read cache should always set/update the last_update_time. So also do this when updating an existing entry.