### PR TITLE
make solana-metrics optional in vote and stake programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -590,7 +590,7 @@ solana-send-transaction-service = { path = "send-transaction-service", version =
 solana-short-vec = { path = "sdk/short-vec", version = "=2.2.0" }
 solana-shred-version = { path = "sdk/shred-version", version = "=2.2.0" }
 solana-stable-layout = { path = "sdk/stable-layout", version = "=2.2.0" }
-solana-stake-program = { path = "programs/stake", version = "=2.2.0" }
+solana-stake-program = { path = "programs/stake", version = "=2.2.0", default-features = false }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.0" }
 solana-storage-proto = { path = "storage-proto", version = "=2.2.0" }
 solana-streamer = { path = "streamer", version = "=2.2.0" }
@@ -619,7 +619,7 @@ solana-udp-client = { path = "udp-client", version = "=2.2.0" }
 solana-validator-exit = { path = "sdk/validator-exit", version = "=2.2.0" }
 solana-version = { path = "version", version = "=2.2.0" }
 solana-vote = { path = "vote", version = "=2.2.0" }
-solana-vote-program = { path = "programs/vote", version = "=2.2.0" }
+solana-vote-program = { path = "programs/vote", version = "=2.2.0", default-features = false }
 solana-wen-restart = { path = "wen-restart", version = "=2.2.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.0" }
 solana-zk-keygen = { path = "zk-keygen", version = "=2.2.0" }

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -19,7 +19,7 @@ solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
 solana-type-overrides = { workspace = true }
-solana-vote-program = { workspace = true }
+solana-vote-program = { workspace = true, default-features = false }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -28,6 +28,10 @@ proptest = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-logger = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+default = ["metrics"]
+metrics = ["solana-vote-program/metrics"]
 
 [lib]
 crate-type = ["lib"]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -30,7 +30,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-metrics = { workspace = true }
+solana-metrics = { workspace = true, optional = true }
 solana-packet = { workspace = true }
 solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
@@ -58,12 +58,14 @@ name = "solana_vote_program"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+default = ["metrics"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-program/frozen-abi",
     "solana-program-runtime/frozen-abi"
 ]
+metrics = ["dep:solana-metrics"]
 
 [lints]
 workspace = true

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -4,7 +4,8 @@ pub mod vote_processor;
 pub mod vote_state;
 pub mod vote_transaction;
 
-#[macro_use]
+#[cfg_attr(feature = "metrics", macro_use)]
+#[cfg(feature = "metrics")]
 extern crate solana_metrics;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -397,6 +397,7 @@ fn check_and_filter_proposed_vote_state(
             proposed_hash,
             slot_hashes[slot_hashes_index].1
         );
+        #[cfg(feature = "metrics")]
         inc_new_counter_info!("dropped-vote-hash", 1);
         return Err(VoteError::SlotHashMismatch);
     }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7791,7 +7791,6 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-metrics",
  "solana-packet",
  "solana-program",
  "solana-program-runtime",


### PR DESCRIPTION
#### Problem
LiteSVM depends on these crates, and their dependency on solana-metrics harms compile times and portability significantly. The vote program uses metrics directly, while the stake program merely depends on solana-metrics crate via its solana-vote-program dependency.

#### Summary of Changes
- Put the one usage of solana-metrics in solana-vote-program behind a feature flag
- Add a metrics feature to the vote and stake programs, and enable it by default
- Add `default-features = false` to the workspace Cargo.toml entries for the vote and stake programs. This is required to allow people to disable default features. This does not actually disable default features for other workspace dependents unless they each individually disable default features. More info here: https://doc.rust-lang.org/edition-guide/rust-2024/cargo-inherited-default-features.html