### PR TITLE
[merlin, zk-sdk] Turn default-features for `merlin` crate to false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 inherits = "release"
 debug = true
 split-debuginfo = "packed"
-lto = false # Preserve the 'thin local LTO' for this build.
+lto = false                # Preserve the 'thin local LTO' for this build.
 
 [profile.release]
 split-debuginfo = "unpacked"
@@ -374,7 +374,7 @@ lru = "0.7.7"
 lz4 = "1.28.1"
 memmap2 = "0.5.10"
 memoffset = "0.9"
-merlin = "3"
+merlin = { version = "3", default-features = false }
 min-max-heap = "1.3.0"
 mockall = "0.11.4"
 modular-bitfield = "0.11.2"

--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -24,6 +24,7 @@ pub mod errors;
 pub mod pod;
 mod range_proof;
 mod sigma_proofs;
+#[cfg(not(target_os = "solana"))]
 mod transcript;
 pub mod zk_elgamal_proof_program;
 

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -1,8 +1,7 @@
-use merlin::Transcript;
-#[cfg(not(target_os = "solana"))]
 use {
     crate::errors::TranscriptError,
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar, traits::IsIdentity},
+    merlin::Transcript,
 };
 
 pub trait TranscriptProtocol {


### PR DESCRIPTION
#### Problem
When building `zk-sdk` with `cargo-build-sbf`, I get the following error
```
error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
   --> src/lib.rs:290:9
    |
290 | /         compile_error!("target is not supported, for more information see: \
291 | |                         https://docs.rs/getrandom/#unsupported-targets");
    | |________________________________________________________________________^

   Compiling solana-sha256-hasher v2.2.0 (/Users/samkim/Projects/solana-program/agave/sdk/sha256-hasher)
error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> src/lib.rs:341:9
    |
341 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`
```

The default features in the `merlin` crate, which `zk-sdk` depends on uses `rand_core`.
```
[features]
default = ["std"]
nightly = []
debug-transcript = ["hex"]
std = ["rand_core/std", "byteorder/std"]
```

#### Summary of Changes
I set `default-features = false` for the `merlin` crate, which resolves the above error with `cargo-build-sbf` (thanks @joncinque!).

After I remove the default features, it complains that the `transcript` module inside zk-sdk is not used in `target_os = "solana"` builds. Not sure why it did not complain before, but I added excluded the `transcript` module from the `target_os = "solana"` target build.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
