### PR TITLE
reduce buffer size of "unused" side of socket

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -52,7 +52,8 @@ use {
     solana_ledger::shred::Shred,
     solana_net_utils::{
         bind_common_in_range_with_config, bind_common_with_config, bind_in_range,
-        bind_in_range_with_config, bind_more_with_config, bind_to_localhost, bind_to_unspecified,
+        bind_in_range_with_config, bind_more_with_config, bind_to_localhost,
+        bind_to_localhost_with_config, bind_to_unspecified, bind_to_unspecified_with_config,
         bind_to_with_config, bind_two_in_range_with_offset_and_config,
         find_available_ports_in_range, multi_bind_in_range_with_config,
         sockets::localhost_port_range_for_tests, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
@@ -2408,18 +2409,29 @@ impl Node {
     ) -> Self {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = localhost_port_range_for_tests();
+
+        // TPU sockets are primarily read only
+        // Broadcast and Retransmit sockets are primarily write only
+        // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
+        let primarily_control_traffic_buffer_size = 2 * 1024 * 1024; // 2 MB doubled to 4 MB by kernel
+
         let udp_config = SocketConfig::default();
-        let quic_config = SocketConfig::default().reuseport(true);
+        let tpu_udp_config =
+            SocketConfig::default().send_buffer_size(primarily_control_traffic_buffer_size);
+        let tpu_quic_config = SocketConfig::default()
+            .reuseport(true)
+            .send_buffer_size(primarily_control_traffic_buffer_size);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config,
-                quic_config,
+                tpu_udp_config,
+                tpu_quic_config,
             )
             .unwrap();
-        let tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints, quic_config).unwrap();
+        let tpu_quic =
+            bind_more_with_config(tpu_quic, num_quic_endpoints, tpu_quic_config).unwrap();
         let (gossip_port, (gossip, ip_echo)) =
             bind_common_in_range_with_config(localhost_ip_addr, port_range, udp_config).unwrap();
         let gossip_addr = SocketAddr::new(localhost_ip_addr, gossip_port);
@@ -2430,24 +2442,31 @@ impl Node {
                 localhost_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                udp_config,
-                quic_config,
+                tpu_udp_config,
+                tpu_quic_config,
             )
             .unwrap();
         let tpu_forwards_quic =
-            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints, quic_config).unwrap();
-        let tpu_vote = bind_to_localhost().unwrap();
-        let tpu_vote_quic = bind_to_localhost().unwrap();
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints, tpu_quic_config).unwrap();
+        let tpu_vote = bind_to_localhost_with_config(tpu_quic_config).unwrap();
+        let tpu_vote_quic = bind_to_localhost_with_config(tpu_quic_config).unwrap();
         let tpu_vote_quic =
-            bind_more_with_config(tpu_vote_quic, num_quic_endpoints, quic_config).unwrap();
+            bind_more_with_config(tpu_vote_quic, num_quic_endpoints, tpu_quic_config).unwrap();
 
         let repair = bind_to_localhost().unwrap();
         let repair_quic = bind_to_localhost().unwrap();
         let rpc_ports = find_available_ports_in_range(localhost_ip_addr, port_range, 2).unwrap();
         let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[0]);
         let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[1]);
-        let broadcast = vec![bind_to_unspecified().unwrap()];
-        let retransmit_socket = bind_to_unspecified().unwrap();
+
+        let broadcast_config =
+            SocketConfig::default().recv_buffer_size(primarily_control_traffic_buffer_size);
+        let broadcast = vec![bind_to_unspecified_with_config(broadcast_config).unwrap()];
+
+        let retransmit_config =
+            SocketConfig::default().recv_buffer_size(primarily_control_traffic_buffer_size);
+        let retransmit_socket = bind_to_unspecified_with_config(retransmit_config).unwrap();
+
         let serve_repair = bind_to_localhost().unwrap();
         let serve_repair_quic = bind_to_localhost().unwrap();
         let ancestor_hashes_requests = bind_to_unspecified().unwrap();
@@ -2578,8 +2597,19 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
 
+        // TPU sockets are primarily read only
+        // Broadcast and Retransmit sockets are primarily write only
+        // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
+        let primarily_control_traffic_buffer_size = 2 * 1024 * 1024; // 2 MB doubled to 4 MB by kernel
+
         let socket_config = SocketConfig::default();
         let socket_config_reuseport = SocketConfig::default().reuseport(true);
