### PR TITLE
blockstore: Reduce intermediate collects from multi_get()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3895,7 +3895,6 @@ impl Blockstore {
         let deduped_shred_checks: Vec<(Hash, bool)> = self
             .data_shred_cf
             .multi_get_bytes(&keys)
-            .into_iter()
             .enumerate()
             .map(|(offset, shred_bytes)| {
                 let shred_bytes = shred_bytes.ok().flatten().ok_or_else(|| {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3747,7 +3747,7 @@ impl Blockstore {
         let data_shred_iterator = self.data_shred_cf.multi_get_bytes(&keys);
 
         let mut data_shreds: Vec<Shred> = Vec::with_capacity(keys.len());
-        for (idx, shred_bytes) in data_shred_iterator.into_iter().enumerate() {
+        for (idx, shred_bytes) in data_shred_iterator.enumerate() {
             let shred_bytes = shred_bytes?;
             if shred_bytes.is_none() {
                 if let Some(slot_meta) = slot_meta {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3749,7 +3749,6 @@ impl Blockstore {
         let mut data_shreds: Vec<Shred> = Vec::with_capacity(keys.len());
         for (idx, shred_bytes) in data_shred_iterator.into_iter().enumerate() {
             let shred_bytes = shred_bytes?;
-
             if shred_bytes.is_none() {
                 if let Some(slot_meta) = slot_meta {
                     if slot > self.lowest_cleanup_slot() {
@@ -3777,7 +3776,6 @@ impl Blockstore {
                     "Could not reconstruct shred from shred payload: {err:?}"
                 ))))
             })?;
-
             data_shreds.push(shred);
         }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3764,11 +3764,10 @@ impl Blockstore {
                         );
                     }
                 }
-                return Err(BlockstoreError::InvalidShredData(Box::new(
-                    bincode::ErrorKind::Custom(format!(
-                        "Missing shred for slot {slot}, index {idx}"
-                    )),
-                )));
+                return Err(BlockstoreError::MissingShred(
+                    slot,
+                    u64::try_from(idx).unwrap(),
+                ));
             }
 
             let shred = Shred::new_from_serialized_shred(shred_bytes.unwrap()).map_err(|err| {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1646,21 +1646,25 @@ impl<C, const K: usize> LedgerColumn<C, K>
 where
     C: TypedColumn + ColumnName,
 {
-    pub(crate) fn multi_get<I>(&self, keys: I) -> Vec<Result<Option<C::Type>>>
+    pub(crate) fn multi_get<'a, I, E>(
+        &'a self,
+        keys: I,
+    ) -> impl Iterator<Item = Result<Option<C::Type>>> + 'a
     where
-        I: IntoIterator<Item = C::Index>,
+        I: IntoIterator<Item = &'a E> + 'a,
+        E: AsRef<[u8]> + 'a + ?Sized,
     {
-        let keys = self.multi_get_keys(keys);
         {
             let is_perf_enabled = maybe_enable_rocksdb_perf(
                 self.column_options.rocks_perf_sample_interval,
                 &self.read_perf_status,
             );
+
             let result = self
                 .backend
-                .multi_get_cf(self.handle(), &keys)
-                .map(|out| Ok(out?.as_deref().map(deserialize).transpose()?))
-                .collect::<Vec<Result<Option<_>>>>();
+                .multi_get_cf(self.handle(), keys)
+                .map(|out| Ok(out?.as_deref().map(deserialize).transpose()?));
+
             if let Some(op_start_instant) = is_perf_enabled {
                 // use multi-get instead
                 report_rocksdb_read_perf(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1654,29 +1654,27 @@ where
         I: IntoIterator<Item = &'a E> + 'a,
         E: AsRef<[u8]> + 'a + ?Sized,
     {
-        {
-            let is_perf_enabled = maybe_enable_rocksdb_perf(
-                self.column_options.rocks_perf_sample_interval,
-                &self.read_perf_status,
+        let is_perf_enabled = maybe_enable_rocksdb_perf(
+            self.column_options.rocks_perf_sample_interval,
+            &self.read_perf_status,
+        );
+
+        let result = self
+            .backend
+            .multi_get_cf(self.handle(), keys)
+            .map(|out| Ok(out?.as_deref().map(deserialize).transpose()?));
+
+        if let Some(op_start_instant) = is_perf_enabled {
+            // use multi-get instead
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_MULTI_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
             );
-
-            let result = self
-                .backend
-                .multi_get_cf(self.handle(), keys)
-                .map(|out| Ok(out?.as_deref().map(deserialize).transpose()?));
-
-            if let Some(op_start_instant) = is_perf_enabled {
-                // use multi-get instead
-                report_rocksdb_read_perf(
-                    C::NAME,
-                    PERF_METRIC_OP_NAME_MULTI_GET,
-                    &op_start_instant.elapsed(),
-                    &self.column_options,
-                );
-            }
-
-            result
         }
+
+        result
     }
 
     pub fn get(&self, index: C::Index) -> Result<Option<C::Type>> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1451,11 +1451,21 @@ where
         result
     }
 
+    /// Create a key type suitable for use with multi_get_bytes() and
+    /// multi_get(). Those functions return iterators, so the keys must be
+    /// created with a separate function in order to live long enough
+    pub(crate) fn multi_get_keys<I>(&self, keys: I) -> Vec<Vec<u8>>
+    where
+        I: IntoIterator<Item = C::Index>,
+    {
+        keys.into_iter().map(C::key).collect()
+    }
+
     pub(crate) fn multi_get_bytes<I>(&self, keys: I) -> Vec<Result<Option<Vec<u8>>>>
     where
         I: IntoIterator<Item = C::Index>,
     {
-        let keys: Vec<_> = keys.into_iter().map(C::key).collect();
+        let keys = self.multi_get_keys(keys);
         {
             let is_perf_enabled = maybe_enable_rocksdb_perf(
                 self.column_options.rocks_perf_sample_interval,
@@ -1638,7 +1648,7 @@ where
     where
         I: IntoIterator<Item = C::Index>,
     {
-        let keys: Vec<_> = keys.into_iter().map(C::key).collect();
+        let keys = self.multi_get_keys(keys);
         {
             let is_perf_enabled = maybe_enable_rocksdb_perf(
                 self.column_options.rocks_perf_sample_interval,


### PR DESCRIPTION
#### Problem
The rocksdb `multi_get()` method allows us to fetch multiple values in a single rocksdb call. We currently return the results as a `Vec` by collecting item in `LedgerColumn` methods. But, we then immediately those `Vec`'s, making the intermediate `.collect()` useless and wasteful.

#### Summary of Changes
- Move key allocation outside of `multi_get()` methods so the keys live long enough
- Make the `multi_get()` methods return `impl Iterator ...` and update call sites