### PR TITLE
reduce memory copying in tpu-client-next

### DIFF
--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -26,13 +26,13 @@ impl TransactionBatch {
     where
         T: AsRef<[u8]> + Send + 'static,
     {
-        let txs = wired_transactions
+        let wired_transactions = wired_transactions
             .into_iter()
             .map(|v| Bytes::from_owner(v))
             .collect();
 
         Self {
-            wired_transactions: txs,
+            wired_transactions,
             timestamp: timestamp(),
         }
     }

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -1,19 +1,20 @@
 //! This module holds [`TransactionBatch`] structure.
 
-use solana_time_utils::timestamp;
+use {solana_time_utils::timestamp, tokio_util::bytes::Bytes};
 
 /// Batch of generated transactions timestamp is used to discard batches which
 /// are too old to have valid blockhash.
 #[derive(Clone, PartialEq)]
 pub struct TransactionBatch {
     wired_transactions: Vec<WiredTransaction>,
+    // Time of creation of this batch, used for batch timeouts
     timestamp: u64,
 }
 
-type WiredTransaction = Vec<u8>;
+type WiredTransaction = Bytes;
 
 impl IntoIterator for TransactionBatch {
-    type Item = Vec<u8>;
+    type Item = Bytes;
     type IntoIter = std::vec::IntoIter<Self::Item>;
     fn into_iter(self) -> Self::IntoIter {
         self.wired_transactions.into_iter()
@@ -21,9 +22,17 @@ impl IntoIterator for TransactionBatch {
 }
 
 impl TransactionBatch {
-    pub fn new(wired_transactions: Vec<WiredTransaction>) -> Self {
+    pub fn new<T>(wired_transactions: Vec<T>) -> Self
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        let txs = wired_transactions
+            .into_iter()
+            .map(|v| Bytes::from_owner(v))
+            .collect();
+
         Self {
-            wired_transactions,
+            wired_transactions: txs,
             timestamp: timestamp(),
         }
     }


### PR DESCRIPTION
#### Problem
Tpu-client-next would clone transaction bytes into multiple (5-8) queues to ensure reliable delivery. This created quite a bit of memory copying. 

#### Summary of Changes

- Change the TransactionBatch implementation to be able to consume any  AsRef<[u8]> object and not just Vec<u8>
- Use Bytes objects instead of Vecs to enable cheap copies.