### PR TITLE
LocalCluster - rename, refactor consts, verify initial transfers

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1432,7 +1432,7 @@ pub mod test {
         initialize_and_add_secondary_indexes(&mut validator_config);
         let num_nodes = 1;
         let mut config = ClusterConfig {
-            cluster_lamports: 10_000_000,
+            mint_lamports: 10_000_000,
             poh_config: PohConfig::new_sleep(Duration::from_millis(50)),
             node_stakes: vec![100; num_nodes],
             validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
@@ -1482,7 +1482,7 @@ pub mod test {
         initialize_and_add_secondary_indexes(&mut validator_config);
         let num_nodes = 1;
         let mut config = ClusterConfig {
-            cluster_lamports: 10_000_000,
+            mint_lamports: 10_000_000,
             poh_config: PohConfig::new_sleep(Duration::from_millis(50)),
             node_stakes: vec![100; num_nodes],
             validator_configs: make_identical_validator_configs(&validator_config, num_nodes),

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -58,7 +58,7 @@ fn test_bench_tps_local_cluster(config: Config) {
     let cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![999_990; NUM_NODES],
-            cluster_lamports: 200_000_000,
+            mint_lamports: 200_000_000,
             validator_configs: make_identical_validator_configs(
                 &ValidatorConfig {
                     rpc_config: JsonRpcConfig {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -1079,7 +1079,7 @@ pub mod test {
         let cluster = LocalCluster::new(
             &mut ClusterConfig {
                 node_stakes: vec![999_990; num_nodes],
-                cluster_lamports: 200_000_000,
+                mint_lamports: 200_000_000,
                 validator_configs: make_identical_validator_configs(
                     &ValidatorConfig {
                         rpc_config: JsonRpcConfig {

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -63,7 +63,6 @@ use {
 pub const RUST_LOG_FILTER: &str =
     "error,solana_core::replay_stage=warn,solana_local_cluster=info,local_cluster=info";
 
-pub const DEFAULT_MINT_LAMPORTS: u64 = 10_000_000 * LAMPORTS_PER_SOL;
 pub const DEFAULT_NODE_STAKE: u64 = 10 * LAMPORTS_PER_SOL;
 
 pub fn last_vote_in_tower(tower_path: &Path, node_pubkey: &Pubkey) -> Option<(Slot, Hash)> {

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -63,7 +63,7 @@ use {
 pub const RUST_LOG_FILTER: &str =
     "error,solana_core::replay_stage=warn,solana_local_cluster=info,local_cluster=info";
 
-pub const DEFAULT_CLUSTER_LAMPORTS: u64 = 10_000_000 * LAMPORTS_PER_SOL;
+pub const DEFAULT_MINT_LAMPORTS: u64 = 10_000_000 * LAMPORTS_PER_SOL;
 pub const DEFAULT_NODE_STAKE: u64 = 10 * LAMPORTS_PER_SOL;
 
 pub fn last_vote_in_tower(tower_path: &Path, node_pubkey: &Pubkey) -> Option<(Slot, Hash)> {
@@ -319,7 +319,7 @@ pub fn run_cluster_partition<C>(
         .map(|stake_weight| 100 * *stake_weight as u64)
         .collect();
     assert_eq!(node_stakes.len(), num_nodes);
-    let cluster_lamports = node_stakes.iter().sum::<u64>() * 2;
+    let mint_lamports = node_stakes.iter().sum::<u64>() * 2;
     let turbine_disabled = Arc::new(AtomicBool::new(false));
     let mut validator_config = ValidatorConfig {
         turbine_disabled: turbine_disabled.clone(),
@@ -351,7 +351,7 @@ pub fn run_cluster_partition<C>(
 
     let slots_per_epoch = 2048;
     let mut config = ClusterConfig {
-        cluster_lamports,
+        mint_lamports,
         node_stakes,
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
         validator_keys: Some(
@@ -490,7 +490,7 @@ pub fn test_faulty_node(
     }
 
     let mut cluster_config = ClusterConfig {
-        cluster_lamports: 10_000,
+        mint_lamports: 10_000,
         node_stakes,
         validator_configs,
         validator_keys: Some(validator_keys.clone()),

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -85,8 +85,8 @@ pub struct ClusterConfig {
     pub node_stakes: Vec<u64>,
     /// Optional vote keypairs to use for each node
     pub node_vote_keys: Option<Vec<Arc<Keypair>>>,
-    /// The total lamports available to the cluster
-    pub cluster_lamports: u64,
+    /// The number of lamports in the mint account
+    pub mint_lamports: u64,
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
@@ -103,12 +103,12 @@ pub struct ClusterConfig {
 impl ClusterConfig {
     pub fn new_with_equal_stakes(
         num_nodes: usize,
-        cluster_lamports: u64,
+        mint_lamports: u64,
         lamports_per_node: u64,
     ) -> Self {
         Self {
             node_stakes: vec![lamports_per_node; num_nodes],
-            cluster_lamports,
+            mint_lamports,
             validator_configs: make_identical_validator_configs(
                 &ValidatorConfig::default_for_test(),
                 num_nodes,
@@ -126,7 +126,7 @@ impl Default for ClusterConfig {
             validator_keys: None,
             node_stakes: vec![],
             node_vote_keys: None,
-            cluster_lamports: 0,
+            mint_lamports: 0,
             ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
             slots_per_epoch: DEFAULT_DEV_SLOTS_PER_EPOCH,
             stakers_slot_offset: DEFAULT_DEV_SLOTS_PER_EPOCH,
@@ -155,16 +155,12 @@ pub struct LocalCluster {
 impl LocalCluster {
     pub fn new_with_equal_stakes(
         num_nodes: usize,
-        cluster_lamports: u64,
+        mint_lamports: u64,
         lamports_per_node: u64,
         socket_addr_space: SocketAddrSpace,
     ) -> Self {
         Self::new(
-            &mut ClusterConfig::new_with_equal_stakes(
-                num_nodes,
-                cluster_lamports,
-                lamports_per_node,
-            ),
+            &mut ClusterConfig::new_with_equal_stakes(num_nodes, mint_lamports, lamports_per_node),
             socket_addr_space,
         )
     }
@@ -292,7 +288,7 @@ impl LocalCluster {
             mint_keypair,
             ..
         } = create_genesis_config_with_vote_accounts_and_cluster_type(
-            config.cluster_lamports,
+            config.mint_lamports,
             &keys_in_genesis,
             stakes_in_genesis,
             config.cluster_type,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -35,6 +35,7 @@ use {
         epoch_schedule::EpochSchedule,
         genesis_config::{ClusterType, GenesisConfig},
         message::Message,
+        native_token::LAMPORTS_PER_SOL,
         poh_config::PohConfig,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
@@ -68,6 +69,7 @@ use {
     },
 };
 
+pub const DEFAULT_MINT_LAMPORTS: u64 = 10_000_000 * LAMPORTS_PER_SOL;
 const DUMMY_SNAPSHOT_CONFIG_PATH_MARKER: &str = "dummy";
 
 pub struct ClusterConfig {
@@ -126,7 +128,7 @@ impl Default for ClusterConfig {
             validator_keys: None,
             node_stakes: vec![],
             node_vote_keys: None,
-            mint_lamports: 0,
+            mint_lamports: DEFAULT_MINT_LAMPORTS,
             ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
             slots_per_epoch: DEFAULT_DEV_SLOTS_PER_EPOCH,
             stakers_slot_offset: DEFAULT_DEV_SLOTS_PER_EPOCH,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -288,7 +288,7 @@ impl LocalCluster {
 
         // Verify mint has enough lamports to fund all required validators.
         assert!(
-            config.mint_lamports > required_mint_lamports,
+            config.mint_lamports >= required_mint_lamports,
             "mint requires additional lamports to fund validators"
         );
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -41,7 +41,7 @@ use {
             run_cluster_partition, run_kill_partition_switch_threshold, save_tower,
             setup_snapshot_validator_config, test_faulty_node, wait_for_duplicate_proof,
             wait_for_last_vote_in_tower_to_land_in_ledger, SnapshotValidatorConfig,
-            ValidatorTestConfig, DEFAULT_CLUSTER_LAMPORTS, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
+            ValidatorTestConfig, DEFAULT_MINT_LAMPORTS, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
         },
         local_cluster::{ClusterConfig, LocalCluster},
         validator_configs::*,
@@ -108,7 +108,7 @@ fn test_local_cluster_start_and_exit() {
     let num_nodes = 1;
     let cluster = LocalCluster::new_with_equal_stakes(
         num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
+        DEFAULT_MINT_LAMPORTS,
         DEFAULT_NODE_STAKE,
         SocketAddrSpace::Unspecified,
     );
@@ -126,7 +126,7 @@ fn test_local_cluster_start_and_exit_with_config() {
             NUM_NODES,
         ),
         node_stakes: vec![DEFAULT_NODE_STAKE; NUM_NODES],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         ticks_per_slot: 8,
         slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH,
         stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH,
@@ -144,7 +144,7 @@ fn test_spend_and_verify_all_nodes_1() {
     let num_nodes = 1;
     let local = LocalCluster::new_with_equal_stakes(
         num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
+        DEFAULT_MINT_LAMPORTS,
         DEFAULT_NODE_STAKE,
         SocketAddrSpace::Unspecified,
     );
@@ -166,7 +166,7 @@ fn test_spend_and_verify_all_nodes_2() {
     let num_nodes = 2;
     let local = LocalCluster::new_with_equal_stakes(
         num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
+        DEFAULT_MINT_LAMPORTS,
         DEFAULT_NODE_STAKE,
         SocketAddrSpace::Unspecified,
     );
@@ -188,7 +188,7 @@ fn test_spend_and_verify_all_nodes_3() {
     let num_nodes = 3;
     let local = LocalCluster::new_with_equal_stakes(
         num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
+        DEFAULT_MINT_LAMPORTS,
         DEFAULT_NODE_STAKE,
         SocketAddrSpace::Unspecified,
     );
@@ -209,7 +209,7 @@ fn test_local_cluster_signature_subscribe() {
     let num_nodes = 2;
     let cluster = LocalCluster::new_with_equal_stakes(
         num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
+        DEFAULT_MINT_LAMPORTS,
         DEFAULT_NODE_STAKE,
         SocketAddrSpace::Unspecified,
     );
@@ -299,7 +299,7 @@ fn test_two_unbalanced_stakes() {
     let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![DEFAULT_NODE_STAKE * 100, DEFAULT_NODE_STAKE],
-            cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
+            mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
             validator_configs: make_identical_validator_configs(&validator_config, 2),
             ticks_per_slot: num_ticks_per_slot,
             slots_per_epoch: num_slots_per_epoch,
@@ -330,7 +330,7 @@ fn test_forwarding() {
     // will be have to be forwarded in order to be confirmed
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE * 100, DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
+        mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
             2,
@@ -376,7 +376,7 @@ fn test_restart_node() {
     let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![DEFAULT_NODE_STAKE],
-            cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+            mint_lamports: DEFAULT_MINT_LAMPORTS,
             validator_configs: vec![safe_clone_config(&validator_config)],
             ticks_per_slot,
             slots_per_epoch,
@@ -417,7 +417,7 @@ fn test_mainnet_beta_cluster_type() {
     let mut config = ClusterConfig {
         cluster_type: ClusterType::MainnetBeta,
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
             1,
@@ -494,7 +494,7 @@ fn test_snapshot_download() {
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -580,7 +580,7 @@ fn test_incremental_snapshot_download() {
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -758,7 +758,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -1239,7 +1239,7 @@ fn test_snapshot_restart_tower() {
 
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE * 100, DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
+        mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         validator_configs: vec![
             safe_clone_config(&leader_snapshot_test_config.validator_config),
             safe_clone_config(&validator_snapshot_test_config.validator_config),
@@ -1319,7 +1319,7 @@ fn test_snapshots_blockstore_floor() {
 
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -1431,7 +1431,7 @@ fn test_snapshots_restart_validity() {
     )];
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &snapshot_test_config.validator_config,
             1,
@@ -1564,7 +1564,7 @@ fn test_wait_for_max_stake() {
     let ticks_per_slot = 32;
     let num_validators = 4;
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE; num_validators],
         validator_configs: make_identical_validator_configs(&validator_config, num_validators),
         slots_per_epoch,
@@ -1610,7 +1610,7 @@ fn test_no_voting() {
         ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE],
         validator_configs: vec![validator_config],
         ..ClusterConfig::default()
@@ -1664,7 +1664,7 @@ fn test_optimistic_confirmation_violation_detection() {
     let node_to_restart = validator_keys[1].0.pubkey();
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -1887,7 +1887,7 @@ fn test_validator_saves_tower() {
     let validator_identity_keypair = Arc::new(Keypair::new());
     let validator_id = validator_identity_keypair.pubkey();
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE],
         validator_configs: vec![validator_config],
         validator_keys: Some(vec![(validator_identity_keypair.clone(), true)]),
@@ -2060,7 +2060,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
     };
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
+        mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -2225,7 +2225,7 @@ fn test_hard_fork_invalidates_tower() {
     let validator_b_pubkey = validators[1];
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -2399,7 +2399,7 @@ fn test_hard_fork_with_gap_in_roots() {
         ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
-        cluster_lamports: 100_000,
+        mint_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(&validator_config, node_stakes.len()),
         validator_keys: Some(validator_keys),
@@ -2559,7 +2559,7 @@ fn test_restart_tower_rollback() {
     let b_pubkey = validator_keys[1].0.pubkey();
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + DEFAULT_NODE_STAKE * 100,
+        mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -2712,7 +2712,7 @@ fn test_rpc_block_subscribe() {
     let rpc_node_pubkey = &validator_keys[1].0.pubkey();
 
     let mut config = ClusterConfig {
-        cluster_lamports: total_stake,
+        mint_lamports: total_stake,
         node_stakes,
         validator_configs: make_identical_validator_configs(&validator_config, 2),
         validator_keys: Some(validator_keys),
@@ -2794,7 +2794,7 @@ fn test_oc_bad_signatures() {
 
     let our_id = validator_keys.last().unwrap().0.pubkey();
     let mut config = ClusterConfig {
-        cluster_lamports: total_stake,
+        mint_lamports: total_stake,
         node_stakes,
         validator_configs: make_identical_validator_configs(&validator_config, 2),
         validator_keys: Some(validator_keys),
@@ -3164,7 +3164,7 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
     );
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -3321,7 +3321,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     });
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes,
         validator_configs,
         validator_keys: Some(validator_keys),
@@ -4351,7 +4351,7 @@ fn test_switch_threshold_uses_gossip_votes() {
 fn test_listener_startup() {
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         num_listeners: 3,
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -4478,7 +4478,7 @@ fn test_leader_failure_4() {
     // not generating leader schedule, and stalling the cluster.
     let skip_warmup_slots = true;
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE; num_nodes],
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
         validator_keys,
@@ -4562,7 +4562,7 @@ fn test_slot_hash_expiry() {
     validator_configs[1].voting_disabled = true;
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes,
         validator_configs,
         validator_keys: Some(validator_keys),
@@ -4802,7 +4802,7 @@ fn test_duplicate_with_pruned_ancestor() {
     });
 
     let mut config = ClusterConfig {
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+        mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes,
         validator_configs,
         validator_keys: Some(validator_keys),
@@ -5038,7 +5038,7 @@ fn test_boot_from_local_state() {
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(&validator1_config.validator_config, 1),
         ..ClusterConfig::default()
     };
@@ -5319,7 +5319,7 @@ fn test_boot_from_local_state_missing_archive() {
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],
-        cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
+        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(&validator_config.validator_config, 1),
         ..ClusterConfig::default()
     };
@@ -5842,11 +5842,8 @@ fn test_randomly_mixed_block_verification_methods_between_bootstrap_and_not() {
     );
 
     let num_nodes = BlockVerificationMethod::COUNT;
-    let mut config = ClusterConfig::new_with_equal_stakes(
-        num_nodes,
-        DEFAULT_CLUSTER_LAMPORTS,
-        DEFAULT_NODE_STAKE,
-    );
+    let mut config =
+        ClusterConfig::new_with_equal_stakes(num_nodes, DEFAULT_MINT_LAMPORTS, DEFAULT_NODE_STAKE);
 
     // Overwrite block_verification_method with shuffled variants
     let mut methods = BlockVerificationMethod::iter().collect::<Vec<_>>();
@@ -5906,7 +5903,7 @@ fn test_invalid_forks_persisted_on_restart() {
 
     let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
-            cluster_lamports: DEFAULT_CLUSTER_LAMPORTS + node_stakes.iter().sum::<u64>(),
+            mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
             validator_configs,
             node_stakes,
             validator_keys: Some(validator_keypairs),

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -41,9 +41,9 @@ use {
             run_cluster_partition, run_kill_partition_switch_threshold, save_tower,
             setup_snapshot_validator_config, test_faulty_node, wait_for_duplicate_proof,
             wait_for_last_vote_in_tower_to_land_in_ledger, SnapshotValidatorConfig,
-            ValidatorTestConfig, DEFAULT_MINT_LAMPORTS, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
+            ValidatorTestConfig, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
         },
-        local_cluster::{ClusterConfig, LocalCluster},
+        local_cluster::{ClusterConfig, LocalCluster, DEFAULT_MINT_LAMPORTS},
         validator_configs::*,
     },
     solana_pubsub_client::pubsub_client::PubsubClient,
@@ -126,7 +126,6 @@ fn test_local_cluster_start_and_exit_with_config() {
             NUM_NODES,
         ),
         node_stakes: vec![DEFAULT_NODE_STAKE; NUM_NODES],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         ticks_per_slot: 8,
         slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH,
         stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH,
@@ -376,7 +375,6 @@ fn test_restart_node() {
     let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![DEFAULT_NODE_STAKE],
-            mint_lamports: DEFAULT_MINT_LAMPORTS,
             validator_configs: vec![safe_clone_config(&validator_config)],
             ticks_per_slot,
             slots_per_epoch,
@@ -417,7 +415,6 @@ fn test_mainnet_beta_cluster_type() {
     let mut config = ClusterConfig {
         cluster_type: ClusterType::MainnetBeta,
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
             1,
@@ -494,7 +491,6 @@ fn test_snapshot_download() {
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -580,7 +576,6 @@ fn test_incremental_snapshot_download() {
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -758,7 +753,6 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     let stake = DEFAULT_NODE_STAKE;
     let mut config = ClusterConfig {
         node_stakes: vec![stake],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -1319,7 +1313,6 @@ fn test_snapshots_blockstore_floor() {
 
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &leader_snapshot_test_config.validator_config,
             1,
@@ -1431,7 +1424,6 @@ fn test_snapshots_restart_validity() {
     )];
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(
             &snapshot_test_config.validator_config,
             1,
@@ -1564,7 +1556,6 @@ fn test_wait_for_max_stake() {
     let ticks_per_slot = 32;
     let num_validators = 4;
     let mut config = ClusterConfig {
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE; num_validators],
         validator_configs: make_identical_validator_configs(&validator_config, num_validators),
         slots_per_epoch,
@@ -1610,7 +1601,6 @@ fn test_no_voting() {
         ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE],
         validator_configs: vec![validator_config],
         ..ClusterConfig::default()
@@ -1887,7 +1877,6 @@ fn test_validator_saves_tower() {
     let validator_identity_keypair = Arc::new(Keypair::new());
     let validator_id = validator_identity_keypair.pubkey();
     let mut config = ClusterConfig {
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE],
         validator_configs: vec![validator_config],
         validator_keys: Some(vec![(validator_identity_keypair.clone(), true)]),
@@ -4351,7 +4340,6 @@ fn test_switch_threshold_uses_gossip_votes() {
 fn test_listener_startup() {
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         num_listeners: 3,
         validator_configs: make_identical_validator_configs(
             &ValidatorConfig::default_for_test(),
@@ -4478,7 +4466,6 @@ fn test_leader_failure_4() {
     // not generating leader schedule, and stalling the cluster.
     let skip_warmup_slots = true;
     let mut config = ClusterConfig {
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         node_stakes: vec![DEFAULT_NODE_STAKE; num_nodes],
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
         validator_keys,
@@ -5038,7 +5025,6 @@ fn test_boot_from_local_state() {
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(&validator1_config.validator_config, 1),
         ..ClusterConfig::default()
     };
@@ -5319,7 +5305,6 @@ fn test_boot_from_local_state_missing_archive() {
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],
-        mint_lamports: DEFAULT_MINT_LAMPORTS,
         validator_configs: make_identical_validator_configs(&validator_config.validator_config, 1),
         ..ClusterConfig::default()
     };

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -684,7 +684,7 @@ pub mod test {
         let validator_config = ValidatorConfig::default_for_test();
         let num_nodes = 1;
         let mut config = ClusterConfig {
-            cluster_lamports: 10_000_000,
+            mint_lamports: 10_000_000,
             poh_config: PohConfig::new_sleep(Duration::from_millis(50)),
             node_stakes: vec![100; num_nodes],
             validator_configs: make_identical_validator_configs(&validator_config, num_nodes),


### PR DESCRIPTION
#### Problem
- Local cluster tests have some misleading names
- consts are in weird places
- we don't make sure we have enough for transfers we attempt

Additional context: #4394 - I'm removing the special-casing in our fee-calculation for zero fees in tests. This requires some changes in several places, including local-cluster tests. Splitting these changes out to make the fee-related changes simpler to do.

#### Summary of Changes
- `cluster_lamports` is not the total cluster lamports...its' the `mint_lamports`. Change the name
- Move default mint lamports constant to the config and actually use it as the default
- Add an assert to make sure mint has at least enough lamports for the setup transfers