### PR TITLE
Replaces static mutable references in entry

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -63,8 +63,9 @@ fn init(name: &OsStr) {
             name
         };
 
-        if let Ok(api) = unsafe { Container::load(lib_name) } {
-            _ = API.set(api);
+        match unsafe { Container::load(lib_name) } {
+            Ok(api) => _ = API.set(api),
+            Err(err) => error!("Unable to load {lib_name:?}: {err}"),
         }
     })
 }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -32,7 +32,7 @@ use {
         cmp,
         ffi::OsStr,
         iter::repeat_with,
-        sync::{Arc, Mutex, Once},
+        sync::{Arc, Mutex, Once, OnceLock},
         thread::{self, JoinHandle},
         time::Instant,
     },
@@ -41,7 +41,7 @@ use {
 pub type EntrySender = Sender<Vec<Entry>>;
 pub type EntryReceiver = Receiver<Vec<Entry>>;
 
-static mut API: Option<Container<Api>> = None;
+static API: OnceLock<Container<Api>> = OnceLock::new();
 
 pub fn init_poh() {
     init(OsStr::new("libpoh-simd.so"));
@@ -51,23 +51,22 @@ fn init(name: &OsStr) {
     static INIT_HOOK: Once = Once::new();
 
     info!("Loading {:?}", name);
-    unsafe {
-        INIT_HOOK.call_once(|| {
-            let path;
-            let lib_name = if let Some(perf_libs_path) = solana_perf::perf_libs::locate_perf_libs()
-            {
-                solana_perf::perf_libs::append_to_ld_library_path(
-                    perf_libs_path.to_str().unwrap_or("").to_string(),
-                );
-                path = perf_libs_path.join(name);
-                path.as_os_str()
-            } else {
-                name
-            };
+    INIT_HOOK.call_once(|| {
+        let path;
+        let lib_name = if let Some(perf_libs_path) = solana_perf::perf_libs::locate_perf_libs() {
+            solana_perf::perf_libs::append_to_ld_library_path(
+                perf_libs_path.to_str().unwrap_or("").to_string(),
+            );
+            path = perf_libs_path.join(name);
+            path.as_os_str()
+        } else {
+            name
+        };
 
-            API = Container::load(lib_name).ok();
-        })
-    }
+        if let Ok(api) = unsafe { Container::load(lib_name) } {
+            _ = API.set(api);
+        }
+    })
 }
 
 pub fn api() -> Option<&'static Container<Api<'static>>> {
@@ -77,10 +76,10 @@ pub fn api() -> Option<&'static Container<Api<'static>>> {
             if std::env::var("TEST_PERF_LIBS").is_ok() {
                 init_poh()
             }
-        })
+        });
     }
 
-    unsafe { API.as_ref() }
+    API.get()
 }
 
 #[derive(SymBorApi)]


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

Some are related to creating references to mutable statics. Here's the new lint for `entry`:

```
warning: creating a shared reference to mutable static is discouraged
  --> entry/src/entry.rs:83:14
   |
83 |     unsafe { API.as_ref() }
   |              ^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
   = note: `#[warn(static_mut_refs)]` on by default
```


#### Summary of Changes

Replace `Once` with `OnceLock` for the API, as it is the preferred way to do `Once`+data.

Partially fixes #4380