### PR TITLE
make solana-metrics optional in solana-bpf-loader-program

### DIFF
--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -35,7 +35,7 @@ solana-precompiles = { workspace = true }
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-memory = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["metrics"] }
+solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sbpf = { workspace = true }
 solana-sdk-ids = { workspace = true }
@@ -76,6 +76,8 @@ harness = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+default = ["metrics"]
+metrics = ["solana-program-runtime/metrics"]
 shuttle-test = [
     "solana-type-overrides/shuttle-test",
     "solana-program-runtime/shuttle-test",


### PR DESCRIPTION
#### Problem
litesvm depends on solana-bpf-loader-program but doesn't need solana-metrics and the very heavy dependencies it brings in. Since metrics are already optional in solana-program-runtime this is a small change

#### Summary of Changes
- Add a `metrics` feature to solana-bpf-loader-program that activates `solana-program-runtime/metrics`
- Enable this `metrics` feature by default