### PR TITLE
Update use of AccountInfo to work with CPI in a 32-bit build

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -74,7 +74,6 @@ impl<T> VmValue<'_, '_, T> {
     }
 }
 
-
 /// Host side representation of VmAccountInfo or SolAccountInfo passed to the CPI syscall.
 ///
 /// At the start of a CPI, this can be different from the data stored in the
@@ -155,7 +154,7 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             translate_type_mut::<u64>(
                 memory_mapping,
                 ptr_box.value,
-                invoke_context.get_check_aligned()
+                invoke_context.get_check_aligned(),
             )?
         };
 
@@ -189,10 +188,9 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             }
 
             // Translate the vmSlice into a physically addressed "true" Rust slice
-            let data_slice = ptr_box.value.translate_mut(
-                memory_mapping,
-                invoke_context.get_check_aligned()
-            )?;
+            let data_slice = ptr_box
+                .value
+                .translate(memory_mapping, invoke_context.get_check_aligned())?;
 
             consume_compute_meter(
                 invoke_context,
@@ -223,7 +221,9 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
                 let translated = translate(
                     memory_mapping,
                     AccessType::Store,
-                    account_info.data.addr.saturating_add(len_offset), 8)? as *mut u64;
+                    account_info.data.addr.saturating_add(len_offset),
+                    8,
+                )? as *mut u64;
                 VmValue::Translated(unsafe { &mut *translated })
             };
 
