### PR TITLE
Backport #3836 ([streamer] Fix musl build) to v2.1 branch

### DIFF
--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -107,17 +107,35 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
             iov_len: buffer.len(),
         });
 
+        #[cfg(not(target_env = "musl"))]
+        let msg_hdr = msghdr {
+            msg_name: addr.as_mut_ptr() as *mut _,
+            msg_namelen: SOCKADDR_STORAGE_SIZE as socklen_t,
+            msg_iov: iov.as_mut_ptr(),
+            msg_iovlen: 1,
+            msg_control: ptr::null::<libc::c_void>() as *mut _,
+            msg_controllen: 0,
+            msg_flags: 0,
+        };
+
+        #[cfg(target_env = "musl")]
+        let msg_hdr = {
+            // Cannot construct msghdr directly on musl
+            // See https://github.com/rust-lang/libc/issues/2344 for more info
+            let mut msg_hdr: msghdr = unsafe { std::mem::zeroed() };
+            msg_hdr.msg_name = addr.as_mut_ptr() as *mut _;
+            msg_hdr.msg_namelen = SOCKADDR_STORAGE_SIZE as socklen_t;
+            msg_hdr.msg_iov = iov.as_mut_ptr();
+            msg_hdr.msg_iovlen = 1;
+            msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
+            msg_hdr.msg_controllen = 0;
+            msg_hdr.msg_flags = 0;
+            msg_hdr
+        };
+
         hdr.write(mmsghdr {
             msg_len: 0,
-            msg_hdr: msghdr {
-                msg_name: addr.as_mut_ptr() as *mut _,
-                msg_namelen: SOCKADDR_STORAGE_SIZE as socklen_t,
-                msg_iov: iov.as_mut_ptr(),
-                msg_iovlen: 1,
-                msg_control: ptr::null::<libc::c_void>() as *mut _,
-                msg_controllen: 0,
-                msg_flags: 0,
-            },
+            msg_hdr,
         });
     }
 

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -95,17 +95,35 @@ fn mmsghdr_for_packet(
         }
     };
 
+    #[cfg(not(target_env = "musl"))]
+    let msg_hdr = msghdr {
+        msg_name: addr as *mut _ as *mut _,
+        msg_namelen,
+        msg_iov: iov.as_mut_ptr(),
+        msg_iovlen: 1,
+        msg_control: ptr::null::<libc::c_void>() as *mut _,
+        msg_controllen: 0,
+        msg_flags: 0,
+    };
+
+    #[cfg(target_env = "musl")]
+    let msg_hdr = {
+        // Cannot construct msghdr directly on musl
+        // See https://github.com/rust-lang/libc/issues/2344 for more info
+        let mut msg_hdr: msghdr = unsafe { std::mem::zeroed() };
+        msg_hdr.msg_name = addr as *mut _ as *mut _;
+        msg_hdr.msg_namelen = msg_namelen;
+        msg_hdr.msg_iov = iov.as_mut_ptr();
+        msg_hdr.msg_iovlen = 1;
+        msg_hdr.msg_control = ptr::null::<libc::c_void>() as *mut _;
+        msg_hdr.msg_controllen = 0;
+        msg_hdr.msg_flags = 0;
+        msg_hdr
+    };
+
     hdr.write(mmsghdr {
         msg_len: 0,
-        msg_hdr: msghdr {
-            msg_name: addr as *mut _ as *mut _,
-            msg_namelen,
-            msg_iov: iov.as_mut_ptr(),
-            msg_iovlen: 1,
-            msg_control: ptr::null::<libc::c_void>() as *mut _,
-            msg_controllen: 0,
-            msg_flags: 0,
-        },
+        msg_hdr,
     });
 }
 


### PR DESCRIPTION
#### Problem

It seems the v2.1 branch doesn't include #3836 which will meet trouble when built with MUSL

#### Summary of Changes

Backport #3836 to the v2.1 branch


