### PR TITLE
CI: Update downstream SPL to program-specific repos

### DIFF
--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -2,20 +2,21 @@
 set -e
 
 here="$(dirname "${BASH_SOURCE[0]}")"
+program="$1"
 
 #shellcheck source=ci/downstream-projects/common.sh
 source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
-rm -rf spl
-git clone https://github.com/solana-labs/solana-program-library.git spl
+rm -rf ${program}
+git clone https://github.com/solana-program/${program}.git
 
 # copy toolchain file to use solana's rust version
-cp "$SOLANA_DIR"/rust-toolchain.toml spl/
-cd spl || exit 1
+cp "$SOLANA_DIR"/rust-toolchain.toml ${program}/
+cd ${program} || exit 1
 echo "HEAD: $(git rev-parse HEAD)"
 
-project_used_solana_version=$(sed -nE 's/solana-sdk = \"[>=<~]*(.*)\"/\1/p' <"token/program/Cargo.toml")
+project_used_solana_version=$(sed -nE 's/solana = \"(.*)\"/\1/p' <"Cargo.toml")
 echo "used solana version: $project_used_solana_version"
 if semverGT "$project_used_solana_version" "$SOLANA_VER"; then
   echo "skip"
@@ -23,4 +24,5 @@ if semverGT "$project_used_solana_version" "$SOLANA_VER"; then
   return
 fi
 
-./patch.crates-io.sh "$SOLANA_DIR"
+update_solana_dependencies . "$SOLANA_VER"
+patch_crates_io_solana Cargo.toml "$SOLANA_DIR"

--- a/.github/scripts/downstream-project-spl-common.sh
+++ b/.github/scripts/downstream-project-spl-common.sh
@@ -8,12 +8,12 @@ program="$1"
 source "$here"/../../ci/downstream-projects/common.sh
 
 set -x
-rm -rf ${program}
-git clone https://github.com/solana-program/${program}.git
+rm -rf "${program}"
+git clone https://github.com/solana-program/"${program}".git
 
 # copy toolchain file to use solana's rust version
-cp "$SOLANA_DIR"/rust-toolchain.toml ${program}/
-cd ${program} || exit 1
+cp "$SOLANA_DIR"/rust-toolchain.toml "${program}"/
+cd "${program}" || exit 1
 echo "HEAD: $(git rev-parse HEAD)"
 
 project_used_solana_version=$(sed -nE 's/solana = \"(.*)\"/\1/p' <"Cargo.toml")

--- a/.github/scripts/downstream-project-spl-install-deps.sh
+++ b/.github/scripts/downstream-project-spl-install-deps.sh
@@ -2,4 +2,4 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install libudev-dev binutils-dev libunwind-dev protobuf-compiler -y
+sudo apt-get install libudev-dev protobuf-compiler -y

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -38,7 +38,8 @@ env:
 
 jobs:
   test:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
+    if: false # restore once all program-specific repos are ready
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -50,8 +50,7 @@ jobs:
           - single-pool
           - slashing
           - stake-pool
-          # re-enable with https://github.com/solana-program/token-2022/pull/56
-          # - token-2022
+          - token-2022
           # re-enable with https://github.com/buffalojoec/mollusk/pull/74
           # - token
     steps:
@@ -81,8 +80,7 @@ jobs:
       matrix:
         programs:
           - single-pool
-          # re-enable with https://github.com/solana-program/token-2022/pull/56
-          # - token-2022
+          - token-2022
     steps:
       - uses: actions/checkout@v4
 
@@ -118,8 +116,7 @@ jobs:
           - single-pool
           - slashing
           - stake-pool
-          # re-enable with https://github.com/solana-program/token-2022/pull/56
-          # - token-2022
+          - token-2022
           # re-enable with https://github.com/buffalojoec/mollusk/pull/74
           # - token
     steps:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -39,6 +39,21 @@ jobs:
   check:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        programs:
+          - associated-token-account
+          - feature-proposal
+          - instruction-padding
+          - memo
+          - record
+          - single-pool
+          - slashing
+          - stake-pool
+          # re-enable with https://github.com/solana-program/token-2022/pull/56
+          # - token-2022
+          # re-enable with https://github.com/buffalojoec/mollusk/pull/74
+          # - token
     steps:
       - uses: actions/checkout@v4
 
