### PR TITLE
[zk-sdk] Hide range proof and inner product proof type fields

### DIFF
--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -19,10 +19,10 @@ use {
 #[allow(non_snake_case)]
 #[derive(Clone)]
 pub struct InnerProductProof {
-    pub L_vec: Vec<CompressedRistretto>, // 32 * log(bit_length)
-    pub R_vec: Vec<CompressedRistretto>, // 32 * log(bit_length)
-    pub a: Scalar,                       // 32 bytes
-    pub b: Scalar,                       // 32 bytes
+    pub(crate) L_vec: Vec<CompressedRistretto>, // 32 * log(bit_length)
+    pub(crate) R_vec: Vec<CompressedRistretto>, // 32 * log(bit_length)
+    pub(crate) a: Scalar,                       // 32 bytes
+    pub(crate) b: Scalar,                       // 32 bytes
 }
 
 #[allow(non_snake_case)]

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -75,14 +75,14 @@ pub const RANGE_PROOF_U256_LEN: usize =
 #[cfg(not(target_os = "solana"))]
 #[derive(Clone)]
 pub struct RangeProof {
-    pub A: CompressedRistretto,       // 32 bytes
-    pub S: CompressedRistretto,       // 32 bytes
-    pub T_1: CompressedRistretto,     // 32 bytes
-    pub T_2: CompressedRistretto,     // 32 bytes
-    pub t_x: Scalar,                  // 32 bytes
-    pub t_x_blinding: Scalar,         // 32 bytes
-    pub e_blinding: Scalar,           // 32 bytes
-    pub ipp_proof: InnerProductProof, // 448 bytes for withdraw; 512 for transfer
+    pub(crate) A: CompressedRistretto,       // 32 bytes
+    pub(crate) S: CompressedRistretto,       // 32 bytes
+    pub(crate) T_1: CompressedRistretto,     // 32 bytes
+    pub(crate) T_2: CompressedRistretto,     // 32 bytes
+    pub(crate) t_x: Scalar,                  // 32 bytes
+    pub(crate) t_x_blinding: Scalar,         // 32 bytes
+    pub(crate) e_blinding: Scalar,           // 32 bytes
+    pub(crate) ipp_proof: InnerProductProof, // 448 bytes for withdraw; 512 for transfer
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
#### Problem
Currently, the `RangeProof` and `InnerProductProof` types contains public fields that are more of an implementation detail than something that should be extracted by downstream projects.

#### Summary of Changes
I updated the visibility of these fields to `pub(crate)` as they shouldn't really be exposed outside of the crate. I verified that all current consumers of the zk-sdk do not make use of these fields.

This change in visibility will also enable exporting out the range proof type as wasm since the dalek `CompressedRistretto` and `Scalar` types are not exported out with wasm_bindgen upstream.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
