### PR TITLE
separate functions for different signature types

### DIFF
--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -176,8 +176,8 @@ pub struct WritableKeysTransaction(pub Vec<Pubkey>);
 
 #[cfg(feature = "dev-context-only-utils")]
 impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
-    fn num_total_signatures(&self) -> u64 {
-        unimplemented!("WritableKeysTransaction::num_total_signatures")
+    fn num_transaction_signatures(&self) -> u64 {
+        unimplemented!("WritableKeysTransaction::num_transaction_signatures")
     }
 
     fn num_write_locks(&self) -> u64 {

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -75,3 +75,93 @@ impl<Tx: SVMMessage> From<&Tx> for SignatureCounts {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_fee_details_internal() {
+        const LAMPORTS_PER_SIGNATURE: u64 = 5_000;
+
+        // Impossible case - 0 signatures.
+        {
+            let signature_counts = SignatureCounts {
+                num_transaction_signatures: 0,
+                num_ed25519_signatures: 0,
+                num_secp256k1_signatures: 0,
+            };
+            let prioritization_fee = 0;
+
+            assert_eq!(
+                calculate_fee_details_internal(
+                    signature_counts,
+                    LAMPORTS_PER_SIGNATURE,
+                    prioritization_fee,
+                    false
+                ),
+                FeeDetails::new(0, 0, false)
+            );
+        }
+
+        // Simple signature
+        {
+            let signature_counts = SignatureCounts {
+                num_transaction_signatures: 1,
+                num_ed25519_signatures: 0,
+                num_secp256k1_signatures: 0,
+            };
+            let prioritization_fee = 0;
+
+            assert_eq!(
+                calculate_fee_details_internal(
+                    signature_counts,
+                    LAMPORTS_PER_SIGNATURE,
+                    prioritization_fee,
+                    false
+                ),
+                FeeDetails::new(LAMPORTS_PER_SIGNATURE, 0, false)
+            );
+        }
+
+        // Simple signature and prioritization.
+        {
+            let signature_counts = SignatureCounts {
+                num_transaction_signatures: 1,
+                num_ed25519_signatures: 0,
+                num_secp256k1_signatures: 0,
+            };
+            let prioritization_fee = 1_000;
+
+            assert_eq!(
+                calculate_fee_details_internal(
+                    signature_counts,
+                    LAMPORTS_PER_SIGNATURE,
+                    prioritization_fee,
+                    false
+                ),
+                FeeDetails::new(LAMPORTS_PER_SIGNATURE, 1_000, false)
+            );
+        }
+
+        // Pre-compile signatures.
+        {
+            let signature_counts = SignatureCounts {
+                num_transaction_signatures: 1,
+                num_ed25519_signatures: 2,
+                num_secp256k1_signatures: 3,
+            };
+            let prioritization_fee = 4_000;
+
+            assert_eq!(
+                calculate_fee_details_internal(
+                    signature_counts,
+                    LAMPORTS_PER_SIGNATURE,
+                    prioritization_fee,
+                    false
+                ),
+                FeeDetails::new(6 * LAMPORTS_PER_SIGNATURE, 4_000, false)
+            );
+        }
+    }
+}

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -28,9 +28,11 @@ pub fn calculate_fee_details(
     if zero_fees_for_test {
         return FeeDetails::default();
     }
-    let signature_fee = message
-        .num_total_signatures()
-        .saturating_mul(lamports_per_signature);
+    let signature_fee = (message
+        .num_transaction_signatures()
+        .saturating_add(message.num_ed25519_signatures())
+        .saturating_add(message.num_secp256k1_signatures()))
+    .saturating_mul(lamports_per_signature);
 
     FeeDetails::new(
         signature_fee,

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -61,9 +61,26 @@ impl<T> Deref for RuntimeTransaction<T> {
 }
 
 impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
+    fn num_transaction_signatures(&self) -> u64 {
+        self.transaction.num_transaction_signatures()
+    }
     // override to access from the cached meta instead of re-calculating
-    fn num_total_signatures(&self) -> u64 {
-        self.meta.signature_details.total_signatures()
+    fn num_ed25519_signatures(&self) -> u64 {
+        self.meta
+            .signature_details
+            .num_ed25519_instruction_signatures()
+    }
+    // override to access from the cached meta instead of re-calculating
+    fn num_secp256k1_signatures(&self) -> u64 {
+        self.meta
+            .signature_details
+            .num_secp256k1_instruction_signatures()
+    }
+    // override to access form the cached meta instead of re-calculating
+    fn num_secp256r1_signatures(&self) -> u64 {
+        self.meta
+            .signature_details
+            .num_secp256r1_instruction_signatures()
     }
 
     fn num_write_locks(&self) -> u64 {

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -10,8 +10,8 @@ use {
 
 // Implement for the "reference" `SanitizedMessage` type.
 impl SVMMessage for SanitizedMessage {
-    fn num_total_signatures(&self) -> u64 {
-        SanitizedMessage::num_total_signatures(self)
+    fn num_transaction_signatures(&self) -> u64 {
+        u64::from(self.header().num_required_signatures)
     }
 
     fn num_write_locks(&self) -> u64 {

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -10,8 +10,8 @@ use {
 };
 
 impl SVMMessage for SanitizedTransaction {
-    fn num_total_signatures(&self) -> u64 {
-        SVMMessage::num_total_signatures(SanitizedTransaction::message(self))
+    fn num_transaction_signatures(&self) -> u64 {
+        SVMMessage::num_transaction_signatures(SanitizedTransaction::message(self))
     }
 
     fn num_write_locks(&self) -> u64 {


### PR DESCRIPTION
#### Problem
- We want to deprecate `TransactionSignatureDetails` from `sdk`. it should have never been a public type
- This first PR simply provides alternative ways to get counts for `svm-message` 

#### Summary of Changes
- First step towards deprecating `TransactionSignatureDetails` and refactoring fees

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
