### PR TITLE
Refactor - loader v4 `SetProgramLength`

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1738,12 +1738,9 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
     let deployment_instruction = deployment_instructions.pop().unwrap();
     let signers: &[&[&Keypair]] = &[
         &[&mint_keypair, &source_program_keypair],
-        &[&mint_keypair, &source_program_keypair, &authority_keypair],
         &[&mint_keypair, &authority_keypair],
     ];
-    let signers = std::iter::once(signers[0])
-        .chain(std::iter::once(signers[1]))
-        .chain(std::iter::repeat(signers[2]));
+    let signers = std::iter::once(signers[0]).chain(std::iter::repeat(signers[1]));
     for (instruction, signers) in deployment_instructions.into_iter().zip(signers) {
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         bank_client
@@ -2065,16 +2062,9 @@ fn test_program_sbf_upgrade() {
     );
     let signers: &[&[&Keypair]] = &[
         &[&mint_keypair, &source_program_keypair],
-        &[
-            &mint_keypair,
-            &source_program_keypair,
-            &new_authority_keypair,
-        ],
         &[&mint_keypair, &new_authority_keypair],
     ];
-    let signers = std::iter::once(signers[0])
-        .chain(std::iter::once(signers[1]))
-        .chain(std::iter::repeat(signers[2]));
+    let signers = std::iter::once(signers[0]).chain(std::iter::repeat(signers[1]));
     for (instruction, signers) in deployment_instructions.into_iter().zip(signers) {
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         bank_client
@@ -2179,16 +2169,9 @@ fn test_program_sbf_upgrade_via_cpi() {
     let mut upgrade_instruction = deployment_instructions.pop().unwrap();
     let signers: &[&[&Keypair]] = &[
         &[&mint_keypair, &source_program_keypair],
-        &[
-            &mint_keypair,
-            &source_program_keypair,
-            &new_authority_keypair,
-        ],
         &[&mint_keypair, &new_authority_keypair],
     ];
-    let signers = std::iter::once(signers[0])
-        .chain(std::iter::once(signers[1]))
-        .chain(std::iter::repeat(signers[2]));
+    let signers = std::iter::once(signers[0]).chain(std::iter::repeat(signers[1]));
     for (instruction, signers) in deployment_instructions.into_iter().zip(signers) {
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         bank_client

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -282,7 +282,7 @@ pub fn instructions_to_load_program_of_loader_v4<T: Client>(
         ));
         program_keypair
     });
-    instructions.push(loader_v4::truncate_uninitialized(
+    instructions.push(loader_v4::set_program_length(
         &program_keypair.pubkey(),
         &authority_keypair.pubkey(),
         program.len() as u32,
@@ -328,12 +328,9 @@ pub fn load_program_of_loader_v4(
     );
     let signers: &[&[&Keypair]] = &[
         &[payer_keypair, &program_keypair],
-        &[payer_keypair, &program_keypair, authority_keypair],
         &[payer_keypair, authority_keypair],
     ];
-    let signers = std::iter::once(signers[0])
-        .chain(std::iter::once(signers[1]))
-        .chain(std::iter::repeat(signers[2]));
+    let signers = std::iter::once(signers[0]).chain(std::iter::repeat(signers[1]));
     for (instruction, signers) in instructions.into_iter().zip(signers) {
         let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client

--- a/sdk/program/src/loader_v4.rs
+++ b/sdk/program/src/loader_v4.rs
@@ -2,9 +2,11 @@
 pub use solana_loader_v4_interface::{
     instruction::{
         create_buffer, deploy, deploy_from_source, finalize, is_deploy_instruction,
-        is_finalize_instruction, is_retract_instruction, is_transfer_authority_instruction,
-        is_truncate_instruction, is_write_instruction, retract, transfer_authority, truncate,
-        truncate_uninitialized, write,
+        is_finalize_instruction, is_retract_instruction, is_set_program_length_instruction,
+        is_set_program_length_instruction as is_truncate_instruction,
+        is_transfer_authority_instruction, is_write_instruction, retract,
+        set_program_length as truncate, set_program_length as truncate_uninitialized,
+        set_program_length, transfer_authority, write,
     },
     state::{LoaderV4State, LoaderV4Status},
     DEPLOYMENT_COOLDOWN_IN_SLOTS,


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/4661#discussion_r1932263401

#### Summary of Changes

- Renames `LoaderV4Instruction::Truncate` to `LoaderV4Instruction::SetProgramLength`
- Removes the check that the program is a signer on the initial invocation of `LoaderV4Instruction::SetProgramLength`
- Makes the recipient optional, but only if the program is not being closed (size set to zero)