### PR TITLE
Fix interface bind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7940,7 +7940,9 @@ dependencies = [
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "clap 3.2.23",
  "crossbeam-channel",
  "log",

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -171,7 +171,7 @@ fn parse_gossip_host(matches: &ArgMatches, entrypoint_addr: Option<SocketAddr>) 
         })
         .unwrap_or_else(|| {
             if let Some(entrypoint_addr) = entrypoint_addr {
-                solana_net_utils::get_public_ip_addr(&entrypoint_addr).unwrap_or_else(|err| {
+                solana_net_utils::get_public_ip_addr(&entrypoint_addr, None).unwrap_or_else(|err| {
                     eprintln!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
                     exit(1);
                 })
@@ -222,7 +222,7 @@ fn get_entrypoint_shred_version(entrypoint: &Option<SocketAddr>) -> Option<u16> 
         error!("cannot obtain shred-version without an entrypoint");
         return None;
     };
-    match solana_net_utils::get_cluster_shred_version(entrypoint) {
+    match solana_net_utils::get_cluster_shred_version(entrypoint, None) {
         Err(err) => {
             error!("get_cluster_shred_version failed: {entrypoint}, {err}");
             None

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -10,7 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
+
 bincode = { workspace = true }
+bytes = { workspace = true }
+
 clap = { version = "3.1.5", features = ["cargo"], optional = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }

--- a/net-utils/src/bin/ip_address.rs
+++ b/net-utils/src/bin/ip_address.rs
@@ -16,7 +16,7 @@ fn main() {
     let addr = solana_net_utils::parse_host_port(host_port)
         .unwrap_or_else(|_| panic!("failed to parse {host_port}"));
 
-    match solana_net_utils::get_public_ip_addr(&addr) {
+    match solana_net_utils::get_public_ip_addr(&addr, None) {
         Ok(ip) => println!("{ip}"),
         Err(err) => {
             eprintln!("{addr}: {err}");

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -62,7 +62,6 @@ async fn ip_echo_server_request(
         ip_echo_server_addr: SocketAddr,
         msg: IpEchoServerMessage,
     ) -> anyhow::Result<BytesMut> {
-        dbg!("Making request");
         let mut stream = socket.connect(ip_echo_server_addr).await?;
         // Start with HEADER_LENGTH null bytes to avoid looking like an HTTP GET/POST request
         let mut bytes = BytesMut::with_capacity(IP_ECHO_SERVER_RESPONSE_LENGTH);
@@ -76,11 +75,9 @@ async fn ip_echo_server_request(
         stream.flush().await?;
 
         bytes.clear();
-        //TODO: consider ready?
         let _n = stream.read_buf(&mut bytes).await?;
         stream.shutdown().await?;
 
-        dbg!("Making request done");
         Ok(bytes)
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6290,7 +6290,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6120,7 +6120,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1111,6 +1111,8 @@ pub fn main() {
         "--gossip-validator",
     );
 
+    let bind_address = solana_net_utils::parse_host(matches.value_of("bind_address").unwrap())
+        .expect("invalid bind_address");
     let rpc_bind_address = if matches.is_present("rpc_bind_address") {
         solana_net_utils::parse_host(matches.value_of("rpc_bind_address").unwrap())
             .expect("invalid rpc_bind_address")
@@ -1172,8 +1174,6 @@ pub fn main() {
             exit(1);
         }
     }
-    let bind_address = solana_net_utils::parse_host(matches.value_of("bind_address").unwrap())
-        .expect("invalid bind_address");
     // TODO: Once entrypoints are updated to return shred-version, this should
     // abort if it fails to obtain a shred-version, so that nodes always join
     // gossip with a valid shred-version. The code to adopt entrypoint shred


### PR DESCRIPTION
#### Problem
There is a bunch of code in net-utils that does not obey bind-address CLI arg when called from agave-validator.
This is part of a bigger problem as outlined in https://github.com/anza-xyz/agave/issues/4440

#### Summary of Changes

 * Switched implementation in net-utils towards tokio (std TCP sockets do not support BINDTODEVICE)
 * Updated callsites in validator main to pass bind-address as needed 

Fixes #
* https://github.com/anza-xyz/agave/issues/4440 (partial fix)

