### PR TITLE
make bank_client optional in tps-client

### DIFF
--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -39,7 +39,7 @@ solana-rpc-client-nonce-utils = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-streamer = { workspace = true }
-solana-tps-client = { workspace = true, features = ["bank-client"] }
+solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
@@ -52,6 +52,7 @@ solana-feature-set = { workspace = true }
 solana-local-cluster = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }
+solana-tps-client = { workspace = true, features = ["bank-client"] }
 tempfile = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -39,7 +39,7 @@ solana-rpc-client-nonce-utils = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }
 solana-streamer = { workspace = true }
-solana-tps-client = { workspace = true }
+solana-tps-client = { workspace = true, features = ["bank-client"] }
 solana-tpu-client = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 log = { workspace = true }
 solana-account = { workspace = true }
 solana-client = { workspace = true }
-solana-client-traits = { workspace = true }
+solana-client-traits = { workspace = true, optional = true }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-connection-cache = { workspace = true }
@@ -24,7 +24,7 @@ solana-pubkey = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
-solana-runtime = { workspace = true }
+solana-runtime = { workspace = true, optional = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }
@@ -42,3 +42,8 @@ tempfile = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bank-client = ["dep:solana-client-traits", "dep:solana-runtime"]

--- a/tps-client/src/lib.rs
+++ b/tps-client/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     log::debug,
     solana_account::Account,
@@ -140,6 +141,7 @@ pub trait TpsClient {
     ) -> TpsClientResult<UiConfirmedBlock>;
 }
 
+#[cfg(feature = "bank-client")]
 mod bank_client;
 mod rpc_client;
 mod tpu_client;


### PR DESCRIPTION
#### Problem
The tps-client crate brings in really heavy dependencies (solana-runtime) in bank_client.rs. Most usage of tps-client doesn't need this, in particular solana-cli which will have way lighter deps when this gets merged

#### Summary of Changes
- Put `solana_tps_client::bank_client` behind a feature gate. This can't be moved to a separate crate because you run into orphan rule problems
- Activate this feature in the one place it's needed: bench-tps