### PR TITLE
quic: increase timeout and keep alive

### DIFF
--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -16,6 +16,10 @@ pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 // forwarded packets from staked nodes.
 pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
+// Connection idle timeout, and keep alive.
+// Quic will close the connection after QUIC_MAX_TIMEOUT,
+// and send a ping every QUIC_KEEP_ALIVE.
+// These shouldn't be too low to avoid unnecessary ping traffic.
 pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
 pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
 

--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -16,8 +16,8 @@ pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 // forwarded packets from staked nodes.
 pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
-pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
-pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
+pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
+pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
 
 // Based on commonly-used handshake timeouts for various TCP
 // applications. Different applications vary, but most seem to


### PR DESCRIPTION
#### Problem

Quic timeout and keep alive are very low.
When a validator is not leader, it still has thousands of connections open that are not expected to send any data.
Because keep alive is 1s, each client sends a quic ping every second, which is a lot of unnecessary traffic.

#### Summary of Changes

Increased timeout to 60s and keep alive to 45s.