### PR TITLE
Switch some functions in net-utils to tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8053,7 +8053,9 @@ dependencies = [
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "clap 3.2.23",
  "crossbeam-channel",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8055,7 +8055,9 @@ dependencies = [
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "clap 3.2.23",
  "crossbeam-channel",
  "log",

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -10,7 +10,9 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 bincode = { workspace = true }
+bytes = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"], optional = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }

--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -1,0 +1,299 @@
+use {
+    crate::{
+        ip_echo_server::{IpEchoServerMessage, IpEchoServerResponse},
+        HEADER_LENGTH, IP_ECHO_SERVER_RESPONSE_LENGTH, MAX_PORT_COUNT_PER_MESSAGE,
+    },
+    anyhow::bail,
+    bytes::{BufMut, BytesMut},
+    log::*,
+    std::{
+        collections::{BTreeMap, HashSet},
+        net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket},
+        sync::{Arc, RwLock},
+        time::{Duration, Instant},
+    },
+    tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpSocket,
+        sync::oneshot,
+    },
+};
+
+/// Applies to all operations with the echo server
+pub(crate) const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Make a request to the echo server, binding the client socket to the provided IP.
+pub(crate) async fn ip_echo_server_request_with_binding(
+    ip_echo_server_addr: SocketAddr,
+    msg: IpEchoServerMessage,
+    bind_address: IpAddr,
+) -> anyhow::Result<IpEchoServerResponse> {
+    let socket = tokio::net::TcpSocket::new_v4()?;
+    socket.bind(SocketAddr::new(bind_address, 0))?;
+
+    let response =
+        tokio::time::timeout(TIMEOUT, make_request(socket, ip_echo_server_addr, msg)).await??;
+    parse_response(response, ip_echo_server_addr)
+}
+
+/// Make a request to the echo server, client socket will be bound by the OS.
+pub(crate) async fn ip_echo_server_request(
+    ip_echo_server_addr: SocketAddr,
+    msg: IpEchoServerMessage,
+) -> anyhow::Result<IpEchoServerResponse> {
+    let socket = tokio::net::TcpSocket::new_v4()?;
+    let response =
+        tokio::time::timeout(TIMEOUT, make_request(socket, ip_echo_server_addr, msg)).await??;
+    parse_response(response, ip_echo_server_addr)
+}
+
+async fn make_request(
+    socket: TcpSocket,
+    ip_echo_server_addr: SocketAddr,
+    msg: IpEchoServerMessage,
+) -> anyhow::Result<BytesMut> {
+    let mut stream = socket.connect(ip_echo_server_addr).await?;
+    // Start with HEADER_LENGTH null bytes to avoid looking like an HTTP GET/POST request
+    let mut bytes = BytesMut::with_capacity(IP_ECHO_SERVER_RESPONSE_LENGTH);
+    bytes.extend_from_slice(&[0u8; HEADER_LENGTH]);
+    bytes.extend_from_slice(&bincode::serialize(&msg)?);
+
+    // End with '\n' to make this request look HTTP-ish and tickle an error response back
+    // from an HTTP server
+    bytes.put_u8(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    bytes.clear();
+    let _n = stream.read_buf(&mut bytes).await?;
+    stream.shutdown().await?;
+
+    Ok(bytes)
+}
+
+fn parse_response(
+    response: BytesMut,
+    ip_echo_server_addr: SocketAddr,
+) -> anyhow::Result<IpEchoServerResponse> {
+    // It's common for users to accidentally confuse the validator's gossip port and JSON
+    // RPC port.  Attempt to detect when this occurs by looking for the standard HTTP
+    // response header and provide the user with a helpful error message
+    if response.len() < HEADER_LENGTH {
+        bail!("Response too short, received {} bytes", response.len());
+    }
+
+    let (response_header, body) =
+        response
+            .split_first_chunk::<HEADER_LENGTH>()
+            .ok_or(anyhow::anyhow!(
+                "Not enough data in the response from {ip_echo_server_addr}!"
+            ))?;
+    let payload = match response_header {
+        [0, 0, 0, 0] => bincode::deserialize(&response[HEADER_LENGTH..])?,
+        [b'H', b'T', b'T', b'P'] => {
+            let http_response = std::str::from_utf8(body);
+            match http_response {
+                Ok(r) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port replying with {r}"),
+                Err(_) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port."),
+            }
+        }
+        _ => {
+            bail!("Invalid gossip entrypoint. {ip_echo_server_addr} provided unexpected header bytes {response_header:?} ");
+        }
+    };
+    Ok(payload)
+}
+
+pub(crate) const DEFAULT_RETRY_COUNT: usize = 5;
+
+/// Checks if all of the provided TCP/UDP ports are not reachable by the machine at
+/// `ip_echo_server_addr`. Tests must complete within timeout provided.
+/// Tests will run in parallel when possible.
+pub(crate) async fn do_verify_reachable_ports(
+    ip_echo_server_addr: SocketAddr,
+    tcp_listeners: Vec<(u16, TcpListener)>,
+    udp_sockets: &[&UdpSocket],
+    timeout: Duration,
+    udp_retry_count: usize,
+) -> bool {
+    info!(
+        "Checking that tcp ports {:?} are reachable from {:?}",
+        tcp_listeners, ip_echo_server_addr
+    );
+
+    let tcp_ports: Vec<_> = tcp_listeners.iter().map(|(port, _)| *port).collect();
+    let _ = ip_echo_server_request(
+        ip_echo_server_addr,
+        IpEchoServerMessage::new(&tcp_ports, &[]),
+    )
+    .await
+    .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+
+    let mut ok = true;
+    let mut checkers = Vec::new();
+
+    // since we do not know if tcp_listeners are nonblocking, we have to run them in native threads.
+    for (port, tcp_listener) in tcp_listeners {
+        let listening_addr = tcp_listener.local_addr().unwrap();
+        let (sender, receiver) = oneshot::channel();
+        let thread_handle = std::thread::Builder::new()
+            .name(format!("solVrfyTcp{port:05}"))
+            .spawn(move || {
+                debug!("Waiting for incoming connection on tcp/{}", port);
+                match tcp_listener.incoming().next() {
+                    Some(_) => {
+                        // ignore errors here since this can only happen if a timeout was detected.
+                        // timeout drops the receiver part of the channel resulting in failure to send.
+                        let _ = sender.send(());
+                    }
+                    None => warn!("tcp incoming failed"),
+                }
+            })
+            .unwrap();
+
+        // Set the timeout on the receiver
+        let receiver = tokio::time::timeout(timeout, receiver);
+        checkers.push((listening_addr, thread_handle, receiver));
+    }
+
+    for (listening_addr, thread_handle, receiver) in checkers {
+        match receiver.await {
+            Ok(Ok(_)) => {
+                info!("tcp/{} is reachable", listening_addr.port());
+            }
+            Ok(Err(_v)) => {
+                unreachable!("The receive on oneshot channel should never fail");
+            }
+            Err(_t) => {
+                error!(
+                    "Received no response at tcp/{}, check your port configuration",
+                    listening_addr.port()
+                );
+                // Ugh, std rustc doesn't provide accepting with timeout or restoring original
+                // nonblocking-status of sockets because of lack of getter, only the setter...
+                // So, to close the thread cleanly, just connect from here.
+                // ref: https://github.com/rust-lang/rust/issues/31615
+                TcpStream::connect_timeout(&listening_addr, timeout).unwrap();
+                ok = false;
+            }
+        }
+        thread_handle.join().expect("Thread should exit cleanly")
+    }
+
+    if !ok {
+        // No retries for TCP, abort on any failure
+        return false;
+    }
+
+    // now check UDP ports
+    let mut ok = true;
+    let mut udp_ports: BTreeMap<_, _> = BTreeMap::new();
+    udp_sockets.iter().for_each(|udp_socket| {
+        let port = udp_socket.local_addr().unwrap().port();
+        udp_ports
+            .entry(port)
+            .or_insert_with(Vec::new)
+            .push(udp_socket);
+    });
+    let udp_ports: Vec<_> = udp_ports.into_iter().collect();
+
+    info!(
+        "Checking that udp ports {:?} are reachable from {:?}",
+        udp_ports.iter().map(|(port, _)| port).collect::<Vec<_>>(),
+        ip_echo_server_addr
+    );
+
+    'outer: for checked_ports_and_sockets in udp_ports.chunks(MAX_PORT_COUNT_PER_MESSAGE) {
+        ok = false;
+
+        for udp_remaining_retry in (0_usize..udp_retry_count).rev() {
+            let (checked_ports, checked_socket_iter) = (
+                checked_ports_and_sockets
+                    .iter()
+                    .map(|(port, _)| *port)
+                    .collect::<Vec<_>>(),
+                checked_ports_and_sockets
+                    .iter()
+                    .flat_map(|(_, sockets)| sockets),
+            );
+
+            let _ = ip_echo_server_request(
+                ip_echo_server_addr,
+                IpEchoServerMessage::new(&[], &checked_ports),
+            )
+            .await
+            .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+
+            // Spawn threads at once!
+            let reachable_ports = Arc::new(RwLock::new(HashSet::new()));
+            let thread_handles: Vec<_> = checked_socket_iter
+                .map(|udp_socket| {
+                    let port = udp_socket.local_addr().unwrap().port();
+                    let udp_socket = udp_socket.try_clone().expect("Unable to clone udp socket");
+                    let reachable_ports = reachable_ports.clone();
+
+                    std::thread::Builder::new()
+                        .name(format!("solVrfyUdp{port:05}"))
+                        .spawn(move || {
+                            let start = Instant::now();
+
+                            let original_read_timeout = udp_socket.read_timeout().unwrap();
+                            udp_socket
+                                .set_read_timeout(Some(Duration::from_millis(250)))
+                                .unwrap();
+                            loop {
+                                if reachable_ports.read().unwrap().contains(&port)
+                                    || Instant::now().duration_since(start) >= timeout
+                                {
+                                    break;
+                                }
+
+                                let recv_result = udp_socket.recv(&mut [0; 1]);
+                                debug!(
+                                    "Waited for incoming datagram on udp/{}: {:?}",
+                                    port, recv_result
+                                );
+
+                                if recv_result.is_ok() {
+                                    reachable_ports.write().unwrap().insert(port);
+                                    break;
+                                }
+                            }
+                            udp_socket.set_read_timeout(original_read_timeout).unwrap();
+                        })
+                        .unwrap()
+                })
+                .collect();
+
+            // Now join threads!
+            // Separate from the above by collect()-ing as an intermediately step to make the iterator
+            // eager not lazy so that joining happens here at once after creating bunch of threads
+            // at once.
+            for thread in thread_handles {
+                thread.join().unwrap();
+            }
+
+            let reachable_ports = reachable_ports.read().unwrap().clone();
+            if reachable_ports.len() == checked_ports.len() {
+                info!(
+                    "checked udp ports: {:?}, reachable udp ports: {:?}",
+                    checked_ports, reachable_ports
+                );
+                ok = true;
+                break;
+            } else if udp_remaining_retry > 0 {
+                // Might have lost a UDP packet, retry a couple times
+                error!(
+                    "checked udp ports: {:?}, reachable udp ports: {:?}",
+                    checked_ports, reachable_ports
+                );
+                error!("There are some udp ports with no response!! Retrying...");
+            } else {
+                error!("Maximum retry count is reached....");
+                break 'outer;
+            }
+        }
+    }
+
+    ok
+}

