### PR TITLE
svm: add program cache tests

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -145,7 +145,7 @@ fn svm_concurrent() {
 
     mock_bank.configure_sysvars();
     batch_processor.fill_missing_sysvar_cache_entries(&*mock_bank);
-    register_builtins(&mock_bank, &batch_processor);
+    register_builtins(&mock_bank, &batch_processor, false);
 
     let mut transaction_builder = SanitizedTransactionBuilder::default();
     let program_id = deploy_program("transfer-from-account".to_string(), 0, &mock_bank);

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -11,6 +11,7 @@ use {
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        bpf_loader_upgradeable,
         clock::Slot,
         compute_budget::ComputeBudgetInstruction,
         entrypoint::MAX_PERMITTED_DATA_INCREASE,
@@ -215,7 +216,7 @@ impl SvmTestEnvironment<'_> {
         }
 
         // first assert all transaction states together, it makes test-driven development much less of a headache
-        let (expected_statuses, actual_statuses): (Vec<_>, Vec<_>) = batch_output
+        let (actual_statuses, expected_statuses): (Vec<_>, Vec<_>) = batch_output
             .processing_results
             .iter()
             .zip(self.test_entry.asserts())
@@ -226,7 +227,27 @@ impl SvmTestEnvironment<'_> {
                 )
             })
             .unzip();
-        assert_eq!(expected_statuses, actual_statuses);
+        assert_eq!(
+            expected_statuses,
+            actual_statuses,
+            "mismatch between expected and actual statuses. execution details:\n{}",
+            batch_output
+                .processing_results
+                .iter()
+                .enumerate()
+                .map(|(i, tx)| {
+                    let details = match tx {
+                        Ok(ProcessedTransaction::Executed(executed)) => {
+                            format!("{:#?}", executed.execution_details)
+                        }
+                        Ok(ProcessedTransaction::FeesOnly(_)) => "(fee-only)".to_string(),
+                        Err(_) => "(not executed)".to_string(),
+                    };
+                    format!("{}: {}", i, details)
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
 
         // check that all the account states we care about are present and correct
         for (pubkey, expected_account_data) in self.test_entry.final_accounts.iter() {
@@ -2286,6 +2307,55 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
     test_entries
 }
 
+fn simd83_program_update_tombstone() -> Vec<SvmTestEntry> {
+    let mut test_entry = SvmTestEntry::default();
+
+    let program_name = "hello-solana";
+    let program_id = program_address(program_name);
+
+    let fee_payer_keypair = Keypair::new();
+    let fee_payer = fee_payer_keypair.pubkey();
+
+    let mut fee_payer_data = AccountSharedData::default();
+    fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+    test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+    test_entry
+        .initial_programs
+        .push((program_name.to_string(), DEPLOYMENT_SLOT, Some(fee_payer)));
+
+    // 0: close a deployed program
+    let instruction = bpf_loader_upgradeable::close_any(
+        &bpf_loader_upgradeable::get_program_data_address(&program_id),
+        &Pubkey::new_unique(),
+        Some(&fee_payer),
+        Some(&program_id),
+    );
+    test_entry.push_transaction(Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        Hash::default(),
+    ));
+
+    // 1: attempt to invoke it, which must fail
+    // this ensures the local program cache reflects the change of state
+    let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+    test_entry.push_transaction_with_status(
+        Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&fee_payer),
+            &[&fee_payer_keypair],
+            Hash::default(),
+        ),
+        ExecutionStatus::ExecutedFailed,
+    );
+
+    test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+    vec![test_entry]
+}
+
 #[test_case(program_medley())]
 #[test_case(simple_transfer(false))]
 #[test_case(simple_transfer(true))]
@@ -2304,6 +2374,7 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
 #[test_case(simd83_fee_payer_deallocate(true))]
 #[test_case(simd83_account_reallocate(false))]
 #[test_case(simd83_account_reallocate(true))]
+#[test_case(simd83_program_update_tombstone())]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
         let env = SvmTestEnvironment::create(test_entry);

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -236,17 +236,14 @@ impl SvmTestEnvironment<'_> {
                 .processing_results
                 .iter()
                 .enumerate()
