### PR TITLE
remove solana-sdk from download-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7176,9 +7176,10 @@ name = "solana-download-utils"
 version = "2.2.0"
 dependencies = [
  "log",
+ "solana-clock",
  "solana-file-download",
+ "solana-genesis-config",
  "solana-runtime",
- "solana-sdk",
 ]
 
 [[package]]

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -11,9 +11,10 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-clock = { workspace = true }
 solana-file-download = { workspace = true }
+solana-genesis-config = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk = { workspace = true }
 
 [dev-dependencies]
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -1,13 +1,14 @@
 pub use solana_file_download::DownloadProgressRecord;
 use {
     log::*,
+    solana_clock::Slot,
     solana_file_download::{download_file, DownloadProgressCallbackOption},
+    solana_genesis_config::DEFAULT_GENESIS_ARCHIVE,
     solana_runtime::{
         snapshot_hash::SnapshotHash,
         snapshot_package::SnapshotKind,
         snapshot_utils::{self, ArchiveFormat, ZstdConfig},
     },
-    solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE},
     std::{
         fs,
         net::SocketAddr,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5749,9 +5749,10 @@ name = "solana-download-utils"
 version = "2.2.0"
 dependencies = [
  "log",
+ "solana-clock",
  "solana-file-download",
+ "solana-genesis-config",
  "solana-runtime",
- "solana-sdk",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk

#### Summary of Changes
Replace with component crates
