### PR TITLE
Reapply 3515: Add new_with_client constructor to SendTransactionService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9566,6 +9566,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "tokio",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7918,6 +7918,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "tokio",
 ]
 
 [[package]]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -20,10 +20,14 @@ solana-metrics = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-tpu-client = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+
+[features]
+dev-context-only-utils = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/src/lib.rs
+++ b/send-transaction-service/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod send_transaction_service;
 pub mod send_transaction_service_stats;
+#[cfg(any(test, feature = "dev-context-only-utils"))]
+pub mod test_utils;
 pub mod tpu_info;
 pub mod transaction_client;
 

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -1,0 +1,64 @@
+//! This module contains functionality required to create tests parameterized
+//! with the client type.
+
+use {
+    crate::{
+        tpu_info::NullTpuInfo,
+        transaction_client::{ConnectionCacheClient, TpuInfoWithSendStatic, TransactionClient},
+    },
+    solana_client::connection_cache::ConnectionCache,
+    std::{net::SocketAddr, sync::Arc},
+    tokio::runtime::Handle,
+};
+
+// `maybe_runtime` argument is introduced to be able to use runtime from test
+// for the TpuClientNext, while ConnectionCache uses runtime created internally
+// in the quic-client module and it is impossible to pass test runtime there.
+pub trait CreateClient: TransactionClient {
+    fn create_client(
+        maybe_runtime: Option<Handle>,
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> Self;
+}
+
+impl CreateClient for ConnectionCacheClient<NullTpuInfo> {
+    fn create_client(
+        maybe_runtime: Option<Handle>,
+        my_tpu_address: SocketAddr,
+        tpu_peers: Option<Vec<SocketAddr>>,
+        leader_forward_count: u64,
+    ) -> Self {
+        assert!(maybe_runtime.is_none());
+        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
+        ConnectionCacheClient::new(
+            connection_cache,
+            my_tpu_address,
+            tpu_peers,
+            None,
+            leader_forward_count,
+        )
+    }
+}
+
+pub trait Cancelable {
+    fn cancel(&self);
+}
+
+impl<T> Cancelable for ConnectionCacheClient<T>
+where
+    T: TpuInfoWithSendStatic,
+{
+    fn cancel(&self) {}
+}
+
+// Define type alias to simplify definition of test functions.
+pub trait ClientWithCreator:
+    CreateClient + TransactionClient + Cancelable + Send + Clone + 'static
+{
+}
+impl<T> ClientWithCreator for T where
+    T: CreateClient + TransactionClient + Cancelable + Send + Clone + 'static
+{
+}

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -11,6 +11,10 @@ use {
     },
 };
 
+// Alias trait to shorten function definitions.
+pub trait TpuInfoWithSendStatic: TpuInfo + std::marker::Send + 'static {}
+impl<T> TpuInfoWithSendStatic for T where T: TpuInfo + std::marker::Send + 'static {}
+
 pub trait TransactionClient {
     fn send_transactions_in_batch(
         &self,
@@ -19,7 +23,7 @@ pub trait TransactionClient {
     );
 }
 
-pub struct ConnectionCacheClient<T: TpuInfo + std::marker::Send + 'static> {
+pub struct ConnectionCacheClient<T: TpuInfoWithSendStatic> {
     connection_cache: Arc<ConnectionCache>,
     tpu_address: SocketAddr,
     tpu_peers: Option<Vec<SocketAddr>>,
@@ -30,7 +34,7 @@ pub struct ConnectionCacheClient<T: TpuInfo + std::marker::Send + 'static> {
 // Manual implementation of Clone without requiring T to be Clone
 impl<T> Clone for ConnectionCacheClient<T>
 where
-    T: TpuInfo + std::marker::Send + 'static,
+    T: TpuInfoWithSendStatic,
 {
     fn clone(&self) -> Self {
         Self {
@@ -45,7 +49,7 @@ where
 
 impl<T> ConnectionCacheClient<T>
 where
-    T: TpuInfo + std::marker::Send + 'static,
+    T: TpuInfoWithSendStatic,
 {
     pub fn new(
         connection_cache: Arc<ConnectionCache>,
@@ -100,7 +104,7 @@ where
 
 impl<T> TransactionClient for ConnectionCacheClient<T>
 where
-    T: TpuInfo + std::marker::Send + 'static,
+    T: TpuInfoWithSendStatic,
 {
     fn send_transactions_in_batch(
         &self,
@@ -131,7 +135,7 @@ pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
 /// used for sending transactions.
 pub struct CurrentLeaderInfo<T>
 where
-    T: TpuInfo + std::marker::Send + 'static,
+    T: TpuInfoWithSendStatic,
 {
     /// The last time the leader info was refreshed
     last_leader_refresh: Option<Instant>,
@@ -145,7 +149,7 @@ where
 
 impl<T> CurrentLeaderInfo<T>
 where
-    T: TpuInfo + std::marker::Send + 'static,
+    T: TpuInfoWithSendStatic,
 {
     /// Get the leader info, refresh if expired
     pub fn get_leader_info(&mut self) -> Option<&T> {

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7247,6 +7247,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client",
+ "tokio",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Summary of Changes

This PR doesn't have any logic changes, instead it prepares ground for future modifications by:

* Introduce `new_with_client` constructor for `SendTransactionService`
* Introduce some test utilities functions to help with using this method for different implementations of `Client` trait

This PR adds back part of changes from https://github.com/anza-xyz/agave/pull/3515/

