### PR TITLE
Support multiple RPC URLs in watchtower

### DIFF
--- a/watchtower/README.md
+++ b/watchtower/README.md
@@ -1,17 +1,18 @@
-The `agave-watchtower` program is used to monitor the health of a cluster.  It
+The `agave-watchtower` program is used to monitor the health of a cluster. It
 periodically polls the cluster over an RPC API to confirm that the transaction
 count is advancing, new blockhashes are available, and no validators are
-delinquent.  Results are reported as InfluxDB metrics, with an optional push
+delinquent. Results are reported as InfluxDB metrics, with an optional push
 notification on sanity failure.
 
-If you only care about the health of one specific validator, the
+If you only care about the health of several specific validators, the
 `--validator-identity` command-line argument can be used to restrict failure
-notifications to issues only affecting that validator.
+notifications to issues only affecting that set of validators.
 
-If you do not want duplicate notifications, for example if you have elected to
-receive notifications by SMS the
-`--no-duplicate-notifications` command-line argument will suppress identical
-failure notifications.
+User can provide either 1 or 3 RPC URLs for the cluster via the `--url` or `--urls`
+command-line arguments respectively. 2 URLs are not accepted because it's not enough
+to have redundnacy, and more than 3 URLs are not accepted because there's little
+benefit from having more than 3. If 3 URLs are provided, at least 2 of them have to
+confirm health of a cluster.
 
 ### Metrics
 #### `watchtower-sanity`

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -410,11 +410,15 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     loop {
         let mut failures = BTreeMap::new(); // test_name -> message
+
+        let mut num_healthy = 0;
         let mut num_unreachable = 0;
 
         for endpoint in &mut endpoints {
             match query_endpoint(&config, endpoint) {
-                Ok(None) => {}
+                Ok(None) => {
+                    num_healthy += 1;
+                }
                 Ok(Some((failure_test_name, failure_error_message))) => {
                     // Collecting only one failure of each type
                     failures
@@ -437,7 +441,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             failures.insert("watchtower-reliability".into(), watchtower_unreliable_msg);
         }
 
-        if !failures.is_empty() {
+        if num_healthy < min_agreeing_endpoints {
             let notification_msg = format!(
                 "agave-watchtower{}: {}",
                 config.name_suffix,

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -280,7 +280,7 @@ fn query_endpoint(
 ) -> client_error::Result<Option<(&'static str, String)>> {
     info!("Querying {}", endpoint.rpc_client.url());
 
-    match get_cluster_info(&config, &endpoint.rpc_client) {
+    match get_cluster_info(config, &endpoint.rpc_client) {
         Ok((transaction_count, recent_blockhash, vote_accounts, validator_balances)) => {
             info!("Current transaction count: {}", transaction_count);
             info!("Recent blockhash: {}", recent_blockhash);
@@ -403,7 +403,7 @@ fn validate_endpoints(
     info!("Validating endpoints...");
 
     let mut max_slot = 0;
-    let mut min_slot = u64::max_value();
+    let mut min_slot = u64::MAX;
 
     let mut opt_common_genesis_hash: Option<Hash> = None;
 
@@ -421,10 +421,9 @@ fn validate_endpoints(
 
         if let Some(common_genesis_hash) = opt_common_genesis_hash {
             if common_genesis_hash != genesis_hash {
-                return Err(format!(
-                    "Endpoints don't aggree on genesis hash, have you mixed up clusters?"
-                )
-                .into());
+                return Err(
+                    "Endpoints don't aggree on genesis hash, have you mixed up clusters?".into(),
+                );
             }
         } else {
             opt_common_genesis_hash = Some(genesis_hash);
@@ -504,7 +503,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 num_reachable,
                 endpoints.len()
             );
-            failures.insert("watchtower-reliability".into(), watchtower_unreliable_msg);
+            failures.insert("watchtower-reliability", watchtower_unreliable_msg);
         }
 
         if num_healthy < min_agreeing_endpoints {
@@ -514,7 +513,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 let watchtower_unreliable_msg =
                     "Watchtower is unreliable, RPC endpoints provide inconsistent information"
                         .into();
-                failures.insert("watchtower-reliability".into(), watchtower_unreliable_msg);
+                failures.insert("watchtower-reliability", watchtower_unreliable_msg);
             }
 
             let (failure_test_name, failure_error_message) = failures.iter().next().unwrap();

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -18,7 +18,7 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::{client_error, response::RpcVoteAccountStatus},
     std::{
-        collections::{BTreeMap, HashMap},
+        collections::HashMap,
         error,
         thread::sleep,
         time::{Duration, Instant},
@@ -403,13 +403,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let notifier = Notifier::default();
 
-    let mut last_notification_msg = "".to_string();
+    let mut last_notification_msg = "".into();
     let mut num_consecutive_failures = 0;
     let mut last_success = Instant::now();
     let mut incident = Hash::new_unique();
 
     loop {
-        let mut failures = BTreeMap::new(); // test_name -> message
+        let mut failures = HashMap::new(); // test_name -> message
 
         let mut num_healthy = 0;
         let mut num_reachable = 0;
@@ -433,10 +433,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
 
         if num_reachable < min_agreeing_endpoints {
-            failures.clear(); // Ignoring other failures when watchtower is unrealiable
+            failures.clear(); // Ignoring other failures when watchtower is unreliable
 
             let watchtower_unreliable_msg = format!(
-                "Watchtower is unrealiable, {} of {} RPC endpoints are reachable",
+                "Watchtower is unreliable, {} of {} RPC endpoints are reachable",
                 num_reachable,
                 endpoints.len()
             );
@@ -445,10 +445,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         if num_healthy < min_agreeing_endpoints {
             if failures.len() > 1 {
-                failures.clear(); // Ignoring other failures when watchtower is unrealiable
+                failures.clear(); // Ignoring other failures when watchtower is unreliable
 
                 let watchtower_unreliable_msg =
-                    "Watchtower is unrealiable, RPC endpoints provide inconsistent information"
+                    "Watchtower is unreliable, RPC endpoints provide inconsistent information"
                         .into();
                 failures.insert("watchtower-reliability".into(), watchtower_unreliable_msg);
             }


### PR DESCRIPTION
#### Problem

Agave watchtower currently supports only one RPC URL. This RPC URL becomes a single point of failure, so we would like to have an ability to specify several RPC endpoints to have redundancy.
More details and discussion is available in this issue: https://github.com/anza-xyz/agave/issues/4621

#### Summary of Changes

- Added `--urls` argument, that takes exactly 3 values and conflicts with `--url` (reasoning is described in README.md, also see the discussion in the issue)
- Added `watchtower-reliability` test, alert for which will be triggered if less than `endpoints.len() / 2 + 1` endpoints are reachable or if they provide inconsistent results.
- Info that's collected from the cluster and the logic of how it's analyzed is unchanged. Only adding the logic on top of it of how the issues from multiple endpoints are aggregated.