### PR TITLE
implements From<ContactInfo> for CrdsData

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1261,10 +1261,7 @@ impl ClusterInfo {
         Vec<(SocketAddr, Protocol)>, // Pull requests
     ) {
         let now = timestamp();
-        let self_info = CrdsValue::new(
-            CrdsData::ContactInfo(self.my_contact_info()),
-            &self.keypair(),
-        );
+        let self_info = CrdsValue::new(CrdsData::from(self.my_contact_info()), &self.keypair());
         let max_bloom_filter_bytes = get_max_bloom_filter_bytes(&self_info);
         let mut pings = Vec::new();
         let mut pulls = {
@@ -3337,7 +3334,7 @@ mod tests {
 
     fn test_crds_values(pubkey: Pubkey) -> Vec<CrdsValue> {
         let entrypoint = ContactInfo::new_localhost(&pubkey, timestamp());
-        let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::ContactInfo(entrypoint));
+        let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::from(entrypoint));
         vec![entrypoint_crdsvalue]
     }
 
@@ -3806,7 +3803,7 @@ mod tests {
         node.set_shred_version(42);
         let epoch_slots = EpochSlots::new_rand(&mut rng, Some(node_pubkey));
         let entries = vec![
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node)),
+            CrdsValue::new_unsigned(CrdsData::from(node)),
             CrdsValue::new_unsigned(CrdsData::EpochSlots(0, epoch_slots)),
         ];
         {
@@ -3862,8 +3859,7 @@ mod tests {
             }
         }
         // now add this message back to the table and make sure after the next pull, the entrypoint is unset
-        let entrypoint_crdsvalue =
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(entrypoint.clone()));
+        let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::from(&entrypoint));
         let cluster_info = Arc::new(cluster_info);
         let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = cluster_info.gossip.make_timeouts(
@@ -4178,7 +4174,7 @@ mod tests {
             let mut rand_ci = ContactInfo::new_rand(&mut rng, Some(keypair.pubkey()));
             rand_ci.set_shred_version(shred_version);
             rand_ci.set_wallclock(timestamp());
-            CrdsValue::new(CrdsData::ContactInfo(rand_ci), &keypair)
+            CrdsValue::new(CrdsData::from(rand_ci), &keypair)
         })
         .take(NO_ENTRIES)
         .collect();
