### PR TITLE
reworks gossip pipeline by applying stake-filter earlier

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -163,7 +163,6 @@ pub struct GossipStats {
     pub(crate) push_response_count: Counter,
     pub(crate) push_vote_read: Counter,
     pub(crate) repair_peers: Counter,
-    pub(crate) require_stake_for_gossip_unknown_stakes: Counter,
     pub(crate) save_contact_info_time: Counter,
     pub(crate) skip_pull_response_shred_version: Counter,
     pub(crate) skip_pull_shred_version: Counter,
@@ -600,11 +599,6 @@ pub(crate) fn submit_gossip_stats(
         (
             "packets_sent_push_messages_count",
             stats.packets_sent_push_messages_count.clear(),
-            i64
-        ),
-        (
-            "require_stake_for_gossip_unknown_stakes",
-            stats.require_stake_for_gossip_unknown_stakes.clear(),
             i64
         ),
         ("trim_crds_table", stats.trim_crds_table.clear(), i64),

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -74,12 +74,14 @@ impl CrdsGossip {
         pubkey: &Pubkey, // This node.
         now: u64,
         stakes: &HashMap<Pubkey, u64>,
+        should_retain_crds_value: impl Fn(&CrdsValue) -> bool,
     ) -> (
         HashMap<Pubkey, Vec<CrdsValue>>,
         usize, // number of values
         usize, // number of push messages
     ) {
-        self.push.new_push_messages(pubkey, &self.crds, now, stakes)
+        self.push
+            .new_push_messages(pubkey, &self.crds, now, stakes, should_retain_crds_value)
     }
 
     pub(crate) fn push_duplicate_shred<F>(
@@ -231,6 +233,7 @@ impl CrdsGossip {
         filters: &[(CrdsValue, CrdsFilter)],
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
+        should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         CrdsGossipPull::generate_pull_responses(
@@ -239,6 +242,7 @@ impl CrdsGossip {
             filters,
             output_size_limit,
             now,
+            should_retain_crds_value,
             stats,
         )
     }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -66,6 +66,7 @@ impl GossipService {
         );
         let (consume_sender, listen_receiver) = unbounded();
         let t_socket_consume = cluster_info.clone().start_socket_consume_thread(
+            bank_forks.clone(),
             request_receiver,
             consume_sender,
             exit.clone(),

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -378,7 +378,14 @@ fn network_run_push(
                 node.gossip.purge(&node_pubkey, thread_pool, now, &timeouts);
                 (
                     node_pubkey,
-                    node.gossip.new_push_messages(&node_pubkey, now, &stakes).0,
+                    node.gossip
+                        .new_push_messages(
+                            &node_pubkey,
+                            now,
+                            &stakes,
+                            |_| true, // should_retain_crds_value
+                        )
+                        .0,
                 )
             })
             .collect();
@@ -577,6 +584,7 @@ fn network_run_pull(
                                 &filters,
                                 usize::MAX, // output_size_limit
                                 now,
+                                |_| true, // should_retain_crds_value
                                 &GossipStats::default(),
                             )
                             .into_iter()


### PR DESCRIPTION

#### Problem

Filtering gossip packets based on stake is done very late in the pipeline both for incoming and outgoing packets:
https://github.com/anza-xyz/agave/blob/4d0fc227d/gossip/src/cluster_info.rs#L1321
https://github.com/anza-xyz/agave/blob/4d0fc227d/gossip/src/cluster_info.rs#L1801
https://github.com/anza-xyz/agave/blob/4d0fc227d/gossip/src/cluster_info.rs#L2222-L2229

Partially processed packets which are ultimately filtered out anyways waste resources.

#### Summary of Changes

In order to avoid wasting resources for packets which are partially processed but are ultimately dropped anyways, the commit applies stake-filter earlier in the gossip pipelines.

