### PR TITLE
Space efficient panic

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -332,7 +332,7 @@ pub fn create_program_runtime_environment_v1<'a>(
     result.register_function("abort", codes::ABORT, SyscallAbort::vm)?;
 
     // Panic
-    result.register_function("sol_panic_", codes::SOL_PANIC, SyscallPanic::vm)?;
+    result.register_function("sol_panic_", codes::SOL_PANIC_, SyscallPanic::vm)?;
 
     // Logging
     result.register_function("sol_log_", codes::SOL_LOG_, SyscallLog::vm)?;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7213,6 +7213,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sbf-rust-efficient-panic"
+version = "2.2.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-sbf-rust-error-handling"
 version = "2.2.0"
 dependencies = [

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -164,6 +164,7 @@ members = [
     "rust/deprecated_loader",
     "rust/divide_by_zero",
     "rust/dup_accounts",
+    "rust/efficient_panic",
     "rust/error_handling",
     "rust/external_spend",
     "rust/finalize",

--- a/programs/sbf/rust/efficient_panic/Cargo.toml
+++ b/programs/sbf/rust/efficient_panic/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-sbf-rust-efficient-panic"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program = { workspace = true }
+
+[features]
+default = ["efficient-panic"]
+efficient-panic = []
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/efficient_panic/src/lib.rs
+++ b/programs/sbf/rust/efficient_panic/src/lib.rs
@@ -1,0 +1,34 @@
+// Cargo clippy runs with 1.81, but cargo-build-sbf is on 1.79.
+#![allow(stable_features)]
+#![feature(panic_info_message)]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+solana_program::entrypoint!(process_instruction);
+
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    match instruction_data[0] {
+        0 => {
+            // Accessing an invalid index creates a dynamic generated panic message.
+            let a = instruction_data[92341];
+            return Err(ProgramError::Custom(a as u32));
+        }
+        1 => {
+            // Unwrap on a None emit a compiler constant panic message.
+            let a: Option<u64> = None;
+            #[allow(clippy::unnecessary_literal_unwrap)]
+            let b = a.unwrap();
+            return Err(ProgramError::Custom(b as u32));
+        }
+
+        _ => (),
+    }
+    Ok(())
+}

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5662,3 +5662,59 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         }
     }
 }
+
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_efficient_panic() {
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(50);
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let authority_keypair = Keypair::new();
+
+    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
+        &mut bank_client,
+        bank_forks.as_ref(),
+        &mint_keypair,
+        &authority_keypair,
+        "solana_sbf_rust_efficient_panic",
+    );
+
+    bank.freeze();
+
+    let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
+    let instruction = Instruction::new_with_bytes(program_id, &[0, 2], account_metas.clone());
+
+    let blockhash = bank.last_blockhash();
+    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+    let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
+    let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+    let result = bank.simulate_transaction(&sanitized_tx, false);
+    assert!(result.logs.contains(&format!(
+        "Program {} \
+    failed: SBF program Panicked in rust/efficient_panic/src/lib.rs at 20:21",
+        program_id
+    )));
+
+    let instruction = Instruction::new_with_bytes(program_id, &[1, 2], account_metas);
+
+    let blockhash = bank.last_blockhash();
+    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+    let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
+    let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+    let result = bank.simulate_transaction(&sanitized_tx, false);
+    assert!(result
+        .logs
+        .contains(&"Program log: called `Option::unwrap()` on a `None` value".to_string()));
+    assert!(result.logs.contains(&format!(
+        "Program {} \
+    failed: SBF program Panicked in rust/efficient_panic/src/lib.rs at 27:23",
+        program_id
+    )));
+}

--- a/sdk/define-syscall/src/codes.rs
+++ b/sdk/define-syscall/src/codes.rs
@@ -9,7 +9,7 @@ macro_rules! define_code {
 }
 
 define_code!(ABORT, 1);
-define_code!(SOL_PANIC, 2);
+define_code!(SOL_PANIC_, 2);
 define_code!(SOL_MEMCPY_, 3);
 define_code!(SOL_MEMMOVE_, 4);
 define_code!(SOL_MEMSET_, 5);

