### PR TITLE
v2.0: ci: bump [upload|download]-artifact to v4

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Artifacts
         if: ${{ steps.build.outputs.channel != '' || steps.build.outputs.tag != '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           path: windows-release/
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: windows-artifact
           path: ./windows-release
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: windows-artifact
           path: ./windows-release/


### PR DESCRIPTION
#### Problem

actions/upload-artifact@v3 and actions/download-artifact@v3 are deprecated

https://github.com/anza-xyz/agave/actions/runs/12812858562

<img width="1164" alt="Screenshot 2025-01-17 at 00 13 02" src="https://github.com/user-attachments/assets/19dfd19f-1d85-4b10-99c4-ce28f60e7abb" />

#### Summary of Changes

bump to v4
