### PR TITLE
Force interface binding for external ip discovery

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -413,14 +413,14 @@ fn validators_set(
     }
 }
 
-fn get_cluster_shred_version(entrypoints: &[SocketAddr]) -> Option<u16> {
+fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -> Option<u16> {
     let entrypoints = {
         let mut index: Vec<_> = (0..entrypoints.len()).collect();
         index.shuffle(&mut rand::thread_rng());
         index.into_iter().map(|i| &entrypoints[i])
     };
     for entrypoint in entrypoints {
-        match solana_net_utils::get_cluster_shred_version(entrypoint) {
+        match solana_net_utils::get_cluster_shred_version_with_binding(entrypoint, bind_address) {
             Err(err) => eprintln!("get_cluster_shred_version failed: {entrypoint}, {err}"),
             Ok(0) => eprintln!("entrypoint {entrypoint} returned shred-version zero"),
             Ok(shred_version) => {
@@ -1179,7 +1179,7 @@ pub fn main() {
     // version can then be deleted from gossip and get_rpc_node above.
     let expected_shred_version = value_t!(matches, "expected_shred_version", u16)
         .ok()
-        .or_else(|| get_cluster_shred_version(&entrypoint_addrs));
+        .or_else(|| get_cluster_shred_version(&entrypoint_addrs, bind_address));
 
     let tower_storage: Arc<dyn tower_storage::TowerStorage> =
         match value_t_or_exit!(matches, "tower_storage", String).as_str() {
@@ -1936,15 +1936,16 @@ pub fn main() {
                         "Contacting {} to determine the validator's public IP address",
                         entrypoint_addr
                     );
-                    solana_net_utils::get_public_ip_addr(entrypoint_addr).map_or_else(
-                        |err| {
-                            eprintln!(
-                                "Failed to contact cluster entrypoint {entrypoint_addr}: {err}"
-                            );
-                            None
-                        },
-                        Some,
-                    )
+                    solana_net_utils::get_public_ip_addr_with_binding(entrypoint_addr, bind_address)
+                        .map_or_else(
+                            |err| {
+                                eprintln!(
+                                    "Failed to contact cluster entrypoint {entrypoint_addr}: {err}"
+                                );
+                                None
+                            },
+                            Some,
+                        )
                 });
 
                 gossip_host.unwrap_or_else(|| {


### PR DESCRIPTION
#### Problem
The binding to bind-address (as specified on the CLI) is not done by all sockets. This PR switches to the new code from net_utils doing that.

#### Summary of Changes

Use the functions from net-utils that bind to the provided interface

Fixes #
 https://github.com/anza-xyz/agave/issues/4440

