### PR TITLE
simplifies blockstore Column::index implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,7 +7712,6 @@ dependencies = [
  "bincode",
  "bitflags 2.8.0",
  "bs58",
- "byteorder",
  "bzip2",
  "chrono",
  "chrono-humanize",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
-byteorder = { workspace = true }
 bzip2 = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 chrono-humanize = { workspace = true }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1188,7 +1188,7 @@ impl Column for columns::ProgramCosts {
 }
 
 impl Column for columns::ShredCode {
-    type Index = (Slot, u64);
+    type Index = (Slot, /*shred index:*/ u64);
     type Key = <columns::ShredData as Column>::Key;
 
     #[inline]
@@ -1214,7 +1214,7 @@ impl ColumnName for columns::ShredCode {
 }
 
 impl Column for columns::ShredData {
-    type Index = (Slot, u64);
+    type Index = (Slot, /*shred index:*/ u64);
     type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u64>()];
 
     #[inline]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6153,7 +6153,6 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bitflags 2.8.0",
- "byteorder 1.5.0",
  "bzip2",
  "chrono",
  "chrono-humanize",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5983,7 +5983,6 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bitflags 2.8.0",
- "byteorder",
  "bzip2",
  "chrono",
  "chrono-humanize",


### PR DESCRIPTION

#### Problem
`Column::index` implementations are verbose and not very readable.

#### Summary of Changes
Implemented a macro to simplify the code.