### PR TITLE
Reapply 3515: add tpu client next to SendTransactionService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9556,17 +9556,22 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
+ "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
  "log",
  "solana-client",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-logger",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "solana-tpu-client-next",
+ "tokio",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7909,16 +7909,21 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
+ "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
  "log",
  "solana-client",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "solana-tpu-client-next",
+ "tokio",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -8447,6 +8452,31 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.11",
  "tokio",
+]
+
+[[package]]
+name = "solana-tpu-client-next"
+version = "2.2.0"
+dependencies = [
+ "async-trait",
+ "log",
+ "lru",
+ "quinn",
+ "rustls 0.23.21",
+ "solana-clock",
+ "solana-connection-cache",
+ "solana-keypair",
+ "solana-logger",
+ "solana-measure",
+ "solana-quic-definitions",
+ "solana-rpc-client",
+ "solana-streamer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-tpu-client",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -10,20 +10,28 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+async-trait = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 solana-client = { workspace = true }
 solana-connection-cache = { workspace = true }
+solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-tpu-client-next = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+
+[features]
+dev-context-only-utils = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -3,7 +3,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::Itertools,
     log::{warn, *},
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_connection_cache::client_connection::ClientConnection as TpuConnection,
     solana_measure::measure::Measure,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -688,6 +688,10 @@ pub trait TransactionClient {
         wire_transactions: Vec<Vec<u8>>,
         stats: &SendTransactionServiceStats,
     );
+
+    fn protocol(&self) -> Protocol;
+
+    fn exit(&self);
 }
 
 pub struct ConnectionCacheClient<T: TpuInfoWithSendStatic> {
@@ -793,6 +797,12 @@ where
             self.send_transactions(address, wire_transactions.clone(), stats);
         }
     }
+
+    fn protocol(&self) -> Protocol {
+        self.connection_cache.protocol()
+    }
+
+    fn exit(&self) {}
 }
 
 #[cfg(test)]

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -1,22 +1,32 @@
 use {
     crate::tpu_info::TpuInfo,
+    async_trait::async_trait,
     crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::Itertools,
     log::{warn, *},
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_connection_cache::client_connection::ClientConnection as TpuConnection,
+    solana_keypair::Keypair,
     solana_measure::measure::Measure,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
-        hash::Hash, nonce_account, pubkey::Pubkey, saturating_add_assign, signature::Signature,
-        timing::AtomicInterval,
+        hash::Hash, nonce_account, pubkey::Pubkey, quic::NotifyKeyUpdate, saturating_add_assign,
+        signature::Signature, timing::AtomicInterval,
+    },
+    solana_tpu_client_next::{
+        connection_workers_scheduler::{
+            ConnectionWorkersSchedulerConfig, Fanout, TransactionStatsAndReceiver,
+        },
+        leader_updater::LeaderUpdater,
+        transaction_batch::TransactionBatch,
+        ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
     },
     std::{
         collections::{
             hash_map::{Entry, HashMap},
             HashSet,
         },
-        net::SocketAddr,
+        net::{Ipv4Addr, SocketAddr},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, Mutex, RwLock,
@@ -24,6 +34,12 @@ use {
         thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
+    tokio::{
+        runtime::Handle,
+        sync::mpsc::{self},
+        task::JoinHandle as TokioJoinHandle,
+    },
+    tokio_util::sync::CancellationToken,
 };
 
 /// Maximum size of the transaction retry pool
@@ -145,6 +161,7 @@ pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
 
 /// A struct responsible for holding up-to-date leader information
 /// used for sending transactions.
+#[derive(Clone)]
 pub struct CurrentLeaderInfo<T>
 where
     T: TpuInfoWithSendStatic,
@@ -803,6 +820,249 @@ where
     }
 
     fn exit(&self) {}
