### PR TITLE
Uses NoHashHasher in AccountsDb::dirty_stores

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -84,7 +84,7 @@ use {
     smallvec::SmallVec,
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{meas_dur, measure::Measure, measure_us},
-    solana_nohash_hasher::{IntMap, IntSet},
+    solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
@@ -1573,7 +1573,7 @@ pub struct AccountsDb {
     /// Set of stores which are recently rooted or had accounts removed
     /// such that potentially a 0-lamport account update could be present which
     /// means we can remove the account from the index entirely.
-    dirty_stores: DashMap<Slot, Arc<AccountStorageEntry>>,
+    dirty_stores: DashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>,
 
     /// Zero-lamport accounts that are *not* purged during clean because they need to stay alive
     /// for incremental snapshot support.


### PR DESCRIPTION
#### Problem

The AccountsDb `dirty_stores` is a map from slot to storage. The map's key is `Slot`, and we don't need to use a "real", nor cryptographically secure, hashing function. Since slots are guaranteed to be unique identifiers, we can use the slot directly as the index into the map.


#### Summary of Changes

Use NoHashHasher for dirty_stores.