### PR TITLE
add buffer pubkey to deployment error message

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3085,7 +3085,7 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic, ephemeral_
     eprintln!("To resume a deploy, pass the recovered keypair as the");
     eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
     eprintln!("Or to recover the account's lamports, use:");
-    eprintln!("{divider}\nsolana program close {}\n{divider}", ephemeral_pubkey.to_string());
+    eprintln!("{divider}\nsolana program close {ephemeral_pubkey}\n{divider}");
 }
 
 fn fetch_feature_set(rpc_client: &RpcClient) -> Result<FeatureSet, Box<dyn std::error::Error>> {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3085,19 +3085,29 @@ fn recover_ephemeral_keypair(
     Ok(keypair)
 }
 
-fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) -> Result<(), Box<dyn std::error::Error>> {
+fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
     let phrase: &str = mnemonic.phrase();
-    let keypair = recover_ephemeral_keypair(phrase)?;
     let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
-    eprintln!("{divider}\nRecover the intermediate account's ephemeral keypair file with");
-    eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
-    eprintln!("{divider}\n{phrase}\n{divider}");
-    eprintln!("To resume a deploy, pass the keypair as the [BUFFER_SIGNER]");
-    eprintln!("to `solana program deploy` or `solana program write-buffer',");
-    eprintln!("Or to recover the account's lamports, pass the public key:");
-    eprintln!("{divider}\n{keypair.pubkey().to_string()}\n{divider}");
-    eprintln!("as the [BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
-    Ok(())
+    match recover_ephemeral_keypair(phrase) {
+        Ok(keypair) => {
+            eprintln!("{divider}\nRecover the intermediate account's ephemeral keypair file with");
+            eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
+            eprintln!("{divider}\n{phrase}\n{divider}");
+            eprintln!("To resume a deploy, pass the recovered keypair as the");
+            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
+            eprintln!("Or to recover the account's lamports, use:");
+            eprintln!("{divider}\nsolana program close {}\n{divider}", keypair.pubkey().to_string());
+        },
+        Err(_) => {
+            eprintln!("{divider}\nRecover the intermediate account's ephemeral keypair file with");
+            eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
+            eprintln!("{divider}\n{phrase}\n{divider}");
+            eprintln!("To resume a deploy, pass the recovered keypair as the");
+            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
+            eprintln!("Or to recover the account's lamports, pass it as the");
+            eprintln!("[BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
+        }
+    }
 }
 
 fn fetch_feature_set(rpc_client: &RpcClient) -> Result<FeatureSet, Box<dyn std::error::Error>> {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3076,16 +3076,28 @@ fn create_ephemeral_keypair(
     Ok((WORDS, mnemonic, new_keypair))
 }
 
-fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
+fn recover_ephemeral_keypair(
+    mnemonic: &str,
+) -> Result<Keypair, Box<dyn std::error::Error>> {
+    let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    let seed = Seed::new(&mnemonic, "");
+    let keypair = keypair_from_seed(seed.as_bytes())?;
+    Ok(keypair)
+}
+
+fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) -> Result<(), Box<dyn std::error::Error>> {
     let phrase: &str = mnemonic.phrase();
+    let keypair = recover_ephemeral_keypair(phrase)?;
     let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
     eprintln!("{divider}\nRecover the intermediate account's ephemeral keypair file with");
     eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
     eprintln!("{divider}\n{phrase}\n{divider}");
-    eprintln!("To resume a deploy, pass the recovered keypair as the");
-    eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
-    eprintln!("Or to recover the account's lamports, pass it as the");
-    eprintln!("[BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
+    eprintln!("To resume a deploy, pass the keypair as the [BUFFER_SIGNER]");
+    eprintln!("to `solana program deploy` or `solana program write-buffer',");
+    eprintln!("Or to recover the account's lamports, pass the public key:");
+    eprintln!("{divider}\n{keypair.pubkey().to_string()}\n{divider}");
+    eprintln!("as the [BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
+    Ok(())
 }
 
 fn fetch_feature_set(rpc_client: &RpcClient) -> Result<FeatureSet, Box<dyn std::error::Error>> {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3094,7 +3094,7 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
             eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
             eprintln!("{divider}\n{phrase}\n{divider}");
             eprintln!("To resume a deploy, pass the recovered keypair as the");
-            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
+            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer`.");
             eprintln!("Or to recover the account's lamports, use:");
             eprintln!("{divider}\nsolana program close {}\n{divider}", keypair.pubkey().to_string());
         },
@@ -3103,7 +3103,7 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
             eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");
             eprintln!("{divider}\n{phrase}\n{divider}");
             eprintln!("To resume a deploy, pass the recovered keypair as the");
-            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.");
+            eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer`.");
             eprintln!("Or to recover the account's lamports, pass it as the");
             eprintln!("[BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{divider}");
         }


### PR DESCRIPTION
#### Problem

Buffer account public key not displayed in the error message shown when a program deployment fails.

#### Summary of Changes

Create a new function to recover the keypair from the ephemeral mnemonic, call it when/if the program deployment fails, and display the public key in the error message.