--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -28,7 +28,7 @@ pub(crate) async fn ip_echo_server_request_with_binding(
     msg: IpEchoServerMessage,
     bind_address: IpAddr,
 ) -> anyhow::Result<IpEchoServerResponse> {
-    let socket = tokio::net::TcpSocket::new_v4()?;
+    let socket = TcpSocket::new_v4()?;
     socket.bind(SocketAddr::new(bind_address, 0))?;
 
     let response =
@@ -41,7 +41,7 @@ pub(crate) async fn ip_echo_server_request(
     ip_echo_server_addr: SocketAddr,
     msg: IpEchoServerMessage,
 ) -> anyhow::Result<IpEchoServerResponse> {
-    let socket = tokio::net::TcpSocket::new_v4()?;
+    let socket = TcpSocket::new_v4()?;
     let response =
         tokio::time::timeout(TIMEOUT, make_request(socket, ip_echo_server_addr, msg)).await??;
     parse_response(response, ip_echo_server_addr)

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -22,8 +22,7 @@ pub type IpEchoServer = Runtime;
 // Enforce a minimum of two threads:
 // - One thread to monitor the TcpListener and spawn async tasks
 // - One thread to service the spawned tasks
-// The unsafe is safe because we're using a fixed, known non-zero value
-pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(2) };
+pub const MINIMUM_IP_ECHO_SERVER_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 // IP echo requests require little computation and come in fairly infrequently,
 // so keep the number of server workers small to avoid overhead
 pub const DEFAULT_IP_ECHO_SERVER_THREADS: NonZeroUsize = MINIMUM_IP_ECHO_SERVER_THREADS;
@@ -173,8 +172,8 @@ async fn run_echo_server(tcp_listener: std::net::TcpListener, shred_version: Opt
     }
 }
 
