### PR TITLE
workspace: Specify packages in `curves/` explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
     "connection-cache",
     "core",
     "cost-model",
-    "curves/*",
+    "curves/curve25519",
     "dos",
     "download-utils",
     "entry",


### PR DESCRIPTION
#### Problem

Because the curves crates are specified with a glob under the cargo workspace, it's possible to get spurious errors for any other directory that exists in `curves/*`.

#### Summary of changes

There's only one curve left in there, so just specify it explicitly.