### PR TITLE
recovers Merkle shreds using mutable references into shreds payloads

### DIFF
--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -40,12 +40,14 @@ macro_rules! impl_shred_common {
             &self.payload
         }
 
+        #[inline]
         fn into_payload(self) -> Vec<u8> {
             self.payload
         }
 
+        #[inline]
         fn set_signature(&mut self, signature: Signature) {
-            bincode::serialize_into(&mut self.payload[..], &signature).unwrap();
+            self.payload[..SIZE_OF_SIGNATURE].copy_from_slice(signature.as_ref());
             self.common_header.signature = signature;
         }
 


### PR DESCRIPTION
#### Problem
Erasure recovery for Merkle shreds copies the erasure shards out of the shreds:
https://github.com/anza-xyz/agave/blob/df5c9ad28/ledger/src/shred/merkle.rs#L893

and then resizes and copies recovered shards after erasure recovery which might cause another re-allocation:
https://github.com/anza-xyz/agave/blob/df5c9ad28/ledger/src/shred/merkle.rs#L157-L158
https://github.com/anza-xyz/agave/blob/df5c9ad28/ledger/src/shred/merkle.rs#L246-L247





#### Summary of Changes
In order to minimize allocations and memory copies, this commit instead uses mutable references into the shred payload, passing them directly as shards to the Reed-Solomon implementation.

