### PR TITLE
cleanup: use `From` impls for tower conversions

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -177,7 +177,7 @@ pub(crate) struct ComputedBankState {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub enum TowerVersions {
-    V1_17_14(Tower1_7_14),
+    V1_7_14(Tower1_7_14),
     V1_14_11(Tower1_14_11),
     Current(Tower),
 }
@@ -189,34 +189,8 @@ impl TowerVersions {
 
     pub fn convert_to_current(self) -> Tower {
         match self {
-            TowerVersions::V1_17_14(tower) => {
-                let box_last_vote = VoteTransaction::from(tower.last_vote.clone());
-
-                Tower {
-                    node_pubkey: tower.node_pubkey,
-                    threshold_depth: tower.threshold_depth,
-                    threshold_size: tower.threshold_size,
-                    vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
-                        .convert_to_current(),
-                    last_vote: box_last_vote,
-                    last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
-                    last_timestamp: tower.last_timestamp,
-                    stray_restored_slot: tower.stray_restored_slot,
-                    last_switch_threshold_check: tower.last_switch_threshold_check,
-                }
-            }
-            TowerVersions::V1_14_11(tower) => Tower {
-                node_pubkey: tower.node_pubkey,
-                threshold_depth: tower.threshold_depth,
-                threshold_size: tower.threshold_size,
-                vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
-                    .convert_to_current(),
-                last_vote: tower.last_vote,
-                last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
-                last_timestamp: tower.last_timestamp,
-                stray_restored_slot: tower.stray_restored_slot,
-                last_switch_threshold_check: tower.last_switch_threshold_check,
-            },
+            TowerVersions::V1_7_14(tower) => tower.into(),
+            TowerVersions::V1_14_11(tower) => tower.into(),
             TowerVersions::Current(tower) => tower,
         }
     }
@@ -284,6 +258,62 @@ impl Default for Tower {
         // VoteState::root_slot is ensured to be Some in Tower
         tower.vote_state.root_slot = Some(Slot::default());
         tower
+    }
+}
+
+// Tower1_14_11 is the persisted data format for the Tower,
+// decoupling it from VoteState::Current.
+impl From<Tower> for Tower1_14_11 {
+    fn from(tower: Tower) -> Self {
+        Self {
+            node_pubkey: tower.node_pubkey,
+            threshold_depth: tower.threshold_depth,
+            threshold_size: tower.threshold_size,
+            vote_state: VoteState1_14_11::from(tower.vote_state.clone()),
+            last_vote: tower.last_vote.clone(),
+            last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
+            last_timestamp: tower.last_timestamp,
+            stray_restored_slot: tower.stray_restored_slot,
+            last_switch_threshold_check: tower.last_switch_threshold_check,
+        }
+    }
+}
+
+// Tower1_14_11 is the persisted data format for the Tower,
+// decoupling it from VoteState::Current.
+impl From<Tower1_14_11> for Tower {
+    fn from(tower: Tower1_14_11) -> Self {
+        Self {
+            node_pubkey: tower.node_pubkey,
+            threshold_depth: tower.threshold_depth,
+            threshold_size: tower.threshold_size,
+            vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
+                .convert_to_current(),
+            last_vote: tower.last_vote,
+            last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
+            last_timestamp: tower.last_timestamp,
+            stray_restored_slot: tower.stray_restored_slot,
+            last_switch_threshold_check: tower.last_switch_threshold_check,
+        }
+    }
+}
+
+impl From<Tower1_7_14> for Tower {
+    fn from(tower: Tower1_7_14) -> Self {
+        let box_last_vote = VoteTransaction::from(tower.last_vote.clone());
+
+        Self {
+            node_pubkey: tower.node_pubkey,
+            threshold_depth: tower.threshold_depth,
+            threshold_size: tower.threshold_size,
+            vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
+                .convert_to_current(),
+            last_vote: box_last_vote,
+            last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
+            last_timestamp: tower.last_timestamp,
+            stray_restored_slot: tower.stray_restored_slot,
+            last_switch_threshold_check: tower.last_switch_threshold_check,
+        }
     }
 }
 
@@ -1662,25 +1692,6 @@ pub enum TowerError {
 
     #[error("The tower is useless because of new hard fork: {0}")]
     HardFork(Slot),
-}
-
-// Tower1_14_11 is the persisted data format for the Tower, decoupling it from VoteState::Current
-// From Tower1_14_11 to Tower is not implemented because it is not an expected conversion
-#[allow(clippy::from_over_into)]
-impl Into<Tower1_14_11> for Tower {
-    fn into(self) -> Tower1_14_11 {
-        Tower1_14_11 {
-            node_pubkey: self.node_pubkey,
-            threshold_depth: self.threshold_depth,
-            threshold_size: self.threshold_size,
-            vote_state: VoteState1_14_11::from(self.vote_state.clone()),
-            last_vote: self.last_vote.clone(),
-            last_vote_tx_blockhash: self.last_vote_tx_blockhash,
-            last_timestamp: self.last_timestamp,
-            stray_restored_slot: self.stray_restored_slot,
-            last_switch_threshold_check: self.last_switch_threshold_check,
-        }
-    }
 }
 
 impl TowerError {

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -31,7 +31,7 @@ impl SavedTowerVersions {
                 if !t.signature.verify(node_pubkey.as_ref(), &t.data) {
                     return Err(TowerError::InvalidSignature);
                 }
-                bincode::deserialize(&t.data).map(TowerVersions::V1_17_14)
+                bincode::deserialize(&t.data).map(TowerVersions::V1_7_14)
             }
             SavedTowerVersions::Current(t) => {
                 if !t.signature.verify(node_pubkey.as_ref(), &t.data) {


### PR DESCRIPTION
#### Problem
`Tower` and the versioned tower structs don't implement the `From` trait

#### Summary of Changes
Implement `From` for tower struct converstions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
