### PR TITLE
Uses NoHashHasher in accounts write cache

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -2,6 +2,7 @@ use {
     crate::{accounts_db::AccountsDb, accounts_hash::AccountHash},
     dashmap::DashMap,
     seqlock::SeqLock,
+    solana_nohash_hasher::BuildNoHashHasher,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
@@ -152,7 +153,7 @@ impl CachedAccountInner {
 
 #[derive(Debug, Default)]
 pub struct AccountsCache {
-    cache: DashMap<Slot, SlotCache>,
+    cache: DashMap<Slot, SlotCache, BuildNoHashHasher<Slot>>,
     // Queue of potentially unflushed roots. Random eviction + cache too large
     // could have triggered a flush of this slot already
     maybe_unflushed_roots: RwLock<BTreeSet<Slot>>,


### PR DESCRIPTION
#### Problem

The accounts write cache internally is a map from slot to cache-per-slot. The outer map's key is `Slot`, and we don't need to use a "real", nor cryptographically secure, hashing function. Since slots are guaranteed to be unique identifiers, we can use the slot directly as the index into the map.


#### Summary of Changes

Use NoHashHasher for the accounts write cache's internal `cache`.