### PR TITLE
Add `TowerVoteState`

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1,5 +1,3 @@
-use crate::replay_stage::DUPLICATE_THRESHOLD;
-
 pub mod fork_choice;
 pub mod heaviest_subtree_fork_choice;
 pub(crate) mod latest_validator_votes_for_frozen_banks;
@@ -7,6 +5,7 @@ pub mod progress_map;
 mod tower1_14_11;
 mod tower1_7_14;
 pub mod tower_storage;
+pub(crate) mod tower_vote_state;
 pub mod tree_diff;
 pub mod vote_stake_tracker;
 
@@ -18,7 +17,9 @@ use {
         tower1_14_11::Tower1_14_11,
         tower1_7_14::Tower1_7_14,
         tower_storage::{SavedTower, SavedTowerVersions, TowerStorage},
+        tower_vote_state::TowerVoteState,
     },
+    crate::replay_stage::DUPLICATE_THRESHOLD,
     chrono::prelude::*,
     solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db},
     solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE},
@@ -32,11 +33,11 @@ use {
     },
     solana_vote::vote_account::VoteAccountsHashMap,
     solana_vote_program::{
+        vote_error::VoteError,
         vote_instruction,
         vote_state::{
-            process_slot_vote_unchecked, process_vote_unchecked, BlockTimestamp, LandedVote,
-            Lockout, TowerSync, Vote, VoteState, VoteState1_14_11, VoteStateUpdate,
-            VoteStateVersions, VoteTransaction, MAX_LOCKOUT_HISTORY,
+            process_slot_vote_unchecked, BlockTimestamp, Lockout, TowerSync, Vote,
+            VoteState1_14_11, VoteStateUpdate, VoteTransaction, MAX_LOCKOUT_HISTORY,
         },
     },
     std::{
@@ -176,6 +177,7 @@ pub(crate) struct ComputedBankState {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TowerVersions {
     V1_7_14(Tower1_7_14),
     V1_14_11(Tower1_14_11),
@@ -215,7 +217,7 @@ pub struct Tower {
     pub node_pubkey: Pubkey,
     pub(crate) threshold_depth: usize,
     threshold_size: f64,
-    pub(crate) vote_state: VoteState,
+    pub(crate) vote_state: TowerVoteState,
     last_vote: VoteTransaction,
     // The blockhash used in the last vote transaction, may or may not equal the
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
@@ -240,7 +242,7 @@ impl Default for Tower {
             node_pubkey: Pubkey::default(),
             threshold_depth: VOTE_THRESHOLD_DEPTH,
             threshold_size: VOTE_THRESHOLD_SIZE,
-            vote_state: VoteState::default(),
+            vote_state: TowerVoteState::default(),
             last_vote: VoteTransaction::from(TowerSync::default()),
             last_timestamp: BlockTimestamp::default(),
             last_vote_tx_blockhash: BlockhashStatus::default(),
@@ -261,8 +263,8 @@ impl From<Tower> for Tower1_14_11 {
             node_pubkey: tower.node_pubkey,
             threshold_depth: tower.threshold_depth,
             threshold_size: tower.threshold_size,
-            vote_state: VoteState1_14_11::from(tower.vote_state.clone()),
-            last_vote: tower.last_vote.clone(),
+            vote_state: VoteState1_14_11::from(tower.vote_state),
+            last_vote: tower.last_vote,
             last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
             last_timestamp: tower.last_timestamp,
             stray_restored_slot: tower.stray_restored_slot,
@@ -279,8 +281,7 @@ impl From<Tower1_14_11> for Tower {
             node_pubkey: tower.node_pubkey,
             threshold_depth: tower.threshold_depth,
             threshold_size: tower.threshold_size,
-            vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
-                .convert_to_current(),
+            vote_state: TowerVoteState::from(tower.vote_state),
             last_vote: tower.last_vote,
             last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
             last_timestamp: tower.last_timestamp,
@@ -298,8 +299,7 @@ impl From<Tower1_7_14> for Tower {
             node_pubkey: tower.node_pubkey,
             threshold_depth: tower.threshold_depth,
             threshold_size: tower.threshold_size,
-            vote_state: VoteStateVersions::V1_14_11(Box::new(tower.vote_state))
-                .convert_to_current(),
+            vote_state: TowerVoteState::from(tower.vote_state),
             last_vote: box_last_vote,
             last_vote_tx_blockhash: tower.last_vote_tx_blockhash,
             last_timestamp: tower.last_timestamp,
@@ -335,7 +335,7 @@ impl Tower {
 
     #[cfg(test)]
     pub fn new_random(node_pubkey: Pubkey) -> Self {
-        use rand::Rng;
+        use {rand::Rng, solana_vote_program::vote_state::VoteState};
 
         let mut rng = rand::thread_rng();
         let root_slot = rng.gen();
@@ -349,7 +349,7 @@ impl Tower {
         );
         Self {
             node_pubkey,
-            vote_state,
+            vote_state: TowerVoteState::from(vote_state),
             last_vote: VoteTransaction::from(last_vote),
             ..Tower::default()
         }
@@ -638,22 +638,14 @@ impl Tower {
     ) {
         let mut new_vote = if enable_tower_sync_ix {
             VoteTransaction::from(TowerSync::new(
-                self.vote_state
-                    .votes
-                    .iter()
-                    .map(|vote| vote.lockout)
-                    .collect(),
+                self.vote_state.votes.clone(),
                 self.vote_state.root_slot,
                 vote_hash,
                 block_id,
             ))
         } else {
             VoteTransaction::from(VoteStateUpdate::new(
-                self.vote_state
-                    .votes
-                    .iter()
-                    .map(|vote| vote.lockout)
-                    .collect(),
+                self.vote_state.votes.clone(),
                 self.vote_state.root_slot,
                 vote_hash,
             ))
@@ -670,17 +662,21 @@ impl Tower {
         enable_tower_sync_ix: bool,
         block_id: Hash,
     ) -> Option<Slot> {
+        if let Some(last_voted_slot) = self.vote_state.last_voted_slot() {
+            if vote_slot <= last_voted_slot {
+                panic!(
+                    "Error while recording vote {} {} in local tower {:?}",
+                    vote_slot,
+                    vote_hash,
+                    VoteError::VoteTooOld
+                );
+            }
+        }
+
         trace!("{} record_vote for {}", self.node_pubkey, vote_slot);
         let old_root = self.root();
 
-        let vote = Vote::new(vec![vote_slot], vote_hash);
-        let result = process_vote_unchecked(&mut self.vote_state, vote);
-        if result.is_err() {
-            panic!(
-                "Error while recording vote {} {} in local tower {:?}",
-                vote_slot, vote_hash, result
-            );
-        }
+        self.vote_state.process_next_vote_slot(vote_slot);
         self.update_last_vote_from_vote_state(vote_hash, enable_tower_sync_ix, block_id);
 
         let new_root = self.root();
@@ -705,8 +701,7 @@ impl Tower {
     #[cfg(feature = "dev-context-only-utils")]
     pub fn increase_lockout(&mut self, confirmation_count_increase: u32) {
         for vote in self.vote_state.votes.iter_mut() {
-            vote.lockout
-                .increase_confirmation_count(confirmation_count_increase);
+            vote.increase_confirmation_count(confirmation_count_increase);
         }
     }
 
@@ -798,7 +793,7 @@ impl Tower {
         // remaining voted slots are on a different fork from the checked slot,
         // it's still locked out.
         let mut vote_state = self.vote_state.clone();
-        process_slot_vote_unchecked(&mut vote_state, slot);
+        vote_state.process_next_vote_slot(slot);
         for vote in &vote_state.votes {
             if slot != vote.slot() && !ancestors.contains(&vote.slot()) {
                 return true;
@@ -1277,11 +1272,11 @@ impl Tower {
     // would have rolled up to earlier votes in the tower, which presumably
     // could have helped us pass the threshold check. Worst case, we'll just
     // recheck later without having increased lockouts.
-    fn optimistically_bypass_vote_stake_threshold_check(
-        vote_state_before_applying_vote: &VoteState,
+    fn optimistically_bypass_vote_stake_threshold_check<'a>(
+        tower_before_applying_vote: impl Iterator<Item = &'a Lockout>,
         threshold_vote: &Lockout,
     ) -> bool {
-        for old_vote in &vote_state_before_applying_vote.votes {
+        for old_vote in tower_before_applying_vote {
             if old_vote.slot() == threshold_vote.slot()
                 && old_vote.confirmation_count() == threshold_vote.confirmation_count()
             {
@@ -1292,9 +1287,9 @@ impl Tower {
     }
 
     /// Checks a single vote threshold for `slot`
-    fn check_vote_stake_threshold(
+    fn check_vote_stake_threshold<'a>(
         threshold_vote: Option<&Lockout>,
-        vote_state_before_applying_vote: &VoteState,
+        tower_before_applying_vote: impl Iterator<Item = &'a Lockout>,
         threshold_depth: usize,
         threshold_size: f64,
         slot: Slot,
@@ -1321,7 +1316,7 @@ impl Tower {
             total_stake
         );
         if Self::optimistically_bypass_vote_stake_threshold_check(
-            vote_state_before_applying_vote,
+            tower_before_applying_vote,
             threshold_vote,
         ) || lockout > threshold_size
         {
@@ -1340,7 +1335,7 @@ impl Tower {
         let mut threshold_decisions = vec![];
         // Generate the vote state assuming this vote is included.
         let mut vote_state = self.vote_state.clone();
-        process_slot_vote_unchecked(&mut vote_state, slot);
+        vote_state.process_next_vote_slot(slot);
 
         // Assemble all the vote thresholds and depths to check.
         let vote_thresholds_and_depths = vec![
@@ -1358,7 +1353,7 @@ impl Tower {
             if let ThresholdDecision::FailedThreshold(vote_depth, stake) =
                 Self::check_vote_stake_threshold(
                     vote_state.nth_recent_lockout(threshold_depth),
-                    &self.vote_state,
+                    self.vote_state.votes.iter(),
                     threshold_depth,
                     threshold_size,
                     slot,
@@ -1620,14 +1615,9 @@ impl Tower {
         bank: &Bank,
     ) {
         if let Some(vote_account) = bank.get_vote_account(vote_account_pubkey) {
-            self.vote_state = vote_account.vote_state().clone();
+            self.vote_state = TowerVoteState::from(vote_account.vote_state().clone());
             self.initialize_root(root);
             self.initialize_lockouts(|v| v.slot() > root);
-            trace!(
-                "Lockouts in tower for {} is initialized using bank {}",
-                self.vote_state.node_pubkey,
-                bank.slot(),
-            );
         } else {
             self.initialize_root(root);
             info!(
@@ -1638,7 +1628,7 @@ impl Tower {
         }
     }
 
-    fn initialize_lockouts<F: FnMut(&LandedVote) -> bool>(&mut self, should_retain: F) {
+    fn initialize_lockouts<F: FnMut(&Lockout) -> bool>(&mut self, should_retain: F) {
         self.vote_state.votes.retain(should_retain);
     }
 
@@ -1801,7 +1791,9 @@ pub mod test {
             slot_history::SlotHistory,
         },
         solana_vote::vote_account::VoteAccount,
-        solana_vote_program::vote_state::{Vote, VoteStateVersions, MAX_LOCKOUT_HISTORY},
+        solana_vote_program::vote_state::{
+            Vote, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+        },
         std::{
             collections::{HashMap, VecDeque},
             fs::{remove_file, OpenOptions},
@@ -3565,14 +3557,8 @@ pub mod test {
     #[test]
     fn test_adjust_lockouts_after_replay_time_warped() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(1)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(0)));
+        tower.vote_state.votes.push_back(Lockout::new(1));
+        tower.vote_state.votes.push_back(Lockout::new(0));
         let vote = Vote::new(vec![0], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3589,14 +3575,8 @@ pub mod test {
     #[test]
     fn test_adjust_lockouts_after_replay_diverged_ancestor() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(1)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(2)));
+        tower.vote_state.votes.push_back(Lockout::new(1));
+        tower.vote_state.votes.push_back(Lockout::new(2));
         let vote = Vote::new(vec![2], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3619,15 +3599,9 @@ pub mod test {
         tower
             .vote_state
             .votes
-            .push_back(LandedVote::from(Lockout::new(MAX_ENTRIES - 1)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(0)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(1)));
+            .push_back(Lockout::new(MAX_ENTRIES - 1));
+        tower.vote_state.votes.push_back(Lockout::new(0));
+        tower.vote_state.votes.push_back(Lockout::new(1));
         let vote = Vote::new(vec![1], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3646,14 +3620,8 @@ pub mod test {
     #[should_panic(expected = "slot_in_tower(2) < checked_slot(1)")]
     fn test_adjust_lockouts_after_replay_reversed_votes() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(2)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(1)));
+        tower.vote_state.votes.push_back(Lockout::new(2));
+        tower.vote_state.votes.push_back(Lockout::new(1));
         let vote = Vote::new(vec![1], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3670,18 +3638,9 @@ pub mod test {
     #[should_panic(expected = "slot_in_tower(3) < checked_slot(3)")]
     fn test_adjust_lockouts_after_replay_repeated_non_root_votes() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(2)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(3)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(3)));
+        tower.vote_state.votes.push_back(Lockout::new(2));
+        tower.vote_state.votes.push_back(Lockout::new(3));
+        tower.vote_state.votes.push_back(Lockout::new(3));
         let vote = Vote::new(vec![3], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3698,18 +3657,9 @@ pub mod test {
     fn test_adjust_lockouts_after_replay_vote_on_root() {
         let mut tower = Tower::new_for_tests(10, 0.9);
         tower.vote_state.root_slot = Some(42);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(42)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(43)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(44)));
+        tower.vote_state.votes.push_back(Lockout::new(42));
+        tower.vote_state.votes.push_back(Lockout::new(43));
+        tower.vote_state.votes.push_back(Lockout::new(44));
         let vote = Vote::new(vec![44], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3723,10 +3673,7 @@ pub mod test {
     #[test]
     fn test_adjust_lockouts_after_replay_vote_on_genesis() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(0)));
+        tower.vote_state.votes.push_back(Lockout::new(0));
         let vote = Vote::new(vec![0], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
 
@@ -3739,14 +3686,8 @@ pub mod test {
     #[test]
     fn test_adjust_lockouts_after_replay_future_tower() {
         let mut tower = Tower::new_for_tests(10, 0.9);
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(13)));
-        tower
-            .vote_state
-            .votes
-            .push_back(LandedVote::from(Lockout::new(14)));
+        tower.vote_state.votes.push_back(Lockout::new(13));
+        tower.vote_state.votes.push_back(Lockout::new(14));
         let vote = Vote::new(vec![14], Hash::default());
         tower.last_vote = VoteTransaction::from(vote);
         tower.initialize_root(12);

--- a/core/src/consensus/tower_vote_state.rs
+++ b/core/src/consensus/tower_vote_state.rs
@@ -1,0 +1,315 @@
+use {
+    solana_sdk::clock::Slot,
+    solana_vote_program::vote_state::{Lockout, VoteState, VoteState1_14_11, MAX_LOCKOUT_HISTORY},
+    std::collections::VecDeque,
+};
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct TowerVoteState {
+    pub votes: VecDeque<Lockout>,
+    pub root_slot: Option<Slot>,
+}
+
+impl TowerVoteState {
+    pub fn tower(&self) -> Vec<Slot> {
+        self.votes.iter().map(|v| v.slot()).collect()
+    }
+
+    pub fn last_lockout(&self) -> Option<&Lockout> {
+        self.votes.back()
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.last_lockout().map(|v| v.slot())
+    }
+
+    pub fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
+        self.votes
+            .len()
+            .checked_sub(position.saturating_add(1))
+            .and_then(|pos| self.votes.get(pos))
+    }
+
+    pub fn process_next_vote_slot(&mut self, next_vote_slot: Slot) {
+        // Ignore votes for slots earlier than we already have votes for
+        if self
+            .last_voted_slot()
+            .is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
+        {
+            return;
+        }
+
+        self.pop_expired_votes(next_vote_slot);
+
+        // Once the stack is full, pop the oldest lockout and distribute rewards
+        if self.votes.len() == MAX_LOCKOUT_HISTORY {
+            let rooted_vote = self.votes.pop_front().unwrap();
+            self.root_slot = Some(rooted_vote.slot());
+        }
+        self.votes.push_back(Lockout::new(next_vote_slot));
+        self.double_lockouts();
+    }
+
+    // Pop all recent votes that are not locked out at the next vote slot.  This
+    // allows validators to switch forks once their votes for another fork have
+    // expired. This also allows validators continue voting on recent blocks in
+    // the same fork without increasing lockouts.
+    fn pop_expired_votes(&mut self, next_vote_slot: Slot) {
+        while let Some(vote) = self.last_lockout() {
+            if !vote.is_locked_out_at_slot(next_vote_slot) {
+                self.votes.pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn double_lockouts(&mut self) {
+        let stack_depth = self.votes.len();
+        for (i, v) in self.votes.iter_mut().enumerate() {
+            // Don't increase the lockout for this vote until we get more confirmations
+            // than the max number of confirmations this vote has seen
+            if stack_depth >
+                i.checked_add(v.confirmation_count() as usize)
+                    .expect("`confirmation_count` and tower_size should be bounded by `MAX_LOCKOUT_HISTORY`")
+            {
+                v.increase_confirmation_count(1);
+            }
+        }
+    }
+}
+
+impl From<VoteState> for TowerVoteState {
+    fn from(vote_state: VoteState) -> Self {
+        let VoteState {
+            votes, root_slot, ..
+        } = vote_state;
+
+        Self {
+            votes: votes
+                .into_iter()
+                .map(|landed_vote| landed_vote.into())
+                .collect(),
+            root_slot,
+        }
+    }
+}
+
+impl From<VoteState1_14_11> for TowerVoteState {
+    fn from(vote_state: VoteState1_14_11) -> Self {
+        let VoteState1_14_11 {
+            votes, root_slot, ..
+        } = vote_state;
+
+        Self { votes, root_slot }
+    }
+}
+
+impl From<TowerVoteState> for VoteState1_14_11 {
+    fn from(vote_state: TowerVoteState) -> Self {
+        let TowerVoteState { votes, root_slot } = vote_state;
+
+        VoteState1_14_11 {
+            votes,
+            root_slot,
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_vote_program::vote_state::INITIAL_LOCKOUT, std::collections::VecDeque};
+
+    fn check_lockouts(vote_state: &TowerVoteState) {
+        for (i, vote) in vote_state.votes.iter().enumerate() {
+            let num_votes = vote_state
+                .votes
+                .len()
+                .checked_sub(i)
+                .expect("`i` is less than `vote_state.votes.len()`");
+            assert_eq!(vote.lockout(), INITIAL_LOCKOUT.pow(num_votes as u32) as u64);
+        }
+    }
+
+    #[test]
+    fn test_basic_vote_state() {
+        let mut vote_state = TowerVoteState::default();
+
+        // Process initial vote
+        vote_state.process_next_vote_slot(1);
+        assert_eq!(vote_state.votes.len(), 1);
+        assert_eq!(vote_state.votes[0].slot(), 1);
+        assert_eq!(vote_state.votes[0].confirmation_count(), 1);
+        assert_eq!(vote_state.root_slot, None);
+
+        // Process second vote
+        vote_state.process_next_vote_slot(2);
+        assert_eq!(vote_state.votes.len(), 2);
+        assert_eq!(vote_state.votes[0].slot(), 1);
+        assert_eq!(vote_state.votes[0].confirmation_count(), 2);
+        assert_eq!(vote_state.votes[1].slot(), 2);
+        assert_eq!(vote_state.votes[1].confirmation_count(), 1);
+    }
+
+    #[test]
+    fn test_vote_lockout() {
+        let mut vote_state = TowerVoteState::default();
+
+        // Fill up the vote history
+        for i in 0..(MAX_LOCKOUT_HISTORY + 1) {
+            vote_state.process_next_vote_slot(i as u64);
+        }
+
+        // Verify the earliest vote was popped and became the root
+        assert_eq!(vote_state.votes.len(), MAX_LOCKOUT_HISTORY);
+        assert_eq!(vote_state.root_slot, Some(0));
+        check_lockouts(&vote_state);
+
+        // Verify lockout counts are correct
+        for (i, vote) in vote_state.votes.iter().enumerate() {
+            let expected_count = MAX_LOCKOUT_HISTORY - i;
+            assert_eq!(vote.confirmation_count(), expected_count as u32);
+        }
+
+        // One more vote that confirms the entire stack,
+        // the root_slot should change to the
+        // second vote
+        let top_vote = vote_state.votes.front().unwrap().slot();
+        let slot = vote_state.last_lockout().unwrap().last_locked_out_slot();
+        vote_state.process_next_vote_slot(slot);
+        assert_eq!(Some(top_vote), vote_state.root_slot);
+
+        // Expire everything except the first vote
+        let slot = vote_state.votes.front().unwrap().last_locked_out_slot();
+        vote_state.process_next_vote_slot(slot);
+        // First vote and new vote are both stored for a total of 2 votes
+        assert_eq!(vote_state.votes.len(), 2);
+    }
+
+    #[test]
+    fn test_vote_double_lockout_after_expiration() {
+        let mut vote_state = TowerVoteState::default();
+
+        for i in 0..3 {
+            vote_state.process_next_vote_slot(i as u64);
+        }
+
+        check_lockouts(&vote_state);
+
+        // Expire the third vote (which was a vote for slot 2). The height of the
+        // vote stack is unchanged, so none of the previous votes should have
+        // doubled in lockout
+        vote_state.process_next_vote_slot((2 + INITIAL_LOCKOUT + 1) as u64);
+        check_lockouts(&vote_state);
+
+        // Vote again, this time the vote stack depth increases, so the votes should
+        // double for everybody
+        vote_state.process_next_vote_slot((2 + INITIAL_LOCKOUT + 2) as u64);
+        check_lockouts(&vote_state);
+
+        // Vote again, this time the vote stack depth increases, so the votes should
+        // double for everybody
+        vote_state.process_next_vote_slot((2 + INITIAL_LOCKOUT + 3) as u64);
+        check_lockouts(&vote_state);
+    }
+
+    #[test]
+    fn test_expire_multiple_votes() {
+        let mut vote_state = TowerVoteState::default();
+
+        for i in 0..3 {
+            vote_state.process_next_vote_slot(i as u64);
+        }
+
+        assert_eq!(vote_state.votes[0].confirmation_count(), 3);
+
+        // Expire the second and third votes
+        let expire_slot = vote_state.votes[1].slot() + vote_state.votes[1].lockout() + 1;
+        vote_state.process_next_vote_slot(expire_slot);
+        assert_eq!(vote_state.votes.len(), 2);
+
+        // Check that the old votes expired
+        assert_eq!(vote_state.votes[0].slot(), 0);
+        assert_eq!(vote_state.votes[1].slot(), expire_slot);
+
+        // Process one more vote
+        vote_state.process_next_vote_slot(expire_slot + 1);
+
+        // Confirmation count for the older first vote should remain unchanged
+        assert_eq!(vote_state.votes[0].confirmation_count(), 3);
+
+        // The later votes should still have increasing confirmation counts
+        assert_eq!(vote_state.votes[1].confirmation_count(), 2);
+        assert_eq!(vote_state.votes[2].confirmation_count(), 1);
+    }
+
+    #[test]
+    fn test_multiple_root_progress() {
+        let mut vote_state = TowerVoteState::default();
+
+        // Add enough votes to create first root
+        for i in 0..(MAX_LOCKOUT_HISTORY + 1) {
+            vote_state.process_next_vote_slot(i as u64);
+        }
+        assert_eq!(vote_state.root_slot, Some(0));
+
+        // Add more votes to advance root
+        vote_state.process_next_vote_slot(MAX_LOCKOUT_HISTORY as u64 + 1);
+        assert_eq!(vote_state.root_slot, Some(1));
+
+        vote_state.process_next_vote_slot(MAX_LOCKOUT_HISTORY as u64 + 2);
+        assert_eq!(vote_state.root_slot, Some(2));
+    }
+
+    #[test]
+    fn test_duplicate_vote() {
+        let mut vote_state = TowerVoteState::default();
+
+        // Process initial votes
+        vote_state.process_next_vote_slot(1);
+        vote_state.process_next_vote_slot(2);
+
+        // Try duplicate vote
+        vote_state.process_next_vote_slot(1);
+
+        // Verify the vote state (duplicate should not affect anything)
+        assert_eq!(vote_state.votes.len(), 2);
+        assert_eq!(vote_state.votes[0].slot(), 1);
+        assert_eq!(vote_state.votes[1].slot(), 2);
+
+        // Try duplicate vote
+        vote_state.process_next_vote_slot(2);
+
+        // Verify the vote state (duplicate should not affect anything)
+        assert_eq!(vote_state.votes.len(), 2);
+        assert_eq!(vote_state.votes[0].slot(), 1);
+        assert_eq!(vote_state.votes[1].slot(), 2);
+    }
+
+    #[test]
+    fn test_vote_state_roots() {
+        let mut vote_state = TowerVoteState {
+            votes: VecDeque::new(),
+            root_slot: Some(5), // Start with existing root
+        };
+
+        // Add votes after root
+        vote_state.process_next_vote_slot(6);
+        vote_state.process_next_vote_slot(7);
+
+        // Verify votes after root are tracked
+        assert_eq!(vote_state.votes.len(), 2);
+        assert_eq!(vote_state.votes[0].slot(), 6);
+        assert_eq!(vote_state.votes[1].slot(), 7);
+        assert_eq!(vote_state.root_slot, Some(5));
+
+        // Fill up vote history to advance root
+        for i in 8..=(MAX_LOCKOUT_HISTORY as u64 + 8) {
+            vote_state.process_next_vote_slot(i);
+        }
+
+        // Verify root has advanced
+        assert!(vote_state.root_slot.unwrap() > 5);
+    }
+}

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -15,6 +15,7 @@ use {
             latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
             progress_map::{ForkProgress, ProgressMap, PropagatedStats},
             tower_storage::{SavedTower, SavedTowerVersions, TowerStorage},
+            tower_vote_state::TowerVoteState,
             BlockhashStatus, ComputedBankState, Stake, SwitchForkDecision, Tower, TowerError,
             VotedStakes, SWITCH_FORK_THRESHOLD,
         },
@@ -76,7 +77,7 @@ use {
         transaction::Transaction,
     },
     solana_timings::ExecuteTimings,
-    solana_vote_program::vote_state::{VoteState, VoteTransaction},
+    solana_vote_program::vote_state::VoteTransaction,
     std::{
         collections::{HashMap, HashSet},
         num::NonZeroUsize,
@@ -2790,7 +2791,7 @@ impl ReplayStage {
         bank: Arc<Bank>,
         root: Slot,
         total_stake: Stake,
-        node_vote_state: (Pubkey, VoteState),
+        node_vote_state: (Pubkey, TowerVoteState),
         lockouts_sender: &Sender<CommitmentAggregationData>,
     ) {
         if let Err(e) = lockouts_sender.send(CommitmentAggregationData::new(
@@ -3602,7 +3603,7 @@ impl ReplayStage {
         }
 
         tower.vote_state.root_slot = bank_vote_state.root_slot;
-        tower.vote_state.votes = bank_vote_state.votes;
+        tower.vote_state.votes = bank_vote_state.votes.into_iter().map(Into::into).collect();
 
         let last_voted_slot = tower.vote_state.last_voted_slot().unwrap_or(
             // If our local root is higher than the highest slot in `bank_vote_state` due to
@@ -5048,14 +5049,14 @@ pub(crate) mod tests {
 
     #[test]
     fn test_replay_commitment_cache() {
-        fn leader_vote(vote_slot: Slot, bank: &Bank, pubkey: &Pubkey) -> (Pubkey, VoteState) {
+        fn leader_vote(vote_slot: Slot, bank: &Bank, pubkey: &Pubkey) -> (Pubkey, TowerVoteState) {
             let mut leader_vote_account = bank.get_account(pubkey).unwrap();
             let mut vote_state = vote_state::from(&leader_vote_account).unwrap();
             vote_state::process_slot_vote_unchecked(&mut vote_state, vote_slot);
             let versioned = VoteStateVersions::new_current(vote_state.clone());
             vote_state::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(pubkey, &leader_vote_account);
-            (*pubkey, vote_state)
+            (*pubkey, TowerVoteState::from(vote_state))
         }
 
         let leader_pubkey = solana_pubkey::new_rand();


### PR DESCRIPTION
#### Problem
Tower attempts to use the latest version of the vote program's vote state for tracking vote updates but is actually only serialized with an old version of vote state. It should instead just use a simple vote state algorithm which is independent of vote program state changes.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
