### PR TITLE
adds shared variant to shred payload type

### DIFF
--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -78,9 +78,7 @@ impl<'a> Shred<'a> for ShredData {
         if payload.len() < Self::SIZE_OF_HEADERS {
             return Err(Error::InvalidPayloadSize(payload.len()));
         }
-        if payload.len() != Self::SIZE_OF_PAYLOAD {
-            Payload::make_mut(&mut payload).resize(Self::SIZE_OF_PAYLOAD, 0u8);
-        }
+        payload.resize(Self::SIZE_OF_PAYLOAD, 0u8);
         let shred = Self {
             common_header,
             data_header,
@@ -146,9 +144,7 @@ impl<'a> Shred<'a> for ShredCode {
         let coding_header = deserialize_from_with_limit(&mut cursor)?;
         // Repair packets have nonce at the end of packet payload:
         // https://github.com/solana-labs/solana/pull/10109
-        if payload.len() > Self::SIZE_OF_PAYLOAD {
-            Payload::make_mut(&mut payload).truncate(Self::SIZE_OF_PAYLOAD);
-        }
+        payload.truncate(Self::SIZE_OF_PAYLOAD);
         let shred = Self {
             common_header,
             coding_header,
@@ -368,7 +364,7 @@ mod test {
         // Corrupt shred by making it too large
         {
             let mut shred = shred.clone();
-            Payload::make_mut(&mut shred.payload).push(10u8);
+            shred.payload.push(10u8);
             assert_matches!(shred.sanitize(), Err(Error::InvalidPayloadSize(1229)));
         }
         {

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -516,9 +516,7 @@ impl<'a> ShredTrait<'a> for ShredData {
         if payload.len() < Self::SIZE_OF_PAYLOAD {
             return Err(Error::InvalidPayloadSize(payload.len()));
         }
-        if payload.len() > Self::SIZE_OF_PAYLOAD {
-            Payload::make_mut(&mut payload).truncate(Self::SIZE_OF_PAYLOAD);
-        }
+        payload.truncate(Self::SIZE_OF_PAYLOAD);
         let (common_header, data_header): (ShredCommonHeader, _) =
             deserialize_from_with_limit(&payload[..])?;
         if !matches!(common_header.shred_variant, ShredVariant::MerkleData { .. }) {
@@ -583,9 +581,7 @@ impl<'a> ShredTrait<'a> for ShredCode {
         if payload.len() < Self::SIZE_OF_PAYLOAD {
             return Err(Error::InvalidPayloadSize(payload.len()));
         }
-        if payload.len() > Self::SIZE_OF_PAYLOAD {
-            Payload::make_mut(&mut payload).truncate(Self::SIZE_OF_PAYLOAD);
-        }
+        payload.truncate(Self::SIZE_OF_PAYLOAD);
         let shred = Self {
             common_header,
             coding_header,


### PR DESCRIPTION

#### Problem
After signature verification shreds payloads are concurrently sent to window-service to be deserialized and inserted into blockstore, while their payload is also sent to retransmit-stage to be further propagated:
https://github.com/anza-xyz/agave/blob/7d8cdd9d3/turbine/src/sigverify_shreds.rs#L242-L243

Similarly, when shreds are recovered from the erasure codes, they are concurrently inserted into blockstore, while their payload is sent to retransmit-stage:
https://github.com/anza-xyz/agave/blob/7d8cdd9d3/ledger/src/blockstore.rs#L1024-L1035

Having a `shred::Payload` variant which allows to share the payload between the two concurrent paths will allow to reduce allocations and memcopies.


#### Summary of Changes
The commit adds shared variant to shred payload type.