### PR TITLE
chore: Removes obsolete comment

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8099,7 +8099,6 @@ impl AccountsDb {
             .store_total_data
             .fetch_add(total_data as u64, Ordering::Relaxed);
 
-        // we use default hashes for now since the same account may be stored to the cache multiple times
         self.store_accounts_unfrozen(
             accounts,
             store_to,


### PR DESCRIPTION
Remove an obsolete comment in AccountsDb::store(), which stopped being relevant once we stopped storing the AccountHash in AppendVecs.