### PR TITLE
svm: `AccountLoader::load_account()` refactor

### DIFF
--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -186,8 +186,9 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
 
     // Load an account either from our own store or accounts-db and inspect it on behalf of Bank.
     // Inspection is required prior to any modifications to the account. This function is used
-    // in transaction loading for that purpose. It returns a different type than other load functions,
-    // which should prevent accidental mix and match of them.
+    // by load_transaction() and validate_transaction_fee_payer() for that purpose. It returns
+    // a different type than other AccountLoader load functions, which should prevent accidental
+    // mix and match of them.
     pub(crate) fn load_transaction_account(
         &mut self,
         account_key: &Pubkey,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -151,7 +151,7 @@ pub struct FeesOnlyTransaction {
 // transaction batch and obviates the need to load accounts from accounts-db
 // more than once. It effectively wraps an `impl TransactionProcessingCallback`
 // type, and itself implements `TransactionProcessingCallback`, behaving
-// exactly like the `Bank` impl of this trait but also returns up-to-date
+// exactly like the implementor of the trait, but also returning up-to-date
 // account states mid-batch.
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
     loaded_accounts: AHashMap<Pubkey, AccountSharedData>,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -147,13 +147,20 @@ pub struct FeesOnlyTransaction {
     pub fee_details: FeeDetails,
 }
 
-#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
+// This is an internal SVM type that tracks account changes throughout a
+// transaction batch and obviates the need to load accounts from accounts-db
+// more than once. It effectively wraps an `impl TransactionProcessingCallback`
+// type, and itself implements `TransactionProcessingCallback`, behaving
+// exactly like the `Bank` impl of this trait but also returns up-to-date
+// account states mid-batch.
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
     account_cache: AHashMap<Pubkey, AccountSharedData>,
     callbacks: &'a CB,
     pub(crate) feature_set: &'a SVMFeatureSet,
 }
+
 impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
+    // create a new AccountLoader for the transaction batch
     pub(crate) fn new_with_account_cache_capacity(
         account_overrides: Option<&'a AccountOverrides>,
         callbacks: &'a CB,
@@ -177,26 +184,16 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         }
     }
 