-/// Starts a simple TCP server on the given port that echos the IP address of any peer that
-/// connects.  Used by |get_public_ip_addr|
+/// Starts a simple TCP server that reports the IP address of the client and shred version
+/// Used by functions like |get_public_ip_addr| and |get_cluster_shred_version|
 pub fn ip_echo_server(
     tcp_listener: std::net::TcpListener,
     num_server_threads: NonZeroUsize,

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -172,7 +172,7 @@ async fn run_echo_server(tcp_listener: std::net::TcpListener, shred_version: Opt
     }
 }
 
-/// Starts a simple TCP server that reports the IP address of the client and shred version
+/// Starts a simple TCP server that echos the IP address of any peer that connects
 /// Used by functions like |get_public_ip_addr| and |get_cluster_shred_version|
 pub fn ip_echo_server(
     tcp_listener: std::net::TcpListener,

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,18 +1,25 @@
 //! The `net_utils` module assists with networking
 #![allow(clippy::arithmetic_side_effects)]
+
 #[cfg(feature = "dev-context-only-utils")]
 use tokio::net::UdpSocket as TokioUdpSocket;
 use {
-    crossbeam_channel::unbounded,
+    anyhow::{anyhow, bail},
+    bytes::{BufMut, BytesMut},
     log::*,
     rand::{thread_rng, Rng},
     socket2::{Domain, SockAddr, Socket, Type},
     std::{
         collections::{BTreeMap, HashSet},
-        io::{self, Read, Write},
+        io::{self},
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket},
         sync::{Arc, RwLock},
         time::{Duration, Instant},
+    },
+    tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpSocket,
+        sync::oneshot,
     },
     url::Url,
 };
