### PR TITLE
Clean up tests that need to shut down transaction status service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9013,6 +9013,7 @@ dependencies = [
  "solana-poh",
  "solana-pubkey",
  "solana-rayon-threadlimit",
+ "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -21,7 +21,7 @@ solana-merkle-tree = { workspace = true }
 solana-perf = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
+solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
@@ -36,6 +36,7 @@ tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -21,7 +21,7 @@ solana-merkle-tree = { workspace = true }
 solana-perf = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
-solana-rpc = { workspace = true }
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -120,7 +120,7 @@ solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"]}
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -120,6 +120,7 @@ solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"]}
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1973,6 +1973,7 @@ mod tests {
             blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 
             let (transaction_status_sender, transaction_status_receiver) = unbounded();
+            let tss_exit = Arc::new(AtomicBool::new(false));
             let transaction_status_service = TransactionStatusService::new(
                 transaction_status_receiver,
                 Arc::new(AtomicU64::default()),
@@ -1980,7 +1981,7 @@ mod tests {
                 None,
                 blockstore.clone(),
                 false,
-                Arc::new(AtomicBool::new(false)),
+                tss_exit.clone(),
             );
 
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -1996,7 +1997,8 @@ mod tests {
             let _ = consumer.process_and_record_transactions(&bank, &transactions, 0);
 
             drop(consumer); // drop/disconnect transaction_status_sender
-            transaction_status_service.join().unwrap();
+
+            transaction_status_service.quiesce_and_join_for_tests(tss_exit);
 
             let confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
             let actual_tx_results: Vec<_> = confirmed_block
@@ -2118,6 +2120,7 @@ mod tests {
             blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 
             let (transaction_status_sender, transaction_status_receiver) = unbounded();
+            let tss_exit = Arc::new(AtomicBool::new(false));
             let transaction_status_service = TransactionStatusService::new(
                 transaction_status_receiver,
                 Arc::new(AtomicU64::default()),
@@ -2125,7 +2128,7 @@ mod tests {
                 None,
                 blockstore.clone(),
                 false,
-                Arc::new(AtomicBool::new(false)),
+                tss_exit.clone(),
             );
 
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -2141,7 +2144,8 @@ mod tests {
             let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
 
             drop(consumer); // drop/disconnect transaction_status_sender
-            transaction_status_service.join().unwrap();
+
+            transaction_status_service.quiesce_and_join_for_tests(tss_exit);
 
             let mut confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
             assert_eq!(confirmed_block.transactions.len(), 1);

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -44,7 +44,7 @@ solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-rpc = { workspace = true , features = ["dev-context-only-utils"] }
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true }
 solana-sbpf = { workspace = true, features = ["debugger"] }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -44,7 +44,7 @@ solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-rpc = { workspace = true }
+solana-rpc = { workspace = true , features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true }
 solana-sbpf = { workspace = true, features = ["debugger"] }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -68,6 +68,7 @@ tokio-util = { workspace = true, features = ["codec", "compat"] }
 [dev-dependencies]
 serial_test = { workspace = true }
 solana-net-utils = { workspace = true }
+solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
@@ -75,6 +76,11 @@ solana-runtime-transaction = { workspace = true, features = [
 solana-stake-program = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }
+
+[features]
+dev-context-only-utils = [
+    "solana-rpc/dev-context-only-utils",
+]
 
 [lib]
 crate-type = ["lib"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -68,7 +68,7 @@ tokio-util = { workspace = true, features = ["codec", "compat"] }
 [dev-dependencies]
 serial_test = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
+solana-rpc = { path = ".", features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1,4 +1,6 @@
 //! The `rpc` module implements the Solana RPC interface.
+#[cfg(feature = "dev-context-only-utils")]
+use solana_runtime::installed_scheduler_pool::BankWithScheduler;
 use {
     crate::{
         filter::filter_allows, max_slots::MaxSlots,
@@ -4483,9 +4485,7 @@ pub fn populate_blockstore_for_tests(
     // that they are matched properly by get_rooted_block
     assert_eq!(
         solana_ledger::blockstore_processor::process_entries_for_tests(
-            &solana_runtime::installed_scheduler_pool::BankWithScheduler::new_without_scheduler(
-                bank
-            ),
+            &BankWithScheduler::new_without_scheduler(bank),
             entries,
             Some(
                 &solana_ledger::blockstore_processor::TransactionStatusSender {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -58,7 +58,6 @@ use {
         bank::{Bank, TransactionSimulationResult},
         bank_forks::BankForks,
         commitment::{BlockCommitmentArray, BlockCommitmentCache},
-        installed_scheduler_pool::BankWithScheduler,
         non_circulating_supply::{calculate_non_circulating_supply, NonCirculatingSupply},
         prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_config::SnapshotConfig,
@@ -4446,6 +4445,7 @@ pub fn create_test_transaction_entries(
     (vec![entry_1, entry_2], signatures)
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn populate_blockstore_for_tests(
     entries: Vec<Entry>,
     bank: Arc<Bank>,
@@ -4483,7 +4483,9 @@ pub fn populate_blockstore_for_tests(
     // that they are matched properly by get_rooted_block
     assert_eq!(
         solana_ledger::blockstore_processor::process_entries_for_tests(
-            &BankWithScheduler::new_without_scheduler(bank),
+            &solana_runtime::installed_scheduler_pool::BankWithScheduler::new_without_scheduler(
+                bank
+            ),
             entries,
             Some(
                 &solana_ledger::blockstore_processor::TransactionStatusSender {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4467,6 +4467,7 @@ pub fn populate_blockstore_for_tests(
 
     let (transaction_status_sender, transaction_status_receiver) = unbounded();
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let tss_exit = Arc::new(AtomicBool::new(false));
     let transaction_status_service =
         crate::transaction_status_service::TransactionStatusService::new(
             transaction_status_receiver,
@@ -4475,7 +4476,7 @@ pub fn populate_blockstore_for_tests(
             None,
             blockstore,
             false,
-            Arc::new(AtomicBool::new(false)),
+            tss_exit.clone(),
         );
 
     // Check that process_entries successfully writes can_commit transactions statuses, and
@@ -4494,7 +4495,7 @@ pub fn populate_blockstore_for_tests(
         Ok(())
     );
 
-    transaction_status_service.join().unwrap();
+    transaction_status_service.quiesce_and_join_for_tests(tss_exit);
 }
 
 #[cfg(test)]

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -20,8 +20,13 @@ use {
     },
 };
 
+// Used when draining and shutting down TSS in unit tests.
+const TSS_TEST_QUIESCE_NUM_RETRIES: usize = 100;
+const TSS_TEST_QUIESCE_SLEEP_TIME_MS: u64 = 50;
+
 pub struct TransactionStatusService {
     thread_hdl: JoinHandle<()>,
+    transaction_status_receiver: Arc<Receiver<TransactionStatusMessage>>,
 }
 
 impl TransactionStatusService {
@@ -34,6 +39,9 @@ impl TransactionStatusService {
         enable_extended_tx_metadata_storage: bool,
         exit: Arc<AtomicBool>,
     ) -> Self {
+        let transaction_status_receiver = Arc::new(write_transaction_status_receiver);
+        let transaction_status_receiver_handle = Arc::clone(&transaction_status_receiver);
+
         let thread_hdl = Builder::new()
             .name("solTxStatusWrtr".to_string())
             .spawn(move || {
@@ -43,7 +51,7 @@ impl TransactionStatusService {
                         break;
                     }
 
-                    let message = match write_transaction_status_receiver
+                    let message = match transaction_status_receiver_handle
                         .recv_timeout(Duration::from_secs(1))
                     {
                         Ok(message) => message,
@@ -74,7 +82,10 @@ impl TransactionStatusService {
                 info!("TransactionStatusService has stopped");
             })
             .unwrap();
-        Self { thread_hdl }
+        Self {
+            thread_hdl,
+            transaction_status_receiver,
+        }
     }
 
     fn write_transaction_status_batch(
@@ -221,6 +232,21 @@ impl TransactionStatusService {
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
     }
+
+    pub fn quiesce_and_join_for_tests(self, exit: Arc<AtomicBool>) {
+        for _ in 0..TSS_TEST_QUIESCE_NUM_RETRIES {
+            if self.transaction_status_receiver.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(TSS_TEST_QUIESCE_SLEEP_TIME_MS));
+        }
+        assert!(
+            self.transaction_status_receiver.is_empty(),
+            "TransactionStatusService timed out before processing all queued up transactions"
+        );
+        exit.store(true, Ordering::Relaxed);
+        self.join().unwrap();
+    }
 }
 
 #[cfg(test)]
@@ -257,14 +283,7 @@ pub(crate) mod tests {
             token_balances::TransactionTokenBalancesSet, TransactionStatusMeta,
             TransactionTokenBalance,
         },
-        std::{
-            sync::{
-                atomic::{AtomicBool, Ordering},
-                Arc,
-            },
-            thread::sleep,
-            time::Duration,
-        },
+        std::sync::{atomic::AtomicBool, Arc},
     };
 
     #[derive(Eq, Hash, PartialEq)]
@@ -431,10 +450,8 @@ pub(crate) mod tests {
         transaction_status_sender
             .send(TransactionStatusMessage::Batch(transaction_status_batch))
             .unwrap();
-        sleep(Duration::from_millis(500));
 
-        exit.store(true, Ordering::Relaxed);
-        transaction_status_service.join().unwrap();
+        transaction_status_service.quiesce_and_join_for_tests(exit);
         assert_eq!(test_notifier.notifications.len(), 1);
         let key = TestNotifierKey {
             slot,
@@ -536,10 +553,7 @@ pub(crate) mod tests {
         transaction_status_sender
             .send(TransactionStatusMessage::Batch(transaction_status_batch))
             .unwrap();
-        sleep(Duration::from_millis(5000));
-
-        exit.store(true, Ordering::Relaxed);
-        transaction_status_service.join().unwrap();
+        transaction_status_service.quiesce_and_join_for_tests(exit);
         assert_eq!(test_notifier.notifications.len(), 2);
 
         let key1 = TestNotifierKey {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -21,17 +21,20 @@ use {
 };
 
 // Used when draining and shutting down TSS in unit tests.
+#[cfg(feature = "dev-context-only-utils")]
 const TSS_TEST_QUIESCE_NUM_RETRIES: usize = 100;
+#[cfg(feature = "dev-context-only-utils")]
 const TSS_TEST_QUIESCE_SLEEP_TIME_MS: u64 = 50;
 
 pub struct TransactionStatusService {
     thread_hdl: JoinHandle<()>,
+    #[cfg(feature = "dev-context-only-utils")]
     transaction_status_receiver: Arc<Receiver<TransactionStatusMessage>>,
 }
 
 impl TransactionStatusService {
     pub fn new(
-        write_transaction_status_receiver: Receiver<TransactionStatusMessage>,
+        writetransaction_status_receiver: Receiver<TransactionStatusMessage>,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierArc>,
@@ -39,7 +42,7 @@ impl TransactionStatusService {
         enable_extended_tx_metadata_storage: bool,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let transaction_status_receiver = Arc::new(write_transaction_status_receiver);
+        let transaction_status_receiver = Arc::new(writetransaction_status_receiver);
         let transaction_status_receiver_handle = Arc::clone(&transaction_status_receiver);
 
         let thread_hdl = Builder::new()
@@ -84,6 +87,7 @@ impl TransactionStatusService {
             .unwrap();
         Self {
             thread_hdl,
+            #[cfg(feature = "dev-context-only-utils")]
             transaction_status_receiver,
         }
     }
@@ -233,6 +237,7 @@ impl TransactionStatusService {
         self.thread_hdl.join()
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn quiesce_and_join_for_tests(self, exit: Arc<AtomicBool>) {
         for _ in 0..TSS_TEST_QUIESCE_NUM_RETRIES {
             if self.transaction_status_receiver.is_empty() {


### PR DESCRIPTION
Unify the wind down of transaction status service across different unit tests to ensure more consistency, and make sure all tx statuses are processed before the verification step of each test.

This change was forked from agave PR #4032 (specifically these comments [here ](https://github.com/anza-xyz/agave/pull/4032#issuecomment-2614703878) and [here](https://github.com/anza-xyz/agave/pull/4032#discussion_r1931157047) for context).