### PR TITLE
rolls out chained Merkle shreds to ~50% of mainnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -507,8 +507,8 @@ fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
     match cluster_type {
         ClusterType::Development => true,
         ClusterType::Devnet => true,
-        // Roll out chained Merkle shreds to ~21% of mainnet slots.
-        ClusterType::MainnetBeta => slot % 19 < 4,
+        // Roll out chained Merkle shreds to ~53% of mainnet slots.
+        ClusterType::MainnetBeta => slot % 19 < 10,
         ClusterType::Testnet => true,
     }
 }


### PR DESCRIPTION
#### Problem
Incrementally rolling out chained Merkle shreds to mainnet.

#### Summary of Changes
The commit rolls out chained Merkle shreds to ~50% of mainnet slots.