### PR TITLE
remove "internal use only" from solana-define-syscall definition

### DIFF
--- a/sdk/define-syscall/Cargo.toml
+++ b/sdk/define-syscall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-define-syscall"
-description = "Solana define_syscall macro. For internal use only."
+description = "Solana define_syscall macro and core syscall definitions."
 documentation = "https://docs.rs/solana-define-syscall"
 version = { workspace = true }
 authors = { workspace = true }


### PR DESCRIPTION
#### Problem
In #1827 I extracted the define-syscall crate which contained nothing that made sense to use outside this repo, so I put "For internal use only" in the description. In #3405 I moved core syscall definitions to this crate. These do make sense to use outside this repo so this description is no longer accurate.

#### Summary of Changes
Update it