### PR TITLE
Reduce public visibility of some SVM related structs and APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6736,6 +6736,7 @@ dependencies = [
 name = "solana-compute-budget"
 version = "2.2.0"
 dependencies = [
+ "qualifier_attr",
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-program-entrypoint",

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -41,14 +41,14 @@ pub enum BuiltinCost {
 }
 
 impl BuiltinCost {
-    pub fn native_cost(&self) -> u64 {
+    fn native_cost(&self) -> u64 {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { native_cost, .. }) => *native_cost,
             BuiltinCost::NotMigrating(NotMigratingBuiltinCost { native_cost }) => *native_cost,
         }
     }
 
-    pub fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
+    fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
                 core_bpf_migration_feature,
@@ -58,7 +58,7 @@ impl BuiltinCost {
         }
     }
 
-    pub fn position(&self) -> Option<usize> {
+    fn position(&self) -> Option<usize> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),
             BuiltinCost::NotMigrating(_) => None,
@@ -137,7 +137,7 @@ pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     ),
 ];
 
-pub const NON_MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
+const NON_MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         vote::id(),
         BuiltinCost::NotMigrating(NotMigratingBuiltinCost {

--- a/compute-budget-instruction/src/builtin_programs_filter.rs
+++ b/compute-budget-instruction/src/builtin_programs_filter.rs
@@ -6,7 +6,7 @@ use {
 };
 
 // The maximum number of pubkeys that a packet can contain.
-pub const FILTER_SIZE: u8 = (PACKET_DATA_SIZE / core::mem::size_of::<Pubkey>()) as u8;
+pub(crate) const FILTER_SIZE: u8 = (PACKET_DATA_SIZE / core::mem::size_of::<Pubkey>()) as u8;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum ProgramKind {

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+qualifier_attr = { workspace = true, optional = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
@@ -17,6 +18,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-program-entrypoint = { workspace = true }
 
 [features]
+dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = ["dep:solana-frozen-abi", "solana-fee-structure/frozen-abi"]
 
 [lints]

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,4 +1,6 @@
 use crate::compute_budget_limits::{self, ComputeBudgetLimits, DEFAULT_HEAP_COST};
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 
 #[cfg(feature = "frozen-abi")]
 impl ::solana_frozen_abi::abi_example::AbiExample for ComputeBudget {
@@ -146,7 +148,8 @@ impl From<ComputeBudgetLimits> for ComputeBudget {
 }
 
 impl ComputeBudget {
-    pub fn new(compute_unit_limit: u64) -> Self {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    fn new(compute_unit_limit: u64) -> Self {
         ComputeBudget {
             compute_unit_limit,
             log_64_units: 100,

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -54,6 +54,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-compute-budget = { workspace = true, features = ["dev-context-only-utils"] }
 solana-instruction = { workspace = true, features = ["bincode"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-transaction-context = { workspace = true, features = [

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -71,6 +71,7 @@ prost = { workspace = true }
 rand0-7 = { workspace = true }
 shuttle = { workspace = true }
 solana-clock = { workspace = true }
+solana-compute-budget = { workspace = true, features = ["dev-context-only-utils"] }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-ed25519-program = { workspace = true }


### PR DESCRIPTION
#### Problem
Some structs and APIs in `builtin-default-costs`, and `compute-budget` can have reduced public visibilty.

#### Summary of Changes
Change the visibility to private or `pub(crate)`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
