### PR TITLE
removes ContactInfo::set_{serve_repair,tpu_vote,tvu}_quic api

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1989,6 +1989,7 @@ mod tests {
 
     #[test]
     fn window_index_request() {
+        use Protocol::{QUIC, UDP};
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
@@ -2022,15 +2023,15 @@ mod tests {
             0u16,        // shred_version
         );
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
-        nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
-        nxt.set_tvu_quic((Ipv4Addr::LOCALHOST, 1236)).unwrap();
+        nxt.set_tvu(UDP, (Ipv4Addr::LOCALHOST, 1235)).unwrap();
+        nxt.set_tvu(QUIC, (Ipv4Addr::LOCALHOST, 1236)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
-        nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();
+        nxt.set_tpu_vote(UDP, (Ipv4Addr::LOCALHOST, 1240)).unwrap();
         nxt.set_rpc((Ipv4Addr::LOCALHOST, 1241)).unwrap();
         nxt.set_rpc_pubsub((Ipv4Addr::LOCALHOST, 1242)).unwrap();
-        nxt.set_serve_repair(serve_repair_addr).unwrap();
-        nxt.set_serve_repair_quic((Ipv4Addr::LOCALHOST, 1237))
+        nxt.set_serve_repair(UDP, serve_repair_addr).unwrap();
+        nxt.set_serve_repair(QUIC, (Ipv4Addr::LOCALHOST, 1237))
             .unwrap();
         cluster_info.insert_info(nxt.clone());
         let rv = serve_repair
@@ -2057,15 +2058,15 @@ mod tests {
             0u16,        // shred_version
         );
         nxt.set_gossip((Ipv4Addr::LOCALHOST, 1234)).unwrap();
-        nxt.set_tvu((Ipv4Addr::LOCALHOST, 1235)).unwrap();
-        nxt.set_tvu_quic((Ipv4Addr::LOCALHOST, 1236)).unwrap();
+        nxt.set_tvu(UDP, (Ipv4Addr::LOCALHOST, 1235)).unwrap();
+        nxt.set_tvu(QUIC, (Ipv4Addr::LOCALHOST, 1236)).unwrap();
         nxt.set_tpu((Ipv4Addr::LOCALHOST, 1238)).unwrap();
         nxt.set_tpu_forwards((Ipv4Addr::LOCALHOST, 1239)).unwrap();
-        nxt.set_tpu_vote((Ipv4Addr::LOCALHOST, 1240)).unwrap();
+        nxt.set_tpu_vote(UDP, (Ipv4Addr::LOCALHOST, 1240)).unwrap();
         nxt.set_rpc((Ipv4Addr::LOCALHOST, 1241)).unwrap();
         nxt.set_rpc_pubsub((Ipv4Addr::LOCALHOST, 1242)).unwrap();
-        nxt.set_serve_repair(serve_repair_addr2).unwrap();
-        nxt.set_serve_repair_quic((Ipv4Addr::LOCALHOST, 1237))
+        nxt.set_serve_repair(UDP, serve_repair_addr2).unwrap();
+        nxt.set_serve_repair(QUIC, (Ipv4Addr::LOCALHOST, 1237))
             .unwrap();
         cluster_info.insert_info(nxt);
         let mut one = false;

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2650,19 +2650,32 @@ impl Node {
                     $name
                 ))
             };
+            ($method:ident, $protocol:ident, $addr:expr, $name:literal) => {{
+                info.$method(contact_info::Protocol::$protocol, $addr)
+                    .expect(&format!(
+                        "Operator must spin up node with valid {} address",
+                        $name
+                    ))
+            }};
         }
         set_socket!(set_gossip, gossip_addr, "gossip");
-        set_socket!(set_tvu, tvu.local_addr().unwrap(), "TVU");
-        set_socket!(set_tvu_quic, tvu_quic.local_addr().unwrap(), "TVU QUIC");
+        set_socket!(set_tvu, UDP, tvu.local_addr().unwrap(), "TVU");
+        set_socket!(set_tvu, QUIC, tvu_quic.local_addr().unwrap(), "TVU QUIC");
         set_socket!(set_tpu, tpu.local_addr().unwrap(), "TPU");
         set_socket!(
             set_tpu_forwards,
             tpu_forwards.local_addr().unwrap(),
             "TPU-forwards"
         );
-        set_socket!(set_tpu_vote, tpu_vote.local_addr().unwrap(), "TPU-vote");
         set_socket!(
-            set_tpu_vote_quic,
+            set_tpu_vote,
+            UDP,
+            tpu_vote.local_addr().unwrap(),
+            "TPU-vote"
+        );
+        set_socket!(
+            set_tpu_vote,
+            QUIC,
             tpu_vote_quic[0].local_addr().unwrap(),
             "TPU-vote QUIC"
         );
@@ -2670,11 +2683,13 @@ impl Node {
         set_socket!(set_rpc_pubsub, rpc_pubsub_addr, "RPC-pubsub");
         set_socket!(
             set_serve_repair,
+            UDP,
             serve_repair.local_addr().unwrap(),
             "serve-repair"
         );
         set_socket!(
-            set_serve_repair_quic,
+            set_serve_repair,
+            QUIC,
             serve_repair_quic.local_addr().unwrap(),
             "serve-repair QUIC"
         );
@@ -2814,22 +2829,30 @@ impl Node {
                     $name
                 ))
             };
+            ($method:ident, $protocol:ident, $port:ident, $name:literal) => {{
+                info.$method(contact_info::Protocol::$protocol, (addr, $port))
+                    .expect(&format!(
+                        "Operator must spin up node with valid {} address",
+                        $name
+                    ))
+            }};
         }
         set_socket!(set_gossip, gossip_port, "gossip");
