### PR TITLE
clippy: rust 1.84.0 auto fixes

### DIFF
--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -135,7 +135,7 @@ impl Config {
             return "".to_string();
         }
         let json_rpc_url = json_rpc_url.unwrap();
-        let is_secure = json_rpc_url.scheme().to_ascii_lowercase() == "https";
+        let is_secure = json_rpc_url.scheme().eq_ignore_ascii_case("https");
         let mut ws_url = json_rpc_url.clone();
         ws_url
             .set_scheme(if is_secure { "wss" } else { "ws" })

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -455,7 +455,7 @@ impl SystemMonitorService {
     ) -> bool {
         current_limits
             .iter()
-            .map(|(key, interesting_limit, current_value)| {
+            .all(|(key, interesting_limit, current_value)| {
                 datapoint_warn!("os-config", (key, *current_value, i64));
                 match interesting_limit {
                     InterestingLimit::Recommend(recommended_value)
@@ -477,7 +477,6 @@ impl SystemMonitorService {
                     }
                 }
             })
-            .all(|good| good)
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -66,7 +66,7 @@ fn send_vote_transaction(
                 .my_contact_info()
                 .tpu(connection_cache.protocol())
         })
-        .ok_or_else(|| SendVoteError::InvalidTpuAddress)?;
+        .ok_or(SendVoteError::InvalidTpuAddress)?;
     let buf = serialize(transaction)?;
     let client = connection_cache.get_connection(&tpu);
 

--- a/rpc-test/tests/nonblocking.rs
+++ b/rpc-test/tests/nonblocking.rs
@@ -40,7 +40,7 @@ async fn test_tpu_send_transaction() {
             .get_signature_statuses(&signatures)
             .await
             .unwrap();
-        if statuses.value.first().is_some() {
+        if !statuses.value.is_empty() {
             break;
         }
     }

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -535,7 +535,7 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
     loop {
         assert!(now.elapsed() < timeout);
         let statuses = rpc_client.get_signature_statuses(&signatures).unwrap();
-        if statuses.value.first().is_some() {
+        if !statuses.value.is_empty() {
             return;
         }
     }

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -104,9 +104,9 @@ pub(super) fn get_chained_merkle_root_from_parent(
     debug_assert!(parent < slot, "parent: {parent} >= slot: {slot}");
     let index = blockstore
         .meta(parent)?
-        .ok_or_else(|| Error::UnknownSlotMeta(parent))?
+        .ok_or(Error::UnknownSlotMeta(parent))?
         .last_index
-        .ok_or_else(|| Error::UnknownLastIndex(parent))?;
+        .ok_or(Error::UnknownLastIndex(parent))?;
     let shred = blockstore
         .get_data_shred(parent, index)?
         .ok_or(Error::ShredNotFound {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2453,7 +2453,7 @@ fn hash_validator(hash: String) -> Result<(), String> {
 /// Test validator
 
 pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<'a, 'a> {
-    return App::new("solana-test-validator")
+    App::new("solana-test-validator")
         .about("Test Validator")
         .version(version)
         .arg({
@@ -2904,7 +2904,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                      argument in the genesis configuration. If the ledger \
                      already exists then this parameter is silently ignored",
                 ),
-        );
+        )
 }
 
 pub struct DefaultTestArgs {

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -66,7 +66,7 @@ fn port_range_validator(port_range: String) -> Result<(), String> {
 }
 
 pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
-    return App::new(crate_name!())
+    App::new(crate_name!())
         .about(crate_description!())
         .version(version)
         .global_setting(AppSettings::ColoredHelp)
@@ -173,5 +173,5 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
-        );
+        )
 }


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

The remaining misc lints after #4376 and #4377 that clippy could auto-fix.


#### Summary of Changes

```
cargo clippy --fix
```