### PR TITLE
moves repair nonce verification from window-service to shred-fetch-stage

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -41,15 +41,6 @@ pub fn repair_response_packet_from_bytes(
     Some(packet)
 }
 
-pub(crate) fn nonce(packet: &Packet) -> Option<Nonce> {
-    // Nonces are attached to both repair and ancestor hashes responses.
-    let data = packet.data(..)?;
-    let offset = data.len().checked_sub(SIZE_OF_NONCE)?;
-    <[u8; SIZE_OF_NONCE]>::try_from(&data[offset..])
-        .map(Nonce::from_le_bytes)
-        .ok()
-}
-
 #[cfg(test)]
 mod test {
     use {

--- a/core/src/repair/request_response.rs
+++ b/core/src/repair/request_response.rs
@@ -1,5 +1,5 @@
 pub trait RequestResponse {
-    type Response;
+    type Response: ?Sized;
     fn num_expected_responses(&self) -> u32;
     fn verify_response(&self, response: &Self::Response) -> bool;
 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -185,6 +185,7 @@ impl Tvu {
             tvu_config.shred_version,
             bank_forks.clone(),
             cluster_info.clone(),
+            outstanding_repair_requests.clone(),
             turbine_disabled,
             exit.clone(),
         );

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1309,7 +1309,7 @@ impl Blockstore {
     // Blockstore::insert_shreds when inserting own shreds during leader slots.
     pub fn insert_shreds_handle_duplicate<F>(
         &self,
-        shreds: impl ExactSizeIterator<Item = (Shred, /*is_repaired:*/ bool)>,
+        shreds: impl IntoIterator<Item = (Shred, /*is_repaired:*/ bool), IntoIter: ExactSizeIterator>,
         leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
         retransmit_sender: &Sender<Vec<shred::Payload>>,
@@ -1324,7 +1324,7 @@ impl Blockstore {
             completed_data_set_infos,
             duplicate_shreds,
         } = self.do_insert_shreds(
-            shreds,
+            shreds.into_iter(),
             leader_schedule,
             is_trusted,
             Some((reed_solomon_cache, retransmit_sender)),

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -653,6 +653,18 @@ pub mod layout {
     }
 
     #[inline]
+    pub fn get_shred_and_repair_nonce(packet: &Packet) -> Option<(&[u8], Option<Nonce>)> {
+        let data = packet.data(..)?;
+        if !packet.meta().repair() {
+            return Some((data, None));
+        }
+        let offset = data.len().checked_sub(4)?;
+        let (shred, nonce) = data.split_at(offset);
+        let nonce = u32::from_le_bytes(<[u8; 4]>::try_from(nonce).unwrap());
+        Some((shred, Some(nonce)))
+    }
+
+    #[inline]
     pub fn get_common_header_bytes(shred: &[u8]) -> Option<&[u8]> {
         shred.get(..SIZE_OF_COMMON_SHRED_HEADER)
     }
@@ -687,7 +699,7 @@ pub mod layout {
     }
 
     #[inline]
-    pub(crate) fn get_index(shred: &[u8]) -> Option<u32> {
+    pub fn get_index(shred: &[u8]) -> Option<u32> {
         let bytes = <[u8; 4]>::try_from(shred.get(73..73 + 4)?).unwrap();
         Some(u32::from_le_bytes(bytes))
     }


### PR DESCRIPTION
#### Problem
Because repair nonce is a randomly generated u32 for each repair request, it can be verified before sigverify so that shreds with invalid repair nonce do not waste sigverify resources.


#### Summary of Changes
The commit moves repair nonce verification from window-service to shred-fetch-stage.
This bypasses sigverify and a full deserialization for shreds with invalid repair nonce.