### PR TITLE
reuses a thread-local weighted-shuffle for get_retransmit_addrs

### DIFF
--- a/gossip/benches/weighted_shuffle.rs
+++ b/gossip/benches/weighted_shuffle.rs
@@ -43,7 +43,8 @@ fn bench_weighted_shuffle_shuffle(c: &mut Criterion) {
         b.iter(|| {
             rng.fill(&mut seed[..]);
             let mut rng = ChaChaRng::from_seed(seed);
-            let shuffle = weighted_shuffle.clone().shuffle(&mut rng);
+            let mut weighted_shuffle = weighted_shuffle.clone();
+            let shuffle = weighted_shuffle.shuffle(&mut rng);
             black_box(shuffle.collect::<Vec<_>>());
         })
     });

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -149,8 +149,8 @@ impl PushActiveSetEntry {
     ) {
         debug_assert_eq!(nodes.len(), weights.len());
         debug_assert!(weights.iter().all(|&weight| weight != 0u64));
-        let shuffle = WeightedShuffle::<u64>::new("rotate-active-set", weights).shuffle(rng);
-        for node in shuffle.map(|k| &nodes[k]) {
+        let mut weighted_shuffle = WeightedShuffle::<u64>::new("rotate-active-set", weights);
+        for node in weighted_shuffle.shuffle(rng).map(|k| &nodes[k]) {
             // We intend to discard the oldest/first entry in the index-map.
             if self.0.len() > size {
                 break;

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -26,6 +26,7 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     std::{
         any::TypeId,
+        cell::RefCell,
         cmp::Ordering,
         collections::{HashMap, HashSet},
         iter::repeat_with,
@@ -36,6 +37,12 @@ use {
     },
     thiserror::Error,
 };
+
+thread_local! {
+    static THREAD_LOCAL_WEIGHTED_SHUFFLE: RefCell<WeightedShuffle<u64>> = RefCell::new(
+        WeightedShuffle::new::<[u64; 0]>("get_retransmit_addrs", []),
+    );
+}
 
 const DATA_PLANE_FANOUT: usize = 200;
 pub(crate) const MAX_NUM_TURBINE_HOPS: usize = 4;
@@ -220,7 +227,6 @@ impl ClusterNodes<RetransmitStage> {
         fanout: usize,
         socket_addr_space: &SocketAddrSpace,
     ) -> Result<(/*root_distance:*/ usize, Vec<SocketAddr>), Error> {
-        let mut weighted_shuffle = self.weighted_shuffle.clone();
         // Exclude slot leader from list of nodes.
         if slot_leader == &self.pubkey {
             return Err(Error::Loopback {
@@ -228,22 +234,25 @@ impl ClusterNodes<RetransmitStage> {
                 shred: *shred,
             });
         }
-        if let Some(index) = self.index.get(slot_leader) {
-            weighted_shuffle.remove_index(*index);
-        }
-        let mut rng = get_seeded_rng(slot_leader, shred);
-        let (index, peers) = get_retransmit_peers(
-            fanout,
-            |k| self.nodes[k].pubkey() == &self.pubkey,
-            weighted_shuffle.shuffle(&mut rng),
-        );
-        let protocol = get_broadcast_protocol(shred);
-        let peers = peers
-            .filter_map(|k| self.nodes[k].contact_info()?.tvu(protocol))
-            .filter(|addr| socket_addr_space.check(addr))
-            .collect();
-        let root_distance = get_root_distance(index, fanout);
-        Ok((root_distance, peers))
+        THREAD_LOCAL_WEIGHTED_SHUFFLE.with_borrow_mut(|weighted_shuffle| {
+            weighted_shuffle.clone_from(&self.weighted_shuffle);
+            if let Some(index) = self.index.get(slot_leader) {
+                weighted_shuffle.remove_index(*index);
+            }
+            let mut rng = get_seeded_rng(slot_leader, shred);
+            let (index, peers) = get_retransmit_peers(
+                fanout,
+                |k| self.nodes[k].pubkey() == &self.pubkey,
+                weighted_shuffle.shuffle(&mut rng),
+            );
+            let protocol = get_broadcast_protocol(shred);
+            let peers = peers
+                .filter_map(|k| self.nodes[k].contact_info()?.tvu(protocol))
+                .filter(|addr| socket_addr_space.check(addr))
+                .collect();
+            let root_distance = get_root_distance(index, fanout);
+            Ok((root_distance, peers))
+        })
     }
 
     // Returns the parent node in the turbine broadcast tree.


### PR DESCRIPTION
#### Problem
`get_retransmit_addrs` does a lot of allocations to clone `WeightedShuffle`:
https://github.com/anza-xyz/agave/blob/a3be62584/turbine/src/cluster_nodes.rs#L223



#### Summary of Changes
The commit uses a thread-local variable along with `WeightedShuffle::clone_from` to hold on to the allocation, reuse the same previously allocated memory, and minimize allocations.