@@ -39,93 +46,128 @@ pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 17; // VALIDATOR_PORT_RANGE 
 pub(crate) const HEADER_LENGTH: usize = 4;
 pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;
 
-fn ip_echo_server_request(
-    ip_echo_server_addr: &SocketAddr,
+async fn ip_echo_server_request(
+    ip_echo_server_addr: SocketAddr,
     msg: IpEchoServerMessage,
-) -> Result<IpEchoServerResponse, String> {
+    bind_address: Option<IpAddr>,
+) -> anyhow::Result<IpEchoServerResponse> {
     let timeout = Duration::new(5, 0);
-    TcpStream::connect_timeout(ip_echo_server_addr, timeout)
-        .and_then(|mut stream| {
-            // Start with HEADER_LENGTH null bytes to avoid looking like an HTTP GET/POST request
-            let mut bytes = vec![0; HEADER_LENGTH];
+    let socket = tokio::net::TcpSocket::new_v4()?;
+    if let Some(addr) = bind_address {
+        socket.bind(SocketAddr::new(addr, 0))?;
+    }
 
-            bytes.append(&mut bincode::serialize(&msg).expect("serialize IpEchoServerMessage"));
+    async fn do_make_request(
+        socket: TcpSocket,
+        ip_echo_server_addr: SocketAddr,
+        msg: IpEchoServerMessage,
+    ) -> anyhow::Result<BytesMut> {
+        let mut stream = socket.connect(ip_echo_server_addr).await?;
+        // Start with HEADER_LENGTH null bytes to avoid looking like an HTTP GET/POST request
+        let mut bytes = BytesMut::with_capacity(IP_ECHO_SERVER_RESPONSE_LENGTH);
+        bytes.extend_from_slice(&[0u8; HEADER_LENGTH]);
+        bytes.extend_from_slice(&bincode::serialize(&msg)?);
 
-            // End with '\n' to make this request look HTTP-ish and tickle an error response back
-            // from an HTTP server
-            bytes.push(b'\n');
+        // End with '\n' to make this request look HTTP-ish and tickle an error response back
+        // from an HTTP server
+        bytes.put_u8(b'\n');
+        stream.write_all(&bytes).await?;
+        stream.flush().await?;
 
-            stream.set_read_timeout(Some(Duration::new(10, 0)))?;
-            stream.write_all(&bytes)?;
-            stream.shutdown(std::net::Shutdown::Write)?;
-            let mut data = vec![0u8; IP_ECHO_SERVER_RESPONSE_LENGTH];
-            let _ = stream.read(&mut data[..])?;
-            Ok(data)
-        })
-        .and_then(|data| {
-            // It's common for users to accidentally confuse the validator's gossip port and JSON
-            // RPC port.  Attempt to detect when this occurs by looking for the standard HTTP
-            // response header and provide the user with a helpful error message
-            if data.len() < HEADER_LENGTH {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Response too short, received {} bytes", data.len()),
-                ));
+        bytes.clear();
+        let _n = stream.read_buf(&mut bytes).await?;
+        stream.shutdown().await?;
+
+        Ok(bytes)
+    }
+
+    let response =
+        tokio::time::timeout(timeout, do_make_request(socket, ip_echo_server_addr, msg)).await??;
+    // It's common for users to accidentally confuse the validator's gossip port and JSON
+    // RPC port.  Attempt to detect when this occurs by looking for the standard HTTP
+    // response header and provide the user with a helpful error message
+    if response.len() < HEADER_LENGTH {
+        bail!("Response too short, received {} bytes", response.len());
+    }
+
+    let (response_header, body) =
+        response
+            .split_first_chunk::<HEADER_LENGTH>()
+            .ok_or(anyhow::anyhow!(
+                "Not enough data in the response from {ip_echo_server_addr}!"
+            ))?;
+    let payload = match response_header {
+        [0, 0, 0, 0] => bincode::deserialize(&response[HEADER_LENGTH..])?,
+        [b'H', b'T', b'T', b'P'] => {
+            let http_response = std::str::from_utf8(body);
+            match http_response {
+                Ok(r) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port replying with {r}"),
+                Err(_) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port."),
             }
+        }
+        _ => {
+            bail!("Invalid gossip entrypoint. {ip_echo_server_addr} provided unexpected header bytes {response_header:?} ");
+        }
+    };
 
-            let response_header: String =
-                data[0..HEADER_LENGTH].iter().map(|b| *b as char).collect();
-            if response_header != "\0\0\0\0" {
-                if response_header == "HTTP" {
-                    let http_response = data.iter().map(|b| *b as char).collect::<String>();
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port: {http_response}"
-                        ),
-                    ));
-                }
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "Invalid gossip entrypoint. {ip_echo_server_addr} provided an invalid response header: '{response_header}'"
-                    ),
-                ));
-            }
-
-            bincode::deserialize(&data[HEADER_LENGTH..]).map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to deserialize: {err:?}"),
-                )
-            })
-        })
-        .map_err(|err| err.to_string())
+    Ok(payload)
 }
 
 /// Determine the public IP address of this machine by asking an ip_echo_server at the given
 /// address
 pub fn get_public_ip_addr(ip_echo_server_addr: &SocketAddr) -> Result<IpAddr, String> {
-    let resp = ip_echo_server_request(ip_echo_server_addr, IpEchoServerMessage::default())?;
+    get_public_ip_addr_with_binding(ip_echo_server_addr, None).map_err(|e| e.to_string())
+}
+
+/// Determine the public IP address of this machine by asking an ip_echo_server at the given
+/// address
+pub fn get_public_ip_addr_with_binding(
+    ip_echo_server_addr: &SocketAddr,
+    bind_address: Option<IpAddr>,
+) -> anyhow::Result<IpAddr> {
+    let fut = ip_echo_server_request(
+        *ip_echo_server_addr,
+        IpEchoServerMessage::default(),
+        bind_address,
+    );
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let resp = rt.block_on(fut)?;
     Ok(resp.address)
 }
 
 pub fn get_cluster_shred_version(ip_echo_server_addr: &SocketAddr) -> Result<u16, String> {
-    let resp = ip_echo_server_request(ip_echo_server_addr, IpEchoServerMessage::default())?;
-    resp.shred_version
-        .ok_or_else(|| String::from("IP echo server does not return a shred-version"))
+    get_cluster_shred_version_with_binding(ip_echo_server_addr, None)
+        .map_err(|_| String::from("IP echo server does not return a shred-version"))
 }
 
