### PR TITLE
chore: remove obsolete comments

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6318,9 +6318,6 @@ impl AccountsDb {
             // `max_flush_root` in the accounts cache.
             self.accounts_cache.set_max_flush_root(root);
         }
-
-        // Only add to the uncleaned roots set *after* we've flushed the previous roots,
-        // so that clean will actually be able to clean the slots.
         let num_new_roots = cached_roots.len();
         (num_new_roots, num_roots_flushed, flush_stats)
     }


### PR DESCRIPTION
#### Problem

When we obsolete `uncleaned_roots` from account index, there are code comments left over, which should be deleted.

split from https://github.com/anza-xyz/agave/pull/4304


#### Summary of Changes

Remove obsolete code comments.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
