### PR TITLE
Remove SVM dependency on solana-fee crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 /builtins-default-costs/ @anza-xyz/svm
 /compute-budget/ @anza-xyz/svm
 /compute-budget-instruction/ @anza-xyz/svm @anza-xyz/fees
-/fee/ @anza-xyz/svm @anza-xyz/fees
+/fee/ @anza-xyz/fees
 /log-collector/ @anza-xyz/svm
 /program-runtime/ @anza-xyz/svm
 /programs/bpf_loader/ @anza-xyz/svm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9918,7 +9918,6 @@ dependencies = [
  "solana-ed25519-program",
  "solana-epoch-schedule",
  "solana-feature-set",
- "solana-fee",
  "solana-fee-calculator",
  "solana-fee-structure",
  "solana-frozen-abi",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8186,7 +8186,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-feature-set",
- "solana-fee",
  "solana-fee-structure",
  "solana-hash",
  "solana-instruction",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6878,6 +6878,22 @@ impl TransactionProcessingCallback for Bank {
             .map(|(stake, _)| (*stake))
             .unwrap_or(0)
     }
+
+    fn calculate_fee(
+        &self,
+        message: &impl SVMMessage,
+        lamports_per_signature: u64,
+        prioritization_fee: u64,
+        feature_set: &FeatureSet,
+    ) -> FeeDetails {
+        solana_fee::calculate_fee_details(
+            message,
+            false, /* zero_fees_for_test */
+            lamports_per_signature,
+            prioritization_fee,
+            FeeFeatures::from(feature_set),
+        )
+    }
 }
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -23,7 +23,6 @@ solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-feature-set = { workspace = true }
-solana-fee = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7515,7 +7515,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-feature-set",
- "solana-fee",
  "solana-fee-structure",
  "solana-hash",
  "solana-instruction",

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,4 +1,8 @@
-use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
+use {
+    solana_account::AccountSharedData, solana_feature_set::FeatureSet,
+    solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
+    solana_svm_transaction::svm_message::SVMMessage,
+};
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
@@ -13,6 +17,15 @@ pub trait TransactionProcessingCallback {
 
     fn get_current_epoch_vote_account_stake(&self, _vote_address: &Pubkey) -> u64 {
         0
+    }
+    fn calculate_fee(
+        &self,
+        _message: &impl SVMMessage,
+        _lamports_per_signature: u64,
+        _prioritization_fee: u64,
+        _feature_set: &FeatureSet,
+    ) -> FeeDetails {
+        FeeDetails::default()
     }
 }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -30,8 +30,7 @@ use {
     solana_feature_set::{
         enable_transaction_loading_failure_fees, remove_accounts_executable_flag_checks, FeatureSet,
     },
-    solana_fee::FeeFeatures,
-    solana_fee_structure::{FeeBudgetLimits, FeeStructure},
+    solana_fee_structure::{FeeBudgetLimits, FeeDetails, FeeStructure},
     solana_hash::Hash,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
     solana_log_collector::LogCollector,
@@ -424,6 +423,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             .rent_collector
                             .unwrap_or(&RentCollector::default()),
                         &mut error_metrics,
+                        callbacks,
                     )
                 }));
             validate_fees_us = validate_fees_us.saturating_add(single_validate_fees_us);
@@ -526,6 +526,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
+        callbacks: &CB,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         // If this is a nonce transaction, validate the nonce info.
         // This must be done for every transaction to support SIMD83 because
@@ -554,6 +555,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             fee_lamports_per_signature,
             rent_collector,
             error_counters,
+            callbacks,
         )
     }
 
@@ -567,6 +569,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
+        callbacks: &CB,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let compute_budget_limits = process_compute_budget_instructions(
             message.program_instructions_iter(),
@@ -599,13 +602,16 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         } = checked_details;
 
         let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
-        let fee_details = solana_fee::calculate_fee_details(
-            message,
-            lamports_per_signature == 0,
-            fee_lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
-            FeeFeatures::from(account_loader.feature_set.as_ref()),
-        );
+        let fee_details = if lamports_per_signature == 0 {
+            FeeDetails::default()
+        } else {
+            callbacks.calculate_fee(
+                message,
+                fee_lamports_per_signature,
+                fee_budget_limits.prioritization_fee,
+                account_loader.feature_set.as_ref(),
+            )
+        };
 
         let fee_payer_index = 0;
         validate_fee_payer(
@@ -1301,6 +1307,25 @@ mod tests {
                 .entry(*address)
                 .or_default()
                 .push((account, is_writable));
+        }
+
+        fn calculate_fee(
+            &self,
+            message: &impl SVMMessage,
+            lamports_per_signature: u64,
+            prioritization_fee: u64,
+            _feature_set: &FeatureSet,
+        ) -> FeeDetails {
+            let signature_count = message
+                .num_transaction_signatures()
+                .saturating_add(message.num_ed25519_signatures())
+                .saturating_add(message.num_secp256k1_signatures())
+                .saturating_add(message.num_secp256r1_signatures());
+
+            FeeDetails::new(
+                signature_count.saturating_mul(lamports_per_signature),
+                prioritization_fee,
+            )
         }
     }
 
@@ -2174,6 +2199,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
+                &mock_bank,
             );
 
         let post_validation_fee_payer_account = {
@@ -2251,6 +2277,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
+                &mock_bank,
             );
 
         let post_validation_fee_payer_account = {
@@ -2299,6 +2326,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
+                &mock_bank,
             );
 
         assert_eq!(error_counters.account_not_found.0, 1);
@@ -2330,6 +2358,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
+                &mock_bank,
             );
 
         assert_eq!(error_counters.insufficient_funds.0, 1);
@@ -2365,6 +2394,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
+                &mock_bank,
             );
 
         assert_eq!(
@@ -2398,6 +2428,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
+                &mock_bank,
             );
 
         assert_eq!(error_counters.invalid_account_for_fee.0, 1);
@@ -2427,6 +2458,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
+                &mock_bank,
             );
 
         assert_eq!(error_counters.invalid_compute_budget.0, 1);
@@ -2500,6 +2532,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
+                &mock_bank,
             );
 
             let post_validation_fee_payer_account = {
@@ -2558,6 +2591,7 @@ mod tests {
                 FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
+                &mock_bank,
             );
 
             assert_eq!(error_counters.insufficient_funds.0, 1);
@@ -2600,6 +2634,7 @@ mod tests {
             FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut TransactionErrorMetrics::default(),
+            &mock_bank,
         )
         .unwrap();
 


### PR DESCRIPTION
#### Problem
SVM is currently dependent on `solana-fee` crate. This is causing interdependency between SVM internal and monorepo
crates, and making it harder to split the repo.

#### Summary of Changes
Add a callback in SVM's interface trait. Implement the callback in `bank.rs`.
Also, remove SVM as a CODEOWNER of solana-fee.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
