### PR TITLE
stops pushing LegacyContactInfo updates over gossip

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -615,6 +615,7 @@ fn sanitize_entries(addrs: &[IpAddr], sockets: &[SocketEntry]) -> Result<(), Err
 }
 
 // Verifies that the other socket is at QUIC_PORT_OFFSET from the first one.
+#[cfg(test)]
 pub(crate) fn sanitize_quic_offset(
     socket: &Option<SocketAddr>, // udp
     other: &Option<SocketAddr>,  // quic: udp + QUIC_PORT_OFFSET

--- a/gossip/src/legacy_contact_info.rs
+++ b/gossip/src/legacy_contact_info.rs
@@ -1,12 +1,10 @@
 #[cfg(test)]
-use crate::contact_info::{get_quic_socket, sanitize_socket};
+use crate::contact_info::{
+    get_quic_socket, sanitize_quic_offset, sanitize_socket, ContactInfo, Error, Protocol,
+    SOCKET_ADDR_UNSPECIFIED,
+};
 use {
-    crate::{
-        contact_info::{
-            sanitize_quic_offset, ContactInfo, Error, Protocol, SOCKET_ADDR_UNSPECIFIED,
-        },
-        crds_data::MAX_WALLCLOCK,
-    },
+    crate::crds_data::MAX_WALLCLOCK,
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
     solana_streamer::socket::SocketAddrSpace,
@@ -169,6 +167,7 @@ impl LegacyContactInfo {
     }
 }
 
+#[cfg(test)]
 impl TryFrom<&ContactInfo> for LegacyContactInfo {
     type Error = Error;
 


### PR DESCRIPTION

#### Problem
We no longer use `LegacyContactInfo` and don't need to push updates over gossip.


#### Summary of Changes
The commit stops pushing `LegacyContactInfo` updates over gossip.