### PR TITLE
fix: error message improvements

### DIFF
--- a/sdk/nonce/src/versions.rs
+++ b/sdk/nonce/src/versions.rs
@@ -20,7 +20,9 @@ pub enum Versions {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum AuthorizeNonceError {
+    #[error("Missing required signature from account authority: {0}")]
     MissingRequiredSignature(/*account authority:*/ Pubkey),
+    #[error("Cannot authorize an uninitialized nonce account")]
     Uninitialized,
 }
 

--- a/sdk/sanitize/src/lib.rs
+++ b/sdk/sanitize/src/lib.rs
@@ -14,9 +14,9 @@ impl Error for SanitizeError {}
 impl fmt::Display for SanitizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SanitizeError::IndexOutOfBounds => f.write_str("index out of bounds"),
-            SanitizeError::ValueOutOfBounds => f.write_str("value out of bounds"),
-            SanitizeError::InvalidValue => f.write_str("invalid value"),
+            SanitizeError::IndexOutOfBounds => f.write_str("array index is out of bounds"),
+            SanitizeError::ValueOutOfBounds => f.write_str("numeric value is out of allowed bounds"),
+            SanitizeError::InvalidValue => f.write_str("value is invalid for this context"),
         }
     }
 }

--- a/zk-sdk/src/errors.rs
+++ b/zk-sdk/src/errors.rs
@@ -33,13 +33,13 @@ pub enum ElGamalError {
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum TranscriptError {
-    #[error("point is the identity")]
+    #[error("Invalid point: point is the identity")]
     ValidationError,
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum ParseError {
-    #[error("String is the wrong size")]
+    #[error("Input string has wrong size")]
     WrongSize,
     #[error("Invalid Base64 string")]
     Invalid,


### PR DESCRIPTION
## Changes
- Enhanced error messages in `zk-sdk/src/errors.rs`:
  - `TranscriptError::ValidationError`: Added context about invalid point
  - `ParseError::WrongSize`: Clarified input string context

- Improved error messages in `sdk/sanitize/src/lib.rs`:
  - Added specific context for array index bounds
  - Clarified numeric value bounds
  - Added context for invalid values

- Enhanced error messages in `sdk/nonce/src/versions.rs`:
  - Added descriptive error messages for nonce authorization
  - Improved uninitialized account error message

## Impact
These changes make error messages more descriptive and helpful for debugging without changing any functionality.