### PR TITLE
Fix clippy lint in `programs/sbf`

### DIFF
--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1437,7 +1437,7 @@ fn process_instruction<'a>(
             msg!("TEST_STACK_HEAP_ZEROED");
             const MM_STACK_START: u64 = 0x200000000;
             const MM_HEAP_START: u64 = 0x300000000;
-            const ZEROS: [u8; 256 * 1024] = [0; 256 * 1024];
+            static ZEROS: [u8; 256 * 1024] = [0; 256 * 1024];
             const STACK_FRAME_SIZE: usize = 4096;
             const MAX_CALL_DEPTH: usize = 64;
 


### PR DESCRIPTION
#### Problem

Cargo clippy nightly 2024-11-22 requires that large constant arrays be declared as static.

#### Summary of Changes

I followed clippy's suggestion to make the array static. In the test, we only use its zeroed values to ensure the stack and heap are initialized as zero in an `assert_eq!` macro.

According to [clippy's documentation](https://rust-lang.github.io/rust-clippy/master/index.html#large_const_arrays), const arrays are inlined, while static are initialized in a fixed memory location to which every usage refers. As we are only using it for a comparison, either constant or static should do the job.