--- a/sdk/define-syscall/src/definitions.rs
+++ b/sdk/define-syscall/src/definitions.rs
@@ -33,6 +33,7 @@ define_syscall!(fn sol_remaining_compute_units() -> u64, SOL_REMAINING_COMPUTE_U
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64, SOL_ALT_BN128_COMPRESSION);
 define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64, SOL_GET_SYSVAR);
 define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64, SOL_GET_EPOCH_STAKE);
+define_syscall!(fn sol_panic_(filename: *const u8, filename_len: u64, line: u64, column: u64), SOL_PANIC_);
 
 // these are to be deprecated once they are superceded by sol_get_sysvar
 define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64, SOL_GET_CLOCK_SYSVAR);

--- a/sdk/program-entrypoint/src/lib.rs
+++ b/sdk/program-entrypoint/src/lib.rs
@@ -284,7 +284,7 @@ macro_rules! custom_panic_default {
     };
 }
 
-/// This is an efficient implementation fo custom panic. It contains two syscalls and has a size
+/// This is an efficient implementation of custom panic. It contains two syscalls and has a size
 /// of about 264 bytes. It depends on the unstable feature `panic_info_message`, which is going to
 /// be stabilized in Rust 1.84.
 ///

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -11,7 +11,7 @@ pub use solana_define_syscall::definitions::{
     sol_curve_group_op, sol_curve_multiscalar_mul, sol_curve_pairing_map, sol_curve_validate_point,
     sol_get_clock_sysvar, sol_get_epoch_rewards_sysvar, sol_get_epoch_schedule_sysvar,
     sol_get_epoch_stake, sol_get_fees_sysvar, sol_get_last_restart_slot, sol_get_rent_sysvar,
-    sol_get_sysvar, sol_keccak256, sol_remaining_compute_units,
+    sol_get_sysvar, sol_keccak256, sol_panic_, sol_remaining_compute_units,
 };
 #[deprecated(since = "2.1.0", note = "Use `solana_instruction::syscalls` instead")]
 pub use solana_instruction::syscalls::{


### PR DESCRIPTION
#### Problem

Our implementation of `custom_panic` can consume up to 25kb in contracts. This happens because it relies on the `format!` macro and, consequently, on `std::fmt::write`. They include many more functions in the contract and utilize dynamic dispatch, a technique that hinders compiler and link side optimizations for size reduction.

#### Summary of Changes

I implemented a new `custom_panic` that functions independently with only two syscalls. It needs the stabilization of `fmt::Arguments::as_str`, which is happening in Rust 1.84 (see https://github.com/rust-lang/rust/pull/132511).

#### Size comparison

Take this simple contract as an example:

```rust
entrypoint!(process_instruction);

fn process_instruction(
    _program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult {
    Ok(())
}
```

The binary size has whooping 18888 bytes (18kb).
The contract with an empty `custom_panic` function has 11536 bytes (11kb), so panic is consuming 7352 bytes.
The contract with my new implementation has 11800 bytes (11kb), so my implementation has 264 bytes.

#### New error messages

The members of `fmt::Arguments` are all private, so I cannot build custom panic messages during runtime as Rust does (think about the error you get when you access an invalid index from a vector: we can only know the index and the vector length during execution time). These messages will be elided in the new panic implementation (see examples below). Error messages whose content is known at compile time will still be shown normally.

The formatting is also different. It is more efficient to call `sol_log` multiple times than to format a string.

##### Accessing an invalid index from a vector:

OLD:
```
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S invoke [1]'
'Program log: panicked at src/lib.rs:19:13:\nindex out of bounds: the len is 44 but the index is 85034'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S consumed 2495 of 200000 compute units'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S failed: SBF program panicked'
```

NEW:
```
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S invoke [1]'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S consumed 546 of 200000 compute units'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S failed: SBF program Panicked in src/lib.rs at 19:13'
```

##### Calling unwrap on a None:

OLD:
```
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S invoke [1]'
'Program log: panicked at src/lib.rs:21:15:\ncalled `Option::unwrap()` on a `None` value'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S consumed 2118 of 200000 compute units'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S failed: SBF program panicked'
```

NEW:
```
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S invoke [1]'
'Program log: called `Option::unwrap()` on a `None` value'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S consumed 643 of 200000 compute units'
'Program C6CNmEDPNNKQwrH8BmAYAux33D1PuzJSNSbXyRWwv27S failed: SBF program Panicked in src/lib.rs at 21:15'
```
