### PR TITLE
[zk-sdk] Add `to_bytes` and `from_bytes` functions for proof context types for wasm target

### DIFF
--- a/zk-sdk/src/encryption/grouped_elgamal.rs
+++ b/zk-sdk/src/encryption/grouped_elgamal.rs
@@ -243,6 +243,20 @@ mod grouped_elgamal_wasm {
                 amount,
             ))
         }
+
+        #[wasm_bindgen(js_name = encryptionWithU64)]
+        pub fn encryption_with_u64(
+            first_pubkey: &ElGamalPubkey,
+            second_pubkey: &ElGamalPubkey,
+            amount: u64,
+            opening: &PedersenOpening,
+        ) -> Self {
+            Self(GroupedElGamal::<2>::encrypt_with(
+                [first_pubkey, second_pubkey],
+                amount,
+                opening,
+            ))
+        }
     }
 
     #[wasm_bindgen]
@@ -260,6 +274,21 @@ mod grouped_elgamal_wasm {
             Self(GroupedElGamal::<3>::encrypt(
                 [first_pubkey, second_pubkey, third_pubkey],
                 amount,
+            ))
+        }
+
+        #[wasm_bindgen(js_name = encryptionWithU64)]
+        pub fn encryption_with_u64(
+            first_pubkey: &ElGamalPubkey,
+            second_pubkey: &ElGamalPubkey,
+            third_pubkey: &ElGamalPubkey,
+            amount: u64,
+            opening: &PedersenOpening,
+        ) -> Self {
+            Self(GroupedElGamal::<3>::encrypt_with(
+                [first_pubkey, second_pubkey, third_pubkey],
+                amount,
+                opening,
             ))
         }
     }

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
@@ -27,7 +27,10 @@ use {
             pedersen::PedersenOpening,
         },
         sigma_proofs::batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProof,
-        zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,
@@ -150,6 +153,13 @@ impl BatchedGroupedCiphertext2HandlesValidityProofData {
     pub fn to_bytes(&self) -> Box<[u8]> {
         bytes_of(self).into()
     }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
+    }
 }
 
 impl ZkProofData<BatchedGroupedCiphertext2HandlesValidityProofContext>
@@ -214,6 +224,22 @@ impl BatchedGroupedCiphertext2HandlesValidityProofContext {
         );
 
         transcript
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl BatchedGroupedCiphertext2HandlesValidityProofContext {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        bytes_of(self).into()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
     }
 }
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
@@ -15,7 +15,7 @@ use {
             elgamal::PodElGamalPubkey, grouped_elgamal::PodGroupedElGamalCiphertext2Handles,
         },
         sigma_proofs::pod::PodBatchedGroupedCiphertext2HandlesValidityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -148,19 +148,9 @@ impl BatchedGroupedCiphertext2HandlesValidityProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = BatchedGroupedCiphertext2HandlesValidityProofData);
 
 impl ZkProofData<BatchedGroupedCiphertext2HandlesValidityProofContext>
     for BatchedGroupedCiphertext2HandlesValidityProofData
@@ -227,21 +217,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl BatchedGroupedCiphertext2HandlesValidityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = BatchedGroupedCiphertext2HandlesValidityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -27,7 +27,10 @@ use {
             pedersen::PedersenOpening,
         },
         sigma_proofs::batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProof,
-        zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,
@@ -160,6 +163,13 @@ impl BatchedGroupedCiphertext3HandlesValidityProofData {
     pub fn to_bytes(&self) -> Box<[u8]> {
         bytes_of(self).into()
     }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
+    }
 }
 
 impl ZkProofData<BatchedGroupedCiphertext3HandlesValidityProofContext>
@@ -231,6 +241,22 @@ impl BatchedGroupedCiphertext3HandlesValidityProofContext {
         );
 
         transcript
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl BatchedGroupedCiphertext3HandlesValidityProofContext {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        bytes_of(self).into()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
     }
 }
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -15,7 +15,7 @@ use {
             elgamal::PodElGamalPubkey, grouped_elgamal::PodGroupedElGamalCiphertext3Handles,
         },
         sigma_proofs::pod::PodBatchedGroupedCiphertext3HandlesValidityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -158,19 +158,9 @@ impl BatchedGroupedCiphertext3HandlesValidityProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = BatchedGroupedCiphertext3HandlesValidityProofData);
 
 impl ZkProofData<BatchedGroupedCiphertext3HandlesValidityProofContext>
     for BatchedGroupedCiphertext3HandlesValidityProofData
@@ -244,21 +234,7 @@ impl BatchedGroupedCiphertext3HandlesValidityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl BatchedGroupedCiphertext3HandlesValidityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = BatchedGroupedCiphertext3HandlesValidityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
@@ -23,7 +23,10 @@ use {
             pedersen::PedersenOpening,
         },
         sigma_proofs::ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProof,
-        zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,
@@ -100,6 +103,13 @@ impl CiphertextCiphertextEqualityProofData {
     pub fn to_bytes(&self) -> Box<[u8]> {
         bytes_of(self).into()
     }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
+    }
 }
 
 impl ZkProofData<CiphertextCiphertextEqualityProofContext>
