### PR TITLE
txview: run status and age checks on incoming transactions

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -202,9 +202,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         );
 
         // Push unschedulables back into the queue
-        for id in self.unschedulables.drain(..) {
-            container.push_id_into_queue(id);
-        }
+        container.push_ids_into_queue(self.unschedulables.drain(..));
 
         Ok(SchedulingSummary {
             num_scheduled,

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -298,14 +298,13 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         saturating_add_assign!(num_sent, self.send_batches(&mut batches)?);
 
         // Push unschedulable ids back into the container
-        for id in unschedulable_ids {
-            container.push_id_into_queue(id);
-        }
+        container.push_ids_into_queue(unschedulable_ids.into_iter());
 
         // Push remaining transactions back into the container
-        while let Some((id, _)) = self.prio_graph.pop_and_unblock() {
-            container.push_id_into_queue(id);
-        }
+        container.push_ids_into_queue(std::iter::from_fn(|| {
+            self.prio_graph.pop_and_unblock().map(|(id, _)| id)
+        }));
+
         // No more remaining items in the queue.
         // Clear here to make sure the next scheduling pass starts fresh
         // without detecting any conflicts.

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -417,7 +417,7 @@ impl TransactionViewReceiveAndBuffer {
         let lock_results: [_; EXTRA_CAPACITY] = core::array::from_fn(|_| Ok(()));
         let mut error_counters = TransactionErrorMetrics::default();
 
-        let mut run_status_age_checks =
+        let mut check_and_push_to_queue =
             |container: &mut TransactionViewStateContainer,
              transaction_ids: &mut ArrayVec<usize, 64>| {
                 // Temporary scope so that transaction references are immediately
@@ -491,14 +491,14 @@ impl TransactionViewReceiveAndBuffer {
 
                     // If at capacity, run checks and remove invalid transactions.
                     if transaction_ids.len() == EXTRA_CAPACITY {
-                        run_status_age_checks(container, &mut transaction_ids);
+                        check_and_push_to_queue(container, &mut transaction_ids);
                     }
                 }
             }
         }
 
         // Any remaining packets undergo status/age checks
-        run_status_age_checks(container, &mut transaction_ids);
+        check_and_push_to_queue(container, &mut transaction_ids);
 
         let buffer_time_us = start.elapsed().as_micros() as u64;
         timing_metrics.update(|timing_metrics| {

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -432,7 +432,7 @@ impl TransactionViewReceiveAndBuffer {
                     }));
                     working_bank.check_transactions::<RuntimeTransaction<_>>(
                         &transactions,
-                        &lock_results,
+                        &lock_results[..transactions.len()],
                         MAX_PROCESSING_AGE,
                         &mut error_counters,
                     )

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -215,9 +215,9 @@ pub struct TransactionViewStateContainer {
 }
 
 impl TransactionViewStateContainer {
-    // Insert into the map, but NOT into the priority queue.
-    // Returns the id of the transaction if it was inserted.
-    pub(crate) fn try_insert_with_data(
+    /// Insert into the map, but NOT into the priority queue.
+    /// Returns the id of the transaction if it was inserted.
+    pub(crate) fn try_insert_map_only_with_data(
         &mut self,
         data: &[u8],
         f: impl FnOnce(SharedBytes) -> Result<TransactionState<RuntimeTransactionView>, ()>,


### PR DESCRIPTION
#### Problem
- `view` transaction parsing option in banking stage does not run status/age checks before inserting transactions into the buffer
- this means that aged out, high priority, transactions may push out lower-priority but still valid transactions

#### Summary of Changes
- Insert **all** valid transactions into the map on receive (map only, not priority queue)
- Check ages in batches (batch size is equal to the extra capacity we reserved in the map)
- Insert only valid transaction's id into priority queue, drop lowest priority if at capacity

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
