### PR TITLE
Report ConsumeWorkerMetrics on 20ms interval

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -194,7 +194,7 @@ pub(crate) struct ConsumeWorkerMetrics {
 impl ConsumeWorkerMetrics {
     /// Report and reset metrics iff the interval has elapsed and the worker did some work.
     pub fn maybe_report_and_reset(&self) {
-        const REPORT_INTERVAL_MS: u64 = 1000;
+        const REPORT_INTERVAL_MS: u64 = 20;
         if self.interval.should_update(REPORT_INTERVAL_MS)
             && self.has_data.swap(false, Ordering::Relaxed)
         {


### PR DESCRIPTION
#### Problem
- 1s interval is too large to report worker metrics
- reporting on a 20s interval, many times per slot, gives us a picture of when and how things are processed as our leader slots progress

#### Summary of Changes
- Report ConsumerWorkerMetrics on a 20ms interval
- Gives us really great charts like this, showing how quickly we're able to fill blocks:
![image](https://github.com/user-attachments/assets/92d30c0d-6a3e-446e-957d-140771fc003a)


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
