### PR TITLE
ConsumeWorkers: report their own metrics

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -563,7 +563,6 @@ impl BankingStage {
         let (finished_work_sender, finished_work_receiver) = unbounded();
 
         // Spawn the worker threads
-        let mut worker_metrics = Vec::with_capacity(num_workers as usize);
         for (index, work_receiver) in work_receivers.into_iter().enumerate() {
             let id = (index as u32).saturating_add(NUM_VOTE_PROCESSING_THREADS);
             let consume_worker = ConsumeWorker::new(
@@ -579,7 +578,6 @@ impl BankingStage {
                 poh_recorder.read().unwrap().new_leader_bank_notifier(),
             );
 
-            worker_metrics.push(consume_worker.metrics_handle());
             bank_thread_hdls.push(
                 Builder::new()
                     .name(format!("solCoWorker{id:02}"))
@@ -615,7 +613,6 @@ impl BankingStage {
                         receive_and_buffer,
                         bank_forks,
                         scheduler,
-                        worker_metrics,
                         forwarder,
                     );
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -35,7 +35,7 @@ pub(crate) struct ConsumeWorker<Tx> {
     consumed_sender: Sender<FinishedConsumeWork<Tx>>,
 
     leader_bank_notifier: Arc<LeaderBankNotifier>,
-    metrics: Arc<ConsumeWorkerMetrics>,
+    metrics: ConsumeWorkerMetrics,
 }
 
 impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
@@ -51,12 +51,8 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             consumer,
             consumed_sender,
             leader_bank_notifier,
-            metrics: Arc::new(ConsumeWorkerMetrics::new(id)),
+            metrics: ConsumeWorkerMetrics::new(id),
         }
-    }
-
-    pub fn metrics_handle(&self) -> Arc<ConsumeWorkerMetrics> {
-        self.metrics.clone()
     }
 
     pub fn run(self) -> Result<(), ConsumeWorkerError<Tx>> {
@@ -73,6 +69,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
                     return Err(ConsumeWorkerError::from(err));
                 }
             }
+            self.metrics.maybe_report_and_reset();
         }
     }
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -4,7 +4,7 @@ use {
         leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
     },
-    crossbeam_channel::{Receiver, RecvError, SendError, Sender},
+    crossbeam_channel::{Receiver, SendError, Sender, TryRecvError},
     solana_measure::measure_us,
     solana_poh::leader_bank_notifier::LeaderBankNotifier,
     solana_runtime::bank::Bank,
@@ -24,7 +24,7 @@ use {
 #[derive(Debug, Error)]
 pub enum ConsumeWorkerError<Tx> {
     #[error("Failed to receive work from scheduler: {0}")]
-    Recv(#[from] RecvError),
+    Recv(#[from] TryRecvError),
     #[error("Failed to send finalized consume work to scheduler: {0}")]
     Send(#[from] SendError<FinishedConsumeWork<Tx>>),
 }
@@ -61,8 +61,18 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
 
     pub fn run(self) -> Result<(), ConsumeWorkerError<Tx>> {
         loop {
-            let work = self.consume_receiver.recv()?;
-            self.consume_loop(work)?;
+            match self.consume_receiver.try_recv() {
+                Ok(work) => {
+                    self.consume_loop(work)?;
+                }
+                Err(TryRecvError::Empty) => {
+                    const SLEEP_DURATION: Duration = Duration::from_millis(5);
+                    std::thread::sleep(SLEEP_DURATION);
+                }
+                Err(err) => {
+                    return Err(ConsumeWorkerError::from(err));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### Problem
- Scheduler currently reports worker metrics because the workers used to only wake up if there was work.
- Following #4723, the workers wake up periodically.
- They can now report their own metrics, simplifying the scheduler & worker interfaces.

#### Summary of Changes
- Workers report their own metrics
- Use simpler non-atomic counters

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
