### PR TITLE
Adds zstd compression level to SnapshotConfig

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -5,7 +5,7 @@ use {
     solana_runtime::{
         snapshot_hash::SnapshotHash,
         snapshot_package::SnapshotKind,
-        snapshot_utils::{self, ArchiveFormat},
+        snapshot_utils::{self, ArchiveFormat, ZstdConfig},
     },
     solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE},
     std::{
@@ -67,7 +67,9 @@ pub fn download_snapshot_archive(
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
     for archive_format in [
-        ArchiveFormat::TarZstd,
+        ArchiveFormat::TarZstd {
+            config: ZstdConfig::default(),
+        },
         ArchiveFormat::TarGzip,
         ArchiveFormat::TarBzip2,
         ArchiveFormat::TarLz4,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1150,7 +1150,7 @@ mod tests {
                 SnapshotVersion::default(),
                 &snapshot_archives_dir,
                 &snapshot_archives_dir,
-                ArchiveFormat::TarZstd,
+                ArchiveFormat::Tar,
             )
             .unwrap();
 
@@ -1395,7 +1395,7 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
-        let snapshot_archive_format = ArchiveFormat::TarZstd;
+        let snapshot_archive_format = ArchiveFormat::Tar;
 
         let full_snapshot_slot = slot;
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
@@ -1878,7 +1878,7 @@ mod tests {
             SnapshotVersion::default(),
             &snapshot_archives_dir,
             &snapshot_archives_dir,
-            ArchiveFormat::TarZstd,
+            ArchiveFormat::Tar,
         )
         .unwrap();
 

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         snapshot_bank_utils,
-        snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
+        snapshot_utils::{self, ArchiveFormat, SnapshotVersion, ZstdConfig},
     },
     solana_sdk::clock::Slot,
     std::{num::NonZeroUsize, path::PathBuf},
@@ -46,9 +46,6 @@ pub struct SnapshotConfig {
 
     // Thread niceness adjustment for snapshot packager service
     pub packager_thread_niceness_adj: i8,
-
-    /// The compression level to use when archiving with zstd
-    pub zstd_compression_level: i32,
 }
 
 impl Default for SnapshotConfig {
@@ -62,7 +59,9 @@ impl Default for SnapshotConfig {
             full_snapshot_archives_dir: PathBuf::default(),
             incremental_snapshot_archives_dir: PathBuf::default(),
             bank_snapshots_dir: PathBuf::default(),
-            archive_format: ArchiveFormat::TarZstd,
+            archive_format: ArchiveFormat::TarZstd {
+                config: ZstdConfig::default(),
+            },
             snapshot_version: SnapshotVersion::default(),
             maximum_full_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -70,7 +69,6 @@ impl Default for SnapshotConfig {
                 snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             accounts_hash_debug_verify: false,
             packager_thread_niceness_adj: 0,
-            zstd_compression_level: 0, // a level of 0 uses zstd's default
         }
     }
 }

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -46,6 +46,9 @@ pub struct SnapshotConfig {
 
     // Thread niceness adjustment for snapshot packager service
     pub packager_thread_niceness_adj: i8,
+
+    /// The compression level to use when archiving with zstd
+    pub zstd_compression_level: i32,
 }
 
 impl Default for SnapshotConfig {
@@ -67,6 +70,7 @@ impl Default for SnapshotConfig {
                 snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             accounts_hash_debug_verify: false,
             packager_thread_niceness_adj: 0,
+            zstd_compression_level: 0, // a level of 0 uses zstd's default
         }
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -818,6 +818,7 @@ pub fn serialize_and_archive_snapshot_package(
         &bank_snapshot_info.snapshot_dir,
         snapshot_archive_path,
         snapshot_config.archive_format,
+        snapshot_config.zstd_compression_level,
     )?;
 
     Ok(snapshot_archive_info)
@@ -975,6 +976,7 @@ fn archive_snapshot(
     bank_snapshot_dir: impl AsRef<Path>,
     archive_path: impl AsRef<Path>,
     archive_format: ArchiveFormat,
+    zstd_compression_level: i32,
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const SNAPSHOTS_DIR: &str = "snapshots";
@@ -1087,9 +1089,8 @@ fn archive_snapshot(
                 encoder.finish().map_err(E::FinishEncoder)?;
             }
             ArchiveFormat::TarZstd => {
-                // Compression level of 1 is optimized for speed.
-                let mut encoder =
-                    zstd::stream::Encoder::new(archive_file, 1).map_err(E::CreateEncoder)?;
+                let mut encoder = zstd::stream::Encoder::new(archive_file, zstd_compression_level)
+                    .map_err(E::CreateEncoder)?;
                 do_archive_files(&mut encoder)?;
                 encoder.finish().map_err(E::FinishEncoder)?;
             }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1798,6 +1798,7 @@ pub fn main() {
         maximum_incremental_snapshot_archives_to_retain,
         accounts_hash_debug_verify: validator_config.accounts_db_test_hash_calculation,
         packager_thread_niceness_adj: snapshot_packager_niceness_adj,
+        zstd_compression_level: 1, // level 1 is optimized for speed
     };
 
     // The accounts hash interval shall match the snapshot interval

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1730,8 +1730,13 @@ pub fn main() {
 
     let archive_format = {
         let archive_format_str = value_t_or_exit!(matches, "snapshot_archive_format", String);
-        ArchiveFormat::from_cli_arg(&archive_format_str)
-            .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"))
+        let mut archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
+            .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"));
+        if let ArchiveFormat::TarZstd { config } = &mut archive_format {
+            // level 1 is optimized for speed
+            config.compression_level = 1;
+        }
+        archive_format
     };
 
     let snapshot_version =
@@ -1798,7 +1803,6 @@ pub fn main() {
         maximum_incremental_snapshot_archives_to_retain,
         accounts_hash_debug_verify: validator_config.accounts_db_test_hash_calculation,
         packager_thread_niceness_adj: snapshot_packager_niceness_adj,
-        zstd_compression_level: 1, // level 1 is optimized for speed
     };
 
     // The accounts hash interval shall match the snapshot interval


### PR DESCRIPTION
#### Problem

When compressing the snapshot archive with zstd, the compression level is hard coded to `1`. This is the value optimized for speed. What if we want to optimize for size instead? This should be a configurable value.


#### Summary of Changes

Adds zstd compression level to SnapshotConfig, and use it when compressing the snapshot archive with zstd.

Note that this PR does *not* add a CLI arg for the operator. That will be handled in a separate PR.