### PR TITLE
defines alias for Fn(&ContactInfo) -> R trait

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -19,7 +19,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_gossip::{
         cluster_info::{ClusterInfo, Node},
-        contact_info::ContactInfo,
+        contact_info::ContactInfoQuery,
     },
     solana_ledger::{
         blockstore::{Blockstore, PurgeType},
@@ -248,10 +248,7 @@ impl LikeClusterInfo for Arc<DummyClusterInfo> {
         *self.id.read().unwrap()
     }
 
-    fn lookup_contact_info<F, Y>(&self, _id: &Pubkey, _map: F) -> Option<Y>
-    where
-        F: FnOnce(&ContactInfo) -> Y,
-    {
+    fn lookup_contact_info<R>(&self, _: &Pubkey, _: impl ContactInfoQuery<R>) -> Option<R> {
         None
     }
 }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -31,7 +31,7 @@ use {
     crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
     histogram::Histogram,
     solana_client::connection_cache::ConnectionCache,
-    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfoQuery},
     solana_ledger::blockstore_processor::TransactionStatusSender,
     solana_measure::measure_us,
     solana_perf::{data_budget::DataBudget, packet::PACKETS_PER_BATCH},
@@ -328,9 +328,7 @@ pub struct FilterForwardingResults {
 pub trait LikeClusterInfo: Send + Sync + 'static + Clone {
     fn id(&self) -> Pubkey;
 
-    fn lookup_contact_info<F, Y>(&self, id: &Pubkey, map: F) -> Option<Y>
-    where
-        F: FnOnce(&ContactInfo) -> Y;
+    fn lookup_contact_info<R>(&self, id: &Pubkey, query: impl ContactInfoQuery<R>) -> Option<R>;
 }
 
 impl LikeClusterInfo for Arc<ClusterInfo> {
@@ -338,11 +336,8 @@ impl LikeClusterInfo for Arc<ClusterInfo> {
         self.deref().id()
     }
 
-    fn lookup_contact_info<F, Y>(&self, id: &Pubkey, map: F) -> Option<Y>
-    where
-        F: FnOnce(&ContactInfo) -> Y,
-    {
-        self.deref().lookup_contact_info(id, map)
+    fn lookup_contact_info<R>(&self, id: &Pubkey, query: impl ContactInfoQuery<R>) -> Option<R> {
+        self.deref().lookup_contact_info(id, query)
     }
 }
 

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -3,7 +3,7 @@ use {
     itertools::Itertools,
     solana_gossip::{
         cluster_info::ClusterInfo,
-        contact_info::{ContactInfo, Protocol},
+        contact_info::{ContactInfoQuery, Protocol},
     },
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, pubkey::Pubkey},
@@ -45,14 +45,11 @@ pub(crate) fn next_leader_tpu_vote(
     })
 }
 
-pub(crate) fn next_leader<F>(
+pub(crate) fn next_leader(
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
-    port_selector: F,
-) -> Option<(Pubkey, SocketAddr)>
-where
-    F: FnOnce(&ContactInfo) -> Option<SocketAddr>,
-{
+    port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
+) -> Option<(Pubkey, SocketAddr)> {
     let leader_pubkey = poh_recorder
         .read()
         .unwrap()

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -5,7 +5,7 @@ use {
     rand::{thread_rng, Rng},
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_connection_cache::client_connection::ClientConnection as TpuConnection,
-    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfoQuery},
     solana_poh::poh_recorder::PohRecorder,
     solana_pubkey::Pubkey,
     std::{
@@ -32,7 +32,7 @@ impl WarmQuicCacheService {
         cache: Option<&ConnectionCache>,
         cluster_info: &ClusterInfo,
         leader_pubkey: &Pubkey,
-        contact_info_selector: impl Fn(&ContactInfo) -> Option<SocketAddr>,
+        contact_info_selector: impl ContactInfoQuery<Option<SocketAddr>>,
         log_context: &str,
     ) {
         if let Some(connection_cache) = cache {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -18,7 +18,7 @@ use {
         cluster_info_metrics::{
             submit_gossip_stats, Counter, GossipStats, ScopedTimer, TimedGuard,
         },
-        contact_info::{self, ContactInfo, Error as ContactInfoError},
+        contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_data::{
             self, CrdsData, EpochSlotsIndex, LowestSlot, NodeInstance, SnapshotHashes, Version,
@@ -464,12 +464,13 @@ impl ClusterInfo {
         Ok(())
     }
 
-    pub fn lookup_contact_info<F, Y>(&self, id: &Pubkey, map: F) -> Option<Y>
-    where
-        F: FnOnce(&ContactInfo) -> Y,
-    {
+    pub fn lookup_contact_info<R>(
+        &self,
+        id: &Pubkey,
+        query: impl ContactInfoQuery<R>,
+    ) -> Option<R> {
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds.get(*id).map(map)
+        gossip_crds.get(*id).map(query)
     }
 
     pub fn lookup_contact_info_by_gossip_addr(
@@ -1112,7 +1113,7 @@ impl ClusterInfo {
     }
 
     /// all validators that have a valid tvu port and are on the same `shred_version`.
-    pub fn tvu_peers<R>(&self, query: impl Fn(&ContactInfo) -> R) -> Vec<R> {
+    pub fn tvu_peers<R>(&self, query: impl ContactInfoQuery<R>) -> Vec<R> {
         let self_pubkey = self.id();
         let self_shred_version = self.my_shred_version();
         self.time_gossip_read_lock("tvu_peers", &self.stats.tvu_peers)

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -42,6 +42,11 @@ const SOCKET_TAG_TVU_QUIC: u8 = 11;
 const_assert_eq!(SOCKET_CACHE_SIZE, 13);
 const SOCKET_CACHE_SIZE: usize = SOCKET_TAG_TPU_VOTE_QUIC as usize + 1usize;
 
+// An alias for a function that reads data from a ContactInfo entry stored in
+// the gossip CRDS table.
+pub trait ContactInfoQuery<R>: Fn(&ContactInfo) -> R {}
+impl<R, F: Fn(&ContactInfo) -> R> ContactInfoQuery<R> for F {}
+
 #[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum Error {
     #[error("Duplicate IP address: {0}")]


### PR DESCRIPTION

#### Problem
https://github.com/anza-xyz/agave/pull/4391 adds type parameter to `ContactInfo.cache` but we don't want to expose that implementation detail to outside of the gossip crate.



#### Summary of Changes
In order to encapsulate that change in gossip crate, this commit adds an alias for:

    Fn(&ContactInfo) -> R

which can be used outside of the gossip crate.
