### PR TITLE
blockstore: Move BlockstoreError to separate file

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -20,7 +20,10 @@ use {
         tower_storage::{SavedTower, SavedTowerVersions, TowerStorage},
     },
     chrono::prelude::*,
-    solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db},
+    solana_ledger::{
+        ancestor_iterator::AncestorIterator,
+        blockstore::{self, Blockstore},
+    },
     solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE},
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
@@ -1725,7 +1728,7 @@ pub fn reconcile_blockstore_roots_with_external_source(
     // blockstore.max_root() might have been updated already.
     // so take a &mut param both to input (and output iff we update root)
     last_blockstore_root: &mut Slot,
-) -> blockstore_db::Result<()> {
+) -> blockstore::Result<()> {
     let external_root = external_source.root();
     if *last_blockstore_root < external_root {
         // Ensure external_root itself to exist and be marked as rooted in the blockstore

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7,7 +7,7 @@ use {
         ancestor_iterator::AncestorIterator,
         blockstore_db::{
             columns as cf, Column, ColumnIndexDeprecation, IteratorDirection, IteratorMode,
-            LedgerColumn, Result, Rocks, WriteBatch,
+            LedgerColumn, Rocks, WriteBatch,
         },
         blockstore_meta::*,
         blockstore_metrics::BlockstoreRpcApiMetrics,
@@ -91,7 +91,7 @@ use static_assertions::const_assert_eq;
 pub use {
     crate::{
         blockstore_db::{
-            default_num_compaction_threads, default_num_flush_threads, BlockstoreError,
+            default_num_compaction_threads, default_num_flush_threads, Result, BlockstoreError,
         },
         blockstore_meta::{OptimisticSlotMetaVersioned, SlotMeta},
         blockstore_metrics::BlockstoreInsertionMetrics,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -86,13 +86,13 @@ use {
     trees::{Tree, TreeWalk},
 };
 pub mod blockstore_purge;
+pub mod error;
 #[cfg(test)]
 use static_assertions::const_assert_eq;
 pub use {
     crate::{
-        blockstore_db::{
-            default_num_compaction_threads, default_num_flush_threads, Result, BlockstoreError,
-        },
+        blockstore::error::{BlockstoreError, Result},
+        blockstore_db::{default_num_compaction_threads, default_num_flush_threads},
         blockstore_meta::{OptimisticSlotMetaVersioned, SlotMeta},
         blockstore_metrics::BlockstoreInsertionMetrics,
     },

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -1,0 +1,63 @@
+//! The error that can be produced from Blockstore operations.
+
+use {
+    log::*, solana_accounts_db::hardened_unpack::UnpackError, solana_sdk::clock::Slot,
+    thiserror::Error,
+};
+
+#[derive(Error, Debug)]
+pub enum BlockstoreError {
+    #[error("shred for index exists")]
+    ShredForIndexExists,
+    #[error("invalid shred data")]
+    InvalidShredData(bincode::Error),
+    #[error("RocksDB error: {0}")]
+    RocksDb(#[from] rocksdb::Error),
+    #[error("slot is not rooted")]
+    SlotNotRooted,
+    #[error("dead slot")]
+    DeadSlot,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serialize(#[from] bincode::Error),
+    #[error("fs extra error: {0}")]
+    FsExtraError(#[from] fs_extra::error::Error),
+    #[error("slot cleaned up")]
+    SlotCleanedUp,
+    #[error("unpack error: {0}")]
+    UnpackError(#[from] UnpackError),
+    #[error("unable to set open file descriptor limit")]
+    UnableToSetOpenFileDescriptorLimit,
+    #[error("transaction status slot mismatch")]
+    TransactionStatusSlotMismatch,
+    #[error("empty epoch stakes")]
+    EmptyEpochStakes,
+    #[error("no vote timestamps in range")]
+    NoVoteTimestampsInRange,
+    #[error("protobuf encode error: {0}")]
+    ProtobufEncodeError(#[from] prost::EncodeError),
+    #[error("protobuf decode error: {0}")]
+    ProtobufDecodeError(#[from] prost::DecodeError),
+    #[error("parent entries unavailable")]
+    ParentEntriesUnavailable,
+    #[error("slot unavailable")]
+    SlotUnavailable,
+    #[error("unsupported transaction version")]
+    UnsupportedTransactionVersion,
+    #[error("missing transaction metadata")]
+    MissingTransactionMetadata,
+    #[error("transaction-index overflow")]
+    TransactionIndexOverflow,
+    #[error("invalid erasure config")]
+    InvalidErasureConfig,
+    #[error("last shred index missing slot {0}")]
+    UnknownLastIndex(Slot),
+    #[error("missing shred slot {0}, index {1}")]
+    MissingShred(Slot, u64),
+    #[error("legacy shred slot {0}, index {1}")]
+    LegacyShred(Slot, u64),
+    #[error("unable to read merkle root slot {0}, index {1}")]
+    MissingMerkleRoot(Slot, u64),
+}
+pub type Result<T> = std::result::Result<T, BlockstoreError>;

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -6,8 +6,8 @@
 
 use {
     crate::{
-        blockstore::{Blockstore, PurgeType},
-        blockstore_db::{columns, ColumnName, Result as BlockstoreResult},
+        blockstore::{self, Blockstore, PurgeType},
+        blockstore_db::{columns, ColumnName},
     },
     solana_measure::measure::Measure,
     solana_sdk::clock::{Slot, DEFAULT_MS_PER_SLOT},
@@ -237,8 +237,8 @@ impl BlockstoreCleanupService {
     }
 
     fn report_disk_metrics(
-        pre: BlockstoreResult<u64>,
-        post: BlockstoreResult<u64>,
+        pre: blockstore::Result<u64>,
+        post: blockstore::Result<u64>,
         total_shreds: u64,
     ) {
         if let (Ok(pre), Ok(post)) = (pre, post) {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1,6 +1,7 @@
 pub use rocksdb::Direction as IteratorDirection;
 use {
     crate::{
+        blockstore::error::{BlockstoreError, Result},
         blockstore_meta::{self, MerkleRootMeta},
         blockstore_metrics::{
             maybe_enable_rocksdb_perf, report_rocksdb_read_perf, report_rocksdb_write_perf,
@@ -22,7 +23,6 @@ use {
         IteratorMode as RocksIteratorMode, LiveFile, Options, WriteBatch as RWriteBatch, DB,
     },
     serde::{de::DeserializeOwned, Serialize},
-    solana_accounts_db::hardened_unpack::UnpackError,
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         pubkey::{Pubkey, PUBKEY_BYTES},
@@ -41,7 +41,6 @@ use {
             Arc,
         },
     },
-    thiserror::Error,
 };
 
 const BLOCKSTORE_METRICS_ERROR: i64 = -1;
@@ -70,63 +69,6 @@ macro_rules! convert_column_key_bytes_to_index {
         ($($f(<[u8; $b-$a]>::try_from(&$k[$a..$b]).unwrap())),*)
     }};
 }
-
-#[derive(Error, Debug)]
-pub enum BlockstoreError {
-    #[error("shred for index exists")]
-    ShredForIndexExists,
-    #[error("invalid shred data")]
-    InvalidShredData(bincode::Error),
-    #[error("RocksDB error: {0}")]
-    RocksDb(#[from] rocksdb::Error),
-    #[error("slot is not rooted")]
-    SlotNotRooted,
-    #[error("dead slot")]
-    DeadSlot,
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("serialization error: {0}")]
-    Serialize(#[from] bincode::Error),
-    #[error("fs extra error: {0}")]
-    FsExtraError(#[from] fs_extra::error::Error),
-    #[error("slot cleaned up")]
-    SlotCleanedUp,
-    #[error("unpack error: {0}")]
-    UnpackError(#[from] UnpackError),
-    #[error("unable to set open file descriptor limit")]
-    UnableToSetOpenFileDescriptorLimit,
-    #[error("transaction status slot mismatch")]
-    TransactionStatusSlotMismatch,
-    #[error("empty epoch stakes")]
-    EmptyEpochStakes,
-    #[error("no vote timestamps in range")]
-    NoVoteTimestampsInRange,
-    #[error("protobuf encode error: {0}")]
-    ProtobufEncodeError(#[from] prost::EncodeError),
-    #[error("protobuf decode error: {0}")]
-    ProtobufDecodeError(#[from] prost::DecodeError),
-    #[error("parent entries unavailable")]
-    ParentEntriesUnavailable,
-    #[error("slot unavailable")]
-    SlotUnavailable,
-    #[error("unsupported transaction version")]
-    UnsupportedTransactionVersion,
-    #[error("missing transaction metadata")]
-    MissingTransactionMetadata,
-    #[error("transaction-index overflow")]
-    TransactionIndexOverflow,
-    #[error("invalid erasure config")]
-    InvalidErasureConfig,
-    #[error("last shred index missing slot {0}")]
-    UnknownLastIndex(Slot),
-    #[error("missing shred slot {0}, index {1}")]
-    MissingShred(Slot, u64),
-    #[error("legacy shred slot {0}, index {1}")]
-    LegacyShred(Slot, u64),
-    #[error("unable to read merkle root slot {0}, index {1}")]
-    MissingMerkleRoot(Slot, u64),
-}
-pub type Result<T> = std::result::Result<T, BlockstoreError>;
 
 pub enum IteratorMode<Index> {
     Start,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
         block_error::BlockError,
-        blockstore::Blockstore,
-        blockstore_db::BlockstoreError,
+        blockstore::{Blockstore, BlockstoreError},
         blockstore_meta::SlotMeta,
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{blockstore::*, blockstore_db::Result, blockstore_meta::SlotMeta},
+    crate::{blockstore::*, blockstore_meta::SlotMeta},
     log::*,
     solana_sdk::clock::Slot,
 };

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -36,8 +36,7 @@ use {
         token_2022::{self, ACCOUNTTYPE_ACCOUNT},
     },
     solana_ledger::{
-        blockstore::{Blockstore, SignatureInfosForAddress},
-        blockstore_db::BlockstoreError,
+        blockstore::{Blockstore, BlockstoreError, SignatureInfosForAddress},
         blockstore_meta::{PerfSample, PerfSampleV1, PerfSampleV2},
         leader_schedule_cache::LeaderScheduleCache,
     },


### PR DESCRIPTION
#### Problem
The `BlockstoreError` type lives in `blockstore_db.rs` which is currently a bit of a junk drawer

#### Summary of Changes
Work towards better organization by moving `BlockstoreError` (and the related `Result`) to their own file