@@ -4291,7 +4287,7 @@ mod tests {
         let mut slots = RestartLastVotedForkSlots::new_rand(&mut rng, Some(node_pubkey));
         slots.shred_version = 42;
         let entries = vec![
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node)),
+            CrdsValue::new_unsigned(CrdsData::from(node)),
             CrdsValue::new_unsigned(CrdsData::RestartLastVotedForkSlots(slots)),
         ];
         {
@@ -4361,7 +4357,7 @@ mod tests {
         let hash2 = Hash::new_unique();
         let stake2 = 23_000_000;
         let entries = vec![
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(new_node)),
+            CrdsValue::new_unsigned(CrdsData::from(new_node)),
             CrdsValue::new_unsigned(CrdsData::RestartHeaviestFork(RestartHeaviestFork {
                 from: pubkey2,
                 wallclock: timestamp(),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -795,7 +795,7 @@ mod tests {
     #[test]
     fn test_insert() {
         let mut crds = Crds::default();
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         assert_eq!(
             crds.insert(val.clone(), 0, GossipRoute::LocalMessage),
             Ok(())
@@ -807,7 +807,7 @@ mod tests {
     #[test]
     fn test_update_old() {
         let mut crds = Crds::default();
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         assert_eq!(
             crds.insert(val.clone(), 0, GossipRoute::LocalMessage),
             Ok(())
@@ -822,13 +822,13 @@ mod tests {
     #[test]
     fn test_update_new() {
         let mut crds = Crds::default();
-        let original = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let original = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &Pubkey::default(),
             0,
         )));
         let value_hash = *original.hash();
         assert_matches!(crds.insert(original, 0, GossipRoute::LocalMessage), Ok(()));
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &Pubkey::default(),
             1,
         )));
@@ -842,7 +842,7 @@ mod tests {
     #[test]
     fn test_update_timestamp() {
         let mut crds = Crds::default();
-        let val1 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let val1 = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &Pubkey::default(),
             0,
         )));
@@ -855,7 +855,7 @@ mod tests {
         assert_eq!(crds.table[&val1.label()].ordinal, 0);
 
         // `val2` is expected to overwrite `val1` based on the `wallclock` value.
-        let val2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let val2 = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &Pubkey::default(),
             1,
         )));
@@ -939,7 +939,7 @@ mod tests {
         let mut crds = Crds::default();
         let val = {
             let node = ContactInfo::new_localhost(&Pubkey::default(), /*now:*/ 1);
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node))
+            CrdsValue::new_unsigned(CrdsData::from(node))
         };
         assert_eq!(
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
@@ -1036,7 +1036,7 @@ mod tests {
     fn test_remove_default() {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut crds = Crds::default();
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         assert_matches!(
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
@@ -1061,7 +1061,7 @@ mod tests {
         let mut crds = Crds::default();
         let val = {
             let node = ContactInfo::new_localhost(&Pubkey::default(), /*now:*/ 1);
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node))
+            CrdsValue::new_unsigned(CrdsData::from(node))
         };
         assert_eq!(
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
@@ -1337,7 +1337,7 @@ mod tests {
         let wallclock = node.wallclock();
         node.set_shred_version(42);
         {
-            let node = CrdsData::ContactInfo(node.clone());
+            let node = CrdsData::from(&node);
             let node = CrdsValue::new_unsigned(node);
             assert_eq!(
                 crds.insert(node, timestamp(), GossipRoute::LocalMessage),
@@ -1349,7 +1349,7 @@ mod tests {
         let mut node = node.clone();
         node.set_wallclock(wallclock - 1); // outdated.
         node.set_shred_version(8);
-        let node = CrdsData::ContactInfo(node);
+        let node = CrdsData::from(node);
         let node = CrdsValue::new_unsigned(node);
         assert_eq!(
             crds.insert(node, timestamp(), GossipRoute::LocalMessage),
@@ -1360,7 +1360,7 @@ mod tests {
         let mut node = ContactInfo::new_rand(&mut rng, Some(pubkey));
         node.set_wallclock(wallclock + 1); // so that it overrides the prev one.
         node.set_shred_version(8);
-        let node = CrdsData::ContactInfo(node);
+        let node = CrdsData::from(node);
         let node = CrdsValue::new_unsigned(node);
         assert_eq!(
             crds.insert(node, timestamp(), GossipRoute::LocalMessage),
@@ -1450,7 +1450,7 @@ mod tests {
     fn test_remove_staked() {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut crds = Crds::default();
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         assert_matches!(
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
@@ -1473,7 +1473,7 @@ mod tests {
     #[test]
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn test_equal() {
-        let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let val = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         let v1 =
             VersionedCrdsValue::new(val.clone(), Cursor::default(), 1, GossipRoute::LocalMessage);
         let v2 = VersionedCrdsValue::new(val, Cursor::default(), 1, GossipRoute::LocalMessage);
@@ -1487,7 +1487,7 @@ mod tests {
     fn test_hash_order() {
         let mut node = ContactInfo::new_localhost(&Pubkey::default(), 0);
         let v1 = VersionedCrdsValue::new(
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node.clone())),
+            CrdsValue::new_unsigned(CrdsData::from(&node)),
             Cursor::default(),
             1, // local_timestamp
             GossipRoute::LocalMessage,
@@ -1495,7 +1495,7 @@ mod tests {
         let v2 = VersionedCrdsValue::new(
             {
                 node.set_rpc((Ipv4Addr::LOCALHOST, 1244)).unwrap();
-                CrdsValue::new_unsigned(CrdsData::ContactInfo(node))
+                CrdsValue::new_unsigned(CrdsData::from(node))
             },
             Cursor::default(),
             1, // local_timestamp
@@ -1520,14 +1520,14 @@ mod tests {
     fn test_wallclock_order() {
         let mut node = ContactInfo::new_localhost(&Pubkey::default(), 1);
         let v1 = VersionedCrdsValue::new(
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node.clone())),
+            CrdsValue::new_unsigned(CrdsData::from(&node)),
             Cursor::default(),
             1, // local_timestamp
             GossipRoute::LocalMessage,
         );
         node.set_wallclock(0);
         let v2 = VersionedCrdsValue::new(
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(node)),
+            CrdsValue::new_unsigned(CrdsData::from(node)),
             Cursor::default(),
             1, // local_timestamp
             GossipRoute::LocalMessage,
@@ -1543,7 +1543,7 @@ mod tests {
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn test_label_order() {
         let v1 = VersionedCrdsValue::new(
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
                 &solana_pubkey::new_rand(),
                 0,
             ))),
@@ -1552,7 +1552,7 @@ mod tests {
             GossipRoute::LocalMessage,
         );
         let v2 = VersionedCrdsValue::new(
-            CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
                 &solana_pubkey::new_rand(),
                 0,
             ))),

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -121,7 +121,7 @@ impl CrdsData {
         // TODO: Assign ranges to each arm proportional to their frequency in
         // the mainnet crds table.
         match kind {
-            0 => CrdsData::ContactInfo(ContactInfo::new_rand(rng, pubkey)),
+            0 => CrdsData::from(ContactInfo::new_rand(rng, pubkey)),
             // Index for LowestSlot is deprecated and should be zero.
             1 => CrdsData::LowestSlot(0, LowestSlot::new_rand(rng, pubkey)),
             2 => CrdsData::LegacySnapshotHashes(LegacySnapshotHashes::new_rand(rng, pubkey)),
@@ -197,6 +197,20 @@ impl CrdsData {
             Self::RestartLastVotedForkSlots(_) => false,
             Self::RestartHeaviestFork(_) => false,
         }
+    }
+}
+
+impl From<ContactInfo> for CrdsData {
+    #[inline]
+    fn from(node: ContactInfo) -> Self {
+        Self::ContactInfo(node)
+    }
+}
+
+impl From<&ContactInfo> for CrdsData {
+    #[inline]
+    fn from(node: &ContactInfo) -> Self {
+        Self::ContactInfo(node.clone())
     }
 }
 

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -423,7 +423,7 @@ mod test {
             .write()
             .unwrap()
             .insert(
-                CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone())),
+                CrdsValue::new_unsigned(CrdsData::from(&ci)),
                 0,
                 GossipRoute::LocalMessage,
             )

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -854,7 +854,7 @@ pub(crate) mod tests {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let crds = RwLock::<Crds>::default();
         let node_keypair = Keypair::new();
-        let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &node_keypair.pubkey(),
             0,
         )));
@@ -904,7 +904,7 @@ pub(crate) mod tests {
             .lock()
             .unwrap()
             .mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
+        let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.write()
             .unwrap()
             .insert(new.clone(), now, GossipRoute::LocalMessage)
@@ -926,7 +926,7 @@ pub(crate) mod tests {
         assert_eq!(peers, vec![new.contact_info().unwrap().clone()]);
 
         let offline = ContactInfo::new_localhost(&solana_pubkey::new_rand(), now);
-        let offline = CrdsValue::new_unsigned(CrdsData::ContactInfo(offline));
+        let offline = CrdsValue::new_unsigned(CrdsData::from(offline));
         crds.write()
             .unwrap()
             .insert(offline, now, GossipRoute::LocalMessage)
@@ -957,7 +957,7 @@ pub(crate) mod tests {
         let mut ping_cache = new_ping_cache();
         let mut crds = Crds::default();
         let node_keypair = Keypair::new();
-        let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &node_keypair.pubkey(),
             0,
         )));
@@ -965,12 +965,12 @@ pub(crate) mod tests {
         crds.insert(entry, now, GossipRoute::LocalMessage).unwrap();
         let old = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ping_cache.mock_pong(*old.pubkey(), old.gossip().unwrap(), Instant::now());
-        let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(old));
+        let old = CrdsValue::new_unsigned(CrdsData::from(old));
         crds.insert(old.clone(), now, GossipRoute::LocalMessage)
             .unwrap();
         let new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
+        let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.insert(new, now, GossipRoute::LocalMessage).unwrap();
         let crds = RwLock::new(crds);
 
@@ -1014,7 +1014,7 @@ pub(crate) mod tests {
         let mut node_crds = Crds::default();
         let mut ping_cache = new_ping_cache();
         let now = timestamp();
-        let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &node_keypair.pubkey(),
             now,
         )));
@@ -1025,7 +1025,7 @@ pub(crate) mod tests {
             .unwrap();
         let new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), now);
         ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
+        let new = CrdsValue::new_unsigned(CrdsData::from(new));
         node_crds
             .insert(new, now, GossipRoute::LocalMessage)
             .unwrap();
@@ -1060,7 +1060,7 @@ pub(crate) mod tests {
         assert_eq!(rsp[0].len(), 0);
 
         let now = now + CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS;
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let new = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             now,
         )));
@@ -1085,7 +1085,7 @@ pub(crate) mod tests {
             // Should return new value since caller is new.
             let now = now + 1;
             let caller = ContactInfo::new_localhost(&Pubkey::new_unique(), now);
-            let caller = CrdsValue::new_unsigned(CrdsData::ContactInfo(caller));
+            let caller = CrdsValue::new_unsigned(CrdsData::from(caller));
             filters
                 .iter()
                 .map(|(_, filter)| (caller.clone(), filter.clone()))
@@ -1112,7 +1112,7 @@ pub(crate) mod tests {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let node_keypair = Keypair::new();
         let mut node_crds = Crds::default();
-        let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &node_keypair.pubkey(),
             1,
         )));
@@ -1125,7 +1125,7 @@ pub(crate) mod tests {
         let mut ping_cache = new_ping_cache();
         let new = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 1);
         ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
+        let new = CrdsValue::new_unsigned(CrdsData::from(new));
         node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
 
         let mut dest_crds = Crds::default();
@@ -1133,7 +1133,7 @@ pub(crate) mod tests {
         let same_key = ContactInfo::new_localhost(&new_id, 0);
         let new = ContactInfo::new_localhost(&new_id, 1);
         ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
-        let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
+        let new = CrdsValue::new_unsigned(CrdsData::from(new));
         dest_crds
             .insert(new.clone(), 0, GossipRoute::LocalMessage)
             .unwrap();
@@ -1145,7 +1145,7 @@ pub(crate) mod tests {
             same_key.gossip().unwrap(),
             Instant::now(),
         );
-        let same_key = CrdsValue::new_unsigned(CrdsData::ContactInfo(same_key));
+        let same_key = CrdsValue::new_unsigned(CrdsData::from(same_key));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());
         node_crds
@@ -1223,7 +1223,7 @@ pub(crate) mod tests {
     fn test_gossip_purge() {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut node_crds = Crds::default();
-        let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -1233,7 +1233,7 @@ pub(crate) mod tests {
         node_crds
             .insert(entry, 0, GossipRoute::LocalMessage)
             .unwrap();
-        let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let old = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -1361,9 +1361,8 @@ pub(crate) mod tests {
         let node = CrdsGossipPull::default();
 
         let peer_pubkey = solana_pubkey::new_rand();
-        let peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
-        ));
+        let peer_entry =
+            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(&peer_pubkey, 0)));
         let stakes = HashMap::from([(peer_pubkey, 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
@@ -1379,9 +1378,8 @@ pub(crate) mod tests {
         );
 
         let node_crds = RwLock::<Crds>::default();
-        let unstaked_peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
-        ));
+        let unstaked_peer_entry =
+            CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(&peer_pubkey, 0)));
         // check that old contact infos fail if they are too old, regardless of "timeouts"
         assert_eq!(
             node.process_pull_response(
@@ -1474,7 +1472,7 @@ pub(crate) mod tests {
             node
         };
         {
-            let caller = CrdsValue::new(CrdsData::ContactInfo(node.clone()), &keypair);
+            let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
             assert_eq!(get_max_bloom_filter_bytes(&caller), 1175);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
@@ -1492,7 +1490,7 @@ pub(crate) mod tests {
             node
         };
         {
-            let caller = CrdsValue::new(CrdsData::ContactInfo(node.clone()), &keypair);
+            let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
             assert_eq!(get_max_bloom_filter_bytes(&caller), 1165);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -298,7 +298,7 @@ mod tests {
     fn test_process_push_one() {
         let crds = RwLock::<Crds>::default();
         let push = CrdsGossipPush::default();
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let value = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -321,7 +321,7 @@ mod tests {
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ci.set_wallclock(1);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
+        let value = CrdsValue::new_unsigned(CrdsData::from(&ci));
 
         // push a new message
         assert_eq!(
@@ -331,7 +331,7 @@ mod tests {
 
         // push an old version
         ci.set_wallclock(0);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
+        let value = CrdsValue::new_unsigned(CrdsData::from(ci));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0)
             .is_empty());
@@ -345,14 +345,14 @@ mod tests {
 
         // push a version to far in the future
         ci.set_wallclock(timeout + 1);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
+        let value = CrdsValue::new_unsigned(CrdsData::from(&ci));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0)
             .is_empty());
 
         // push a version to far in the past
         ci.set_wallclock(0);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
+        let value = CrdsValue::new_unsigned(CrdsData::from(ci));
         assert!(push
             .process_push_message(&crds, vec![(Pubkey::default(), vec![value])], timeout + 1)
             .is_empty());
@@ -364,7 +364,7 @@ mod tests {
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         let origin = *ci.pubkey();
         ci.set_wallclock(0);
-        let value_old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
+        let value_old = CrdsValue::new_unsigned(CrdsData::from(&ci));
 
         // push a new message
         assert_eq!(
@@ -374,7 +374,7 @@ mod tests {
 
         // push an old version
         ci.set_wallclock(1);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
+        let value = CrdsValue::new_unsigned(CrdsData::from(ci));
         assert_eq!(
             push.process_push_message(&crds, vec![(Pubkey::default(), vec![value])], 0),
             [origin].into_iter().collect()
@@ -389,7 +389,7 @@ mod tests {
         let mut ping_cache = new_ping_cache();
         let peer = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
-        let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(peer));
+        let peer = CrdsValue::new_unsigned(CrdsData::from(peer));
         assert_eq!(
             crds.insert(peer.clone(), now, GossipRoute::LocalMessage),
             Ok(())
@@ -407,7 +407,7 @@ mod tests {
             &SocketAddrSpace::Unspecified,
         );
 
-        let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let new_msg = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -442,7 +442,7 @@ mod tests {
                 let mut peer = ContactInfo::new_rand(&mut rng, /*pubkey=*/ None);
                 peer.set_wallclock(wallclock);
                 ping_cache.mock_pong(*peer.pubkey(), peer.gossip().unwrap(), Instant::now());
-                CrdsValue::new_unsigned(CrdsData::ContactInfo(peer))
+                CrdsValue::new_unsigned(CrdsData::from(peer))
             })
             .collect();
         let origin: Vec<_> = peers.iter().map(|node| node.pubkey()).collect();
@@ -498,7 +498,7 @@ mod tests {
         let mut crds = Crds::default();
         let self_id = solana_pubkey::new_rand();
         let push = CrdsGossipPush::default();
-        let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let peer = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -519,7 +519,7 @@ mod tests {
             &SocketAddrSpace::Unspecified,
         );
 
-        let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let new_msg = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -550,7 +550,7 @@ mod tests {
     fn test_purge_old_pending_push_messages() {
         let mut crds = Crds::default();
         let push = CrdsGossipPush::default();
-        let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let peer = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
             0,
         )));
@@ -570,7 +570,7 @@ mod tests {
 
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ci.set_wallclock(1);
-        let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
+        let new_msg = CrdsValue::new_unsigned(CrdsData::from(ci));
         let expected = HashMap::new();
         let origin = new_msg.pubkey();
         assert_eq!(
@@ -595,7 +595,7 @@ mod tests {
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ci.set_wallclock(0);
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
+        let value = CrdsValue::new_unsigned(CrdsData::from(ci));
         let label = value.label();
         // push a new message
         assert_eq!(

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -258,7 +258,7 @@ mod test {
     #[test]
     fn test_keys_and_values() {
         let mut rng = rand::thread_rng();
-        let v = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let v = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         assert_eq!(v.wallclock(), 0);
         let key = *v.contact_info().unwrap().pubkey();
         assert_eq!(v.label(), CrdsValueLabel::ContactInfo(key));
@@ -289,7 +289,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keypair = Keypair::new();
         let wrong_keypair = Keypair::new();
-        let mut v = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+        let mut v = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &keypair.pubkey(),
             timestamp(),
         )));
@@ -339,7 +339,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let pubkey = Pubkey::new_unique();
         assert!(
-            !CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_rand(
+            !CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_rand(
                 &mut rng,
                 Some(pubkey)
             )))

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -473,7 +473,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_split_messages_small() {
-        let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::default()));
+        let value = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::default()));
         test_split_messages(value);
     }
 

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -101,7 +101,7 @@ fn star_network_create(num: usize) -> Network {
     let gossip_port_offset = 9000;
     let node_keypair = Arc::new(Keypair::new());
     let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
-    let entry = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+    let entry = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
     let mut network: HashMap<_, _> = (1..num)
         .map(|k| {
             let node_keypair = Arc::new(Keypair::new());
@@ -112,7 +112,7 @@ fn star_network_create(num: usize) -> Network {
             contact_info
                 .set_gossip((Ipv4Addr::LOCALHOST, gossip_port))
                 .unwrap();
-            let new = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+            let new = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
             let node = CrdsGossip::default();
             {
                 let mut node_crds = node.crds.write().unwrap();
@@ -142,7 +142,7 @@ fn star_network_create(num: usize) -> Network {
 fn rstar_network_create(num: usize) -> Network {
     let node_keypair = Arc::new(Keypair::new());
     let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
-    let entry = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+    let entry = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
     let origin = CrdsGossip::default();
     let id = entry.label().pubkey();
     origin
@@ -155,7 +155,7 @@ fn rstar_network_create(num: usize) -> Network {
         .map(|_| {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
-            let new = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+            let new = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
             let node = CrdsGossip::default();
             node.crds
                 .write()
@@ -182,7 +182,7 @@ fn ring_network_create(num: usize) -> Network {
         .map(|_| {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
-            let new = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+            let new = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
             let node = CrdsGossip::default();
             node.crds
                 .write()
@@ -217,7 +217,7 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
         .map(|n| {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
-            let new = CrdsValue::new(CrdsData::ContactInfo(contact_info.clone()), &node_keypair);
+            let new = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
             let node = CrdsGossip::default();
             node.crds
                 .write()
@@ -772,7 +772,7 @@ fn test_prune_errors() {
         .write()
         .unwrap()
         .insert(
-            CrdsValue::new(CrdsData::ContactInfo(ci.clone()), &Keypair::new()),
+            CrdsValue::new(CrdsData::from(&ci), &Keypair::new()),
             0,
             GossipRoute::LocalMessage,
         )

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -640,7 +640,7 @@ pub fn make_test_cluster<R: Rng>(
         let mut gossip_crds = cluster_info.gossip.crds.write().unwrap();
         // First node is pushed to crds table by ClusterInfo constructor.
         for node in nodes.iter().skip(1) {
-            let node = CrdsData::ContactInfo(node.clone());
+            let node = CrdsData::from(node);
             let node = CrdsValue::new(node, &keypair);
             assert_eq!(
                 gossip_crds.insert(node, now, GossipRoute::LocalMessage),

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1488,7 +1488,7 @@ mod tests {
         )
         .unwrap();
         let entries = vec![
-            CrdsValue::new(CrdsData::ContactInfo(node.clone()), node_keypair),
+            CrdsValue::new(CrdsData::from(node), node_keypair),
             CrdsValue::new(CrdsData::RestartLastVotedForkSlots(slots), node_keypair),
         ];
         {


### PR DESCRIPTION

#### Problem
https://github.com/anza-xyz/agave/pull/4391 adds type parameter to gossip `ContactInfo`, but `CrdsData::ContactInfo(_)` can only be initialized with a specific type.



#### Summary of Changes
In order to simplify the change and avoid verbosity, this commit implements `From<ContactInfo>` for `CrdsData` which allows to generically handle different types without changing the call sites.
