### PR TITLE
Remove unnecessary input to transaction_accounts_lamports_sum

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -929,6 +929,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ) -> ExecutedTransaction {
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
 
+        // Ensure the length of accounts matches the expected length from tx.account_keys().
+        // This is a sanity check in case that someone starts adding some additional accounts
+        // since this has been done before. See discussion in PR #4497 for details
+        debug_assert!(transaction_accounts.len() == tx.account_keys().len());
+
         fn transaction_accounts_lamports_sum(
             accounts: &[(Pubkey, AccountSharedData)],
         ) -> Option<u128> {


### PR DESCRIPTION
#### Problem
Function `transaction_accounts_lamports_sum` has an input `message`. Only `message.account_keys().len()` is used from it. But the input `accounts` was built from `message.account_keys()` [here](https://github.com/anza-xyz/agave/blob/1d1e1c160b9613fddd1a5b2850903a1ad4d1df04/svm/src/account_loader.rs#L430), so the lengths of these vectors are the same


#### Summary of Changes
1. Removed unnecessary input
2. Replaced for loop with iterator

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
