### PR TITLE
turbine: Adjust reference tick calculation

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -9,7 +9,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::{
         blockstore,
-        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
+        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_sdk::{
         genesis_config::ClusterType, hash::Hash, signature::Keypair, timing::AtomicInterval,
@@ -79,11 +79,11 @@ impl StandardBroadcastRun {
         cluster_type: ClusterType,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
-        const SHRED_TICK_REFERENCE_MASK: u8 = ShredFlags::SHRED_TICK_REFERENCE_MASK.bits();
         if self.completed {
             return vec![];
         }
-        let reference_tick = max_ticks_in_slot & SHRED_TICK_REFERENCE_MASK;
+        // Set the reference_tick as if the PoH completed for this slot
+        let reference_tick = max_ticks_in_slot;
         let (mut shreds, coding_shreds) =
             Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
                 .unwrap()

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -268,7 +268,11 @@ impl StandardBroadcastRun {
 
         // 2) Convert entries to shreds and coding shreds
         let is_last_in_slot = last_tick_height == bank.max_tick_height();
-        let reference_tick = bank.tick_height() % bank.ticks_per_slot();
+        // Calculate how many ticks have already occurred in this slot, the
+        // possible range of values is [0, bank.ticks_per_slot()]
+        let reference_tick = last_tick_height
+            .saturating_add(bank.ticks_per_slot())
+            .saturating_sub(bank.max_tick_height());
         let (data_shreds, coding_shreds) = self
             .entries_to_shreds(
                 keypair,


### PR DESCRIPTION
#### Problem
The current reference tick calculation results in the reference tick being recorded as 0 when a Bank has reached max tick height

#### Summary of Changes
Adjust the calculation to saturate at `bank.ticks_per_slot() - 1`, which coincides with the max value of 63 that fit in the 6 bits allocated for `reference_tick` in the shred header.

I sampled a random block (`313491481`) from MNB and plotted reference tick vs. shred index to show the issue:
![image](https://github.com/user-attachments/assets/4c3d099b-d8d1-40ac-9411-9c06bbd49f1a)

