### PR TITLE
Inherit lints from workspace for `programs/sbf`

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -9,7 +9,10 @@ edition = "2021"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(target_os, values("solana"))']
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("custom-panic", "custom-heap"))'
+]
 
 [workspace.dependencies]
 array-bytes = "=1.4.1"

--- a/programs/sbf/rust/128bit/Cargo.toml
+++ b/programs/sbf/rust/128bit/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-128bit-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/account_mem/Cargo.toml
+++ b/programs/sbf/rust/account_mem/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/alloc/Cargo.toml
+++ b/programs/sbf/rust/alloc/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/alt_bn128/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128/Cargo.toml
@@ -15,3 +15,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/alt_bn128_compression/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128_compression/Cargo.toml
@@ -15,3 +15,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/big_mod_exp/Cargo.toml
+++ b/programs/sbf/rust/big_mod_exp/Cargo.toml
@@ -17,3 +17,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/call_args/Cargo.toml
+++ b/programs/sbf/rust/call_args/Cargo.toml
@@ -14,3 +14,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/call_depth/Cargo.toml
+++ b/programs/sbf/rust/call_depth/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/caller_access/Cargo.toml
+++ b/programs/sbf/rust/caller_access/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/curve25519/Cargo.toml
+++ b/programs/sbf/rust/curve25519/Cargo.toml
@@ -14,3 +14,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/divide_by_zero/Cargo.toml
+++ b/programs/sbf/rust/divide_by_zero/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/dup_accounts/Cargo.toml
+++ b/programs/sbf/rust/dup_accounts/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/error_handling/Cargo.toml
+++ b/programs/sbf/rust/error_handling/Cargo.toml
@@ -17,3 +17,6 @@ thiserror = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/external_spend/Cargo.toml
+++ b/programs/sbf/rust/external_spend/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/finalize/Cargo.toml
+++ b/programs/sbf/rust/finalize/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/sbf/rust/get_minimum_delegation/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/instruction_introspection/Cargo.toml
+++ b/programs/sbf/rust/instruction_introspection/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -16,3 +16,6 @@ solana-sbf-rust-realloc-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoke_and_error/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_error/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_ok/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoke_and_return/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_return/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoked/Cargo.toml
+++ b/programs/sbf/rust/invoked/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-invoked-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/iter/Cargo.toml
+++ b/programs/sbf/rust/iter/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/log_data/Cargo.toml
+++ b/programs/sbf/rust/log_data/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/many_args/Cargo.toml
+++ b/programs/sbf/rust/many_args/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-many-args-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-mem-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/noop/Cargo.toml
+++ b/programs/sbf/rust/noop/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/param_passing/Cargo.toml
+++ b/programs/sbf/rust/param_passing/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-param-passing-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -15,3 +15,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/rand/Cargo.toml
+++ b/programs/sbf/rust/rand/Cargo.toml
@@ -15,3 +15,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/realloc/Cargo.toml
+++ b/programs/sbf/rust/realloc/Cargo.toml
@@ -14,3 +14,6 @@ solana-sbf-rust-realloc-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/realloc_invoke/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke/Cargo.toml
@@ -15,3 +15,6 @@ solana-sbf-rust-realloc-invoke-dep = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/remaining_compute_units/Cargo.toml
+++ b/programs/sbf/rust/remaining_compute_units/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/ro_account_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_account_modify/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/sbf/rust/secp256k1_recover/Cargo.toml
@@ -15,3 +15,6 @@ solana-secp256k1-recover = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/sha/Cargo.toml
+++ b/programs/sbf/rust/sha/Cargo.toml
@@ -14,3 +14,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/sibling_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_instructions/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/spoof1/Cargo.toml
+++ b/programs/sbf/rust/spoof1/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/spoof1_system/Cargo.toml
+++ b/programs/sbf/rust/spoof1_system/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
+++ b/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
@@ -13,3 +13,6 @@ solana-program = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/upgradeable/Cargo.toml
+++ b/programs/sbf/rust/upgradeable/Cargo.toml
@@ -14,3 +14,6 @@ solana-program = { workspace = true }
 [lib]
 name = "solana_sbf_rust_upgradeable"
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/upgraded/Cargo.toml
+++ b/programs/sbf/rust/upgraded/Cargo.toml
@@ -14,3 +14,6 @@ solana-program = { workspace = true }
 [lib]
 name = "solana_sbf_rust_upgraded"
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/pull/4439, we noticed that simply adding `unexpected_cfgs` to the workspace lints would still raise lints errors for `programs/sbf`.

#### Summary of Changes

When using rust nightly, we must inherit the lint specification from the workspace so that they can be correctly applied.
