### PR TITLE
remove solana-sdk from store-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,8 +248,10 @@ dependencies = [
  "ahash 0.8.11",
  "clap 2.33.3",
  "rayon",
+ "solana-account",
  "solana-accounts-db",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-system-interface",
  "solana-version",
 ]
 

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -13,8 +13,10 @@ edition = { workspace = true }
 ahash = { workspace = true }
 clap = { workspace = true }
 rayon = { workspace = true }
+solana-account = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
-solana-sdk = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-system-interface = { workspace = true }
 solana-version = { workspace = true }
 
 [features]

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -5,10 +5,10 @@ use {
         ArgMatches, SubCommand,
     },
     rayon::prelude::*,
+    solana_account::ReadableAccount,
     solana_accounts_db::append_vec::AppendVec,
-    solana_sdk::{
-        account::ReadableAccount, pubkey::Pubkey, system_instruction::MAX_PERMITTED_DATA_LENGTH,
-    },
+    solana_pubkey::Pubkey,
+    solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
         fs, io,
         mem::ManuallyDrop,


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk

#### Summary of Changes
Replace with component crates