+pub fn get_cluster_shred_version_with_binding(
+    ip_echo_server_addr: &SocketAddr,
+    bind_address: Option<IpAddr>,
+) -> anyhow::Result<u16> {
+    let fut = ip_echo_server_request(
+        *ip_echo_server_addr,
+        IpEchoServerMessage::default(),
+        bind_address,
+    );
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let resp = rt.block_on(fut)?;
+    resp.shred_version
+        .ok_or_else(|| anyhow!("IP echo server does not return a shred-version"))
+}
 // Checks if any of the provided TCP/UDP ports are not reachable by the machine at
 // `ip_echo_server_addr`
-const DEFAULT_TIMEOUT_SECS: u64 = 5;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_RETRY_COUNT: usize = 5;
 
-fn do_verify_reachable_ports(
-    ip_echo_server_addr: &SocketAddr,
+async fn do_verify_reachable_ports(
+    ip_echo_server_addr: SocketAddr,
     tcp_listeners: Vec<(u16, TcpListener)>,
     udp_sockets: &[&UdpSocket],
-    timeout: u64,
+    timeout: Duration,
     udp_retry_count: usize,
 ) -> bool {
     info!(
@@ -137,36 +179,50 @@ fn do_verify_reachable_ports(
     let _ = ip_echo_server_request(
         ip_echo_server_addr,
         IpEchoServerMessage::new(&tcp_ports, &[]),
+        None,
     )
+    .await
     .map_err(|err| warn!("ip_echo_server request failed: {}", err));
 
     let mut ok = true;
-    let timeout = Duration::from_secs(timeout);
+    let mut checkers = Vec::new();
 
-    // Wait for a connection to open on each TCP port
+    // since we do not know if tcp_listeners are nonblocking, we have to run them in native threads.
     for (port, tcp_listener) in tcp_listeners {
-        let (sender, receiver) = unbounded();
         let listening_addr = tcp_listener.local_addr().unwrap();
+        let (sender, receiver) = oneshot::channel();
         let thread_handle = std::thread::Builder::new()
             .name(format!("solVrfyTcp{port:05}"))
             .spawn(move || {
                 debug!("Waiting for incoming connection on tcp/{}", port);
                 match tcp_listener.incoming().next() {
-                    Some(_) => sender
-                        .send(())
-                        .unwrap_or_else(|err| warn!("send failure: {}", err)),
+                    Some(_) => {
+                        // ignore errors here since this can only happen if a timeout was detected.
+                        // timeout drops the receiver part of the channel resulting in failure to send.
+                        let _ = sender.send(());
+                    }
                     None => warn!("tcp incoming failed"),
                 }
             })
             .unwrap();
-        match receiver.recv_timeout(timeout) {
-            Ok(_) => {
-                info!("tcp/{} is reachable", port);
+
+        // Set the timeout on the receiver
+        let receiver = tokio::time::timeout(timeout, receiver);
+        checkers.push((listening_addr, thread_handle, receiver));
+    }
+
+    for (listening_addr, thread_handle, receiver) in checkers {
+        match receiver.await {
+            Ok(Ok(_)) => {
+                info!("tcp/{} is reachable", listening_addr.port());
             }
-            Err(err) => {
+            Ok(Err(_v)) => {
+                unreachable!("The receive on oneshot channel should never fail");
+            }
+            Err(_t) => {
                 error!(
-                    "Received no response at tcp/{}, check your port configuration: {}",
-                    port, err
+                    "Received no response at tcp/{}, check your port configuration",
+                    listening_addr.port()
                 );
                 // Ugh, std rustc doesn't provide accepting with timeout or restoring original
                 // nonblocking-status of sockets because of lack of getter, only the setter...
@@ -176,15 +232,16 @@ fn do_verify_reachable_ports(
                 ok = false;
             }
         }
-        // ensure to reap the thread
-        thread_handle.join().unwrap();
+        thread_handle.join().expect("Thread should exit cleanly")
     }
 
     if !ok {
-        // No retries for TCP, abort on the first failure
-        return ok;
+        // No retries for TCP, abort on any failure
+        return false;
     }
 
+    // now check UDP ports
+    let mut ok = true;
     let mut udp_ports: BTreeMap<_, _> = BTreeMap::new();
     udp_sockets.iter().for_each(|udp_socket| {
         let port = udp_socket.local_addr().unwrap().port();
@@ -218,7 +275,9 @@ fn do_verify_reachable_ports(
             let _ = ip_echo_server_request(
                 ip_echo_server_addr,
                 IpEchoServerMessage::new(&[], &checked_ports),
+                None,
             )
+            .await
             .map_err(|err| warn!("ip_echo_server request failed: {}", err));
 
             // Spawn threads at once!
@@ -300,13 +359,18 @@ pub fn verify_reachable_ports(
     tcp_listeners: Vec<(u16, TcpListener)>,
     udp_sockets: &[&UdpSocket],
 ) -> bool {
-    do_verify_reachable_ports(
-        ip_echo_server_addr,
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Tokio builder should be able to reliably create a current thread runtime");
+    let fut = do_verify_reachable_ports(
+        *ip_echo_server_addr,
         tcp_listeners,
         udp_sockets,
-        DEFAULT_TIMEOUT_SECS,
+        DEFAULT_TIMEOUT,
         DEFAULT_RETRY_COUNT,
-    )
+    );
+    rt.block_on(fut)
 }
 
 pub fn parse_port_or_addr(optstr: Option<&str>, default_addr: SocketAddr) -> SocketAddr {
@@ -780,8 +844,14 @@ pub fn bind_more_with_config(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::net::Ipv4Addr};
+    use {super::*, std::net::Ipv4Addr, tokio::runtime::Runtime};
 
+    fn runtime() -> Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Can not create a runtime")
+    }
     #[test]
     fn test_response_length() {
         let resp = IpEchoServerResponse {
@@ -957,10 +1027,13 @@ mod tests {
 
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
-            get_public_ip_addr(&server_ip_echo_addr),
-            parse_host("127.0.0.1"),
+            get_public_ip_addr_with_binding(&server_ip_echo_addr, None).unwrap(),
+            parse_host("127.0.0.1").unwrap(),
         );
-        assert_eq!(get_cluster_shred_version(&server_ip_echo_addr), Ok(42));
+        assert_eq!(
+            get_cluster_shred_version_with_binding(&server_ip_echo_addr, None).unwrap(),
+            42
+        );
         assert!(verify_reachable_ports(&server_ip_echo_addr, vec![], &[],));
     }
 
@@ -982,10 +1055,13 @@ mod tests {
 
         let ip_echo_server_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
-            get_public_ip_addr(&ip_echo_server_addr),
-            parse_host("127.0.0.1"),
+            get_public_ip_addr_with_binding(&ip_echo_server_addr, None).unwrap(),
+            parse_host("127.0.0.1").unwrap(),
         );
-        assert_eq!(get_cluster_shred_version(&ip_echo_server_addr), Ok(65535));
+        assert_eq!(
+            get_cluster_shred_version_with_binding(&ip_echo_server_addr, None).unwrap(),
+            65535
+        );
         assert!(verify_reachable_ports(
             &ip_echo_server_addr,
             vec![(client_port, client_tcp_listener)],
@@ -1008,13 +1084,14 @@ mod tests {
         let (correct_client_port, (_client_udp_socket, client_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config).unwrap();
 
-        assert!(!do_verify_reachable_ports(
-            &server_ip_echo_addr,
+        let rt = runtime();
+        assert!(!rt.block_on(do_verify_reachable_ports(
+            server_ip_echo_addr,
             vec![(correct_client_port, client_tcp_listener)],
             &[],
-            2,
+            Duration::from_secs(2),
             3,
-        ));
+        )));
     }
 
     #[test]
@@ -1032,13 +1109,14 @@ mod tests {
         let (_correct_client_port, (client_udp_socket, _client_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, (3200, 3250), config).unwrap();
 
-        assert!(!do_verify_reachable_ports(
-            &server_ip_echo_addr,
+        let rt = runtime();
+        assert!(!rt.block_on(do_verify_reachable_ports(
+            server_ip_echo_addr,
             vec![],
             &[&client_udp_socket],
-            2,
+            Duration::from_secs(2),
             3,
-        ));
+        )));
     }
 
     #[test]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6344,7 +6344,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6346,7 +6346,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6174,7 +6174,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6176,7 +6176,9 @@ version = "2.2.0"
 name = "solana-net-utils"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "bytes",
  "crossbeam-channel",
  "log",
  "nix",


### PR DESCRIPTION
#### Problem
There is a bunch of code in net-utils that could be better implemented with tokio rather than std sockets. This is primarily to address a bigger problem as outlined in https://github.com/anza-xyz/agave/issues/4440, but also async implementations are nicer and cleaner.

#### Summary of Changes

 * Switched implementation of fn ip_echo_server_request in net-utils towards tokio (std TCP sockets do not support BINDTODEVICE)
 * Updated  do_verify_reachable_ports to be async as well. It will now also verify all TCP ports concurrently (used to be serial).


