### PR TITLE
removes Option<...> wrapper from retransmit-sender in blockstore

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -347,7 +347,7 @@ where
         repairs,
         Some(leader_schedule_cache),
         false, // is_trusted
-        Some(retransmit_sender),
+        retransmit_sender,
         &handle_duplicate,
         reed_solomon_cache,
         metrics,
@@ -708,6 +708,7 @@ mod test {
             let _ = duplicate_shred_sender.send(shred);
         };
         let num_trials = 100;
+        let (dummy_retransmit_sender, _) = crossbeam_channel::bounded(0);
         for slot in 0..num_trials {
             let (shreds, _) = make_many_slot_entries(slot, 1, 10);
             let duplicate_index = 0;
@@ -724,7 +725,7 @@ mod test {
                     vec![false, false],
                     None,
                     false, // is_trusted
-                    None,
+                    &dummy_retransmit_sender,
                     &handle_duplicate,
                     &ReedSolomonCache::default(),
                     &mut BlockstoreInsertionMetrics::default(),


### PR DESCRIPTION

#### Problem
When inserting shreds into blockstore, the retransmit-sender is `None` only in tests. 


#### Summary of Changes
Instead of wrapping the channel in `Option<...>`, this commit uses a dummy sender channel for tests. Doing so will simplify the code and does not add any overhead to the prod runtime just to handle tests.
