### PR TITLE
cli: demote solana-sdk to dev deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,6 +6811,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-memo",
+ "static_assertions",
  "tempfile",
  "test-case",
  "thiserror 2.0.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,7 +6811,6 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-memo",
- "static_assertions",
  "tempfile",
  "test-case",
  "thiserror 2.0.11",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -69,7 +69,6 @@ solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true, features = ["clap"] }
 solana-sbpf = { workspace = true }
-solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
@@ -95,6 +94,7 @@ solana-faucet = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
 solana-rpc = { workspace = true }
+solana-sdk = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -98,7 +98,6 @@ solana-sdk = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
-static_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -98,6 +98,7 @@ solana-sdk = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
+static_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -78,12 +78,6 @@ use {
 
 const DEFAULT_RPC_PORT_STR: &str = "8899";
 
-#[cfg(test)]
-static_assertions::const_assert_eq!(
-    DEFAULT_RPC_PORT_STR,
-    solana_sdk::rpc_port::DEFAULT_RPC_PORT_STR
-);
-
 pub trait ClusterQuerySubCommands {
     fn cluster_query_subcommands(self) -> Self;
 }
@@ -2440,5 +2434,13 @@ mod tests {
                 signers: vec![Box::new(default_keypair)],
             }
         );
+    }
+
+    #[test]
+    fn check_default_rpc_port_inline() {
+        assert_eq!(
+            DEFAULT_RPC_PORT_STR,
+            solana_sdk::rpc_port::DEFAULT_RPC_PORT_STR
+        )
     }
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -50,7 +50,6 @@ use {
         request::DELINQUENT_VALIDATOR_SLOT_DISTANCE,
         response::{RpcPerfSample, RpcPrioritizationFee, SlotInfo},
     },
-    solana_sdk::rpc_port::DEFAULT_RPC_PORT_STR,
     solana_sdk_ids::sysvar::{self, stake_history},
     solana_signature::Signature,
     solana_slot_history::{self as slot_history, SlotHistory},
@@ -76,6 +75,14 @@ use {
     },
     thiserror::Error,
 };
+
+const DEFAULT_RPC_PORT_STR: &str = "8899";
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    DEFAULT_RPC_PORT_STR,
+    solana_sdk::rpc_port::DEFAULT_RPC_PORT_STR
+);
 
 pub trait ClusterQuerySubCommands {
     fn cluster_query_subcommands(self) -> Self;

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -21,7 +21,7 @@ use {
     solana_feature_gate_client::{
         errors::SolanaFeatureGateError, instructions::RevokePendingActivation,
     },
-    solana_feature_gate_interface::Feature,
+    solana_feature_gate_interface::{activate_with_lamports, from_account, Feature},
     solana_feature_set::FEATURE_NAMES,
     solana_message::Message,
     solana_pubkey::Pubkey,
@@ -31,7 +31,6 @@ use {
         client_error::Error as ClientError, request::MAX_MULTIPLE_ACCOUNTS,
         response::RpcVoteAccountInfo,
     },
-    solana_sdk::feature,
     solana_sdk_ids::{incinerator, system_program},
     solana_system_interface::error::SystemError,
     solana_transaction::Transaction,
@@ -878,7 +877,7 @@ fn feature_activation_allowed(
 }
 
 pub(super) fn status_from_account(account: Account) -> Option<CliFeatureStatus> {
-    feature::from_account(&account).map(|feature| match feature.activated_at {
+    from_account(&account).map(|feature| match feature.activated_at {
         None => CliFeatureStatus::Pending,
         Some(activation_slot) => CliFeatureStatus::Active(activation_slot),
     })
@@ -1000,7 +999,7 @@ fn process_activate(
         .unwrap();
 
     if let Some(account) = account {
-        if feature::from_account(&account).is_some() {
+        if from_account(&account).is_some() {
             return Err(format!("{feature_id} has already been activated").into());
         }
     }
@@ -1033,7 +1032,7 @@ fn process_activate(
         ComputeUnitLimit::Default,
         |lamports| {
             Message::new(
-                &feature::activate_with_lamports(&feature_id, &fee_payer.pubkey(), lamports),
+                &activate_with_lamports(&feature_id, &fee_payer.pubkey(), lamports),
                 Some(&fee_payer.pubkey()),
             )
         },


### PR DESCRIPTION
#### Problem
This crate no longer needs all of solana-sdk

#### Summary of Changes
- Replace with constituent crates
- inline the `DEFAULT_RPC_PORT_STR` const and add a test to ensure it's the same as what's in solana-sdk
