### PR TITLE
CI: Disable downstream testing

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -38,7 +38,8 @@ env:
 
 jobs:
   test:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -37,7 +37,8 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +62,8 @@ jobs:
           cargo check
 
   test:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -124,7 +126,8 @@ jobs:
           done
 
   cargo-test-sbf:
-    if: github.repository == 'anza-xyz/agave'
+    #if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
#### Problem

The SPL repo is about to get decommissioned with
https://github.com/solana-labs/solana-program-library/pull/7644, but this repo still runs downstream tests against it, which will immediately fail when the PR lands.

#### Summary of changes

#4371 has the real fix, but since time is of the essence, just disable the downstream jobs while the other one is reviewed / lands.