### PR TITLE
Thread manager resource leak tracking improvements

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1822,7 +1822,9 @@ impl Validator {
         self.poh_timing_report_service
             .join()
             .expect("poh_timing_report_service");
-        self.thread_manager.destroy();
+        if let Err(e) = self.thread_manager.shutdown() {
+            warn!("Thread resource leak detected: {e:?}");
+        }
     }
 }
 

--- a/thread-manager/examples/core_contention_basics.rs
+++ b/thread-manager/examples/core_contention_basics.rs
@@ -54,11 +54,11 @@ fn main() -> anyhow::Result<()> {
             rx2.blocking_recv().unwrap();
 
             let join_handle =
-                scope.spawn(|| workload_runtime.block_on(workload_main(&[8888, 8889], 1000)));
+                scope.spawn(|| workload_runtime.block_on(workload_main(&[8888, 8889], 200)));
             join_handle.join().expect("Load generator crashed!")
         });
         //print out the results of the bench run
-        info!("Results are: {:?}", results);
+        info!("Results for {exp} are: {:?}", results);
     }
     Ok(())
 }

--- a/thread-manager/examples/core_contention_sweep.rs
+++ b/thread-manager/examples/core_contention_sweep.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
                 let jh = match regime {
                     Regime::Single => s.spawn(|| {
                         rx1.blocking_recv().unwrap();
-                        workload_runtime.block_on(workload_main(&[8888, 8888], 3000))
+                        workload_runtime.block_on(workload_main(&[8888, 8888], 200))
                     }),
                     _ => {
                         s.spawn(|| {
@@ -116,7 +116,7 @@ fn main() -> anyhow::Result<()> {
                         s.spawn(|| {
                             rx1.blocking_recv().unwrap();
                             rx2.blocking_recv().unwrap();
-                            workload_runtime.block_on(workload_main(&[8888, 8889], 3000))
+                            workload_runtime.block_on(workload_main(&[8888, 8889], 200))
                         })
                     }
                 };

--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -268,14 +268,14 @@ pub enum ShutdownError {
 
 #[cfg(test)]
 mod tests {
-    use {
-        crate::ThreadManagerConfig,
-        std::{io::Read, time::Duration},
-    };
     #[cfg(target_os = "linux")]
     use {
-        crate::{CoreAllocation, NativeConfig, RayonConfig, ThreadManager},
+        crate::{CoreAllocation, NativeConfig, RayonConfig},
         std::collections::HashMap,
+    };
+    use {
+        crate::{ThreadManager, ThreadManagerConfig},
+        std::{io::Read, time::Duration},
     };
 
     #[test]

--- a/thread-manager/src/tokio_runtime.rs
+++ b/thread-manager/src/tokio_runtime.rs
@@ -91,10 +91,8 @@ impl TokioRuntime {
         let counters = Arc::new(ThreadCounters {
             // no workaround, metrics crate will only consume 'static str
             namespace: format!("thread-manager-tokio-{}", &base_name).leak(),
-            total_threads_cnt: cfg.worker_threads as u64,
-            active_threads_cnt: AtomicU64::new(
-                (num_workers.wrapping_add(cfg.max_blocking_threads)) as u64,
-            ),
+            total_threads_cnt: num_workers as u64,
+            active_threads_cnt: AtomicU64::new(num_workers as u64),
         });
         builder
             .event_interval(cfg.event_interval)
@@ -157,7 +155,9 @@ impl TokioRuntime {
 #[derive(Debug)]
 pub struct ThreadCounters {
     pub namespace: &'static str,
+    // total worker threads
     pub total_threads_cnt: u64,
+    // active worker threads (does not count blocking threads)
     pub active_threads_cnt: AtomicU64,
 }
 


### PR DESCRIPTION
#### Problem
In https://github.com/anza-xyz/agave/pull/4603 it was suggested that resource leakage tracking be improved, specifically around leaked threads during validator shutdown. This PR addresses this requirement.

#### Summary of Changes

* Added reporting for number of leaked threads
* Added unittests for thread leakage report
* Suppress spurious errors in benchmarks that sometimes resulted in crashes

