### PR TITLE
clippy: needless_lifetimes

### DIFF
--- a/programs/sbf/rust/param_passing_dep/src/lib.rs
+++ b/programs/sbf/rust/param_passing_dep/src/lib.rs
@@ -18,8 +18,8 @@ pub struct Data<'a> {
 pub struct TestDep {
     pub thirty: u32,
 }
-impl<'a> TestDep {
-    pub fn new(data: &Data<'a>, _one: u64, _two: u64, _three: u64, _four: u64, five: u64) -> Self {
+impl TestDep {
+    pub fn new(data: &Data<'_>, _one: u64, _two: u64, _three: u64, _four: u64, five: u64) -> Self {
         Self {
             thirty: data.twentyfive + five as u32,
         }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -835,7 +835,7 @@ impl Serialize for SerializableAccountsDb<'_> {
 }
 
 #[cfg(feature = "frozen-abi")]
-impl<'a> solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountsDb<'a> {}
+impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountsDb<'_> {}
 
 /// This struct contains side-info while reconstructing the bank from fields
 #[derive(Debug)]

--- a/sdk/frozen-abi/src/abi_example.rs
+++ b/sdk/frozen-abi/src/abi_example.rs
@@ -237,10 +237,10 @@ impl<T: BlockType> EvenAsOpaque for BitVec<T> {
 }
 
 use serde_with::ser::SerializeAsWrap;
-impl<'a, T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'a, T, U> {}
+impl<T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'_, T, U> {}
 // This (EvenAsOpaque) marker trait is needed for serde_with's serde_as(...) because this struct is
 // basically a wrapper struct.
-impl<'a, T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'a, T, U> {
+impl<T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'_, T, U> {
     const TYPE_NAME_MATCHER: &'static str = "serde_with::ser::SerializeAsWrap<";
 }
 


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.84.0.

```
error: the following explicit lifetimes could be elided: 'a
   --> sdk/frozen-abi/src/abi_example.rs:240:6
    |
240 | impl<'a, T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'a, T, U> {}
    |      ^^                                                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
    |
240 - impl<'a, T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'a, T, U> {}
240 + impl<T: ?Sized, U: ?Sized> TransparentAsHelper for SerializeAsWrap<'_, T, U> {}
    |
error: the following explicit lifetimes could be elided: 'a
   --> sdk/frozen-abi/src/abi_example.rs:243:6
    |
243 | impl<'a, T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'a, T, U> {
    |      ^^                                                         ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
243 - impl<'a, T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'a, T, U> {
243 + impl<T: ?Sized, U: ?Sized> EvenAsOpaque for SerializeAsWrap<'_, T, U> {
    |
```

Similar to #4377.


#### Summary of Changes

```
cargo clippy --fix
```

Partially fixes #4380 