### PR TITLE
Change visibility of `svm-internal` structs and APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6285,12 +6285,14 @@ dependencies = [
  "byteorder",
  "criterion",
  "libsecp256k1",
+ "qualifier_attr",
  "rand 0.8.5",
  "scopeguard",
  "solana-account",
  "solana-account-info",
  "solana-bincode",
  "solana-bn254",
+ "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
  "solana-cpi",
@@ -6390,9 +6392,11 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
+ "qualifier_attr",
  "rand 0.8.5",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
+ "solana-builtins-default-costs",
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-feature-set",
@@ -6806,6 +6810,7 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.2.0"
 dependencies = [
+ "qualifier_attr",
  "solana-program-runtime",
 ]
 
@@ -7739,6 +7744,7 @@ version = "2.2.0"
 dependencies = [
  "bincode",
  "log",
+ "qualifier_attr",
  "solana-account",
  "solana-bincode",
  "solana-bpf-loader-program",

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -13,15 +13,16 @@ edition = { workspace = true }
 ahash = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+qualifier_attr = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
-solana-compute-budget-program = { workspace = true }
+solana-bpf-loader-program = { workspace = true, features = ["svm-internal"] }
+solana-compute-budget-program = { workspace = true, features = ["svm-internal"] }
 solana-config-program = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-loader-v4-program = { workspace = true }
+solana-loader-v4-program = { workspace = true, features = ["svm-internal"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-stake-program = { workspace = true }
@@ -35,6 +36,7 @@ name = "solana_builtins_default_costs"
 
 [dev-dependencies]
 rand = "0.8.5"
+solana-builtins-default-costs = { path = ".", features = ["svm-internal"] }
 static_assertions = { workspace = true }
 
 [package.metadata.docs.rs]
@@ -46,6 +48,7 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 dev-context-only-utils = []
+svm-internal = []
 
 [lints]
 workspace = true

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 use {
     ahash::AHashMap,
     lazy_static::lazy_static,
@@ -13,7 +15,8 @@ use {
 };
 
 #[derive(Clone)]
-pub struct MigratingBuiltinCost {
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+struct MigratingBuiltinCost {
     native_cost: u64,
     core_bpf_migration_feature: Pubkey,
     // encoding positional information explicitly for migration feature item,
@@ -24,7 +27,8 @@ pub struct MigratingBuiltinCost {
 }
 
 #[derive(Clone)]
-pub struct NotMigratingBuiltinCost {
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+struct NotMigratingBuiltinCost {
     native_cost: u64,
 }
 
@@ -35,12 +39,14 @@ pub struct NotMigratingBuiltinCost {
 /// When migration completed, eg the feature gate is enabled everywhere, please
 /// remove that builtin entry from MIGRATING_BUILTINS_COSTS.
 #[derive(Clone)]
-pub enum BuiltinCost {
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+enum BuiltinCost {
     Migrating(MigratingBuiltinCost),
     NotMigrating(NotMigratingBuiltinCost),
 }
 
 impl BuiltinCost {
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn native_cost(&self) -> u64 {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { native_cost, .. }) => *native_cost,
@@ -48,6 +54,8 @@ impl BuiltinCost {
         }
     }
 
+    #[cfg(feature = "svm-internal")]
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -58,6 +66,8 @@ impl BuiltinCost {
         }
     }
 
+    #[cfg(feature = "svm-internal")]
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn position(&self) -> Option<usize> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),
@@ -65,6 +75,7 @@ impl BuiltinCost {
         }
     }
 
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn has_migrated(&self, feature_set: &FeatureSet) -> bool {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -109,7 +120,8 @@ static_assertions::const_assert_eq!(
     TOTAL_COUNT_BUILTINS
 );
 
-pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         stake::id(),
         BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -215,13 +227,17 @@ pub fn get_builtin_instruction_cost<'a>(
         .map(|builtin_cost| builtin_cost.native_cost())
 }
 
-pub enum BuiltinMigrationFeatureIndex {
+#[cfg(feature = "svm-internal")]
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+enum BuiltinMigrationFeatureIndex {
     NotBuiltin,
     BuiltinNoMigrationFeature,
     BuiltinWithMigrationFeature(usize),
 }
 
-pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
+#[cfg(feature = "svm-internal")]
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
     BUILTIN_INSTRUCTION_COSTS.get(program_id).map_or(
         BuiltinMigrationFeatureIndex::NotBuiltin,
         |builtin_cost| {
@@ -254,7 +270,9 @@ const _: () = validate_position(MIGRATING_BUILTINS_COSTS);
 
 /// Helper function to return ref of migration feature Pubkey at position `index`
 /// from MIGRATING_BUILTINS_COSTS
-pub fn get_migration_feature_id(index: usize) -> &'static Pubkey {
+#[cfg(feature = "svm-internal")]
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+pub(crate) fn get_migration_feature_id(index: usize) -> &'static Pubkey {
     MIGRATING_BUILTINS_COSTS
         .get(index)
         .expect("valid index of MIGRATING_BUILTINS_COSTS")

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -53,6 +53,7 @@ impl BuiltinCost {
         }
     }
 
+    #[cfg(feature = "svm-internal")]
     fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -63,6 +64,7 @@ impl BuiltinCost {
         }
     }
 
+    #[cfg(feature = "svm-internal")]
     fn position(&self) -> Option<usize> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -46,7 +46,6 @@ enum BuiltinCost {
 }
 
 impl BuiltinCost {
-    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn native_cost(&self) -> u64 {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { native_cost, .. }) => *native_cost,
@@ -54,8 +53,6 @@ impl BuiltinCost {
         }
     }
 
-    #[cfg(feature = "svm-internal")]
-    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -66,8 +63,6 @@ impl BuiltinCost {
         }
     }
 
-    #[cfg(feature = "svm-internal")]
-    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn position(&self) -> Option<usize> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),
@@ -75,7 +70,6 @@ impl BuiltinCost {
         }
     }
 
-    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
     fn has_migrated(&self, feature_set: &FeatureSet) -> bool {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 [dependencies]
 log = { workspace = true }
 solana-borsh = { workspace = true }
-solana-builtins-default-costs = { workspace = true }
+solana-builtins-default-costs = { workspace = true, features = ["svm-internal"] }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-feature-set = { workspace = true }
@@ -32,7 +32,7 @@ name = "solana_compute_budget_instruction"
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { workspace = true, features = ["dev-context-only-utils"] }
+solana-builtins-default-costs = { workspace = true, features = ["dev-context-only-utils", "svm-internal"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 bincode = { workspace = true }
 byteorder = { workspace = true }
 libsecp256k1 = { workspace = true }
+qualifier_attr = { workspace = true }
 scopeguard = { workspace = true }
 solana-account = { workspace = true }
 solana-account-info = { workspace = true }
@@ -54,6 +55,7 @@ thiserror = { workspace = true }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
+solana-bpf-loader-program = { path = ".", features = ["svm-internal"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
@@ -87,3 +89,4 @@ shuttle-test = [
     "solana-program-runtime/shuttle-test",
     "solana-sbpf/shuttle-test"
 ]
+svm-internal = []

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod serialization;
 pub mod syscalls;
 
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 use {
     solana_account::WritableAccount,
     solana_bincode::limited_deserialize,
@@ -42,19 +44,20 @@ use {
         verifier::RequisiteVerifier,
         vm::{ContextObject, EbpfVm},
     },
-    solana_sdk_ids::{
-        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
-    },
+    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, native_loader},
     solana_system_interface::{instruction as system_instruction, MAX_PERMITTED_DATA_LENGTH},
     solana_transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
     solana_type_overrides::sync::{atomic::Ordering, Arc},
     std::{cell::RefCell, mem, rc::Rc},
-    syscalls::{create_program_runtime_environment_v1, morph_into_deployment_environment_v1},
+    syscalls::morph_into_deployment_environment_v1,
 };
 
-pub const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
-pub const DEPRECATED_LOADER_COMPUTE_UNITS: u64 = 1_140;
-pub const UPGRADEABLE_LOADER_COMPUTE_UNITS: u64 = 2_370;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEFAULT_LOADER_COMPUTE_UNITS: u64 = 570;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEPRECATED_LOADER_COMPUTE_UNITS: u64 = 1_140;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const UPGRADEABLE_LOADER_COMPUTE_UNITS: u64 = 2_370;
 
 thread_local! {
     pub static MEMORY_POOL: RefCell<VmMemoryPool> = RefCell::new(VmMemoryPool::new());
@@ -106,7 +109,8 @@ pub fn load_program_from_bytes(
 /// Directly deploy a program using a provided invoke context.
 /// This function should only be invoked from the runtime, since it does not
 /// provide any account loads or checks.
-pub fn deploy_program_internal(
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn deploy_program_internal(
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
     program_runtime_environment: ProgramRuntimeEnvironment,
@@ -181,7 +185,7 @@ macro_rules! deploy_program {
                 // This will never fail since the epoch schedule is already configured.
                 InstructionError::ProgramEnvironmentSetupFailure
             })?;
-        let load_program_metrics = deploy_program_internal(
+        let load_program_metrics = $crate::deploy_program_internal(
             $invoke_context.get_log_collector(),
             $invoke_context.program_cache_for_tx_batch,
             environments.program_runtime_v1.clone(),
@@ -193,6 +197,27 @@ macro_rules! deploy_program {
         )?;
         load_program_metrics.submit_datapoint(&mut $invoke_context.timings);
     };
+}
+
+// This function/wrapper is added specifically for non "svm-internal" users. It enables the reducing
+// of public visibility of some internal APIs.
+pub fn deploy_program(
+    invoke_context: &mut InvokeContext,
+    program_id: &Pubkey,
+    loader_key: &Pubkey,
+    account_size: usize,
+    programdata: &[u8],
+    deployment_slot: Slot,
+) -> Result<(), InstructionError> {
+    deploy_program!(
+        invoke_context,
+        program_id,
+        loader_key,
+        account_size,
+        programdata,
+        deployment_slot
+    );
+    Ok(())
 }
 
 fn write_program_data(
@@ -220,13 +245,6 @@ fn write_program_data(
     Ok(())
 }
 
-pub fn check_loader_id(id: &Pubkey) -> bool {
-    bpf_loader::check_id(id)
-        || bpf_loader_deprecated::check_id(id)
-        || bpf_loader_upgradeable::check_id(id)
-        || loader_v4::check_id(id)
-}
-
 /// Only used in macro, do not use directly!
 pub fn calculate_heap_cost(heap_size: u32, heap_cost: u64) -> u64 {
     const KIBIBYTE: u64 = 1024;
@@ -242,7 +260,8 @@ pub fn calculate_heap_cost(heap_size: u32, heap_cost: u64) -> u64 {
 }
 
 /// Only used in macro, do not use directly!
-pub fn create_vm<'a, 'b>(
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn create_vm<'a, 'b>(
     program: &'a Executable<InvokeContext<'b>>,
     regions: Vec<MemoryRegion>,
     accounts_metadata: Vec<SerializedAccountMetadata>,
@@ -397,7 +416,8 @@ declare_builtin_function!(
     }
 );
 
-pub fn process_instruction_inner(
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+pub(crate) fn process_instruction_inner(
     invoke_context: &mut InvokeContext,
 ) -> Result<u64, Box<dyn std::error::Error>> {
     let log_collector = invoke_context.get_log_collector();
@@ -1370,7 +1390,8 @@ fn common_close_account(
     Ok(())
 }
 
-pub fn execute<'a, 'b: 'a>(
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+fn execute<'a, 'b: 'a>(
     executable: &'a Executable<InvokeContext<'static>>,
     invoke_context: &'a mut InvokeContext<'b>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1571,13 +1592,27 @@ pub fn execute<'a, 'b: 'a>(
     execute_or_deserialize_result
 }
 
-pub mod test_utils {
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+mod test_utils {
+    #[cfg(feature = "svm-internal")]
     use {
-        super::*, solana_account::ReadableAccount, solana_program::loader_v4::LoaderV4State,
+        super::*, crate::syscalls::create_program_runtime_environment_v1,
+        solana_account::ReadableAccount, solana_program::loader_v4,
+        solana_program::loader_v4::LoaderV4State,
         solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
     };
 
-    pub fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
+    #[cfg(feature = "svm-internal")]
+    fn check_loader_id(id: &Pubkey) -> bool {
+        bpf_loader::check_id(id)
+            || bpf_loader_deprecated::check_id(id)
+            || bpf_loader_upgradeable::check_id(id)
+            || loader_v4::check_id(id)
+    }
+
+    #[cfg(feature = "svm-internal")]
+    #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+    fn load_all_invoked_programs(invoke_context: &mut InvokeContext) {
         let mut load_program_metrics = LoadProgramMetrics::default();
         let program_runtime_environment = create_program_runtime_environment_v1(
             invoke_context.get_feature_set(),
@@ -3833,15 +3868,14 @@ mod tests {
         let mut file = File::open("test_elfs/out/sbpfv3_return_ok.so").expect("file open failed");
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        deploy_program!(
+        deploy_program(
             invoke_context,
             &program_id,
             &bpf_loader_upgradeable::id(),
             elf.len(),
             &elf,
             2_u64,
-        );
-        Ok(())
+        )
     }
 
     #[test]

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -30,7 +30,7 @@ enum SerializeAccount<'a> {
 }
 
 struct Serializer {
-    pub buffer: AlignedMemory<HOST_ALIGN>,
+    buffer: AlignedMemory<HOST_ALIGN>,
     regions: Vec<MemoryRegion>,
     vaddr: u64,
     region_start: usize,
@@ -54,7 +54,7 @@ impl Serializer {
         self.buffer.fill_write(num, value)
     }
 
-    pub fn write<T: Pod>(&mut self, value: T) -> u64 {
+    fn write<T: Pod>(&mut self, value: T) -> u64 {
         self.debug_assert_alignment::<T>();
         let vaddr = self
             .vaddr
@@ -249,7 +249,7 @@ pub fn serialize_parameters(
     }
 }
 
-pub fn deserialize_parameters(
+pub(crate) fn deserialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     copy_account_data: bool,
@@ -358,7 +358,7 @@ fn serialize_parameters_unaligned(
     Ok((mem, regions, accounts_metadata))
 }
 
-pub fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
+fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     copy_account_data: bool,
@@ -498,7 +498,7 @@ fn serialize_parameters_aligned(
     Ok((mem, regions, accounts_metadata))
 }
 
-pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
+fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     copy_account_data: bool,
@@ -1029,7 +1029,7 @@ mod tests {
 
     // the old bpf_loader in-program deserializer bpf_loader::id()
     #[deny(unsafe_op_in_unsafe_fn)]
-    pub unsafe fn deserialize_unaligned<'a>(
+    unsafe fn deserialize_unaligned<'a>(
         input: *mut u8,
     ) -> (&'a Pubkey, Vec<AccountInfo<'a>>, &'a [u8]) {
         // this boring boilerplate struct is needed until inline const...

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -77,7 +77,7 @@ mod mem_ops;
 mod sysvar;
 
 /// Maximum signers
-pub const MAX_SIGNERS: usize = 16;
+const MAX_SIGNERS: usize = 16;
 
 /// Error definitions
 #[derive(Debug, ThisError, PartialEq, Eq)]
@@ -134,7 +134,7 @@ pub enum SyscallError {
 
 type Error = Box<dyn std::error::Error>;
 
-pub trait HasherImpl {
+trait HasherImpl {
     const NAME: &'static str;
     type Output: AsRef<[u8]>;
 
@@ -146,9 +146,9 @@ pub trait HasherImpl {
     fn get_max_slices(compute_budget: &ComputeBudget) -> u64;
 }
 
-pub struct Sha256Hasher(Hasher);
-pub struct Blake3Hasher(blake3::Hasher);
-pub struct Keccak256Hasher(keccak::Hasher);
+struct Sha256Hasher(Hasher);
+struct Blake3Hasher(blake3::Hasher);
+struct Keccak256Hasher(keccak::Hasher);
 
 impl HasherImpl for Sha256Hasher {
     const NAME: &'static str = "Sha256";
@@ -246,7 +246,7 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn morph_into_deployment_environment_v1(
+pub(crate) fn morph_into_deployment_environment_v1(
     from: Arc<BuiltinProgram<InvokeContext>>,
 ) -> Result<BuiltinProgram<InvokeContext>, Error> {
     let mut config = from.get_config().clone();
@@ -2257,8 +2257,8 @@ mod tests {
 
     #[allow(dead_code)]
     struct MockSlice {
-        pub vm_addr: u64,
-        pub len: usize,
+        vm_addr: u64,
+        len: usize,
     }
 
     #[test]
@@ -5040,12 +5040,12 @@ mod tests {
         unsafe { slice::from_raw_parts_mut(slice::from_mut(val).as_mut_ptr().cast(), size) }
     }
 
-    pub fn bytes_of_slice<T>(val: &[T]) -> &[u8] {
+    fn bytes_of_slice<T>(val: &[T]) -> &[u8] {
         let size = val.len().wrapping_mul(mem::size_of::<T>());
         unsafe { slice::from_raw_parts(val.as_ptr().cast(), size) }
     }
 
-    pub fn bytes_of_slice_mut<T>(val: &mut [T]) -> &mut [u8] {
+    fn bytes_of_slice_mut<T>(val: &mut [T]) -> &mut [u8] {
         let size = val.len().wrapping_mul(mem::size_of::<T>());
         unsafe { slice::from_raw_parts_mut(val.as_mut_ptr().cast(), size) }
     }

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -10,11 +10,15 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+qualifier_attr = { workspace = true }
 solana-program-runtime = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
 name = "solana_compute_budget_program"
+
+[features]
+svm-internal = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 use solana_program_runtime::declare_process_instruction;
 
-pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEFAULT_COMPUTE_UNITS: u64 = 150;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |_invoke_context| {
     // Do nothing, compute budget instructions handled by the runtime

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -10,9 +10,10 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+qualifier_attr = { workspace = true }
 solana-account = { workspace = true }
 solana-bincode = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
+solana-bpf-loader-program = { workspace = true, features = ["svm-internal"] }
 solana-compute-budget = { workspace = true }
 solana-instruction = { workspace = true }
 solana-log-collector = { workspace = true }
@@ -43,3 +44,4 @@ shuttle-test = [
     "solana-program-runtime/shuttle-test",
     "solana-sbpf/shuttle-test"
 ]
+svm-internal = []

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "svm-internal")]
+use qualifier_attr::qualifiers;
 use {
     solana_bincode::limited_deserialize,
-    solana_bpf_loader_program::{deploy_program, deploy_program_internal, execute},
+    solana_bpf_loader_program::{deploy_program, execute},
     solana_instruction::error::InstructionError,
     solana_log_collector::{ic_logger_msg, LogCollector},
     solana_measure::measure::Measure,
@@ -19,7 +21,8 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
-pub const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
+#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
 
 pub fn get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {
     unsafe {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5204,6 +5204,7 @@ dependencies = [
  "bincode",
  "byteorder 1.5.0",
  "libsecp256k1 0.6.0",
+ "qualifier_attr",
  "scopeguard",
  "solana-account",
  "solana-account-info",
@@ -5287,6 +5288,7 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
+ "qualifier_attr",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -5515,6 +5517,7 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.2.0"
 dependencies = [
+ "qualifier_attr",
  "solana-program-runtime",
 ]
 
@@ -6193,6 +6196,7 @@ name = "solana-loader-v4-program"
 version = "2.2.0"
 dependencies = [
  "log",
+ "qualifier_attr",
  "solana-account",
  "solana-bincode",
  "solana-bpf-loader-program",

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -173,14 +173,26 @@ impl Bank {
                 compute_budget,
             );
 
-            solana_bpf_loader_program::deploy_program(
-                &mut dummy_invoke_context,
+            let environments = dummy_invoke_context
+                .get_environments_for_slot(self.slot.saturating_add(
+                    solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
+                ))
+                .map_err(|_err| {
+                    // This will never fail since the epoch schedule is already configured.
+                    InstructionError::ProgramEnvironmentSetupFailure
+                })?;
+
+            let load_program_metrics = solana_bpf_loader_program::deploy_program(
+                dummy_invoke_context.get_log_collector(),
+                dummy_invoke_context.program_cache_for_tx_batch,
+                environments.program_runtime_v1.clone(),
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 data_len,
                 elf,
                 self.slot,
             )?;
+            load_program_metrics.submit_datapoint(&mut dummy_invoke_context.timings);
         }
 
         // Update the program cache by merging with `programs_modified`, which

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -173,15 +173,14 @@ impl Bank {
                 compute_budget,
             );
 
-            use solana_bpf_loader_program::deploy_program_internal;
-            solana_bpf_loader_program::deploy_program!(
-                dummy_invoke_context,
+            solana_bpf_loader_program::deploy_program(
+                &mut dummy_invoke_context,
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 data_len,
                 elf,
                 self.slot,
-            );
+            )?;
         }
 
         // Update the program cache by merging with `programs_modified`, which

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5065,6 +5065,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "libsecp256k1",
+ "qualifier_attr",
  "scopeguard",
  "solana-account",
  "solana-account-info",
@@ -5148,6 +5149,7 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
+ "qualifier_attr",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -5376,6 +5378,7 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.2.0"
 dependencies = [
+ "qualifier_attr",
  "solana-program-runtime",
 ]
 
@@ -6023,6 +6026,7 @@ name = "solana-loader-v4-program"
 version = "2.2.0"
 dependencies = [
  "log",
+ "qualifier_attr",
  "solana-account",
  "solana-bincode",
  "solana-bpf-loader-program",


### PR DESCRIPTION
#### Problem
Some APIs and structs in SVM crates are only used internally (among these crates). The visibility should be limited to these crates.

#### Summary of Changes
Limit the visibility using `svm-internal` cfg feature.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
