### PR TITLE
remove solana-program from solana-vote-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10417,7 +10417,6 @@ dependencies = [
  "solana-logger",
  "solana-metrics",
  "solana-packet",
- "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rent",
@@ -10427,6 +10426,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-transaction",
  "solana-transaction-context",
+ "solana-vote-interface",
  "test-case",
  "thiserror 2.0.11",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8611,7 +8611,6 @@ dependencies = [
  "solana-keypair",
  "solana-metrics",
  "solana-packet",
- "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rent",
@@ -8620,6 +8619,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-transaction",
  "solana-transaction-context",
+ "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -32,15 +32,15 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-metrics = { workspace = true, optional = true }
 solana-packet = { workspace = true }
-solana-program = { workspace = true }
 solana-program-runtime = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
+solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -62,8 +62,8 @@ default = ["metrics"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
-    "solana-program/frozen-abi",
-    "solana-program-runtime/frozen-abi"
+    "solana-program-runtime/frozen-abi",
+    "solana-vote-interface/frozen-abi"
 ]
 metrics = ["dep:solana-metrics"]
 

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -12,7 +12,7 @@ extern crate solana_metrics;
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
-pub use solana_program::vote::{
+pub use solana_vote_interface::{
     authorized_voters, error as vote_error, instruction as vote_instruction,
     program::{check_id, id},
 };

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -6,13 +6,13 @@ use {
     solana_bincode::limited_deserialize,
     solana_feature_set as feature_set,
     solana_instruction::error::InstructionError,
-    solana_program::vote::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     solana_program_runtime::{
         declare_process_instruction, invoke_context::InvokeContext,
         sysvar_cache::get_sysvar_with_account_check,
     },
     solana_pubkey::Pubkey,
     solana_transaction_context::{BorrowedAccount, InstructionContext, TransactionContext},
+    solana_vote_interface::{instruction::VoteInstruction, program::id, state::VoteAuthorize},
     std::collections::HashSet,
 };
 
@@ -276,12 +276,12 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction},
-        solana_program::vote::instruction::{tower_sync, tower_sync_switch},
         solana_program_runtime::invoke_context::mock_process_instruction,
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_sdk_ids::sysvar,
         solana_slot_hashes::SlotHashes,
+        solana_vote_interface::instruction::{tower_sync, tower_sync_switch},
         std::{collections::HashSet, str::FromStr},
     };
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1,6 +1,6 @@
 //! Vote state, vote program
 //! Receive and processes votes from validators
-pub use solana_program::vote::state::{vote_state_versions::*, *};
+pub use solana_vote_interface::state::{vote_state_versions::*, *};
 use {
     log::*,
     serde_derive::{Deserialize, Serialize},
@@ -10,13 +10,13 @@ use {
     solana_feature_set::{self as feature_set, FeatureSet},
     solana_hash::Hash,
     solana_instruction::error::InstructionError,
-    solana_program::vote::{error::VoteError, program::id},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
     solana_transaction_context::{
         BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
     },
+    solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
         collections::{HashSet, VecDeque},

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -2,12 +2,12 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_program::vote::{
-        self,
-        state::{TowerSync, Vote, VoteStateUpdate},
-    },
     solana_signer::Signer,
     solana_transaction::Transaction,
+    solana_vote_interface::{
+        self as vote,
+        state::{TowerSync, Vote, VoteStateUpdate},
+    },
 };
 
 pub fn new_vote_transaction(

--- a/sdk/vote-interface/Cargo.toml
+++ b/sdk/vote-interface/Cargo.toml
@@ -58,7 +58,8 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "serde",
     "solana-hash/frozen-abi",
-    "solana-pubkey/frozen-abi"
+    "solana-pubkey/frozen-abi",
+    "solana-short-vec/frozen-abi",
 ]
 serde = [
     "dep:serde",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7956,7 +7956,6 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-packet",
- "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rent",
@@ -7965,6 +7964,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-transaction",
  "solana-transaction-context",
+ "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-program

#### Summary of Changes
- Replace with solana-vote-interface
- Add a missing feature activation for frozen-abi to solana-vote-interface