### PR TITLE
replace solana-sdk with solana-program in account-decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5866,7 +5866,6 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -31,7 +31,6 @@ solana-program = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
-solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-slot-history = { workspace = true }

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -166,7 +166,7 @@ mod test {
             state::{Data, State},
             versions::Versions,
         },
-        solana_sdk::vote::{
+        solana_program::vote::{
             program::id as vote_program_id,
             state::{VoteState, VoteStateVersions},
         },

--- a/account-decoder/src/parse_bpf_loader.rs
+++ b/account-decoder/src/parse_bpf_loader.rs
@@ -5,8 +5,8 @@ use {
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::{deserialize, serialized_size},
+    solana_program::bpf_loader_upgradeable::UpgradeableLoaderState,
     solana_pubkey::Pubkey,
-    solana_sdk::bpf_loader_upgradeable::UpgradeableLoaderState,
 };
 
 pub fn parse_bpf_upgradeable_loader(

--- a/account-decoder/src/parse_config.rs
+++ b/account-decoder/src/parse_config.rs
@@ -6,10 +6,10 @@ use {
     bincode::deserialize,
     serde_json::Value,
     solana_config_program::{get_config_data, ConfigKeys},
-    solana_pubkey::Pubkey,
-    solana_sdk::stake::config::{
+    solana_program::stake::config::{
         Config as StakeConfig, {self as stake_config},
     },
+    solana_pubkey::Pubkey,
 };
 
 pub fn parse_config(data: &[u8], pubkey: &Pubkey) -> Result<ConfigAccountType, ParseAccountError> {
@@ -68,7 +68,7 @@ pub struct UiConfigKey {
 
 #[deprecated(
     since = "1.16.7",
-    note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
+    note = "Please use `solana_program::stake::state::warmup_cooldown_rate()` instead"
 )]
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -5,7 +5,7 @@ use {
     },
     bincode::deserialize,
     solana_clock::{Epoch, UnixTimestamp},
-    solana_sdk::stake::state::{Authorized, Delegation, Lockup, Meta, Stake, StakeStateV2},
+    solana_program::stake::state::{Authorized, Delegation, Lockup, Meta, Stake, StakeStateV2},
 };
 
 pub fn parse_stake(data: &[u8]) -> Result<StakeAccountType, ParseAccountError> {
@@ -119,7 +119,7 @@ pub struct UiDelegation {
     pub deactivation_epoch: StringAmount,
     #[deprecated(
         since = "1.16.7",
-        note = "Please use `solana_sdk::stake::stake::warmup_cooldown_rate()` instead"
+        note = "Please use `solana_program::stake::stake::warmup_cooldown_rate()` instead"
     )]
     pub warmup_cooldown_rate: f64,
 }
@@ -139,7 +139,7 @@ impl From<Delegation> for UiDelegation {
 
 #[cfg(test)]
 mod test {
-    use {super::*, bincode::serialize, solana_sdk::stake::stake_flags::StakeFlags};
+    use {super::*, bincode::serialize, solana_program::stake::stake_flags::StakeFlags};
 
     #[test]
     #[allow(deprecated)]

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -1,8 +1,8 @@
 use {
     crate::{parse_account_data::ParseAccountError, StringAmount},
     solana_clock::{Epoch, Slot},
+    solana_program::vote::state::{BlockTimestamp, Lockout, VoteState},
     solana_pubkey::Pubkey,
-    solana_sdk::vote::state::{BlockTimestamp, Lockout, VoteState},
 };
 
 pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
@@ -121,7 +121,7 @@ struct UiEpochCredits {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_sdk::vote::state::VoteStateVersions};
+    use {super::*, solana_program::vote::state::VoteStateVersions};
 
     #[test]
     fn test_parse_vote() {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4934,7 +4934,6 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -4785,7 +4785,6 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",


### PR DESCRIPTION
#### Problem
This crate can use solana-program in all the places where it still uses solana-sdk

#### Summary of Changes
Do that