### PR TITLE
Reduce unnecessary public visibility of some SVM related programs/ crates

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -287,7 +287,7 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Pop a stack frame from the invocation stack
-    pub fn pop(&mut self) -> Result<(), InstructionError> {
+    fn pop(&mut self) -> Result<(), InstructionError> {
         if let Some(Some(syscall_context)) = self.syscall_context.pop() {
             self.traces.push(syscall_context.trace_log);
         }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -2602,7 +2602,7 @@ mod tests {
         assert_eq!(caller_account.original_data_len, original_data_len);
     }
 
-    pub type TestTransactionAccount = (Pubkey, AccountSharedData, bool);
+    type TestTransactionAccount = (Pubkey, AccountSharedData, bool);
     struct MockCallerAccount {
         lamports: u64,
         owner: Pubkey,

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -79,7 +79,7 @@ fn check_program_account(
     Ok(*state)
 }
 
-pub fn process_instruction_write(
+fn process_instruction_write(
     invoke_context: &mut InvokeContext,
     offset: u32,
     bytes: Vec<u8>,
@@ -116,7 +116,7 @@ pub fn process_instruction_write(
     Ok(())
 }
 
-pub fn process_instruction_truncate(
+fn process_instruction_truncate(
     invoke_context: &mut InvokeContext,
     new_size: u32,
 ) -> Result<(), InstructionError> {
@@ -204,9 +204,7 @@ pub fn process_instruction_truncate(
     Ok(())
 }
 
-pub fn process_instruction_deploy(
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+fn process_instruction_deploy(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -283,9 +281,7 @@ pub fn process_instruction_deploy(
     Ok(())
 }
 
-pub fn process_instruction_retract(
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
+fn process_instruction_retract(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -327,7 +323,7 @@ pub fn process_instruction_retract(
     Ok(())
 }
 
-pub fn process_instruction_transfer_authority(
+fn process_instruction_transfer_authority(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
@@ -359,7 +355,7 @@ pub fn process_instruction_transfer_authority(
     Ok(())
 }
 
-pub fn process_instruction_finalize(
+fn process_instruction_finalize(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
@@ -419,7 +415,7 @@ declare_builtin_function!(
     }
 );
 
-pub fn process_instruction_inner(
+fn process_instruction_inner(
     invoke_context: &mut InvokeContext,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -76,7 +76,7 @@ pub fn advance_nonce_account(
     }
 }
 
-pub fn withdraw_nonce_account(
+pub(crate) fn withdraw_nonce_account(
     from_account_index: IndexOfAccount,
     lamports: u64,
     to_account_index: IndexOfAccount,
@@ -158,7 +158,7 @@ pub fn withdraw_nonce_account(
     Ok(())
 }
 
-pub fn initialize_nonce_account(
+pub(crate) fn initialize_nonce_account(
     account: &mut BorrowedAccount,
     nonce_authority: &Pubkey,
     rent: &Rent,
@@ -208,7 +208,7 @@ pub fn initialize_nonce_account(
     }
 }
 
-pub fn authorize_nonce_account(
+pub(crate) fn authorize_nonce_account(
     account: &mut BorrowedAccount,
     nonce_authority: &Pubkey,
     signers: &HashSet<Pubkey>,


### PR DESCRIPTION
#### Problem
Some structs/APIs in `programs/` crates do not need `pub` visibility

#### Summary of Changes
Reduce the visibility to private or `pub(crate)`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
