### PR TITLE
Fix CI failure with missing blake3 feature 

### DIFF
--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
-solana-message = { workspace = true }
+solana-message = { workspace = true, features = ["blake3"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }


### PR DESCRIPTION
#### Problem

Fix CI failure with missing blake3 feature.

For example: https://buildkite.com/anza/agave/builds/18794#0194d767-3407-42b5-881d-37f23522dbf4

The error is:
```
error[E0599]: no method named `hash` found for enum `solana_message::VersionedMessage` in the current scope
  --> runtime-transaction/src/runtime_transaction/sdk_transactions.rs:28:82
   |
28 |             MessageHash::Compute => sanitized_versioned_tx.get_message().message.hash(),
   |                                                                                  ^^^^ method not found in `VersionedMessage`
```

Method `Message::hash` is enabled only when feature "bincode" or "blake3" is used with message crate and `hash_raw_message` only when blake3 is active. Which means that sdk_transactions should probably use the blake3 to work.


#### Summary of Changes

