### PR TITLE
encapsulates shred's payload type

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -23,10 +23,11 @@ pub fn repair_response_packet(
 }
 
 pub fn repair_response_packet_from_bytes(
-    bytes: Vec<u8>,
+    bytes: impl AsRef<[u8]>,
     dest: &SocketAddr,
     nonce: Nonce,
 ) -> Option<Packet> {
+    let bytes = bytes.as_ref();
     let mut packet = Packet::default();
     let size = bytes.len() + SIZE_OF_NONCE;
     if size > packet.buffer_mut().len() {
@@ -34,7 +35,7 @@ pub fn repair_response_packet_from_bytes(
     }
     packet.meta_mut().size = size;
     packet.meta_mut().set_socket_addr(dest);
-    packet.buffer_mut()[..bytes.len()].copy_from_slice(&bytes);
+    packet.buffer_mut()[..bytes.len()].copy_from_slice(bytes);
     let mut wr = io::Cursor::new(&mut packet.buffer_mut()[bytes.len()..]);
     bincode::serialize_into(&mut wr, &nonce).expect("Buffer not large enough to fit nonce");
     Some(packet)

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -50,7 +50,6 @@ use {
     tokio::sync::mpsc::Sender as AsyncSender,
 };
 
-type ShredPayload = Vec<u8>;
 type DuplicateSlotSender = Sender<Slot>;
 pub(crate) type DuplicateSlotReceiver = Receiver<Slot>;
 
@@ -202,7 +201,7 @@ fn run_check_duplicate(
                     existing_shred_payload.clone(),
                     shred.clone().into_payload(),
                 )?;
-                (shred, existing_shred_payload)
+                (shred, shred::Payload::from(existing_shred_payload))
             }
         };
 
