### PR TITLE
no resize area for unaligned programs

### DIFF
--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -80,7 +80,7 @@ declare_builtin_function!(
             )?;
             let syscall_context = invoke_context.get_syscall_context()?;
 
-            *cmp_result = memcmp_non_contiguous(s1_addr, s2_addr, n, &syscall_context.accounts_metadata, memory_mapping)?;
+            *cmp_result = memcmp_non_contiguous(s1_addr, s2_addr, n, &syscall_context.accounts_metadata, memory_mapping, invoke_context.get_check_aligned())?;
         } else {
             let s1 = translate_slice::<u8>(
                 memory_mapping,
@@ -133,7 +133,7 @@ declare_builtin_function!(
         {
             let syscall_context = invoke_context.get_syscall_context()?;
 
-            memset_non_contiguous(dst_addr, c as u8, n, &syscall_context.accounts_metadata, memory_mapping)
+            memset_non_contiguous(dst_addr, c as u8, n, &syscall_context.accounts_metadata, memory_mapping, invoke_context.get_check_aligned())
         } else {
             let s = translate_slice_mut::<u8>(
                 memory_mapping,
@@ -166,6 +166,7 @@ fn memmove(
             n,
             &syscall_context.accounts_metadata,
             memory_mapping,
+            invoke_context.get_check_aligned(),
         )
     } else {
         let dst_ptr = translate_slice_mut::<u8>(
@@ -194,6 +195,7 @@ fn memmove_non_contiguous(
     n: u64,
     accounts: &[SerializedAccountMetadata],
     memory_mapping: &MemoryMapping,
+    check_aligned: bool,
 ) -> Result<u64, Error> {
     let reverse = dst_addr.wrapping_sub(src_addr) < n;
     iter_memory_pair_chunks(
@@ -205,6 +207,7 @@ fn memmove_non_contiguous(
         accounts,
         memory_mapping,
         reverse,
+        check_aligned,
         |src_host_addr, dst_host_addr, chunk_len| {
             unsafe { std::ptr::copy(src_host_addr, dst_host_addr as *mut u8, chunk_len) };
             Ok(0)
@@ -231,6 +234,7 @@ fn memcmp_non_contiguous(
     n: u64,
     accounts: &[SerializedAccountMetadata],
     memory_mapping: &MemoryMapping,
+    check_aligned: bool,
 ) -> Result<i32, Error> {
     let memcmp_chunk = |s1_addr, s2_addr, chunk_len| {
         let res = unsafe {
@@ -256,6 +260,7 @@ fn memcmp_non_contiguous(
         accounts,
         memory_mapping,
         false,
+        check_aligned,
         memcmp_chunk,
     ) {
         Ok(res) => Ok(res),
@@ -293,9 +298,16 @@ fn memset_non_contiguous(
     n: u64,
     accounts: &[SerializedAccountMetadata],
     memory_mapping: &MemoryMapping,
+    check_aligned: bool,
 ) -> Result<u64, Error> {
-    let dst_chunk_iter =
-        MemoryChunkIterator::new(memory_mapping, accounts, AccessType::Store, dst_addr, n)?;
+    let dst_chunk_iter = MemoryChunkIterator::new(
+        memory_mapping,
+        accounts,
+        AccessType::Store,
+        dst_addr,
+        n,
+        check_aligned,
+    )?;
     for item in dst_chunk_iter {
         let (dst_region, dst_vm_addr, dst_len) = item?;
         let dst_host_addr = Result::from(dst_region.vm_to_host(dst_vm_addr, dst_len as u64))?;
@@ -305,6 +317,7 @@ fn memset_non_contiguous(
     Ok(0)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn iter_memory_pair_chunks<T, F>(
     src_access: AccessType,
     src_addr: u64,
@@ -314,18 +327,31 @@ fn iter_memory_pair_chunks<T, F>(
     accounts: &[SerializedAccountMetadata],
     memory_mapping: &MemoryMapping,
     reverse: bool,
+    check_aligned: bool,
     mut fun: F,
 ) -> Result<T, Error>
 where
     T: Default,
     F: FnMut(*const u8, *const u8, usize) -> Result<T, Error>,
 {
-    let mut src_chunk_iter =
-        MemoryChunkIterator::new(memory_mapping, accounts, src_access, src_addr, n_bytes)
-            .map_err(EbpfError::from)?;
-    let mut dst_chunk_iter =
-        MemoryChunkIterator::new(memory_mapping, accounts, dst_access, dst_addr, n_bytes)
-            .map_err(EbpfError::from)?;
+    let mut src_chunk_iter = MemoryChunkIterator::new(
+        memory_mapping,
+        accounts,
+        src_access,
+        src_addr,
+        n_bytes,
+        check_aligned,
+    )
+    .map_err(EbpfError::from)?;
+    let mut dst_chunk_iter = MemoryChunkIterator::new(
+        memory_mapping,
+        accounts,
+        dst_access,
+        dst_addr,
+        n_bytes,
+        check_aligned,
+    )
+    .map_err(EbpfError::from)?;
 
     let mut src_chunk = None;
     let mut dst_chunk = None;
@@ -421,6 +447,7 @@ struct MemoryChunkIterator<'a> {
     len: u64,
     account_index: Option<usize>,
     is_account: Option<bool>,
+    check_aligned: bool,
 }
 
 impl<'a> MemoryChunkIterator<'a> {
@@ -430,6 +457,7 @@ impl<'a> MemoryChunkIterator<'a> {
         access_type: AccessType,
         vm_addr: u64,
         len: u64,
+        check_aligned: bool,
     ) -> Result<MemoryChunkIterator<'a>, EbpfError> {
         let vm_addr_end = vm_addr.checked_add(len).ok_or(EbpfError::AccessViolation(
             access_type,
@@ -448,6 +476,7 @@ impl<'a> MemoryChunkIterator<'a> {
             vm_addr_end,
             account_index: None,
             is_account: None,
+            check_aligned,
         })
     }
 
@@ -503,8 +532,9 @@ impl<'a> Iterator for MemoryChunkIterator<'a> {
                     account_index = account_index.saturating_add(1);
                     self.account_index = Some(account_index);
                 } else {
-                    region_is_account =
-                        region.vm_addr == account_addr || region.vm_addr == resize_addr;
+                    region_is_account = region.vm_addr == account_addr
+                        // unaligned programs do not have a resize area
+                        || (self.check_aligned && region.vm_addr == resize_addr);
                     break;
                 }
             } else {
@@ -576,7 +606,9 @@ impl DoubleEndedIterator for MemoryChunkIterator<'_> {
 
                 self.account_index = Some(account_index);
             } else {
-                region_is_account = region.vm_addr == account_addr || region.vm_addr == resize_addr;
+                region_is_account = region.vm_addr == account_addr
+                    // unaligned programs do not have a resize area
+                    || (self.check_aligned && region.vm_addr == resize_addr);
                 break;
             }
         }
@@ -633,7 +665,7 @@ mod tests {
         let memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
 
         let mut src_chunk_iter =
-            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, 0, 1).unwrap();
+            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, 0, 1, true).unwrap();
         src_chunk_iter.next().unwrap().unwrap();
     }
 
@@ -647,7 +679,8 @@ mod tests {
         let memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
 
         let mut src_chunk_iter =
-            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, u64::MAX, 1).unwrap();
+            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, u64::MAX, 1, true)
+                .unwrap();
         src_chunk_iter.next().unwrap().unwrap();
     }
 
@@ -672,6 +705,7 @@ mod tests {
             AccessType::Load,
             MM_RODATA_START - 1,
             42,
+            true,
         )
         .unwrap();
         assert_matches!(
@@ -681,9 +715,15 @@ mod tests {
 
         // check oob at the upper bound. Since the memory mapping isn't empty,
         // this always happens on the second next().
-        let mut src_chunk_iter =
-            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, MM_RODATA_START, 43)
-                .unwrap();
+        let mut src_chunk_iter = MemoryChunkIterator::new(
+            &memory_mapping,
+            &[],
+            AccessType::Load,
+            MM_RODATA_START,
+            43,
+            true,
+        )
+        .unwrap();
         assert!(src_chunk_iter.next().unwrap().is_ok());
         assert_matches!(
             src_chunk_iter.next().unwrap().unwrap_err().downcast_ref().unwrap(),
@@ -691,10 +731,16 @@ mod tests {
         );
 
         // check oob at the upper bound on the first next_back()
-        let mut src_chunk_iter =
-            MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, MM_RODATA_START, 43)
-                .unwrap()
-                .rev();
+        let mut src_chunk_iter = MemoryChunkIterator::new(
+            &memory_mapping,
+            &[],
+            AccessType::Load,
+            MM_RODATA_START,
+            43,
+            true,
+        )
+        .unwrap()
+        .rev();
         assert_matches!(
             src_chunk_iter.next().unwrap().unwrap_err().downcast_ref().unwrap(),
             EbpfError::AccessViolation(AccessType::Load, addr, 43, "program") if *addr == MM_RODATA_START
@@ -707,6 +753,7 @@ mod tests {
             AccessType::Load,
             MM_RODATA_START - 1,
             43,
+            true,
         )
         .unwrap()
         .rev();
@@ -738,6 +785,7 @@ mod tests {
             AccessType::Load,
             MM_RODATA_START - 1,
             1,
+            true,
         )
         .unwrap();
         assert!(src_chunk_iter.next().unwrap().is_err());
@@ -749,6 +797,7 @@ mod tests {
             AccessType::Load,
             MM_RODATA_START + 42,
             1,
+            true,
         )
         .unwrap();
         assert!(src_chunk_iter.next().unwrap().is_err());
@@ -761,9 +810,15 @@ mod tests {
             (MM_RODATA_START + 41, 1),
         ] {
             for rev in [true, false] {
-                let iter =
-                    MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, vm_addr, len)
-                        .unwrap();
+                let iter = MemoryChunkIterator::new(
+                    &memory_mapping,
+                    &[],
+                    AccessType::Load,
+                    vm_addr,
+                    len,
+                    true,
+                )
+                .unwrap();
                 let res = if rev {
                     to_chunk_vec(iter.rev())
                 } else {
@@ -806,9 +861,15 @@ mod tests {
             (MM_RODATA_START + 8, 4, vec![(MM_RODATA_START + 8, 4)]),
         ] {
             for rev in [false, true] {
-                let iter =
-                    MemoryChunkIterator::new(&memory_mapping, &[], AccessType::Load, vm_addr, len)
-                        .unwrap();
+                let iter = MemoryChunkIterator::new(
+                    &memory_mapping,
+                    &[],
+                    AccessType::Load,
+                    vm_addr,
+                    len,
+                    true,
+                )
+                .unwrap();
                 let res = if rev {
                     expected.reverse();
                     to_chunk_vec(iter.rev())
@@ -850,6 +911,7 @@ mod tests {
                 &[],
                 &memory_mapping,
                 false,
+                true,
                 |_src, _dst, _len| Ok::<_, Error>(0),
             ).unwrap_err().downcast_ref().unwrap(),
             EbpfError::AccessViolation(AccessType::Load, addr, 8, "program") if *addr == MM_RODATA_START + 8
@@ -866,6 +928,7 @@ mod tests {
                 &[],
                 &memory_mapping,
                 false,
+                true,
                 |_src, _dst, _len| Ok::<_, Error>(0),
             ).unwrap_err().downcast_ref().unwrap(),
             EbpfError::AccessViolation(AccessType::Load, addr, 3, "program") if *addr == MM_RODATA_START + 10
@@ -897,6 +960,7 @@ mod tests {
             4,
             &[],
             &memory_mapping,
+            true,
         )
         .unwrap();
     }
@@ -947,6 +1011,7 @@ mod tests {
             len as u64,
             &[],
             &memory_mapping,
+            true,
         )
         .unwrap();
 
@@ -977,7 +1042,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            memset_non_contiguous(MM_RODATA_START, 0x33, 9, &[], &memory_mapping).unwrap(),
+            memset_non_contiguous(MM_RODATA_START, 0x33, 9, &[], &memory_mapping, true).unwrap(),
             0
         );
     }
@@ -1005,7 +1070,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            memset_non_contiguous(MM_RODATA_START + 1, 0x55, 7, &[], &memory_mapping).unwrap(),
+            memset_non_contiguous(MM_RODATA_START + 1, 0x55, 7, &[], &memory_mapping, true)
+                .unwrap(),
             0
         );
         assert_eq!(&mem1, &[0x11]);
@@ -1041,7 +1107,8 @@ mod tests {
                 MM_RODATA_START + 9,
                 9,
                 &[],
-                &memory_mapping
+                &memory_mapping,
+                true
             )
             .unwrap(),
             0
@@ -1054,7 +1121,8 @@ mod tests {
                 MM_RODATA_START + 1,
                 8,
                 &[],
-                &memory_mapping
+                &memory_mapping,
+                true
             )
             .unwrap(),
             0
@@ -1067,7 +1135,8 @@ mod tests {
                 MM_RODATA_START + 11,
                 5,
                 &[],
-                &memory_mapping
+                &memory_mapping,
+                true
             )
             .unwrap(),
             unsafe { memcmp(b"oobar", b"obarb", 5) }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7316,6 +7316,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sbf-rust-account-mem-deprecated"
+version = "2.2.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-sbf-rust-alloc"
 version = "2.2.0"
 dependencies = [

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -151,6 +151,7 @@ members = [
     "rust/128bit",
     "rust/128bit_dep",
     "rust/account_mem",
+    "rust/account_mem_deprecated",
     "rust/alloc",
     "rust/alt_bn128",
     "rust/alt_bn128_compression",

--- a/programs/sbf/rust/account_mem_deprecated/Cargo.toml
+++ b/programs/sbf/rust/account_mem_deprecated/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-sbf-rust-account-mem-deprecated"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-program = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/account_mem_deprecated/src/lib.rs
+++ b/programs/sbf/rust/account_mem_deprecated/src/lib.rs
@@ -1,0 +1,129 @@
+//! Test mem functions
+
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    program_memory::{sol_memcmp, sol_memcpy, sol_memmove, sol_memset},
+    pubkey::Pubkey,
+};
+
+solana_program::entrypoint_deprecated!(process_instruction);
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let mut buf = [0u8; 2048];
+
+    let account = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let data_len = account.try_borrow_data()?.len();
+    let data_ptr = account.try_borrow_mut_data()?.as_mut_ptr();
+    // re-create slice with resize area
+    let data = unsafe { std::slice::from_raw_parts_mut(data_ptr, data_len) };
+
+    let mut too_early = |before: usize| -> &mut [u8] {
+        let data = data.as_mut_ptr().wrapping_sub(before);
+
+        unsafe { std::slice::from_raw_parts_mut(data, data_len) }
+    };
+
+    match instruction_data[0] {
+        0 => {
+            // memcmp overlaps end
+            sol_memcmp(&buf, &data[data_len.saturating_sub(8)..], 16);
+        }
+        1 => {
+            // memcmp overlaps end
+            sol_memcmp(&data[data_len.saturating_sub(7)..], &buf, 15);
+        }
+        2 => {
+            // memcmp overlaps begining
+            #[allow(clippy::manual_memcpy)]
+            for i in 0..500 {
+                buf[i] = too_early(8)[i];
+            }
+
+            sol_memcmp(too_early(8), &buf, 500);
+        }
+        3 => {
+            // memcmp overlaps begining
+            #[allow(clippy::manual_memcpy)]
+            for i in 0..12 {
+                buf[i] = too_early(9)[i];
+            }
+
+            sol_memcmp(&buf, too_early(9), 12);
+        }
+        4 => {
+            // memset overlaps end of account
+            sol_memset(&mut data[data_len.saturating_sub(2)..], 0, 3);
+        }
+        5 => {
+            // memset overlaps begin of account area
+            sol_memset(too_early(2), 3, 3);
+        }
+        6 => {
+            // memcpy src overlaps end of account
+            sol_memcpy(&mut buf, &data[data_len.saturating_sub(3)..], 10);
+        }
+        7 => {
+            // memmov src overlaps end of account
+            unsafe {
+                sol_memmove(
+                    buf.as_mut_ptr(),
+                    data[data_len.saturating_sub(3)..].as_ptr(),
+                    10,
+                )
+            };
+        }
+        8 => {
+            // memcpy src overlaps begin of account
+            sol_memcpy(&mut buf, too_early(3), 10);
+        }
+        9 => {
+            // memmov src overlaps begin of account
+            unsafe { sol_memmove(buf.as_mut_ptr(), too_early(3).as_ptr(), 10) };
+        }
+
+        10 => {
+            // memcpy dst overlaps end of account
+            sol_memcpy(&mut data[data_len.saturating_sub(3)..], &buf, 10);
+        }
+        11 => {
+            // memmov dst overlaps end of account
+            unsafe {
+                sol_memmove(
+                    data[data_len.saturating_sub(3)..].as_mut_ptr(),
+                    buf.as_ptr(),
+                    10,
+                )
+            };
+        }
+        12 => {
+            // memcpy dst overlaps begin of account
+            sol_memcpy(too_early(3), &buf, 10);
+        }
+        13 => {
+            // memmov dst overlaps begin of account
+            unsafe { sol_memmove(too_early(3).as_mut_ptr(), buf.as_ptr(), 10) };
+        }
+        14 => {
+            // memmove dst overlaps begin of account, reverse order
+            unsafe { sol_memmove(too_early(0).as_mut_ptr(), too_early(3).as_ptr(), 10) };
+        }
+        15 => {
+            // memmove dst overlaps end of account, reverse order
+            unsafe {
+                sol_memmove(
+                    data[data_len..].as_mut_ptr(),
+                    data[data_len.saturating_sub(3)..].as_mut_ptr(),
+                    10,
+                )
+            };
+        }
+        _ => {}
+    }
+
+    Ok(())
+}

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -5146,7 +5146,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         let mut bank_client = BankClient::new_shared(bank);
         let authority_keypair = Keypair::new();
 
-        let (bank, program_id) = load_program_of_loader_v4(
+        let (bank, loader_v4_program_id) = load_program_of_loader_v4(
             &mut bank_client,
             &bank_forks,
             &mint_keypair,
@@ -5154,30 +5154,45 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
             "solana_sbf_rust_account_mem",
         );
 
+        let deprecated_program_id = create_program(
+            &bank,
+            &bpf_loader_deprecated::id(),
+            "solana_sbf_rust_account_mem_deprecated",
+        );
+
         let mint_pubkey = mint_keypair.pubkey();
-        let account_metas = vec![
-            AccountMeta::new(mint_pubkey, true),
-            AccountMeta::new_readonly(program_id, false),
-            AccountMeta::new(account_keypair.pubkey(), false),
-        ];
 
-        let account = AccountSharedData::new(42, 1024, &program_id);
-        bank.store_account(&account_keypair.pubkey(), &account);
+        for deprecated in [false, true] {
+            let program_id = if deprecated {
+                deprecated_program_id
+            } else {
+                loader_v4_program_id
+            };
 
-        for instr in 0..=15 {
-            println!("Testing direct_mapping:{direct_mapping} instruction:{instr}");
-            let instruction =
-                Instruction::new_with_bytes(program_id, &[instr], account_metas.clone());
+            let account_metas = vec![
+                AccountMeta::new(mint_pubkey, true),
+                AccountMeta::new_readonly(program_id, false),
+                AccountMeta::new(account_keypair.pubkey(), false),
+            ];
 
-            let message = Message::new(&[instruction], Some(&mint_pubkey));
-            let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
-            let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
+            let account = AccountSharedData::new(42, 1024, &program_id);
+            bank.store_account(&account_keypair.pubkey(), &account);
 
-            if direct_mapping {
-                assert!(logs.last().unwrap().ends_with(" failed: InvalidLength"));
-            } else if result.is_err() {
-                // without direct mapping, we should never get the InvalidLength error
-                assert!(!logs.last().unwrap().ends_with(" failed: InvalidLength"));
+            for instr in 0..=15 {
+                println!("Testing deprecated:{deprecated} direct_mapping:{direct_mapping} instruction:{instr}");
+                let instruction =
+                    Instruction::new_with_bytes(program_id, &[instr], account_metas.clone());
+
+                let message = Message::new(&[instruction], Some(&mint_pubkey));
+                let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
+                let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
+
+                if direct_mapping {
+                    assert!(logs.last().unwrap().ends_with(" failed: InvalidLength"));
+                } else if result.is_err() {
+                    // without direct mapping, we should never get the InvalidLength error
+                    assert!(!logs.last().unwrap().ends_with(" failed: InvalidLength"));
+                }
             }
         }
     }

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -621,7 +621,7 @@ pub mod apply_cost_tracker_during_replay {
     solana_pubkey::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 pub mod bpf_account_data_direct_mapping {
-    solana_pubkey::declare_id!("FNPWmNbHbYy1R8JWVZgCPqsoRBcRu4F6ezSnq5o97Px");
+    solana_pubkey::declare_id!("AjX3A4Nv2rzUuATEUWLP4rrBaBropyUnHxEvFDj1dKbx");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {


### PR DESCRIPTION
#### Problem

- Unaligned programs do not have a resize area, so the memcpy syscalls should not check for resize areas in deprecated programs.
- Rekey direct mapping again since this is a breaking change.

Found by @yufeng-jump and @kbhargava-jump