+}
+
+impl<T> NotifyKeyUpdate for ConnectionCacheClient<T>
+where
+    T: TpuInfoWithSendStatic,
+{
+    fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+        self.connection_cache.update_key(identity)
+    }
+}
+
+/// `TpuClientNextClient` provides an interface for managing the
+/// [`ConnectionWorkersScheduler`].
+///
+/// It allows:
+/// * Create and initializes the scheduler with runtime configurations,
+/// * Send transactions to the connection scheduler,
+/// * Update the validator identity keypair and propagate the changes to the
+///   scheduler. Most of the complexity of this structure arises from this
+///   functionality.
+#[derive(Clone)]
+pub struct TpuClientNextClient<T>
+where
+    T: TpuInfoWithSendStatic + Clone,
+{
+    runtime_handle: Handle,
+    sender: mpsc::Sender<TransactionBatch>,
+    // This handle is needed to implement `NotifyKeyUpdate` trait. It's only
+    // method takes &self and thus we need to wrap with Mutex.
+    join_and_cancel: Arc<Mutex<(Option<TpuClientJoinHandle>, CancellationToken)>>,
+    leader_updater: SendTransactionServiceLeaderUpdater<T>,
+    leader_forward_count: u64,
+}
+
+type TpuClientJoinHandle =
+    TokioJoinHandle<Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>>;
+
+impl<T> TpuClientNextClient<T>
+where
+    T: TpuInfoWithSendStatic + Clone,
+{
+    pub fn new(
+        runtime_handle: Handle,
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_info: Option<T>,
+        leader_forward_count: u64,
+        identity: Option<Keypair>,
+    ) -> Self
+    where
+        T: TpuInfoWithSendStatic + Clone,
+    {
+        // The channel size represents 8s worth of transactions at a rate of
+        // 1000 tps, assuming batch size is 64.
+        let (sender, receiver) = mpsc::channel(128);
+
+        let cancel = CancellationToken::new();
+
+        let leader_info_provider = CurrentLeaderInfo::new(leader_info);
+        let leader_updater: SendTransactionServiceLeaderUpdater<T> =
+            SendTransactionServiceLeaderUpdater {
+                leader_info_provider,
+                my_tpu_address,
+                tpu_peers,
+            };
+        let config = Self::create_config(identity, leader_forward_count as usize);
+        let handle = runtime_handle.spawn(ConnectionWorkersScheduler::run(
+            config,
+            Box::new(leader_updater.clone()),
+            receiver,
+            cancel.clone(),
+        ));
+
+        Self {
+            runtime_handle,
+            join_and_cancel: Arc::new(Mutex::new((Some(handle), cancel))),
+            sender,
+            leader_updater,
+            leader_forward_count,
+        }
+    }
+
+    fn create_config(
+        stake_identity: Option<Keypair>,
+        leader_forward_count: usize,
+    ) -> ConnectionWorkersSchedulerConfig {
+        ConnectionWorkersSchedulerConfig {
+            bind: SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0),
+            stake_identity,
+            // to match MAX_CONNECTIONS from ConnectionCache
+            num_connections: 1024,
+            skip_check_transaction_age: true,
+            // experimentally found parameter values
+            worker_channel_size: 64,
+            max_reconnect_attempts: 4,
+            leaders_fanout: Fanout {
+                connect: leader_forward_count,
+                send: leader_forward_count,
+            },
+        }
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub fn cancel(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let Ok(lock) = self.join_and_cancel.lock() else {
+            return Err("Failed to stop scheduler: TpuClientNext task panicked.".into());
+        };
+        lock.1.cancel();
+        Ok(())
+    }
+
+    async fn do_update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+        let runtime_handle = self.runtime_handle.clone();
+        let config = Self::create_config(
+            Some(identity.insecure_clone()),
+            self.leader_forward_count as usize,
+        );
+        let leader_updater = self.leader_updater.clone();
+        let handle = self.join_and_cancel.clone();
+
+        let join_handle = {
+            let Ok(mut lock) = handle.lock() else {
+                return Err("TpuClientNext task panicked.".into());
+            };
+            let (handle, token) = std::mem::take(&mut *lock);
+            token.cancel();
+            handle
+        };
+
+        if let Some(join_handle) = join_handle {
+            let Ok(result) = join_handle.await else {
+                return Err("TpuClientNext task panicked.".into());
+            };
+
+            match result {
+                Ok((_stats, receiver)) => {
+                    let cancel = CancellationToken::new();
+                    let join_handle = runtime_handle.spawn(ConnectionWorkersScheduler::run(
+                        config,
+                        Box::new(leader_updater),
+                        receiver,
+                        cancel.clone(),
+                    ));
+
+                    let Ok(mut lock) = handle.lock() else {
+                        return Err("TpuClientNext task panicked.".into());
+                    };
+                    *lock = (Some(join_handle), cancel);
+                }
+                Err(error) => {
+                    return Err(Box::new(error));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T> NotifyKeyUpdate for TpuClientNextClient<T>
+where
+    T: TpuInfoWithSendStatic + Clone,
+{
+    fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+        self.runtime_handle.block_on(self.do_update_key(identity))
+    }
+}
+
+impl<T> TransactionClient for TpuClientNextClient<T>
+where
+    T: TpuInfoWithSendStatic + Clone,
+{
+    fn send_transactions_in_batch(
+        &self,
+        wire_transactions: Vec<Vec<u8>>,
+        stats: &SendTransactionServiceStats,
+    ) {
+        let mut measure = Measure::start("send-us");
+        self.runtime_handle.spawn({
+            let sender = self.sender.clone();
+            async move {
+                let res = sender.send(TransactionBatch::new(wire_transactions)).await;
+                if res.is_err() {
+                    warn!("Failed to send transaction to channel: it is closed.");
+                }
+            }
+        });
+
+        measure.stop();
+        stats.send_us.fetch_add(measure.as_us(), Ordering::Relaxed);
+        stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn protocol(&self) -> Protocol {
+        Protocol::QUIC
+    }
+
+    fn exit(&self) {
+        let Ok(mut lock) = self.join_and_cancel.lock() else {
+            error!("Failed to stop scheduler: TpuClientNext task panicked.");
+            return;
+        };
+        let (handle, token) = std::mem::take(&mut *lock);
+        token.cancel();
+        if let Some(handle) = handle {
+            match self.runtime_handle.block_on(handle) {
+                Ok(result) => match result {
+                    Ok(stats) => {
+                        debug!("tpu-client-next statistics over all the connections: {stats:?}");
+                    }
+                    Err(error) => error!("tpu-client-next exits with error {error}."),
+                },
+                Err(error) => error!("Failed to join task {error}."),
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SendTransactionServiceLeaderUpdater<T: TpuInfoWithSendStatic> {
+    leader_info_provider: CurrentLeaderInfo<T>,
+    my_tpu_address: SocketAddr,
+    tpu_peers: Option<Vec<SocketAddr>>,
+}
+
+#[async_trait]
+impl<T> LeaderUpdater for SendTransactionServiceLeaderUpdater<T>
+where
+    T: TpuInfoWithSendStatic,
+{
+    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
+        let discovered_peers = self
+            .leader_info_provider
+            .get_leader_info()
+            .map(|leader_info| {
+                leader_info.get_leader_tpus(lookahead_leaders as u64, Protocol::QUIC)
+            })
+            .filter(|addresses| !addresses.is_empty())
+            .unwrap_or_else(|| vec![&self.my_tpu_address]);
+        let mut all_peers = self.tpu_peers.clone().unwrap_or_default();
+        all_peers.extend(discovered_peers.into_iter().cloned());
+        all_peers
+    }
+    async fn stop(&mut self) {}
 }
 
 #[cfg(test)]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7239,16 +7239,21 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "2.2.0"
 dependencies = [
+ "async-trait",
  "crossbeam-channel",
  "itertools 0.12.1",
  "log",
  "solana-client",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "solana-tpu-client-next",
+ "tokio",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -7794,6 +7799,31 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.11",
  "tokio",
+]
+
+[[package]]
+name = "solana-tpu-client-next"
+version = "2.2.0"
+dependencies = [
+ "async-trait",
+ "log",
+ "lru",
+ "quinn",
+ "rustls 0.23.21",
+ "solana-clock",
+ "solana-connection-cache",
+ "solana-keypair",
+ "solana-logger",
+ "solana-measure",
+ "solana-quic-definitions",
+ "solana-rpc-client",
+ "solana-streamer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-tpu-client",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

This PR does not change the current behaviour of SendTransactionService, but introduces the new client component. It is split in several commits for the simplicity of review. In particular it does the following:
* extends `TransactionClient` trait
* adds a new implementation of this trait called `TpuClientNextClient`
* instruments SendTransactionService tests to use this new client.

This PR partially reapplies https://github.com/anza-xyz/agave/pull/3515/files#diff-a3caa5df6489d5460449094b87e57398a081eb6d7feca10bf89fa5847b429251