@@ -261,7 +260,7 @@ fn run_insert<F>(
     metrics: &mut BlockstoreInsertionMetrics,
     ws_metrics: &mut WindowServiceMetrics,
     completed_data_sets_sender: Option<&CompletedDataSetsSender>,
-    retransmit_sender: &Sender<Vec<ShredPayload>>,
+    retransmit_sender: &Sender<Vec<shred::Payload>>,
     outstanding_requests: &RwLock<OutstandingShredRepairs>,
     reed_solomon_cache: &ReedSolomonCache,
     accept_repairs_only: bool,
@@ -354,7 +353,7 @@ impl WindowService {
     pub(crate) fn new(
         blockstore: Arc<Blockstore>,
         verified_receiver: Receiver<Vec<PacketBatch>>,
-        retransmit_sender: Sender<Vec<ShredPayload>>,
+        retransmit_sender: Sender<Vec<shred::Payload>>,
         repair_socket: Arc<UdpSocket>,
         ancestor_hashes_socket: Arc<UdpSocket>,
         repair_request_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -462,7 +461,7 @@ impl WindowService {
         verified_receiver: Receiver<Vec<PacketBatch>>,
         check_duplicate_sender: Sender<PossibleDuplicateShred>,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
-        retransmit_sender: Sender<Vec<ShredPayload>>,
+        retransmit_sender: Sender<Vec<shred::Payload>>,
         outstanding_requests: Arc<RwLock<OutstandingShredRepairs>>,
         accept_repairs_only: bool,
     ) -> JoinHandle<()> {

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -201,10 +201,10 @@ where
     Err(Error::InvalidErasureMetaConflict)
 }
 
-pub(crate) fn from_shred<F>(
+pub(crate) fn from_shred<T: AsRef<[u8]>, F>(
     shred: Shred,
     self_pubkey: Pubkey, // Pubkey of my node broadcasting crds value.
-    other_payload: Vec<u8>,
+    other_payload: T,
     leader_schedule: Option<F>,
     wallclock: u64,
     max_size: usize, // Maximum serialized size of each DuplicateShred.
@@ -212,8 +212,9 @@ pub(crate) fn from_shred<F>(
 ) -> Result<impl Iterator<Item = DuplicateShred>, Error>
 where
     F: FnOnce(Slot) -> Option<Pubkey>,
+    shred::Payload: From<T>,
 {
-    if shred.payload() == &other_payload {
+    if shred.payload().as_ref() == other_payload.as_ref() {
         return Err(Error::InvalidDuplicateShreds);
     }
     let other_shred = Shred::new_from_serialized_shred(other_payload)?;

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -16,7 +16,7 @@ use {
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreError},
         blockstore_meta::{DuplicateSlotProof, ErasureMeta},
-        shred::{Shred, ShredType},
+        shred::{self, Shred, ShredType},
     },
     solana_runtime::bank::{Bank, TotalAccountsStats},
     solana_sdk::{
@@ -408,7 +408,7 @@ impl From<Shred> for CliDuplicateShred {
             merkle_root: shred.merkle_root().ok(),
             chained_merkle_root: shred.chained_merkle_root().ok(),
             last_in_slot: shred.last_in_slot(),
-            payload: shred.payload().clone(),
+            payload: shred::Payload::unwrap_or_clone(shred.payload().clone()),
         }
     }
 }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         blockstore::MAX_DATA_SHREDS_PER_SLOT,
-        shred::{Shred, ShredType},
+        shred::{self, Shred, ShredType},
     },
     bitflags::bitflags,
     serde::{Deserialize, Deserializer, Serialize, Serializer},
@@ -224,10 +224,10 @@ pub struct MerkleRootMeta {
 
 #[derive(Deserialize, Serialize)]
 pub struct DuplicateSlotProof {
-    #[serde(with = "serde_bytes")]
-    pub shred1: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub shred2: Vec<u8>,
+    #[serde(with = "shred::serde_bytes_payload")]
+    pub shred1: shred::Payload,
+    #[serde(with = "shred::serde_bytes_payload")]
+    pub shred2: shred::Payload,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -774,8 +774,14 @@ impl MerkleRootMeta {
 }
 
 impl DuplicateSlotProof {
-    pub(crate) fn new(shred1: Vec<u8>, shred2: Vec<u8>) -> Self {
-        DuplicateSlotProof { shred1, shred2 }
+    pub(crate) fn new<S, T>(shred1: S, shred2: T) -> Self
+    where
+        shred::Payload: From<S> + From<T>,
+    {
+        DuplicateSlotProof {
+            shred1: shred::Payload::from(shred1),
+            shred2: shred::Payload::from(shred2),
+        }
     }
 }
 

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -36,12 +36,12 @@ macro_rules! impl_shred_common {
         }
 
         #[inline]
-        fn payload(&self) -> &Vec<u8> {
+        fn payload(&self) -> &Payload {
             &self.payload
         }
 
         #[inline]
-        fn into_payload(self) -> Vec<u8> {
+        fn into_payload(self) -> Payload {
             self.payload
         }
 

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -1,0 +1,71 @@
+use std::ops::{Deref, DerefMut};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Payload(Vec<u8>);
+
+macro_rules! dispatch {
+    ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
+        #[inline]
+        $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
+            self.0.$name($($arg, )?)
+        }
+    };
+}
+
+impl Payload {
+    #[inline]
+    pub(super) fn make_mut(this: &mut Self) -> &mut Vec<u8> {
+        &mut this.0
+    }
+
+    #[inline]
+    pub fn unwrap_or_clone(this: Self) -> Vec<u8> {
+        this.0
+    }
+}
+
+pub(crate) mod serde_bytes_payload {
+    use {
+        super::*,
+        serde::{Deserialize, Deserializer, Serializer},
+        serde_bytes::ByteBuf,
+    };
+
+    pub(crate) fn serialize<S: Serializer>(
+        payload: &Payload,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(payload)
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Payload, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer)
+            .map(ByteBuf::into_vec)
+            .map(Payload::from)
+    }
+}
+
+impl From<Vec<u8>> for Payload {
+    #[inline]
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl AsRef<[u8]> for Payload {
+    dispatch!(fn as_ref(&self) -> &[u8]);
+}
+
+impl Deref for Payload {
+    type Target = [u8];
+    dispatch!(fn deref(&self) -> &Self::Target);
+}
+
+impl DerefMut for Payload {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Payload::make_mut(self)
+    }
+}

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -2,6 +2,7 @@ use {
     crate::shred::{
         common::dispatch,
         legacy, merkle,
+        payload::Payload,
         traits::{Shred, ShredCode as ShredCodeTrait},
         CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
         DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
@@ -31,8 +32,8 @@ impl ShredCode {
     dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);
-    dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
-    dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
+    dispatch!(pub(super) fn into_payload(self) -> Payload);
+    dispatch!(pub(super) fn payload(&self) -> &Payload);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -3,6 +3,7 @@ use {
         self,
         common::dispatch,
         legacy, merkle,
+        payload::Payload,
         traits::{Shred as _, ShredData as ShredDataTrait},
         DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant, SignedData,
         MAX_DATA_SHREDS_PER_SLOT,
@@ -23,9 +24,9 @@ impl ShredData {
     dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
     dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
-    dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
+    dispatch!(pub(super) fn into_payload(self) -> Payload);
     dispatch!(pub(super) fn parent(&self) -> Result<Slot, Error>);
-    dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
+    dispatch!(pub(super) fn payload(&self) -> &Payload);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -1,5 +1,7 @@
 use {
-    crate::shred::{CodingShredHeader, DataShredHeader, Error, ShredCommonHeader},
+    crate::shred::{
+        payload::Payload, CodingShredHeader, DataShredHeader, Error, ShredCommonHeader,
+    },
     solana_sdk::{clock::Slot, signature::Signature},
 };
 
@@ -12,14 +14,16 @@ pub(super) trait Shred<'a>: Sized {
 
     type SignedData: AsRef<[u8]>;
 
-    fn from_payload(shred: Vec<u8>) -> Result<Self, Error>;
+    fn from_payload<T>(shred: T) -> Result<Self, Error>
+    where
+        Payload: From<T>;
     fn common_header(&self) -> &ShredCommonHeader;
     fn sanitize(&self) -> Result<(), Error>;
 
     fn set_signature(&mut self, signature: Signature);
 
-    fn payload(&self) -> &Vec<u8>;
-    fn into_payload(self) -> Vec<u8>;
+    fn payload(&self) -> &Payload;
+    fn into_payload(self) -> Payload;
 
     // Returns the shard index within the erasure coding set.
     fn erasure_shard_index(&self) -> Result<usize, Error>;

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -16,7 +16,10 @@ use {
         cluster_info::{ClusterInfo, ClusterInfoError},
         contact_info::Protocol,
     },
-    solana_ledger::{blockstore::Blockstore, shred::Shred},
+    solana_ledger::{
+        blockstore::Blockstore,
+        shred::{self, Shred},
+    },
     solana_measure::measure::Measure,
     solana_metrics::{inc_new_counter_error, inc_new_counter_info},
     solana_poh::poh_recorder::WorkingBankEntry,
@@ -486,7 +489,7 @@ pub fn broadcast_shreds(
     transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();
     transmit_stats.total_packets += packets.len() + quic_packets.len();
     for (shred, addr) in quic_packets {
-        let shred = Bytes::from(shred.clone());
+        let shred = Bytes::from(shred::Payload::unwrap_or_clone(shred.clone()));
         if let Err(err) = quic_endpoint_sender.blocking_send((addr, shred)) {
             transmit_stats.dropped_packets_quic += 1;
             result = Err(Error::from(err));


### PR DESCRIPTION

#### Problem
A wrapper type would allow to hide the implementation from the rest of the code-base and more easily roll-out changes.


#### Summary of Changes
The commit defines:

    pub struct Payload(Vec<u8>);

as the new shred payload type.