### PR TITLE
clippy: type_complexity

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -673,6 +673,7 @@ impl Blockstore {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
+    #[allow(clippy::type_complexity)]
     pub fn iterator_cf(
         &self,
         cf_name: &str,
@@ -682,6 +683,7 @@ impl Blockstore {
         Ok(iterator.map(|pair| pair.unwrap()))
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn slot_data_iterator(
         &self,
         slot: Slot,
@@ -694,6 +696,7 @@ impl Blockstore {
         Ok(slot_iterator.take_while(move |((shred_slot, _), _)| *shred_slot == slot))
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn slot_coding_iterator(
         &self,
         slot: Slot,


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: very complex type used. Consider factoring parts into `type` definitions
   --> ledger/src/blockstore.rs:679:10
    |
679 |     ) -> Result<impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
    = note: `#[warn(clippy::type_complexity)]` on by default

warning: very complex type used. Consider factoring parts into `type` definitions
   --> ledger/src/blockstore.rs:689:10
    |
689 |     ) -> Result<impl Iterator<Item = ((u64, u64), Box<[u8]>)> + '_> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity

warning: very complex type used. Consider factoring parts into `type` definitions
   --> ledger/src/blockstore.rs:701:10
    |
701 |     ) -> Result<impl Iterator<Item = ((u64, u64), Box<[u8]>)> + '_> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
```


#### Summary of Changes

Resolve the lints by using the suggestions from clippy and checking the code.

Partially fixes #4380 