### PR TITLE
bench-vote, vortexor: Fix build and lint errors

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -5,7 +5,7 @@ use {
     crossbeam_channel::unbounded,
     solana_client::connection_cache::ConnectionCache,
     solana_connection_cache::client_connection::ClientConnection,
-    solana_net_utils::bind_to_unspecified,
+    solana_net_utils::{bind_to_unspecified, SocketConfig},
     solana_sdk::{
         hash::Hash, message::Message, signature::Keypair, signer::Signer, transaction::Transaction,
     },
@@ -139,9 +139,11 @@ fn main() -> Result<()> {
         let mut read_channels = Vec::new();
         let mut read_threads = Vec::new();
         let recycler = PacketBatchRecycler::default();
-        let (port, read_sockets) = solana_net_utils::multi_bind_in_range(
+        let config = SocketConfig::default().reuseport(true);
+        let (port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
             ip_addr,
             (port, port + num_sockets as u16),
+            config,
             num_sockets,
         )
         .unwrap();

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -54,24 +54,24 @@ impl Vortexor {
         dynamic_port_range: (u16, u16),
         num_quic_endpoints: u64,
     ) -> TpuSockets {
-        let quic_config = SocketConfig { reuseport: true };
+        let quic_config = SocketConfig::default().reuseport(true);
 
         let (_, tpu_quic) =
-            bind_in_range_with_config(bind_address, dynamic_port_range, quic_config.clone())
+            bind_in_range_with_config(bind_address, dynamic_port_range, quic_config)
                 .expect("expected bind to succeed");
 
         let tpu_quic_port = tpu_quic.local_addr().unwrap().port();
         let tpu_quic = bind_more_with_config(
             tpu_quic,
             num_quic_endpoints.try_into().unwrap(),
-            quic_config.clone(),
+            quic_config,
         )
         .unwrap();
 
         let (_, tpu_quic_fwd) = bind_in_range_with_config(
             bind_address,
             (tpu_quic_port.saturating_add(1), dynamic_port_range.1),
-            quic_config.clone(),
+            quic_config,
         )
         .expect("expected bind to succeed");
 


### PR DESCRIPTION
#### Problem

* All `SocketConfig`'s fields are private, therefore it cannot be constructed with struct literal syntax.
* `SocketConfig` implements `Copy`, so an explicit `clone()` call is unnecessary.
* `solana_net_utils::multi_bind_in_range` is deprecated.

#### Summary of Changes

* Construct `SocketConfig` with `default()` and call `reuseport()`.
* Remove unnecessary `clone()` calls.
* Use `mutli_bind_in_range_with_config` instead.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
