### PR TITLE
blockstore: Defer multi_get_bytes() allocation to caller

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1468,11 +1468,12 @@ pub struct WriteBatch {
     write_batch: RWriteBatch,
 }
 
-pub struct BlockstoreByteReference<'a> {
+pub(crate) struct BlockstoreByteReference<'a> {
     slice: DBPinnableSlice<'a>,
 }
 
 impl<'a> From<DBPinnableSlice<'a>> for BlockstoreByteReference<'a> {
+    #[inline]
     fn from(slice: DBPinnableSlice<'a>) -> Self {
         Self { slice }
     }
@@ -1481,6 +1482,7 @@ impl<'a> From<DBPinnableSlice<'a>> for BlockstoreByteReference<'a> {
 impl std::ops::Deref for BlockstoreByteReference<'_> {
     type Target = [u8];
 
+    #[inline]
     fn deref(&self) -> &[u8] {
         &self.slice
     }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1468,6 +1468,31 @@ pub struct WriteBatch {
     write_batch: RWriteBatch,
 }
 
+pub struct BlockstoreByteReference<'a> {
+    slice: DBPinnableSlice<'a>,
+}
+
+impl<'a> From<DBPinnableSlice<'a>> for BlockstoreByteReference<'a> {
+    fn from(slice: DBPinnableSlice<'a>) -> Self {
+        Self { slice }
+    }
+}
+
+impl std::ops::Deref for BlockstoreByteReference<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.slice
+    }
+}
+
+impl AsRef<[u8]> for BlockstoreByteReference<'_> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
 impl WriteBatch {
     fn put_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K, value: &[u8]) -> Result<()> {
         self.write_batch.put_cf(cf, key, value);
@@ -1522,7 +1547,7 @@ where
     pub(crate) fn multi_get_bytes<'a, K>(
         &'a self,
         keys: impl IntoIterator<Item = &'a K> + 'a,
-    ) -> impl Iterator<Item = Result<Option<Vec<u8>>>> + 'a
+    ) -> impl Iterator<Item = Result<Option<BlockstoreByteReference<'a>>>> + 'a
     where
         K: AsRef<[u8]> + 'a + ?Sized,
     {
@@ -1534,10 +1559,9 @@ where
         let result = self
             .backend
             .multi_get_cf(self.handle(), keys)
-            .map(|out| Ok(out?.as_deref().map(<[u8]>::to_vec)));
+            .map(|out| Ok(out?.map(BlockstoreByteReference::from)));
 
         if let Some(op_start_instant) = is_perf_enabled {
-            // use multi-get instead
             report_rocksdb_read_perf(
                 C::NAME,
                 PERF_METRIC_OP_NAME_MULTI_GET,


### PR DESCRIPTION
#### Problem
`multi_get_bytes()` currently returns owned memory (`Vec<u8>`). But, the callers of `multi_get_bytes()` only require borrowed memory (`&[u8]`).

#### Summary of Changes
So, `update multi_get_bytes()` to return a reference to rocksdb owned memory; the caller can copy to owned memory if they require it

#### Future Work
Some similar work can likely be done with other methods that call `.get_bytes()`. For example, this one here:
https://github.com/anza-xyz/agave/blob/e48672c122baf62e936d4d489d20ff7ad7ba53f9/ledger/src/blockstore.rs#L2266-L2268

However, the call to `ShredData::resize_stored_shred` requires owned memory, but is only applicable to legacy data shreds as far as I know. Additional rework beyond just changing the underlying rocksdb type will be necessary, so I plan to tackle those in a follow-on PR