### PR TITLE
Update metrics & ema before breaking the connection loop

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1168,7 +1168,7 @@ async fn handle_connection(
                         CONNECTION_CLOSE_REASON_INVALID_STREAM,
                     );
                     stats.total_streams.fetch_sub(1, Ordering::Relaxed);
-                    stream_load_ema.update_ema_if_needed();            
+                    stream_load_ema.update_ema_if_needed();
                     break 'conn;
                 }
             }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1167,6 +1167,8 @@ async fn handle_connection(
                         CONNECTION_CLOSE_CODE_INVALID_STREAM.into(),
                         CONNECTION_CLOSE_REASON_INVALID_STREAM,
                     );
+                    stats.total_streams.fetch_sub(1, Ordering::Relaxed);
+                    stream_load_ema.update_ema_if_needed();            
                     break 'conn;
                 }
             }


### PR DESCRIPTION
#### Problem
It is found that active_streams is none zero even after no connections to the server. This is due to we missed updating metrics in case of connection error when handling chunks.

#### Summary of Changes
Update metrics and ema before break conn loop.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