-        set_socket!(set_tvu, tvu_port, "TVU");
-        set_socket!(set_tvu_quic, tvu_quic_port, "TVU QUIC");
+        set_socket!(set_tvu, UDP, tvu_port, "TVU");
+        set_socket!(set_tvu, QUIC, tvu_quic_port, "TVU QUIC");
         set_socket!(set_tpu, tpu_port, "TPU");
         set_socket!(set_tpu_forwards, tpu_forwards_port, "TPU-forwards");
-        set_socket!(set_tpu_vote, tpu_vote_port, "TPU-vote");
+        set_socket!(set_tpu_vote, UDP, tpu_vote_port, "TPU-vote");
+        set_socket!(set_tpu_vote, QUIC, tpu_vote_quic_port, "TPU-vote QUIC");
         set_socket!(set_rpc, rpc_port, "RPC");
         set_socket!(set_rpc_pubsub, rpc_pubsub_port, "RPC-pubsub");
-        set_socket!(set_serve_repair, serve_repair_port, "serve-repair");
+        set_socket!(set_serve_repair, UDP, serve_repair_port, "serve-repair");
         set_socket!(
-            set_serve_repair_quic,
+            set_serve_repair,
+            QUIC,
             serve_repair_quic_port,
             "serve-repair QUIC"
         );
-        set_socket!(set_tpu_vote_quic, tpu_vote_quic_port, "TPU-vote QUIC");
 
         trace!("new ContactInfo: {:?}", info);
 
@@ -2959,20 +2982,22 @@ impl Node {
             0u16,        // shred_version
         );
         let addr = gossip_addr.ip();
+        use contact_info::Protocol::{QUIC, UDP};
         info.set_gossip((addr, gossip_port)).unwrap();
-        info.set_tvu((addr, tvu_port)).unwrap();
-        info.set_tvu_quic((addr, tvu_quic_port)).unwrap();
+        info.set_tvu(UDP, (addr, tvu_port)).unwrap();
+        info.set_tvu(QUIC, (addr, tvu_quic_port)).unwrap();
         info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_port)))
             .unwrap();
         info.set_tpu_forwards(
             public_tpu_forwards_addr.unwrap_or_else(|| SocketAddr::new(addr, tpu_forwards_port)),
         )
         .unwrap();
-        info.set_tpu_vote((addr, tpu_vote_port)).unwrap();
-        info.set_serve_repair((addr, serve_repair_port)).unwrap();
-        info.set_serve_repair_quic((addr, serve_repair_quic_port))
+        info.set_tpu_vote(UDP, (addr, tpu_vote_port)).unwrap();
+        info.set_tpu_vote(QUIC, (addr, tpu_vote_quic_port)).unwrap();
+        info.set_serve_repair(UDP, (addr, serve_repair_port))
             .unwrap();
-        info.set_tpu_vote_quic((addr, tpu_vote_quic_port)).unwrap();
+        info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
+            .unwrap();
 
         trace!("new ContactInfo: {:?}", info);
 

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -1441,7 +1441,7 @@ pub(crate) mod tests {
         caller: &CrdsValue,
         num_items: usize,
     ) {
-        let packet_data_size_range = (PACKET_DATA_SIZE - 5)..=PACKET_DATA_SIZE;
+        let packet_data_size_range = (PACKET_DATA_SIZE - 7)..=PACKET_DATA_SIZE;
         let max_bytes = get_max_bloom_filter_bytes(caller);
         let filters = CrdsFilterSet::new(rng, num_items, max_bytes);
         let request_bytes = caller.bincode_serialized_size() as u64;
@@ -1467,7 +1467,7 @@ pub(crate) mod tests {
         let keypair = Keypair::new();
         let node = {
             let mut node =
-                ContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ rng.gen());
+                ContactInfo::new_localhost(&keypair.pubkey(), /*wallclock:*/ timestamp());
             node.set_shred_version(rng.gen());
             node
         };
@@ -1491,7 +1491,7 @@ pub(crate) mod tests {
         };
         {
             let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 1165);
+            assert_eq!(get_max_bloom_filter_bytes(&caller), 1155);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
         let node = LegacyContactInfo::try_from(&node).unwrap();

--- a/turbine/benches/retransmit_stage.rs
+++ b/turbine/benches/retransmit_stage.rs
@@ -63,7 +63,9 @@ fn bench_retransmitter(bencher: &mut Bencher) {
         let socket = bind_to_unspecified().unwrap();
         let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
         let port = socket.local_addr().unwrap().port();
-        contact_info.set_tvu((Ipv4Addr::LOCALHOST, port)).unwrap();
+        contact_info
+            .set_tvu(Protocol::UDP, (Ipv4Addr::LOCALHOST, port))
+            .unwrap();
         info!("local: {:?}", contact_info.tvu(Protocol::UDP).unwrap());
         cluster_info.insert_info(contact_info);
         socket.set_nonblocking(true).unwrap();


### PR DESCRIPTION

#### Problem
It is not obvious that

    ContactInfo::set_{serve_repair,tpu_vote,tvu}(...)

are only setting the UDP port. Also having separate api for

    ContactInfo::set_{serve_repair,tpu_vote,tvu}_quic(...)

is redundant and the intended protocol can instead be explicitly passed as an argument.


#### Summary of Changes
The commit removes `ContactInfo::set_{serve_repair,tpu_vote,tvu}_quic` api and adds the intended protocol as an argument. For example:

    node.set_tvu(Protocol::QUIC, socket)

or

    node.set_tvu(Protocol::UDP, socket)
