### PR TITLE
remove solana-sdk from unified-scheduler-logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10063,6 +10063,8 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-instruction",
+ "solana-message",
  "solana-pubkey",
  "solana-runtime-transaction",
  "solana-transaction",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10063,8 +10063,9 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-pubkey",
  "solana-runtime-transaction",
- "solana-sdk",
+ "solana-transaction",
  "static_assertions",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8355,8 +8355,9 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-pubkey",
  "solana-runtime-transaction",
- "solana-sdk",
+ "solana-transaction",
  "static_assertions",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7691,8 +7691,9 @@ name = "solana-unified-scheduler-logic"
 version = "2.2.0"
 dependencies = [
  "assert_matches",
+ "solana-pubkey",
  "solana-runtime-transaction",
- "solana-sdk",
+ "solana-transaction",
  "static_assertions",
 ]
 

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -11,8 +11,9 @@ edition = { workspace = true }
 
 [dependencies]
 assert_matches = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-sdk = { workspace = true }
+solana-transaction = { workspace = true }
 static_assertions = { workspace = true }
 
 [dev-dependencies]

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -17,6 +17,8 @@ solana-transaction = { workspace = true }
 static_assertions = { workspace = true }
 
 [dev-dependencies]
+solana-instruction = { workspace = true }
+solana-message = { workspace = true }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
 ] }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -98,8 +98,9 @@
 use {
     crate::utils::{ShortCounter, Token, TokenCell},
     assert_matches::assert_matches,
+    solana_pubkey::Pubkey,
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction},
+    solana_transaction::sanitized::SanitizedTransaction,
     static_assertions::const_assert_eq,
     std::{collections::VecDeque, mem, sync::Arc},
 };

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -885,12 +885,10 @@ impl SchedulingStateMachine {
 mod tests {
     use {
         super::*,
-        solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            message::Message,
-            pubkey::Pubkey,
-            transaction::{SanitizedTransaction, Transaction},
-        },
+        solana_instruction::{AccountMeta, Instruction},
+        solana_message::Message,
+        solana_pubkey::Pubkey,
+        solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         std::{cell::RefCell, collections::HashMap, rc::Rc},
     };
 


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk

#### Summary of Changes
Replace with component crates