+        let tpu_udp_config =
+            SocketConfig::default().send_buffer_size(primarily_control_traffic_buffer_size);
+        let tpu_quic_config = SocketConfig::default()
+            .reuseport(true)
+            .send_buffer_size(primarily_control_traffic_buffer_size);
+
         let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
@@ -2588,8 +2618,8 @@ impl Node {
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                socket_config,
-                socket_config_reuseport,
+                tpu_udp_config,
+                tpu_quic_config,
             )
             .unwrap();
         let tpu_quic: Vec<UdpSocket> =
@@ -2601,37 +2631,35 @@ impl Node {
                 bind_ip_addr,
                 port_range,
                 QUIC_PORT_OFFSET,
-                socket_config,
-                socket_config_reuseport,
+                tpu_udp_config,
+                tpu_quic_config,
             )
             .unwrap();
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_udp_config);
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
-        let tpu_vote_quic: Vec<UdpSocket> = bind_more_with_config(
-            tpu_vote_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_udp_config);
+        let tpu_vote_quic: Vec<UdpSocket> =
+            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, tpu_quic_config).unwrap();
 
+        let retransmit_config =
+            SocketConfig::default().recv_buffer_size(primarily_control_traffic_buffer_size);
         let (_, retransmit_socket) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+            Self::bind_with_config(bind_ip_addr, port_range, retransmit_config);
         let (_, repair) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (_, repair_quic) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (serve_repair_port, serve_repair) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (serve_repair_quic_port, serve_repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
-        let (_, broadcast) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+
+        let broadcast_config =
+            SocketConfig::default().recv_buffer_size(primarily_control_traffic_buffer_size);
+        let (_, broadcast) = Self::bind_with_config(bind_ip_addr, port_range, broadcast_config);
         let (_, ancestor_hashes_requests) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (_, ancestor_hashes_requests_quic) =
@@ -2731,8 +2759,18 @@ impl Node {
         let (gossip_port, (gossip, ip_echo)) =
             Self::get_gossip_port(&gossip_addr, port_range, bind_ip_addr);
 
+        // TPU sockets are primarily read only
+        // Broadcast and Retransmit sockets are primarily write only
+        // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
+        let primarily_control_traffic_buffer_size = 2 * 1024 * 1024; // 2 MB doubled to 4 MB by kernel
+
         let socket_config = SocketConfig::default();
         let socket_config_reuseport = SocketConfig::default().reuseport(true);
+        let tpu_udp_config =
+            SocketConfig::default().send_buffer_size(primarily_control_traffic_buffer_size);
+        let tpu_quic_config = SocketConfig::default()
+            .reuseport(true)
+            .send_buffer_size(primarily_control_traffic_buffer_size);
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
@@ -2746,17 +2784,16 @@ impl Node {
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (tpu_port, tpu_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 32)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_quic_config, 32)
                 .expect("tpu multi_bind");
 
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            socket_config_reuseport,
+            tpu_quic_config,
         );
         let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config_reuseport)
-                .unwrap();
+            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), tpu_quic_config).unwrap();
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 8)
@@ -2768,33 +2805,30 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            socket_config_reuseport,
+            tpu_quic_config,
         );
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), tpu_quic_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 1)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, tpu_quic_config, 1)
                 .expect("tpu_vote multi_bind");
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
+            Self::bind_with_config(bind_ip_addr, port_range, tpu_udp_config);
 
-        let tpu_vote_quic = bind_more_with_config(
-            tpu_vote_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_vote_quic =
+            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), tpu_quic_config)
+                .unwrap();
 
+        let retransmit_config = SocketConfig::default()
+            .reuseport(true)
+            .recv_buffer_size(primarily_control_traffic_buffer_size);
         let (_, retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport,
+            retransmit_config,
             num_tvu_retransmit_sockets.get(),
         )
         .expect("retransmit multi_bind");
@@ -2807,8 +2841,11 @@ impl Node {
         let (serve_repair_quic_port, serve_repair_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
+        let broadcast_config = SocketConfig::default()
+            .reuseport(true)
+            .recv_buffer_size(primarily_control_traffic_buffer_size);
         let (_, broadcast) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 4)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, broadcast_config, 4)
                 .expect("broadcast multi_bind");
 
         let (_, ancestor_hashes_requests) =

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -483,6 +483,10 @@ pub fn bind_to_localhost() -> io::Result<UdpSocket> {
     )
 }
 
