### PR TITLE
repair: do not print best path debug info

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -442,12 +442,14 @@ impl HeaviestSubtreeForkChoice {
         self.tree_root = root_parent;
     }
 
-    pub fn add_new_leaf_slot(&mut self, slot_hash_key: SlotHashKey, parent: Option<SlotHashKey>) {
+    pub fn maybe_print_state(&mut self) {
         if self.last_root_time.elapsed().as_secs() > MAX_ROOT_PRINT_SECONDS {
             self.print_state();
             self.last_root_time = Instant::now();
         }
+    }
 
+    pub fn add_new_leaf_slot(&mut self, slot_hash_key: SlotHashKey, parent: Option<SlotHashKey>) {
         if self.fork_infos.contains_key(&slot_hash_key) {
             // Can potentially happen if we repair the same version of the duplicate slot, after
             // dumping the original version

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3217,6 +3217,7 @@ impl ReplayStage {
                     (bank.slot(), bank.hash()),
                     Some((bank.parent_slot(), bank.parent_hash())),
                 );
+                heaviest_subtree_fork_choice.maybe_print_state();
                 bank_progress.fork_stats.bank_hash = Some(bank.hash());
                 let bank_frozen_state = BankFrozenState::new_from_state(
                     bank.slot(),


### PR DESCRIPTION
#### Problem
Fork choice will print out the heaviest path every 30 seconds.
Since this code is reused in repair, we also print out path information for various repair trees.
This clutters logs and is unnecessary duplicate information.

#### Summary of Changes
Only print this debug state in replay for fork choice.