### PR TITLE
use solana-pubkey instead of solana-sdk in stake-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9263,6 +9263,7 @@ dependencies = [
  "solana-log-collector",
  "solana-logger",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-sdk",
  "solana-type-overrides",
  "solana-vote-program",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7773,6 +7773,7 @@ dependencies = [
  "solana-feature-set",
  "solana-log-collector",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-sdk",
  "solana-type-overrides",
  "solana-vote-program",

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -16,6 +16,7 @@ solana-config-program = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana-vote-program = { workspace = true }
@@ -26,6 +27,7 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-logger = { workspace = true }
+solana-pubkey = { workspace = true }
 test-case = { workspace = true }
 
 [lib]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -27,7 +27,6 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-logger = { workspace = true }
-solana-pubkey = { workspace = true }
 test-case = { workspace = true }
 
 [lib]

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -3,11 +3,11 @@ use {
     criterion::{black_box, criterion_group, criterion_main, Criterion},
     solana_feature_set::FeatureSet,
     solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{create_account_shared_data_for_test, AccountSharedData, WritableAccount},
         clock::{Clock, Epoch},
         instruction::AccountMeta,
-        pubkey::Pubkey,
         stake::{
             instruction::{
                 self, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs,
@@ -48,7 +48,7 @@ impl TestSetup {
             StakeStateV2::size_of(),
             &solana_stake_program::id(),
         );
-        let stake_address = solana_sdk::pubkey::Pubkey::new_unique();
+        let stake_address = solana_pubkey::Pubkey::new_unique();
         Self {
             // some stake instructions are behind feature gate, enable all
             // feature gates to bench all instructions

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -2,10 +2,10 @@
 //! Used by `solana-runtime`.
 
 use {
+    solana_pubkey::Pubkey,
     solana_sdk::{
         clock::Epoch,
         instruction::InstructionError,
-        pubkey::Pubkey,
         stake::state::{Delegation, Stake, StakeStateV2},
         stake_history::StakeHistory,
     },

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -231,7 +231,8 @@ mod tests {
     use {
         super::*,
         crate::{points::null_tracer, stake_state::new_stake},
-        solana_sdk::{native_token, pubkey::Pubkey},
+        solana_pubkey::Pubkey,
+        solana_sdk::native_token,
         test_case::test_case,
     };
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -8,10 +8,10 @@ use {
     solana_program_runtime::{
         declare_process_instruction, sysvar_cache::get_sysvar_with_account_check,
     },
+    solana_pubkey::Pubkey,
     solana_sdk::{
         instruction::InstructionError,
         program_utils::limited_deserialize,
-        pubkey::Pubkey,
         stake::{
             instruction::{LockupArgs, StakeError, StakeInstruction},
             program::id,
@@ -392,6 +392,7 @@ mod tests {
         bincode::serialize,
         solana_feature_set::FeatureSet,
         solana_program_runtime::invoke_context::mock_process_instruction,
+        solana_pubkey::Pubkey,
         solana_sdk::{
             account::{
                 create_account_shared_data_for_test, AccountSharedData, ReadableAccount,
@@ -401,7 +402,6 @@ mod tests {
             clock::{Clock, Epoch, UnixTimestamp},
             epoch_schedule::EpochSchedule,
             instruction::{AccountMeta, Instruction},
-            pubkey::Pubkey,
             rent::Rent,
             stake::{
                 config as stake_config,
@@ -1468,9 +1468,9 @@ mod tests {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_lamports = rent_exempt_reserve;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new(stake_lamports, StakeStateV2::size_of(), &id());
-        let custodian_address = solana_sdk::pubkey::new_rand();
+        let custodian_address = solana_pubkey::new_rand();
         let lockup = Lockup {
             epoch: 1,
             unix_timestamp: 0,
@@ -1570,9 +1570,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_authorize(feature_set: Arc<FeatureSet>) {
-        let authority_address = solana_sdk::pubkey::new_rand();
-        let authority_address_2 = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
+        let authority_address_2 = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
@@ -1581,7 +1581,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let to_address = solana_sdk::pubkey::new_rand();
+        let to_address = solana_pubkey::new_rand();
         let to_account = AccountSharedData::new(1, 0, &system_program::id());
         let mut transaction_accounts = vec![
             (stake_address, stake_account),
@@ -1755,9 +1755,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_authorize_override(feature_set: Arc<FeatureSet>) {
-        let authority_address = solana_sdk::pubkey::new_rand();
-        let mallory_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
+        let mallory_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
@@ -1874,8 +1874,8 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_authorize_with_seed(feature_set: Arc<FeatureSet>) {
-        let authority_base_address = solana_sdk::pubkey::new_rand();
-        let authority_address = solana_sdk::pubkey::new_rand();
+        let authority_base_address = solana_pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
         let seed = "42";
         let stake_address = Pubkey::create_with_seed(&authority_base_address, seed, &id()).unwrap();
         let stake_lamports = 42;
@@ -1991,8 +1991,8 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_authorize_delegated_stake(feature_set: Arc<FeatureSet>) {
-        let authority_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
@@ -2002,12 +2002,12 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-        let vote_address_2 = solana_sdk::pubkey::new_rand();
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+        let vote_address_2 = solana_pubkey::new_rand();
         let mut vote_account_2 =
-            vote_state::create_account(&vote_address_2, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address_2, &solana_pubkey::new_rand(), 0, 100);
         vote_account_2.set_state(&VoteState::default()).unwrap();
         #[allow(deprecated)]
         let mut transaction_accounts = vec![
@@ -2193,12 +2193,12 @@ mod tests {
             vote_state::process_slot_vote_unchecked(&mut vote_state, i);
         }
         let vote_state_credits = vote_state.credits();
-        let vote_address = solana_sdk::pubkey::new_rand();
-        let vote_address_2 = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
+        let vote_address_2 = solana_pubkey::new_rand();
         let mut vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         let mut vote_account_2 =
-            vote_state::create_account(&vote_address_2, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address_2, &solana_pubkey::new_rand(), 0, 100);
         vote_account
             .set_state(&VoteStateVersions::new_current(vote_state.clone()))
             .unwrap();
@@ -2207,7 +2207,7 @@ mod tests {
             .unwrap();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let mut stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeStateV2::Initialized(Meta {
@@ -2410,7 +2410,7 @@ mod tests {
         transaction_accounts[1] = (vote_address_2, vote_account_2);
         transaction_accounts[1]
             .1
-            .set_owner(solana_sdk::pubkey::new_rand());
+            .set_owner(solana_pubkey::new_rand());
         process_instruction(
             Arc::clone(&feature_set),
             &serialize(&StakeInstruction::DelegateStake).unwrap(),
@@ -2440,12 +2440,12 @@ mod tests {
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let initial_lamports = 4242424242;
         let stake_lamports = rent_exempt_reserve + initial_lamports;
-        let recipient_address = solana_sdk::pubkey::new_rand();
-        let authority_address = solana_sdk::pubkey::new_rand();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-        let stake_address = solana_sdk::pubkey::new_rand();
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeStateV2::Initialized(Meta {
@@ -2647,10 +2647,10 @@ mod tests {
             epoch: current_epoch,
             ..Clock::default()
         };
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation * 2;
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeStateV2::Uninitialized,
@@ -2758,7 +2758,7 @@ mod tests {
             0,
             &StakeStateV2::Uninitialized,
             StakeStateV2::size_of(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
         )
         .unwrap();
         transaction_accounts[1] = (split_to_address, split_to_account);
@@ -2774,10 +2774,10 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_withdraw_stake(feature_set: Arc<FeatureSet>) {
-        let recipient_address = solana_sdk::pubkey::new_rand();
-        let authority_address = solana_sdk::pubkey::new_rand();
-        let custodian_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
+        let authority_address = solana_pubkey::new_rand();
+        let custodian_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
@@ -2787,9 +2787,9 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let mut vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         vote_account
             .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
@@ -3068,8 +3068,8 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_withdraw_stake_before_warmup(feature_set: Arc<FeatureSet>) {
-        let recipient_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
         let total_lamports = stake_lamports + 33;
@@ -3080,9 +3080,9 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let mut vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         vote_account
             .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
@@ -3202,9 +3202,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_withdraw_lockup(feature_set: Arc<FeatureSet>) {
-        let recipient_address = solana_sdk::pubkey::new_rand();
-        let custodian_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
+        let custodian_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let total_lamports = 100;
         let mut meta = Meta {
             lockup: Lockup {
@@ -3326,9 +3326,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_withdraw_rent_exempt(feature_set: Arc<FeatureSet>) {
-        let recipient_address = solana_sdk::pubkey::new_rand();
-        let custodian_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
+        let custodian_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
@@ -3422,7 +3422,7 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_deactivate(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
@@ -3432,9 +3432,9 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let mut vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         vote_account
             .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
@@ -3552,9 +3552,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_set_lockup(feature_set: Arc<FeatureSet>) {
-        let custodian_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let custodian_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
@@ -3564,9 +3564,9 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let mut vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         vote_account
             .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
@@ -3843,7 +3843,7 @@ mod tests {
     fn test_initialize_minimum_balance(feature_set: Arc<FeatureSet>) {
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let instruction_data = serialize(&StakeInstruction::Initialize(
             Authorized::auto(&stake_address),
             Lockup::default(),
@@ -3899,14 +3899,14 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
             ..Meta::auto(&stake_address)
         };
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
         #[allow(deprecated)]
         let instruction_accounts = vec![
             AccountMeta {
@@ -4476,12 +4476,12 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
             ..Meta::auto(&stake_address)
         };
-        let recipient_address = solana_sdk::pubkey::new_rand();
+        let recipient_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -4586,16 +4586,16 @@ mod tests {
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new(
             rent_exempt_reserve + minimum_delegation,
             StakeStateV2::size_of(),
             &id(),
         );
-        let vote_address = solana_sdk::pubkey::new_rand();
+        let vote_address = solana_pubkey::new_rand();
         let vote_account =
-            vote_state::create_account(&vote_address, &solana_sdk::pubkey::new_rand(), 0, 100);
-        let recipient_address = solana_sdk::pubkey::new_rand();
+            vote_state::create_account(&vote_address, &solana_pubkey::new_rand(), 0, 100);
+        let recipient_address = solana_pubkey::new_rand();
         let mut clock = Clock::default();
         #[allow(deprecated)]
         let mut transaction_accounts = vec![
@@ -4760,7 +4760,7 @@ mod tests {
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeStateV2::Uninitialized,
@@ -4768,7 +4768,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeStateV2::Uninitialized,
@@ -4857,7 +4857,7 @@ mod tests {
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_split_split_not_uninitialized(feature_set: Arc<FeatureSet>) {
         let stake_lamports = 42;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&stake_address), stake_lamports),
@@ -4865,7 +4865,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -4913,7 +4913,7 @@ mod tests {
         let current_epoch = 100;
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(
@@ -4927,7 +4927,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             rent_exempt_reserve,
             &StakeStateV2::Uninitialized,
@@ -4989,8 +4989,8 @@ mod tests {
             ..Clock::default()
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeStateV2::Uninitialized,
@@ -5122,7 +5122,7 @@ mod tests {
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve,
@@ -5136,7 +5136,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -5300,7 +5300,7 @@ mod tests {
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = (source_larger_rent_exempt_reserve + minimum_delegation) * 2;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve: source_larger_rent_exempt_reserve,
@@ -5314,7 +5314,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -5467,7 +5467,7 @@ mod tests {
         let stake_history = StakeHistory::default();
         let current_epoch = 100;
         let stake_lamports = split_rent_exempt_reserve + 1;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve: source_smaller_rent_exempt_reserve,
@@ -5481,7 +5481,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -5564,13 +5564,13 @@ mod tests {
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve,
             ..Meta::default()
         };
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeStateV2::Uninitialized,
@@ -5683,7 +5683,7 @@ mod tests {
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve,
@@ -5697,7 +5697,7 @@ mod tests {
             &id(),
         )
         .unwrap();
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -5803,13 +5803,13 @@ mod tests {
         };
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let stake_lamports = source_rent_exempt_reserve + minimum_delegation;
-        let stake_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
         let meta = Meta {
             authorized: Authorized::auto(&stake_address),
             rent_exempt_reserve: source_rent_exempt_reserve,
             ..Meta::default()
         };
-        let split_to_address = solana_sdk::pubkey::new_rand();
+        let split_to_address = solana_pubkey::new_rand();
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: stake_address,
@@ -6157,9 +6157,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let merge_from_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let merge_from_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
         let meta = Meta::auto(&authorized_address);
         let stake_lamports = 42;
         let mut instruction_accounts = vec![
@@ -6292,8 +6292,8 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge_self_fails(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
         let stake_amount = 4242424242;
@@ -6369,10 +6369,10 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge_incorrect_authorized_staker(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let merge_from_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
-        let wrong_authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let merge_from_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
+        let wrong_authorized_address = solana_pubkey::new_rand();
         let stake_lamports = 42;
         let mut instruction_accounts = vec![
             AccountMeta {
@@ -6467,9 +6467,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge_invalid_account_data(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let merge_from_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let merge_from_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
         let stake_lamports = 42;
         let instruction_accounts = vec![
             AccountMeta {
@@ -6552,9 +6552,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge_fake_stake_source(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let merge_from_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let merge_from_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
@@ -6567,7 +6567,7 @@ mod tests {
             stake_lamports,
             &just_stake(Meta::auto(&authorized_address), stake_lamports),
             StakeStateV2::size_of(),
-            &solana_sdk::pubkey::new_rand(),
+            &solana_pubkey::new_rand(),
         )
         .unwrap();
         let transaction_accounts = vec![
@@ -6623,9 +6623,9 @@ mod tests {
     #[test_case(feature_set_no_minimum_delegation(); "no_min_delegation")]
     #[test_case(feature_set_all_enabled(); "all_enabled")]
     fn test_merge_active_stake(feature_set: Arc<FeatureSet>) {
-        let stake_address = solana_sdk::pubkey::new_rand();
-        let merge_from_address = solana_sdk::pubkey::new_rand();
-        let authorized_address = solana_sdk::pubkey::new_rand();
+        let stake_address = solana_pubkey::new_rand();
+        let merge_from_address = solana_pubkey::new_rand();
+        let authorized_address = solana_pubkey::new_rand();
         let base_lamports = 4242424242;
         let rent = Rent::default();
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -12,12 +12,12 @@ use {
     solana_feature_set::FeatureSet,
     solana_log_collector::ic_msg,
     solana_program_runtime::invoke_context::InvokeContext,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         account_utils::StateMut,
         clock::{Clock, Epoch},
         instruction::{checked_add, InstructionError},
-        pubkey::Pubkey,
         rent::Rent,
         stake::{
             instruction::{LockupArgs, StakeError},
@@ -1448,10 +1448,10 @@ mod tests {
         super::*,
         proptest::prelude::*,
         solana_program_runtime::with_mock_invoke_context,
+        solana_pubkey::Pubkey,
         solana_sdk::{
             account::{create_account_shared_data_for_test, AccountSharedData},
             epoch_schedule::EpochSchedule,
-            pubkey::Pubkey,
             stake::state::warmup_cooldown_rate,
             sysvar::{epoch_schedule, SysvarId},
         },
@@ -1460,7 +1460,7 @@ mod tests {
 
     #[test]
     fn test_authorized_authorize() {
-        let staker = solana_sdk::pubkey::new_rand();
+        let staker = solana_pubkey::new_rand();
         let mut authorized = Authorized::auto(&staker);
         let mut signers = HashSet::new();
         assert_eq!(
@@ -1476,9 +1476,9 @@ mod tests {
 
     #[test]
     fn test_authorized_authorize_with_custodian() {
-        let staker = solana_sdk::pubkey::new_rand();
-        let custodian = solana_sdk::pubkey::new_rand();
-        let invalid_custodian = solana_sdk::pubkey::new_rand();
+        let staker = solana_pubkey::new_rand();
+        let custodian = solana_pubkey::new_rand();
+        let invalid_custodian = solana_pubkey::new_rand();
         let mut authorized = Authorized::auto(&staker);
         let mut signers = HashSet::new();
         signers.insert(staker);
@@ -2174,7 +2174,7 @@ mod tests {
 
     #[test]
     fn test_lockup_is_expired() {
-        let custodian = solana_sdk::pubkey::new_rand();
+        let custodian = solana_pubkey::new_rand();
         let lockup = Lockup {
             epoch: 1,
             unix_timestamp: 1,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7092,6 +7092,7 @@ dependencies = [
  "solana-feature-set",
  "solana-log-collector",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-sdk",
  "solana-type-overrides",
  "solana-vote-program",


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk, but just replacing the pubkey usage makes for a big enough PR

#### Summary of Changes
Replace all imports from solana_sdk::pubkey with solana_pubkey
