### PR TITLE
fix windows clippy

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -424,7 +424,7 @@ fn add_to_path(new_path: &str) -> bool {
                 HWND_BROADCAST,
                 WM_SETTINGCHANGE,
                 0_usize,
-                "Environment\0".as_ptr() as LPARAM,
+                c"Environment".as_ptr() as LPARAM,
                 SMTO_ABORTIFHUNG,
                 5000,
                 ptr::null_mut(),


### PR DESCRIPTION
#### Problem
Seeing CI failures:
```
error: manually constructing a nul-terminated string
   --> install\src\command.rs:427:17
    |
427 |                 "Environment\0".as_ptr() as LPARAM,
    |                 ^^^^^^^^^^^^^^^ help: use a `c""` literal: `c"Environment"`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals
    = note: `-D clippy::manual-c-str-literals` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_c_str_literals)]`

error: could not compile `agave-install` (lib) due to 1 previous error
```

#### Summary of Changes
Switch to using c literal