### PR TITLE
integrating vortexor with sigverifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10285,6 +10285,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "solana-clap-utils",
+ "solana-core",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -267,7 +267,7 @@ impl BankingTracer {
         Self::channel(label, self.active_tracer.as_ref().cloned())
     }
 
-    fn create_channel_non_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
+    pub fn create_channel_non_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
         self.create_channel(ChannelLabel::NonVote)
     }
 

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -35,6 +35,7 @@ rustls = { workspace = true }
 smallvec = { workspace = true }
 socket2 = { workspace = true }
 solana-clap-utils = { workspace = true }
+solana-core = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -1,6 +1,6 @@
 use {
     clap::{value_t, value_t_or_exit},
-    crossbeam_channel::unbounded,
+    crossbeam_channel::bounded,
     solana_clap_utils::input_parsers::keypair_of,
     solana_core::banking_trace::BankingTracer,
     solana_sdk::net::DEFAULT_TPU_COALESCE,
@@ -14,6 +14,8 @@ use {
         time::Duration,
     },
 };
+
+const DEFAULT_CHANNEL_SIZE: usize = 100_000;
 
 pub fn main() {
     let default_args = DefaultArgs::default();
@@ -54,8 +56,8 @@ pub fn main() {
     let max_streams_per_ms = value_t_or_exit!(matches, "max_streams_per_ms", u64);
     let exit = Arc::new(AtomicBool::new(false));
     // To be linked with the Tpu sigverify and forwarder service
-    let (tpu_sender, tpu_receiver) = unbounded();
-    let (tpu_fwd_sender, _tpu_fwd_receiver) = unbounded();
+    let (tpu_sender, tpu_receiver) = bounded(DEFAULT_CHANNEL_SIZE);
+    let (tpu_fwd_sender, _tpu_fwd_receiver) = bounded(DEFAULT_CHANNEL_SIZE);
 
     let tpu_sockets =
         Vortexor::create_tpu_sockets(bind_address, dynamic_port_range, num_quic_endpoints);

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -60,7 +60,10 @@ pub fn main() {
     let tpu_sockets =
         Vortexor::create_tpu_sockets(bind_address, dynamic_port_range, num_quic_endpoints);
 
-    let (banking_tracer, _) = BankingTracer::new(None).unwrap();
+    let (banking_tracer, _) = BankingTracer::new(
+        None, // Not interesed in banking tracing
+    )
+    .unwrap();
 
     // The _non_vote_receiver will forward the verified transactions to its configured validator
     let (non_vote_sender, _non_vote_receiver) = banking_tracer.create_channel_non_vote();

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -1,5 +1,9 @@
 use {
-    crossbeam_channel::Sender,
+    crossbeam_channel::{Receiver, Sender},
+    solana_core::{
+        banking_trace::TracedSender, sigverify::TransactionSigVerifier,
+        sigverify_stage::SigVerifyStage,
+    },
     solana_net_utils::{bind_in_range_with_config, bind_more_with_config, SocketConfig},
     solana_perf::packet::PacketBatch,
     solana_sdk::{quic::NotifyKeyUpdate, signature::Keypair},
@@ -86,6 +90,16 @@ impl Vortexor {
             tpu_quic,
             tpu_quic_fwd,
         }
+    }
+
+    pub fn create_sigverify_stage(
+        tpu_receiver: Receiver<solana_perf::packet::PacketBatch>,
+        non_vote_sender: TracedSender,
+    ) -> SigVerifyStage {
+        // Not interesed of banking tracing
+
+        let verifier = TransactionSigVerifier::new(non_vote_sender);
+        SigVerifyStage::new(tpu_receiver, verifier, "solSigVerTpu", "tpu-verifier")
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -99,7 +99,12 @@ impl Vortexor {
         // Not interesed of banking tracing
 
         let verifier = TransactionSigVerifier::new(non_vote_sender);
-        SigVerifyStage::new(tpu_receiver, verifier, "solSigVerTpu", "tpu-verifier")
+        SigVerifyStage::new(
+            tpu_receiver,
+            verifier,
+            "solSigVtxTpu",
+            "tpu-vortexor-verifier",
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -96,8 +96,6 @@ impl Vortexor {
         tpu_receiver: Receiver<solana_perf::packet::PacketBatch>,
         non_vote_sender: TracedSender,
     ) -> SigVerifyStage {
-        // Not interesed of banking tracing
-
         let verifier = TransactionSigVerifier::new(non_vote_sender);
         SigVerifyStage::new(
             tpu_receiver,


### PR DESCRIPTION
sigverify integration for vortexor.

#### Problem


#### Summary of Changes
sigverify integration for vortexor.

Note the sigverify is only called and the packets sent to the dummy receiver. In next PR we will integrate a sender which will send the verified packets to the Validator side.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
