### PR TITLE
tpu-client-next: add mechanism to implement custom scheduler

### DIFF
--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -159,15 +159,13 @@ impl ConnectionWorkersScheduler {
     /// Starts the scheduler, which manages the distribution of transactions to
     /// the network's upcoming leaders.
     ///
-    /// Runs the main loop that handles worker scheduling and management for
-    /// connections. Returns the error quic statistics per connection address or
-    /// an error along with receiver for transactions. The receiver returned
-    /// back to the user because in some cases we need to re-utilize the same
-    /// receiver for the new scheduler. For example, this happens when the
-    /// identity for the validator is updated.
+    /// This method is a shorthand for
+    /// [`ConnectionWorkersScheduler::run_with_broadcaster`] using
+    /// [`NonblockingBroadcaster`] strategy.
     ///
-    /// Importantly, if some transactions were not delivered due to network
-    /// problems, they will not be retried when the problem is resolved.
+    /// Transactions that fail to be delivered to workers due to full channels
+    /// will be dropped. The same for transactions that failed to be delivered
+    /// over the network.
     pub async fn run(
         config: ConnectionWorkersSchedulerConfig,
         leader_updater: Box<dyn LeaderUpdater>,
@@ -183,6 +181,19 @@ impl ConnectionWorkersScheduler {
         .await
     }
 
+    /// Starts the scheduler, which manages the distribution of transactions to
+    /// the network's upcoming leaders. `Broadcaster` allows to customize the
+    /// way transactions are send to the leaders, see [`WorkersBroadcaster`].
+    ///
+    /// Runs the main loop that handles worker scheduling and management for
+    /// connections. Returns the error quic statistics per connection address or
+    /// an error along with receiver for transactions. The receiver returned
+    /// back to the user because in some cases we need to re-utilize the same
+    /// receiver for the new scheduler. For example, this happens when the
+    /// identity for the validator is updated.
+    ///
+    /// Importantly, if some transactions were not delivered due to network
+    /// problems, they will not be retried when the problem is resolved.
     pub async fn run_with_broadcaster<Broadcaster: WorkersBroadcaster>(
         ConnectionWorkersSchedulerConfig {
             bind,

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -92,7 +92,7 @@ pub struct ConnectionWorkersSchedulerConfig {
 }
 
 #[async_trait]
-pub trait WorkersBroadcast {
+pub trait WorkersBroadcaster {
     async fn send_to_workers(
         workers: &mut WorkersCache,
         leaders: &[SocketAddr],
@@ -100,9 +100,10 @@ pub trait WorkersBroadcast {
     ) -> Result<(), ConnectionWorkersSchedulerError>;
 }
 
-struct WorkersBroadcasterWithoutBackpressure;
+struct NonblockingBroadcaster;
 
-impl WorkersBroadcast for WorkersBroadcasterWithoutBackpressure {
+#[async_trait]
+impl WorkersBroadcaster for NonblockingBroadcaster {
     async fn send_to_workers(
         workers: &mut WorkersCache,
         leaders: &[SocketAddr],

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -1,7 +1,7 @@
 pub(crate) mod connection_worker;
 pub mod connection_workers_scheduler;
 pub mod send_transaction_stats;
-pub(crate) mod workers_cache;
+pub mod workers_cache;
 pub use crate::{
     connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
     send_transaction_stats::{SendTransactionStats, SendTransactionStatsPerAddr},

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -7,7 +7,7 @@ use {
     },
     solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS},
     solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
-    solana_tls_utils::tls_client_config_builder,
+    solana_tls_utils::SkipServerVerification,
     std::{net::SocketAddr, sync::Arc},
 };
 
@@ -20,7 +20,9 @@ pub use {
 
 pub(crate) fn create_client_config(client_certificate: QuicClientCertificate) -> ClientConfig {
     // adapted from QuicLazyInitializedEndpoint::create_endpoint
-    let mut crypto = tls_client_config_builder()
+    let mut crypto = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
         .with_client_auth_cert(
             vec![client_certificate.certificate.clone()],
             client_certificate.key.clone_key(),

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -7,7 +7,7 @@ use {
     },
     solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS},
     solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
-    solana_tls_utils::SkipServerVerification,
+    solana_tls_utils::tls_client_config_builder,
     std::{net::SocketAddr, sync::Arc},
 };
 
@@ -20,9 +20,7 @@ pub use {
 
 pub(crate) fn create_client_config(client_certificate: QuicClientCertificate) -> ClientConfig {
     // adapted from QuicLazyInitializedEndpoint::create_endpoint
-    let mut crypto = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(SkipServerVerification::new())
+    let mut crypto = tls_client_config_builder()
         .with_client_auth_cert(
             vec![client_certificate.certificate.clone()],
             client_certificate.key.clone_key(),

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -101,7 +101,7 @@ impl WorkersCache {
         }
     }
 
-    pub(crate) fn contains(&self, peer: &SocketAddr) -> bool {
+    pub fn contains(&self, peer: &SocketAddr) -> bool {
         self.workers.contains(peer)
     }
 
@@ -119,7 +119,7 @@ impl WorkersCache {
         None
     }
 
-    pub(crate) fn pop(&mut self, leader: SocketAddr) -> Option<ShutdownWorker> {
+    pub fn pop(&mut self, leader: SocketAddr) -> Option<ShutdownWorker> {
         if let Some(popped_worker) = self.workers.pop(&leader) {
             return Some(ShutdownWorker {
                 leader,
@@ -228,7 +228,7 @@ impl WorkersCache {
 /// [`ShutdownWorker`] takes care of stopping the worker. It's method
 /// `shutdown()` should be executed in a separate task to hide the latency of
 /// finishing worker gracefully.
-pub(crate) struct ShutdownWorker {
+pub struct ShutdownWorker {
     leader: SocketAddr,
     worker: WorkerInfo,
 }
@@ -243,7 +243,7 @@ impl ShutdownWorker {
     }
 }
 
-pub(crate) fn maybe_shutdown_worker(worker: Option<ShutdownWorker>) {
+pub fn maybe_shutdown_worker(worker: Option<ShutdownWorker>) {
     let Some(worker) = worker else {
         return;
     };

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -17,7 +17,7 @@ use {
 
 /// [`WorkerInfo`] holds information about a worker responsible for sending
 /// transaction batches.
-pub(crate) struct WorkerInfo {
+pub struct WorkerInfo {
     sender: mpsc::Sender<TransactionBatch>,
     handle: JoinHandle<()>,
     cancel: CancellationToken,
@@ -69,11 +69,11 @@ impl WorkerInfo {
 
 /// [`WorkersCache`] manages and caches workers. It uses an LRU cache to store and
 /// manage workers. It also tracks transaction statistics for each peer.
-pub(crate) struct WorkersCache {
+pub struct WorkersCache {
     workers: LruCache<SocketAddr, WorkerInfo>,
 
     /// Indicates that the `WorkersCache` is been `shutdown()`, interrupting any outstanding
-    /// `send_txs()` invocations.
+    /// `send_transactions_to_address()` invocations.
     cancel: CancellationToken,
 }
 
@@ -130,7 +130,7 @@ impl WorkersCache {
     }
 
     /// Try sending a batch of transactions to the worker for a given peer.
-    pub(crate) fn try_send_transactions_to_address(
+    pub fn try_send_transactions_to_address(
         &mut self,
         peer: &SocketAddr,
         txs_batch: TransactionBatch,
@@ -195,6 +195,7 @@ impl WorkersCache {
 
             send_res
         };
+
         cancel
             .run_until_cancelled(body)
             .await


### PR DESCRIPTION
#### Problem

The current scheduler implementation works for SendTransactionService or similar applications where the client checks if the transaction has been added to the block and retries when necessary. But for some other applications, like transaction-bench client, we want to have a custom strategy. For example, a combination of try_send and send to some future leaders.

This PR introduces trait that implements most of the logic except one method `send_to_workers`, which should be implemented by user. 

For the sake of backport simplicity, should be added after https://github.com/anza-xyz/agave/pull/4454

#### Summary of Changes

