### PR TITLE
fix: return error for malformed program account filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Release channels have their own copy of this changelog:
 #### Breaking
 * A signature verification failure in `simulateTransaction()` or the preflight stage of `sendTransaction()` will now be attached to the simulation result's `err` property as `TransactionError::SignatureFailure` instead of being thrown as a JSON RPC API error (-32003). Applications that already guard against JSON RPC exceptions should expect signature verification errors to appear on the simulation result instead. Applications that already handle the materialization of `TransactionErrors` on simulation results can now expect to receive errors of type `TransactionError::SignatureFailure` at those verification sites.
 #### Changes
+* The `getProgramAccounts` RPC endpoint now returns JSON-RPC errors when malformed filters are provided (previously these malformed filters would be silently ignored and the RPC call would execute an unfiltered query).
 * `PubsubClient` can now be constructed with the URI of an RPC (as a `str`, `String`, or `Uri`) as well as an `http::Request<()>`. The addition of `Request` allows you to set request headers when establishing a websocket connection with an RPC.
 ### Validator
 #### Breaking

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8783,6 +8783,22 @@ pub mod tests {
         )
         .unwrap()
         .is_none());
+
+        // Test invalid filters
+
+        // Filtering on invalid length pubkey
+        let owner = Pubkey::new_unique();
+        let mut first_half_bytes = owner.to_bytes().to_vec();
+        first_half_bytes.resize(16, 0);
+        assert!(get_spl_token_owner_filter(
+            &spl_generic_token::token::id(),
+            &[
+                RpcFilterType::Memcmp(Memcmp::new_raw_bytes(32, first_half_bytes)),
+                RpcFilterType::DataSize(165)
+            ],
+        )
+        .is_err_and(|err| err.code == ErrorCode::InvalidParams
+            && err.message == "Incorrect byte length 16 for SPL token owner filter, expected 32"));
     }
 
     #[test]
@@ -8871,6 +8887,25 @@ pub mod tests {
         )
         .unwrap()
         .is_none());
+
+        // Test invalid filters
+
+        // Filtering on invalid length pubkey
+        let owner = Pubkey::new_unique();
+        let mut first_half_bytes = owner.to_bytes().to_vec();
+        first_half_bytes.resize(16, 0);
+        assert!(get_spl_token_mint_filter(
+            &spl_generic_token::token::id(),
+            &[
+                RpcFilterType::Memcmp(Memcmp::new_raw_bytes(0, first_half_bytes)),
+                RpcFilterType::DataSize(165)
+            ],
+        )
+        .is_err_and(|err| {
+            print!("{err:?}");
+            err.code == ErrorCode::InvalidParams
+                && err.message == "Incorrect byte length 16 for SPL token mint filter, expected 32"
+        }));
     }
 
     #[test]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -618,7 +618,7 @@ impl JsonRpcRequestProcessor {
         let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
         optimize_filters(&mut filters);
         let keyed_accounts = {
-            if let Some(owner) = get_spl_token_owner_filter(&program_id, &filters) {
+            if let Some(owner) = get_spl_token_owner_filter(&program_id, &filters)? {
                 self.get_filtered_spl_token_accounts_by_owner(
                     Arc::clone(&bank),
                     program_id,
@@ -627,7 +627,7 @@ impl JsonRpcRequestProcessor {
                     sort_results,
                 )
                 .await?
-            } else if let Some(mint) = get_spl_token_mint_filter(&program_id, &filters) {
+            } else if let Some(mint) = get_spl_token_mint_filter(&program_id, &filters)? {
                 self.get_filtered_spl_token_accounts_by_mint(
                     Arc::clone(&bank),
                     program_id,
@@ -2547,14 +2547,16 @@ fn encode_account<T: ReadableAccount>(
 /// owner.
 /// NOTE: `optimize_filters()` should almost always be called before using this method because of
 /// the requirement that `Memcmp::raw_bytes_as_ref().is_some()`.
-fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> Option<Pubkey> {
+fn get_spl_token_owner_filter(
+    program_id: &Pubkey,
+    filters: &[RpcFilterType],
+) -> Result<Option<Pubkey>> {
     if !is_known_spl_token_id(program_id) {
-        return None;
+        return Ok(None);
     }
     let mut data_size_filter: Option<u64> = None;
     let mut memcmp_filter: Option<&[u8]> = None;
     let mut owner_key: Option<Pubkey> = None;
-    let mut incorrect_owner_len: Option<usize> = None;
     let mut token_account_state_filter = false;
     let account_packed_len = TokenAccount::get_packed_len();
     for filter in filters {
@@ -2569,7 +2571,11 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
                         if bytes.len() == PUBKEY_BYTES {
                             owner_key = Pubkey::try_from(bytes).ok();
                         } else {
-                            incorrect_owner_len = Some(bytes.len());
+                            return Err(Error::invalid_params(format!(
+                                "Incorrect byte length {} for SPL token owner filter, expected {}",
+                                bytes.len(),
+                                PUBKEY_BYTES
+                            )));
                         }
                     }
                 }
@@ -2581,15 +2587,10 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
         || memcmp_filter == Some(&[ACCOUNTTYPE_ACCOUNT])
         || token_account_state_filter
     {
-        if let Some(incorrect_owner_len) = incorrect_owner_len {
-            info!(
-                "Incorrect num bytes ({incorrect_owner_len:?}) provided for spl_token_owner_filter"
-            );
-        }
-        owner_key
+        Ok(owner_key)
     } else {
         debug!("spl_token program filters do not match by-owner index requisites");
-        None
+        Ok(None)
     }
 }
 
@@ -2597,14 +2598,16 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
 /// mint.
 /// NOTE: `optimize_filters()` should almost always be called before using this method because of
 /// the requirement that `Memcmp::raw_bytes_as_ref().is_some()`.
-fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> Option<Pubkey> {
+fn get_spl_token_mint_filter(
+    program_id: &Pubkey,
+    filters: &[RpcFilterType],
+) -> Result<Option<Pubkey>> {
     if !is_known_spl_token_id(program_id) {
-        return None;
+        return Ok(None);
     }
     let mut data_size_filter: Option<u64> = None;
     let mut memcmp_filter: Option<&[u8]> = None;
     let mut mint: Option<Pubkey> = None;
-    let mut incorrect_mint_len: Option<usize> = None;
     let mut token_account_state_filter = false;
     let account_packed_len = TokenAccount::get_packed_len();
     for filter in filters {
@@ -2619,7 +2622,11 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
                         if bytes.len() == PUBKEY_BYTES {
                             mint = Pubkey::try_from(bytes).ok();
                         } else {
-                            incorrect_mint_len = Some(bytes.len());
+                            return Err(Error::invalid_params(format!(
+                                "Incorrect byte length {} for SPL token mint filter, expected {}",
+                                bytes.len(),
+                                PUBKEY_BYTES
+                            )));
                         }
                     }
                 }
@@ -2631,15 +2638,10 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
         || memcmp_filter == Some(&[ACCOUNTTYPE_ACCOUNT])
         || token_account_state_filter
     {
-        if let Some(incorrect_mint_len) = incorrect_mint_len {
-            info!(
-                "Incorrect num bytes ({incorrect_mint_len:?}) provided for spl_token_mint_filter"
-            );
-        }
-        mint
+        Ok(mint)
     } else {
         debug!("spl_token program filters do not match by-mint index requisites");
-        None
+        Ok(None)
     }
 }
 
@@ -8707,6 +8709,7 @@ pub mod tests {
                     RpcFilterType::DataSize(165)
                 ],
             )
+            .unwrap()
             .unwrap(),
             owner
         );
@@ -8720,6 +8723,7 @@ pub mod tests {
                     RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
                 ],
             )
+            .unwrap()
             .unwrap(),
             owner
         );
@@ -8733,6 +8737,7 @@ pub mod tests {
                     RpcFilterType::TokenAccountState,
                 ],
             )
+            .unwrap()
             .unwrap(),
             owner
         );
