### PR TITLE
removes redundant allocations when reconstructing Vec<Entry> from shreds

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -122,7 +122,7 @@ pub enum BlockstoreError {
     #[error("shred for index exists")]
     ShredForIndexExists,
     #[error("invalid shred data")]
-    InvalidShredData(Box<bincode::ErrorKind>),
+    InvalidShredData(bincode::Error),
     #[error("RocksDB error: {0}")]
     RocksDb(#[from] rocksdb::Error),
     #[error("slot is not rooted")]
@@ -132,7 +132,7 @@ pub enum BlockstoreError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("serialization error: {0}")]
-    Serialize(#[from] Box<bincode::ErrorKind>),
+    Serialize(#[from] bincode::Error),
     #[error("fs extra error: {0}")]
     FsExtraError(#[from] fs_extra::error::Error),
     #[error("slot cleaned up")]

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -135,6 +135,8 @@ pub enum Error {
     ErasureError(#[from] reed_solomon_erasure::Error),
     #[error("Invalid data size: {size}, payload: {payload}")]
     InvalidDataSize { size: u16, payload: usize },
+    #[error("Invalid deshred set")]
+    InvalidDeshredSet,
     #[error("Invalid erasure shard index: {0:?}")]
     InvalidErasureShardIndex(/*headers:*/ Box<dyn Debug + Send>),
     #[error("Invalid merkle proof")]


### PR DESCRIPTION

#### Problem
`Shredder::deshred` requires an already allocated slice of shreds, and itself does several redundant intermediate allocations: 
https://github.com/anza-xyz/agave/blob/ab440cb7f/ledger/src/shredder.rs#L394-L415

#### Summary of Changes
The commit avoids these redundant intermediate allocations by updating `Shredder::deshred` to work with an iterator argument.
