### PR TITLE
trims down ContactInfos stored in turbine ClusterNodes

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1112,7 +1112,7 @@ impl ClusterInfo {
     }
 
     /// all validators that have a valid tvu port and are on the same `shred_version`.
-    pub fn tvu_peers(&self) -> Vec<ContactInfo> {
+    pub fn tvu_peers<R>(&self, query: impl Fn(&ContactInfo) -> R) -> Vec<R> {
         let self_pubkey = self.id();
         let self_shred_version = self.my_shred_version();
         self.time_gossip_read_lock("tvu_peers", &self.stats.tvu_peers)
@@ -1122,7 +1122,7 @@ impl ClusterInfo {
                     && node.shred_version() == self_shred_version
                     && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
             })
-            .cloned()
+            .map(query)
             .collect()
     }
 

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -400,7 +400,7 @@ mod tests {
         let (met_criteria, elapsed, _, tvu_peers) = spy(spy_ref.clone(), None, TIMEOUT, None, None);
         assert!(!met_criteria);
         assert!((TIMEOUT..TIMEOUT + Duration::from_secs(1)).contains(&elapsed));
-        assert_eq!(tvu_peers, spy_ref.tvu_peers());
+        assert_eq!(tvu_peers, spy_ref.tvu_peers(ContactInfo::clone));
 
         // Find num_nodes
         let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(1), TIMEOUT, None, None);

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -257,7 +257,7 @@ pub fn cluster_info_retransmit() {
     assert!(done);
     let mut p = Packet::default();
     p.meta_mut().size = 10;
-    let peers = c1.tvu_peers();
+    let peers = c1.tvu_peers(ContactInfo::clone);
     let retransmit_peers: Vec<_> = peers.iter().collect();
     retransmit_to(
         &retransmit_peers,

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     solana_entry::entry::Entry,
+    solana_gossip::contact_info::ContactInfo,
     solana_ledger::shred::{self, ProcessShredsStats, ReedSolomonCache, Shredder},
     solana_sdk::{hash::Hash, signature::Keypair},
 };
@@ -153,7 +154,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
     ) -> Result<()> {
         for (data_shreds, batch_info) in receiver {
             let fake = batch_info.is_some();
-            let peers = cluster_info.tvu_peers();
+            let peers = cluster_info.tvu_peers(ContactInfo::clone);
             peers.iter().enumerate().for_each(|(i, peer)| {
                 if fake == (i <= self.partition) {
                     // Send fake shreds to the first N peers
@@ -179,7 +180,6 @@ impl BroadcastRun for BroadcastFakeShredsRun {
 mod tests {
     use {
         super::*,
-        solana_gossip::contact_info::ContactInfo,
         solana_sdk::signature::Signer,
         solana_streamer::socket::SocketAddrSpace,
         std::net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -198,10 +198,10 @@ mod tests {
                 &SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, k)), 8080),
             ));
         }
-        let tvu_peers1 = cluster.tvu_peers();
+        let tvu_peers1 = cluster.tvu_peers(ContactInfo::clone);
         (0..5).for_each(|_| {
             cluster
-                .tvu_peers()
+                .tvu_peers(ContactInfo::clone)
                 .iter()
                 .zip(tvu_peers1.iter())
                 .for_each(|(v1, v2)| {

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -6,7 +6,7 @@ use {
     solana_feature_set as feature_set,
     solana_gossip::{
         cluster_info::ClusterInfo,
-        contact_info::{ContactInfo, Protocol},
+        contact_info::{ContactInfo as GossipContactInfo, Protocol},
         crds::GossipRoute,
         crds_data::CrdsData,
         crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
@@ -30,7 +30,7 @@ use {
         collections::{HashMap, HashSet},
         iter::repeat_with,
         marker::PhantomData,
-        net::{IpAddr, SocketAddr},
+        net::SocketAddr,
         sync::{Arc, RwLock},
         time::{Duration, Instant},
     },
@@ -56,6 +56,16 @@ enum NodeId {
     ContactInfo(ContactInfo),
     // Staked node with no contact-info in gossip table.
     Pubkey(Pubkey),
+}
+
+// A lite version of gossip ContactInfo local to turbine where we only hold on
+// to a few necessary fields from gossip ContactInfo.
+#[derive(Clone, Debug)]
+pub(crate) struct ContactInfo {
+    pubkey: Pubkey,
+    wallclock: u64,
+    tvu_quic: Option<SocketAddr>,
+    tvu_udp: Option<SocketAddr>,
 }
 
 pub struct Node {
@@ -97,6 +107,48 @@ impl Node {
         match &self.node {
             NodeId::Pubkey(_) => None,
             NodeId::ContactInfo(node) => Some(node),
+        }
+    }
+
+    #[inline]
+    fn contact_info_mut(&mut self) -> Option<&mut ContactInfo> {
+        match &mut self.node {
+            NodeId::Pubkey(_) => None,
+            NodeId::ContactInfo(node) => Some(node),
+        }
+    }
+}
+
+impl ContactInfo {
+    #[inline]
+    pub(crate) fn pubkey(&self) -> &Pubkey {
+        &self.pubkey
+    }
+
+    #[inline]
+    pub(crate) fn wallclock(&self) -> u64 {
+        self.wallclock
+    }
+
+    #[inline]
+    pub(crate) fn tvu(&self, protocol: Protocol) -> Option<SocketAddr> {
+        match protocol {
+            Protocol::QUIC => self.tvu_quic,
+            Protocol::UDP => self.tvu_udp,
+        }
+    }
+
+    // Removes respective TVU address from the ContactInfo so that no more
+    // shreds are sent to that socket address.
+    #[inline]
+    fn remove_tvu_addr(&mut self, protocol: Protocol) {
+        match protocol {
+            Protocol::QUIC => {
+                self.tvu_quic = None;
+            }
+            Protocol::UDP => {
+                self.tvu_udp = None;
+            }
         }
     }
 }
@@ -179,25 +231,14 @@ impl ClusterNodes<RetransmitStage> {
             weighted_shuffle.remove_index(*index);
         }
         let mut rng = get_seeded_rng(slot_leader, shred);
-        let nodes = {
-            let protocol = get_broadcast_protocol(shred);
-            // If there are 2 nodes in the shuffle with the same socket-addr,
-            // we only send shreds to the first one. The hash-set below allows
-            // to track if a socket-addr was observed earlier in the shuffle.
-            let mut addrs = HashSet::<SocketAddr>::with_capacity(self.nodes.len());
-            weighted_shuffle.shuffle(&mut rng).map(move |index| {
-                let node = &self.nodes[index];
-                let addr: Option<SocketAddr> = node
-                    .contact_info()
-                    .and_then(|node| node.tvu(protocol))
-                    .filter(|&addr| addrs.insert(addr));
-                (node, addr)
-            })
-        };
-        let (index, peers) =
-            get_retransmit_peers(fanout, |(node, _)| node.pubkey() == &self.pubkey, nodes);
+        let (index, peers) = get_retransmit_peers(
+            fanout,
+            |k| self.nodes[k].pubkey() == &self.pubkey,
+            weighted_shuffle.shuffle(&mut rng),
+        );
+        let protocol = get_broadcast_protocol(shred);
         let peers = peers
-            .filter_map(|(_, addr)| addr)
+            .filter_map(|k| self.nodes[k].contact_info()?.tvu(protocol))
             .filter(|addr| socket_addr_space.check(addr))
             .collect();
         let root_distance = get_root_distance(index, fanout);
@@ -276,27 +317,28 @@ fn get_nodes(
     stakes: &HashMap<Pubkey, u64>,
 ) -> Vec<Node> {
     let self_pubkey = cluster_info.id();
-    let should_dedup_addrs = match cluster_type {
+    let should_dedup_tvu_addrs = match cluster_type {
         ClusterType::Development => false,
         ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => true,
-    };
-    // Maps IP addresses to number of nodes at that IP address.
-    let mut counts = {
-        let capacity = if should_dedup_addrs { stakes.len() } else { 0 };
-        HashMap::<IpAddr, usize>::with_capacity(capacity)
     };
     let mut nodes: Vec<Node> = std::iter::once({
         // The local node itself.
         let stake = stakes.get(&self_pubkey).copied().unwrap_or_default();
-        let node = NodeId::from(cluster_info.my_contact_info());
+        let node = ContactInfo::from(&cluster_info.my_contact_info());
+        let node = NodeId::from(node);
         Node { node, stake }
     })
     // All known tvu-peers from gossip.
-    .chain(cluster_info.tvu_peers().into_iter().map(|node| {
-        let stake = stakes.get(node.pubkey()).copied().unwrap_or_default();
-        let node = NodeId::from(node);
-        Node { node, stake }
-    }))
+    .chain(
+        cluster_info
+            .tvu_peers(|node| ContactInfo::from(node))
+            .into_iter()
+            .map(|node| {
+                let stake = stakes.get(node.pubkey()).copied().unwrap_or_default();
+                let node = NodeId::from(node);
+                Node { node, stake }
+            }),
+    )
     // All staked nodes.
     .chain(
         stakes
@@ -309,33 +351,9 @@ fn get_nodes(
     )
     .collect();
     sort_and_dedup_nodes(&mut nodes);
-    nodes.retain_mut(|node| {
-        if !should_dedup_addrs
-            || node
-                .contact_info()
-                .and_then(|node| node.tvu(Protocol::UDP))
-                .map(|addr| {
-                    *counts
-                        .entry(addr.ip())
-                        .and_modify(|count| *count += 1)
-                        .or_insert(1)
-                })
-                <= Some(MAX_NUM_NODES_PER_IP_ADDRESS)
-        {
-            true
-        } else if node.stake > 0u64 {
-            // Staked node: keep the pubkey for deterministic shuffle, but
-            // strip the contact-info so that no more packets are sent to this
-            // IP address.
-            *node = Node {
-                node: NodeId::from(*node.pubkey()),
-                stake: node.stake,
-            };
-            true
-        } else {
-            false // Non-staked node: drop it entirely.
-        }
-    });
+    if should_dedup_tvu_addrs {
+        dedup_tvu_addrs(&mut nodes);
+    };
     nodes
 }
 
@@ -361,6 +379,48 @@ fn cmp_nodes_stake(a: &Node, b: &Node) -> Ordering {
             (NodeId::Pubkey(_), NodeId::ContactInfo(_)) => Ordering::Less,
             (NodeId::Pubkey(_), NodeId::Pubkey(_)) => Ordering::Equal,
         })
+}
+
+// Dedups socket addresses so that if there are 2 nodes in the cluster with the
+// same TVU socket-addr, we only send shreds to one of them.
+// Additionally limits number of nodes at the same IP address to
+// MAX_NUM_NODES_PER_IP_ADDRESS.
+fn dedup_tvu_addrs(nodes: &mut Vec<Node>) {
+    const TVU_PROTOCOLS: [Protocol; 2] = [Protocol::UDP, Protocol::QUIC];
+    let capacity = nodes.len().saturating_mul(2);
+    // Tracks (Protocol, SocketAddr) tuples already observed.
+    let mut addrs = HashSet::with_capacity(capacity);
+    // Maps IP addresses to number of nodes at that IP address.
+    let mut counts = HashMap::with_capacity(capacity);
+    nodes.retain_mut(|node| {
+        let node_stake = node.stake;
+        let Some(node) = node.contact_info_mut() else {
+            // Need to keep staked identities without gossip ContactInfo for
+            // deterministic shuffle.
+            return node_stake > 0u64;
+        };
+        // Dedup socket addresses and limit nodes at same IP address.
+        for protocol in TVU_PROTOCOLS {
+            let Some(addr) = node.tvu(protocol) else {
+                continue;
+            };
+            let count: usize = *counts
+                .entry((protocol, addr.ip()))
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            if !addrs.insert((protocol, addr)) || count > MAX_NUM_NODES_PER_IP_ADDRESS {
+                // Remove the respective TVU address so that no more shreds are
+                // sent to this socket address.
+                node.remove_tvu_addr(protocol);
+            }
+        }
+        // Always keep staked nodes for deterministic shuffle,
+        // but drop non-staked nodes if they have no valid TVU address.
+        node_stake > 0u64
+            || TVU_PROTOCOLS
+                .into_iter()
+                .any(|protocol| node.tvu(protocol).is_some())
+    })
 }
 
 fn get_seeded_rng(leader: &Pubkey, shred: &ShredId) -> ChaChaRng {
@@ -498,14 +558,28 @@ impl<T: 'static> ClusterNodesCache<T> {
 }
 
 impl From<ContactInfo> for NodeId {
+    #[inline]
     fn from(node: ContactInfo) -> Self {
         NodeId::ContactInfo(node)
     }
 }
 
 impl From<Pubkey> for NodeId {
+    #[inline]
     fn from(pubkey: Pubkey) -> Self {
         NodeId::Pubkey(pubkey)
+    }
+}
+
+impl From<&GossipContactInfo> for ContactInfo {
+    #[inline]
+    fn from(node: &GossipContactInfo) -> Self {
+        Self {
+            pubkey: *node.pubkey(),
+            wallclock: node.wallclock(),
+            tvu_quic: node.tvu(Protocol::QUIC),
+            tvu_udp: node.tvu(Protocol::UDP),
+        }
     }
 }
 
@@ -532,20 +606,20 @@ pub fn make_test_cluster<R: Rng>(
     num_nodes: usize,
     unstaked_ratio: Option<(u32, u32)>,
 ) -> (
-    Vec<ContactInfo>,
+    Vec<GossipContactInfo>,
     HashMap<Pubkey, u64>, // stakes
     ClusterInfo,
 ) {
     let (unstaked_numerator, unstaked_denominator) = unstaked_ratio.unwrap_or((1, 7));
     let mut nodes: Vec<_> = repeat_with(|| {
         let pubkey = solana_sdk::pubkey::new_rand();
-        ContactInfo::new_localhost(&pubkey, /*wallclock:*/ timestamp())
+        GossipContactInfo::new_localhost(&pubkey, /*wallclock:*/ timestamp())
     })
     .take(num_nodes)
     .collect();
     nodes.shuffle(rng);
     let keypair = Arc::new(Keypair::new());
-    nodes[0] = ContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ timestamp());
+    nodes[0] = GossipContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ timestamp());
     let this_node = nodes[0].clone();
     let mut stakes: HashMap<Pubkey, u64> = nodes
         .iter()
@@ -644,7 +718,10 @@ mod tests {
         let mut rng = rand::thread_rng();
         let (nodes, stakes, cluster_info) = make_test_cluster(&mut rng, 1_000, None);
         // ClusterInfo::tvu_peers excludes the node itself.
-        assert_eq!(cluster_info.tvu_peers().len(), nodes.len() - 1);
+        assert_eq!(
+            cluster_info.tvu_peers(GossipContactInfo::clone).len(),
+            nodes.len() - 1
+        );
         let cluster_nodes =
             new_cluster_nodes::<RetransmitStage>(&cluster_info, ClusterType::Development, &stakes);
         // All nodes with contact-info should be in the index.
@@ -680,7 +757,10 @@ mod tests {
         let mut rng = rand::thread_rng();
         let (nodes, stakes, cluster_info) = make_test_cluster(&mut rng, 1_000, None);
         // ClusterInfo::tvu_peers excludes the node itself.
-        assert_eq!(cluster_info.tvu_peers().len(), nodes.len() - 1);
+        assert_eq!(
+            cluster_info.tvu_peers(GossipContactInfo::clone).len(),
+            nodes.len() - 1
+        );
         let cluster_nodes =
             ClusterNodes::<BroadcastStage>::new(&cluster_info, ClusterType::Development, &stakes);
         // All nodes with contact-info should be in the index.
@@ -908,10 +988,10 @@ mod tests {
         let mut nodes: Vec<Node> = std::iter::repeat_with(|| {
             let pubkey = pubkeys.choose(&mut rng).copied().unwrap();
             let stake = stakes[&pubkey];
-            let node = ContactInfo::new_localhost(&pubkey, /*wallclock:*/ timestamp());
+            let node = GossipContactInfo::new_localhost(&pubkey, /*wallclock:*/ timestamp());
             [
                 Node {
-                    node: NodeId::from(node),
+                    node: NodeId::from(ContactInfo::from(&node)),
                     stake,
                 },
                 Node {


### PR DESCRIPTION

#### Problem
* In turbine `ClusterNodes`, we only need few fields from gossip `ContactInfo` and there is no need to hold on to the whole thing.
* Socket address deduping logic can be done more efficiently with a locally defined `ContactInfo`.

#### Summary of Changes
The commit introduces a liter `ContactInfo` local to turbine where we only hold on to the few necessary fields from gossip `ContactInfo`. This would also allow us to more efficiently dedup socket addresses.
