### PR TITLE
Set Shards in Inner Cache to constant value

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -169,7 +169,10 @@ pub struct AccountsCache {
 impl AccountsCache {
     pub fn new_inner(&self) -> SlotCache {
         Arc::new(SlotCacheInner {
-            cache: DashMap::with_shard_amount(ACCOUNTS_CACHE_INNER_NUM_SHARDS),
+            cache: DashMap::with_hasher_and_shard_amount(
+                AHashRandomState::default(),
+                ACCOUNTS_CACHE_INNER_NUM_SHARDS,
+            ),
             same_account_writes: AtomicU64::default(),
             same_account_writes_size: AtomicU64::default(),
             unique_account_writes_size: AtomicU64::default(),

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -21,6 +21,10 @@ use {
 
 pub type SlotCache = Arc<SlotCacheInner>;
 
+// Set to 8192 to reduce shard collision rate
+// Must be power of 2.
+const ACCOUNTS_CACHE_INNER_NUM_SHARDS: usize = 8192;
+
 #[derive(Debug)]
 pub struct SlotCacheInner {
     cache: DashMap<Pubkey, CachedAccount, AHashRandomState>,
@@ -165,7 +169,7 @@ pub struct AccountsCache {
 impl AccountsCache {
     pub fn new_inner(&self) -> SlotCache {
         Arc::new(SlotCacheInner {
-            cache: DashMap::default(),
+            cache: DashMap::with_shard_amount(ACCOUNTS_CACHE_INNER_NUM_SHARDS),
             same_account_writes: AtomicU64::default(),
             same_account_writes_size: AtomicU64::default(),
             unique_account_writes_size: AtomicU64::default(),


### PR DESCRIPTION
#### Problem
Dashmap shard collisions are occurring when reading from or adding a value to a shard in the write cache dashmap. Increasing the number of shards is cheap (from a memory perspective), while the collision cost is potentially high. 

#### Summary of Changes
Increased the number of shards to 8192. It lead to a near zero collision rate. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
