### PR TITLE
sdk: Fixup features for separation

### DIFF
--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -11,6 +11,9 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
+# Needed by the monorepo for checks in CI, can be removed when the SDK is
+# extracted
+dummy-for-ci-check = []
 # "program" feature is a legacy feature retained to support v1.3 and older
 # programs.  New development should not use this feature.  Instead use the
 # solana-program crate
@@ -68,6 +71,7 @@ frozen-abi = [
     "solana-genesis-config/frozen-abi",
     "solana-hard-forks/frozen-abi",
     "solana-inflation/frozen-abi",
+    "solana-packet/frozen-abi",
     "solana-poh-config/frozen-abi",
     "solana-program/frozen-abi",
     "solana-rent-collector/frozen-abi",


### PR DESCRIPTION
#### Problem

During the work to extricate the sdk from the rest of the monorepo in #4685, there were a couple of issues with CI.

First, the `dummy-for-ci-check` feature doesn't exist in any sdk crate, so the `clippy` and `check` steps were failing when trying to activate the feature.

Next, the frozen-abi tests were failing because the sdk doesn't activate `solana-packet`'s frozen-abi feature when its frozen-abi is active.

#### Summary of changes

Add a `dummy-for-ci-check` to `solana-sdk`, and correctly activate `frozen-abi` on `solana-packet`.