### PR TITLE
refactor: consolidate simple transaction validations to instruction_details sanitization

### DIFF
--- a/compute-budget-instruction/src/instructions_processor.rs
+++ b/compute-budget-instruction/src/instructions_processor.rs
@@ -1,5 +1,5 @@
 use {
-    crate::compute_budget_instruction_details::*, solana_compute_budget::compute_budget_limits::*,
+    crate::instruction_details::*, solana_compute_budget::compute_budget_limits::*,
     solana_feature_set::FeatureSet, solana_pubkey::Pubkey,
     solana_svm_transaction::instruction::SVMInstruction,
     solana_transaction_error::TransactionError,
@@ -14,7 +14,7 @@ pub fn process_compute_budget_instructions<'a>(
     instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
     feature_set: &FeatureSet,
 ) -> Result<ComputeBudgetLimits, TransactionError> {
-    ComputeBudgetInstructionDetails::try_from(instructions)?
+    InstructionDetails::try_from(instructions)?
         .sanitize_and_convert_to_compute_budget_limits(feature_set)
 }
 

--- a/compute-budget-instruction/src/lib.rs
+++ b/compute-budget-instruction/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 mod builtin_programs_filter;
-pub mod compute_budget_instruction_details;
 mod compute_budget_program_id_filter;
