### PR TITLE
add validation of allowed CrdsValues in gossip

### DIFF
--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -89,7 +89,7 @@ impl Sanitize for CrdsData {
                 }
                 val.sanitize()
             }
-            CrdsData::LegacyVersion(_) => Err(SanitizeError::InvalidValue),
+            CrdsData::LegacyVersion(version) => version.sanitize(),
             CrdsData::Version(version) => version.sanitize(),
             CrdsData::NodeInstance(node) => node.sanitize(),
             CrdsData::DuplicateShred(ix, shred) => {

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -89,7 +89,7 @@ impl Sanitize for CrdsData {
                 }
                 val.sanitize()
             }
-            CrdsData::LegacyVersion(version) => version.sanitize(),
+            CrdsData::LegacyVersion(_) => Err(SanitizeError::InvalidValue),
             CrdsData::Version(version) => version.sanitize(),
             CrdsData::NodeInstance(node) => node.sanitize(),
             CrdsData::DuplicateShred(ix, shred) => {

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -165,18 +165,10 @@ impl Sanitize for Protocol {
                 val.sanitize()
             }
             Protocol::PushMessage(_, val) => {
-                //Push is allowed to carry anything in its CrdsData, except for deprecated fields
-                for v in val {
-                    match v.data() {
-                        CrdsData::LegacyVersion(_) => {
-                            return Err(SanitizeError::InvalidValue);
-                        }
-                        _ => {
-                            v.sanitize()?;
-                        }
-                    }
-                }
-                Ok(())
+                // PushMessage is allowed to carry anything in its CrdsData, including deprecated Crds
+                // such that a deprecated Crds gets ingested instead of the node having to pull it from
+                // other nodes that have inserted it into their Crds table
+                val.sanitize()
             }
             Protocol::PruneMessage(from, val) => {
                 if *from != val.pubkey {

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -154,14 +154,10 @@ impl Sanitize for Protocol {
             Protocol::PullRequest(filter, val) => {
                 filter.sanitize()?;
                 // PullRequest is only allowed to have ContactInfo in its CrdsData
-                match val.data() {
-                    CrdsData::LegacyContactInfo(_) => {}
-                    CrdsData::ContactInfo(_) => {}
-                    _ => {
-                        return Err(SanitizeError::InvalidValue);
-                    }
+                if let CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) = val.data() {
+                    return val.sanitize();
                 }
-                val.sanitize()
+                return Err(SanitizeError::InvalidValue);
             }
             Protocol::PullResponse(_, val) => {
                 // PullResponse is allowed to carry anything in its CrdsData, except for deprecated fields

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -160,18 +160,9 @@ impl Sanitize for Protocol {
                 }
             }
             Protocol::PullResponse(_, val) => {
-                // PullResponse is allowed to carry anything in its CrdsData, except for deprecated fields
-                for v in val {
-                    match v.data() {
-                        CrdsData::LegacyVersion(_) => {
-                            return Err(SanitizeError::InvalidValue);
-                        }
-                        _ => {
-                            v.sanitize()?;
-                        }
-                    }
-                }
-                Ok(())
+                // PullResponse is allowed to carry anything in its CrdsData, including deprecated Crds
+                // such that a deprecated Crds does not get pulled and then rejected.
+                val.sanitize()
             }
             Protocol::PushMessage(_, val) => {
                 //Push is allowed to carry anything in its CrdsData, except for deprecated fields

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -154,10 +154,10 @@ impl Sanitize for Protocol {
             Protocol::PullRequest(filter, val) => {
                 filter.sanitize()?;
                 // PullRequest is only allowed to have ContactInfo in its CrdsData
-                if let CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) = val.data() {
-                    return val.sanitize();
+                match val.data() {
+                    CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) => val.sanitize(),
+                    _ => Err(SanitizeError::InvalidValue),
                 }
-                return Err(SanitizeError::InvalidValue);
             }
             Protocol::PullResponse(_, val) => {
                 // PullResponse is allowed to carry anything in its CrdsData, except for deprecated fields


### PR DESCRIPTION
Protocol enum variants can now be pruned better in Sanitize impl

#### Problem

Sanitize implementation allowed certain invalid PullRequest variants to travel through the code

#### Summary of Changes
 * Expand Sanitize impl to eliminate values that should not be present in valid traffic.