### PR TITLE
[message] Do not include secp256r1 signature from the total number of signature counts

### DIFF
--- a/sdk/message/src/sanitized.rs
+++ b/sdk/message/src/sanitized.rs
@@ -455,7 +455,6 @@ impl TransactionSignatureDetails {
         self.num_transaction_signatures
             .saturating_add(self.num_secp256k1_instruction_signatures)
             .saturating_add(self.num_ed25519_instruction_signatures)
-            .saturating_add(self.num_secp256r1_instruction_signatures)
     }
 
     /// return the number of transaction signatures


### PR DESCRIPTION
#### Problem
The secp256r1 precompile signatures were added and included (https://github.com/anza-xyz/agave/pull/3878) to the total signature count in `TransactionSignatureDetails`. Although the secp256r1 precompile is behind a feature gate, this could potentially result in different fees for different versions.

#### Summary of Changes
Exclude the secp256r1 signatures from the total signature count.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