@@ -53,45 +68,21 @@ jobs:
       - shell: bash
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
-          source .github/scripts/downstream-project-spl-common.sh
+          source .github/scripts/downstream-project-spl-common.sh "${{ matrix.programs }}"
           if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
             exit 0
           fi
-
           cargo check
 
-  test:
+  test_cli:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arrays:
-          [
-            {
-              test_paths: ["token/cli"],
-              required_programs:
-                [
-                  "token/program",
-                  "token/program-2022",
-                  "associated-token-account/program",
-                  "instruction-padding/program",
-                ],
-            },
-            {
-              test_paths: ["single-pool/cli"],
-              required_programs:
-                [
-                  "single-pool/program",
-                ],
-            },
-            {
-              test_paths: ["token-upgrade/cli"],
-              required_programs:
-                [
-                  "token-upgrade/program",
-                ],
-            },
-          ]
+        programs:
+          - single-pool
+          # re-enable with https://github.com/solana-program/token-2022/pull/56
+          # - token-2022
     steps:
       - uses: actions/checkout@v4
 
@@ -106,22 +97,12 @@ jobs:
       - shell: bash
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
-          source .github/scripts/downstream-project-spl-common.sh
+          source .github/scripts/downstream-project-spl-common.sh "${{ matrix.programs }}"
           if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
             exit 0
           fi
-
-          programStr="${{ tojson(matrix.arrays.required_programs) }}"
-          IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
-          for program in "${programs[@]}"; do
-            $CARGO_BUILD_SBF --manifest-path "$program"/Cargo.toml
-          done
-
-          testPathsStr="${{ tojson(matrix.arrays.test_paths) }}"
-          IFS=', ' read -ra test_paths <<<"${testPathsStr//[\[\]$'\n'$'\r' ]/}"
-          for test_path in "${test_paths[@]}"; do
-            cargo test --manifest-path "$test_path"/Cargo.toml
-          done
+          $CARGO_BUILD_SBF --manifest-path program/Cargo.toml
+          cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
     if: github.repository == 'anza-xyz/agave'
@@ -129,22 +110,18 @@ jobs:
     strategy:
       matrix:
         programs:
-          - [token/program]
-          - [
-              instruction-padding/program,
-              token/program-2022,
-              token/program-2022-test,
-            ]
-          - [
-              associated-token-account/program,
-              associated-token-account/program-test,
-            ]
-          - [token-upgrade/program]
-          - [feature-proposal/program]
-          - [governance/addin-mock/program, governance/program]
-          - [name-service/program]
-          - [stake-pool/program]
-          - [single-pool/program]
+          - associated-token-account
+          - feature-proposal
+          - instruction-padding
+          - memo
+          - record
+          - single-pool
+          - slashing
+          - stake-pool
+          # re-enable with https://github.com/solana-program/token-2022/pull/56
+          # - token-2022
+          # re-enable with https://github.com/buffalojoec/mollusk/pull/74
+          # - token
     steps:
       - uses: actions/checkout@v4
 
@@ -159,14 +136,8 @@ jobs:
       - shell: bash
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
-          source .github/scripts/downstream-project-spl-common.sh
+          source .github/scripts/downstream-project-spl-common.sh "${{ matrix.programs }}"
           if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
             exit 0
           fi
-
-          programStr="${{ tojson(matrix.programs) }}"
-          IFS=', ' read -ra programs <<<"${programStr//[\[\]$'\n'$'\r' ]/}"
-
-          for program in "${programs[@]}"; do
-            $CARGO_TEST_SBF --manifest-path "$program"/Cargo.toml
-          done
+          $CARGO_TEST_SBF --manifest-path program/Cargo.toml


### PR DESCRIPTION
#### Problem

SPL has been split up into multiple program-specific repos and will soon be archived, but the downstream jobs are still run against the SPL repo.

#### Summary of changes

Rather than use the SPL repo, check out the individual program-specific repos and run `check`, `build-sbf`, and `test`.

Once other PRs land, we can add back other programs and repos.