### PR TITLE
ForwardingStage

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -502,9 +502,10 @@ mod tests {
     }
 
     fn meta_with_flags(packet_flags: PacketFlags) -> packet::Meta {
-        let mut meta = packet::Meta::default();
-        meta.flags = packet_flags;
-        meta
+        packet::Meta {
+            flags: packet_flags,
+            ..packet::Meta::default()
+        }
     }
 
     fn simple_transfer_with_flags(packet_flags: PacketFlags) -> Packet {

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -79,12 +79,14 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
         connection_cache: Arc<ConnectionCache>,
         root_bank_cache: RootBankCache,
         forward_address_getter: F,
+        data_budget: DataBudget,
     ) -> JoinHandle<()> {
         let forwarding_stage = Self::new(
             receiver,
             connection_cache,
             root_bank_cache,
             forward_address_getter,
+            data_budget,
         );
         Builder::new()
             .name("solFwdStage".to_string())
@@ -97,6 +99,7 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
         connection_cache: Arc<ConnectionCache>,
         root_bank_cache: RootBankCache,
         forward_address_getter: F,
+        data_budget: DataBudget,
     ) -> Self {
         Self {
             receiver,
@@ -104,7 +107,7 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
             root_bank_cache,
             forward_address_getter,
             connection_cache,
-            data_budget: DataBudget::default(),
+            data_budget,
             udp_socket: bind_to_unspecified().unwrap(),
             metrics: ForwardingStageMetrics::default(),
         }
@@ -587,6 +590,7 @@ mod tests {
             connection_cache,
             root_bank_cache,
             forwarding_addresses,
+            DataBudget::default(),
         );
 
         // Send packet batches.

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -169,7 +169,7 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
                     }
                 };
 
