### PR TITLE
Reduce unnecessary public visibility of some SVM structs and APIs

### DIFF
--- a/svm/src/account_overrides.rs
+++ b/svm/src/account_overrides.rs
@@ -28,7 +28,7 @@ impl AccountOverrides {
     }
 
     /// Gets the account if it's found in the list of overrides
-    pub fn get(&self, pubkey: &Pubkey) -> Option<&AccountSharedData> {
+    pub(crate) fn get(&self, pubkey: &Pubkey) -> Option<&AccountSharedData> {
         self.accounts.get(pubkey)
     }
 }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -11,7 +11,7 @@ use {
 };
 
 #[derive(Debug, Default, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
-pub struct MessageProcessor {}
+pub(crate) struct MessageProcessor {}
 
 #[cfg(feature = "frozen-abi")]
 impl ::solana_frozen_abi::abi_example::AbiExample for MessageProcessor {
@@ -28,7 +28,7 @@ impl MessageProcessor {
     /// For each instruction it calls the program entrypoint method and verifies that the result of
     /// the call does not violate the bank's accounting rules.
     /// The accounts are committed back to the bank only if every instruction succeeds.
-    pub fn process_message(
+    pub(crate) fn process_message(
         message: &impl SVMMessage,
         program_indices: &[Vec<IndexOfAccount>],
         invoke_context: &mut InvokeContext,

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     solana_account::{state_traits::StateMut, AccountSharedData},
     solana_nonce::{
@@ -16,7 +18,8 @@ pub struct NonceInfo {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum AdvanceNonceError {
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+enum AdvanceNonceError {
     #[error("Invalid account")]
     Invalid,
     #[error("Uninitialized nonce")]
@@ -31,7 +34,8 @@ impl NonceInfo {
     // Advance the stored blockhash to prevent fee theft by someone
     // replaying nonce transactions that have failed with an
     // `InstructionError`.
-    pub fn try_advance_nonce(
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn try_advance_nonce(
         &mut self,
         durable_nonce: DurableNonce,
         lamports_per_signature: u64,

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,14 +1,14 @@
 #[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
-    solana_account::{state_traits::StateMut, AccountSharedData},
+    qualifier_attr::qualifiers,
+    solana_account::state_traits::StateMut,
     solana_nonce::{
         state::{DurableNonce, State as NonceState},
         versions::Versions as NonceVersions,
     },
-    solana_pubkey::Pubkey,
     thiserror::Error,
 };
+use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
 
 /// Holds limited nonce info available during transaction checks
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -18,6 +18,7 @@ pub struct NonceInfo {
 }
 
 #[derive(Error, Debug, PartialEq)]
+#[cfg(feature = "dev-context-only-utils")]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 enum AdvanceNonceError {
     #[error("Invalid account")]
@@ -34,6 +35,7 @@ impl NonceInfo {
     // Advance the stored blockhash to prevent fee theft by someone
     // replaying nonce transactions that have failed with an
     // `InstructionError`.
+    #[cfg(feature = "dev-context-only-utils")]
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn try_advance_nonce(
         &mut self,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -275,8 +275,8 @@ mod tests {
     }
 
     #[derive(Default, Clone)]
-    pub struct MockBankCallback {
-        pub account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
+    pub(crate) struct MockBankCallback {
+        pub(crate) account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
     impl TransactionProcessingCallback for MockBankCallback {

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -31,7 +31,7 @@ impl Default for RollbackAccounts {
 }
 
 impl RollbackAccounts {
-    pub fn new(
+    pub(crate) fn new(
         nonce: Option<NonceInfo>,
         fee_payer_address: Pubkey,
         mut fee_payer_account: AccountSharedData,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_loader::{
@@ -69,8 +67,12 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
-        sync::Weak,
     },
+};
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    qualifier_attr::{field_qualifiers, qualifiers},
+    std::sync::Weak,
 };
 
 /// A list of log messages emitted during a transaction
@@ -240,6 +242,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///
     /// The cache will still not contain any builtin programs. It's advisable to
     /// call `add_builtin` to add the required builtins before using the processor.
+    #[cfg(feature = "dev-context-only-utils")]
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn new(
         slot: Slot,
@@ -1192,6 +1195,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         debug!("Added program {} under {:?}", name, program_id);
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn writable_sysvar_cache(&self) -> &RwLock<SysvarCache> {
         &self.sysvar_cache

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_loader::{
@@ -67,12 +69,8 @@ use {
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::{Debug, Formatter},
         rc::Rc,
+        sync::Weak,
     },
-};
-#[cfg(feature = "dev-context-only-utils")]
-use {
-    qualifier_attr::{field_qualifiers, qualifiers},
-    std::sync::Weak,
 };
 
 /// A list of log messages emitted during a transaction
@@ -242,9 +240,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///
     /// The cache will still not contain any builtin programs. It's advisable to
     /// call `add_builtin` to add the required builtins before using the processor.
-    #[cfg(feature = "dev-context-only-utils")]
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    fn new(
+    pub fn new(
         slot: Slot,
         epoch: Epoch,
         fork_graph: Weak<RwLock<FG>>,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -240,7 +240,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ///
     /// The cache will still not contain any builtin programs. It's advisable to
     /// call `add_builtin` to add the required builtins before using the processor.
-    pub fn new(
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn new(
         slot: Slot,
         epoch: Epoch,
         fork_graph: Weak<RwLock<FG>>,
@@ -1191,8 +1192,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         debug!("Added program {} under {:?}", name, program_id);
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn writable_sysvar_cache(&self) -> &RwLock<SysvarCache> {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn writable_sysvar_cache(&self) -> &RwLock<SysvarCache> {
         &self.sysvar_cache
     }
 }
@@ -1250,10 +1251,10 @@ mod tests {
     }
 
     #[derive(Default, Clone)]
-    pub struct MockBankCallback {
-        pub account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
+    struct MockBankCallback {
+        account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
         #[allow(clippy::type_complexity)]
-        pub inspected_accounts:
+        inspected_accounts:
             Arc<RwLock<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>>,
     }
 


### PR DESCRIPTION
#### Problem
Some structs and APIs in SVM do not need to be `pub`.

#### Summary of Changes
Reduce the visibility to private or `pub(crate)`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
