### PR TITLE
Fix - loader v4 CLI signer aliasing and UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6782,6 +6782,7 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
+ "solana-loader-v4-interface",
  "solana-loader-v4-program",
  "solana-logger",
  "solana-message",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ solana-feature-set = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
+solana-loader-v4-interface = { workspace = true }
 solana-loader-v4-program = { workspace = true }
 solana-logger = { workspace = true }
 solana-message = { workspace = true }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -132,8 +132,8 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .help("Optionally stops writing after this byte offset"),
                         )
                         .arg(
-                            Arg::with_name("program")
-                                .long("program")
+                            Arg::with_name("program-keypair")
+                                .long("program-keypair")
                                 .value_name("PROGRAM_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
@@ -323,12 +323,12 @@ pub fn parse_program_v4_subcommand(
 
             let program_address = pubkey_of(matches, "program-id");
             let program_pubkey = if let Ok((program_signer, Some(program_pubkey))) =
-                signer_of(matches, "program", wallet_manager)
+                signer_of(matches, "program-keypair", wallet_manager)
             {
                 bulk_signers.push(program_signer);
                 Some(program_pubkey)
             } else {
-                pubkey_of_signer(matches, "program", wallet_manager)?
+                pubkey_of_signer(matches, "program-keypair", wallet_manager)?
             };
 
             let buffer_pubkey = if let Ok((buffer_signer, Some(buffer_pubkey))) =
@@ -348,7 +348,7 @@ pub fn parse_program_v4_subcommand(
             let program_signer_index = signer_info.index_of_or_none(program_pubkey);
             assert!(
                 program_address.is_some() != program_signer_index.is_some(),
-                "Requires either program signer or program address",
+                "Requires either --program-keypair or --program-id",
             );
 
             CliCommandInfo {
@@ -1754,7 +1754,7 @@ mod tests {
             "program-v4",
             "deploy",
             "/Users/test/program.so",
-            "--program",
+            "--program-keypair",
             &program_keypair_file,
         ]);
         assert_eq!(
@@ -1781,7 +1781,7 @@ mod tests {
             "program-v4",
             "deploy",
             "/Users/test/program.so",
-            "--program",
+            "--program-keypair",
             &program_keypair_file,
             "--authority",
             &authority_keypair_file,

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -71,7 +71,7 @@ pub enum ProgramV4CliCommand {
         program_signer_index: Option<SignerIndex>,
         buffer_signer_index: Option<SignerIndex>,
         authority_signer_index: SignerIndex,
-        program_location: String,
+        path_to_elf: String,
         upload_range: Range<Option<usize>>,
         use_rpc: bool,
     },
@@ -114,9 +114,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                     SubCommand::with_name("deploy")
                         .about("Deploy a new or redeploy an existing program")
                         .arg(
-                            Arg::with_name("program-location")
+                            Arg::with_name("path-to-elf")
                                 .index(1)
-                                .value_name("PROGRAM_FILEPATH")
+                                .value_name("PATH-TO-ELF")
                                 .takes_value(true)
                                 .help("/path/to/program.so"),
                         )
@@ -320,8 +320,8 @@ pub fn parse_program_v4_subcommand(
                 default_signer.signer_from_path(matches, wallet_manager)?,
             )];
 
-            let program_location = matches
-                .value_of("program-location")
+            let path_to_elf = matches
+                .value_of("path-to-elf")
                 .map(|location| location.to_string());
 
             let program_address = pubkey_of(matches, "program-id");
@@ -362,7 +362,7 @@ pub fn parse_program_v4_subcommand(
                     authority_signer_index: signer_info
                         .index_of(authority_pubkey)
                         .expect("Authority signer is missing"),
-                    program_location: program_location.expect("Program location is missing"),
+                    path_to_elf: path_to_elf.expect("Path to ELF is missing"),
                     upload_range: value_t!(matches, "start-offset", usize).ok()
                         ..value_t!(matches, "end-offset", usize).ok(),
                     use_rpc: matches.is_present("use_rpc"),
@@ -491,12 +491,12 @@ pub fn process_program_v4_subcommand(
             program_signer_index,
             buffer_signer_index,
             authority_signer_index,
-            program_location,
+            path_to_elf,
             upload_range,
             use_rpc,
         } => {
             let mut program_data = Vec::new();
-            let mut file = File::open(program_location)
+            let mut file = File::open(path_to_elf)
                 .map_err(|err| format!("Unable to open program file: {err}"))?;
             file.read_to_end(&mut program_data)
                 .map_err(|err| format!("Unable to read program file: {err}"))?;
@@ -1768,7 +1768,7 @@ mod tests {
                     program_signer_index: Some(1),
                     buffer_signer_index: None,
                     authority_signer_index: 0,
-                    program_location: "/Users/test/program.so".to_string(),
+                    path_to_elf: "/Users/test/program.so".to_string(),
                     upload_range: None..None,
                     use_rpc: false,
                 }),
@@ -1797,7 +1797,7 @@ mod tests {
                     program_signer_index: Some(1),
                     buffer_signer_index: None,
                     authority_signer_index: 2,
-                    program_location: "/Users/test/program.so".to_string(),
+                    path_to_elf: "/Users/test/program.so".to_string(),
                     upload_range: None..None,
                     use_rpc: false,
                 }),
@@ -1827,7 +1827,7 @@ mod tests {
                     program_signer_index: None,
                     buffer_signer_index: None,
                     authority_signer_index: 1,
-                    program_location: "/Users/test/program.so".to_string(),
+                    path_to_elf: "/Users/test/program.so".to_string(),
                     upload_range: None..None,
                     use_rpc: false,
                 }),
@@ -1858,7 +1858,7 @@ mod tests {
                     program_signer_index: None,
                     buffer_signer_index: Some(1),
                     authority_signer_index: 2,
-                    program_location: "/Users/test/program.so".to_string(),
+                    path_to_elf: "/Users/test/program.so".to_string(),
                     upload_range: None..None,
                     use_rpc: false,
                 }),
@@ -1895,7 +1895,7 @@ mod tests {
                     program_signer_index: None,
                     buffer_signer_index: Some(1),
                     authority_signer_index: 2,
-                    program_location: "/Users/test/program.so".to_string(),
+                    path_to_elf: "/Users/test/program.so".to_string(),
                     upload_range: Some(16)..Some(32),
                     use_rpc: true,
                 }),

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -676,12 +676,12 @@ pub fn process_deploy_program(
     if buffer_signer.is_none() || &buffer_address != program_address {
         // Redeploy an existing program
         if !program_account_exists {
-            return Err("Program account does not exist".into());
+            return Err("Program account does not exist. Did you perhaps intent to deploy a new program instead? Then use --program-keypair instead of --program-id.".into());
         }
     } else {
         // Deploy new program
         if program_account_exists {
-            return Err("Program account does exist already".into());
+            return Err("Program account does exist already. Did you perhaps intent to redeploy an existing program instead? Then use --program-id instead of --program-keypair.".into());
         }
     }
 


### PR DESCRIPTION
#### Problem
The authority keypair is optional and if skipped, it will fallback to the payer keypair. This aliasing of signers means that the number of unique signers can be smaller than the number of signers. Thus it should not be used to identify which message is the initial message.

#### Summary of Changes
Switches from checking `num_required_signatures` (the number of unique signers) to checking `message.account_keys.contains(&system_program::id())` instead.

Also improves some of the dApp dev facing interfaces to be more user friendly.