### PR TITLE
Upgrades Rust to 1.84.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html