### PR TITLE
Reduce DEFAULT_MAX_COALESCE_CHANNEL_SIZE to 1M as it offers similar performance

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -68,7 +68,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 10_000_000;
+pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 1_000_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527


### PR DESCRIPTION

#### Problem
Reduce DEFAULT_MAX_COALESCE_CHANNEL_SIZE to 1M as it offers similar performance
In the testing configuration with two sender clients the coalescer is able to 
ingest packets at 2.8 million/5 seconds.

This is true for both 10M and 1 M.

In the even less case like 100 K, I saw it drops to 1.5 million/5 seconds.

#### Summary of Changes

Change DEFAULT_MAX_COALESCE_CHANNEL_SIZE to 1_000_000

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
