### PR TITLE
docs: fix quotation marks

### DIFF
--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -66,9 +66,9 @@ solana --version
 - Open a Command Prompt (`cmd.exe`) as an Administrator
 
   - Search for Command Prompt in the Windows search bar. When the Command Prompt
-    app appears, right-click and select “Open as Administrator”. If you are
-    prompted by a pop-up window asking “Do you want to allow this app to make
-    changes to your device?”, click Yes.
+    app appears, right-click and select "Open as Administrator". If you are
+    prompted by a pop-up window asking "Do you want to allow this app to make
+    changes to your device?", click Yes.
 
 - Copy and paste the following command, then press Enter to download the Solana
   installer into a temporary directory:

--- a/docs/src/consensus/fork-generation.md
+++ b/docs/src/consensus/fork-generation.md
@@ -8,7 +8,7 @@ description:
 The Solana protocol doesn’t wait for all validators to agree on a newly produced
 block before the next block is produced. Because of that, it’s quite common for
 two different blocks to be chained to the same parent block. In those
-situations, we call each conflicting chain a [“fork.”](./fork-generation.md)
+situations, we call each conflicting chain a ["fork."](./fork-generation.md)
 
 Solana validators need to vote on one of these forks and reach agreement on
 which one to use through a consensus algorithm (that is beyond the scope of this
@@ -34,11 +34,11 @@ only a single leader's transactions will be accepted.
 
 The table below illustrates what competing forks could look like. Time
 progresses from left to right and each slot is assigned to a validator that
-temporarily becomes the cluster “leader” and may produce a block for that slot.
+temporarily becomes the cluster "leader" and may produce a block for that slot.
 
-In this example, the leader for slot 3 chose to chain its “Block 3” directly to
-“Block 1” and in doing so skipped “Block 2”. Similarly, the leader for slot 5
-chose to chain “Block 5” directly to “Block 3” and skipped “Block 4”.
+In this example, the leader for slot 3 chose to chain its "Block 3" directly to
+"Block 1" and in doing so skipped "Block 2". Similarly, the leader for slot 5
+chose to chain "Block 5" directly to "Block 3" and skipped "Block 4".
 
 > Note that across different forks, the block produced for a given slot is
 > _always_ the same because producing two different blocks for the same slot is

--- a/docs/src/operations/guides/validator-stake.md
+++ b/docs/src/operations/guides/validator-stake.md
@@ -28,7 +28,7 @@ your validator and the rest of the cluster.
 ## Create Stake Keypair
 
 If you haven’t already done so, create a staking keypair. If you have completed
-this step, you should see the “validator-stake-keypair.json” in your Solana
+this step, you should see the "validator-stake-keypair.json" in your Solana
 runtime directory.
 
 ```bash
@@ -99,7 +99,7 @@ account.
 This is a normal transaction so the standard transaction fee will apply. The
 transaction fee range is defined by the genesis block. The actual fee will
 fluctuate based on transaction load. You can determine the current fee via the
-[RPC API “getRecentBlockhash”](https://solana.com/docs/rpc/deprecated/getrecentblockhash) before submitting
+[RPC API "getRecentBlockhash"](https://solana.com/docs/rpc/deprecated/getrecentblockhash) before submitting
 a transaction.
 
 Learn more about
@@ -140,7 +140,7 @@ Helpful JSON-RPC methods:
 - `getLeaderSchedule` At any given moment, the network expects only one
   validator to produce ledger entries. The
   [validator currently selected to produce ledger entries](../../consensus/leader-rotation.md#leader-rotation)
-  is called the “leader”. This will return the complete leader schedule \(on a
+  is called the "leader". This will return the complete leader schedule \(on a
   slot-by-slot basis\) for currently activated stake, the identity pubkey will
   show up 1 or more times here.
 

--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -116,7 +116,7 @@ The identity public key can now be viewed by running:
 solana-keygen pubkey ~/validator-keypair.json
 ```
 
-> Note: The "validator-keypair.json” file is also your \(ed25519\) private key.
+> Note: The "validator-keypair.json" file is also your \(ed25519\) private key.
 
 ### Paper Wallet identity
 
@@ -168,7 +168,7 @@ VALIDATOR if you lose access to it. If this happens, YOU WILL LOSE YOUR
 ALLOCATION OF SOL TOO.
 
 To back-up your validator identify keypair, **back-up your
-"validator-keypair.json” file or your seed phrase to a secure location.**
+"validator-keypair.json" file or your seed phrase to a secure location.**
 
 ## More Solana CLI Configuration
 
@@ -235,7 +235,7 @@ solana-keygen new -o ~/authorized-withdrawer-keypair.json
 
 If you haven’t already done so, create a vote-account keypair and create the
 vote account on the network. If you have completed this step, you should see the
-“vote-account-keypair.json” in your Solana runtime directory:
+"vote-account-keypair.json" in your Solana runtime directory:
 
 ```bash
 solana-keygen new -o ~/vote-account-keypair.json

--- a/docs/src/proposals/interchain-transaction-verification.md
+++ b/docs/src/proposals/interchain-transaction-verification.md
@@ -68,7 +68,7 @@ A contract deployed on Solana which coordinates and intermediates the interactio
 
 ### Proof Request
 
-A message sent by the Client to the SPV engine denoting a request for a proof of a specific transaction or set of transactions. Proof Requests can either manually specify a certain transaction by its hash or can elect to submit a filter that matches multiple transactions or classes of transactions. For example, a filter matching “any transaction from address xxx to address yyy” could be used to detect payment of a debt or settlement of an inter-chain swap. Likewise, a filter matching “any transaction from address xxx” could be used by a lending or synthetic token minting contract to monitor and react to changes in collateralization. Proof Requests are sent with a fee, which is disbursed by the SPV engine contract to the appropriate Prover once a proof matching that request is validated.
+A message sent by the Client to the SPV engine denoting a request for a proof of a specific transaction or set of transactions. Proof Requests can either manually specify a certain transaction by its hash or can elect to submit a filter that matches multiple transactions or classes of transactions. For example, a filter matching "any transaction from address xxx to address yyy" could be used to detect payment of a debt or settlement of an inter-chain swap. Likewise, a filter matching "any transaction from address xxx" could be used by a lending or synthetic token minting contract to monitor and react to changes in collateralization. Proof Requests are sent with a fee, which is disbursed by the SPV engine contract to the appropriate Prover once a proof matching that request is validated.
 
 ### Request Book
 


### PR DESCRIPTION
Some editors could have trouble accurately rendering these characters, with these characters showing up as gibberish or causing formatting problems. It will confuse readers.