### PR TITLE
removes Arc::unwrap_or_clone from StandardBroadcastRun::insert

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -367,15 +367,15 @@ impl StandardBroadcastRun {
     ) {
         // Insert shreds into blockstore
         let insert_shreds_start = Instant::now();
-        let mut shreds = Arc::unwrap_or_clone(shreds);
         // The first data shred is inserted synchronously.
         // https://github.com/solana-labs/solana/blob/92a0b310c/turbine/src/broadcast_stage/standard_broadcast_run.rs#L268-L283
-        if let Some(shred) = shreds.first() {
-            if shred.is_data() && shred.index() == 0 {
-                shreds.swap_remove(0);
-            }
-        }
+        let skip = shreds
+            .first()
+            .map(|shred| shred.is_data() && shred.index() == 0u32)
+            .map(usize::from)
+            .unwrap_or_default();
         let num_shreds = shreds.len();
+        let shreds = shreds.into_iter().skip(skip);
         blockstore
             .insert_shreds(
                 shreds, /*leader_schedule:*/ None, /*is_trusted:*/ true,


### PR DESCRIPTION
#### Problem
Broadcast stage wraps `Vec<Shred>` in `Arc` to reduce allocations and cloning when shreds are concurrently sent to both `BroadcastRun::record` and `BroadcastRun::transmit`:
https://github.com/anza-xyz/agave/blob/b59c1aee7/turbine/src/broadcast_stage/standard_broadcast_run.rs#L224-L226
https://github.com/anza-xyz/agave/blob/b59c1aee7/turbine/src/broadcast_stage.rs#L344
https://github.com/anza-xyz/agave/blob/b59c1aee7/turbine/src/broadcast_stage.rs#L321

However, the unnecessary `Arc::unwrap_or_clone` in `StandardBroadcastRun::insert` breaks this memory sharing and forces a clone on shreds transmitted:
https://github.com/anza-xyz/agave/blob/b59c1aee7/turbine/src/broadcast_stage/standard_broadcast_run.rs#L370


#### Summary of Changes

The commit removes the unnecessary `Arc::unwrap_or_clone` and instead just skips the iterator of shreds by one when needed.

