### PR TITLE
svm: optimize `filter_executable_program_accounts`

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -51,10 +51,10 @@ fn program_cache_execution(threads: usize) {
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
     ];
 
-    let account_maps: HashMap<Pubkey, (&Pubkey, u64)> = programs
+    let account_maps: HashMap<Pubkey, u64> = programs
         .iter()
         .enumerate()
-        .map(|(idx, key)| (*key, (&LOADER, idx as u64)))
+        .map(|(idx, key)| (*key, idx as u64))
         .collect();
 
     let ths: Vec<_> = (0..threads)

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -216,7 +216,7 @@ pub fn deploy_program_with_upgrade_authority(
     let mut account_data = AccountSharedData::default();
     let state = UpgradeableLoaderState::ProgramData {
         slot: deployment_slot,
-        upgrade_authority_address: None,
+        upgrade_authority_address,
     };
     let mut header = bincode::serialize(&state).unwrap();
     let mut complement = vec![


### PR DESCRIPTION
#### Problem
presently, `filter_executable_program_accounts` makes an expensive accounts-db lookup for every account in every transaction batch. this used to be an unfortunate necessity because transaction account loading could not happen until the local program cache was built. a recent feature gate activation has severed that dependency, giving us freedom to improve this

#### Summary of Changes
initialize the `AccountLoader` _before_ constructing the program cache, and change `filter_executable_program_accounts` to use it instead of accounts-db. this eliminates all expensive calls to `account_matches_owners`. this change does not increase the number of calls to `get_account_shared_data` because the same `AccountLoader` object is then used for transaction loading

we also remove the program owner from `program_accounts_map`. this was removed in an early version of 2.0 but had to be added back; we can now definitively remove it, since it is no longer required for owner validation in transaction loading

we also fix an incidental bug where usage counts of builtin programs were reset to zero

#### Notes
the initial attempt at this pr (#4553) tried to move program cache creation _after_ account loading, creating one local program cache per transaction. however we _cannot_ easily do this: under normal operation, `config.check_program_modification_slot` is `false`. this makes it impossible to determine whether a loaderv3 program should be tombstoned because it was modified in-entry. presently this behaves correctly as a side effect of reusing the same local program cache

in the long term we do want to move in this direction, cutting back the functionality of the local program cache into a much simpler passthrough to retrieve compiled/verified program bytecode, with extremely minimal internal state-tracking and no merge/update logic. this might be straightforward if we can simply remove `check_program_modification_slot` and make it behave as if it were always `true`, but this may require a feature gate

in the interim we may also be able to remove accounts-db lookups from `replenish_program_cache` and its children by using `AccountLoader` instead of the callback. this should not require major redesign but it is complicated by the fact that `load_program_with_pubkey` and `load_program_accounts` are required by `Bank`. in theory we could just `impl TransactionProcessingCallback` for `AccountLoader` but this has soundness concerns because it itself contains a `TransactionProcessingCallback` type and merits further discussion