### PR TITLE
clippy: unnecessary_map_or

### DIFF
--- a/accounts-db/src/account_locks.rs
+++ b/accounts-db/src/account_locks.rs
@@ -62,9 +62,7 @@ impl AccountLocks {
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn is_locked_readonly(&self, key: &Pubkey) -> bool {
-        self.readonly_locks
-            .get(key)
-            .map_or(false, |count| *count > 0)
+        self.readonly_locks.get(key).is_some_and(|count| *count > 0)
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]

--- a/bench-tps/src/log_transaction_service.rs
+++ b/bench-tps/src/log_transaction_service.rs
@@ -476,7 +476,7 @@ impl TransactionLogWriter {
                     .latest()
                     .expect("valid timestamp")
             }),
-            successful: meta.as_ref().map_or(false, |m| m.status.is_ok()),
+            successful: meta.as_ref().is_some_and(|m| m.status.is_ok()),
             error: meta
                 .as_ref()
                 .and_then(|m| m.err.as_ref().map(|x| x.to_string())),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2428,7 +2428,7 @@ impl ReplayStage {
             // The following differs from  rooted_slots by including the parent slot of the oldest parent bank.
             let rooted_slots_with_parents = bank_notification_sender
                 .as_ref()
-                .map_or(false, |sender| sender.should_send_parents)
+                .is_some_and(|sender| sender.should_send_parents)
                 .then(|| {
                     let mut new_chain = rooted_slots.clone();
                     new_chain.push(oldest_parent.unwrap_or_else(|| bank.parent_slot()));

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -76,9 +76,7 @@ impl WarmQuicCacheService {
                         .unwrap()
                         .leader_after_n_slots((CACHE_OFFSET_SLOT + slot_jitter) as u64);
                     if let Some(leader_pubkey) = leader_pubkey {
-                        if maybe_last_leader
-                            .map_or(true, |last_leader| last_leader != leader_pubkey)
-                        {
+                        if maybe_last_leader != Some(leader_pubkey) {
                             maybe_last_leader = Some(leader_pubkey);
                             // Warm cache for regular transactions
                             Self::warmup_connection(

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -352,15 +352,14 @@ impl PohRecorder {
 
     pub fn would_be_leader(&self, within_next_n_ticks: u64) -> bool {
         self.has_bank()
-            || self.leader_first_tick_height_including_grace_ticks.map_or(
-                false,
-                |leader_first_tick_height_including_grace_ticks| {
+            || self
+                .leader_first_tick_height_including_grace_ticks
+                .is_some_and(|leader_first_tick_height_including_grace_ticks| {
                     let ideal_leader_tick_height = leader_first_tick_height_including_grace_ticks
                         .saturating_sub(self.grace_ticks);
                     self.tick_height + within_next_n_ticks >= ideal_leader_tick_height
                         && self.tick_height <= self.leader_last_tick_height
-                },
-            )
+                })
     }
 
     // Return the slot for a given tick height

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -451,7 +451,7 @@ fn check_slots_are_valid(
         // where `s` >= `last_voted_slot`
         if vote_state
             .last_voted_slot()
-            .map_or(false, |last_voted_slot| vote_slots[i] <= last_voted_slot)
+            .is_some_and(|last_voted_slot| vote_slots[i] <= last_voted_slot)
         {
             i = i
                 .checked_add(1)

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -33,9 +33,7 @@ pub trait SnapshotArchiveInfoGetter {
         self.snapshot_archive_info()
             .path
             .parent()
-            .map_or(false, |p| {
-                p.ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
-            })
+            .is_some_and(|p| p.ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR))
     }
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -114,7 +114,7 @@ impl FromStr for SnapshotVersion {
         // Remove leading 'v' or 'V' from slice
         let version_string = if version_string
             .get(..1)
-            .map_or(false, |s| s.eq_ignore_ascii_case("v"))
+            .is_some_and(|s| s.eq_ignore_ascii_case("v"))
         {
             &version_string[1..]
         } else {

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -701,7 +701,7 @@ impl VoteState {
         // Ignore votes for slots earlier than we already have votes for
         if self
             .last_voted_slot()
-            .map_or(false, |last_voted_slot| next_vote_slot <= last_voted_slot)
+            .is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
         {
             return;
         }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -189,7 +189,7 @@ fn get_rpc_peers(
             cluster_entrypoint
                 .gossip()
                 .and_then(|addr| cluster_info.lookup_contact_info_by_gossip_addr(&addr))
-                .map_or(false, |entrypoint| entrypoint.shred_version() == 0)
+                .is_some_and(|entrypoint| entrypoint.shred_version() == 0)
         });
 
         if all_zero_shred_versions {

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -357,7 +357,7 @@ fn is_over_stake_threshold(
     epoch_info_vec
         .iter()
         .find(|info| info.epoch == epoch)
-        .map_or(false, |info| {
+        .is_some_and(|info| {
             let threshold = info
                 .actively_voting_stake
                 .checked_sub((info.total_stake as f64 * HEAVIEST_FORK_THRESHOLD_DELTA) as u64)


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: this `map_or` is redundant
   --> sdk/program/src/vote/state/mod.rs:702:12
    |
702 |           if self
    |  ____________^
703 | |             .last_voted_slot()
704 | |             .map_or(false, |last_voted_slot| next_vote_slot <= last_voted_slot)
    | |_______________________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
help: use is_some_and instead
    |
702 ~         if self
703 +             .last_voted_slot().is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
```


#### Summary of Changes

Resolve the lints by using the suggestions from clippy and checking the code.

Partially fixes #4380 