### PR TITLE
TransactionView::num_requested_write_locks

### DIFF
--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -146,14 +146,6 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         is_writable_cache
     }
 
-    fn num_readonly_accounts(&self) -> usize {
-        usize::from(self.view.total_readonly_lookup_accounts())
-            .wrapping_add(usize::from(self.view.num_readonly_signed_static_accounts()))
-            .wrapping_add(usize::from(
-                self.view.num_readonly_unsigned_static_accounts(),
-            ))
-    }
-
     pub fn loaded_addresses(&self) -> Option<&LoadedAddresses> {
         self.resolved_addresses.as_ref()
     }
@@ -165,9 +157,7 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
     }
 
     fn num_write_locks(&self) -> u64 {
-        self.account_keys()
-            .len()
-            .wrapping_sub(self.num_readonly_accounts()) as u64
+        self.view.num_requested_write_locks()
     }
 
     fn recent_blockhash(&self) -> &Hash {

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -209,6 +209,19 @@ impl<D: TransactionData> TransactionView<true, D> {
             .wrapping_add(self.total_writable_lookup_accounts())
             .wrapping_add(self.total_readonly_lookup_accounts())
     }
+
+    /// Return the number of requested writable keys.
+    #[inline]
+    pub fn num_requested_write_locks(&self) -> u64 {
+        u64::from(
+            u16::from(
+                (self.num_static_account_keys())
+                    .wrapping_sub(self.num_readonly_signed_static_accounts())
+                    .wrapping_sub(self.num_readonly_unsigned_static_accounts()),
+            )
+            .wrapping_add(self.total_writable_lookup_accounts()),
+        )
+    }
 }
 
 // Manual implementation of `Debug` - avoids bound on `D`.


### PR DESCRIPTION
#### Problem
- Current type functions only allow you to get the number of requested write locks (used in cost model) if the type has ALTs resolved (`ResolvedTransactionView`).
- This number **should** be accessible as soon as we have run basic sanitization (`SanitizedTransactionView`)

#### Summary of Changes
- Refactor functions so that `SanitizedTransactionView::num_requested_write_locks` exists

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