-                // If timeout waas reached, prevent backup by draining all
+                // If timeout was reached, prevent backup by draining all
                 // packets in the channel.
                 if timed_out {
                     warn!("ForwardingStage is backed up, dropping packets");

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -1,11 +1,18 @@
 use {
     agave_banking_stage_ingress_types::BankingPacketBatch,
+    agave_transaction_view::transaction_view::SanitizedTransactionView,
     crossbeam_channel::{Receiver, RecvTimeoutError},
     min_max_heap::MinMaxHeap,
     slab::Slab,
     solana_client::connection_cache::ConnectionCache,
+    solana_cost_model::cost_model::CostModel,
     solana_net_utils::bind_to_unspecified,
     solana_perf::{data_budget::DataBudget, packet::Packet},
+    solana_runtime::{bank::Bank, root_bank_cache::RootBankCache},
+    solana_runtime_transaction::{
+        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+    },
+    solana_sdk::fee::FeeBudgetLimits,
     std::{
         net::UdpSocket,
         sync::Arc,
@@ -19,6 +26,7 @@ pub struct ForwardingStage {
     vote_packet_container: PacketContainer,
     non_vote_packet_container: PacketContainer,
 
+    root_bank_cache: RootBankCache,
     connection_cache: Arc<ConnectionCache>,
     data_budget: DataBudget,
     udp_socket: UdpSocket,
@@ -28,8 +36,9 @@ impl ForwardingStage {
     pub fn spawn(
         receiver: Receiver<(BankingPacketBatch, bool)>,
         connection_cache: Arc<ConnectionCache>,
+        root_bank_cache: RootBankCache,
     ) -> JoinHandle<()> {
-        let forwarding_stage = Self::new(receiver, connection_cache);
+        let forwarding_stage = Self::new(receiver, connection_cache, root_bank_cache);
         Builder::new()
             .name("solFwdStage".to_string())
             .spawn(move || forwarding_stage.run())
@@ -39,11 +48,13 @@ impl ForwardingStage {
     fn new(
         receiver: Receiver<(BankingPacketBatch, bool)>,
         connection_cache: Arc<ConnectionCache>,
+        root_bank_cache: RootBankCache,
     ) -> Self {
         Self {
             receiver,
             vote_packet_container: PacketContainer::with_capacity(4096),
             non_vote_packet_container: PacketContainer::with_capacity(4 * 4096),
+            root_bank_cache,
             connection_cache,
             data_budget: DataBudget::default(),
             udp_socket: bind_to_unspecified().unwrap(),
@@ -52,19 +63,20 @@ impl ForwardingStage {
 
     fn run(mut self) {
         loop {
-            if !self.receive_and_buffer() {
+            let root_bank = self.root_bank_cache.root_bank();
+            if !self.receive_and_buffer(&root_bank) {
                 break;
             }
             self.forward_buffered_packets();
         }
     }
 
-    fn receive_and_buffer(&mut self) -> bool {
+    fn receive_and_buffer(&mut self, bank: &Bank) -> bool {
         let now = Instant::now();
         const TIMEOUT: Duration = Duration::from_millis(10);
         match self.receiver.recv_timeout(TIMEOUT) {
             Ok((packet_batches, tpu_vote_batch)) => {
-                self.buffer_packet_batches(packet_batches, tpu_vote_batch);
+                self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank);
 
                 // Drain the channel up to timeout
                 let timed_out = loop {
@@ -73,7 +85,7 @@ impl ForwardingStage {
                     }
                     match self.receiver.try_recv() {
                         Ok((packet_batches, tpu_vote_batch)) => {
-                            self.buffer_packet_batches(packet_batches, tpu_vote_batch)
+                            self.buffer_packet_batches(packet_batches, tpu_vote_batch, bank)
                         }
                         Err(_) => break false,
                     }
@@ -93,10 +105,86 @@ impl ForwardingStage {
         }
     }
 
-    fn buffer_packet_batches(&mut self, packet_batches: BankingPacketBatch, tpu_vote_batch: bool) {}
+    fn buffer_packet_batches(
+        &mut self,
+        packet_batches: BankingPacketBatch,
+        tpu_vote_batch: bool,
+        bank: &Bank,
+    ) {
+        let packet_container = if tpu_vote_batch {
+            &mut self.vote_packet_container
+        } else {
+            &mut self.non_vote_packet_container
+        };
+
+        for batch in packet_batches.iter() {
+            for packet in batch.iter().filter(|p| Self::initial_packet_meta_filter(p)) {
+                let Some(packet_data) = packet.data(..) else {
+                    // should never occur since we've already checked the
+                    // packet is not marked for discard.
+                    continue;
+                };
+
+                // Parse the transaction, make sure it passes basic sanitization checks.
+                let Ok(transaction) = SanitizedTransactionView::try_new_sanitized(packet_data)
+                else {
+                    continue;
+                };
+
+                // Calculate static metadata for the transaction so that we
+                // are able to calculate fees for prioritization.
+                let Ok(transaction) = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
+                    transaction,
+                    solana_sdk::transaction::MessageHash::Compute,
+                    Some(packet.meta().is_simple_vote_tx()),
+                ) else {
+                    continue;
+                };
+
+                // Calculate priority if we can, if this fails we drop.
+                let Some(priority) = calculate_priority(&transaction, bank) else {
+                    continue;
+                };
+
+                // If at capacity, check lowest priority item.
+                if packet_container.priority_queue.len()
+                    == packet_container.priority_queue.capacity()
+                {
+                    let min_priority = packet_container
+                        .priority_queue
+                        .peek_min()
+                        .expect("not empty")
+                        .priority;
+                    // If priority of current packet is not higher than the min
+                    // drop the current packet.
+                    if min_priority >= priority {
+                        continue;
+                    }
+
+                    let dropped_index = packet_container
+                        .priority_queue
+                        .pop_min()
+                        .expect("not empty")
+                        .index;
+                    packet_container.packets.remove(dropped_index);
+                }
+
+                let entry = packet_container.packets.vacant_entry();
+                let index = entry.key();
+                entry.insert(packet.clone());
+                let priority_index = PriorityIndex { priority, index };
+                packet_container.priority_queue.push(priority_index);
+            }
+        }
+    }
 
     fn forward_buffered_packets(&mut self) {
         todo!()
+    }
+
+    fn initial_packet_meta_filter(packet: &Packet) -> bool {
+        let meta = packet.meta();
+        !meta.discard() && !meta.forwarded() && meta.is_from_staked_node()
     }
 }
 
@@ -114,10 +202,61 @@ impl PacketContainer {
     }
 }
 
-type Index = u16;
-
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 struct PriorityIndex {
     priority: u64,
-    index: u16,
+    index: usize,
+}
+
+/// Calculate priority for a transaction:
+///
+/// The priority is calculated as:
+/// P = R / (1 + C)
+/// where P is the priority, R is the reward,
+/// and C is the cost towards block-limits.
+///
+/// Current minimum costs are on the order of several hundred,
+/// so the denominator is effectively C, and the +1 is simply
+/// to avoid any division by zero due to a bug - these costs
+/// are estimate by the cost-model and are not direct
+/// from user input. They should never be zero.
+/// Any difference in the prioritization is negligible for
+/// the current transaction costs.
+fn calculate_priority<'a>(
+    transaction: &RuntimeTransaction<SanitizedTransactionView<&'a [u8]>>,
+    bank: &Bank,
+) -> Option<u64> {
+    let compute_budget_limits = transaction
+        .compute_budget_instruction_details()
+        .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
+        .ok()?;
+    let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
+
+    // Manually estimate fee here since currently interface doesn't allow a on SVM type.
+    // Doesn't need to be 100% accurate so long as close and consistent.
+    let prioritization_fee = fee_budget_limits.prioritization_fee;
+    let signature_details = transaction.signature_details();
+    let signature_fee = signature_details
+        .total_signatures()
+        .saturating_mul(bank.fee_structure().lamports_per_signature);
+    let fee = signature_fee.saturating_add(prioritization_fee);
+
+    let cost = CostModel::estimate_cost(
+        transaction,
+        transaction.program_instructions_iter(),
+        transaction.num_requested_write_locks(),
+        &bank.feature_set,
+    );
+
+    // We need a multiplier here to avoid rounding down too aggressively.
+    // For many transactions, the cost will be greater than the fees in terms of raw lamports.
+    // For the purposes of calculating prioritization, we multiply the fees by a large number so that
+    // the cost is a small fraction.
+    // An offset of 1 is used in the denominator to explicitly avoid division by zero.
+    const MULTIPLIER: u64 = 1_000_000;
+    Some(
+        MULTIPLIER
+            .saturating_mul(fee)
+            .wrapping_div(cost.sum().saturating_add(1)),
+    )
 }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -71,10 +71,9 @@ impl VoteClient {
         }
     }
 
-    fn send_batch(&self, input_batch: &mut Vec<(Vec<u8>, SocketAddr)>) {
-        let mut batch = Vec::with_capacity(FORWARD_BATCH_SIZE);
-        core::mem::swap(&mut batch, input_batch);
-        let _res = batch_send(&self.udp_socket, &batch);
+    fn send_batch(&self, batch: &mut Vec<(Vec<u8>, SocketAddr)>) {
+        let _res = batch_send(&self.udp_socket, batch);
+        batch.clear();
     }
 }
 

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -73,7 +73,7 @@ impl VoteClient {
 
     fn send_batch(&self, input_batch: &mut Vec<(Vec<u8>, SocketAddr)>) {
         let mut batch = Vec::with_capacity(FORWARD_BATCH_SIZE);
-        core::mem::swap(&mut batch, input_batch); // why do we swap?
+        core::mem::swap(&mut batch, input_batch);
         let _res = batch_send(&self.udp_socket, &batch);
     }
 }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -1,0 +1,90 @@
+use {
+    agave_banking_stage_ingress_types::BankingPacketBatch,
+    crossbeam_channel::Receiver,
+    min_max_heap::MinMaxHeap,
+    slab::Slab,
+    solana_client::connection_cache::ConnectionCache,
+    solana_net_utils::bind_to_unspecified,
+    solana_perf::{data_budget::DataBudget, packet::Packet},
+    std::{
+        net::UdpSocket,
+        sync::Arc,
+        thread::{Builder, JoinHandle},
+    },
+};
+
+pub struct ForwardingStage {
+    receiver: Receiver<(BankingPacketBatch, bool)>,
+    vote_packet_container: PacketContainer,
+    non_vote_packet_container: PacketContainer,
+
+    connection_cache: Arc<ConnectionCache>,
+    data_budget: DataBudget,
+    udp_socket: UdpSocket,
+}
+
+impl ForwardingStage {
+    pub fn spawn(
+        receiver: Receiver<(BankingPacketBatch, bool)>,
+        connection_cache: Arc<ConnectionCache>,
+    ) -> JoinHandle<()> {
+        let forwarding_stage = Self::new(receiver, connection_cache);
+        Builder::new()
+            .name("solFwdStage".to_string())
+            .spawn(move || forwarding_stage.run())
+            .unwrap()
+    }
+
+    fn new(
+        receiver: Receiver<(BankingPacketBatch, bool)>,
+        connection_cache: Arc<ConnectionCache>,
+    ) -> Self {
+        Self {
+            receiver,
+            vote_packet_container: PacketContainer::with_capacity(4096),
+            non_vote_packet_container: PacketContainer::with_capacity(4 * 4096),
+            connection_cache,
+            data_budget: DataBudget::default(),
+            udp_socket: bind_to_unspecified().unwrap(),
+        }
+    }
+
+    fn run(mut self) {
+        loop {
+            if !self.receive_and_buffer() {
+                break;
+            }
+            self.forward_buffered_packets();
+        }
+    }
+
+    fn receive_and_buffer(&mut self) -> bool {
+        todo!()
+    }
+
+    fn forward_buffered_packets(&mut self) {
+        todo!()
+    }
+}
+
+struct PacketContainer {
+    priority_queue: MinMaxHeap<PriorityIndex>,
+    packets: Slab<Packet>,
+}
+
+impl PacketContainer {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            priority_queue: MinMaxHeap::with_capacity(capacity),
+            packets: Slab::with_capacity(capacity),
+        }
+    }
+}
+
+type Index = u16;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+struct PriorityIndex {
+    priority: u64,
+    index: u16,
+}

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -19,7 +19,7 @@ use {
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
     },
-    solana_sdk::fee::FeeBudgetLimits,
+    solana_sdk::{fee::FeeBudgetLimits, transaction::MessageHash},
     solana_streamer::sendmmsg::batch_send,
     std::{
         net::{SocketAddr, UdpSocket},
@@ -159,7 +159,7 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
                 // are able to calculate fees for prioritization.
                 let Ok(transaction) = RuntimeTransaction::<SanitizedTransactionView<_>>::try_from(
                     transaction,
-                    solana_sdk::transaction::MessageHash::Compute,
+                    MessageHash::Compute,
                     Some(packet.meta().is_simple_vote_tx()),
                 ) else {
                     continue;

--- a/core/src/forwarding_stage/packet_container.rs
+++ b/core/src/forwarding_stage/packet_container.rs
@@ -54,3 +54,77 @@ struct PriorityIndex {
     priority: u64,
     index: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_sdk::packet::PacketFlags};
+
+    fn simple_packet_with_flags(packet_flags: PacketFlags) -> Packet {
+        let mut packet = Packet::default();
+        packet.meta_mut().flags = packet_flags;
+        packet
+    }
+
+    #[test]
+    fn test_packet_container_status() {
+        let mut container = PacketContainer::with_capacity(2);
+        assert!(container.is_empty());
+        assert!(!container.is_full());
+        container.insert(simple_packet_with_flags(PacketFlags::empty()), 1);
+        assert!(!container.is_empty());
+        assert!(!container.is_full());
+        container.insert(simple_packet_with_flags(PacketFlags::all()), 2);
+        assert!(!container.is_empty());
+        assert!(container.is_full());
+    }
+
+    #[test]
+    fn test_packet_container_pop_and_remove_min() {
+        let mut container = PacketContainer::with_capacity(2);
+        assert!(container.pop_and_remove_min().is_none());
+        container.insert(simple_packet_with_flags(PacketFlags::empty()), 1);
+        container.insert(simple_packet_with_flags(PacketFlags::all()), 2);
+        assert_eq!(
+            container
+                .pop_and_remove_min()
+                .expect("not empty")
+                .meta()
+                .flags,
+            PacketFlags::empty()
+        );
+        assert_eq!(
+            container
+                .pop_and_remove_min()
+                .expect("not empty")
+                .meta()
+                .flags,
+            PacketFlags::all()
+        );
+        assert!(container.pop_and_remove_min().is_none());
+    }
+
+    #[test]
+    fn test_packet_container_pop_and_remove_max() {
+        let mut container = PacketContainer::with_capacity(2);
+        assert!(container.pop_and_remove_max().is_none());
+        container.insert(simple_packet_with_flags(PacketFlags::empty()), 1);
+        container.insert(simple_packet_with_flags(PacketFlags::all()), 2);
+        assert_eq!(
+            container
+                .pop_and_remove_max()
+                .expect("not empty")
+                .meta()
+                .flags,
+            PacketFlags::all()
+        );
+        assert_eq!(
+            container
+                .pop_and_remove_max()
+                .expect("not empty")
+                .meta()
+                .flags,
+            PacketFlags::empty()
+        );
+        assert!(container.pop_and_remove_max().is_none());
+    }
+}

--- a/core/src/forwarding_stage/packet_container.rs
+++ b/core/src/forwarding_stage/packet_container.rs
@@ -1,0 +1,56 @@
+use {min_max_heap::MinMaxHeap, slab::Slab, solana_perf::packet::Packet};
+
+/// Container for storing packets.
+/// Packet IDs are stored with priority in a priority queue and the actual
+/// `Packet` are stored in a map.
+pub struct PacketContainer {
+    priority_queue: MinMaxHeap<PriorityIndex>,
+    packets: Slab<Packet>,
+}
+
+impl PacketContainer {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            priority_queue: MinMaxHeap::with_capacity(capacity),
+            packets: Slab::with_capacity(capacity),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.priority_queue.is_empty()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.priority_queue.len() == self.priority_queue.capacity()
+    }
+
+    pub fn min_priority(&self) -> Option<u64> {
+        self.priority_queue.peek_min().map(|min| min.priority)
+    }
+
+    pub fn pop_and_remove_max(&mut self) -> Option<Packet> {
+        self.priority_queue
+            .pop_max()
+            .map(|max| self.packets.remove(max.index))
+    }
+
+    pub fn pop_and_remove_min(&mut self) -> Option<Packet> {
+        self.priority_queue
+            .pop_min()
+            .map(|min| self.packets.remove(min.index))
+    }
+
+    pub fn insert(&mut self, packet: Packet, priority: u64) {
+        let entry = self.packets.vacant_entry();
+        let index = entry.key();
+        entry.insert(packet.clone());
+        let priority_index = PriorityIndex { priority, index };
+        self.priority_queue.push(priority_index);
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+struct PriorityIndex {
+    priority: u64,
+    index: usize,
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod consensus;
 pub mod cost_update_service;
 pub mod drop_bank_service;
 pub mod fetch_stage;
+pub mod forwarding_stage;
 pub mod gen_keys;
 pub mod next_leader;
 pub mod optimistic_confirmation_verifier;


### PR DESCRIPTION
#### Problem
- Forwarding logic makes banking stage excessively more complicated than it needs to be.
- Most nodes run without forwarding of non-vote transactions at all

#### Summary of Changes
- Create a new ForwardingStage in the TPU that is intended to run parallel to banking-stage
- Since the message types sent from Sigverify to BankingStage are wrapped in an Arc, we can (optionally) clone them and send to ForwardingStage.
- This initial PR introduces `ForwardingStage` for simple receiving, buffering, forwarding logic, but does NOT hook it up yet.
- A follow-up PR will be done to combine the hooking up of this `ForwardingStage` with the removal of all forwarding logic in `BankingStage`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