@@ -145,6 +155,22 @@ impl CiphertextCiphertextEqualityProofContext {
         transcript.append_message(b"second-ciphertext", bytes_of(&self.second_ciphertext));
 
         transcript
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl CiphertextCiphertextEqualityProofContext {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        bytes_of(self).into()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
     }
 }
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_ciphertext_equality.rs
@@ -11,7 +11,7 @@ use {
     crate::{
         encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
         sigma_proofs::pod::PodCiphertextCiphertextEqualityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -98,19 +98,9 @@ impl CiphertextCiphertextEqualityProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = CiphertextCiphertextEqualityProofData);
 
 impl ZkProofData<CiphertextCiphertextEqualityProofContext>
     for CiphertextCiphertextEqualityProofData
@@ -158,21 +148,7 @@ impl CiphertextCiphertextEqualityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl CiphertextCiphertextEqualityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = CiphertextCiphertextEqualityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/ciphertext_commitment_equality.rs
@@ -14,7 +14,7 @@ use {
             pedersen::PodPedersenCommitment,
         },
         sigma_proofs::pod::PodCiphertextCommitmentEqualityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -91,19 +91,9 @@ impl CiphertextCommitmentEqualityProofData {
             proof: proof.into(),
         })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = CiphertextCommitmentEqualityProofData);
 
 impl ZkProofData<CiphertextCommitmentEqualityProofContext>
     for CiphertextCommitmentEqualityProofData
@@ -141,21 +131,7 @@ impl CiphertextCommitmentEqualityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl CiphertextCommitmentEqualityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = CiphertextCommitmentEqualityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/errors.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/errors.rs
@@ -1,4 +1,6 @@
 use thiserror::Error;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofDataError {
@@ -12,4 +14,13 @@ pub enum ProofDataError {
     Overflow,
     #[error("invalid proof type")]
     InvalidProofType,
+    #[error("deserialization failed")]
+    Deserialization,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<ProofDataError> for JsValue {
+    fn from(err: ProofDataError) -> Self {
+        js_sys::Error::new(&err.to_string()).into()
+    }
 }

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
@@ -15,7 +15,7 @@ use {
             elgamal::PodElGamalPubkey, grouped_elgamal::PodGroupedElGamalCiphertext2Handles,
         },
         sigma_proofs::pod::PodGroupedCiphertext2HandlesValidityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -132,19 +132,9 @@ impl GroupedCiphertext2HandlesValidityProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = GroupedCiphertext2HandlesValidityProofData);
 
 impl ZkProofData<GroupedCiphertext2HandlesValidityProofContext>
     for GroupedCiphertext2HandlesValidityProofData
@@ -195,21 +185,7 @@ impl GroupedCiphertext2HandlesValidityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl GroupedCiphertext2HandlesValidityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = GroupedCiphertext2HandlesValidityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_2.rs
@@ -27,7 +27,10 @@ use {
             pedersen::PedersenOpening,
         },
         sigma_proofs::grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProof,
-        zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,
@@ -134,6 +137,13 @@ impl GroupedCiphertext2HandlesValidityProofData {
     pub fn to_bytes(&self) -> Box<[u8]> {
         bytes_of(self).into()
     }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
+    }
 }
 
 impl ZkProofData<GroupedCiphertext2HandlesValidityProofContext>
@@ -182,6 +192,22 @@ impl GroupedCiphertext2HandlesValidityProofContext {
         transcript.append_message(b"grouped-ciphertext", bytes_of(&self.grouped_ciphertext));
 
         transcript
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl GroupedCiphertext2HandlesValidityProofContext {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        bytes_of(self).into()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
     }
 }
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -15,7 +15,7 @@ use {
             elgamal::PodElGamalPubkey, grouped_elgamal::PodGroupedElGamalCiphertext3Handles,
         },
         sigma_proofs::pod::PodGroupedCiphertext3HandlesValidityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -142,19 +142,9 @@ impl GroupedCiphertext3HandlesValidityProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = GroupedCiphertext3HandlesValidityProofData);
 
 impl ZkProofData<GroupedCiphertext3HandlesValidityProofContext>
     for GroupedCiphertext3HandlesValidityProofData
@@ -210,21 +200,7 @@ impl GroupedCiphertext3HandlesValidityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl GroupedCiphertext3HandlesValidityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = GroupedCiphertext3HandlesValidityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -27,7 +27,10 @@ use {
             pedersen::PedersenOpening,
         },
         sigma_proofs::grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProof,
-        zk_elgamal_proof_program::errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,
@@ -144,6 +147,13 @@ impl GroupedCiphertext3HandlesValidityProofData {
     pub fn to_bytes(&self) -> Box<[u8]> {
         bytes_of(self).into()
     }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
+    }
 }
 
 impl ZkProofData<GroupedCiphertext3HandlesValidityProofContext>
