### PR TITLE
Do not unwrap directory in `cargo-build-sbf`

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -165,9 +165,9 @@ fn home_dir() -> PathBuf {
 fn find_installed_platform_tools() -> Vec<String> {
     let solana = home_dir().join(".cache").join("solana");
     let package = "platform-tools";
-    std::fs::read_dir(solana)
-        .unwrap()
-        .filter_map(|e| match e {
+
+    if let Ok(dir) = std::fs::read_dir(solana) {
+        dir.filter_map(|e| match e {
             Err(_) => None,
             Ok(e) => {
                 if e.path().join(package).is_dir() {
@@ -178,6 +178,9 @@ fn find_installed_platform_tools() -> Vec<String> {
             }
         })
         .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    }
 }
 
 fn get_latest_platform_tools_version() -> Result<String, String> {


### PR DESCRIPTION
#### Problem

When we try to use `cargo-build-sbf` without previously installing a version of platform tools and choose a specific version of it with `--tools-version`, the binary crashes.

#### Summary of Changes

Do not unwrap the result of `read_dir` and return an empty vector instead.
