### PR TITLE
fix: use atomic to check if leader bank changed

### DIFF
--- a/poh/src/leader_bank_notifier.rs
+++ b/poh/src/leader_bank_notifier.rs
@@ -89,6 +89,9 @@ impl LeaderBankNotifier {
         self.condvar.notify_all();
     }
 
+    /// Fetch the bank id of the bank inside the mutex wrapped state field. Due
+    /// to the usage of relaxed ordering, this is not a guarantee that the
+    /// caller thread will see the updated bank in the mutex wrapped state yet.
     pub fn get_current_bank_id(&self) -> Option<u64> {
         let current_bank_id = self.current_bank_id.load(Ordering::Relaxed);
         if current_bank_id == STAND_BY_SENTINEL_ID {


### PR DESCRIPTION
#### Problem
Banking stage consume workers don't check if a leader bank got interrupted while consuming work. This can cause them to get stuck consuming work for a bank that was abandoned rather than switching to the newest leader bank.

#### Summary of Changes
Add a lightweight atomic variable which holds the current leader bank id and check it before each consumed piece of work to see if the bank was interrupted.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
