### PR TITLE
svm: speed up `filter_executable_program_accounts`

### DIFF
--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -234,17 +234,14 @@ impl SvmTestEnvironment<'_> {
                 .processing_results
                 .iter()
                 .enumerate()
-                .map(|(i, tx)| {
-                    let details = match tx {
-                        Ok(ProcessedTransaction::Executed(executed)) => {
-                            format!("(executed): {:#?}", executed.execution_details)
-                        }
-                        Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
-                            format!("(fee-only): {:?}", fee_only.load_error)
-                        }
-                        Err(e) => format!("(discarded): {:?}", e),
-                    };
-                    format!("{} {}", i, details)
+                .map(|(i, tx)| match tx {
+                    Ok(ProcessedTransaction::Executed(executed)) => {
+                        format!("{} (executed): {:#?}", i, executed.execution_details)
+                    }
+                    Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
+                        format!("{} (fee-only): {:?}", i, fee_only.load_error)
+                    }
+                    Err(e) => format!("{} (discarded): {:?}", i, e),
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2474,34 +2474,36 @@ fn svm_inspect_account() {
     let recipient = Pubkey::new_unique();
 
     // Setting up the accounts for the transfer
+    // Non-programs are inspected twice, once when loaded and once during program cache setup
+    // Builtin programs are inspected twice, once when loaded and once during owner validation
+    // Non-builtin programs woud be inspected more, but this test does not have any
 
     // fee payer
     let mut fee_payer_account = AccountSharedData::default();
     fee_payer_account.set_lamports(85_000);
     fee_payer_account.set_rent_epoch(u64::MAX);
     initial_test_entry.add_initial_account(fee_payer, &fee_payer_account);
-    expected_inspected_accounts
-        .entry(fee_payer)
-        .or_default()
-        .push((Some(fee_payer_account.clone()), true));
+
+    let entry = expected_inspected_accounts.entry(fee_payer).or_default();
+    entry.push((Some(fee_payer_account.clone()), true));
+    entry.push((Some(fee_payer_account.clone()), false));
 
     // sender
     let mut sender_account = AccountSharedData::default();
     sender_account.set_lamports(11_000_000);
     sender_account.set_rent_epoch(u64::MAX);
     initial_test_entry.add_initial_account(sender, &sender_account);
-    expected_inspected_accounts
-        .entry(sender)
-        .or_default()
-        .push((Some(sender_account.clone()), true));
+
+    let entry = expected_inspected_accounts.entry(sender).or_default();
+    entry.push((Some(sender_account.clone()), true));
+    entry.push((Some(sender_account.clone()), false));
 
     // recipient -- initially dead
-    expected_inspected_accounts
-        .entry(recipient)
-        .or_default()
-        .push((None, true));
+    let entry = expected_inspected_accounts.entry(recipient).or_default();
+    entry.push((None, true));
+    entry.push((None, false));
 
-    // system, inspected twice due to owner checks
+    // system
     let system_account = AccountSharedData::create(
         5000,
         "system_program".as_bytes().to_vec(),
@@ -2510,13 +2512,11 @@ fn svm_inspect_account() {
         0,
     );
 
-    {
-        let system_entry = expected_inspected_accounts
-            .entry(system_program::id())
-            .or_default();
-        system_entry.push((Some(system_account.clone()), false));
-        system_entry.push((Some(system_account.clone()), false));
-    }
+    let entry = expected_inspected_accounts
+        .entry(system_program::id())
+        .or_default();
+    entry.push((Some(system_account.clone()), false));
+    entry.push((Some(system_account.clone()), false));
 
     let transfer_amount = 1_000_000;
     let transaction = Transaction::new_signed_with_payer(
@@ -2551,37 +2551,32 @@ fn svm_inspect_account() {
     let intermediate_fee_payer_account = initial_test_entry.final_accounts.get(&fee_payer).cloned();
     assert!(intermediate_fee_payer_account.is_some());
 
-    expected_inspected_accounts
-        .entry(fee_payer)
-        .or_default()
-        .push((intermediate_fee_payer_account, true));
+    let entry = expected_inspected_accounts.entry(fee_payer).or_default();
+    entry.push((intermediate_fee_payer_account.clone(), true));
+    entry.push((intermediate_fee_payer_account.clone(), false));
 
     // sender
     let intermediate_sender_account = initial_test_entry.final_accounts.get(&sender).cloned();
     assert!(intermediate_sender_account.is_some());
 
-    expected_inspected_accounts
-        .entry(sender)
-        .or_default()
-        .push((intermediate_sender_account, true));
+    let entry = expected_inspected_accounts.entry(sender).or_default();
+    entry.push((intermediate_sender_account.clone(), true));
+    entry.push((intermediate_sender_account.clone(), false));
 
     // recipient -- now alive
     let intermediate_recipient_account = initial_test_entry.final_accounts.get(&recipient).cloned();
     assert!(intermediate_recipient_account.is_some());
 
-    expected_inspected_accounts
-        .entry(recipient)
-        .or_default()
-        .push((intermediate_recipient_account, true));
+    let entry = expected_inspected_accounts.entry(recipient).or_default();
+    entry.push((intermediate_recipient_account.clone(), true));
+    entry.push((intermediate_recipient_account.clone(), false));
 
     // system
-    {
-        let system_entry = expected_inspected_accounts
-            .entry(system_program::id())
-            .or_default();
-        system_entry.push((Some(system_account.clone()), false));
-        system_entry.push((Some(system_account.clone()), false));
-    }
+    let entry = expected_inspected_accounts
+        .entry(system_program::id())
+        .or_default();
+    entry.push((Some(system_account.clone()), false));
+    entry.push((Some(system_account.clone()), false));
 
     let mut final_test_entry = SvmTestEntry {
         initial_accounts: initial_test_entry.final_accounts.clone(),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -9,6 +9,7 @@ use {
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        bpf_loader_upgradeable,
         clock::Slot,
         compute_budget::ComputeBudgetInstruction,
         entrypoint::MAX_PERMITTED_DATA_INCREASE,
@@ -213,7 +214,7 @@ impl SvmTestEnvironment<'_> {
         }
 
         // first assert all transaction states together, it makes test-driven development much less of a headache
-        let (expected_statuses, actual_statuses): (Vec<_>, Vec<_>) = batch_output
+        let (actual_statuses, expected_statuses): (Vec<_>, Vec<_>) = batch_output
             .processing_results
             .iter()
             .zip(self.test_entry.asserts())
@@ -224,7 +225,27 @@ impl SvmTestEnvironment<'_> {
                 )
             })
             .unzip();
-        assert_eq!(expected_statuses, actual_statuses);
+        assert_eq!(
+            expected_statuses,
+            actual_statuses,
+            "mismatch between expected and actual statuses. execution details:\n{}",
+            batch_output
+                .processing_results
+                .iter()
+                .enumerate()
+                .map(|(i, tx)| {
+                    let details = match tx {
+                        Ok(ProcessedTransaction::Executed(executed)) => {
+                            format!("{:#?}", executed.execution_details)
+                        }
+                        Ok(ProcessedTransaction::FeesOnly(_)) => "(fee-only)".to_string(),
+                        Err(_) => "(not executed)".to_string(),
+                    };
+                    format!("{}: {}", i, details)
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
 
         // check that all the account states we care about are present and correct
         for (pubkey, expected_account_data) in self.test_entry.final_accounts.iter() {
@@ -2270,6 +2291,55 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
     test_entries
 }
 
+fn simd83_program_update_tombstone() -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+
+    let program_name = "hello-solana";
+    let program_id = program_address(program_name);
+
+    let fee_payer_keypair = Keypair::new();
+    let fee_payer = fee_payer_keypair.pubkey();
+
+    let mut fee_payer_data = AccountSharedData::default();
+    fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+    test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+    test_entry
+        .initial_programs
+        .push((program_name.to_string(), DEPLOYMENT_SLOT, Some(fee_payer)));
+
+    // 0: close a deployed program
+    let instruction = bpf_loader_upgradeable::close_any(
+        &bpf_loader_upgradeable::get_program_data_address(&program_id),
+        &Pubkey::new_unique(),
+        Some(&fee_payer),
+        Some(&program_id),
+    );
+    test_entry.push_transaction(Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        Hash::default(),
+    ));
+
+    // 1: attempt to invoke it, which must fail
+    // this ensures the local program cache reflects the change of state
+    let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+    test_entry.push_transaction_with_status(
+        Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        ),
+        ExecutionStatus::ExecutedFailed,
+    );
+
+    test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+    vec![test_entry]
+}
+
 #[test_case(program_medley())]
 #[test_case(simple_transfer(false))]
 #[test_case(simple_transfer(true))]
@@ -2288,6 +2358,7 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
 #[test_case(simd83_fee_payer_deallocate(true))]
 #[test_case(simd83_account_reallocate(false))]
 #[test_case(simd83_account_reallocate(true))]
+#[test_case(simd83_program_update_tombstone())]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
         let env = SvmTestEnvironment::create(test_entry);

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -7,6 +7,7 @@ use {
         register_builtins, MockBankCallback, MockForkGraph, EXECUTION_EPOCH, EXECUTION_SLOT,
         WALLCLOCK_TIME,
     },
+    solana_account::PROGRAM_OWNERS,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable,
@@ -16,7 +17,7 @@ use {
         feature_set::{self, FeatureSet},
         hash::Hash,
         instruction::{AccountMeta, Instruction},
-        native_loader,
+        loader_v4, native_loader,
         native_token::LAMPORTS_PER_SOL,
         nonce::{self, state::DurableNonce},
         pubkey::Pubkey,
@@ -41,7 +42,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_type_overrides::sync::{Arc, RwLock},
     std::collections::HashMap,
-    test_case::test_case,
+    test_case::{test_case, test_matrix},
 };
 
 // This module contains the implementation of TransactionProcessingCallback
@@ -236,12 +237,14 @@ impl SvmTestEnvironment<'_> {
                 .map(|(i, tx)| {
                     let details = match tx {
                         Ok(ProcessedTransaction::Executed(executed)) => {
-                            format!("{:#?}", executed.execution_details)
+                            format!("(executed): {:#?}", executed.execution_details)
                         }
-                        Ok(ProcessedTransaction::FeesOnly(_)) => "(fee-only)".to_string(),
-                        Err(_) => "(not executed)".to_string(),
+                        Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
+                            format!("(fee-only): {:?}", fee_only.load_error)
+                        }
+                        Err(e) => format!("(discarded): {:?}", e),
                     };
-                    format!("{}: {}", i, details)
+                    format!("{} {}", i, details)
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -2291,7 +2294,7 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
     test_entries
 }
 
-fn simd83_program_update_tombstone() -> Vec<SvmTestEntry> {
+fn program_cache_update_tombstone() -> Vec<SvmTestEntry> {
     let mut test_entry = SvmTestEntry::default();
 
     let program_name = "hello-solana";
@@ -2358,10 +2361,105 @@ fn simd83_program_update_tombstone() -> Vec<SvmTestEntry> {
 #[test_case(simd83_fee_payer_deallocate(true))]
 #[test_case(simd83_account_reallocate(false))]
 #[test_case(simd83_account_reallocate(true))]
-#[test_case(simd83_program_update_tombstone())]
+#[test_case(program_cache_update_tombstone())]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
         let env = SvmTestEnvironment::create(test_entry);
+        env.execute();
+    }
+}
+
+#[test_matrix([false, true], [false, true])]
+fn program_cache_create_account(enable_fee_only_transactions: bool, disable_executable_flag: bool) {
+    for loader_id in PROGRAM_OWNERS {
+        let mut test_entry = SvmTestEntry::default();
+        if enable_fee_only_transactions {
+            test_entry
+                .enabled_features
+                .push(feature_set::enable_transaction_loading_failure_fees::id());
+        }
+        if disable_executable_flag {
+            test_entry
+                .enabled_features
+                .push(feature_set::remove_accounts_executable_flag_checks::id());
+        }
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL * 10);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let new_account_keypair = Keypair::new();
+        let program_id = new_account_keypair.pubkey();
+
+        let create_transaction = system_transaction::create_account(
+            &fee_payer_keypair,
+            &new_account_keypair,
+            Hash::default(),
+            LAMPORTS_PER_SOL,
+            0,
+            loader_id,
+        );
+
+        test_entry.push_transaction(create_transaction);
+
+        test_entry
+            .decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SOL + LAMPORTS_PER_SIGNATURE * 2);
+
+        let invoke_transaction = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(program_id, &[], vec![])],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        );
+
+        let expected_status = match (enable_fee_only_transactions, disable_executable_flag) {
+            (_, true) => ExecutionStatus::ExecutedFailed,
+            (true, false) => ExecutionStatus::ProcessedFailed,
+            (false, false) => ExecutionStatus::Discarded,
+        };
+
+        test_entry.push_transaction_with_status(invoke_transaction.clone(), expected_status);
+
+        if expected_status != ExecutionStatus::Discarded {
+            test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+        }
+
+        let mut env = SvmTestEnvironment::create(test_entry);
+
+        // NOTE this ensures we dont fail with the missing loader
+        // once LoaderV4 is ready for testing, adding it to mock_bank.rs means the test runs
+        // and this branch will always be false and can be removed
+        if *loader_id == loader_v4::id()
+            && !env
+                .batch_processor
+                .builtin_program_ids
+                .read()
+                .unwrap()
+                .contains(loader_id)
+        {
+            continue;
+        }
+
+        // test in same entry as account creation
+        env.execute();
+
+        let mut test_entry = SvmTestEntry {
+            initial_accounts: env.test_entry.final_accounts.clone(),
+            final_accounts: env.test_entry.final_accounts.clone(),
+            ..SvmTestEntry::default()
+        };
+
+        test_entry.push_transaction_with_status(invoke_transaction, expected_status);
+
+        if expected_status != ExecutionStatus::Discarded {
+            test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+        }
+
+        // test in different entry same slot
+        env.test_entry = test_entry;
         env.execute();
     }
 }

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -216,7 +216,7 @@ pub fn deploy_program_with_upgrade_authority(
     let mut account_data = AccountSharedData::default();
     let state = UpgradeableLoaderState::ProgramData {
         slot: deployment_slot,
-        upgrade_authority_address: None,
+        upgrade_authority_address,
     };
     let mut header = bincode::serialize(&state).unwrap();
     let mut complement = vec![

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -18,6 +18,7 @@ use {
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Clock, UnixTimestamp},
         compute_budget, native_loader,
@@ -246,16 +247,40 @@ pub fn register_builtins(
     batch_processor: &TransactionBatchProcessor<MockForkGraph>,
 ) {
     const DEPLOYMENT_SLOT: u64 = 0;
-    // We must register the bpf loader account as a loadable account, otherwise programs
-    // won't execute.
-    let bpf_loader_name = "solana_bpf_loader_upgradeable_program";
+    // We must register LoaderV3 as a loadable account, otherwise programs won't execute.
+    let loader_v3_name = "solana_bpf_loader_upgradeable_program";
     batch_processor.add_builtin(
         mock_bank,
         bpf_loader_upgradeable::id(),
-        bpf_loader_name,
+        loader_v3_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            bpf_loader_name.len(),
+            loader_v3_name.len(),
+            solana_bpf_loader_program::Entrypoint::vm,
+        ),
+    );
+
+    // Other loaders are needed for testing program cache behavior.
+    // NOTE when LoaderV4 is ready for testing, it must be added here.
+    let loader_v1_name = "solana_bpf_loader_deprecated_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        bpf_loader_deprecated::id(),
+        loader_v1_name,
+        ProgramCacheEntry::new_builtin(
+            DEPLOYMENT_SLOT,
+            loader_v1_name.len(),
+            solana_bpf_loader_program::Entrypoint::vm,
+        ),
+    );
+    let loader_v2_name = "solana_bpf_loader_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        bpf_loader::id(),
+        loader_v2_name,
+        ProgramCacheEntry::new_builtin(
+            DEPLOYMENT_SLOT,
+            loader_v2_name.len(),
             solana_bpf_loader_program::Entrypoint::vm,
         ),
     );

--- a/timings/src/lib.rs
+++ b/timings/src/lib.rs
@@ -58,7 +58,6 @@ pub enum ExecuteTimingType {
     UpdateTransactionStatuses,
     ProgramCacheUs,
     CheckBlockLimitsUs,
-    FilterExecutableUs,
 }
 
 pub struct Metrics([Saturating<u64>; ExecuteTimingType::CARDINALITY]);
@@ -107,13 +106,6 @@ eager_macro_rules! { $eager_1
                 $self
                     .metrics
                     .index(ExecuteTimingType::ValidateFeesUs).0,
-                i64
-            ),
-            (
-                "filter_executable_us",
-                $self
-                    .metrics
-                    .index(ExecuteTimingType::FilterExecutableUs).0,
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
presently, `filter_executable_program_accounts` makes an expensive accounts-db lookup for every account in every transaction batch. this used to be an unfortunate necessity because account loading could not happen until the local program cache was built. a recent feature gate activation has severed that dependency, giving us freedom to improve this

#### Summary of Changes
create a local program cache for every transaction, instead of every batch, and do this _after_ the transaction accounts have been loaded. this allows us to obviate _all_ accounts-db lookups in `filter_executable_program_accounts` for checking if an account is owned by a program loader because we _already_ have that information. based on testing done by @alessandrod, this speeds up transaction execution by 30-40%

~~this pr will be immediately followed by another which removes nearly all accounts-db lookups from `replenish_program_cache` as well. this pr will remain a draft until then; they are spiritually similar but split into two for readability and ease of review~~

edit: this pr will not be as easy as originally hoped. there are some challenges moving from a per-batch to a per-tx cache (our ultimate goal) due to how the current implementation handles tombstones, and some challenges using the results of account loading to incrementally update a per-batch cache (a plausible short-term goal until the local program cache can be partially redesigned to behave better)

edit2: its viable again. because the other approach is nonviable. lol. clean up the comment history later but rn im based on #4656 for test coverage and need to:
* figure out something for `load_program_with_pubkey` that plays nice w bank
* check modification slot somehwere when replenishing to set up tombstones. v3 this is easy. v1/v2 im not sure the right behavior... actually mb it doesnt matter? we dont really care if it goes in the cache or not if it always fails since it doesnt affect loading anymore? we only need to handle v1/2 i think