+pub mod instruction_details;
 pub mod instructions_processor;

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -574,7 +574,7 @@ impl Consumer {
             .iter()
             .filter_map(|transaction| {
                 transaction
-                    .compute_budget_instruction_details()
+                    .instruction_details()
                     .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
                     .ok()
                     .map(|limits| limits.compute_unit_price)
@@ -759,7 +759,7 @@ impl Consumer {
         let fee_payer = transaction.fee_payer();
         let fee_budget_limits = FeeBudgetLimits::from(
             transaction
-                .compute_budget_instruction_details()
+                .instruction_details()
                 .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)?,
         );
         let fee = solana_fee::calculate_fee(

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -210,7 +210,7 @@ impl SanitizedTransactionReceiveAndBuffer {
                     .is_ok()
                 })
                 .filter_map(|(packet, tx, deactivation_slot)| {
-                    tx.compute_budget_instruction_details()
+                    tx.instruction_details()
                         .sanitize_and_convert_to_compute_budget_limits(&working_bank.feature_set)
                         .map(|compute_budget| {
                             (packet, tx, deactivation_slot, compute_budget.into())
@@ -519,7 +519,7 @@ impl TransactionViewReceiveAndBuffer {
         }
 
         let Ok(compute_budget_limits) = view
-            .compute_budget_instruction_details()
+            .instruction_details()
             .sanitize_and_convert_to_compute_budget_limits(&working_bank.feature_set)
         else {
             return Err(());

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -251,7 +251,7 @@ impl CostModel {
         // will not be executed by `bank`, therefore it should be considered
         // as no execution cost by cost model.
         match meta
-            .compute_budget_instruction_details()
+            .instruction_details()
             .sanitize_and_convert_to_compute_budget_limits(feature_set)
         {
             Ok(compute_budget_limits) => {
@@ -293,7 +293,7 @@ impl CostModel {
         // if failed to process compute_budget instructions, the transaction will not be executed
         // by `bank`, therefore it should be considered as no execution cost by cost model.
         let (programs_execution_costs, loaded_accounts_data_size_cost) = match transaction
-            .compute_budget_instruction_details()
+            .instruction_details()
             .sanitize_and_convert_to_compute_budget_limits(feature_set)
         {
             Ok(compute_budget_limits) => (

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "dev-context-only-utils")]
-use solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails;
+use solana_compute_budget_instruction::instruction_details::InstructionDetails;
 use {
     crate::block_cost_limits, solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_meta::StaticMeta,
@@ -265,8 +265,8 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
         &DUMMY
     }
 
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
-        unimplemented!("WritableKeysTransaction::compute_budget_instruction_details")
+    fn instruction_details(&self) -> &InstructionDetails {
+        unimplemented!("WritableKeysTransaction::instruction_details")
     }
 }
 

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -12,7 +12,7 @@
 use {
     crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     core::ops::Deref,
-    solana_compute_budget_instruction::compute_budget_instruction_details::*,
+    solana_compute_budget_instruction::instruction_details::*,
     solana_hash::Hash,
     solana_message::{AccountKeys, TransactionSignatureDetails},
     solana_pubkey::Pubkey,
@@ -45,8 +45,8 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn signature_details(&self) -> &TransactionSignatureDetails {
         &self.meta.signature_details
     }
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
-        &self.meta.compute_budget_instruction_details
+    fn instruction_details(&self) -> &InstructionDetails {
+        &self.meta.instruction_details
     }
 }
 

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -1,5 +1,5 @@
 use {
-    super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
+    super::{InstructionDetails, RuntimeTransaction},
     crate::{
         signature_details::get_precompile_signature_details,
         transaction_meta::{StaticMeta, TransactionMeta},
@@ -48,7 +48,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             precompile_signature_details.num_ed25519_instruction_signatures,
             precompile_signature_details.num_secp256r1_instruction_signatures,
         );
-        let compute_budget_instruction_details = ComputeBudgetInstructionDetails::try_from(
+        let instruction_details = InstructionDetails::try_from(
             sanitized_versioned_tx
                 .get_message()
                 .program_instructions_iter()
@@ -61,7 +61,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
                 message_hash,
                 is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,
-                compute_budget_instruction_details,
+                instruction_details,
             },
         })
     }
@@ -328,7 +328,7 @@ mod tests {
 
         for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
             let compute_budget_limits = runtime_transaction_static
-                .compute_budget_instruction_details()
+                .instruction_details()
                 .sanitize_and_convert_to_compute_budget_limits(&feature_set)
                 .unwrap();
             assert_eq!(compute_unit_limit, compute_budget_limits.compute_unit_limit);

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -1,5 +1,5 @@
 use {
-    super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
+    super::{InstructionDetails, RuntimeTransaction},
     crate::{
         signature_details::get_precompile_signature_details,
         transaction_meta::{StaticMeta, TransactionMeta},
@@ -59,8 +59,8 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
             precompile_signature_details.num_ed25519_instruction_signatures,
             precompile_signature_details.num_secp256r1_instruction_signatures,
         );
-        let compute_budget_instruction_details =
-            ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?;
+        let instruction_details =
+            InstructionDetails::try_from(transaction.program_instructions_iter())?;
 
         Ok(Self {
             transaction,
@@ -68,7 +68,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
                 message_hash,
                 is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,
-                compute_budget_instruction_details,
+                instruction_details,
             },
         })
     }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -12,8 +12,8 @@
 //! RuntimeTransaction types, not the TransactionMeta itself.
 //!
 use {
-    solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
-    solana_hash::Hash, solana_message::TransactionSignatureDetails,
+    solana_compute_budget_instruction::instruction_details::InstructionDetails, solana_hash::Hash,
+    solana_message::TransactionSignatureDetails,
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -22,7 +22,7 @@ pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails;
+    fn instruction_details(&self) -> &InstructionDetails;
 }
 
 /// Statically loaded meta is a supertrait of Dynamically loaded meta, when
@@ -38,5 +38,5 @@ pub struct TransactionMeta {
     pub(crate) message_hash: Hash,
     pub(crate) is_simple_vote_transaction: bool,
     pub(crate) signature_details: TransactionSignatureDetails,
-    pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
+    pub(crate) instruction_details: InstructionDetails,
 }

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -208,7 +208,7 @@ impl PrioritizationFeeCache {
                 }
 
                 let compute_budget_limits = sanitized_transaction
-                    .compute_budget_instruction_details()
+                    .instruction_details()
                     .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set);
 
                 let lock_result = validate_account_locks(


### PR DESCRIPTION
#### Problem

banking_stage (for both legacy and central scheduler) filters out transactions that have insufficient CU limit, or have excessive precompiles. Each check takes an additional iteration of instructions. These filtering/validations can be done once during RuntimeTransaction sanitizing instruction details, could yield positive performance impact. 

#### Summary of Changes
- refactor "instruction_details" to include sig/builtin/compute-unit details
- error out sanitization of instruction_details for above listed conditions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
