### PR TITLE
Bumps solana_sbpf to v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9348,9 +9348,9 @@ version = "2.2.0"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b4c060a707fdb0754a876cbbf49591b60a573b5521b485125d2a4d6ff68ce3"
+checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -603,7 +603,7 @@ solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.0" }
 solana-runtime = { path = "runtime", version = "=2.2.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.0" }
-solana-sbpf = "=0.9.0"
+solana-sbpf = "=0.10.0"
 solana-sdk = { path = "sdk/sdk", version = "=2.2.0" }
 solana-sdk-ids = { path = "sdk/sdk-ids", version = "=2.2.0" }
 solana-sdk-macro = { path = "sdk/macro", version = "=2.2.0" }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -536,7 +536,7 @@ impl<'a> InvokeContext<'a> {
             .ok_or(InstructionError::UnsupportedProgramId)?;
         let function = match &entry.program {
             ProgramCacheEntryType::Builtin(program) => program
-                .get_function_registry(SBPFVersion::V0)
+                .get_function_registry()
                 .lookup_by_key(ENTRYPOINT_KEY)
                 .map(|(_name, function)| function),
             _ => None,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -5,10 +5,7 @@ use {
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_sbpf::{
-        elf::Executable,
-        program::{BuiltinProgram, FunctionRegistry},
-        verifier::RequisiteVerifier,
-        vm::Config,
+        elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier, vm::Config,
     },
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
@@ -449,9 +446,9 @@ impl ProgramCacheEntry {
         account_size: usize,
         builtin_function: BuiltinFunctionWithContext,
     ) -> Self {
-        let mut function_registry = FunctionRegistry::default();
-        function_registry
-            .register_function_hashed(*b"entrypoint", builtin_function)
+        let mut program = BuiltinProgram::new_builtin();
+        program
+            .register_function("entrypoint", builtin_function)
             .unwrap();
         Self {
             deployment_slot,
@@ -459,7 +456,7 @@ impl ProgramCacheEntry {
             account_size,
             effective_slot: deployment_slot,
             tx_usage_counter: AtomicU64::new(0),
-            program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_builtin(function_registry)),
+            program: ProgramCacheEntryType::Builtin(program),
             ix_usage_counter: AtomicU64::new(0),
             latest_access_slot: AtomicU64::new(0),
         }
@@ -530,10 +527,7 @@ pub struct ProgramRuntimeEnvironments {
 
 impl Default for ProgramRuntimeEnvironments {
     fn default() -> Self {
-        let empty_loader = Arc::new(BuiltinProgram::new_loader(
-            Config::default(),
-            FunctionRegistry::default(),
-        ));
+        let empty_loader = Arc::new(BuiltinProgram::new_loader(Config::default()));
         Self {
             program_runtime_v1: empty_loader.clone(),
             program_runtime_v2: empty_loader,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7735,9 +7735,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b4c060a707fdb0754a876cbbf49591b60a573b5521b485125d2a4d6ff68ce3"
+checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
 dependencies = [
  "byteorder 1.5.0",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -62,7 +62,7 @@ solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version =
 solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.0" }
 solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.0" }
 solana-sdk = { path = "../../sdk/sdk", version = "=2.2.0" }
-solana-sbpf = "=0.9.0"
+solana-sbpf = "=0.10.0"
 solana-secp256k1-recover = { path = "../../curves/secp256k1-recover", version = "=2.2.0" }
 solana-svm = { path = "../../svm", version = "=2.2.0" }
 solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.0" }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7065,9 +7065,9 @@ version = "2.2.0"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b4c060a707fdb0754a876cbbf49591b60a573b5521b485125d2a4d6ff68ce3"
+checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/svm/examples/json-rpc/server/src/svm_bridge.rs
+++ b/svm/examples/json-rpc/server/src/svm_bridge.rs
@@ -13,7 +13,7 @@ use {
             ProgramRuntimeEnvironments,
         },
         solana_sbpf::{
-            program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+            program::{BuiltinProgram, SBPFVersion},
             vm::Config,
         },
     },
@@ -160,38 +160,38 @@ pub fn create_custom_environment<'a>() -> BuiltinProgram<InvokeContext<'a>> {
     };
 
     // Register system calls that the compiled contract calls during execution.
-    let mut function_registry = FunctionRegistry::<BuiltinFunction<InvokeContext>>::default();
-    function_registry
-        .register_function_hashed(*b"abort", SyscallAbort::vm)
+    let mut loader = BuiltinProgram::new_loader(vm_config);
+    loader
+        .register_function("abort", SyscallAbort::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_log_", SyscallLog::vm)
+    loader
+        .register_function("sol_log_", SyscallLog::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_log_64_", SyscallLogU64::vm)
+    loader
+        .register_function("sol_log_64_", SyscallLogU64::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_log_compute_units_", SyscallLogBpfComputeUnits::vm)
+    loader
+        .register_function("sol_log_compute_units_", SyscallLogBpfComputeUnits::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_log_pubkey", SyscallLogPubkey::vm)
+    loader
+        .register_function("sol_log_pubkey", SyscallLogPubkey::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_memcpy_", SyscallMemcpy::vm)
+    loader
+        .register_function("sol_memcpy_", SyscallMemcpy::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_memset_", SyscallMemset::vm)
+    loader
+        .register_function("sol_memset_", SyscallMemset::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_invoke_signed_rust", SyscallInvokeSignedRust::vm)
+    loader
+        .register_function("sol_invoke_signed_rust", SyscallInvokeSignedRust::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_set_return_data", SyscallSetReturnData::vm)
+    loader
+        .register_function("sol_set_return_data", SyscallSetReturnData::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_get_clock_sysvar", SyscallGetClockSysvar::vm)
+    loader
+        .register_function("sol_get_clock_sysvar", SyscallGetClockSysvar::vm)
         .expect("Registration failed");
-    BuiltinProgram::new_loader(vm_config, function_registry)
+    loader
 }
 
 pub fn create_executable_environment(
@@ -205,10 +205,7 @@ pub fn create_executable_environment(
     program_cache.environments = ProgramRuntimeEnvironments {
         program_runtime_v1: Arc::new(create_custom_environment()),
         // We are not using program runtime v2
-        program_runtime_v2: Arc::new(BuiltinProgram::new_loader(
-            Config::default(),
-            FunctionRegistry::default(),
-        )),
+        program_runtime_v2: Arc::new(BuiltinProgram::new_loader(Config::default())),
     };
 
     program_cache.fork_graph = Some(Arc::downgrade(&fork_graph));

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -47,10 +47,7 @@ use {
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
             ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
         },
-        solana_sbpf::{
-            program::{BuiltinProgram, FunctionRegistry},
-            vm::Config as VmConfig,
-        },
+        solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -282,12 +279,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         program_runtime_environment_v1: Option<ProgramRuntimeEnvironment>,
         program_runtime_environment_v2: Option<ProgramRuntimeEnvironment>,
     ) {
-        let empty_loader = || {
-            Arc::new(BuiltinProgram::new_loader(
-                VmConfig::default(),
-                FunctionRegistry::default(),
-            ))
-        };
+        let empty_loader = || Arc::new(BuiltinProgram::new_loader(VmConfig::default()));
 
         program_cache.latest_root_slot = self.slot;
         program_cache.latest_root_epoch = self.epoch;

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -12,7 +12,7 @@ use {
         invoke_context::InvokeContext,
         loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
         solana_sbpf::{
-            program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+            program::{BuiltinProgram, SBPFVersion},
             vm::Config,
         },
     },
@@ -309,35 +309,30 @@ pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a>> {
 
     // These functions are system calls the compile contract calls during execution, so they
     // need to be registered.
-    let mut function_registry = FunctionRegistry::<BuiltinFunction<InvokeContext>>::default();
-    function_registry
-        .register_function_hashed(*b"abort", SyscallAbort::vm)
+    let mut loader = BuiltinProgram::new_loader(vm_config);
+    loader
+        .register_function("abort", SyscallAbort::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_log_", SyscallLog::vm)
+    loader
+        .register_function("sol_log_", SyscallLog::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_memcpy_", SyscallMemcpy::vm)
+    loader
+        .register_function("sol_memcpy_", SyscallMemcpy::vm)
         .expect("Registration failed");
-    function_registry
-        .register_function_hashed(*b"sol_memset_", SyscallMemset::vm)
+    loader
+        .register_function("sol_memset_", SyscallMemset::vm)
         .expect("Registration failed");
-
-    function_registry
-        .register_function_hashed(*b"sol_invoke_signed_rust", SyscallInvokeSignedRust::vm)
+    loader
+        .register_function("sol_invoke_signed_rust", SyscallInvokeSignedRust::vm)
         .expect("Registration failed");
-
-    function_registry
-        .register_function_hashed(*b"sol_set_return_data", SyscallSetReturnData::vm)
+    loader
+        .register_function("sol_set_return_data", SyscallSetReturnData::vm)
         .expect("Registration failed");
-
-    function_registry
-        .register_function_hashed(*b"sol_get_clock_sysvar", SyscallGetClockSysvar::vm)
+    loader
+        .register_function("sol_get_clock_sysvar", SyscallGetClockSysvar::vm)
         .expect("Registration failed");
-
-    function_registry
-        .register_function_hashed(*b"sol_get_rent_sysvar", SyscallGetRentSysvar::vm)
+    loader
+        .register_function("sol_get_rent_sysvar", SyscallGetRentSysvar::vm)
         .expect("Registration failed");
-
-    BuiltinProgram::new_loader(vm_config, function_registry)
+    loader
 }


### PR DESCRIPTION
#### Problem
[SBPF virtual machine v0.10.0](https://github.com/anza-xyz/sbpf/releases/tag/v0.10.0) was released.

#### Summary of Changes
Reverts the dense syscall registry by removing the key parameter from syscall registration.