### PR TITLE
removes feature gated code enabling chained Merkle shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -836,7 +836,6 @@ pub fn should_discard_shred(
     root: Slot,
     max_slot: Slot,
     shred_version: u16,
-    enable_chained_merkle_shreds: impl Fn(Slot) -> bool,
     stats: &mut ShredFetchStats,
 ) -> bool {
     debug_assert!(root < max_slot);
@@ -918,9 +917,6 @@ pub fn should_discard_shred(
             stats.num_shreds_merkle_code = stats.num_shreds_merkle_code.saturating_add(1);
         }
         ShredVariant::MerkleCode { chained: true, .. } => {
-            if !enable_chained_merkle_shreds(slot) {
-                return true;
-            }
             stats.num_shreds_merkle_code_chained =
                 stats.num_shreds_merkle_code_chained.saturating_add(1);
         }
@@ -928,9 +924,6 @@ pub fn should_discard_shred(
             stats.num_shreds_merkle_data = stats.num_shreds_merkle_data.saturating_add(1);
         }
         ShredVariant::MerkleData { chained: true, .. } => {
-            if !enable_chained_merkle_shreds(slot) {
-                return true;
-            }
             stats.num_shreds_merkle_data_chained =
                 stats.num_shreds_merkle_data_chained.saturating_add(1);
         }
@@ -1201,7 +1194,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
         }
@@ -1214,7 +1206,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_overrun, 1);
@@ -1225,7 +1216,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_overrun, 2);
@@ -1236,7 +1226,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_overrun, 3);
@@ -1247,7 +1236,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_overrun, 4);
@@ -1258,7 +1246,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.bad_parent_offset, 1);
@@ -1270,7 +1257,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version.wrapping_add(1),
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.shred_version_mismatch, 1);
@@ -1282,7 +1268,6 @@ mod tests {
                 parent_slot + 1, // root
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.slot_out_of_range, 1);
@@ -1304,7 +1289,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.slot_out_of_range, 1);
@@ -1326,7 +1310,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.bad_parent_offset, 1);
@@ -1347,7 +1330,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_out_of_bounds, 1);
@@ -1364,7 +1346,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
         }
@@ -1375,7 +1356,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version.wrapping_add(1),
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.shred_version_mismatch, 1);
@@ -1387,7 +1367,6 @@ mod tests {
                 slot, // root
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.slot_out_of_range, 1);
@@ -1408,7 +1387,6 @@ mod tests {
                 root,
                 max_slot,
                 shred_version,
-                |_| true, // enable_chained_merkle_shreds
                 &mut stats
             ));
             assert_eq!(stats.index_out_of_bounds, 1);


### PR DESCRIPTION
#### Problem
Chained Merkle shreds are enabled on all clusters.

```
$ solana -um feature status 7uZBkJXJ1HkuP6R3MJfZs7mLwymBcDbKdqbF51ZWLier
Feature                                      | Status                  | Activation Slot | Description
7uZBkJXJ1HkuP6R3MJfZs7mLwymBcDbKdqbF51ZWLier | active since epoch 710  | 306720000       | Enable chained Merkle shreds #34916
```

#### Summary of Changes
The commit removes feature gated code enabling chained Merkle shreds.