### PR TITLE
clippy: empty_line_after_outer_attr

### DIFF
--- a/zk-sdk/src/sigma_proofs/pod.rs
+++ b/zk-sdk/src/sigma_proofs/pod.rs
@@ -122,8 +122,8 @@ impl From<GroupedCiphertext2HandlesValidityProof> for PodGroupedCiphertext2Handl
         Self(decoded_proof.to_bytes())
     }
 }
-#[cfg(not(target_os = "solana"))]
 
+#[cfg(not(target_os = "solana"))]
 impl TryFrom<PodGroupedCiphertext2HandlesValidityProof> for GroupedCiphertext2HandlesValidityProof {
     type Error = ValidityProofVerificationError;
 


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: empty line after outer attribute
   --> zk-sdk/src/sigma_proofs/pod.rs:125:1
    |
125 | / #[cfg(not(target_os = "solana"))]
126 | |
    | |_^
127 |   impl TryFrom<PodGroupedCiphertext2HandlesValidityProof> for GroupedCiphertext2HandlesValidityProof {
    |   -------------------------------------------------------------------------------------------------- the attribute applies to this implementation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr
    = note: `#[warn(clippy::empty_line_after_outer_attr)]` on by default
    = help: if the empty line is unintentional remove it
```


#### Summary of Changes

Resolve the lints by using the suggestions from clippy and checking the code.

Partially fixes #4380 