+pub fn bind_to_localhost_with_config(config: SocketConfig) -> io::Result<UdpSocket> {
+    bind_to_with_config(IpAddr::V4(Ipv4Addr::LOCALHOST), /*port:*/ 0, config)
+}
+
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
     bind_to_async(
@@ -499,6 +503,10 @@ pub fn bind_to_unspecified() -> io::Result<UdpSocket> {
         /*port:*/ 0,
         /*reuseport:*/ false,
     )
+}
+
+pub fn bind_to_unspecified_with_config(config: SocketConfig) -> io::Result<UdpSocket> {
+    bind_to_with_config(IpAddr::V4(Ipv4Addr::UNSPECIFIED), /*port:*/ 0, config)
 }
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -262,7 +262,10 @@ impl SocketConfig {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF
+    /// However, "Linux assumes that half of the send/receive buffer is used for
+    /// internal kernel structures; thus the values in the corresponding
+    /// /proc files are twice what can be observed on the wire."
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF, NOTES
     pub fn recv_buffer_size(mut self, size: usize) -> Self {
         self.recv_buffer_size = Some(size);
         self
@@ -273,7 +276,10 @@ impl SocketConfig {
     /// **Note:** On Linux the kernel will double the value you specify.
     /// For example, if you specify `16MB`, the kernel will configure the
     /// socket to use `32MB`.
-    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF
+    /// However, "Linux assumes that half of the send/receive buffer is used for
+    /// internal kernel structures; thus the values in the corresponding
+    /// /proc files are twice what can be observed on the wire."
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF, NOTES
     pub fn send_buffer_size(mut self, size: usize) -> Self {
         self.send_buffer_size = Some(size);
         self

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -77,7 +77,9 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            let config = SocketConfig::default();
+            // The `quic-client` primarily sends data and only receives control traffic
+            // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
+            let config = SocketConfig::default().recv_buffer_size(2 * 1024 * 1024); // 2 MB buffer doubled to 4 MB by kernel
             let client_socket = solana_net_utils::bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -79,7 +79,7 @@ impl QuicLazyInitializedEndpoint {
         } else {
             // The `quic-client` primarily sends data and only receives control traffic
             // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
-            let config = SocketConfig::default().recv_buffer_size(2 * 1024 * 1024); // 2 MB buffer doubled to 4 MB by kernel
+            let config = SocketConfig::default().recv_buffer_size(4 * 1024 * 1024);
             let client_socket = solana_net_utils::bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -65,7 +65,7 @@ impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
         // The `udp-client` primarily sends data and only receives control traffic
         // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
-        let config = SocketConfig::default().recv_buffer_size(2 * 1024 * 1024); // 2 MB buffer doubled to 4 MB by kernel
+        let config = SocketConfig::default().recv_buffer_size(4 * 1024 * 1024);
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             config,

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -63,9 +63,12 @@ pub struct UdpConfig {
 
 impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
+        // The `udp-client` primarily sends data and only receives control traffic
+        // Set a 4 MB buffer size for the minimally used side of the socket for QUIC control traffic
+        let config = SocketConfig::default().recv_buffer_size(2 * 1024 * 1024); // 2 MB buffer doubled to 4 MB by kernel
         let socket = solana_net_utils::bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            SocketConfig::default(),
+            config,
         )
         .map_err(Into::<ClientError>::into)?;
         Ok(Self {


### PR DESCRIPTION
Follow Up to PR: https://github.com/anza-xyz/agave/pull/3929

#### Problem
We allocate large send and receive buffers for all sockets. However, not all sockets read and write equally from/to their buffers. In fact, 6 sockets are primarily Read and 2 are primarily Write. Meaning we are allocating memory that is never used.

#### Summary of Changes
1) TPU write side of sockets are only QUIC control traffic. Set buffer size to 4 MB
2) Broadcast and Repair read side of sockets are only QUIC control traffic. Set buffer size to $ MB

Services/Sockets
Read/Write

Gossip
RPC - TCP
Ip_echo - TCP
Repair
Repair_quic
Serve_repair
Serve_repair_quic
Ancestor_hashes_requests_quic
Ancestor_hashes_requests


Primarily Read
TVU
tvu_quic
Tpu
Tpu_forwards
Tpu_vote
Tpu_quic
Tpu_forwards_quic
Tpu_vote_quic


Primarily Write
Retransmitter
Broadcast

Follow Up PR:
1) Make better sizing decisions for the sockets that don't need a full 128MB buffer
