### PR TITLE
use solana-pubkey in accounts-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
  "rayon",
  "solana-accounts-db",
  "solana-clap-utils",
- "solana-program",
+ "solana-pubkey",
  "solana-version",
 ]
 

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -18,7 +18,7 @@ memmap2 = { workspace = true }
 rayon = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
-solana-program = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-version = { workspace = true }
 
 [features]

--- a/accounts-db/accounts-hash-cache-tool/src/main.rs
+++ b/accounts-db/accounts-hash-cache-tool/src/main.rs
@@ -14,7 +14,7 @@ use {
         ParsedCacheHashDataFilename,
     },
     solana_clap_utils::input_parsers::values_of,
-    solana_program::pubkey::Pubkey,
+    solana_pubkey::Pubkey,
     std::{
         cmp::{self, Ordering},
         fs::{self, File, Metadata},

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -17,10 +17,10 @@ use {
         accounts_index::ScanConfig,
         ancestors::Ancestors,
     },
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
         hash::Hash,
-        pubkey::Pubkey,
         rent_collector::RentCollector,
         sysvar::epoch_schedule::EpochSchedule,
     },

--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -11,7 +11,7 @@ use {
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         },
     },
-    solana_sdk::{account::AccountSharedData, pubkey},
+    solana_sdk::account::AccountSharedData,
     std::sync::Arc,
     test::Bencher,
 };
@@ -19,7 +19,9 @@ use {
 #[bench]
 fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_PUBKEYS: usize = 10_000;
-    let pubkeys: Vec<_> = (0..NUM_PUBKEYS).map(|_| pubkey::new_rand()).collect();
+    let pubkeys: Vec<_> = (0..NUM_PUBKEYS)
+        .map(|_| solana_pubkey::new_rand())
+        .collect();
 
     const NUM_FORKS: u64 = 16;
 

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -9,10 +9,10 @@ use {
             hot::{HotStorageReader, HotStorageWriter},
         },
     },
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        pubkey::Pubkey,
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
         system_instruction::MAX_PERMITTED_DATA_LENGTH,
     },

--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -5,7 +5,8 @@ use {
         accounts_db::AccountsDb,
         accounts_hash::{AccountHash, AccountsHasher},
     },
-    solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, hash::Hash},
 };
 
 const KB: usize = 1024;

--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -2,9 +2,9 @@ use {
     criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
     itertools::iproduct,
     solana_accounts_db::{accounts::Accounts, accounts_db::AccountsDb},
+    solana_pubkey::Pubkey,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
         system_program,
         transaction::{SanitizedTransaction, Transaction, MAX_TX_ACCOUNT_LOCKS},
     },

--- a/accounts-db/benches/bench_serde.rs
+++ b/accounts-db/benches/bench_serde.rs
@@ -1,7 +1,8 @@
 use {
     criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput},
     serde::{Deserialize, Serialize},
-    solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::Account, clock::Epoch},
     std::mem,
 };
 

--- a/accounts-db/benches/utils.rs
+++ b/accounts-db/benches/utils.rs
@@ -8,10 +8,8 @@ use {
         Rng, SeedableRng,
     },
     rand_chacha::ChaChaRng,
-    solana_sdk::{
-        account::AccountSharedData, pubkey::Pubkey, rent::Rent,
-        rent_collector::RENT_EXEMPT_RENT_EPOCH,
-    },
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, rent::Rent, rent_collector::RENT_EXEMPT_RENT_EPOCH},
     std::iter,
 };
 

--- a/accounts-db/src/account_locks.rs
+++ b/accounts-db/src/account_locks.rs
@@ -2,9 +2,9 @@
 use qualifier_attr::qualifiers;
 use {
     ahash::{AHashMap, AHashSet},
+    solana_pubkey::Pubkey,
     solana_sdk::{
         message::AccountKeys,
-        pubkey::Pubkey,
         transaction::{TransactionError, MAX_TX_ACCOUNT_LOCKS},
     },
     std::{cell::RefCell, collections::hash_map},

--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -5,7 +5,8 @@ use {
         append_vec::AppendVecStoredAccountMeta,
         tiered_storage::hot::{HotAccount, HotAccountMeta},
     },
-    solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::ReadableAccount, hash::Hash, stake_history::Epoch},
 };
 
 pub type StoredMetaWriteVersion = u64;

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -11,12 +11,12 @@ use {
     },
     dashmap::DashMap,
     log::*,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         address_lookup_table::{self, error::AddressLookupError, state::AddressLookupTable},
         clock::{BankId, Slot},
         message::v0::LoadedAddresses,
