### PR TITLE
Revert "quic: increase timeout and keep alive (#4585)"

### DIFF
--- a/sdk/quic-definitions/src/lib.rs
+++ b/sdk/quic-definitions/src/lib.rs
@@ -16,12 +16,8 @@ pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 // forwarded packets from staked nodes.
 pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
-// Connection idle timeout, and keep alive.
-// Quic will close the connection after QUIC_MAX_TIMEOUT,
-// and send a ping every QUIC_KEEP_ALIVE.
-// These shouldn't be too low to avoid unnecessary ping traffic.
-pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
-pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
+pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
+pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
 
 // Disable Quic send fairness.
 // When set to false, streams are still scheduled based on priority,


### PR DESCRIPTION
This reverts commit a1d26ad4580881b9127368684c35fd0d5f4dad36.

#### Problem
CI seems to have difficulty passing snapshots tests: https://buildkite.com/anza/agave/builds/17947

#### Summary of Changes
Reverted temporarily to investigate the CI issue.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
