### PR TITLE
CU for VoteInstruction::InitializeAccount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10645,6 +10645,7 @@ version = "2.2.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "criterion",
  "log",
  "num-derive",
  "num-traits",
@@ -10666,6 +10667,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rent",
+ "solana-sdk",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-signer",

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -45,10 +45,21 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+criterion = { workspace = true }
+solana-account = { workspace = true }
+solana-clock = { workspace = true }
+solana-instruction = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+solana-rent = { workspace = true }
+solana-sdk = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 test-case = { workspace = true }
+
+[[bench]]
+name = "vote_instructions"
+harness = false
 
 [lib]
 crate-type = ["lib"]

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -1,0 +1,189 @@
+use {
+    bincode::serialize,
+    criterion::{criterion_group, criterion_main, Criterion},
+    solana_account::{self as account, AccountSharedData},
+    solana_clock::Clock,
+    solana_instruction::{error::InstructionError, AccountMeta},
+    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_sdk::sysvar,
+    solana_sdk_ids::vote::id,
+    solana_vote_program::{
+        vote_instruction::VoteInstruction,
+        vote_processor::Entrypoint,
+        vote_state::{create_account, VoteAuthorize, VoteInit, VoteState},
+    },
+};
+
+fn create_default_rent_account() -> AccountSharedData {
+    account::create_account_shared_data_for_test(&Rent::free())
+}
+
+fn create_default_clock_account() -> AccountSharedData {
+    account::create_account_shared_data_for_test(&Clock::default())
+}
+
+fn create_test_account() -> (Pubkey, AccountSharedData) {
+    let rent = Rent::default();
+    let balance = VoteState::get_rent_exempt_reserve(&rent);
+    let vote_pubkey = solana_pubkey::new_rand();
+    (
+        vote_pubkey,
+        create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, balance),
+    )
+}
+
+fn process_instruction(
+    instruction_data: &[u8],
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+    expected_result: Result<(), InstructionError>,
+) -> Vec<AccountSharedData> {
+    mock_process_instruction(
+        &id(),
+        Vec::new(),
+        instruction_data,
+        transaction_accounts,
+        instruction_accounts,
+        expected_result,
+        Entrypoint::vm,
+        |_invoke_context| {},
+        |_invoke_context| {},
+    )
+}
+
+struct BenchAuthorize {
+    instruction_data: Vec<u8>,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+}
+
+impl BenchAuthorize {
+    fn new() -> Self {
+        let (vote_pubkey, vote_account) = create_test_account();
+        let authorized_voter_pubkey = solana_pubkey::new_rand();
+        let clock = Clock {
+            epoch: 1,
+            leader_schedule_epoch: 2,
+            ..Clock::default()
+        };
+        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let instruction_data = serialize(&VoteInstruction::Authorize(
+            authorized_voter_pubkey,
+            VoteAuthorize::Voter,
+        ))
+        .unwrap();
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::clock::id(), clock_account),
+            (authorized_voter_pubkey, AccountSharedData::default()),
+        ];
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey,
+                is_signer: true,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+        ];
+        Self {
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+        }
+    }
+
+    fn run(&self) {
+        let _accounts = process_instruction(
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+        );
+    }
+}
+
+struct BenchInitializeAccount {
+    instruction_data: Vec<u8>,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+}
+
+impl BenchInitializeAccount {
+    fn new() -> Self {
+        let vote_pubkey = solana_pubkey::new_rand();
+        let vote_account = AccountSharedData::new(100, VoteState::size_of(), &id());
+        let node_pubkey = solana_pubkey::new_rand();
+        let node_account = AccountSharedData::default();
+        let instruction_data = serialize(&VoteInstruction::InitializeAccount(VoteInit {
+            node_pubkey,
+            authorized_voter: vote_pubkey,
+            authorized_withdrawer: vote_pubkey,
+            commission: 0,
+        }))
+        .unwrap();
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: sysvar::rent::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: node_pubkey,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::rent::id(), create_default_rent_account()),
+            (sysvar::clock::id(), create_default_clock_account()),
+            (node_pubkey, node_account),
+        ];
+        Self {
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+        }
+    }
+    pub fn run(&self) {
+        let _accounts = process_instruction(
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+        );
+    }
+}
+
+fn bench_initialize_account(c: &mut Criterion) {
+    let test_setup = BenchInitializeAccount::new();
+    c.bench_function("vote_instruction_initialize_account", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
+fn bench_authorize(c: &mut Criterion) {
+    let test_setup = BenchAuthorize::new();
+    c.bench_function("vote_instruction_authorize", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
+criterion_group!(benches, bench_initialize_account, bench_authorize);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem

Part of #3364

```
$ cargo +nightly bench --bench vote_instructions

    Finished `bench` profile [optimized] target(s) in 0.47s
     Running benches/vote_instructions.rs (/home/sol/src/agave/target/release/deps/vote_instructions-4f954f25ea9aea56)
Gnuplot not found, using plotters backend
Benchmarking vote_instruction_initialize_account: Collecting 100 samples in estimated 5.0920 
vote_instruction_initialize_account
                        time:   [18.559 µs 18.580 µs 18.606 µs]
                        change: [-44.503% -44.117% -43.657%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

Benchmarking vote_instruction_authorize: Collecting 100 samples in estimated 5.0854 s (273k i
vote_instruction_authorize
                        time:   [18.356 µs 18.425 µs 18.485 µs]
                        change: [+2.2509% +2.7272% +3.1463%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low severe
  3 (3.00%) high mild
  5 (5.00%) high severe

```