### PR TITLE
removes trailing bytes before de-duplicating shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -673,6 +673,7 @@ impl From<ShredVariant> for ShredType {
 }
 
 impl From<ShredVariant> for u8 {
+    #[inline]
     fn from(shred_variant: ShredVariant) -> u8 {
         match shred_variant {
             ShredVariant::LegacyCode => u8::from(ShredType::Code),
@@ -723,6 +724,7 @@ impl From<ShredVariant> for u8 {
 
 impl TryFrom<u8> for ShredVariant {
     type Error = Error;
+    #[inline]
     fn try_from(shred_variant: u8) -> Result<Self, Self::Error> {
         if shred_variant == u8::from(ShredType::Code) {
             Ok(ShredVariant::LegacyCode)
@@ -1261,7 +1263,7 @@ mod tests {
                 |_| false, // drop_unchained_merkle_shreds
                 &mut stats
             ));
-            assert_eq!(stats.bad_parent_offset, 1);
+            assert_eq!(stats.index_overrun, 5);
         }
         {
             let mut stats = ShredFetchStats::default();


### PR DESCRIPTION
#### Problem

For backward compatibility we need to allow trailing bytes in the packet after the shred payload.

The extra bytes are truncated in `Shred{Code,Data}::from_payload`:
https://github.com/anza-xyz/agave/blob/744482070/ledger/src/shred/merkle.rs#L513
https://github.com/anza-xyz/agave/blob/744482070/ledger/src/shred/merkle.rs#L574

but that happens late after shred deduper which might allow duplicate shreds to pass through.



#### Summary of Changes
The commit updates `shred::wire::get_shred{,_mut}` to remove trailing bytes and excludes them from the deduper.
