### PR TITLE
fix: secp256r1 metrics bug and doc typo

### DIFF
--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -127,6 +127,7 @@ impl CostTracker {
         self.transaction_signature_count = Saturating(0);
         self.secp256k1_instruction_signature_count = Saturating(0);
         self.ed25519_instruction_signature_count = Saturating(0);
+        self.secp256r1_instruction_signature_count = Saturating(0);
         self.in_flight_transaction_count = Saturating(0);
     }
 

--- a/sdk/message/src/sanitized.rs
+++ b/sdk/message/src/sanitized.rs
@@ -472,7 +472,7 @@ impl TransactionSignatureDetails {
         self.num_ed25519_instruction_signatures
     }
 
-    /// return the number of secp256k1 instruction signatures
+    /// return the number of secp256r1 instruction signatures
     pub fn num_secp256r1_instruction_signatures(&self) -> u64 {
         self.num_secp256r1_instruction_signatures
     }


### PR DESCRIPTION
#### Problem
Metrics bug and doc typo in secp256r1 handling

#### Summary of Changes
- Properly reset secp256r1 instruction count
- Fix doc typo

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
