### PR TITLE
clippy: manual_div_ceil

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -57,7 +57,7 @@ fn make_shreds(num_shreds: usize) -> Vec<Shred> {
 fn bench_shredder_ticks(bencher: &mut Bencher) {
     let kp = Keypair::new();
     let shred_size = LEGACY_SHRED_DATA_CAPACITY;
-    let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
+    let num_shreds = 1_000_000_usize.div_ceil(shred_size);
     // ~1Mb
     let num_ticks = max_ticks_per_n_shreds(1, Some(LEGACY_SHRED_DATA_CAPACITY)) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
@@ -83,7 +83,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
 fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let kp = Keypair::new();
     let shred_size = LEGACY_SHRED_DATA_CAPACITY;
-    let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
+    let num_shreds = 1_000_000_usize.div_ceil(shred_size);
     let txs_per_entry = 128;
     let num_entries = max_entries_per_n_shred(
         &make_test_entry(txs_per_entry),
@@ -115,7 +115,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
     let kp = Keypair::new();
     let shred_size = LEGACY_SHRED_DATA_CAPACITY;
     // ~10Mb
-    let num_shreds = ((10000 * 1000) + (shred_size - 1)) / shred_size;
+    let num_shreds = 10_000_000_usize.div_ceil(shred_size);
     let num_ticks = max_ticks_per_n_shreds(1, Some(shred_size)) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
warning: manually reimplementing `div_ceil`
  --> core/benches/shredder.rs:60:22
   |
60 |     let num_shreds = ((1000 * 1000) + (shred_size - 1)) / shred_size;
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `(1000 * 1000).div_ceil(shred_size)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
   = note: `#[warn(clippy::manual_div_ceil)]` on by default
```


#### Summary of Changes

Replace with `div_ceil()`.


Similar to #4376
Partially fixes #4380