-        pubkey::Pubkey,
         slot_hashes::SlotHashes,
         transaction::{Result, SanitizedTransaction},
         transaction_context::TransactionAccount,

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -3,10 +3,10 @@ use {
     dashmap::DashMap,
     seqlock::SeqLock,
     solana_nohash_hasher::BuildNoHashHasher,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        pubkey::Pubkey,
     },
     std::{
         collections::BTreeSet,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -85,6 +85,7 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{meas_dur, measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
+    solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
@@ -92,7 +93,6 @@ use {
         epoch_schedule::EpochSchedule,
         genesis_config::GenesisConfig,
         hash::Hash,
-        pubkey::Pubkey,
         rent_collector::RentCollector,
         saturating_add_assign,
         transaction::SanitizedTransaction,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -2,9 +2,8 @@ use {
     crate::{account_storage::meta::StoredAccountMeta, accounts_db::AccountsDb},
     solana_measure::measure::Measure,
     solana_metrics::*,
-    solana_sdk::{
-        account::AccountSharedData, clock::Slot, pubkey::Pubkey, transaction::SanitizedTransaction,
-    },
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, clock::Slot, transaction::SanitizedTransaction},
     std::collections::{HashMap, HashSet},
 };
 
@@ -172,10 +171,10 @@ pub mod tests {
             },
         },
         dashmap::DashMap,
+        solana_pubkey::Pubkey,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             clock::Slot,
-            pubkey::Pubkey,
             transaction::SanitizedTransaction,
         },
         std::sync::{

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -11,7 +11,8 @@ use {
     },
     rayon::prelude::*,
     solana_measure::{measure::Measure, measure_us},
-    solana_sdk::{account::ReadableAccount as _, clock::Slot, hash::Hash, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::ReadableAccount as _, clock::Slot, hash::Hash},
     std::{
         hash::{DefaultHasher, Hash as _, Hasher as _},
         ops::Range,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -16,10 +16,10 @@ use {
     assert_matches::assert_matches,
     itertools::Itertools,
     rand::{prelude::SliceRandom, thread_rng, Rng},
+    solana_pubkey::PUBKEY_BYTES,
     solana_sdk::{
         account::{accounts_equal, Account, AccountSharedData, ReadableAccount, WritableAccount},
         hash::HASH_BYTES,
-        pubkey::PUBKEY_BYTES,
     },
     std::{
         hash::DefaultHasher,

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -9,7 +9,8 @@ use {
             error::TieredStorageError, hot::HOT_FORMAT, index::IndexOffset, TieredStorage,
         },
     },
-    solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, clock::Slot},
     std::{
         mem,
         path::{Path, PathBuf},

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -11,9 +11,9 @@ use {
     rayon::prelude::*,
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{measure::Measure, measure_us},
+    solana_pubkey::Pubkey,
     solana_sdk::{
         hash::{Hash, Hasher, HASH_BYTES},
-        pubkey::Pubkey,
         rent_collector::RentCollector,
         slot_history::Slot,
         sysvar::epoch_schedule::EpochSchedule,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -18,10 +18,10 @@ use {
         ThreadPool,
     },
     solana_measure::measure::Measure,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::ReadableAccount,
         clock::{BankId, Slot},
-        pubkey::Pubkey,
     },
     std::{
         collections::{btree_map::BTreeMap, HashSet},
@@ -2082,10 +2082,8 @@ pub mod tests {
     use {
         super::*,
         solana_inline_spl::token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET,
-        solana_sdk::{
-            account::{AccountSharedData, WritableAccount},
-            pubkey::PUBKEY_BYTES,
-        },
+        solana_pubkey::PUBKEY_BYTES,
+        solana_sdk::account::{AccountSharedData, WritableAccount},
         std::ops::RangeInclusive,
     };
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -11,7 +11,8 @@ use {
     rand::{thread_rng, Rng},
     solana_bucket_map::bucket_api::BucketApi,
     solana_measure::measure::Measure,
-    solana_sdk::{clock::Slot, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::clock::Slot,
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::Debug,

--- a/accounts-db/src/accounts_partition.rs
+++ b/accounts-db/src/accounts_partition.rs
@@ -2,9 +2,9 @@
 use {
     itertools::Itertools,
     log::trace,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         clock::{Slot, SlotCount, SlotIndex},
-        pubkey::Pubkey,
         stake_history::Epoch,
         sysvar::epoch_schedule::EpochSchedule,
     },

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -1,8 +1,7 @@
 use {
     crate::account_storage::meta::StoredAccountMeta,
-    solana_sdk::{
-        account::AccountSharedData, clock::Slot, pubkey::Pubkey, transaction::SanitizedTransaction,
-    },
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, clock::Slot, transaction::SanitizedTransaction},
     std::sync::Arc,
 };
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1237,10 +1237,10 @@ pub mod tests {
             storable_accounts::{tests::build_accounts_from_storage, StorableAccountsBySlot},
         },
         rand::seq::SliceRandom as _,
+        solana_pubkey::Pubkey,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount, WritableAccount},
             hash::Hash,
-            pubkey::Pubkey,
         },
         std::{collections::HashSet, ops::Range},
         strum::IntoEnumIterator,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -20,10 +20,10 @@ use {
     },
     log::*,
     memmap2::MmapMut,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         hash::Hash,
-        pubkey::Pubkey,
         stake_history::Epoch,
         system_instruction::MAX_PERMITTED_DATA_LENGTH,
     },

--- a/accounts-db/src/append_vec/test_utils.rs
+++ b/accounts-db/src/append_vec/test_utils.rs
@@ -3,7 +3,8 @@
 use {
     super::StoredMeta,
     rand::{distributions::Alphanumeric, Rng},
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::account::AccountSharedData,
     std::path::PathBuf,
 };
 

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -11,10 +11,10 @@ use {
         thread_rng, Rng,
     },
     solana_measure::{measure::Measure, measure_us},
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Slot,
-        pubkey::Pubkey,
     },
     std::{
         mem::ManuallyDrop,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -2,9 +2,8 @@
 
 use {
     crate::storable_accounts::{AccountForStorage, StorableAccounts},
-    solana_sdk::{
-        account::AccountSharedData, clock::Slot, pubkey::Pubkey, reward_info::RewardInfo,
-    },
+    solana_pubkey::Pubkey,
+    solana_sdk::{account::AccountSharedData, clock::Slot, reward_info::RewardInfo},
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -5,10 +5,10 @@ use {
         accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
         accounts_index::ZeroLamport,
     },
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::{Epoch, Slot},
-        pubkey::Pubkey,
     },
     std::sync::{Arc, RwLock},
 };

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -178,10 +178,10 @@ mod tests {
         file::TieredStorageMagicNumber,
         footer::TieredStorageFooter,
         hot::HOT_FORMAT,
+        solana_pubkey::Pubkey,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             clock::Slot,
-            pubkey::Pubkey,
             system_instruction::MAX_PERMITTED_DATA_LENGTH,
         },
         std::{

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -10,7 +10,8 @@ use {
     bytemuck::Zeroable,
     memmap2::Mmap,
     num_enum::TryFromPrimitiveError,
-    solana_sdk::{hash::Hash, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::hash::Hash,
     std::{mem, path::Path, ptr},
     thiserror::Error,
 };

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -22,9 +22,9 @@ use {
     bytemuck_derive::{Pod, Zeroable},
     memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
-        pubkey::Pubkey,
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
         stake_history::Epoch,
     },
@@ -833,9 +833,9 @@ mod tests {
         assert_matches::assert_matches,
         memoffset::offset_of,
         rand::{seq::SliceRandom, Rng},
+        solana_pubkey::Pubkey,
         solana_sdk::{
-            account::ReadableAccount, hash::Hash, pubkey::Pubkey, slot_history::Slot,
-            stake_history::Epoch,
+            account::ReadableAccount, hash::Hash, slot_history::Slot, stake_history::Epoch,
         },
         std::path::PathBuf,
         tempfile::TempDir,

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -11,7 +11,8 @@ use {
             TieredStorageResult,
         },
     },
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_pubkey::Pubkey,
+    solana_sdk::account::AccountSharedData,
     std::path::Path,
 };
 

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -6,10 +6,10 @@ use {
         account_storage::meta::{StoredAccountMeta, StoredMeta},
         accounts_hash::AccountHash,
     },
+    solana_pubkey::Pubkey,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
         hash::Hash,
-        pubkey::Pubkey,
         rent_collector::RENT_EXEMPT_RENT_EPOCH,
     },
 };


### PR DESCRIPTION
#### Problem
This crate doesn't need all of solana-sdk but there's a lot to remove, so starting with pubkey stuff.

#### Summary of Changes
Use solana_pubkey instead of solana_sdk everywhere