### PR TITLE
use solana-instruction instead of solana-sdk in solana-stake-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9296,6 +9296,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-config-program",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-logger",
  "solana-program-runtime",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7853,6 +7853,7 @@ dependencies = [
  "solana-account",
  "solana-config-program",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
  "solana-pubkey",

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true }
 solana-account = { workspace = true }
 solana-config-program = { workspace = true }
 solana-feature-set = { workspace = true }
+solana-instruction = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -3,11 +3,11 @@ use {
     criterion::{black_box, criterion_group, criterion_main, Criterion},
     solana_account::{create_account_shared_data_for_test, AccountSharedData, WritableAccount},
     solana_feature_set::FeatureSet,
+    solana_instruction::AccountMeta,
     solana_program_runtime::invoke_context::mock_process_instruction,
     solana_pubkey::Pubkey,
     solana_sdk::{
         clock::{Clock, Epoch},
-        instruction::AccountMeta,
         stake::{
             instruction::{
                 self, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs,

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -2,10 +2,10 @@
 //! Used by `solana-runtime`.
 
 use {
+    solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
     solana_sdk::{
         clock::Epoch,
-        instruction::InstructionError,
         stake::state::{Delegation, Stake, StakeStateV2},
         stake_history::StakeHistory,
     },

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -7,10 +7,10 @@ use {
         PointValue, SkippedReason,
     },
     solana_account::{AccountSharedData, WritableAccount},
+    solana_instruction::error::InstructionError,
     solana_sdk::{
         account_utils::StateMut,
         clock::Epoch,
-        instruction::InstructionError,
         stake::{
             instruction::StakeError,
             state::{Stake, StakeStateV2},

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -5,12 +5,12 @@ use {
         withdraw,
     },
     log::*,
+    solana_instruction::error::InstructionError,
     solana_program_runtime::{
         declare_process_instruction, sysvar_cache::get_sysvar_with_account_check,
     },
     solana_pubkey::Pubkey,
     solana_sdk::{
-        instruction::InstructionError,
         program_utils::limited_deserialize,
         stake::{
             instruction::{LockupArgs, StakeError, StakeInstruction},
@@ -395,12 +395,12 @@ mod tests {
             ReadableAccount, WritableAccount,
         },
         solana_feature_set::FeatureSet,
+        solana_instruction::{AccountMeta, Instruction},
         solana_program_runtime::invoke_context::mock_process_instruction,
         solana_pubkey::Pubkey,
         solana_sdk::{
             clock::{Clock, Epoch, UnixTimestamp},
             epoch_schedule::EpochSchedule,
-            instruction::{AccountMeta, Instruction},
             rent::Rent,
             stake::{
                 config as stake_config,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -11,12 +11,12 @@ pub use solana_sdk::stake::state::*;
 use {
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},
     solana_feature_set::FeatureSet,
+    solana_instruction::error::InstructionError,
     solana_log_collector::ic_msg,
     solana_program_runtime::invoke_context::InvokeContext,
     solana_pubkey::Pubkey,
     solana_sdk::{
         clock::{Clock, Epoch},
-        instruction::{checked_add, InstructionError},
         rent::Rent,
         stake::{
             instruction::{LockupArgs, StakeError},
@@ -66,6 +66,10 @@ pub(crate) fn new_warmup_cooldown_rate_epoch(invoke_context: &InvokeContext) -> 
     invoke_context
         .get_feature_set()
         .new_warmup_cooldown_rate_epoch(epoch_schedule.as_ref())
+}
+
+fn checked_add(a: u64, b: u64) -> Result<u64, InstructionError> {
+    a.checked_add(b).ok_or(InstructionError::InsufficientFunds)
 }
 
 fn get_stake_status(

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7182,6 +7182,7 @@ dependencies = [
  "solana-account",
  "solana-config-program",
  "solana-feature-set",
+ "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
  "solana-pubkey",


### PR DESCRIPTION
Same idea as #4327

This program uses the one-line utility function `checked_add` which is in solana-program but not in solana-instruction. I just copied it to this crate as was already done with the system program and address lookup table program