### PR TITLE
clippy: large_enum_variant

### DIFF
--- a/rpc-client-api/src/request.rs
+++ b/rpc-client-api/src/request.rs
@@ -199,6 +199,7 @@ impl fmt::Display for RpcResponseErrorData {
 }
 
 #[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum RpcError {
     #[error("RPC request error: {0}")]
     RpcRequestError(String),


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: large size difference between variants
   --> rpc-client-api/src/request.rs:202:1
    |
202 | /  pub enum RpcError {
203 | |      #[error("RPC request error: {0}")]
204 | |      RpcRequestError(String),
    | |      ----------------------- the second-largest variant contains at least 24 bytes
205 | |      #[error("RPC response error {code}: {message}; {data}")]
206 | |/     RpcResponseError {
207 | ||         code: i64,
208 | ||         message: String,
209 | ||         data: RpcResponseErrorData,
210 | ||     },
    | ||_____- the largest variant contains at least 232 bytes
...   |
216 | |      ForUser(String), /* "direct-to-user message" */
217 | |  }
    | |__^ the entire enum is at least 232 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
    |
209 |         data: Box<RpcResponseErrorData>,
    |               ~~~~~~~~~~~~~~~~~~~~~~~~~
```


#### Summary of Changes

Resolve the lints by using the suggestions from clippy and checking the code.

Partially fixes #4380 