@@ -8745,6 +8750,7 @@ pub mod tests {
                 RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
             ],
         )
+        .unwrap()
         .is_none());
 
         // Filtering on mint instead of owner
@@ -8755,6 +8761,7 @@ pub mod tests {
                 RpcFilterType::DataSize(165)
             ],
         )
+        .unwrap()
         .is_none());
 
         // Wrong program id
@@ -8765,6 +8772,7 @@ pub mod tests {
                 RpcFilterType::DataSize(165)
             ],
         )
+        .unwrap()
         .is_none());
         assert!(get_spl_token_owner_filter(
             &Pubkey::new_unique(),
@@ -8773,6 +8781,7 @@ pub mod tests {
                 RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
             ],
         )
+        .unwrap()
         .is_none());
     }
 
@@ -8788,6 +8797,7 @@ pub mod tests {
                     RpcFilterType::DataSize(165)
                 ],
             )
+            .unwrap()
             .unwrap(),
             mint
         );
@@ -8801,6 +8811,7 @@ pub mod tests {
                     RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
                 ],
             )
+            .unwrap()
             .unwrap(),
             mint
         );
@@ -8814,6 +8825,7 @@ pub mod tests {
                     RpcFilterType::TokenAccountState,
                 ],
             )
+            .unwrap()
             .unwrap(),
             mint
         );
@@ -8826,6 +8838,7 @@ pub mod tests {
                 RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
             ],
         )
+        .unwrap()
         .is_none());
 
         // Filtering on owner instead of mint
@@ -8836,6 +8849,7 @@ pub mod tests {
                 RpcFilterType::DataSize(165)
             ],
         )
+        .unwrap()
         .is_none());
 
         // Wrong program id
@@ -8846,6 +8860,7 @@ pub mod tests {
                 RpcFilterType::DataSize(165)
             ],
         )
+        .unwrap()
         .is_none());
         assert!(get_spl_token_mint_filter(
             &Pubkey::new_unique(),
@@ -8854,6 +8869,7 @@ pub mod tests {
                 RpcFilterType::Memcmp(Memcmp::new_raw_bytes(165, vec![ACCOUNTTYPE_ACCOUNT])),
             ],
         )
+        .unwrap()
         .is_none());
     }
 


### PR DESCRIPTION
#### Problem
- The getProgramAccounts RPC endpoint would silently ignore malformed filters and execute an unfiltered query, potentially causing unnecessary load on the node.

#### Summary of Changes
- Added error handling to `get_spl_token_owner_filter` and `get_spl_token_mint_filter` to return a JSON-RPC error when malformed filters are provided
- This prevents fallback to unfiltered queries which could be resource-intensive
- Improves error visibility for API users

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
