### PR TITLE
shred: Consolidate and document ShredFlags logic

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -133,7 +133,7 @@ impl ShredFlags {
     /// SHRED_TICK_REFERENCE_MASK is comprised of only six bits whereas the
     /// reference_tick has 8 bits (u8). The reference_tick bits will saturate
     /// in the event that reference_tick > SHRED_TICK_REFERENCE_MASK
-    pub(crate) fn new_from_reference_tick(reference_tick: u8) -> Self {
+    pub(crate) fn from_reference_tick(reference_tick: u8) -> Self {
         Self::from_bits_retain(Self::SHRED_TICK_REFERENCE_MASK.bits().min(reference_tick))
     }
 }
@@ -1458,7 +1458,7 @@ mod tests {
     fn test_shred_flags_reference_tick_saturates() {
         const MAX_REFERENCE_TICK: u8 = ShredFlags::SHRED_TICK_REFERENCE_MASK.bits();
         for tick in 0..=u8::MAX {
-            let flags = ShredFlags::new_from_reference_tick(tick);
+            let flags = ShredFlags::from_reference_tick(tick);
             assert!(flags.bits() == tick || flags.bits() == MAX_REFERENCE_TICK);
         }
     }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -127,6 +127,17 @@ bitflags! {
     }
 }
 
+impl ShredFlags {
+    /// Creates a new ShredFlags from the given reference_tick
+    ///
+    /// SHRED_TICK_REFERENCE_MASK is comprised of only six bits whereas the
+    /// reference_tick has 8 bits (u8). The reference_tick bits will saturate
+    /// in the event that reference_tick > SHRED_TICK_REFERENCE_MASK
+    pub(crate) fn new_from_reference_tick(reference_tick: u8) -> Self {
+        Self::from_bits_retain(Self::SHRED_TICK_REFERENCE_MASK.bits().min(reference_tick))
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
@@ -1441,6 +1452,15 @@ mod tests {
             SIZE_OF_SHRED_INDEX,
             bincode::serialized_size(&common_header.index).unwrap() as usize
         );
+    }
+
+    #[test]
+    fn test_shred_flags_reference_tick_saturates() {
+        const MAX_REFERENCE_TICK: u8 = ShredFlags::SHRED_TICK_REFERENCE_MASK.bits();
+        for tick in 0..=u8::MAX {
+            let flags = ShredFlags::new_from_reference_tick(tick);
+            assert!(flags.bits() == tick || flags.bits() == MAX_REFERENCE_TICK);
+        }
     }
 
     #[test]

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1459,7 +1459,7 @@ mod tests {
         const MAX_REFERENCE_TICK: u8 = ShredFlags::SHRED_TICK_REFERENCE_MASK.bits();
         for tick in 0..=u8::MAX {
             let flags = ShredFlags::from_reference_tick(tick);
-            assert!(flags.bits() == tick || flags.bits() == MAX_REFERENCE_TICK);
+            assert_eq!(flags.bits(), tick.min(MAX_REFERENCE_TICK));
         }
     }
 

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -235,12 +235,7 @@ impl ShredData {
             fec_set_index,
         };
         let size = (data.len() + Self::SIZE_OF_HEADERS) as u16;
-        let flags = flags
-            | ShredFlags::from_bits_retain(
-                ShredFlags::SHRED_TICK_REFERENCE_MASK
-                    .bits()
-                    .min(reference_tick),
-            );
+        let flags = flags | ShredFlags::new_from_reference_tick(reference_tick);
         let data_header = DataShredHeader {
             parent_offset,
             flags,

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -235,7 +235,7 @@ impl ShredData {
             fec_set_index,
         };
         let size = (data.len() + Self::SIZE_OF_HEADERS) as u16;
-        let flags = flags | ShredFlags::new_from_reference_tick(reference_tick);
+        let flags = flags | ShredFlags::from_reference_tick(reference_tick);
         let data_header = DataShredHeader {
             parent_offset,
             flags,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1096,7 +1096,7 @@ pub(super) fn make_shreds_from_data(
             .checked_sub(parent_slot)
             .and_then(|offset| u16::try_from(offset).ok())
             .ok_or(Error::InvalidParentSlot { slot, parent_slot })?;
-        let flags = ShredFlags::new_from_reference_tick(reference_tick);
+        let flags = ShredFlags::from_reference_tick(reference_tick);
         DataShredHeader {
             parent_offset,
             flags,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1096,11 +1096,7 @@ pub(super) fn make_shreds_from_data(
             .checked_sub(parent_slot)
             .and_then(|offset| u16::try_from(offset).ok())
             .ok_or(Error::InvalidParentSlot { slot, parent_slot })?;
-        let flags = ShredFlags::from_bits_retain(
-            ShredFlags::SHRED_TICK_REFERENCE_MASK
-                .bits()
-                .min(reference_tick),
-        );
+        let flags = ShredFlags::new_from_reference_tick(reference_tick);
         DataShredHeader {
             parent_offset,
             flags,


### PR DESCRIPTION
#### Summary of Changes
- Document behavior that `ShredFlags` will saturate if `reference_tick` exceeds number of bytes
- Add a unit test to guarantee the above