### PR TITLE
ci: remove default args from the ci dockerfile

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -4,10 +4,10 @@ FROM ${BASE_IMAGE}
 ARG \
   RUST_VERSION= \
   RUST_NIGHTLY_VERSION= \
-  GOLANG_VERSION=1.21.3 \
-  NODE_MAJOR=18 \
-  SCCACHE_VERSION=v0.9.1 \
-  GRCOV_VERSION=v0.8.18
+  GOLANG_VERSION= \
+  NODE_MAJOR= \
+  SCCACHE_VERSION= \
+  GRCOV_VERSION=
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -27,6 +27,10 @@ ENV \
 RUN \
   if [ -z "$RUST_VERSION" ]; then echo "ERROR: The RUST_VERSION argument is required!" && exit 1; fi && \
   if [ -z "$RUST_NIGHTLY_VERSION" ]; then echo "ERROR: The RUST_NIGHTLY_VERSION argument is required!" && exit 1; fi && \
+  if [ -z "$GOLANG_VERSION" ]; then echo "ERROR: The GOLANG_VERSION argument is required!" && exit 1; fi && \
+  if [ -z "$NODE_MAJOR" ]; then echo "ERROR: The NODE_MAJOR argument is required!" && exit 1; fi && \
+  if [ -z "$SCCACHE_VERSION" ]; then echo "ERROR: The SCCACHE_VERSION argument is required!" && exit 1; fi && \
+  if [ -z "$GRCOV_VERSION" ]; then echo "ERROR: The GRCOV_VERSION argument is required!" && exit 1; fi && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
   # basic

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -6,6 +6,7 @@ This image is manually maintained:
 
 1. Edit
    1. `ci/rust-version.sh` for rust and rust nightly version
-   2. `ci/docker/Dockerfile` for other packages
+   2. `ci/docker/env.sh` for some environment variables
+   3. `ci/docker/Dockerfile` for some other packages
 2. Ensure you're a member of the [Solana Docker Hub Organization](https://hub.docker.com/u/solanalabs/) and already `docker login`
 3. Run `ci/docker/build.sh` to build/publish the new image


### PR DESCRIPTION
#### Problem

I define the args in `ci/docker/env.sh`. It’s a bit confusing for other devs to update the version in the right place if I define them in two places


#### Summary of Changes

remove the default args from the Dockerfile so that the env vars can be updated in a single place