### PR TITLE
reduces number of iterations when recovering Merkle shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1140,15 +1140,15 @@ pub(crate) fn recover(
             // The same signature also verifies for recovered shreds because
             // when reconstructing the Merkle tree for the erasure batch, we
             // will obtain the same Merkle root.
-            Ok(merkle::recover(shreds, reed_solomon_cache)?
+            merkle::recover(shreds, reed_solomon_cache)?
                 .map(|shred| {
-                    let shred = Shred::from(shred);
+                    let shred = Shred::from(shred?);
                     debug_assert!(get_slot_leader(shred.slot())
                         .map(|pubkey| shred.verify(&pubkey))
                         .unwrap_or_default());
-                    shred
+                    Ok(shred)
                 })
-                .collect())
+                .collect()
         }
     }
 }


### PR DESCRIPTION
#### Problem
Changing the iterator type returned from `shred::merkle::recover` to

    Iterator<Item = Result<Shred, Error>>

instead of

    Iterator<Item = Shred>

will save us one traversal over the vector of shreds.



#### Summary of Changes

The commit reduces number of iterations over the vector of shreds by updating the iterator type returned.