### PR TITLE
Enable IndexV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Release channels have their own copy of this changelog:
 <a name="edge-channel"></a>
 ## [2.2.0] - Unreleased
 * Breaking:
+  * Blockstore Index column format change
+    * The Blockstore Index column format has been updated. The column format written in v2.2 is compatible with v2.1, but incompatible with v2.0 and older.
   * Snapshot format change
     * The snapshot format has been modified to implement SIMD-215. Since only adjacent versions are guaranteed to maintain snapshot compatibility, this means snapshots created with v2.2 are compatible with v2.1 and incompatible with v2.0 and older.
 * Changes

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1267,7 +1267,7 @@ impl TypedColumn for columns::Index {
         match index {
             Ok(index) => Ok(index),
             Err(_) => {
-                let index: blockstore_meta::IndexV2 = config.deserialize(data)?;
+                let index: blockstore_meta::IndexFallback = config.deserialize(data)?;
                 Ok(index.into())
             }
         }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -107,12 +107,16 @@ mod serde_compat {
     }
 }
 
+pub type Index = IndexV2;
+pub type ShredIndex = ShredIndexV2;
+pub type IndexFallback = IndexLegacy;
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 /// Index recording presence/absence of shreds
-pub struct Index {
+pub struct IndexLegacy {
     pub slot: Slot,
-    data: ShredIndex,
-    coding: ShredIndex,
+    data: ShredIndexLegacy,
+    coding: ShredIndexLegacy,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -122,9 +126,9 @@ pub struct IndexV2 {
     coding: ShredIndexV2,
 }
 
-impl From<IndexV2> for Index {
+impl From<IndexV2> for IndexLegacy {
     fn from(index: IndexV2) -> Self {
-        Index {
+        IndexLegacy {
             slot: index.slot,
             data: index.data.into(),
             coding: index.coding.into(),
@@ -132,8 +136,8 @@ impl From<IndexV2> for Index {
     }
 }
 
-impl From<Index> for IndexV2 {
-    fn from(index: Index) -> Self {
+impl From<IndexLegacy> for IndexV2 {
+    fn from(index: IndexLegacy) -> Self {
         IndexV2 {
             slot: index.slot,
             data: index.data.into(),
@@ -143,7 +147,7 @@ impl From<Index> for IndexV2 {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ShredIndex {
+pub struct ShredIndexLegacy {
     /// Map representing presence/absence of shreds
     index: BTreeSet<u64>,
 }
@@ -251,7 +255,7 @@ pub struct FrozenHashStatus {
 
 impl Index {
     pub(crate) fn new(slot: Slot) -> Self {
-        Index {
+        Self {
             slot,
             data: ShredIndex::default(),
             coding: ShredIndex::default(),
@@ -277,7 +281,8 @@ impl Index {
 ///
 /// TODO: Remove this once new [`ShredIndexV2`] is fully rolled out
 /// and no longer relies on it for fallback.
-impl ShredIndex {
+#[allow(unused)]
+impl ShredIndexLegacy {
     pub fn num_shreds(&self) -> usize {
         self.index.len()
     }
@@ -498,23 +503,23 @@ impl FromIterator<u64> for ShredIndexV2 {
     }
 }
 
-impl FromIterator<u64> for ShredIndex {
+impl FromIterator<u64> for ShredIndexLegacy {
     fn from_iter<T: IntoIterator<Item = u64>>(iter: T) -> Self {
-        ShredIndex {
+        ShredIndexLegacy {
             index: iter.into_iter().collect(),
         }
     }
 }
 
-impl From<ShredIndex> for ShredIndexV2 {
-    fn from(value: ShredIndex) -> Self {
+impl From<ShredIndexLegacy> for ShredIndexV2 {
+    fn from(value: ShredIndexLegacy) -> Self {
         value.index.into_iter().collect()
     }
 }
 
-impl From<ShredIndexV2> for ShredIndex {
+impl From<ShredIndexV2> for ShredIndexLegacy {
     fn from(value: ShredIndexV2) -> Self {
-        ShredIndex {
+        ShredIndexLegacy {
             index: value.iter().collect(),
         }
     }
@@ -922,7 +927,7 @@ mod test {
             shreds in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
             range in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64)
         ) {
-            let mut legacy = ShredIndex::default();
+            let mut legacy = ShredIndexLegacy::default();
             let mut v2 = ShredIndexV2::default();
 
             for i in shreds {
@@ -942,7 +947,7 @@ mod test {
             );
 
             assert_eq!(ShredIndexV2::from(legacy.clone()), v2.clone());
-            assert_eq!(ShredIndex::from(v2), legacy);
+            assert_eq!(ShredIndexLegacy::from(v2), legacy);
         }
 
         /// Property: [`Index`] cannot be deserialized from [`IndexV2`].
@@ -965,7 +970,7 @@ mod test {
                 slot,
             };
             let config = bincode::DefaultOptions::new().with_fixint_encoding().reject_trailing_bytes();
-            let legacy = config.deserialize::<Index>(&config.serialize(&index).unwrap());
+            let legacy = config.deserialize::<IndexLegacy>(&config.serialize(&index).unwrap());
             prop_assert!(legacy.is_err());
         }
 
@@ -983,7 +988,7 @@ mod test {
             data_indices in rand_range(0..MAX_DATA_SHREDS_PER_SLOT as u64),
             slot in 0..u64::MAX
         ) {
-            let index = Index {
+            let index = IndexLegacy {
                 coding: coding_indices.into_iter().collect(),
                 data: data_indices.into_iter().collect(),
                 slot,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -311,6 +311,7 @@ impl IndexFallback {
 ///
 /// TODO: Remove this once new [`ShredIndexV2`] is fully rolled out
 /// and no longer relies on it for fallback.
+#[cfg(test)]
 #[allow(unused)]
 impl ShredIndexV1 {
     pub fn num_shreds(&self) -> usize {
@@ -332,7 +333,6 @@ impl ShredIndexV1 {
         self.index.insert(index);
     }
 
-    #[cfg(test)]
     fn remove(&mut self, index: u64) {
         self.index.remove(&index);
     }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -110,6 +110,7 @@ mod serde_compat {
 pub type Index = IndexV2;
 pub type ShredIndex = ShredIndexV2;
 pub type IndexFallback = IndexV1;
+pub type ShredIndexFallback = ShredIndexV1;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 /// Index recording presence/absence of shreds
@@ -273,6 +274,32 @@ impl Index {
         &mut self.data
     }
     pub(crate) fn coding_mut(&mut self) -> &mut ShredIndex {
+        &mut self.coding
+    }
+}
+
+#[cfg(test)]
+#[allow(unused)]
+impl IndexFallback {
+    pub(crate) fn new(slot: Slot) -> Self {
+        Self {
+            slot,
+            data: ShredIndexFallback::default(),
+            coding: ShredIndexFallback::default(),
+        }
+    }
+
+    pub fn data(&self) -> &ShredIndexFallback {
+        &self.data
+    }
+    pub fn coding(&self) -> &ShredIndexFallback {
+        &self.coding
+    }
+
+    pub(crate) fn data_mut(&mut self) -> &mut ShredIndexFallback {
+        &mut self.data
+    }
+    pub(crate) fn coding_mut(&mut self) -> &mut ShredIndexFallback {
         &mut self.coding
     }
 }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -109,6 +109,9 @@ mod serde_compat {
 
 pub type Index = IndexV2;
 pub type ShredIndex = ShredIndexV2;
+/// We currently support falling back to the previous format for migration purposes.
+///
+/// See https://github.com/anza-xyz/agave/issues/3570.
 pub type IndexFallback = IndexV1;
 pub type ShredIndexFallback = ShredIndexV1;
 


### PR DESCRIPTION
#### Problem

The current blockstore index type, backed by a `BTreeSet`, suffers from performance issues in serialization / deserialization due to its dynamically allocated and balanced nature. See https://github.com/anza-xyz/agave/issues/3570 and #3900 for context.

#### Summary of Changes

A follow up of #3900, this enables `IndexV2` as the primary read/write target for the blockstore's `Index` type.

#### Other notes
In a follow up PR, I'll introduce a test case that exercises the fallback deserialization logic, where data in the blockstore is written as `IndexFallback`, deserialized as such, and recovered as `Index`.