@@ -197,6 +207,22 @@ impl GroupedCiphertext3HandlesValidityProofContext {
         transcript.append_message(b"grouped-ciphertext", bytes_of(&self.grouped_ciphertext));
 
         transcript
+    }
+}
+
+#[cfg(not(target_os = "solana"))]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl GroupedCiphertext3HandlesValidityProofContext {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
+    pub fn to_bytes(&self) -> Box<[u8]> {
+        bytes_of(self).into()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
+        bytemuck::try_from_bytes(bytes)
+            .copied()
+            .map_err(|_| ProofDataError::Deserialization)
     }
 }
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
@@ -13,7 +13,10 @@ use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
         sigma_proofs::percentage_with_cap::PercentageWithCapProof,
-        zk_elgamal_proof_program::{errors::{ProofGenerationError, ProofVerificationError}, proof_data::errors::ProofDataError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
+            proof_data::errors::ProofDataError,
+        },
     },
     bytemuck::bytes_of,
     merlin::Transcript,

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/percentage_with_cap.rs
@@ -27,7 +27,7 @@ use {
         encryption::pod::pedersen::PodPedersenCommitment,
         pod::PodU64,
         sigma_proofs::pod::PodPercentageWithCapProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -113,19 +113,9 @@ impl PercentageWithCapProofData {
 
         Ok(Self { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = PercentageWithCapProofData);
 
 impl ZkProofData<PercentageWithCapProofContext> for PercentageWithCapProofData {
     const PROOF_TYPE: ProofType = ProofType::PercentageWithCap;
@@ -171,21 +161,7 @@ impl PercentageWithCapProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl PercentageWithCapProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = PercentageWithCapProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
@@ -12,7 +12,8 @@ use {
     crate::{
         encryption::elgamal::ElGamalKeypair,
         sigma_proofs::pubkey_validity::PubkeyValidityProof,
-        zk_elgamal_proof_program::{errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
             proof_data::errors::ProofDataError,
         },
     },

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/pubkey_validity.rs
@@ -25,7 +25,7 @@ use {
     crate::{
         encryption::pod::elgamal::PodElGamalPubkey,
         sigma_proofs::pod::PodPubkeyValidityProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -68,19 +68,9 @@ impl PubkeyValidityProofData {
 
         Ok(PubkeyValidityProofData { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = PubkeyValidityProofData);
 
 impl ZkProofData<PubkeyValidityProofContext> for PubkeyValidityProofData {
     const PROOF_TYPE: ProofType = ProofType::PubkeyValidity;
@@ -108,21 +98,7 @@ impl PubkeyValidityProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl PubkeyValidityProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = PubkeyValidityProofContext);
 
 #[cfg(test)]
 mod test {

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
@@ -11,7 +11,8 @@ use {
     crate::{
         encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
         sigma_proofs::zero_ciphertext::ZeroCiphertextProof,
-        zk_elgamal_proof_program::{errors::{ProofGenerationError, ProofVerificationError},
+        zk_elgamal_proof_program::{
+            errors::{ProofGenerationError, ProofVerificationError},
             proof_data::errors::ProofDataError,
         },
     },

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
@@ -24,7 +24,7 @@ use {
     crate::{
         encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
         sigma_proofs::pod::PodZeroCiphertextProof,
-        zk_elgamal_proof_program::proof_data::{ProofType, ZkProofData},
+        zk_elgamal_proof_program::proof_data::{pod::impl_wasm_to_bytes, ProofType, ZkProofData},
     },
     bytemuck_derive::{Pod, Zeroable},
 };
@@ -76,19 +76,9 @@ impl ZeroCiphertextProofData {
 
         Ok(ZeroCiphertextProofData { context, proof })
     }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
 }
+
+impl_wasm_to_bytes!(TYPE = ZeroCiphertextProofData);
 
 impl ZkProofData<ZeroCiphertextProofContext> for ZeroCiphertextProofData {
     const PROOF_TYPE: ProofType = ProofType::ZeroCiphertext;
@@ -122,21 +112,7 @@ impl ZeroCiphertextProofContext {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl ZeroCiphertextProofContext {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toBytes))]
-    pub fn to_bytes(&self) -> Box<[u8]> {
-        bytes_of(self).into()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromBytes))]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofDataError> {
-        bytemuck::try_from_bytes(bytes)
-            .copied()
-            .map_err(|_| ProofDataError::Deserialization)
-    }
-}
+impl_wasm_to_bytes!(TYPE = ZeroCiphertextProofContext);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
#### Problem
Currently, there is on-going work to create client-side JS code for interacting with the ZK ElGamal proof program (e.g. https://github.com/solana-program/zk-elgamal-proof/pull/1). There has been a sequence of PRs to expose specific functionality in the zk-sdk for wasm build using wasm-bindgen.

#### Summary of Changes
In this PR, I added functionality to encode and decode zk proof data and context types as bytes.
- [ab6cf77](https://github.com/anza-xyz/agave/pull/4645/commits/ab6cf771d6d7246481aeb1183f10539bdd509f06): I first added the `encryption_with_u64` function for grouped ciphertexts to wasm build as I missed adding it in the previous PR ([ab6cf77](https://github.com/anza-xyz/agave/pull/4315)).
- [41a4907](https://github.com/anza-xyz/agave/pull/4645/commits/41a4907fbd53390e9f7a653ed5f308632418319c): I added the `to_bytes` and `from_bytes` functions for the proof data and context types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
