### PR TITLE
Reapply 3515: add `get_not_unique_leader_tpus` and depricate `get_leader_tpus_with_slots`

### DIFF
--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -1,7 +1,10 @@
 use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{clock::NUM_CONSECUTIVE_LEADER_SLOTS, pubkey::Pubkey},
+    solana_sdk::{
+        clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+        pubkey::Pubkey,
+    },
     solana_send_transaction_service::tpu_info::TpuInfo,
     std::{
         collections::HashMap,
@@ -81,6 +84,39 @@ impl TpuInfo for ClusterTpuInfo {
                     })
             })
             .collect()
+    }
+
+    fn get_leader_tpus_with_slots(
+        &self,
+        max_count: u64,
+        protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)> {
+        let recorder = self.poh_recorder.read().unwrap();
+        let leaders: Vec<_> = (0..max_count)
+            .rev()
+            .filter_map(|future_slot| {
+                NUM_CONSECUTIVE_LEADER_SLOTS
+                    .checked_mul(future_slot)
+                    .and_then(|slots_in_the_future| {
+                        recorder.leader_and_slot_after_n_slots(slots_in_the_future)
+                    })
+            })
+            .collect();
+        drop(recorder);
+        let addrs_to_slots = leaders
+            .into_iter()
+            .filter_map(|(leader_id, leader_slot)| {
+                self.recent_peers
+                    .get(&leader_id)
+                    .map(|(udp_tpu, quic_tpu)| match protocol {
+                        Protocol::UDP => (udp_tpu, leader_slot),
+                        Protocol::QUIC => (quic_tpu, leader_slot),
+                    })
+            })
+            .collect::<HashMap<_, _>>();
+        let mut unique_leaders = Vec::from_iter(addrs_to_slots);
+        unique_leaders.sort_by_key(|(_addr, slot)| *slot);
+        unique_leaders
     }
 }
 

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -1,10 +1,7 @@
 use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{
-        clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-        pubkey::Pubkey,
-    },
+    solana_sdk::{clock::NUM_CONSECUTIVE_LEADER_SLOTS, pubkey::Pubkey},
     solana_send_transaction_service::tpu_info::TpuInfo,
     std::{
         collections::HashMap,
@@ -67,37 +64,23 @@ impl TpuInfo for ClusterTpuInfo {
         unique_leaders
     }
 
-    fn get_leader_tpus_with_slots(
-        &self,
-        max_count: u64,
-        protocol: Protocol,
-    ) -> Vec<(&SocketAddr, Slot)> {
+    fn get_not_unique_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr> {
         let recorder = self.poh_recorder.read().unwrap();
-        let leaders: Vec<_> = (0..max_count)
-            .rev()
-            .filter_map(|future_slot| {
-                NUM_CONSECUTIVE_LEADER_SLOTS
-                    .checked_mul(future_slot)
-                    .and_then(|slots_in_the_future| {
-                        recorder.leader_and_slot_after_n_slots(slots_in_the_future)
-                    })
-            })
+        let leader_pubkeys: Vec<_> = (0..max_count)
+            .filter_map(|i| recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS))
             .collect();
         drop(recorder);
-        let addrs_to_slots = leaders
-            .into_iter()
-            .filter_map(|(leader_id, leader_slot)| {
+        leader_pubkeys
+            .iter()
+            .filter_map(|leader_pubkey| {
                 self.recent_peers
-                    .get(&leader_id)
-                    .map(|(udp_tpu, quic_tpu)| match protocol {
-                        Protocol::UDP => (udp_tpu, leader_slot),
-                        Protocol::QUIC => (quic_tpu, leader_slot),
+                    .get(leader_pubkey)
+                    .map(|addr| match protocol {
+                        Protocol::UDP => &addr.0,
+                        Protocol::QUIC => &addr.1,
                     })
             })
-            .collect::<HashMap<_, _>>();
-        let mut unique_leaders = Vec::from_iter(addrs_to_slots);
-        unique_leaders.sort_by_key(|(_addr, slot)| *slot);
-        unique_leaders
+            .collect()
     }
 }
 
@@ -276,8 +259,8 @@ mod test {
             vec![&recent_peers.get(&first_leader).unwrap().0]
         );
         assert_eq!(
-            leader_info.get_leader_tpus_with_slots(1, Protocol::UDP),
-            vec![(&recent_peers.get(&first_leader).unwrap().0, 0)]
+            leader_info.get_not_unique_leader_tpus(1, Protocol::UDP),
+            vec![&recent_peers.get(&first_leader).unwrap().0]
         );
 
         let second_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
@@ -295,11 +278,8 @@ mod test {
             expected_leader_sockets
         );
         assert_eq!(
-            leader_info.get_leader_tpus_with_slots(2, Protocol::UDP),
+            leader_info.get_not_unique_leader_tpus(2, Protocol::UDP),
             expected_leader_sockets
-                .into_iter()
-                .zip([0, 4])
-                .collect::<Vec<_>>()
         );
 
         let third_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
@@ -307,33 +287,29 @@ mod test {
             &bank,
         )
         .unwrap();
-        let mut expected_leader_sockets = vec![
+        let expected_leader_sockets = vec![
             &recent_peers.get(&first_leader).unwrap().0,
             &recent_peers.get(&second_leader).unwrap().0,
             &recent_peers.get(&third_leader).unwrap().0,
         ];
-        expected_leader_sockets.dedup();
+        let mut unique_expected_leader_sockets = expected_leader_sockets.clone();
+        unique_expected_leader_sockets.dedup();
         assert_eq!(
             leader_info.get_leader_tpus(3, Protocol::UDP),
-            expected_leader_sockets
+            unique_expected_leader_sockets
         );
-        // Only 2 leader tpus are returned always... so [0, 4, 8] isn't right here.
-        // This assumption is safe. After all, leader schedule generation must be deterministic.
         assert_eq!(
-            leader_info.get_leader_tpus_with_slots(3, Protocol::UDP),
+            leader_info.get_not_unique_leader_tpus(3, Protocol::UDP),
             expected_leader_sockets
-                .into_iter()
-                .zip([0, 4])
-                .collect::<Vec<_>>()
         );
 
         for x in 4..8 {
             assert!(leader_info.get_leader_tpus(x, Protocol::UDP).len() <= recent_peers.len());
-            assert!(
+            assert_eq!(
                 leader_info
-                    .get_leader_tpus_with_slots(x, Protocol::UDP)
-                    .len()
-                    <= recent_peers.len()
+                    .get_not_unique_leader_tpus(x, Protocol::UDP)
+                    .len(),
+                x as usize
             );
         }
     }

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,4 +1,7 @@
-use {solana_connection_cache::connection_cache::Protocol, std::net::SocketAddr};
+use {
+    solana_connection_cache::connection_cache::Protocol, solana_sdk::clock::Slot,
+    std::net::SocketAddr,
+};
 
 /// A trait to abstract out the leader estimation for the
 /// SendTransactionService.
@@ -25,6 +28,14 @@ pub trait TpuInfo {
         reason = "This function will be used when tpu-client-next will be added to this module."
     )]
     fn get_not_unique_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
+
+    /// In addition to the tpu address, also return the leader slot
+    #[deprecated(since = "2.2.0", note = "This function is not used anywhere.")]
+    fn get_leader_tpus_with_slots(
+        &self,
+        max_count: u64,
+        protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)>;
 }
 
 #[derive(Clone)]
@@ -36,6 +47,14 @@ impl TpuInfo for NullTpuInfo {
         vec![]
     }
     fn get_not_unique_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
+        vec![]
+    }
+
+    fn get_leader_tpus_with_slots(
+        &self,
+        _max_count: u64,
+        _protocol: Protocol,
+    ) -> Vec<(&SocketAddr, Slot)> {
         vec![]
     }
 }

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -1,17 +1,30 @@
-use {
-    solana_connection_cache::connection_cache::Protocol, solana_sdk::clock::Slot,
-    std::net::SocketAddr,
-};
+use {solana_connection_cache::connection_cache::Protocol, std::net::SocketAddr};
 
+/// A trait to abstract out the leader estimation for the
+/// SendTransactionService.
 pub trait TpuInfo {
     fn refresh_recent_peers(&mut self);
+
+    /// Takes `max_count` which specifies how many leaders per
+    /// `NUM_CONSECUTIVE_LEADER_SLOTS` we want to receive and returns *unique*
+    /// TPU socket addresses for these leaders.
+    ///
+    /// For example, if leader schedule was `[L1, L1, L1, L1, L2, L2, L2, L2,
+    /// L1, ...]` it will return `[L1, L2]` (the last L1 will be not added to
+    /// the result).
     fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
-    /// In addition to the tpu address, also return the leader slot
-    fn get_leader_tpus_with_slots(
-        &self,
-        max_count: u64,
-        protocol: Protocol,
-    ) -> Vec<(&SocketAddr, Slot)>;
+
+    /// Takes `max_count` which specifies how many leaders per
+    /// `NUM_CONSECUTIVE_LEADER_SLOTS` we want to receive and returns TPU socket
+    /// addresses for these leaders.
+    ///
+    /// For example, if leader schedule was `[L1, L1, L1, L1, L2, L2, L2, L2,
+    /// L1, ...]` it will return `[L1, L2, L1]`.
+    #[allow(
+        dead_code,
+        reason = "This function will be used when tpu-client-next will be added to this module."
+    )]
+    fn get_not_unique_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
 }
 
 #[derive(Clone)]
@@ -22,11 +35,7 @@ impl TpuInfo for NullTpuInfo {
     fn get_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
         vec![]
     }
-    fn get_leader_tpus_with_slots(
-        &self,
-        _max_count: u64,
-        _protocol: Protocol,
-    ) -> Vec<(&SocketAddr, Slot)> {
+    fn get_not_unique_leader_tpus(&self, _max_count: u64, _protocol: Protocol) -> Vec<&SocketAddr> {
         vec![]
     }
 }


### PR DESCRIPTION
#### Problem

* Add `get_not_unique_leader_tpus` and added comment explaining what this function does
* ~removed~ marked deprecated unused `get_leader_tpus_with_slots`

These changes are part of reverted https://github.com/anza-xyz/agave/pull/3515/. The difference is that I haven't renamed the function `get_leader_tpus` to `get_unique_leader_tpus` as before because it breaks public API. Instead I've added a new function `get_not_unique_leader_tpus`

#### Summary of Changes

