### PR TITLE
Feature - Write lock demotion exemption for loader-v4

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -220,7 +220,11 @@ fn write_transaction<W: io::Write>(
     for (account_index, account) in account_keys.iter().enumerate() {
         let account_meta = CliAccountMeta {
             is_signer: message.is_signer(account_index),
-            is_writable: message.is_maybe_writable(account_index, Some(&reserved_account_keys)),
+            is_writable: message.is_maybe_writable(
+                account_index,
+                Some(&reserved_account_keys),
+                true,
+            ),
             is_invoked: message.is_invoked(account_index),
         };
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1175,6 +1175,7 @@ mod tests {
                 None,
                 loader,
                 &HashSet::default(),
+                true,
             )
             .unwrap()
         };

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2072,6 +2072,7 @@ mod tests {
             Some(false),
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -8,7 +8,7 @@ use {
     solana_sanitize::SanitizeError,
     solana_sdk::{
         clock::Slot,
-        feature_set::FeatureSet,
+        feature_set::{self, FeatureSet},
         hash::Hash,
         message::{v0::LoadedAddresses, AddressLoaderError, Message, SimpleAddressLoader},
         pubkey::Pubkey,
@@ -148,6 +148,8 @@ impl ImmutableDeserializedPacket {
                 tx,
                 address_loader,
                 reserved_account_keys,
+                bank.feature_set
+                    .is_active(&feature_set::enable_loader_v4::id()),
             )
         })
         .ok()?;

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -139,6 +139,7 @@ mod tests {
             Some(false),
             bank,
             bank.get_reserved_account_keys(),
+            true,
         )
         .unwrap()
     }

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -24,6 +24,7 @@ use {
     crossbeam_channel::{RecvTimeoutError, TryRecvError},
     solana_accounts_db::account_locks::validate_account_locks,
     solana_cost_model::cost_model::CostModel,
+    solana_feature_set::enable_loader_v4,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
@@ -507,6 +508,7 @@ impl TransactionViewReceiveAndBuffer {
             view,
             loaded_addresses,
             root_bank.get_reserved_account_keys(),
+            root_bank.feature_set.is_active(&enable_loader_v4::id()),
         ) else {
             return Err(());
         };

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -323,6 +323,7 @@ mod tests {
             Some(true),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 
@@ -333,6 +334,7 @@ mod tests {
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -45,6 +45,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
+                    true,
                 )
             }?;
 
@@ -89,6 +90,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
+                    true,
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -1081,6 +1081,7 @@ mod tests {
                         None,
                         SimpleAddressLoader::Disabled,
                         &ReservedAccountKeys::empty_key_set(),
+                        true,
                     )
                 }?;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -479,6 +479,7 @@ fn compute_slot_cost(
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,
+                    true,
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {:?}", err);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3443,6 +3443,7 @@ fn test_program_fees() {
     let sanitized_message = SanitizedMessage::try_from_legacy_message(
         message.clone(),
         &ReservedAccountKeys::empty_key_set(),
+        true,
     )
     .unwrap();
     let fee_budget_limits = FeeBudgetLimits::from(
@@ -3476,6 +3477,7 @@ fn test_program_fees() {
     let sanitized_message = SanitizedMessage::try_from_legacy_message(
         message.clone(),
         &ReservedAccountKeys::empty_key_set(),
+        true,
     )
     .unwrap();
     let fee_budget_limits = FeeBudgetLimits::from(

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -340,6 +340,7 @@ pub(crate) mod tests {
             None,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 
@@ -469,6 +470,7 @@ pub(crate) mod tests {
             None,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 
@@ -480,6 +482,7 @@ pub(crate) mod tests {
             None,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         )
         .unwrap();
 

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -76,6 +76,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
+        enable_loader_v4: bool,
     ) -> Result<Self> {
         let statically_loaded_runtime_tx =
             RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(
@@ -87,6 +88,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
             statically_loaded_runtime_tx,
             address_loader,
             reserved_account_keys,
+            enable_loader_v4,
         )
     }
 
@@ -97,6 +99,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedVersionedTransaction>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
+        enable_loader_v4: bool,
     ) -> Result<Self> {
         let hash = *statically_loaded_runtime_tx.message_hash();
         let is_simple_vote_tx = statically_loaded_runtime_tx.is_simple_vote_transaction();
@@ -106,6 +109,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
             is_simple_vote_tx,
             address_loader,
             reserved_account_keys,
+            enable_loader_v4,
         )?;
 
         let mut tx = Self {
@@ -144,6 +148,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
+            true,
         )
         .expect("failed to create RuntimeTransaction from Transaction")
     }
@@ -290,6 +295,7 @@ mod tests {
             statically_loaded_transaction,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         );
         let dynamically_loaded_transaction =
             dynamically_loaded_transaction.expect("created from statically loaded tx");

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -82,15 +82,20 @@ impl<D: TransactionData> RuntimeTransaction<ResolvedTransactionView<D>> {
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedTransactionView<D>>,
         loaded_addresses: Option<LoadedAddresses>,
         reserved_account_keys: &HashSet<Pubkey>,
+        enable_loader_v4: bool,
     ) -> Result<Self> {
         let RuntimeTransaction { transaction, meta } = statically_loaded_runtime_tx;
         // transaction-view does not distinguish between different types of errors here.
         // return generic sanitize failure error here.
         // these transactions should be immediately dropped, and we generally
         // will not care about the specific error at this point.
-        let transaction =
-            ResolvedTransactionView::try_new(transaction, loaded_addresses, reserved_account_keys)
-                .map_err(|_| TransactionError::SanitizeFailure)?;
+        let transaction = ResolvedTransactionView::try_new(
+            transaction,
+            loaded_addresses,
+            reserved_account_keys,
+            enable_loader_v4,
+        )
+        .map_err(|_| TransactionError::SanitizeFailure)?;
         let mut tx = Self { transaction, meta };
         tx.load_dynamic_metadata()?;
 
@@ -233,6 +238,7 @@ mod tests {
                 static_runtime_transaction,
                 None,
                 &ReservedAccountKeys::empty_key_set(),
+                true,
             )
             .unwrap();
 
@@ -259,6 +265,7 @@ mod tests {
                 runtime_transaction,
                 loaded_addresses,
                 reserved_account_keys,
+                true,
             )
             .unwrap();
 
@@ -325,6 +332,7 @@ mod tests {
                 runtime_transaction,
                 loaded_addresses,
                 reserved_account_keys,
+                true,
             )
             .unwrap();
 
@@ -350,6 +358,7 @@ mod tests {
             None,
             SimpleAddressLoader::Disabled,
             &reserved_key_set,
+            true,
         )
         .unwrap();
         assert_translation(sanitized_transaction, None, &reserved_key_set);
@@ -382,6 +391,7 @@ mod tests {
             None,
             SimpleAddressLoader::Enabled(loaded_addresses.clone()),
             &reserved_key_set,
+            true,
         )
         .unwrap();
         assert_translation(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3112,6 +3112,9 @@ impl Bank {
         &self,
         txs: Vec<VersionedTransaction>,
     ) -> Result<TransactionBatch<RuntimeTransaction<SanitizedTransaction>>> {
+        let enable_loader_v4 = self
+            .feature_set
+            .is_active(&feature_set::enable_loader_v4::id());
         let sanitized_txs = txs
             .into_iter()
             .map(|tx| {
@@ -3121,6 +3124,7 @@ impl Bank {
                     None,
                     self,
                     self.get_reserved_account_keys(),
+                    enable_loader_v4,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -5638,6 +5642,9 @@ impl Bank {
         tx: VersionedTransaction,
         verification_mode: TransactionVerificationMode,
     ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+        let enable_loader_v4 = self
+            .feature_set
+            .is_active(&feature_set::enable_loader_v4::id());
         let sanitized_tx = {
             let size =
                 bincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
@@ -5657,6 +5664,7 @@ impl Bank {
                 None,
                 self,
                 self.get_reserved_account_keys(),
+                enable_loader_v4,
             )
         }?;
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -200,7 +200,7 @@ pub(in crate::bank) fn create_genesis_config(lamports: u64) -> (GenesisConfig, K
 }
 
 pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessage {
-    SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
+    SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set(), true)
         .unwrap()
 }
 

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -6,6 +6,7 @@ use {
         client::{AsyncClient, Client, SyncClient},
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
+        feature_set,
         hash::Hash,
         instruction::Instruction,
         message::{Message, SanitizedMessage},
@@ -233,9 +234,14 @@ impl SyncClient for BankClient {
     }
 
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
+        let enable_loader_v4 = self
+            .bank
+            .feature_set
+            .is_active(&feature_set::enable_loader_v4::id());
         SanitizedMessage::try_from_legacy_message(
             message.clone(),
             self.bank.get_reserved_account_keys(),
+            enable_loader_v4,
         )
         .ok()
         .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -33,6 +33,7 @@ fn bench_construct_instructions_data(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &ReservedAccountKeys::empty_key_set(),
+        true,
     )
     .unwrap();
     b.iter(|| {
@@ -56,6 +57,7 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &ReservedAccountKeys::empty_key_set(),
+        true,
     )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
@@ -73,6 +75,7 @@ fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &ReservedAccountKeys::empty_key_set(),
+        true,
     )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());

--- a/sdk/message/src/versions/mod.rs
+++ b/sdk/message/src/versions/mod.rs
@@ -90,10 +90,15 @@ impl VersionedMessage {
         &self,
         index: usize,
         reserved_account_keys: Option<&HashSet<Pubkey>>,
+        enable_loader_v4: bool,
     ) -> bool {
         match self {
-            Self::Legacy(message) => message.is_maybe_writable(index, reserved_account_keys),
-            Self::V0(message) => message.is_maybe_writable(index, reserved_account_keys),
+            Self::Legacy(message) => {
+                message.is_maybe_writable(index, reserved_account_keys, enable_loader_v4)
+            }
+            Self::V0(message) => {
+                message.is_maybe_writable(index, reserved_account_keys, enable_loader_v4)
+            }
         }
     }
 

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -63,6 +63,7 @@ fn test_get_durable_nonce() {
             SanitizedVersionedMessage::try_new(versioned_message).unwrap(),
             loader,
             &HashSet::new(),
+            true,
         )
         .unwrap()
     }
@@ -268,6 +269,7 @@ fn test_get_ix_signers() {
             instructions,
         ),
         &HashSet::default(),
+        true,
     )
     .unwrap();
 

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -900,6 +900,7 @@ fn sanitize_transaction(
         None,
         address_loader,
         reserved_account_keys,
+        true,
     )
     .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
 }

--- a/svm/examples/paytube/src/transaction.rs
+++ b/svm/examples/paytube/src/transaction.rs
@@ -66,6 +66,7 @@ impl From<&PayTubeTransaction> for SolanaSanitizedTransaction {
         SolanaSanitizedTransaction::try_from_legacy_transaction(
             SolanaTransaction::from(value),
             &HashSet::new(),
+            true,
         )
         .unwrap()
     }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -768,6 +768,7 @@ mod tests {
         SanitizedMessage::Legacy(LegacyMessage::new(
             message,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         ))
     }
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -146,8 +146,12 @@ mod tests {
     };
 
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
-            .unwrap()
+        SanitizedMessage::try_from_legacy_message(
+            message,
+            &ReservedAccountKeys::empty_key_set(),
+            true,
+        )
+        .unwrap()
     }
 
     #[test]

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -115,6 +115,7 @@ mod test {
         let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(
             message,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         ));
 
         let transaction_accounts = vec![
@@ -175,6 +176,7 @@ mod test {
         let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(
             message,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         ));
 
         let transaction_accounts = vec![

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1235,6 +1235,7 @@ mod tests {
         SanitizedMessage::Legacy(LegacyMessage::new(
             message,
             &ReservedAccountKeys::empty_key_set(),
+            true,
         ))
     }
 

--- a/svm/tests/transaction_builder.rs
+++ b/svm/tests/transaction_builder.rs
@@ -227,6 +227,7 @@ impl SanitizedTransactionBuilder {
             } else {
                 reserved_active
             },
+            true,
         )
     }
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -559,6 +559,7 @@ impl VersionedTransactionWithStatusMeta {
                     message,
                     &self.meta.loaded_addresses,
                     &reserved_account_keys.active,
+                    true,
                 );
                 parse_v0_message_accounts(&loaded_message)
             }
@@ -768,7 +769,7 @@ impl Encodable for v0::Message {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             let loaded_addresses = LoadedAddresses::default();
             let loaded_message =
-                LoadedMessage::new_borrowed(self, &loaded_addresses, &HashSet::new());
+                LoadedMessage::new_borrowed(self, &loaded_addresses, &HashSet::new(), true);
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),
@@ -809,6 +810,7 @@ impl EncodableWithMeta for v0::Message {
                 self,
                 &meta.loaded_addresses,
                 &reserved_account_keys.active,
+                true,
             );
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_v0_message_accounts(&loaded_message),

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -10,7 +10,7 @@ pub fn parse_legacy_message_accounts(message: &Message) -> Vec<ParsedAccount> {
     for (i, account_key) in message.account_keys.iter().enumerate() {
         accounts.push(ParsedAccount {
             pubkey: account_key.to_string(),
-            writable: message.is_maybe_writable(i, Some(&reserved_account_keys)),
+            writable: message.is_maybe_writable(i, Some(&reserved_account_keys), true),
             signer: message.is_signer(i),
             source: Some(ParsedAccountSource::Transaction),
         });
@@ -115,6 +115,7 @@ mod test {
                 readonly: vec![pubkey5],
             },
             &ReservedAccountKeys::empty_key_set(),
+            true,
         );
 
         assert_eq!(


### PR DESCRIPTION
#### Problem
Split off from #2796.

#### Summary of Changes
Wires a `enable_loader_v4` parameter through all `Message` constructors which then ends up in `is_upgradeable_loader_present()`. The parameter is a `bool` and not `&FeatureSet` on purpose so that the feature check can be hoisted outside of loops at the call sites. All consensus irrelevant parts (such as tests, benchmarks and some tools) have it hard coded to `true`.