### PR TITLE
prevent check-crates from crashing on PRs which do not touch any cargo.toml files

### DIFF
--- a/sdk/scripts/check-crates.sh
+++ b/sdk/scripts/check-crates.sh
@@ -25,7 +25,7 @@ printf "%s\n" "${files[@]}"
 
 has_error=0
 for file in "${files[@]}"; do
-  if [ -z $file ]; then
+  if [ -z "$file" ]; then
     continue
   fi
   read -r crate_name package_publish workspace < <(toml get "$file" . | jq -r '(.package.name | tostring)+" "+(.package.publish | tostring)+" "+(.workspace | tostring)')

--- a/sdk/scripts/check-crates.sh
+++ b/sdk/scripts/check-crates.sh
@@ -25,6 +25,9 @@ printf "%s\n" "${files[@]}"
 
 has_error=0
 for file in "${files[@]}"; do
+  if [ -z $file ]; then
+    continue
+  fi
   read -r crate_name package_publish workspace < <(toml get "$file" . | jq -r '(.package.name | tostring)+" "+(.package.publish | tostring)+" "+(.workspace | tostring)')
   echo "=== $crate_name ($file) ==="
 


### PR DESCRIPTION
#### Problem
CI fails on PRs that do not modify any toml files

#### Summary of Changes
add a check that skips checks if file array is empty
