### PR TITLE
:pencil2: Fix ssh typo in setup validator doc

### DIFF
--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -445,7 +445,7 @@ Test that your `validator.sh` file is running properly by executing the
 ```
 
 The script should execute the `agave-validator` process. In a new terminal
-window, shh into your server, then verify that the process is running:
+window, ssh into your server, then verify that the process is running:
 
 ```
 ps aux | grep agave-validator


### PR DESCRIPTION
#### Problem

There is a typo in the documentation

#### Summary of Changes

Fixes ssh typo in setup validator doc