### PR TITLE
Removes EAH from the lattice-based snapshot hash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5765,7 +5765,7 @@ impl Bank {
     pub fn get_lattice_snapshot_hash(&self) -> SnapshotHash {
         SnapshotHash::new(
             &MerkleOrLatticeAccountsHash::Lattice,
-            self.get_epoch_accounts_hash_to_serialize().as_ref(),
+            None,
             Some(self.accounts_lt_hash.lock().unwrap().0.checksum()),
         )
     }


### PR DESCRIPTION
#### Problem

Per [SIMD-220](https://github.com/solana-foundation/solana-improvement-documents/pull/220), the lattice-based snapshot hash is defined as:

```
let snapshot_hash = accounts_lt_hash.checksum();
```

In the current code, we still mix in the EAH if is it `Some`. Once the accounts lt hash feature is enabled, EAH will always be None, so the existing code is correct once the feature gate is enabled, but it is kind of confusing seeing the EAH here at all. It is more clear to not mention the EAH when getting the lattice-based snapshot hash.


#### Summary of Changes

Explicitly set the EAH to None in the lattice-based snapshot hash.