### PR TITLE
CI: Re-enable downstream jobs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -11,6 +11,7 @@ on:
       - v[0-9]+.[0-9]+
     paths:
       - "**.rs"
+      - "rust-toolchain.toml"
       - "Cargo.toml"
       - "Cargo.lock"
       - "cargo-build-sbf"
@@ -37,8 +38,7 @@ env:
 
 jobs:
   check:
-    #if: github.repository == 'anza-xyz/agave'
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,8 +75,7 @@ jobs:
           cargo check
 
   test_cli:
-    #if: github.repository == 'anza-xyz/agave'
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -105,8 +104,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    #if: github.repository == 'anza-xyz/agave'
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
#### Problem

The downstream SPL jobs were disabled due to a new error caught by Rust 1.84. All of the program repos have been updated to mark their public test modules as `pub(crate)`:

* record: https://github.com/solana-program/record/pull/18
* libraries: https://github.com/solana-program/libraries/pull/22
* token-2022: https://github.com/solana-program/token-2022/pull/80

#### Summary of changes

Re-enable the tests! Also, run the downstream jobs when rust-toolchain.toml is modified.