### PR TITLE
Make tpu coalescer channel bounded

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -527,12 +527,14 @@ impl ValidatorTpuConfig {
     pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
         let tpu_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
+            coalesce_channel_size: 100_000, // smaller channel size for faster test
             ..Default::default()
         };
 
         let tpu_fwd_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
             max_unstaked_connections: 0,
+            coalesce_channel_size: 100_000, // smaller channel size for faster test
             ..Default::default()
         };
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -84,6 +84,7 @@ mod tests {
                 max_connections_per_peer: 1,
                 max_staked_connections: 10,
                 max_unstaked_connections: 10,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )
@@ -170,6 +171,7 @@ mod tests {
                 max_staked_connections: 10,
                 max_unstaked_connections: 10,
                 wait_for_chunk_timeout: Duration::from_secs(1),
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )
@@ -233,6 +235,7 @@ mod tests {
                 max_connections_per_peer: 1,
                 max_staked_connections: 10,
                 max_unstaked_connections: 10,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )
@@ -262,6 +265,7 @@ mod tests {
                 max_connections_per_peer: 1,
                 max_staked_connections: 10,
                 max_unstaked_connections: 10,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -314,7 +314,7 @@ async fn run_server(
         .store(endpoints.len(), Ordering::Relaxed);
     let staked_connection_table: Arc<Mutex<ConnectionTable>> =
         Arc::new(Mutex::new(ConnectionTable::new()));
-    let (sender, receiver) = async_bounded(1000000);
+    let (sender, receiver) = async_bounded(10_000_000);
     tokio::spawn(packet_batch_sender(
         packet_sender,
         receiver,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -315,9 +315,7 @@ async fn run_server(
         .store(endpoints.len(), Ordering::Relaxed);
     let staked_connection_table: Arc<Mutex<ConnectionTable>> =
         Arc::new(Mutex::new(ConnectionTable::new()));
-    info!("Creating the packet_batch_sender, and async channel");
     let (sender, receiver) = async_bounded(coalesce_channel_size);
-    info!("Created async channel");
     tokio::spawn(packet_batch_sender(
         packet_sender,
         receiver,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1980,6 +1980,7 @@ pub mod test {
             staked_nodes,
             QuicServerParams {
                 max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )
@@ -2013,6 +2014,7 @@ pub mod test {
             staked_nodes,
             QuicServerParams {
                 max_connections_per_peer: 2,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -11,7 +11,7 @@ use {
         streamer::StakedNodes,
     },
     async_channel::{
-        unbounded as async_unbounded, Receiver as AsyncReceiver, Sender as AsyncSender,
+        bounded as async_bounded, Receiver as AsyncReceiver, Sender as AsyncSender,
     },
     bytes::Bytes,
     crossbeam_channel::Sender,
@@ -314,7 +314,7 @@ async fn run_server(
         .store(endpoints.len(), Ordering::Relaxed);
     let staked_connection_table: Arc<Mutex<ConnectionTable>> =
         Arc::new(Mutex::new(ConnectionTable::new()));
-    let (sender, receiver) = async_unbounded();
+    let (sender, receiver) = async_bounded(1000000);
     tokio::spawn(packet_batch_sender(
         packet_sender,
         receiver,

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -58,6 +58,7 @@ pub struct TestServerConfig {
     pub max_unstaked_connections: usize,
     pub max_streams_per_ms: u64,
     pub max_connections_per_ipaddr_per_min: u64,
+    pub coalesce_channel_size: usize,
 }
 
 impl Default for TestServerConfig {
@@ -68,6 +69,7 @@ impl Default for TestServerConfig {
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
+            coalesce_channel_size: 500_000, // use a smaller value for test as create a huge bounded channel can take time
         }
     }
 }
@@ -121,6 +123,7 @@ pub fn setup_quic_server_with_sockets(
         max_unstaked_connections,
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min,
+        coalesce_channel_size,
     }: TestServerConfig,
 ) -> SpawnTestServerResult {
     let exit = Arc::new(AtomicBool::new(false));
@@ -136,6 +139,7 @@ pub fn setup_quic_server_with_sockets(
         max_connections_per_ipaddr_per_min,
         wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
         coalesce: DEFAULT_TPU_COALESCE,
+        coalesce_channel_size,
     };
     let SpawnNonBlockingServerResult {
         endpoints: _,

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -69,7 +69,7 @@ impl Default for TestServerConfig {
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            coalesce_channel_size: 500_000, // use a smaller value for test as create a huge bounded channel can take time
+            coalesce_channel_size: 100_000, // use a smaller value for test as create a huge bounded channel can take time
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -67,6 +67,9 @@ pub struct SpawnServerResult {
     pub key_updater: Arc<EndpointKeyUpdater>,
 }
 
+/// Controls the the channel size for the PacketBatch coalesce
+pub(crate) const MAX_COALESCE_CHANNEL_SIZE: usize = 1_000_000;
+
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
@@ -594,6 +597,7 @@ pub struct QuicServerParams {
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub coalesce: Duration,
+    pub coalesce_channel_size: usize,
 }
 
 impl Default for QuicServerParams {
@@ -606,6 +610,7 @@ impl Default for QuicServerParams {
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: DEFAULT_TPU_COALESCE,
+            coalesce_channel_size: MAX_COALESCE_CHANNEL_SIZE,
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -68,7 +68,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const MAX_COALESCE_CHANNEL_SIZE: usize = 10_000_000;
+pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 10_000_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
@@ -610,7 +610,7 @@ impl Default for QuicServerParams {
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: DEFAULT_TPU_COALESCE,
-            coalesce_channel_size: MAX_COALESCE_CHANNEL_SIZE,
+            coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -68,7 +68,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const MAX_COALESCE_CHANNEL_SIZE: usize = 1_000_000;
+pub(crate) const MAX_COALESCE_CHANNEL_SIZE: usize = 10_000_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -690,7 +690,10 @@ mod test {
             sender,
             exit.clone(),
             staked_nodes,
-            QuicServerParams::default(),
+            QuicServerParams {
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
+                ..Default::default()
+            },
         )
         .unwrap();
         (t, exit, receiver, server_address)
@@ -747,6 +750,7 @@ mod test {
             staked_nodes,
             QuicServerParams {
                 max_connections_per_peer: 2,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )
@@ -792,6 +796,7 @@ mod test {
             staked_nodes,
             QuicServerParams {
                 max_unstaked_connections: 0,
+                coalesce_channel_size: 100_000, // smaller channel size for faster test
                 ..QuicServerParams::default()
             },
         )

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -113,6 +113,7 @@ impl Vortexor {
             max_connections_per_ipaddr_per_min,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: tpu_coalesce,
+            ..Default::default()
         };
 
         let TpuSockets {


### PR DESCRIPTION
#### Problem
It is found that under constant high load of incoming TPU traffic. The packet batch coalescer cannot keep up the incoming packets and cause ever increasing memory usage in the async channel.  

#### Summary of Changes

Be defensive and limit the async channel to 10 million about 1G max memory usage for the channel.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
