### PR TITLE
Upgrades Rust to 1.84.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.0"


### PR DESCRIPTION
Upgrades Rust to 1.84.0

https://releases.rs/docs/1.84.0/

I also built this commit and ran it on a validator, which was able to catch up successfully. 