-    pub(crate) fn load_account(
+    // Load an account either from our own store or accounts-db and inspect it on behalf of Bank.
+    // Inspection is required prior to any modifications to the account. This function is used
+    // in transaction loading for that purpose. It returns a different type than other load functions,
+    // which should prevent accidental mix and match of them.
+    pub(crate) fn load_transaction_account(
         &mut self,
         account_key: &Pubkey,
         is_writable: bool,
     ) -> Option<LoadedTransactionAccount> {
-        let account = if let Some(account) = self.account_cache.get(account_key) {
-            // If lamports is 0, a previous transaction deallocated this account.
-            // We return None instead of the account we found so it can be created fresh.
-            // We never evict from the cache, or else we would fetch stale state from accounts-db.
-            if account.lamports() == 0 {
-                None
-            } else {
-                Some(account.clone())
-            }
-        } else if let Some(account) = self.callbacks.get_account_shared_data(account_key) {
-            self.account_cache.insert(*account_key, account.clone());
-            Some(account)
-        } else {
-            None
-        };
+        let account = self.load_account(account_key);
 
         // Inspect prior to collecting rent, since rent collection can modify the account.
         self.callbacks.inspect_account(
@@ -214,6 +211,41 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             account,
             rent_collected: 0,
         })
+    }
+
+    // Load an account as above, with no inspection and no LoadedTransactionAccount wrapper.
+    // This is a general purpose function suitable for usage outside initial transaction loading.
+    pub(crate) fn load_account(&mut self, account_key: &Pubkey) -> Option<AccountSharedData> {
+        match self.do_load(account_key) {
+            (Some(account), true) => {
+                self.account_cache.insert(*account_key, account.clone());
+                Some(account)
+            }
+            (account, false) => account,
+            (None, true) => unreachable!(),
+        }
+    }
+
+    // Internal helper for core loading logic to prevent code duplication. Returns a bool
+    // indicating whether the account came from accounts-db, which allows wrappers with
+    // &mut self to insert the account. Wrappers with &self ignore it.
+    fn do_load(&self, account_key: &Pubkey) -> (Option<AccountSharedData>, bool) {
+        if let Some(account) = self.account_cache.get(account_key) {
+            // If lamports is 0, a previous transaction deallocated this account.
+            // We return None instead of the account we found so it can be created fresh.
+            // We *never* remove accounts, or else we would fetch stale state from accounts-db.
+            let option_account = if account.lamports() == 0 {
+                None
+            } else {
+                Some(account.clone())
+            };
+
+            (option_account, false)
+        } else if let Some(account) = self.callbacks.get_account_shared_data(account_key) {
+            (Some(account), true)
+        } else {
+            (None, false)
+        }
     }
 
     pub(crate) fn update_accounts_for_executed_tx(
@@ -481,11 +513,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
 
             let program_index = instruction.program_id_index as usize;
 
-            let Some(LoadedTransactionAccount {
-                account: program_account,
-                ..
-            }) = account_loader.load_account(program_id, false)
-            else {
+            let Some(program_account) = account_loader.load_account(program_id) else {
                 error_metrics.account_not_found += 1;
                 return Err(TransactionError::ProgramAccountNotFound);
             };
@@ -522,12 +550,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 // and SIMD-186 are active, we do not need to load loaders at all to comply with consensus rules
                 // we may verify program ids are owned by `PROGRAM_OWNERS` purely as an optimization
                 // this could even be done before loading the rest of the accounts for a transaction
-                if let Some(LoadedTransactionAccount {
-                    account: owner_account,
-                    loaded_size: owner_size,
-                    ..
-                }) = account_loader.load_account(owner_id, false)
-                {
+                if let Some(owner_account) = account_loader.load_account(owner_id) {
                     if !native_loader::check_id(owner_account.owner())
                         || (!account_loader
                             .feature_set
@@ -539,7 +562,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     }
                     accumulate_and_check_loaded_account_data_size(
                         &mut accumulated_accounts_data_size,
-                        owner_size,
+                        owner_account.data().len(),
                         loaded_accounts_bytes_limit,
                         error_metrics,
                     )?;
@@ -578,7 +601,9 @@ fn load_transaction_account<CB: TransactionProcessingCallback>(
             account: construct_instructions_account(message),
             rent_collected: 0,
         }
-    } else if let Some(mut loaded_account) = account_loader.load_account(account_key, is_writable) {
+    } else if let Some(mut loaded_account) =
+        account_loader.load_transaction_account(account_key, is_writable)
+    {
         loaded_account.rent_collected = if is_writable {
             collect_rent_from_account(
                 account_loader.feature_set,
@@ -2226,11 +2251,7 @@ mod tests {
             // *not* key0, since it is loaded during fee payer validation
             (address1, vec![(Some(account1), true)]),
             (address2, vec![(None, true)]),
-            (
-                address3,
-                vec![(Some(account3.clone()), false), (Some(account3), false)],
-            ),
-            (bpf_loader::id(), vec![(None, false)]),
+            (address3, vec![(Some(account3), false)]),
         ];
         expected_inspected_accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -316,12 +316,6 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     }
 }
 
-// HANA TODO i might want to break txpcb into two traits rather than do this
-impl<CB: TransactionProcessingCallback> solana_svm_callback::InvokeContextCallback
-    for AccountLoader<'_, CB>
-{
-}
-
 // Program loaders and parsers require a type that impls TransactionProcessingCallback,
 // because they are used in both SVM and by Bank. We impl it, with the consequence
 // that if we fall back to accounts-db, we cannot store the state for future loads.
@@ -337,6 +331,14 @@ impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for Accoun
             .0
             .and_then(|account| owners.iter().position(|entry| entry == account.owner()))
     }
+}
+
+// NOTE this is a required subtrait of TransactionProcessingCallback.
+// It may make sense to break out a second subtrait just for the above two functions,
+// but this would be a nontrivial breaking change and require careful consideration.
+impl<CB: TransactionProcessingCallback> solana_svm_callback::InvokeContextCallback
+    for AccountLoader<'_, CB>
+{
 }
 
 /// Collect rent from an account if rent is still enabled and regardless of

--- a/svm/src/transaction_balances.rs
+++ b/svm/src/transaction_balances.rs
@@ -86,11 +86,7 @@ impl BalanceCollector {
         let has_token_program = transaction.account_keys().iter().any(is_known_spl_token_id);
 
         for (index, key) in transaction.account_keys().iter().enumerate() {
-            // we load as read-only to avoid triggering a bad account inspection
-            let Some(account) = account_loader
-                .load_account(key, false)
-                .map(|loaded| loaded.account)
-            else {
+            let Some(account) = account_loader.load_account(key) else {
                 native_balances.push(0);
                 continue;
             };
@@ -190,8 +186,7 @@ impl SvmTokenInfo {
             amount,
         } = generic_token::Account::unpack(account.data(), &program_id)?;
 
-        // we load as read-only to avoid triggering a bad account inspection
-        let mint_account = account_loader.load_account(&mint, false)?.account;
+        let mint_account = account_loader.load_account(&mint)?;
         if *mint_account.owner() != program_id {
             return None;
         }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -383,7 +383,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let account_keys_in_batch = sanitized_txs.iter().map(|tx| tx.account_keys().len()).sum();
 
         // Create the account loader, which wraps all external account fetching.
-        let mut account_loader = AccountLoader::new_with_account_cache_capacity(
+        let mut account_loader = AccountLoader::new_with_loaded_accounts_capacity(
             config.account_overrides,
             callbacks,
             &environment.feature_set,
@@ -1224,7 +1224,7 @@ mod tests {
 
     impl<'a> From<&'a MockBankCallback> for AccountLoader<'a, MockBankCallback> {
         fn from(callbacks: &'a MockBankCallback) -> AccountLoader<'a, MockBankCallback> {
-            AccountLoader::new_with_account_cache_capacity(
+            AccountLoader::new_with_loaded_accounts_capacity(
                 None,
                 callbacks,
                 &callbacks.feature_set,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -632,6 +632,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // We must validate the account in case it was reopened, either as a normal system account,
         // or a fake nonce account. We must also check the signer in case the authority was changed.
         //
+        // We do not need to inspect the nonce account here, because by definition it is either the
+        // first account, inspected in `validate_transaction_fee_payer()`, or the second through nth
+        // account, inspected in `load_transaction()`.
+        //
         // Note these checks are *not* obviated by fee-only transactions.
         let nonce_is_valid = account_loader
             .load_account(nonce_info.address())

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2446,12 +2446,6 @@ impl InspectedAccounts {
     fn inspect(&mut self, pubkey: Pubkey, inspect: Inspect) {
         self.0.entry(pubkey).or_default().push(inspect.into())
     }
-
-    fn inspect_n(&mut self, pubkey: Pubkey, inspect: Inspect, times: usize) {
-        for _ in 0..times {
-            self.inspect(pubkey, inspect.clone());
-        }
-    }
 }
 
 #[test]
@@ -2493,11 +2487,7 @@ fn svm_inspect_account() {
         true,
         0,
     );
-    expected_inspected_accounts.inspect_n(
-        system_program::id(),
-        Inspect::LiveRead(&system_account),
-        2,
-    );
+    expected_inspected_accounts.inspect(system_program::id(), Inspect::LiveRead(&system_account));
 
     let transfer_amount = 1_000_000;
     let transaction = Transaction::new_signed_with_payer(
@@ -2559,11 +2549,7 @@ fn svm_inspect_account() {
     );
 
     // system program
-    expected_inspected_accounts.inspect_n(
-        system_program::id(),
-        Inspect::LiveRead(&system_account),
-        2,
-    );
+    expected_inspected_accounts.inspect(system_program::id(), Inspect::LiveRead(&system_account));
 
     let mut final_test_entry = SvmTestEntry {
         initial_accounts: initial_test_entry.final_accounts.clone(),


### PR DESCRIPTION
#### Problem
the program cache refactor (#6036) requires `AccountLoader` for loading program accounts in functions that are shared with `runtime` . the cleanest way to do this is to `impl TransactionProcessingCallback for AccountLoader`

the trick is that `AccountLoader` updates its internal store with a mut ref, but TXPCB requires an immut ref previously in this pr we attempted to do this by adding interior mutability in `AccountLoader`, but this was deemed undesirable

also, it is a bit cumbersome for `load_account()` to accept a bool everywhere. usually we pass in `false` and it has no effect, but a `true` in the wrong place could cause bankhash to break. and finally it is annoying that we inspect accounts everywhere we use `AccountLoader` when really this only needs to be done once per transaction

#### Summary of Changes
the elegant solution to all these is to cleanly divide up the kinds of loading possible:
* `pub fn load_transaction_account(&mut self, ...)`: a renamed version of the existing `load_account()`, which loads from accounts-db or our store, adds to our store if it came from accounts-db, inspects on behalf of bank, and wraps in a `LoadedTransactionAccount`
* `pub fn load_account(&mut self, ...)`: a new function that loads and stores but does not inspect or wrap
* `pub fn get_account_shared_data(&self, ...)`: the TXPCB trait function, which loads and does not store, inspect, or wrap
* `fn do_load(&self, ...)`: a private helper used by all three, so that the load `match` is not copy-pasted anywhere, because it is crucial that it behaves predictably across all variant interfaces

despite the added complexity, this is mostly foolproof. as long as you use `load_transaction_account()` for transaction loading (inspecting any writable accounts before they are written to) it really doesnt matter which function you use anywhere else, they all have the same correctness

also im renaming `account_cache` to `loaded_accounts`. this was a very ill-chosen name. the intermediate `AccountLoader` store a) does not evict, and b) never becomes stale. so its not technically a cache, its just a memoization layer