### PR TITLE
banking_stage: add metric to report drained votes from tpu/gossip

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -568,6 +568,12 @@ pub(crate) struct VotePacketCountMetrics {
 
     // How many votes ingested from tpu were dropped
     dropped_tpu_votes: u64,
+
+    // How many votes were drained from gossip
+    drained_gossip_votes: u64,
+
+    // How many votes were drained from tpu
+    drained_tpu_votes: u64,
 }
 
 impl VotePacketCountMetrics {
@@ -581,7 +587,9 @@ impl VotePacketCountMetrics {
             "id" => id,
             ("slot", slot, i64),
             ("dropped_gossip_votes", self.dropped_gossip_votes, i64),
-            ("dropped_tpu_votes", self.dropped_tpu_votes, i64)
+            ("dropped_tpu_votes", self.dropped_tpu_votes, i64),
+            ("drained_gossip_votes", self.drained_gossip_votes, i64),
+            ("drained_tpu_votes", self.drained_tpu_votes, i64),
         );
     }
 }
@@ -1080,6 +1088,28 @@ impl LeaderSlotMetricsTracker {
                 leader_slot_metrics
                     .vote_packet_count_metrics
                     .dropped_tpu_votes,
+                count
+            );
+        }
+    }
+
+    pub(crate) fn increment_drained_gossip_vote_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .vote_packet_count_metrics
+                    .drained_gossip_votes,
+                count
+            );
+        }
+    }
+
+    pub(crate) fn increment_drained_tpu_vote_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .vote_packet_count_metrics
+                    .drained_tpu_votes,
                 count
             );
         }

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -510,9 +510,12 @@ impl VoteStorage {
         // Based on the stake distribution present in the supplied bank, drain the unprocessed votes
         // from each validator using a weighted random ordering. Votes from validators with
         // 0 stake are ignored.
-        let all_vote_packets = self
+        let (all_vote_packets, num_drained_tpu_votes, num_drained_gossip_votes) = self
             .latest_unprocessed_votes
             .drain_unprocessed(bank.clone());
+
+        slot_metrics_tracker.increment_drained_tpu_vote_count(num_drained_tpu_votes);
+        slot_metrics_tracker.increment_drained_gossip_vote_count(num_drained_gossip_votes);
 
         // vote storage does not have a message hash map, so pass in an empty one
         let mut dummy_message_hash_to_transaction = HashMap::new();


### PR DESCRIPTION
#### Problem
After removing the intermediate buffer between gossip -> banking stage we don't have an accurate metric for measuring the types of votes that end up in a block

#### Summary of Changes
Add a slot metric that's incremented for each type of vote that is drained into the block. Note this is not 100% accurate since some of these packets are double counted if they go through retry.