### PR TITLE
Feature - Adds `LoaderV4Instruction::Copy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8091,6 +8091,7 @@ dependencies = [
  "solana-clock",
  "solana-compute-budget",
  "solana-instruction",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -16,6 +16,7 @@ solana-bincode = { workspace = true }
 solana-bpf-loader-program = { workspace = true, features = ["svm-internal"] }
 solana-compute-budget = { workspace = true }
 solana-instruction = { workspace = true }
+solana-loader-v3-interface = { workspace = true }
 solana-loader-v4-interface = { workspace = true }
 solana-log-collector = { workspace = true }
 solana-measure = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6302,6 +6302,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget",
  "solana-instruction",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6132,6 +6132,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget",
  "solana-instruction",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",


### PR DESCRIPTION
#### Problem
A new loader-v4 instruction was added to [SIMD-0167](https://github.com/solana-foundation/solana-improvement-documents/pull/167).

#### Summary of Changes
Adds:
- `LoaderV4Instruction::Copy`
- `is_copy_instruction()`
- `copy()`
- `test_copy_instruction()`
- `process_instruction_copy()`
- `test_loader_instruction_copy()`