### PR TITLE
demote solana-vote-program to dev deps of solana-stake-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9754,6 +9754,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-type-overrides",
+ "solana-vote-interface",
  "solana-vote-program",
  "test-case",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -614,7 +614,7 @@ solana-short-vec = { path = "sdk/short-vec", version = "=2.2.0" }
 solana-shred-version = { path = "sdk/shred-version", version = "=2.2.0" }
 solana-stable-layout = { path = "sdk/stable-layout", version = "=2.2.0" }
 solana-stake-interface = { version = "1.2.1" }
-solana-stake-program = { path = "programs/stake", version = "=2.2.0", default-features = false }
+solana-stake-program = { path = "programs/stake", version = "=2.2.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.0" }
 solana-storage-proto = { path = "storage-proto", version = "=2.2.0" }
 solana-streamer = { path = "streamer", version = "=2.2.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8058,7 +8058,6 @@ dependencies = [
  "solana-sysvar",
  "solana-transaction-context",
  "solana-type-overrides",
- "solana-vote-program",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8058,6 +8058,7 @@ dependencies = [
  "solana-sysvar",
  "solana-transaction-context",
  "solana-type-overrides",
+ "solana-vote-interface",
 ]
 
 [[package]]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -30,7 +30,6 @@ solana-sdk-ids = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-type-overrides = { workspace = true }
-solana-vote-program = { workspace = true, default-features = false }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -41,11 +40,8 @@ solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-logger = { workspace = true }
 solana-sysvar-id = { workspace = true }
+solana-vote-program = { workspace = true, default-features = false }
 test-case = { workspace = true }
-
-[features]
-default = ["metrics"]
-metrics = ["solana-vote-program/metrics"]
 
 [lib]
 crate-type = ["lib"]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -30,6 +30,7 @@ solana-sdk-ids = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-type-overrides = { workspace = true }
+solana-vote-interface = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -5,13 +5,16 @@ use {
     solana_clock::{Clock, Epoch},
     solana_feature_set::FeatureSet,
     solana_instruction::AccountMeta,
-    solana_program::stake::{
-        instruction::{
-            self, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs,
-            LockupCheckedArgs, StakeInstruction,
+    solana_program::{
+        stake::{
+            instruction::{
+                self, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs, LockupArgs,
+                LockupCheckedArgs, StakeInstruction,
+            },
+            stake_flags::StakeFlags,
+            state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
         },
-        stake_flags::StakeFlags,
-        state::{Authorized, Lockup, StakeAuthorize, StakeStateV2},
+        vote::state::{VoteState, VoteStateVersions},
     },
     solana_program_runtime::invoke_context::mock_process_instruction,
     solana_pubkey::Pubkey,
@@ -22,7 +25,7 @@ use {
         stake_state::{Delegation, Meta, Stake},
     },
     solana_sysvar::stake_history::StakeHistory,
-    solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
+    solana_vote_program::vote_state,
     std::sync::Arc,
 };
 
@@ -629,7 +632,7 @@ fn bench_deactivate_delinquent(c: &mut Criterion) {
         1,
         &VoteStateVersions::new_current(vote_state),
         VoteState::size_of(),
-        &solana_vote_program::id(),
+        &solana_sdk_ids::vote::id(),
     )
     .unwrap();
 

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -4,10 +4,12 @@
 use {
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
-    solana_program::stake::state::{Delegation, Stake, StakeStateV2},
+    solana_program::{
+        stake::state::{Delegation, Stake, StakeStateV2},
+        vote::state::VoteState,
+    },
     solana_pubkey::Pubkey,
     solana_sysvar::stake_history::StakeHistory,
-    solana_vote_program::vote_state::VoteState,
     std::cmp::Ordering,
 };
 

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -4,12 +4,10 @@
 use {
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
-    solana_program::{
-        stake::state::{Delegation, Stake, StakeStateV2},
-        vote::state::VoteState,
-    },
+    solana_program::stake::state::{Delegation, Stake, StakeStateV2},
     solana_pubkey::Pubkey,
     solana_sysvar::stake_history::StakeHistory,
+    solana_vote_interface::state::VoteState,
     std::cmp::Ordering,
 };
 

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -9,12 +9,14 @@ use {
     solana_account::{state_traits::StateMut, AccountSharedData, WritableAccount},
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
-    solana_program::stake::{
-        instruction::StakeError,
-        state::{Stake, StakeStateV2},
+    solana_program::{
+        stake::{
+            instruction::StakeError,
+            state::{Stake, StakeStateV2},
+        },
+        vote::state::VoteState,
     },
     solana_sysvar::stake_history::StakeHistory,
-    solana_vote_program::vote_state::VoteState,
 };
 
 #[derive(Debug, PartialEq, Eq)]

--- a/programs/stake/src/rewards.rs
+++ b/programs/stake/src/rewards.rs
@@ -9,14 +9,12 @@ use {
     solana_account::{state_traits::StateMut, AccountSharedData, WritableAccount},
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
-    solana_program::{
-        stake::{
-            instruction::StakeError,
-            state::{Stake, StakeStateV2},
-        },
-        vote::state::VoteState,
+    solana_program::stake::{
+        instruction::StakeError,
+        state::{Stake, StakeStateV2},
     },
     solana_sysvar::stake_history::StakeHistory,
+    solana_vote_interface::state::VoteState,
 };
 
 #[derive(Debug, PartialEq, Eq)]

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -398,16 +398,19 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_feature_set::FeatureSet,
         solana_instruction::{AccountMeta, Instruction},
-        solana_program::stake::{
-            config as stake_config,
-            instruction::{
-                self, authorize_checked, authorize_checked_with_seed, initialize_checked,
-                set_lockup_checked, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs,
-                LockupArgs, StakeError,
+        solana_program::{
+            stake::{
+                config as stake_config,
+                instruction::{
+                    self, authorize_checked, authorize_checked_with_seed, initialize_checked,
+                    set_lockup_checked, AuthorizeCheckedWithSeedArgs, AuthorizeWithSeedArgs,
+                    LockupArgs, StakeError,
+                },
+                stake_flags::StakeFlags,
+                state::{warmup_cooldown_rate, Authorized, Lockup, StakeAuthorize},
+                MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
             },
-            stake_flags::StakeFlags,
-            state::{warmup_cooldown_rate, Authorized, Lockup, StakeAuthorize},
-            MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
+            vote::state::{VoteState, VoteStateVersions},
         },
         solana_program_runtime::invoke_context::mock_process_instruction,
         solana_pubkey::Pubkey,
@@ -420,7 +423,7 @@ mod tests {
             rewards::Rewards,
             stake_history::{StakeHistory, StakeHistoryEntry},
         },
-        solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
+        solana_vote_program::vote_state,
         std::{collections::HashSet, str::FromStr, sync::Arc},
         test_case::test_case,
     };
@@ -516,7 +519,7 @@ mod tests {
                     } else if *pubkey == invalid_stake_state_pubkey() {
                         AccountSharedData::new(0, 0, &id())
                     } else if *pubkey == invalid_vote_state_pubkey() {
-                        AccountSharedData::new(0, 0, &solana_vote_program::id())
+                        AccountSharedData::new(0, 0, &solana_sdk_ids::vote::id())
                     } else if *pubkey == spoofed_stake_state_pubkey() {
                         AccountSharedData::new(0, 0, &spoofed_stake_program_id())
                     } else {
@@ -844,7 +847,7 @@ mod tests {
         let stake_history_address = stake_history::id();
         let stake_history_account = create_account_shared_data_for_test(&StakeHistory::default());
         let vote_address = Pubkey::new_unique();
-        let vote_account = AccountSharedData::new(0, 0, &solana_vote_program::id());
+        let vote_account = AccountSharedData::new(0, 0, &solana_sdk_ids::vote::id());
         let clock_address = clock::id();
         let clock_account = create_account_shared_data_for_test(&Clock::default());
         #[allow(deprecated)]
@@ -7035,7 +7038,7 @@ mod tests {
             1, /* lamports */
             &VoteStateVersions::new_current(VoteState::default()),
             VoteState::size_of(),
-            &solana_vote_program::id(),
+            &solana_sdk_ids::vote::id(),
         )
         .unwrap();
 
@@ -7043,7 +7046,7 @@ mod tests {
             1, /* lamports */
             &VoteStateVersions::new_current(VoteState::default()),
             VoteState::size_of(),
-            &solana_vote_program::id(),
+            &solana_sdk_ids::vote::id(),
         )
         .unwrap();
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7388,6 +7388,7 @@ dependencies = [
  "solana-sysvar",
  "solana-transaction-context",
  "solana-type-overrides",
+ "solana-vote-interface",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7388,7 +7388,6 @@ dependencies = [
  "solana-sysvar",
  "solana-transaction-context",
  "solana-type-overrides",
- "solana-vote-program",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
Following #4425, I realised solana-stake-program only needs solana-vote-program in dev deps

#### Summary of Changes
- Replace `solana_vote_program` with `solana_program::vote` where possible in solana-stake-program
- Move solana-vote-program to dev deps
- Remove superfluous `metrics` feature from solana-stake-program