### PR TITLE
renames Shred::erasure_shard_as_slice{,_mut} to erasure_shard{,_mut}

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -364,9 +364,7 @@ impl Shred {
 
     dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
     // Returns the portion of the shred's payload which is erasure coded.
-    dispatch!(pub(crate) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
-    // Like Shred::erasure_shard but returning a slice.
-    dispatch!(pub(crate) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(crate) fn erasure_shard(&self) -> Result<&[u8], Error>);
     // Returns the shard index within the erasure coding set.
     dispatch!(pub(crate) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -94,16 +94,7 @@ impl<'a> Shred<'a> for ShredData {
         })
     }
 
-    fn erasure_shard(self) -> Result<Vec<u8>, Error> {
-        if self.payload.len() != Self::SIZE_OF_PAYLOAD {
-            return Err(Error::InvalidPayloadSize(self.payload.len()));
-        }
-        let mut shard = Payload::unwrap_or_clone(self.payload);
-        shard.truncate(SIZE_OF_ERASURE_ENCODED_SLICE);
-        Ok(shard)
-    }
-
-    fn erasure_shard_as_slice(&self) -> Result<&[u8], Error> {
+    fn erasure_shard(&self) -> Result<&[u8], Error> {
         if self.payload.len() != Self::SIZE_OF_PAYLOAD {
             return Err(Error::InvalidPayloadSize(self.payload.len()));
         }
@@ -160,18 +151,7 @@ impl<'a> Shred<'a> for ShredCode {
         })
     }
 
-    fn erasure_shard(self) -> Result<Vec<u8>, Error> {
-        if self.payload.len() != Self::SIZE_OF_PAYLOAD {
-            return Err(Error::InvalidPayloadSize(self.payload.len()));
-        }
-        let mut shard = Payload::unwrap_or_clone(self.payload);
-        // ShredCode::SIZE_OF_HEADERS bytes at the beginning of the coding
-        // shreds contains the header and is not part of erasure coding.
-        shard.drain(..Self::SIZE_OF_HEADERS);
-        Ok(shard)
-    }
-
-    fn erasure_shard_as_slice(&self) -> Result<&[u8], Error> {
+    fn erasure_shard(&self) -> Result<&[u8], Error> {
         if self.payload.len() != Self::SIZE_OF_PAYLOAD {
             return Err(Error::InvalidPayloadSize(self.payload.len()));
         }

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -28,8 +28,7 @@ impl ShredCode {
     dispatch!(fn coding_header(&self) -> &CodingShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
-    dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
-    dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);
     dispatch!(pub(super) fn into_payload(self) -> Payload);
@@ -175,7 +174,7 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
         ));
     }
     let _shard_index = shred.erasure_shard_index()?;
-    let _erasure_shard = shred.erasure_shard_as_slice()?;
+    let _erasure_shard = shred.erasure_shard()?;
     Ok(())
 }
 

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -21,8 +21,7 @@ impl ShredData {
     dispatch!(fn data_header(&self) -> &DataShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
-    dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
-    dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn into_payload(self) -> Payload);
     dispatch!(pub(super) fn parent(&self) -> Result<Slot, Error>);
@@ -192,6 +191,6 @@ pub(super) fn sanitize<T: ShredDataTrait>(shred: &T) -> Result<(), Error> {
     let _data = shred.data()?;
     let _parent = shred.parent()?;
     let _shard_index = shred.erasure_shard_index()?;
-    let _erasure_shard = shred.erasure_shard_as_slice()?;
+    let _erasure_shard = shred.erasure_shard()?;
     Ok(())
 }

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -28,9 +28,7 @@ pub(super) trait Shred<'a>: Sized {
     // Returns the shard index within the erasure coding set.
     fn erasure_shard_index(&self) -> Result<usize, Error>;
     // Returns the portion of the shred's payload which is erasure coded.
-    fn erasure_shard(self) -> Result<Vec<u8>, Error>;
-    // Like Shred::erasure_shard but returning a slice.
-    fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>;
+    fn erasure_shard(&self) -> Result<&[u8], Error>;
 
     // Portion of the payload which is signed.
     fn signed_data(&'a self) -> Result<Self::SignedData, Error>;

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -304,7 +304,7 @@ impl Shredder {
         let data: Vec<_> = data
             .iter()
             .map(Borrow::borrow)
-            .map(Shred::erasure_shard_as_slice)
+            .map(Shred::erasure_shard)
             .collect::<Result<_, _>>()
             .unwrap();
         let mut parity = vec![vec![0u8; data[0].len()]; num_coding];
@@ -372,7 +372,7 @@ impl Shredder {
                 Ok(index) if index < fec_set_size => index,
                 _ => return Err(Error::from(InvalidIndex)),
             };
-            shards[index] = Some(shred.erasure_shard()?);
+            shards[index] = Some(shred.erasure_shard()?.to_vec());
             if index < num_data_shreds {
                 mask[index] = true;
             }


### PR DESCRIPTION
#### Problem
Clean up code.

#### Summary of Changes
The commit
* removes old `Shred::erasure_shard`.
* renames `Shred::erasure_shard_as_slice{,_mut}` to `erasure_shard{,_mut}`.