### PR TITLE
Reduce public visible api/structs in svm crate

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2573,43 +2573,22 @@ mod tests {
             Consumer::filter_valid_transaction_indexes(&[
                 Err(TransactionError::BlockhashNotFound),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0
-                }),
+                Ok(CheckedTransactionDetails::default()),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0
-                }),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0
-                }),
+                Ok(CheckedTransactionDetails::default()),
+                Ok(CheckedTransactionDetails::default()),
             ]),
             [2, 4, 5]
         );
 
         assert_eq!(
             Consumer::filter_valid_transaction_indexes(&[
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0,
-                }),
+                Ok(CheckedTransactionDetails::default()),
                 Err(TransactionError::BlockhashNotFound),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0,
-                }),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0,
-                }),
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 0,
-                }),
+                Ok(CheckedTransactionDetails::default()),
+                Ok(CheckedTransactionDetails::default()),
+                Ok(CheckedTransactionDetails::default()),
             ]),
             [0, 3, 4, 5]
         );

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -113,10 +113,7 @@ impl Bank {
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.recent_blockhash();
         if let Some(hash_info) = hash_queue.get_hash_info_if_valid(recent_blockhash, max_age) {
-            Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: hash_info.lamports_per_signature(),
-            })
+            Ok(CheckedTransactionDetails::new(None, hash_info.lamports_per_signature()))
         } else if let Some((nonce, previous_lamports_per_signature)) = self
             .check_load_and_advance_message_nonce_account(
                 tx,
@@ -124,10 +121,9 @@ impl Bank {
                 next_lamports_per_signature,
             )
         {
-            Ok(CheckedTransactionDetails {
-                nonce: Some(nonce),
-                lamports_per_signature: previous_lamports_per_signature,
-            })
+            Ok(CheckedTransactionDetails::new(Some(nonce),
+                previous_lamports_per_signature)
+            )
         } else {
             error_counters.blockhash_not_found += 1;
             Err(TransactionError::BlockhashNotFound)

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -113,7 +113,10 @@ impl Bank {
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.recent_blockhash();
         if let Some(hash_info) = hash_queue.get_hash_info_if_valid(recent_blockhash, max_age) {
-            Ok(CheckedTransactionDetails::new(None, hash_info.lamports_per_signature()))
+            Ok(CheckedTransactionDetails::new(
+                None,
+                hash_info.lamports_per_signature(),
+            ))
         } else if let Some((nonce, previous_lamports_per_signature)) = self
             .check_load_and_advance_message_nonce_account(
                 tx,
@@ -121,9 +124,10 @@ impl Bank {
                 next_lamports_per_signature,
             )
         {
-            Ok(CheckedTransactionDetails::new(Some(nonce),
-                previous_lamports_per_signature)
-            )
+            Ok(CheckedTransactionDetails::new(
+                Some(nonce),
+                previous_lamports_per_signature,
+            ))
         } else {
             error_counters.blockhash_not_found += 1;
             Err(TransactionError::BlockhashNotFound)

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -423,10 +423,7 @@ impl JsonRpcRequestProcessor {
         _error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionCheckResult {
         /* for now just return defaults */
-        Ok(CheckedTransactionDetails {
-            nonce: None,
-            lamports_per_signature: u64::default(),
-        })
+        Ok(CheckedTransactionDetails::new(None, u64::default()))
     }
 
     fn clock(&self) -> sysvar::clock::Clock {

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -92,11 +92,5 @@ pub(crate) fn get_transaction_check_results(
     len: usize,
     lamports_per_signature: u64,
 ) -> Vec<transaction::Result<CheckedTransactionDetails>> {
-    vec![
-        transaction::Result::Ok(CheckedTransactionDetails {
-            nonce: None,
-            lamports_per_signature,
-        });
-        len
-    ]
+    vec![transaction::Result::Ok(CheckedTransactionDetails::new(None, lamports_per_signature)); len]
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -60,8 +60,17 @@ pub(crate) enum TransactionLoadResult {
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
 pub struct CheckedTransactionDetails {
-    pub nonce: Option<NonceInfo>,
-    pub lamports_per_signature: u64,
+    pub(crate) nonce: Option<NonceInfo>,
+    pub(crate) lamports_per_signature: u64,
+}
+
+impl CheckedTransactionDetails {
+    pub fn new(nonce: Option<NonceInfo>, lamports_per_signature: u64) -> Self {
+        Self {
+            nonce,
+            lamports_per_signature,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -85,7 +94,11 @@ pub(crate) struct LoadedTransactionAccount {
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
 #[cfg_attr(
     feature = "dev-context-only-utils",
-    field_qualifiers(program_indices(pub), compute_budget_limits(pub))
+    field_qualifiers(
+        program_indices(pub),
+        compute_budget_limits(pub),
+        loaded_accounts_data_size(pub)
+    )
 )]
 pub struct LoadedTransaction {
     pub accounts: Vec<TransactionAccount>,
@@ -95,7 +108,7 @@ pub struct LoadedTransaction {
     pub(crate) compute_budget_limits: ComputeBudgetLimits,
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
-    pub loaded_accounts_data_size: u32,
+    pub(crate) loaded_accounts_data_size: u32,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::transaction_processing_callback::TransactionProcessingCallback,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},
@@ -116,7 +118,8 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
-pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+pub(crate) fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     environments: &ProgramRuntimeEnvironments,
     pubkey: &Pubkey,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2488,9 +2488,8 @@ mod tests {
                 .try_advance_nonce(next_durable_nonce, lamports_per_signature)
                 .unwrap();
 
-            let tx_details = CheckedTransactionDetails::new(Some(future_nonce.clone()),
-                lamports_per_signature
-            );
+            let tx_details =
+                CheckedTransactionDetails::new(Some(future_nonce.clone()), lamports_per_signature);
 
             let result = TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1340,10 +1340,7 @@ mod tests {
         ];
 
         let check_results = vec![
-            TransactionCheckResult::Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 0
-            });
+            TransactionCheckResult::Ok(CheckedTransactionDetails::default());
             check_results_len
         ];
 
@@ -2171,10 +2168,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2251,10 +2245,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2302,10 +2293,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
@@ -2336,10 +2324,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
@@ -2374,10 +2359,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2410,10 +2392,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
@@ -2442,10 +2421,7 @@ mod tests {
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
@@ -2512,10 +2488,9 @@ mod tests {
                 .try_advance_nonce(next_durable_nonce, lamports_per_signature)
                 .unwrap();
 
-            let tx_details = CheckedTransactionDetails {
-                nonce: Some(future_nonce.clone()),
-                lamports_per_signature,
-            };
+            let tx_details = CheckedTransactionDetails::new(Some(future_nonce.clone()),
+                lamports_per_signature
+            );
 
             let result = TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
@@ -2578,10 +2553,7 @@ mod tests {
             let result = TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
                 &message,
-                CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature,
-                },
+                CheckedTransactionDetails::new(None, lamports_per_signature),
                 &Hash::default(),
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
@@ -2623,10 +2595,7 @@ mod tests {
         TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
             &mut account_loader,
             &message,
-            CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: 5000,
-            },
+            CheckedTransactionDetails::new(None, 5000),
             &Hash::default(),
             FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -239,10 +239,7 @@ fn svm_concurrent() {
             let local_bank = mock_bank.clone();
             let th_txs = std::mem::take(&mut transactions[idx]);
             let check_results = vec![
-                Ok(CheckedTransactionDetails {
-                    nonce: None,
-                    lamports_per_signature: 20
-                }) as TransactionCheckResult;
+                Ok(CheckedTransactionDetails::new(None, 20)) as TransactionCheckResult;
                 TRANSACTIONS_PER_THREAD
             ];
             let processing_config = TransactionProcessingConfig {

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -239,7 +239,8 @@ fn svm_concurrent() {
             let local_bank = mock_bank.clone();
             let th_txs = std::mem::take(&mut transactions[idx]);
             let check_results = vec![
-                Ok(CheckedTransactionDetails::new(None, 20)) as TransactionCheckResult;
+                Ok(CheckedTransactionDetails::new(None, 20))
+                    as TransactionCheckResult;
                 TRANSACTIONS_PER_THREAD
             ];
             let processing_config = TransactionProcessingConfig {

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -430,10 +430,9 @@ pub struct TransactionBatchItem {
 impl TransactionBatchItem {
     fn with_nonce(nonce_info: NonceInfo) -> Self {
         Self {
-            check_result: Ok(CheckedTransactionDetails {
-                nonce: Some(nonce_info),
-                lamports_per_signature: LAMPORTS_PER_SIGNATURE,
-            }),
+            check_result: Ok(CheckedTransactionDetails::new(Some(nonce_info),
+                 LAMPORTS_PER_SIGNATURE)
+            ),
             ..Self::default()
         }
     }
@@ -443,10 +442,7 @@ impl Default for TransactionBatchItem {
     fn default() -> Self {
         Self {
             transaction: Transaction::default(),
-            check_result: Ok(CheckedTransactionDetails {
-                nonce: None,
-                lamports_per_signature: LAMPORTS_PER_SIGNATURE,
-            }),
+            check_result: Ok(CheckedTransactionDetails::new(None, LAMPORTS_PER_SIGNATURE)),
             asserts: TransactionBatchItemAsserts::default(),
         }
     }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -430,9 +430,10 @@ pub struct TransactionBatchItem {
 impl TransactionBatchItem {
     fn with_nonce(nonce_info: NonceInfo) -> Self {
         Self {
-            check_result: Ok(CheckedTransactionDetails::new(Some(nonce_info),
-                 LAMPORTS_PER_SIGNATURE)
-            ),
+            check_result: Ok(CheckedTransactionDetails::new(
+                Some(nonce_info),
+                LAMPORTS_PER_SIGNATURE,
+            )),
             ..Self::default()
         }
     }


### PR DESCRIPTION
#### Problem
Some public APIs and structs in SVM crate could have reduced visibility

#### Summary of Changes
Reduce the visibility to private or pub(crate)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