-                .map(|(i, tx)| {
-                    let details = match tx {
-                        Ok(ProcessedTransaction::Executed(executed)) => {
-                            format!("(executed): {:#?}", executed.execution_details)
-                        }
-                        Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
-                            format!("(fee-only): {:?}", fee_only.load_error)
-                        }
-                        Err(e) => format!("(discarded): {:?}", e),
-                    };
-                    format!("{} {}", i, details)
+                .map(|(i, tx)| match tx {
+                    Ok(ProcessedTransaction::Executed(executed)) => {
+                        format!("{} (executed): {:#?}", i, executed.execution_details)
+                    }
+                    Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
+                        format!("{} (fee-only): {:?}", i, fee_only.load_error)
+                    }
+                    Err(e) => format!("{} (discarded): {:?}", i, e),
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2383,7 +2383,10 @@ fn svm_integration(test_entries: Vec<SvmTestEntry>) {
 }
 
 #[test_matrix([false, true], [false, true])]
-fn program_cache_create_account(enable_fee_only_transactions: bool, disable_executable_flag: bool) {
+fn program_cache_create_account(
+    enable_fee_only_transactions: bool,
+    remove_accounts_executable_flag_checks: bool,
+) {
     for loader_id in PROGRAM_OWNERS {
         let mut test_entry = SvmTestEntry::default();
         if enable_fee_only_transactions {
@@ -2391,7 +2394,7 @@ fn program_cache_create_account(enable_fee_only_transactions: bool, disable_exec
                 .enabled_features
                 .push(feature_set::enable_transaction_loading_failure_fees::id());
         }
-        if disable_executable_flag {
+        if remove_accounts_executable_flag_checks {
             test_entry
                 .enabled_features
                 .push(feature_set::remove_accounts_executable_flag_checks::id());
@@ -2428,7 +2431,10 @@ fn program_cache_create_account(enable_fee_only_transactions: bool, disable_exec
             Hash::default(),
         );
 
-        let expected_status = match (enable_fee_only_transactions, disable_executable_flag) {
+        let expected_status = match (
+            enable_fee_only_transactions,
+            remove_accounts_executable_flag_checks,
+        ) {
             (_, true) => ExecutionStatus::ExecutedFailed,
             (true, false) => ExecutionStatus::ProcessedFailed,
             (false, false) => ExecutionStatus::Discarded,

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -237,7 +237,7 @@ pub fn deploy_program_with_upgrade_authority(
     let mut account_data = AccountSharedData::default();
     let state = UpgradeableLoaderState::ProgramData {
         slot: deployment_slot,
-        upgrade_authority_address: None,
+        upgrade_authority_address,
     };
     let mut header = bincode::serialize(&state).unwrap();
     let mut complement = vec![

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -19,6 +19,7 @@ use {
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Clock, UnixTimestamp},
         compute_budget, native_loader,
@@ -267,16 +268,40 @@ pub fn register_builtins(
     batch_processor: &TransactionBatchProcessor<MockForkGraph>,
 ) {
     const DEPLOYMENT_SLOT: u64 = 0;
-    // We must register the bpf loader account as a loadable account, otherwise programs
-    // won't execute.
-    let bpf_loader_name = "solana_bpf_loader_upgradeable_program";
+    // We must register LoaderV3 as a loadable account, otherwise programs won't execute.
+    let loader_v3_name = "solana_bpf_loader_upgradeable_program";
     batch_processor.add_builtin(
         mock_bank,
         bpf_loader_upgradeable::id(),
-        bpf_loader_name,
+        loader_v3_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            bpf_loader_name.len(),
+            loader_v3_name.len(),
+            solana_bpf_loader_program::Entrypoint::vm,
+        ),
+    );
+
+    // Other loaders are needed for testing program cache behavior.
+    // NOTE when LoaderV4 is ready for testing, it must be added here.
+    let loader_v1_name = "solana_bpf_loader_deprecated_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        bpf_loader_deprecated::id(),
+        loader_v1_name,
+        ProgramCacheEntry::new_builtin(
+            DEPLOYMENT_SLOT,
+            loader_v1_name.len(),
+            solana_bpf_loader_program::Entrypoint::vm,
+        ),
+    );
+    let loader_v2_name = "solana_bpf_loader_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        bpf_loader::id(),
+        loader_v2_name,
+        ProgramCacheEntry::new_builtin(
+            DEPLOYMENT_SLOT,
+            loader_v2_name.len(),
             solana_bpf_loader_program::Entrypoint::vm,
         ),
     );


### PR DESCRIPTION
#### Problem
we are planning on refactoring transaction processing to use a per-transaction (changed from per-batch) local program cache. this requires new logic for handling tombstones, which lacks test coverage

#### Summary of Changes
add tests. also fix a bug in the svm test framework for setting program upgrade authority, and improve logging failures for better test-driven development