@@ -242,7 +242,9 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
                 // _yet_, but we will be able to once the caller returns.
                 &mut []
             } else {
-                data_slice
+                ptr_box
+                    .value
+                    .translate_mut(memory_mapping, invoke_context.get_check_aligned())?
             };
             (serialized_data, vm_data_addr, ref_to_len_in_vm)
         };

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -139,7 +139,7 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
                 invoke_context.get_check_aligned(),
             )?;
             if direct_mapping {
-                if account_info.lamports.addr as u64 >= ebpf::MM_INPUT_START {
+                if account_info.lamports.addr >= ebpf::MM_INPUT_START {
                     return Err(SyscallError::InvalidPointer.into());
                 }
 

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1617,7 +1617,6 @@ mod tests {
         crate::mock_create_vm,
         assert_matches::assert_matches,
         solana_account::{Account, AccountSharedData, ReadableAccount},
-        solana_clock::Epoch,
         solana_feature_set::bpf_account_data_direct_mapping,
         solana_instruction::Instruction,
         solana_program_runtime::{
@@ -1793,7 +1792,7 @@ mod tests {
         };
         let memory_mapping = MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap();
 
-        let account_info = translate_type::<AccountInfo>(&memory_mapping, vm_addr, false).unwrap();
+        let account_info = translate_type::<VmAccountInfo>(&memory_mapping, vm_addr, false).unwrap();
 
         let caller_account = CallerAccount::from_vm_account_info(
             &invoke_context,
@@ -2892,7 +2891,7 @@ mod tests {
         }
 
         fn into_region(self, vm_addr: u64) -> (Vec<u8>, MemoryRegion, SerializedAccountMetadata) {
-            let size = mem::size_of::<AccountInfo>()
+            let size = mem::size_of::<VmAccountInfo>()
                 + mem::size_of::<Pubkey>() * 2
                 + mem::size_of::<RcBox<RefCell<&mut u64>>>()
                 + mem::size_of::<u64>()
@@ -2901,14 +2900,14 @@ mod tests {
             let mut data = vec![0; size];
 
             let vm_addr = vm_addr as usize;
-            let key_addr = vm_addr + mem::size_of::<AccountInfo>();
+            let key_addr = vm_addr + mem::size_of::<VmAccountInfo>();
             let lamports_cell_addr = key_addr + mem::size_of::<Pubkey>();
             let lamports_addr = lamports_cell_addr + mem::size_of::<RcBox<RefCell<&mut u64>>>();
             let owner_addr = lamports_addr + mem::size_of::<u64>();
             let data_cell_addr = owner_addr + mem::size_of::<Pubkey>();
             let data_addr = data_cell_addr + mem::size_of::<RcBox<RefCell<&mut [u8]>>>();
 
-            let info = AccountInfo {
+            let info = VmAccountInfo {
                 key: unsafe { (key_addr as *const Pubkey).as_ref() }.unwrap(),
                 is_signer: self.is_signer,
                 is_writable: self.is_writable,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -298,16 +298,14 @@ impl<T> VmSlice<T> {
 // the 64-bit virtual address space even when built in 32-bit mode.
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmNonNull<T>
-{
+pub struct VmNonNull<T> {
     pub addr: u64,
     resource_type: PhantomData<T>,
 }
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmBoxOfRefCell<T>
-{
+pub struct VmBoxOfRefCell<T> {
     _strong_addr: u64,
     _weak_addr: u64,
     _borrow_flag: u64,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -12,7 +12,6 @@ pub use self::{
 };
 #[allow(deprecated)]
 use {
-    solana_account_info::AccountInfo,
     solana_bn254::prelude::{
         alt_bn128_addition, alt_bn128_multiplication, alt_bn128_multiplication_128,
         alt_bn128_pairing, AltBn128Error, ALT_BN128_ADDITION_OUTPUT_LEN,
@@ -243,6 +242,7 @@ impl HasherImpl for Keccak256Hasher {
 // This class must consist only of 16 bytes: a u64 ptr and a u64 len, to match the 64-bit
 // implementation of a slice in Rust. The PhantomData entry takes up 0 bytes.
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct VmSlice<T> {
     ptr: u64,
@@ -292,6 +292,53 @@ impl<T> VmSlice<T> {
     ) -> Result<&mut [T], Error> {
         translate_slice_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
     }
+}
+
+// Structs to allow the AccountInfo translation to properly reference elements within
+// the 64-bit virtual address space even when built in 32-bit mode.
+#[derive(Clone)]
+#[repr(C)]
+pub struct VmNonNull<T>
+{
+    pub addr: u64,
+    resource_type: PhantomData<T>,
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub struct VmBoxOfRefCell<T>
+{
+    _strong_addr: u64,
+    _weak_addr: u64,
+    _borrow_flag: u64,
+    pub value: T,
+}
+
+/// Account information, in the virtual address space. Note: Since the addresses are u64,
+/// there is no lifetime on this struct, and the borrow checker cannot properly reason
+/// about references to the virtual memory via these addresses.
+#[derive(Clone)]
+#[repr(C)]
+pub struct VmAccountInfo<'a> {
+    /// Public key of the account (&'a Pubkey)
+    pub key: u64,
+    /// The address to the lamports in the account.  Modifiable by programs. (in `AccountInfo`: &'a mut u64)
+    pub lamports: VmNonNull<VmBoxOfRefCell<u64>>,
+    /// The data slice held in this account.  Modifiable by programs. (In `AccountInfo`: &'a mut [u8])
+    pub data: VmNonNull<VmBoxOfRefCell<VmSlice<u8>>>,
+    /// Program that owns this account (in `AccountInfo`: &'a Pubkey)
+    pub owner: u64,
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: u64,
+
+    /// Was the transaction signed by this account's public key?
+    pub is_signer: bool,
+    /// Is the account writable?
+    pub is_writable: bool,
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    phantom: PhantomData<&'a u8>,
 }
 
 fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {


### PR DESCRIPTION
#### Problem

When running Agave as a 32-bit build (as one might do if running inside a zk-prover, for example), CPI does not work properly, due to assumptions made about pointer sizes being 64-bit (which they are not), vs. the actual 64-bit addresses stored within the VM inside of the AccountInfo struct. This PR adds a VmAccountInfo struct, as well as a few auxiliary structs, to represent an AccountInfo struct within the VM without using pointers or slices directly.

