### PR TITLE
removes unnecessary allocations in shreds ingestion path

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -294,7 +294,7 @@ impl StandardBroadcastRun {
             if shred.index() == 0 {
                 blockstore
                     .insert_shreds(
-                        vec![shred.clone()],
+                        [shred.clone()],
                         None, // leader_schedule
                         true, // is_trusted
                     )


### PR DESCRIPTION
#### Problem
Ingesting shreds unnecessarily allocates a `HashSet` to remove invalid repair-meta:
https://github.com/anza-xyz/agave/blob/0f56076a2/core/src/window_service.rs#L250

and a separate vector for repair flags:
https://github.com/anza-xyz/agave/blob/0f56076a2/core/src/window_service.rs#L338-L341

Similarly `Blockstore::insert_shreds` (called in broadcast-stage to insert own shreds during leader slots), allocates a vector for repair flags:
https://github.com/anza-xyz/agave/blob/0f56076a2/ledger/src/blockstore.rs#L1381

All can be avoided if blockstore `insert_shreds...` api are updated to take an argument of type

    shreds: impl ExactSizeIterator<Item = (Shred, /*is_repaired:*/ bool)>,


#### Summary of Changes
Removed unnecessary allocations in shreds ingestion path.