### PR TITLE
blockstore: Cleanup redundant constants

### DIFF
--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -7,7 +7,7 @@
 use {
     crate::{
         blockstore::{Blockstore, PurgeType},
-        blockstore_db::{Result as BlockstoreResult, DATA_SHRED_CF},
+        blockstore_db::{columns, ColumnName, Result as BlockstoreResult},
     },
     solana_measure::measure::Measure,
     solana_sdk::clock::{Slot, DEFAULT_MS_PER_SLOT},
@@ -105,14 +105,12 @@ impl BlockstoreCleanupService {
         root: Slot,
         max_ledger_shreds: u64,
     ) -> (bool, Slot, u64) {
-        let data_shred_cf_name = DATA_SHRED_CF.to_string();
-
         let live_files = blockstore
             .live_files_metadata()
             .expect("Blockstore::live_files_metadata()");
         let num_shreds = live_files
             .iter()
-            .filter(|live_file| live_file.column_family_name == data_shred_cf_name)
+            .filter(|live_file| live_file.column_family_name == columns::ShredData::NAME)
             .map(|file_meta| file_meta.num_entries)
             .sum();
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -82,8 +82,6 @@ const PERF_SAMPLES_CF: &str = "perf_samples";
 const BLOCK_HEIGHT_CF: &str = "block_height";
 /// Column family for ProgramCosts
 const PROGRAM_COSTS_CF: &str = "program_costs";
-/// Column family for optimistic slots
-const OPTIMISTIC_SLOTS_CF: &str = "optimistic_slots";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1341,7 +1339,7 @@ impl TypedColumn for columns::ErasureMeta {
 
 impl SlotColumn for columns::OptimisticSlots {}
 impl ColumnName for columns::OptimisticSlots {
-    const NAME: &'static str = OPTIMISTIC_SLOTS_CF;
+    const NAME: &'static str = "optimistic_slots";
 }
 impl TypedColumn for columns::OptimisticSlots {
     type Type = blockstore_meta::OptimisticSlotMetaVersioned;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family for metadata about a leader slot
-const META_CF: &str = "meta";
 // Column family for slots that have been marked as dead
 const DEAD_SLOTS_CF: &str = "dead_slots";
 // Column family for storing proof that there were multiple
@@ -1316,7 +1314,7 @@ impl TypedColumn for columns::Root {
 
 impl SlotColumn for columns::SlotMeta {}
 impl ColumnName for columns::SlotMeta {
-    const NAME: &'static str = META_CF;
+    const NAME: &'static str = "meta";
 }
 impl TypedColumn for columns::SlotMeta {
     type Type = blockstore_meta::SlotMeta;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -62,10 +62,6 @@ const TRANSACTION_STATUS_CF: &str = "transaction_status";
 const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
 /// Column family for TransactionMemos
 const TRANSACTION_MEMOS_CF: &str = "transaction_memos";
-/// Column family for the Transaction Status Index.
-/// This column family is used for tracking the active primary index for columns that for
-/// query performance reasons should not be indexed by Slot.
-const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1092,7 +1088,7 @@ impl Column for columns::TransactionStatusIndex {
     }
 }
 impl ColumnName for columns::TransactionStatusIndex {
-    const NAME: &'static str = TRANSACTION_STATUS_INDEX_CF;
+    const NAME: &'static str = "transaction_status_index";
 }
 
 impl SlotColumn for columns::Rewards {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -70,8 +70,6 @@ const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 const REWARDS_CF: &str = "rewards";
 /// Column family for Blocktime
 const BLOCKTIME_CF: &str = "blocktime";
-/// Column family for Performance Samples
-const PERF_SAMPLES_CF: &str = "perf_samples";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1119,7 +1117,7 @@ impl TypedColumn for columns::Blocktime {
 
 impl SlotColumn for columns::PerfSamples {}
 impl ColumnName for columns::PerfSamples {
-    const NAME: &'static str = PERF_SAMPLES_CF;
+    const NAME: &'static str = "perf_samples";
 }
 
 impl SlotColumn for columns::BlockHeight {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -60,8 +60,6 @@ const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 const TRANSACTION_STATUS_CF: &str = "transaction_status";
 /// Column family for Address Signatures
 const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
-/// Column family for TransactionMemos
-const TRANSACTION_MEMOS_CF: &str = "transaction_memos";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1035,7 +1033,7 @@ impl Column for columns::TransactionMemos {
     }
 }
 impl ColumnName for columns::TransactionMemos {
-    const NAME: &'static str = TRANSACTION_MEMOS_CF;
+    const NAME: &'static str = "transaction_memos";
 }
 
 impl ColumnIndexDeprecation for columns::TransactionMemos {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -58,8 +58,6 @@ const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
 /// Column family for Transaction Status
 const TRANSACTION_STATUS_CF: &str = "transaction_status";
-/// Column family for Address Signatures
-const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -959,7 +957,7 @@ impl Column for columns::AddressSignatures {
     }
 }
 impl ColumnName for columns::AddressSignatures {
-    const NAME: &'static str = ADDRESS_SIGNATURES_CF;
+    const NAME: &'static str = "address_signatures";
 }
 
 impl ColumnIndexDeprecation for columns::AddressSignatures {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -84,8 +84,6 @@ const BLOCK_HEIGHT_CF: &str = "block_height";
 const PROGRAM_COSTS_CF: &str = "program_costs";
 /// Column family for optimistic slots
 const OPTIMISTIC_SLOTS_CF: &str = "optimistic_slots";
-/// Column family for merkle roots
-const MERKLE_ROOT_META_CF: &str = "merkle_root_meta";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1378,7 +1376,7 @@ impl Column for columns::MerkleRootMeta {
 }
 
 impl ColumnName for columns::MerkleRootMeta {
-    const NAME: &'static str = MERKLE_ROOT_META_CF;
+    const NAME: &'static str = "merkle_root_meta";
 }
 impl TypedColumn for columns::MerkleRootMeta {
     type Type = MerkleRootMeta;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-/// Column family for indexes
-const INDEX_CF: &str = "index";
 /// Column family for Data Shreds
 pub const DATA_SHRED_CF: &str = "data_shred";
 /// Column family for Code Shreds
@@ -1227,7 +1225,7 @@ impl ColumnName for columns::ShredData {
 
 impl SlotColumn for columns::Index {}
 impl ColumnName for columns::Index {
-    const NAME: &'static str = INDEX_CF;
+    const NAME: &'static str = "index";
 }
 impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,9 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-/// Column family for Transaction Status
-const TRANSACTION_STATUS_CF: &str = "transaction_status";
-
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
         let mut key = [0u8; std::mem::size_of::<Self::$key>()];
@@ -879,7 +876,7 @@ impl Column for columns::TransactionStatus {
     }
 }
 impl ColumnName for columns::TransactionStatus {
-    const NAME: &'static str = TRANSACTION_STATUS_CF;
+    const NAME: &'static str = "transaction_status";
 }
 impl ProtobufColumn for columns::TransactionStatus {
     type Type = generated::TransactionStatusMeta;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -74,8 +74,6 @@ const BLOCKTIME_CF: &str = "blocktime";
 const PERF_SAMPLES_CF: &str = "perf_samples";
 /// Column family for BlockHeight
 const BLOCK_HEIGHT_CF: &str = "block_height";
-/// Column family for ProgramCosts
-const PROGRAM_COSTS_CF: &str = "program_costs";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1135,7 +1133,7 @@ impl TypedColumn for columns::BlockHeight {
 }
 
 impl ColumnName for columns::ProgramCosts {
-    const NAME: &'static str = PROGRAM_COSTS_CF;
+    const NAME: &'static str = "program_costs";
 }
 impl TypedColumn for columns::ProgramCosts {
     type Type = blockstore_meta::ProgramCost;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -72,8 +72,6 @@ const REWARDS_CF: &str = "rewards";
 const BLOCKTIME_CF: &str = "blocktime";
 /// Column family for Performance Samples
 const PERF_SAMPLES_CF: &str = "perf_samples";
-/// Column family for BlockHeight
-const BLOCK_HEIGHT_CF: &str = "block_height";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1126,7 +1124,7 @@ impl ColumnName for columns::PerfSamples {
 
 impl SlotColumn for columns::BlockHeight {}
 impl ColumnName for columns::BlockHeight {
-    const NAME: &'static str = BLOCK_HEIGHT_CF;
+    const NAME: &'static str = "block_height";
 }
 impl TypedColumn for columns::BlockHeight {
     type Type = u64;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family for root data
-const ROOT_CF: &str = "root";
 /// Column family for indexes
 const INDEX_CF: &str = "index";
 /// Column family for Data Shreds
@@ -1295,7 +1293,7 @@ impl TypedColumn for columns::BankHash {
 
 impl SlotColumn for columns::Root {}
 impl ColumnName for columns::Root {
-    const NAME: &'static str = ROOT_CF;
+    const NAME: &'static str = "root";
 }
 impl TypedColumn for columns::Root {
     type Type = bool;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -66,8 +66,6 @@ const TRANSACTION_MEMOS_CF: &str = "transaction_memos";
 /// This column family is used for tracking the active primary index for columns that for
 /// query performance reasons should not be indexed by Slot.
 const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
-/// Column family for Rewards
-const REWARDS_CF: &str = "rewards";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1099,7 +1097,7 @@ impl ColumnName for columns::TransactionStatusIndex {
 
 impl SlotColumn for columns::Rewards {}
 impl ColumnName for columns::Rewards {
-    const NAME: &'static str = REWARDS_CF;
+    const NAME: &'static str = "rewards";
 }
 impl ProtobufColumn for columns::Rewards {
     type Type = generated::Rewards;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,9 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family for storing proof that there were multiple
-// versions of a slot
-const DUPLICATE_SLOTS_CF: &str = "duplicate_slots";
 // Column family storing erasure metadata for a slot
 const ERASURE_META_CF: &str = "erasure_meta";
 // Column family for orphans data
@@ -1280,7 +1277,7 @@ impl TypedColumn for columns::DeadSlots {
 
 impl SlotColumn for columns::DuplicateSlots {}
 impl ColumnName for columns::DuplicateSlots {
-    const NAME: &'static str = DUPLICATE_SLOTS_CF;
+    const NAME: &'static str = "duplicate_slots";
 }
 impl TypedColumn for columns::DuplicateSlots {
     type Type = blockstore_meta::DuplicateSlotProof;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-/// Column family for Data Shreds
-pub const DATA_SHRED_CF: &str = "data_shred";
 /// Column family for Code Shreds
 const CODE_SHRED_CF: &str = "code_shred";
 /// Column family for Transaction Status
@@ -1220,7 +1218,7 @@ impl Column for columns::ShredData {
     }
 }
 impl ColumnName for columns::ShredData {
-    const NAME: &'static str = DATA_SHRED_CF;
+    const NAME: &'static str = "data_shred";
 }
 
 impl SlotColumn for columns::Index {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -68,8 +68,6 @@ const TRANSACTION_MEMOS_CF: &str = "transaction_memos";
 const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 /// Column family for Rewards
 const REWARDS_CF: &str = "rewards";
-/// Column family for Blocktime
-const BLOCKTIME_CF: &str = "blocktime";
 
 macro_rules! convert_column_index_to_key_bytes {
     ($key:ident, $($range:expr => $bytes:expr),* $(,)?) => {{
@@ -1109,7 +1107,7 @@ impl ProtobufColumn for columns::Rewards {
 
 impl SlotColumn for columns::Blocktime {}
 impl ColumnName for columns::Blocktime {
-    const NAME: &'static str = BLOCKTIME_CF;
+    const NAME: &'static str = "blocktime";
 }
 impl TypedColumn for columns::Blocktime {
     type Type = UnixTimestamp;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family storing erasure metadata for a slot
-const ERASURE_META_CF: &str = "erasure_meta";
 // Column family for orphans data
 const ORPHANS_CF: &str = "orphans";
 /// Column family for bank hashes
@@ -1343,7 +1341,7 @@ impl Column for columns::ErasureMeta {
     }
 }
 impl ColumnName for columns::ErasureMeta {
-    const NAME: &'static str = ERASURE_META_CF;
+    const NAME: &'static str = "erasure_meta";
 }
 impl TypedColumn for columns::ErasureMeta {
     type Type = blockstore_meta::ErasureMeta;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-/// Column family for Code Shreds
-const CODE_SHRED_CF: &str = "code_shred";
 /// Column family for Transaction Status
 const TRANSACTION_STATUS_CF: &str = "transaction_status";
 /// Column family for Address Signatures
@@ -1187,7 +1185,7 @@ impl Column for columns::ShredCode {
     }
 }
 impl ColumnName for columns::ShredCode {
-    const NAME: &'static str = CODE_SHRED_CF;
+    const NAME: &'static str = "code_shred";
 }
 
 impl Column for columns::ShredData {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-/// Column family for bank hashes
-const BANK_HASH_CF: &str = "bank_hashes";
 // Column family for root data
 const ROOT_CF: &str = "root";
 /// Column family for indexes
@@ -1289,7 +1287,7 @@ impl TypedColumn for columns::Orphans {
 
 impl SlotColumn for columns::BankHash {}
 impl ColumnName for columns::BankHash {
-    const NAME: &'static str = BANK_HASH_CF;
+    const NAME: &'static str = "bank_hashes";
 }
 impl TypedColumn for columns::BankHash {
     type Type = blockstore_meta::FrozenHashVersioned;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family for slots that have been marked as dead
-const DEAD_SLOTS_CF: &str = "dead_slots";
 // Column family for storing proof that there were multiple
 // versions of a slot
 const DUPLICATE_SLOTS_CF: &str = "duplicate_slots";
@@ -1274,7 +1272,7 @@ impl TypedColumn for columns::Index {
 
 impl SlotColumn for columns::DeadSlots {}
 impl ColumnName for columns::DeadSlots {
-    const NAME: &'static str = DEAD_SLOTS_CF;
+    const NAME: &'static str = "dead_slots";
 }
 impl TypedColumn for columns::DeadSlots {
     type Type = bool;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,8 +56,6 @@ const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 //   include/rocksdb/advanced_options.h#L908C30-L908C30
 const PERIODIC_COMPACTION_SECONDS: u64 = 60 * 60 * 24;
 
-// Column family for orphans data
-const ORPHANS_CF: &str = "orphans";
 /// Column family for bank hashes
 const BANK_HASH_CF: &str = "bank_hashes";
 // Column family for root data
@@ -1283,7 +1281,7 @@ impl TypedColumn for columns::DuplicateSlots {
 
 impl SlotColumn for columns::Orphans {}
 impl ColumnName for columns::Orphans {
-    const NAME: &'static str = ORPHANS_CF;
+    const NAME: &'static str = "orphans";
 }
 impl TypedColumn for columns::Orphans {
     type Type = bool;


### PR DESCRIPTION
#### Problem
We declare a constant per column family, but the only use of that constant is setting the `NAME` constant in `ColumnName` trait. This is needlessly repetitive.

#### Summary of Changes
Drop the needless intermediate constants