### PR TITLE
increase repair delays

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -56,13 +56,13 @@ use {
 };
 
 // Time to defer repair requests to allow for turbine propagation
-const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(200);
+const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
 const DEFER_REPAIR_THRESHOLD_TICKS: u64 = DEFER_REPAIR_THRESHOLD.as_millis() as u64 / MS_PER_TICK;
 
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
 // expected network delays in requesting repairs and receiving shreds.
-const REPAIR_REQUEST_TIMEOUT_MS: u64 = 100;
+const REPAIR_REQUEST_TIMEOUT_MS: u64 = 150;
 
 // When requesting repair for a specific shred through the admin RPC, we will
 // request up to NUM_PEERS_TO_SAMPLE_FOR_REPAIRS in the event a specific, valid


### PR DESCRIPTION
#### Problem
After changes from #4485 , repair rate is overly aggressive.

There are two main sources of change:

1. The delay was always 200ms, but the repair loop only ran once every 100ms. This means on average, repairs would get triggered when shreds were 250ms late
2. There is a bug where reference tick is 0 for the final set of shreds, which effectively means they are eligible for repair immediately. This was likely partially masked with the 100ms repair period because we would have had to receive a shred from this group (to establish the ref tick), and still have more than half of shreds to insert when the repair period came up. With a more prompt repair triggering, this window is much easier to hit.

The second problem will not be solved by this PR. There is a separate discussion to fix that portion.

#### Summary of Changes
* increase repair delay from 200ms to 250ms
* increase repair request timeout from 100ms to 150ms

#### Data
See this comment for data on repair tuning testing: https://github.com/anza-xyz/agave/pull/4485#issuecomment-2613171921

Collecting some repair data for a node in SG on mainnet. Most data collection periods were ~1 hour (some were much longer):
|DEFER_REPAIR_THRESHOLD|REPAIR_REQUEST_TIMEOUT_MS|Repairs per second (runtime)|Block full time|Successful repair %|
|--|--|--|--|--|
|200|100|110|475|2.5|
|250|100|68|475|2.7|
|300|100|52|485|2.9|
|300|150|52|490|3.2|
|250|150|58|475|2.95|
|200|150|65|475|2.5|

![image](https://github.com/user-attachments/assets/f7fdd95c-c4f1-4003-84f6-b14b512419b6)

Collecting some repair data for a node in HK on mainnet. Most data collection periods were ~1 hour (some were much longer):
|DEFER_REPAIR_THRESHOLD|REPAIR_REQUEST_TIMEOUT_MS|Repairs per second (runtime)|Block full time|Successful repair %|
|--|--|--|--|--|
|200|100|110|453|1.95|
|250|100|83|456|1.95|
|250|150|83|456|1.9|
|200|150|117|453|2.0|
|300|200|59|465|2.5|
|500|200|17|500|3.0|


Here's a common sequence seen when running with 200ms delay:
[2025-01-26T19:04:28.080781179Z ERROR solana_core::repair::repair_service] #BW: slot 316547008 index 952 shred repair
[2025-01-26T19:04:28.116726260Z ERROR solana_ledger::shred] #BW: slot 316547008 index 952 fetch - repair = false
[2025-01-26T19:04:28.116803935Z ERROR solana_ledger::blockstore] #BW: slot 316547008 index 952 insert turbine
[2025-01-26T19:04:28.299676948Z ERROR solana_ledger::shred] #BW: slot 316547008 index 952 fetch - repair = true
[2025-01-26T19:04:28.299764151Z ERROR solana_ledger::blockstore] #BW: slot 316547008 index 952 insert repair exists

Two things to note:
1. The repair was triggered ~36ms before the turbine shred arrived. With the 250ms delay, we wouldn't have requested this repair
2. The repair request took ~220ms to arrive after the request was made. This highlights how long these can take and how we shouldn't be overly aggressive in retrying. Additionally, only a handful of repairs generally need to land to have enough to perform erasure recovery.
