### PR TITLE
tpu-client-next: return receiver in scheduler::run

### DIFF
--- a/tls-utils/src/quic_client_certificate.rs
+++ b/tls-utils/src/quic_client_certificate.rs
@@ -10,8 +10,13 @@ pub struct QuicClientCertificate {
 }
 
 impl QuicClientCertificate {
-    pub fn new(keypair: &Keypair) -> Self {
-        let (certificate, key) = new_dummy_x509_certificate(keypair);
-        Self { certificate, key }
+    pub fn new(keypair: Option<&Keypair>) -> Self {
+        if let Some(keypair) = keypair {
+            let (certificate, key) = new_dummy_x509_certificate(keypair);
+            Self { certificate, key }
+        } else {
+            let (certificate, key) = new_dummy_x509_certificate(&Keypair::new());
+            Self { certificate, key }
+        }
     }
 }

--- a/tls-utils/src/quic_client_certificate.rs
+++ b/tls-utils/src/quic_client_certificate.rs
@@ -11,12 +11,12 @@ pub struct QuicClientCertificate {
 
 impl QuicClientCertificate {
     pub fn new(keypair: Option<&Keypair>) -> Self {
-        if let Some(keypair) = keypair {
-            let (certificate, key) = new_dummy_x509_certificate(keypair);
-            Self { certificate, key }
+        let keypair = if let Some(keypair) = keypair {
+            keypair
         } else {
-            let (certificate, key) = new_dummy_x509_certificate(&Keypair::new());
-            Self { certificate, key }
-        }
+            &Keypair::new()
+        };
+        let (certificate, key) = new_dummy_x509_certificate(keypair);
+        Self { certificate, key }
     }
 }

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -18,7 +18,7 @@ pub use {
     solana_tls_utils::QuicClientCertificate,
 };
 
-pub(crate) fn create_client_config(client_certificate: Arc<QuicClientCertificate>) -> ClientConfig {
+pub(crate) fn create_client_config(client_certificate: QuicClientCertificate) -> ClientConfig {
     // adapted from QuicLazyInitializedEndpoint::create_endpoint
     let mut crypto = tls_client_config_builder()
         .with_client_auth_cert(

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -15,11 +15,13 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
-        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
+        connection_workers_scheduler::{
+            ConnectionWorkersSchedulerConfig, Fanout, TransactionStatsAndReceiver,
+        },
         leader_updater::create_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
         transaction_batch::TransactionBatch,
-        ConnectionWorkersScheduler, ConnectionWorkersSchedulerError, SendTransactionStatsPerAddr,
+        ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
     },
     std::{
         collections::HashMap,
@@ -40,10 +42,10 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-fn test_config(validator_identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
+fn test_config(identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
     ConnectionWorkersSchedulerConfig {
         bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
-        stake_identity: validator_identity,
+        identity,
         num_connections: 1,
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try
@@ -63,9 +65,9 @@ fn test_config(validator_identity: Option<Keypair>) -> ConnectionWorkersSchedule
 async fn setup_connection_worker_scheduler(
     tpu_address: SocketAddr,
     transaction_receiver: Receiver<TransactionBatch>,
-    validator_identity: Option<Keypair>,
+    identity: Option<Keypair>,
 ) -> (
-    JoinHandle<Result<SendTransactionStatsPerAddr, ConnectionWorkersSchedulerError>>,
+    JoinHandle<Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>>,
     CancellationToken,
 ) {
     let json_rpc_url = "http://127.0.0.1:8899";
@@ -82,7 +84,7 @@ async fn setup_connection_worker_scheduler(
         .expect("Leader updates was successfully created");
 
     let cancel = CancellationToken::new();
-    let config = test_config(validator_identity);
+    let config = test_config(identity);
     let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
         config,
         leader_updater,
@@ -95,10 +97,10 @@ async fn setup_connection_worker_scheduler(
 
 async fn join_scheduler(
     scheduler_handle: JoinHandle<
-        Result<SendTransactionStatsPerAddr, ConnectionWorkersSchedulerError>,
+        Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>,
     >,
 ) -> SendTransactionStatsNonAtomic {
-    let stats_per_ip = scheduler_handle
+    let (stats_per_ip, _) = scheduler_handle
         .await
         .unwrap()
         .expect("Scheduler should stop successfully.");
@@ -400,8 +402,8 @@ async fn test_connection_pruned_and_reopened() {
 /// connection and verify that all the txs has been received.
 #[tokio::test]
 async fn test_staked_connection() {
-    let validator_identity = Keypair::new();
-    let stakes = HashMap::from([(validator_identity.pubkey(), 100_000)]);
+    let identity = Keypair::new();
+    let stakes = HashMap::from([(identity.pubkey(), 100_000)]);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {
@@ -432,8 +434,7 @@ async fn test_staked_connection() {
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
     let (scheduler_handle, _scheduler_cancel) =
-        setup_connection_worker_scheduler(server_address, tx_receiver, Some(validator_identity))
-            .await;
+        setup_connection_worker_scheduler(server_address, tx_receiver, Some(identity)).await;
 
     // Check results
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
@@ -533,7 +534,7 @@ async fn test_no_host() {
 
     // While attempting to establish a connection with a nonexistent host, we fill the worker's
     // channel.
-    let stats = scheduler_handle
+    let (stats, _) = scheduler_handle
         .await
         .expect("Scheduler should stop successfully")
         .expect("Scheduler execution was successful");

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -45,7 +45,7 @@ use {
 fn test_config(identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
     ConnectionWorkersSchedulerConfig {
         bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
-        identity,
+        stake_identity: identity,
         num_connections: 1,
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -42,10 +42,10 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-fn test_config(identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
+fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
     ConnectionWorkersSchedulerConfig {
         bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
-        stake_identity: identity,
+        stake_identity,
         num_connections: 1,
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try
@@ -65,7 +65,7 @@ fn test_config(identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
 async fn setup_connection_worker_scheduler(
     tpu_address: SocketAddr,
     transaction_receiver: Receiver<TransactionBatch>,
-    identity: Option<Keypair>,
+    stake_identity: Option<Keypair>,
 ) -> (
     JoinHandle<Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>>,
     CancellationToken,
@@ -84,7 +84,7 @@ async fn setup_connection_worker_scheduler(
         .expect("Leader updates was successfully created");
 
     let cancel = CancellationToken::new();
-    let config = test_config(identity);
+    let config = test_config(stake_identity);
     let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
         config,
         leader_updater,
@@ -402,8 +402,8 @@ async fn test_connection_pruned_and_reopened() {
 /// connection and verify that all the txs has been received.
 #[tokio::test]
 async fn test_staked_connection() {
-    let identity = Keypair::new();
-    let stakes = HashMap::from([(identity.pubkey(), 100_000)]);
+    let stake_identity = Keypair::new();
+    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {
@@ -434,7 +434,7 @@ async fn test_staked_connection() {
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
     let (scheduler_handle, _scheduler_cancel) =
-        setup_connection_worker_scheduler(server_address, tx_receiver, Some(identity)).await;
+        setup_connection_worker_scheduler(server_address, tx_receiver, Some(stake_identity)).await;
 
     // Check results
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;


### PR DESCRIPTION
#### Problem & Solution

Return receiver from scheduler run so that it can be reused if required. This is needed to use in validator because user can make an rpc call to update underlying authority, and due to the way this mechanism is implemented, we have to reutilize the same receiver. 

These changes are part of the reverted PR https://github.com/anza-xyz/agave/pull/3515/files#diff-17507818c3be9c444eb55f6c0b2d82ac0662746abf0dff6b200d43bf9ca125c2

They are split into a separate PR for the sake of backporting and to have a clearer history. 

