### PR TITLE
clippy: needless_lifetimes

### DIFF
--- a/account-decoder/src/parse_address_lookup_table.rs
+++ b/account-decoder/src/parse_address_lookup_table.rs
@@ -37,7 +37,7 @@ pub struct UiLookupTable {
     pub addresses: Vec<String>,
 }
 
-impl<'a> From<AddressLookupTable<'a>> for UiLookupTable {
+impl From<AddressLookupTable<'_>> for UiLookupTable {
     fn from(address_lookup_table: AddressLookupTable) -> Self {
         Self {
             deactivation_slot: address_lookup_table.meta.deactivation_slot.to_string(),

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -238,7 +238,7 @@ impl<'a> AccountStorageIter<'a> {
     }
 }
 
-impl<'a> Iterator for AccountStorageIter<'a> {
+impl Iterator for AccountStorageIter<'_> {
     type Item = (Slot, Arc<AccountStorageEntry>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -264,7 +264,7 @@ pub struct ShrinkInProgress<'a> {
 }
 
 /// called when the shrink is no longer in progress. This means we can release the old append vec and update the map of slot -> append vec
-impl<'a> Drop for ShrinkInProgress<'a> {
+impl Drop for ShrinkInProgress<'_> {
     fn drop(&mut self) {
         assert_eq!(
             self.storage
@@ -289,7 +289,7 @@ impl<'a> Drop for ShrinkInProgress<'a> {
     }
 }
 
-impl<'a> ShrinkInProgress<'a> {
+impl ShrinkInProgress<'_> {
     pub fn new_storage(&self) -> &Arc<AccountStorageEntry> {
         &self.new_store
     }

--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -84,7 +84,7 @@ impl<'storage> StoredAccountMeta<'storage> {
     }
 }
 
-impl<'storage> ReadableAccount for StoredAccountMeta<'storage> {
+impl ReadableAccount for StoredAccountMeta<'_> {
     fn lamports(&self) -> u64 {
         match self {
             Self::AppendVec(av) => av.lamports(),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -166,7 +166,7 @@ enum StoreTo<'a> {
     Storage(&'a Arc<AccountStorageEntry>),
 }
 
-impl<'a> StoreTo<'a> {
+impl StoreTo<'_> {
     fn is_cached(&self) -> bool {
         matches!(self, StoreTo::Cache)
     }
@@ -1091,7 +1091,7 @@ pub enum LoadedAccount<'a> {
     Cached(Cow<'a, CachedAccount>),
 }
 
-impl<'a> LoadedAccount<'a> {
+impl LoadedAccount<'_> {
     pub fn loaded_hash(&self) -> AccountHash {
         match self {
             LoadedAccount::Stored(stored_account_meta) => *stored_account_meta.hash(),
@@ -1131,7 +1131,7 @@ impl<'a> LoadedAccount<'a> {
     }
 }
 
-impl<'a> ReadableAccount for LoadedAccount<'a> {
+impl ReadableAccount for LoadedAccount<'_> {
     fn lamports(&self) -> u64 {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.lamports(),
@@ -1875,7 +1875,7 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
     }
 }
 
-impl<'a> ZeroLamport for StoredAccountMeta<'a> {
+impl ZeroLamport for StoredAccountMeta<'_> {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -55,7 +55,7 @@ struct ScanState<'a> {
     stats_num_zero_lamport_accounts_ancient: Arc<AtomicU64>,
 }
 
-impl<'a> AppendVecScan for ScanState<'a> {
+impl AppendVecScan for ScanState<'_> {
     fn set_slot(&mut self, slot: Slot, is_ancient: bool) {
         self.current_slot = slot;
         self.is_ancient = is_ancient;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2361,7 +2361,7 @@ lazy_static! {
     pub static ref RENT_COLLECTOR: RentCollector = RentCollector::default();
 }
 
-impl<'a> CalcAccountsHashConfig<'a> {
+impl CalcAccountsHashConfig<'_> {
     pub(crate) fn default() -> Self {
         Self {
             use_bg_thread_pool: false,

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -519,7 +519,7 @@ struct ItemLocation<'a> {
     pointer: SlotGroupPointer,
 }
 
-impl<'a> AccountsHasher<'a> {
+impl AccountsHasher<'_> {
     pub fn calculate_hash(hashes: Vec<Vec<Hash>>) -> (Hash, usize) {
         let cumulative_offsets = CumulativeOffsets::from_raw(&hashes);
 
@@ -1384,7 +1384,7 @@ mod tests {
         static ref ACTIVE_STATS: ActiveStats = ActiveStats::default();
     }
 
-    impl<'a> AccountsHasher<'a> {
+    impl AccountsHasher<'_> {
         fn new(dir_for_temp_cache_files: PathBuf) -> Self {
             Self {
                 zero_lamport_accounts: ZeroLamportAccounts::Excluded,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -583,8 +583,8 @@ impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexIter
     }
 }
 
-impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
-    for AccountsIndexIterator<'a, T, U>
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
+    for AccountsIndexIterator<'_, T, U>
 {
     type Item = Vec<(Pubkey, AccountMapEntry<T>)>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/accounts-db/src/active_stats.rs
+++ b/accounts-db/src/active_stats.rs
@@ -46,7 +46,7 @@ pub struct ActiveStatGuard<'a> {
     item: ActiveStatItem,
 }
 
-impl<'a> Drop for ActiveStatGuard<'a> {
+impl Drop for ActiveStatGuard<'_> {
     fn drop(&mut self) {
         self.stats.update_and_log(self.item, |stat| {
             stat.fetch_sub(1, Ordering::Relaxed).wrapping_sub(1)

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -32,7 +32,7 @@ impl<'a> From<&'a StoredAccountMeta<'a>> for AccountForStorage<'a> {
     }
 }
 
-impl<'a> ZeroLamport for AccountForStorage<'a> {
+impl ZeroLamport for AccountForStorage<'_> {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }
@@ -47,7 +47,7 @@ impl<'a> AccountForStorage<'a> {
     }
 }
 
-impl<'a> ReadableAccount for AccountForStorage<'a> {
+impl ReadableAccount for AccountForStorage<'_> {
     fn lamports(&self) -> u64 {
         match self {
             AccountForStorage::AddressAndAccount((_pubkey, account)) => account.lamports(),

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -193,7 +193,7 @@ trait Sliceable {
     fn get_pubkey(&self) -> Pubkey;
 }
 
-impl<'a, T: Sliceable + Send + Sync> SendBatchTransactions<'a, T> for Vec<(T, Transaction)>
+impl<T: Sliceable + Send + Sync> SendBatchTransactions<'_, T> for Vec<(T, Transaction)>
 where
     <T as Sliceable>::Slice: Signers,
 {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -135,7 +135,7 @@ impl RollingCondition for RollingConditionGrouped {
     }
 }
 
-impl<'a> Write for GroupedWriter<'a> {
+impl Write for GroupedWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, io::Error> {
         self.underlying.write_with_datetime(buf, &self.now)
     }

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -1402,7 +1402,7 @@ impl<'a> AncestorIterator<'a> {
     }
 }
 
-impl<'a> Iterator for AncestorIterator<'a> {
+impl Iterator for AncestorIterator<'_> {
     type Item = SlotHashKey;
     fn next(&mut self) -> Option<Self::Item> {
         let parent_slot_hash_key = self

--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -22,7 +22,7 @@ impl<'a> GenericTraversal<'a> {
     }
 }
 
-impl<'a> Iterator for GenericTraversal<'a> {
+impl Iterator for GenericTraversal<'_> {
     type Item = Slot;
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.pending.pop();

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -38,7 +38,7 @@ impl<'a> RepairWeightTraversal<'a> {
     }
 }
 
-impl<'a> Iterator for RepairWeightTraversal<'a> {
+impl Iterator for RepairWeightTraversal<'_> {
     type Item = Visit;
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.pending.pop();

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -22,7 +22,7 @@ pub enum TransactionCost<'a, Tx> {
     Transaction(UsageCostDetails<'a, Tx>),
 }
 
-impl<'a, Tx> TransactionCost<'a, Tx> {
+impl<Tx> TransactionCost<'_, Tx> {
     pub fn sum(&self) -> u64 {
         #![allow(clippy::assertions_on_constants)]
         match self {
@@ -160,7 +160,7 @@ pub struct UsageCostDetails<'a, Tx> {
     pub allocated_accounts_data_size: u64,
 }
 
-impl<'a, Tx> UsageCostDetails<'a, Tx> {
+impl<Tx> UsageCostDetails<'_, Tx> {
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -68,20 +68,20 @@ impl<'a, T> TimedGuard<'a, T> {
     }
 }
 
-impl<'a, T> Deref for TimedGuard<'a, T> {
+impl<T> Deref for TimedGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.guard
     }
 }
 
-impl<'a, T> DerefMut for TimedGuard<'a, T> {
+impl<T> DerefMut for TimedGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.guard
     }
 }
 
-impl<'a, T> Drop for TimedGuard<'a, T> {
+impl<T> Drop for TimedGuard<'_, T> {
     fn drop(&mut self) {
         self.counter.add_measure(&mut self.timer);
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -585,7 +585,7 @@ impl<'a> CrdsTimeouts<'a> {
     }
 }
 
-impl<'a> Index<&Pubkey> for CrdsTimeouts<'a> {
+impl Index<&Pubkey> for CrdsTimeouts<'_> {
     type Output = u64;
 
     fn index(&self, pubkey: &Pubkey) -> &Self::Output {

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -30,7 +30,7 @@ impl<'a> AncestorIterator<'a> {
         }
     }
 }
-impl<'a> Iterator for AncestorIterator<'a> {
+impl Iterator for AncestorIterator<'_> {
     type Item = Slot;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -57,7 +57,7 @@ impl<'a> From<AncestorIterator<'a>> for AncestorIteratorWithHash<'a> {
         Self { ancestor_iterator }
     }
 }
-impl<'a> Iterator for AncestorIteratorWithHash<'a> {
+impl Iterator for AncestorIteratorWithHash<'_> {
     type Item = (Slot, Hash);
     fn next(&mut self) -> Option<Self::Item> {
         self.ancestor_iterator

--- a/ledger/src/next_slots_iterator.rs
+++ b/ledger/src/next_slots_iterator.rs
@@ -17,7 +17,7 @@ impl<'a> NextSlotsIterator<'a> {
     }
 }
 
-impl<'a> Iterator for NextSlotsIterator<'a> {
+impl Iterator for NextSlotsIterator<'_> {
     type Item = (Slot, SlotMeta);
     fn next(&mut self) -> Option<Self::Item> {
         if self.pending_slots.is_empty() {

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -23,7 +23,7 @@ impl<'a> RootedSlotIterator<'a> {
         }
     }
 }
-impl<'a> Iterator for RootedSlotIterator<'a> {
+impl Iterator for RootedSlotIterator<'_> {
     type Item = (Slot, Option<SlotMeta>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -245,7 +245,7 @@ pub(crate) enum SignedData<'a> {
     MerkleRoot(Hash),
 }
 
-impl<'a> AsRef<[u8]> for SignedData<'a> {
+impl AsRef<[u8]> for SignedData<'_> {
     fn as_ref(&self) -> &[u8] {
         match self {
             Self::Chunk(chunk) => chunk,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -83,7 +83,7 @@ macro_rules! declare_process_instruction {
     };
 }
 
-impl<'a> ContextObject for InvokeContext<'a> {
+impl ContextObject for InvokeContext<'_> {
     fn trace(&mut self, state: [u64; 12]) {
         self.syscall_context
             .last_mut()

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -50,7 +50,7 @@ enum VmValue<'a, 'b, T> {
     Translated(&'a mut T),
 }
 
-impl<'a, 'b, T> VmValue<'a, 'b, T> {
+impl<T> VmValue<'_, '_, T> {
     fn get(&self) -> Result<&T, Error> {
         match self {
             VmValue::VmAddress {
@@ -2867,7 +2867,7 @@ mod tests {
         rent_epoch: Epoch,
     }
 
-    impl<'a> MockAccountInfo<'a> {
+    impl MockAccountInfo<'_> {
         fn new(key: Pubkey, account: &AccountSharedData) -> MockAccountInfo {
             MockAccountInfo {
                 key,

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -536,7 +536,7 @@ impl<'a> Iterator for MemoryChunkIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for MemoryChunkIterator<'a> {
+impl DoubleEndedIterator for MemoryChunkIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.vm_addr_start == self.vm_addr_end {
             return None;

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -119,7 +119,7 @@ impl<'a> StatsUpdater<'a> {
     }
 }
 
-impl<'a> Drop for StatsUpdater<'a> {
+impl Drop for StatsUpdater<'_> {
     fn drop(&mut self) {
         let mut stats = self.stats.write().unwrap();
         stats.request_count += 1;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -694,7 +694,7 @@ struct SerializableBankAndStorage<'a> {
 }
 
 #[cfg(test)]
-impl<'a> Serialize for SerializableBankAndStorage<'a> {
+impl Serialize for SerializableBankAndStorage<'_> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
@@ -738,7 +738,7 @@ struct SerializableBankAndStorageNoExtra<'a> {
 }
 
 #[cfg(test)]
-impl<'a> Serialize for SerializableBankAndStorageNoExtra<'a> {
+impl Serialize for SerializableBankAndStorageNoExtra<'_> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
@@ -788,7 +788,7 @@ struct SerializableAccountsDb<'a> {
     write_version: StoredMetaWriteVersion,
 }
 
-impl<'a> Serialize for SerializableAccountsDb<'a> {
+impl Serialize for SerializableAccountsDb<'_> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -97,7 +97,7 @@ impl<'a, 'b, Tx: SVMMessage> TransactionBatch<'a, 'b, Tx> {
 }
 
 // Unlock all locked accounts in destructor.
-impl<'a, 'b, Tx: SVMMessage> Drop for TransactionBatch<'a, 'b, Tx> {
+impl<Tx: SVMMessage> Drop for TransactionBatch<'_, '_, Tx> {
     fn drop(&mut self) {
         if self.needs_unlock() {
             self.set_needs_unlock(false);

--- a/sdk/account-info/src/lib.rs
+++ b/sdk/account-info/src/lib.rs
@@ -38,7 +38,7 @@ pub struct AccountInfo<'a> {
     pub executable: bool,
 }
 
-impl<'a> fmt::Debug for AccountInfo<'a> {
+impl fmt::Debug for AccountInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("AccountInfo");
 

--- a/sdk/file-download/src/lib.rs
+++ b/sdk/file-download/src/lib.rs
@@ -130,7 +130,7 @@ pub fn download_file<'a, 'b>(
         notification_count: u64,
     }
 
-    impl<'e, 'f, R: Read> Read for DownloadProgress<'e, 'f, R> {
+    impl<R: Read> Read for DownloadProgress<'_, '_, R> {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
             let n = self.response.read(buf)?;
 

--- a/sdk/message/src/sanitized.rs
+++ b/sdk/message/src/sanitized.rs
@@ -36,7 +36,7 @@ pub struct LegacyMessage<'a> {
     pub is_writable_account_cache: Vec<bool>,
 }
 
-impl<'a> LegacyMessage<'a> {
+impl LegacyMessage<'_> {
     pub fn new(message: legacy::Message, reserved_account_keys: &HashSet<Pubkey>) -> Self {
         let is_writable_account_cache = message
             .account_keys

--- a/sdk/message/src/versions/mod.rs
+++ b/sdk/message/src/versions/mod.rs
@@ -216,7 +216,7 @@ impl<'de> serde::Deserialize<'de> for MessagePrefix {
     {
         struct PrefixVisitor;
 
-        impl<'de> Visitor<'de> for PrefixVisitor {
+        impl Visitor<'_> for PrefixVisitor {
             type Value = MessagePrefix;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/sdk/program/src/vote/instruction.rs
+++ b/sdk/program/src/vote/instruction.rs
@@ -261,7 +261,7 @@ pub struct CreateVoteAccountConfig<'a> {
     pub with_seed: Option<(&'a Pubkey, &'a str)>,
 }
 
-impl<'a> Default for CreateVoteAccountConfig<'a> {
+impl Default for CreateVoteAccountConfig<'_> {
     fn default() -> Self {
         Self {
             space: VoteStateVersions::vote_state_size_of(false) as u64,

--- a/sdk/sysvar/src/recent_blockhashes.rs
+++ b/sdk/sysvar/src/recent_blockhashes.rs
@@ -65,21 +65,21 @@ impl Entry {
 #[derive(Clone, Debug)]
 pub struct IterItem<'a>(pub u64, pub &'a Hash, pub u64);
 
-impl<'a> Eq for IterItem<'a> {}
+impl Eq for IterItem<'_> {}
 
-impl<'a> PartialEq for IterItem<'a> {
+impl PartialEq for IterItem<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'a> Ord for IterItem<'a> {
+impl Ord for IterItem<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 }
 
-impl<'a> PartialOrd for IterItem<'a> {
+impl PartialOrd for IterItem<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/sdk/transaction-context/src/lib.rs
+++ b/sdk/transaction-context/src/lib.rs
@@ -760,7 +760,7 @@ pub struct BorrowedAccount<'a> {
     account: RefMut<'a, AccountSharedData>,
 }
 
-impl<'a> BorrowedAccount<'a> {
+impl BorrowedAccount<'_> {
     /// Returns the transaction context
     pub fn transaction_context(&self) -> &TransactionContext {
         self.transaction_context

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1503,7 +1503,7 @@ struct EndpointAccept<'a> {
     accept: Accept<'a>,
 }
 
-impl<'a> Future for EndpointAccept<'a> {
+impl Future for EndpointAccept<'_> {
     type Output = (Option<quinn::Incoming>, usize);
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {

--- a/unified-scheduler-pool/src/sleepless_testing.rs
+++ b/unified-scheduler-pool/src/sleepless_testing.rs
@@ -285,7 +285,7 @@ mod real {
             spawned_thread
         }
 
-        impl<'scope, 'env> ScopeTracked<'scope> for Scope<'scope, 'env> {
+        impl<'scope> ScopeTracked<'scope> for Scope<'scope, '_> {
             fn spawn_tracked<T: Send + 'scope>(
                 &'scope self,
                 f: impl FnOnce() -> T + Send + 'scope,
@@ -350,7 +350,7 @@ mod dummy {
             spawn(f)
         }
 
-        impl<'scope, 'env> ScopeTracked<'scope> for Scope<'scope, 'env> {
+        impl<'scope> ScopeTracked<'scope> for Scope<'scope, '_> {
             #[inline]
             fn spawn_tracked<T: Send + 'scope>(
                 &'scope self,

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -683,7 +683,7 @@ impl fmt::Display for ElGamalCiphertext {
     }
 }
 
-impl<'a, 'b> Add<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
+impl<'b> Add<&'b ElGamalCiphertext> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn add(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -700,7 +700,7 @@ define_add_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Sub<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
+impl<'b> Sub<&'b ElGamalCiphertext> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn sub(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -717,7 +717,7 @@ define_sub_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a ElGamalCiphertext {
+impl<'b> Mul<&'b Scalar> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn mul(self, scalar: &'b Scalar) -> ElGamalCiphertext {
@@ -734,7 +734,7 @@ define_mul_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Mul<&'b ElGamalCiphertext> for &'a Scalar {
+impl<'b> Mul<&'b ElGamalCiphertext> for &Scalar {
     type Output = ElGamalCiphertext;
 
     fn mul(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -780,7 +780,7 @@ impl DecryptHandle {
     }
 }
 
-impl<'a, 'b> Add<&'b DecryptHandle> for &'a DecryptHandle {
+impl<'b> Add<&'b DecryptHandle> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn add(self, handle: &'b DecryptHandle) -> DecryptHandle {
@@ -794,7 +794,7 @@ define_add_variants!(
     Output = DecryptHandle
 );
 
-impl<'a, 'b> Sub<&'b DecryptHandle> for &'a DecryptHandle {
+impl<'b> Sub<&'b DecryptHandle> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn sub(self, handle: &'b DecryptHandle) -> DecryptHandle {
@@ -808,7 +808,7 @@ define_sub_variants!(
     Output = DecryptHandle
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a DecryptHandle {
+impl<'b> Mul<&'b Scalar> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn mul(self, scalar: &'b Scalar) -> DecryptHandle {
@@ -818,7 +818,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a DecryptHandle {
 
 define_mul_variants!(LHS = DecryptHandle, RHS = Scalar, Output = DecryptHandle);
 
-impl<'a, 'b> Mul<&'b DecryptHandle> for &'a Scalar {
+impl<'b> Mul<&'b DecryptHandle> for &Scalar {
     type Output = DecryptHandle;
 
     fn mul(self, handle: &'b DecryptHandle) -> DecryptHandle {

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -110,7 +110,7 @@ impl ConstantTimeEq for PedersenOpening {
     }
 }
 
-impl<'a, 'b> Add<&'b PedersenOpening> for &'a PedersenOpening {
+impl<'b> Add<&'b PedersenOpening> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn add(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -124,7 +124,7 @@ define_add_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Sub<&'b PedersenOpening> for &'a PedersenOpening {
+impl<'b> Sub<&'b PedersenOpening> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn sub(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -138,7 +138,7 @@ define_sub_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenOpening {
+impl<'b> Mul<&'b Scalar> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn mul(self, scalar: &'b Scalar) -> PedersenOpening {
@@ -152,7 +152,7 @@ define_mul_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Mul<&'b PedersenOpening> for &'a Scalar {
+impl<'b> Mul<&'b PedersenOpening> for &Scalar {
     type Output = PedersenOpening;
 
     fn mul(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -196,7 +196,7 @@ impl PedersenCommitment {
     }
 }
 
-impl<'a, 'b> Add<&'b PedersenCommitment> for &'a PedersenCommitment {
+impl<'b> Add<&'b PedersenCommitment> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn add(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
@@ -210,7 +210,7 @@ define_add_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Sub<&'b PedersenCommitment> for &'a PedersenCommitment {
+impl<'b> Sub<&'b PedersenCommitment> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn sub(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
@@ -224,7 +224,7 @@ define_sub_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenCommitment {
+impl<'b> Mul<&'b Scalar> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn mul(self, scalar: &'b Scalar) -> PedersenCommitment {
@@ -238,7 +238,7 @@ define_mul_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Mul<&'b PedersenCommitment> for &'a Scalar {
+impl<'b> Mul<&'b PedersenCommitment> for &Scalar {
     type Output = PedersenCommitment;
 
     fn mul(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -716,7 +716,7 @@ impl fmt::Display for ElGamalCiphertext {
     }
 }
 
-impl<'a, 'b> Add<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
+impl<'b> Add<&'b ElGamalCiphertext> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn add(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -733,7 +733,7 @@ define_add_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Sub<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
+impl<'b> Sub<&'b ElGamalCiphertext> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn sub(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -750,7 +750,7 @@ define_sub_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a ElGamalCiphertext {
+impl<'b> Mul<&'b Scalar> for &ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
     fn mul(self, scalar: &'b Scalar) -> ElGamalCiphertext {
@@ -767,7 +767,7 @@ define_mul_variants!(
     Output = ElGamalCiphertext
 );
 
-impl<'a, 'b> Mul<&'b ElGamalCiphertext> for &'a Scalar {
+impl<'b> Mul<&'b ElGamalCiphertext> for &Scalar {
     type Output = ElGamalCiphertext;
 
     fn mul(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
@@ -813,7 +813,7 @@ impl DecryptHandle {
     }
 }
 
-impl<'a, 'b> Add<&'b DecryptHandle> for &'a DecryptHandle {
+impl<'b> Add<&'b DecryptHandle> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn add(self, handle: &'b DecryptHandle) -> DecryptHandle {
@@ -827,7 +827,7 @@ define_add_variants!(
     Output = DecryptHandle
 );
 
-impl<'a, 'b> Sub<&'b DecryptHandle> for &'a DecryptHandle {
+impl<'b> Sub<&'b DecryptHandle> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn sub(self, handle: &'b DecryptHandle) -> DecryptHandle {
@@ -841,7 +841,7 @@ define_sub_variants!(
     Output = DecryptHandle
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a DecryptHandle {
+impl<'b> Mul<&'b Scalar> for &DecryptHandle {
     type Output = DecryptHandle;
 
     fn mul(self, scalar: &'b Scalar) -> DecryptHandle {
@@ -851,7 +851,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a DecryptHandle {
 
 define_mul_variants!(LHS = DecryptHandle, RHS = Scalar, Output = DecryptHandle);
 
-impl<'a, 'b> Mul<&'b DecryptHandle> for &'a Scalar {
+impl<'b> Mul<&'b DecryptHandle> for &Scalar {
     type Output = DecryptHandle;
 
     fn mul(self, handle: &'b DecryptHandle) -> DecryptHandle {

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -118,7 +118,7 @@ impl ConstantTimeEq for PedersenOpening {
     }
 }
 
-impl<'a, 'b> Add<&'b PedersenOpening> for &'a PedersenOpening {
+impl<'b> Add<&'b PedersenOpening> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn add(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -132,7 +132,7 @@ define_add_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Sub<&'b PedersenOpening> for &'a PedersenOpening {
+impl<'b> Sub<&'b PedersenOpening> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn sub(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -146,7 +146,7 @@ define_sub_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenOpening {
+impl<'b> Mul<&'b Scalar> for &PedersenOpening {
     type Output = PedersenOpening;
 
     fn mul(self, scalar: &'b Scalar) -> PedersenOpening {
@@ -160,7 +160,7 @@ define_mul_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Mul<&'b PedersenOpening> for &'a Scalar {
+impl<'b> Mul<&'b PedersenOpening> for &Scalar {
     type Output = PedersenOpening;
 
     fn mul(self, opening: &'b PedersenOpening) -> PedersenOpening {
@@ -202,7 +202,7 @@ impl PedersenCommitment {
     }
 }
 
-impl<'a, 'b> Add<&'b PedersenCommitment> for &'a PedersenCommitment {
+impl<'b> Add<&'b PedersenCommitment> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn add(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
@@ -216,7 +216,7 @@ define_add_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Sub<&'b PedersenCommitment> for &'a PedersenCommitment {
+impl<'b> Sub<&'b PedersenCommitment> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn sub(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
@@ -230,7 +230,7 @@ define_sub_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenCommitment {
+impl<'b> Mul<&'b Scalar> for &PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn mul(self, scalar: &'b Scalar) -> PedersenCommitment {
@@ -244,7 +244,7 @@ define_mul_variants!(
     Output = PedersenCommitment
 );
 
-impl<'a, 'b> Mul<&'b PedersenCommitment> for &'a Scalar {
+impl<'b> Mul<&'b PedersenCommitment> for &Scalar {
     type Output = PedersenCommitment;
 
     fn mul(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: the following explicit lifetimes could be elided: 'a
  --> sdk/account-info/src/lib.rs:41:6
   |
41 | impl<'a> fmt::Debug for AccountInfo<'a> {
   |      ^^                             ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
41 - impl<'a> fmt::Debug for AccountInfo<'a> {
41 + impl fmt::Debug for AccountInfo<'_> {
   |
```


#### Summary of Changes

```
cargo clippy --fix
```