### PR TITLE
Adds --snapshot-zstd-compression-level to agave-validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Release channels have their own copy of this changelog:
     * Add new command `solana feature revoke` for revoking pending feature activations. When a feature is activated, `solana feature revoke <feature-keypair> <cluster>` can be used to deallocate and reassign the account to the System program, undoing the operation. This can only be done before the feature becomes active.
   * Unhide `--accounts-db-access-storages-method` for agave-validator and agave-ledger-tool and change default to `file`
   * Remove tracer stats from banking-trace. `banking-trace` directory should be cleared when restarting on v2.2 for first time. It will not break if not cleared, but the file will be a mix of new/old format. (#4043)
+  * Add `--snapshot-zstd-compression-level` to set the compression level when archiving snapshots with zstd.
 
 ## [2.1.0]
 * Breaking:

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1293,7 +1293,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .default_value(&default_args.snapshot_zstd_compression_level)
                 .value_name("LEVEL")
                 .takes_value(true)
-                .requires_if("snapshot-archive-format", "zstd")
                 .help("The compression level to use when archiving with zstd")
                 .long_help(
                     "The compression level to use when archiving with zstd. \

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1288,6 +1288,21 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Snapshot archive format to use."),
         )
         .arg(
+            Arg::with_name("snapshot_zstd_compression_level")
+                .long("snapshot-zstd-compression-level")
+                .default_value(&default_args.snapshot_zstd_compression_level)
+                .value_name("LEVEL")
+                .takes_value(true)
+                .requires_if("snapshot-archive-format", "zstd")
+                .help("The compression level to use when archiving with zstd")
+                .long_help(
+                    "The compression level to use when archiving with zstd. \
+                     Higher compression levels generally produce higher \
+                     compression ratio at the expense of speed and memory. \
+                     See the zstd manpage for more information."
+                ),
+        )
+        .arg(
             Arg::with_name("max_genesis_archive_unpacked_size")
                 .long("max-genesis-archive-unpacked-size")
                 .value_name("NUMBER")
@@ -2360,6 +2375,7 @@ pub struct DefaultArgs {
 
     pub snapshot_version: SnapshotVersion,
     pub snapshot_archive_format: String,
+    pub snapshot_zstd_compression_level: String,
 
     pub rocksdb_shred_compaction: String,
     pub rocksdb_ledger_compression: String,
@@ -2460,6 +2476,7 @@ impl DefaultArgs {
             min_snapshot_download_speed: DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED.to_string(),
             max_snapshot_download_abort: MAX_SNAPSHOT_DOWNLOAD_ABORT.to_string(),
             snapshot_archive_format: DEFAULT_ARCHIVE_COMPRESSION.to_string(),
+            snapshot_zstd_compression_level: "1".to_string(), // level 1 is optimized for speed
             contact_debug_interval: "120000".to_string(),
             snapshot_version: SnapshotVersion::default(),
             rocksdb_shred_compaction: "level".to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1733,8 +1733,8 @@ pub fn main() {
         let mut archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
             .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"));
         if let ArchiveFormat::TarZstd { config } = &mut archive_format {
-            // level 1 is optimized for speed
-            config.compression_level = 1;
+            config.compression_level =
+                value_t_or_exit!(matches, "snapshot_zstd_compression_level", i32);
         }
         archive_format
     };


### PR DESCRIPTION
#### Problem

As snapshot sizes continue to grow on mnb, validators may want to set the zstd compression level to something other than `1`. This is particularly pertinent for the Anza-run known validators, since they serve the majority of snapshots, and having them generate smaller snapshots could be a material benefit for the network as a whole.


#### Summary of Changes

Adds --snapshot-zstd-compression-level to agave-validator

Adding the cli arg to ledger-tool will be in a separate PR.

Fixes #3105