### PR TITLE
use solana-message in transaction-status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9899,6 +9899,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-message",
  "solana-pubkey",
  "solana-sdk",
  "solana-transaction-status-client-types",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8220,6 +8220,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-message",
  "solana-pubkey",
  "solana-sdk",
  "solana-transaction-status-client-types",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7556,6 +7556,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-message",
  "solana-pubkey",
  "solana-sdk",
  "solana-transaction-status-client-types",

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }

--- a/transaction-status/benches/extract_memos.rs
+++ b/transaction-status/benches/extract_memos.rs
@@ -3,7 +3,8 @@
 extern crate test;
 
 use {
-    solana_sdk::{instruction::CompiledInstruction, message::Message, pubkey::Pubkey},
+    solana_message::{compiled_instruction::CompiledInstruction, Message},
+    solana_sdk::pubkey::Pubkey,
     solana_transaction_status::extract_memos::{spl_memo_id_v1, spl_memo_id_v3, ExtractMemos},
     test::Bencher,
 };

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -1,10 +1,9 @@
 use {
     crate::{parse_instruction::parse_memo_data, VersionedTransactionWithStatusMeta},
-    solana_sdk::{
-        instruction::CompiledInstruction,
-        message::{AccountKeys, Message, SanitizedMessage},
-        pubkey::Pubkey,
+    solana_message::{
+        compiled_instruction::CompiledInstruction, AccountKeys, Message, SanitizedMessage,
     },
+    solana_sdk::pubkey::Pubkey,
 };
 
 // A helper function to convert spl_memo::v1::id() as spl_sdk::pubkey::Pubkey to

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -23,14 +23,14 @@ use {
         parse_instruction::parse,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        v0::{self, LoadedAddresses, LoadedMessage},
+        AccountKeys, Message, VersionedMessage,
+    },
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         hash::Hash,
-        instruction::CompiledInstruction,
-        message::{
-            v0::{self, LoadedAddresses, LoadedMessage},
-            AccountKeys, Message, VersionedMessage,
-        },
         pubkey::Pubkey,
         reserved_account_keys::ReservedAccountKeys,
         signature::Signature,

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -1,8 +1,8 @@
-use solana_sdk::{
-    message::{v0::LoadedMessage, Message},
-    reserved_account_keys::ReservedAccountKeys,
-};
 pub use solana_transaction_status_client_types::{ParsedAccount, ParsedAccountSource};
+use {
+    solana_message::{v0::LoadedMessage, Message},
+    solana_sdk::reserved_account_keys::ReservedAccountKeys,
+};
 
 pub fn parse_legacy_message_accounts(message: &Message) -> Vec<ParsedAccount> {
     let reserved_account_keys = ReservedAccountKeys::new_all_activated().active;
@@ -40,11 +40,8 @@ pub fn parse_v0_message_accounts(message: &LoadedMessage) -> Vec<ParsedAccount> 
 mod test {
     use {
         super::*,
-        solana_sdk::{
-            message::{v0, v0::LoadedAddresses, MessageHeader},
-            pubkey::Pubkey,
-            reserved_account_keys::ReservedAccountKeys,
-        },
+        solana_message::{v0, v0::LoadedAddresses, MessageHeader},
+        solana_sdk::{pubkey::Pubkey, reserved_account_keys::ReservedAccountKeys},
     };
 
     #[test]

--- a/transaction-status/src/parse_address_lookup_table.rs
+++ b/transaction-status/src/parse_address_lookup_table.rs
@@ -4,10 +4,8 @@ use {
     },
     bincode::deserialize,
     serde_json::json,
-    solana_sdk::{
-        address_lookup_table::instruction::ProgramInstruction, instruction::CompiledInstruction,
-        message::AccountKeys,
-    },
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::address_lookup_table::instruction::ProgramInstruction,
 };
 
 pub fn parse_address_lookup_table(
@@ -117,9 +115,8 @@ fn check_num_address_lookup_table_accounts(
 mod test {
     use {
         super::*,
-        solana_sdk::{
-            address_lookup_table::instruction, message::Message, pubkey::Pubkey, system_program,
-        },
+        solana_message::Message,
+        solana_sdk::{address_lookup_table::instruction, pubkey::Pubkey, system_program},
         std::str::FromStr,
     };
 

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -4,7 +4,8 @@ use {
     },
     borsh::BorshDeserialize,
     serde_json::json,
-    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey},
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::pubkey::Pubkey,
     spl_associated_token_account::instruction::AssociatedTokenAccountInstruction,
 };
 
@@ -94,7 +95,8 @@ mod test {
     use spl_associated_token_account::create_associated_token_account as create_associated_token_account_deprecated;
     use {
         super::*,
-        solana_sdk::{message::Message, sysvar},
+        solana_message::Message,
+        solana_sdk::sysvar,
         spl_associated_token_account::{
             get_associated_token_address, get_associated_token_address_with_program_id,
             instruction::{

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -5,9 +5,10 @@ use {
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::deserialize,
     serde_json::json,
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
     solana_sdk::{
-        instruction::CompiledInstruction, loader_instruction::LoaderInstruction,
-        loader_upgradeable_instruction::UpgradeableLoaderInstruction, message::AccountKeys,
+        loader_instruction::LoaderInstruction,
+        loader_upgradeable_instruction::UpgradeableLoaderInstruction,
     },
 };
 
@@ -207,9 +208,9 @@ mod test {
     use {
         super::*,
         serde_json::Value,
+        solana_message::Message,
         solana_sdk::{
             bpf_loader_upgradeable,
-            message::Message,
             pubkey::{self, Pubkey},
             system_program, sysvar,
         },

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -13,10 +13,8 @@ use {
     inflector::Inflector,
     serde_json::Value,
     solana_account_decoder::parse_token::spl_token_ids,
-    solana_sdk::{
-        address_lookup_table, instruction::CompiledInstruction, message::AccountKeys,
-        pubkey::Pubkey, stake, system_program, vote,
-    },
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::{address_lookup_table, pubkey::Pubkey, stake, system_program, vote},
     std::{
         collections::HashMap,
         str::{from_utf8, Utf8Error},

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -4,10 +4,8 @@ use {
     },
     bincode::deserialize,
     serde_json::{json, Map, Value},
-    solana_sdk::{
-        instruction::CompiledInstruction, message::AccountKeys,
-        stake::instruction::StakeInstruction,
-    },
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::stake::instruction::StakeInstruction,
 };
 
 pub fn parse_stake(
@@ -333,9 +331,9 @@ fn check_num_stake_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInst
 mod test {
     use {
         super::*,
+        solana_message::Message,
         solana_sdk::{
             instruction::Instruction,
-            message::Message,
             pubkey::Pubkey,
             stake::{
                 config,

--- a/transaction-status/src/parse_system.rs
+++ b/transaction-status/src/parse_system.rs
@@ -4,10 +4,8 @@ use {
     },
     bincode::deserialize,
     serde_json::json,
-    solana_sdk::{
-        instruction::CompiledInstruction, message::AccountKeys,
-        system_instruction::SystemInstruction,
-    },
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::system_instruction::SystemInstruction,
 };
 
 pub fn parse_system(
@@ -211,7 +209,8 @@ fn check_num_system_accounts(accounts: &[u8], num: usize) -> Result<(), ParseIns
 mod test {
     use {
         super::*,
-        solana_sdk::{message::Message, pubkey::Pubkey, system_instruction, sysvar},
+        solana_message::Message,
+        solana_sdk::{pubkey::Pubkey, system_instruction, sysvar},
     };
 
     #[test]

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -13,7 +13,7 @@ use {
     solana_account_decoder::{
         parse_account_data::SplTokenAdditionalData, parse_token::token_amount_to_ui_amount_v2,
     },
-    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys},
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
     spl_token_2022::{
         extension::ExtensionType,
         instruction::{AuthorityType, TokenInstruction},
@@ -863,10 +863,8 @@ fn map_coption_pubkey(pubkey: COption<Pubkey>) -> Option<String> {
 #[cfg(test)]
 mod test {
     use {
-        super::*,
-        solana_sdk::{message::Message, pubkey::Pubkey},
-        spl_token_2022::instruction::*,
-        std::iter::repeat_with,
+        super::*, solana_message::Message, solana_sdk::pubkey::Pubkey,
+        spl_token_2022::instruction::*, std::iter::repeat_with,
     };
 
     fn test_parse_token(program_id: &Pubkey) {

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -4,9 +4,8 @@ use {
     },
     bincode::deserialize,
     serde_json::json,
-    solana_sdk::{
-        instruction::CompiledInstruction, message::AccountKeys, vote::instruction::VoteInstruction,
-    },
+    solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
+    solana_sdk::vote::instruction::VoteInstruction,
 };
 
 pub fn parse_vote(
@@ -285,9 +284,9 @@ fn check_num_vote_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInstr
 mod test {
     use {
         super::*,
+        solana_message::Message,
         solana_sdk::{
             hash::Hash,
-            message::Message,
             pubkey::Pubkey,
             sysvar,
             vote::{


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk but it would be quite a big PR to remove it all at once

#### Summary of Changes
Use solana-message instead of solana-sdk where applicable