### PR TITLE
shares recovered Merkle data shreds payloads

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1010,10 +1010,14 @@ impl Blockstore {
                 // are not stored in blockstore.
                 match shred.shred_type() {
                     ShredType::Code => {
+                        // Don't need Arc overhead here!
+                        debug_assert_matches!(shred.payload(), shred::Payload::Unique(_));
                         recovered_shreds.push(shred.into_payload());
                         None
                     }
                     ShredType::Data => {
+                        // Verify that the cloning is cheap here.
+                        debug_assert_matches!(shred.payload(), shred::Payload::Shared(_));
                         recovered_shreds.push(shred.payload().clone());
                         Some(shred)
                     }

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq)]
 pub enum Payload {
     Shared(Arc<Vec<u8>>),
     Unique(Vec<u8>),
@@ -84,6 +84,13 @@ pub(crate) mod serde_bytes_payload {
         Deserialize::deserialize(deserializer)
             .map(ByteBuf::into_vec)
             .map(Payload::from)
+    }
+}
+
+impl PartialEq for Payload {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
     }
 }
 


### PR DESCRIPTION
#### Problem
Recovered data shreds are concurrently inserted into blockstore while their payload is sent to retransmit-stage. Using a shared payload between the two concurrent paths will reduce allocations and memcopies.



#### Summary of Changes
The commit shares recovered Merkle data shreds payloads between blockstore insert path and retransmit.