### PR TITLE
v2.0: ci: hardcode crate publishing version

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -66,7 +66,7 @@ for Cargo_toml in $Cargo_tomls; do
     set -x
 
     crate=$(dirname "$Cargo_toml")
-    cargoCommand="cargo publish --token $CRATES_IO_TOKEN"
+    cargoCommand="cargo +$rust_stable publish --token $CRATES_IO_TOKEN"
 
     numRetries=10
     for ((i = 1; i <= numRetries; i++)); do


### PR DESCRIPTION
#### Problem

I sent #4228. however it's not able to fix it. the process will use the version defined in the `rust-toolchain.toml` 🫠 

#### Summary of Changes

explicitly overwrite the version