### PR TITLE
reduce memory allocation pressure in retransmit_shred pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10483,6 +10483,7 @@ dependencies = [
  "bs58",
  "bytes",
  "crossbeam-channel",
+ "dashmap",
  "futures 0.3.31",
  "itertools 0.12.1",
  "lazy-lru",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8551,6 +8551,7 @@ dependencies = [
  "bincode",
  "bytes",
  "crossbeam-channel",
+ "dashmap",
  "futures 0.3.31",
  "itertools 0.12.1",
  "lazy-lru",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7898,6 +7898,7 @@ dependencies = [
  "bincode",
  "bytes",
  "crossbeam-channel",
+ "dashmap",
  "futures 0.3.31",
  "itertools 0.12.1",
  "lazy-lru",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 lazy-lru = { workspace = true }


### PR DESCRIPTION
#### Problem
Turbine retransmit is dominating the bytes allocated / s charts in agave. Much of those allocations appear to happen in the stats collection part of the retransmit stage.

#### Summary of Changes

- Cache several internal structures to retain their allocated blocks across iterations of retransmit
- Use dashmap to collect slot stats instead of many many hashmaps

Fixes #
![kuva](https://github.com/user-attachments/assets/89e46c7d-6b60-4065-93c6-98bdb947e0d2)
