### PR TITLE
fix spelling

### DIFF
--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -102,11 +102,11 @@ lazy_static! {
 /// correctly furnishing `core_bpf_migration_feature`.
 ///
 #[allow(dead_code)]
-const TOTAL_COUNT_BUILTS: usize = 12;
+const TOTAL_COUNT_BUILTINS: usize = 12;
 #[cfg(test)]
 static_assertions::const_assert_eq!(
     MIGRATING_BUILTINS_COSTS.len() + NON_MIGRATING_BUILTINS_COSTS.len(),
-    TOTAL_COUNT_BUILTS
+    TOTAL_COUNT_BUILTINS
 );
 
 pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[


### PR DESCRIPTION
#### Problem

const `TOTAL_COUNT_BUILTS` is misspelt 

#### Summary of Changes
- correct the spelling

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
