### PR TITLE
svm: remove `disable_account_loader_special_case`

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -19,7 +19,6 @@ use {
     solana_instruction::{BorrowedAccountMeta, BorrowedInstruction},
     solana_instructions_sysvar::construct_instructions_data,
     solana_nonce::state::State as NonceState,
-    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_pubkey::Pubkey,
     solana_rent::RentDue,
     solana_rent_debits::RentDebits,
@@ -34,7 +33,6 @@ use {
     solana_transaction_context::{IndexOfAccount, TransactionAccount},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::{
-        collections::HashMap,
         num::{NonZeroU32, Saturating},
         sync::Arc,
     },
@@ -109,8 +107,6 @@ pub struct FeesOnlyTransaction {
 
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
-    pub(crate) program_cache: ProgramCacheForTxBatch,
-    program_accounts: HashMap<Pubkey, (&'a Pubkey, u64)>,
     account_cache: AHashMap<Pubkey, AccountSharedData>,
     callbacks: &'a CB,
     pub(crate) feature_set: Arc<FeatureSet>,
@@ -118,8 +114,6 @@ pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
 impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     pub(crate) fn new_with_account_cache_capacity(
         account_overrides: Option<&'a AccountOverrides>,
-        program_cache: ProgramCacheForTxBatch,
-        program_accounts: HashMap<Pubkey, (&'a Pubkey, u64)>,
         callbacks: &'a CB,
         feature_set: Arc<FeatureSet>,
         capacity: usize,
@@ -135,10 +129,8 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         }
 
         Self {
-            program_cache,
             account_cache,
             callbacks,
-            program_accounts,
             feature_set,
         }
     }
@@ -149,24 +141,6 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         usage_pattern: AccountUsagePattern,
     ) -> Option<LoadedTransactionAccount> {
         let is_writable = usage_pattern == AccountUsagePattern::Writable;
-        let is_invisible_read = usage_pattern == AccountUsagePattern::ReadOnlyInvisible;
-        let use_program_cache = !self
-            .feature_set
-            .is_active(&feature_set::disable_account_loader_special_case::id());
-
-        if let Some(program) = (use_program_cache && is_invisible_read)
-            .then_some(())
-            .and_then(|_| self.program_cache.find(account_key))
-        {
-            // Optimization to skip loading of accounts which are only used as
-            // programs in top-level instructions and not passed as instruction accounts.
-            return Some(LoadedTransactionAccount {
-                loaded_size: program.account_size,
-                account: account_shared_data_from_program(account_key, &self.program_accounts)
-                    .ok()?,
-                rent_collected: 0,
-            });
-        }
 
         let account = if let Some(account) = self.account_cache.get(account_key) {
             // If lamports is 0, a previous transaction deallocated this account.
@@ -208,9 +182,6 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         executed_transaction: &ExecutedTransaction,
     ) {
         if executed_transaction.was_successful() {
-            self.program_cache
-                .merge(&executed_transaction.programs_modified_by_tx);
-
             self.update_accounts_for_successful_tx(
                 message,
                 &executed_transaction.loaded_transaction.accounts,
@@ -625,22 +596,6 @@ fn load_transaction_account<CB: TransactionProcessingCallback>(
     loaded_account
 }
 
-fn account_shared_data_from_program(
-    key: &Pubkey,
-    program_accounts: &HashMap<Pubkey, (&Pubkey, u64)>,
-) -> Result<AccountSharedData> {
-    // It's an executable program account. The program is already loaded in the cache.
-    // So the account data is not needed. Return a dummy AccountSharedData with meta
-    // information.
-    let mut program_account = AccountSharedData::default();
-    let (program_owner, _count) = program_accounts
-        .get(key)
-        .ok_or(TransactionError::AccountNotFound)?;
-    program_account.set_owner(**program_owner);
-    program_account.set_executable(true);
-    Ok(program_account)
-}
-
 /// Accumulate loaded account data size into `accumulated_accounts_data_size`.
 /// Returns TransactionErr::MaxLoadedAccountsDataSizeExceeded if
 /// `accumulated_accounts_data_size` exceeds
@@ -718,15 +673,10 @@ mod tests {
         solana_native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
         solana_nonce::{self as nonce, versions::Versions as NonceVersions},
         solana_program::bpf_loader_upgradeable::UpgradeableLoaderState,
-        solana_program_runtime::loaded_programs::{
-            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
-            ProgramCacheForTxBatch,
-        },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_rent_debits::RentDebits,
         solana_reserved_account_keys::ReservedAccountKeys,
-        solana_sbpf::program::BuiltinProgram,
         solana_sdk::rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
         solana_sdk_ids::{
             bpf_loader, bpf_loader_upgradeable, native_loader, system_program, sysvar,
@@ -779,8 +729,6 @@ mod tests {
         fn from(callbacks: &'a TestCallbacks) -> AccountLoader<'a, TestCallbacks> {
             AccountLoader::new_with_account_cache_capacity(
                 None,
-                ProgramCacheForTxBatch::default(),
-                HashMap::default(),
                 callbacks,
                 Arc::<FeatureSet>::default(),
                 0,
@@ -838,28 +786,6 @@ mod tests {
             message,
             &ReservedAccountKeys::empty_key_set(),
         ))
-    }
-
-    fn new_unchecked_sanitized_transaction_with_writable_program(
-        program_id: Pubkey,
-        fee_payer: Pubkey,
-    ) -> SanitizedTransaction {
-        let mut message = Message::new(
-            &[Instruction::new_with_bytes(program_id, &[], vec![])],
-            Some(&fee_payer),
-        );
-        message.header.num_readonly_unsigned_accounts = 0;
-
-        let legacy_message = LegacyMessage {
-            message: Cow::Owned(message),
-            is_writable_account_cache: vec![true, true],
-        };
-
-        SanitizedTransaction::new_for_tests(
-            SanitizedMessage::Legacy(legacy_message),
-            vec![Signature::default()],
-            false,
-        )
     }
 
     fn load_accounts_aux_test(
@@ -1124,8 +1050,6 @@ mod tests {
         };
         let mut account_loader = AccountLoader::new_with_account_cache_capacity(
             account_overrides,
-            ProgramCacheForTxBatch::default(),
-            HashMap::default(),
             &callbacks,
             Arc::new(FeatureSet::all_enabled()),
             0,
@@ -1505,163 +1429,6 @@ mod tests {
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size: 0,
             }
-        );
-    }
-
-    #[test]
-    fn test_load_transaction_accounts_program_account_executable_bypass() {
-        // currently, the account loader retrieves read-only non-instruction accounts from the program cache
-        // it creates a mock AccountSharedData with the executable flag set to true
-        // however, it does not check whether these accounts are actually executable before doing so
-        // this affects consensus: a transaction that uses a cached non-executable program executes and fails
-        // but if the transaction gets the program from accounts-db, it will be dropped during account loading
-        // this test enforces the current behavior, so that future account loader changes do not break consensus
-
-        let mut mock_bank = TestCallbacks::default();
-        let account_keypair = Keypair::new();
-        let program_keypair = Keypair::new();
-        let loader_v2 = bpf_loader::id();
-
-        let mut account_data = AccountSharedData::default();
-        account_data.set_lamports(200);
-        mock_bank
-            .accounts_map
-            .insert(account_keypair.pubkey(), account_data.clone());
-
-        let mut program_data = AccountSharedData::default();
-        program_data.set_lamports(200);
-        program_data.set_owner(loader_v2);
-        mock_bank
-            .accounts_map
-            .insert(program_keypair.pubkey(), program_data);
-
-        let mut loader_data = AccountSharedData::default();
-        loader_data.set_lamports(200);
-        loader_data.set_executable(true);
-        loader_data.set_owner(native_loader::id());
-        mock_bank
-            .accounts_map
-            .insert(loader_v2, loader_data.clone());
-        mock_bank
-            .accounts_map
-            .insert(native_loader::id(), loader_data.clone());
-
-        let transaction =
-            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
-                &[Instruction::new_with_bytes(
-                    program_keypair.pubkey(),
-                    &[],
-                    vec![],
-                )],
-                Some(&account_keypair.pubkey()),
-                &[&account_keypair],
-                Hash::default(),
-            ));
-
-        let mut program_accounts = HashMap::new();
-        program_accounts.insert(program_keypair.pubkey(), (&loader_v2, 0));
-        let mut loaded_programs = ProgramCacheForTxBatch::default();
-        loaded_programs.replenish(
-            program_keypair.pubkey(),
-            Arc::new(ProgramCacheEntry::new_tombstone(
-                0,
-                ProgramCacheEntryOwner::LoaderV2,
-                ProgramCacheEntryType::Closed,
-            )),
-        );
-
-        let mut account_loader = AccountLoader::new_with_account_cache_capacity(
-            None,
-            loaded_programs,
-            program_accounts,
-            &mock_bank,
-            Arc::<FeatureSet>::default(),
-            0,
-        );
-
-        let mut error_metrics = TransactionErrorMetrics::default();
-        let result = load_transaction_accounts(
-            &mut account_loader,
-            transaction.message(),
-            LoadedTransactionAccount {
-                account: account_data.clone(),
-                ..LoadedTransactionAccount::default()
-            },
-            &ComputeBudgetLimits::default(),
-            &mut error_metrics,
-            &RentCollector::default(),
-        );
-
-        // Executable flag is bypassed
-        let mut cached_program = AccountSharedData::default();
-        cached_program.set_owner(loader_v2);
-        cached_program.set_executable(true);
-
-        assert_eq!(
-            result.unwrap(),
-            LoadedTransactionAccounts {
-                accounts: vec![
-                    (account_keypair.pubkey(), account_data.clone()),
-                    (program_keypair.pubkey(), cached_program),
-                ],
-                program_indices: vec![vec![1]],
-                rent: 0,
-                rent_debits: RentDebits::default(),
-                loaded_accounts_data_size: 0,
-            }
-        );
-
-        let transaction =
-            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
-                &[Instruction::new_with_bytes(
-                    program_keypair.pubkey(),
-                    &[],
-                    vec![AccountMeta::new_readonly(program_keypair.pubkey(), false)],
-                )],
-                Some(&account_keypair.pubkey()),
-                &[&account_keypair],
-                Hash::default(),
-            ));
-
-        let result = load_transaction_accounts(
-            &mut account_loader,
-            transaction.message(),
-            LoadedTransactionAccount {
-                account: account_data.clone(),
-                ..LoadedTransactionAccount::default()
-            },
-            &ComputeBudgetLimits::default(),
-            &mut error_metrics,
-            &RentCollector::default(),
-        );
-
-        // including program as instruction account bypasses executable bypass
-        assert_eq!(
-            result.err(),
-            Some(TransactionError::InvalidProgramForExecution)
-        );
-
-        let transaction = new_unchecked_sanitized_transaction_with_writable_program(
-            program_keypair.pubkey(),
-            account_keypair.pubkey(),
-        );
-
-        let result = load_transaction_accounts(
-            &mut account_loader,
-            transaction.message(),
-            LoadedTransactionAccount {
-                account: account_data.clone(),
-                ..LoadedTransactionAccount::default()
-            },
-            &ComputeBudgetLimits::default(),
-            &mut error_metrics,
-            &RentCollector::default(),
-        );
-
-        // including program as writable bypasses executable bypass
-        assert_eq!(
-            result.err(),
-            Some(TransactionError::InvalidProgramForExecution)
         );
     }
 
@@ -2548,32 +2315,15 @@ mod tests {
         let (bpf_loader_size, _) = make_account(loader_v2, native_loader::id(), true);
         let (upgradeable_loader_size, _) = make_account(loader_v3, native_loader::id(), true);
 
-        let (_program1_size, _) = make_account(program1, loader_v2, true);
+        let (program1_size, _) = make_account(program1, loader_v2, true);
 
         let mut program_accounts = HashMap::new();
         program_accounts.insert(program1, (&loader_v2, 0));
         program_accounts.insert(program2, (&loader_v3, 0));
-        let mut program_cache = ProgramCacheForTxBatch::default();
-        let program1_entry = ProgramCacheEntry {
-            account_size: 0,
-            account_owner: ProgramCacheEntryOwner::LoaderV2,
-            program: ProgramCacheEntryType::Closed,
-            ..ProgramCacheEntry::default()
-        };
-        program_cache.replenish(program1, Arc::new(program1_entry));
-        let program2_entry = ProgramCacheEntry {
-            account_size: (program2_size + programdata2_size) as usize,
-            account_owner: ProgramCacheEntryOwner::LoaderV3,
-            program: ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
-            ..ProgramCacheEntry::default()
-        };
-        program_cache.replenish(program2, Arc::new(program2_entry));
 
         let test_transaction_data_size = |transaction, expected_size| {
             let mut account_loader = AccountLoader::new_with_account_cache_capacity(
                 None,
-                program_cache.clone(),
-                program_accounts.clone(),
                 &mock_bank,
                 Arc::<FeatureSet>::default(),
                 0,
@@ -2615,7 +2365,7 @@ mod tests {
         for account_meta in [AccountMeta::new, AccountMeta::new_readonly] {
             // one program plus loader
             let ixns = vec![Instruction::new_with_bytes(program1, &[], vec![])];
-            test_data_size(ixns, bpf_loader_size + fee_payer_size);
+            test_data_size(ixns, program1_size + bpf_loader_size + fee_payer_size);
 
             // two programs, two loaders, two accounts
             let ixns = vec![
@@ -2626,20 +2376,12 @@ mod tests {
                 ixns,
                 account1_size
                     + account2_size
+                    + program1_size
                     + program2_size
-                    + programdata2_size
                     + bpf_loader_size
                     + upgradeable_loader_size
                     + fee_payer_size,
             );
-
-            // ordinary owners not counted
-            let ixns = vec![Instruction::new_with_bytes(
-                program1,
-                &[],
-                vec![account_meta(account2, false)],
-            )];
-            test_data_size(ixns, account2_size + bpf_loader_size + fee_payer_size);
 
             // program and loader counted once
             let ixns = vec![
@@ -2648,7 +2390,7 @@ mod tests {
             ];
             test_data_size(
                 ixns,
-                upgradeable_loader_size + program2_size + programdata2_size + fee_payer_size,
+                program2_size + upgradeable_loader_size + fee_payer_size,
             );
 
             // native loader not counted if loader
@@ -2687,7 +2429,7 @@ mod tests {
             )];
             test_data_size(
                 ixns,
-                upgradeable_loader_size * 2 + program2_size + programdata2_size + fee_payer_size,
+                upgradeable_loader_size * 2 + program2_size + fee_payer_size,
             );
 
             // loader counted twice even if included first
@@ -2697,7 +2439,7 @@ mod tests {
             ];
             test_data_size(
                 ixns,
-                upgradeable_loader_size * 2 + program2_size + programdata2_size + fee_payer_size,
+                upgradeable_loader_size * 2 + program2_size + fee_payer_size,
             );
 
             // cover that case with multiple loaders to be sure
@@ -2720,8 +2462,8 @@ mod tests {
             test_data_size(
                 ixns,
                 account1_size
+                    + program1_size
                     + program2_size
-                    + programdata2_size
                     + bpf_loader_size * 2
                     + upgradeable_loader_size * 2
                     + fee_payer_size,
@@ -2733,39 +2475,20 @@ mod tests {
                 &[],
                 vec![account_meta(fee_payer, false)],
             )];
-            test_data_size(ixns, bpf_loader_size + fee_payer_size);
+            test_data_size(ixns, program1_size + bpf_loader_size + fee_payer_size);
 
-            // normal function call uses the combined cache size
-            let ixns = vec![Instruction::new_with_bytes(program2, &[], vec![])];
-            test_data_size(
-                ixns,
-                program2_size + programdata2_size + upgradeable_loader_size + fee_payer_size,
-            );
-
-            // program as instruction account bypasses the cache
-            let ixns = vec![Instruction::new_with_bytes(
-                program2,
-                &[],
-                vec![account_meta(program2, false)],
-            )];
-            test_data_size(
-                ixns,
-                program2_size + upgradeable_loader_size + fee_payer_size,
-            );
-
-            // programdata as instruction account double-counts it
+            // programdata as instruction account counts it once
             let ixns = vec![Instruction::new_with_bytes(
                 program2,
                 &[],
                 vec![account_meta(programdata2, false)],
             )];
-
             test_data_size(
                 ixns,
-                program2_size + programdata2_size * 2 + upgradeable_loader_size + fee_payer_size,
+                program2_size + programdata2_size + upgradeable_loader_size + fee_payer_size,
             );
 
-            // both as instruction accounts, for completeness
+            // program and programdata as instruction accounts behaves the same
             let ixns = vec![Instruction::new_with_bytes(
                 program2,
                 &[],
@@ -2778,16 +2501,6 @@ mod tests {
                 ixns,
                 program2_size + programdata2_size + upgradeable_loader_size + fee_payer_size,
             );
-
-            // writable program bypasses the cache
-            let tx = new_unchecked_sanitized_transaction_with_writable_program(program2, fee_payer);
-            test_transaction_data_size(
-                tx,
-                program2_size + upgradeable_loader_size + fee_payer_size,
-            );
-
-            // NOTE for the new loader we *must* also test arbitrary permutations of the cache transactions
-            // to ensure that the batched loading is overridden on a tx-per-tx basis
         }
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -4,8 +4,8 @@ use {
     crate::{
         account_loader::{
             collect_rent_from_account, load_transaction, validate_fee_payer, AccountLoader,
-            AccountUsagePattern, CheckedTransactionDetails, LoadedTransaction,
-            TransactionCheckResult, TransactionLoadResult, ValidatedTransactionDetails,
+            CheckedTransactionDetails, LoadedTransaction, TransactionCheckResult,
+            TransactionLoadResult, ValidatedTransactionDetails,
         },
         account_overrides::AccountOverrides,
         message_processor::process_message,
@@ -578,8 +578,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let fee_payer_address = message.fee_payer();
 
-        let Some(mut loaded_fee_payer) =
-            account_loader.load_account(fee_payer_address, AccountUsagePattern::Writable)
+        let Some(mut loaded_fee_payer) = account_loader.load_account(fee_payer_address, true)
         else {
             error_counters.account_not_found += 1;
             return Err(TransactionError::AccountNotFound);
@@ -653,7 +652,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         //
         // Note these checks are *not* obviated by fee-only transactions.
         let nonce_is_valid = account_loader
-            .load_account(nonce_info.address(), AccountUsagePattern::Writable)
+            .load_account(nonce_info.address(), true)
             .and_then(|loaded_nonce| {
                 let current_nonce_account = &loaded_nonce.account;
                 system_program::check_id(current_nonce_account.owner()).then_some(())?;


### PR DESCRIPTION
#### Problem
this feature is now queued to activate on mainnet, so it can be removed once the epoch advances

#### Summary of Changes
remove it. account loading no longer depends on the program cache, so it can be removed from `AccountLoader` entirely. `AccountUsagePattern` is also simplified back to an `is_writable` bool because the instruction/invisible distinction is irrelevant

we remove a unit test that was testing program cache usage that no longer happens, and change another unit test that checks loaded account data sizes which have now changed

we fix two integration tests, but neither was testing program cache directly. the realloc test had to have its loaded data size limit changed because programdata is no longer counted against transaction size, and the inspect test had to be modified because programs which used to come from the program cache are now loaded normally and thus inspected