### PR TITLE
change channel size to 200K

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -68,7 +68,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 1_000_000;
+pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 200_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527


### PR DESCRIPTION
#### Problem
Test shows the channel size can be further reduced to 200K without much impacting the throughput of the coalesce.

#### Summary of Changes
Changed channel size to 200K.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->


