### PR TITLE
rpc: Remove deprecated helper function

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1814,30 +1814,6 @@ impl JsonRpcRequestProcessor {
         Ok(None)
     }
 
-    pub fn get_confirmed_signatures_for_address(
-        &self,
-        pubkey: Pubkey,
-        start_slot: Slot,
-        end_slot: Slot,
-    ) -> Vec<Signature> {
-        if self.config.enable_rpc_transaction_history {
-            // TODO: Add bigtable_ledger_storage support as a part of
-            // https://github.com/solana-labs/solana/pull/10928
-            let end_slot = min(
-                end_slot,
-                self.block_commitment_cache
-                    .read()
-                    .unwrap()
-                    .highest_super_majority_root(),
-            );
-            self.blockstore
-                .get_confirmed_signatures_for_address(pubkey, start_slot, end_slot)
-                .unwrap_or_default()
-        } else {
-            vec![]
-        }
-    }
-
     pub async fn get_signatures_for_address(
         &self,
         address: Pubkey,


### PR DESCRIPTION
#### Summary of Changes
getConfirmedSignaturesForAddress was removed in v2.0. This changes removes get_confirmed_signatures_for_address(), which was a helper function for that RPC method. This was seemingly just missed in the commit that removed the deprecated functions

In https://github.com/anza-xyz/agave/pull/1809, we can see that the only caller of this function was removed. `clippy` probably just missed this function as unused due to `pub`:
https://github.com/anza-xyz/agave/pull/1809/files#diff-b55d9bcb5d2e7eae09fd352edcc765f9c2a4c05b97e9847582071d35850e8671L4735-L4762