### PR TITLE
ci: run 5 partitions for tests

### DIFF
--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -15,8 +15,8 @@ partitions=$(
   "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh",
   "timeout_in_minutes": 30,
   "agent": "$agent",
-  "parallelism": 4,
-  "retry": 3
+  "parallelism": 5,
+  "retry": 2
 }
 EOF
 )

--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -15,7 +15,7 @@ partitions=$(
   "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh",
   "timeout_in_minutes": 30,
   "agent": "$agent",
-  "parallelism": 2,
+  "parallelism": 4,
   "retry": 3
 }
 EOF

--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -16,7 +16,7 @@ partitions=$(
   "timeout_in_minutes": 30,
   "agent": "$agent",
   "parallelism": 5,
-  "retry": 2
+  "retry": 3
 }
 EOF
 )

--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -13,7 +13,7 @@ partitions=$(
 {
   "name": "partitions",
   "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh",
-  "timeout_in_minutes": 30,
+  "timeout_in_minutes": 25,
   "agent": "$agent",
   "parallelism": 5,
   "retry": 3


### PR DESCRIPTION
#### Problem

having only 2 partitions is taking too much time for each step

#### Summary of Changes

run them in 5 parallel