### PR TITLE
clippy: empty_line_after_doc_comments

### DIFF
--- a/sdk/define-syscall/src/codes.rs
+++ b/sdk/define-syscall/src/codes.rs
@@ -1,12 +1,13 @@
+//! These are syscall codes specified in SIMD-0178.
+//! If a new syscall is to be included, add a new number constant
+//! for correct registration.
+
 macro_rules! define_code {
     ($name:ident, $code:literal) => {
         pub const $name: u32 = $code;
     };
 }
 
-// These are syscall codes specified in SIMD-0178.
-// If a new syscall is to be included, add a new number constant
-// for correct registration.
 define_code!(ABORT, 1);
 define_code!(SOL_PANIC, 2);
 define_code!(SOL_MEMCPY_, 3);

--- a/sdk/define-syscall/src/codes.rs
+++ b/sdk/define-syscall/src/codes.rs
@@ -1,13 +1,12 @@
-/// These are syscall codes specified in SIMD-0178.
-/// If a new syscall is to be included, add a new number constant
-/// for correct registration.
-
 macro_rules! define_code {
     ($name:ident, $code:literal) => {
         pub const $name: u32 = $code;
     };
 }
 
+// These are syscall codes specified in SIMD-0178.
+// If a new syscall is to be included, add a new number constant
+// for correct registration.
 define_code!(ABORT, 1);
 define_code!(SOL_PANIC, 2);
 define_code!(SOL_MEMCPY_, 3);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -230,7 +230,6 @@ pub fn spawn_server_multi(
 /// litter the code with open connection tracking. This is added into the
 /// connection table as part of the ConnectionEntry. The reference is auto
 /// reduced when it is dropped.
-
 struct ClientConnectionTracker {
     stats: Arc<StreamerStats>,
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -2451,7 +2451,6 @@ fn hash_validator(hash: String) -> Result<(), String> {
 }
 
 /// Test validator
-
 pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<'a, 'a> {
     App::new("solana-test-validator")
         .about("Test Validator")


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: empty line after doc comment
   --> streamer/src/nonblocking/quic.rs:232:1
    |
232 | / /// reduced when it is dropped.
233 | |
    | |_^
234 |   struct ClientConnectionTracker {
    |   ------------------------------ the comment documents this struct
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
    = note: `#[warn(clippy::empty_line_after_doc_comments)]` on by default
    = help: if the empty line is unintentional remove it
```


#### Summary of Changes

Resolve the lints by using the suggestions from clippy and checking the code.

Partially fixes #4380 