### PR TITLE
accounts-db: Use NoHashHasher in `AccountStorageMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9314,6 +9314,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
  "solana-program",

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -4,6 +4,7 @@ use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
     solana_clock::Slot,
+    solana_nohash_hasher::BuildNoHashHasher,
     std::sync::Arc,
 };
 
@@ -18,7 +19,7 @@ pub struct AccountStorageReference {
     pub id: AccountsFileId,
 }
 
-pub type AccountStorageMap = DashMap<Slot, AccountStorageReference>;
+pub type AccountStorageMap = DashMap<Slot, AccountStorageReference, BuildNoHashHasher<Slot>>;
 
 #[derive(Default, Debug)]
 pub struct AccountStorage {
@@ -27,7 +28,7 @@ pub struct AccountStorage {
     /// while shrink is operating on a slot, there can be 2 append vecs active for that slot
     /// Once the index has been updated to only refer to the new append vec, the single entry for the slot in 'map' can be updated.
     /// Entries in 'shrink_in_progress_map' can be found by 'get_account_storage_entry'
-    shrink_in_progress_map: DashMap<Slot, Arc<AccountStorageEntry>>,
+    shrink_in_progress_map: DashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>,
 }
 
 impl AccountStorage {
@@ -227,7 +228,7 @@ impl AccountStorage {
 
 /// iterate contents of AccountStorage without exposing internals
 pub struct AccountStorageIter<'a> {
-    iter: dashmap::iter::Iter<'a, Slot, AccountStorageReference>,
+    iter: dashmap::iter::Iter<'a, Slot, AccountStorageReference, BuildNoHashHasher<Slot>>,
 }
 
 impl<'a> AccountStorageIter<'a> {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7371,6 +7371,7 @@ dependencies = [
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
+ "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
  "solana-program",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,6 +67,7 @@ solana-inline-spl = { workspace = true }
 solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-nohash-hasher = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-perf = { workspace = true }
 solana-program = { workspace = true }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -31,6 +31,7 @@ mod tests {
             accounts_hash::{AccountsDeltaHash, AccountsHash},
             epoch_accounts_hash::EpochAccountsHash,
         },
+        solana_nohash_hasher::BuildNoHashHasher,
         solana_sdk::{
             epoch_schedule::EpochSchedule, genesis_config::create_genesis_config, hash::Hash,
             pubkey::Pubkey, stake::state::Stake,
@@ -53,7 +54,10 @@ mod tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
+            storage_entries.len(),
+            BuildNoHashHasher::default(),
+        );
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -23,6 +23,7 @@ mod serde_snapshot_tests {
             accounts_hash::AccountsHash,
             ancestors::Ancestors,
         },
+        solana_nohash_hasher::BuildNoHashHasher,
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount},
             clock::Slot,
@@ -133,7 +134,10 @@ mod serde_snapshot_tests {
         storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
-        let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
+        let storage: AccountStorageMap = AccountStorageMap::with_capacity_and_hasher(
+            storage_entries.len(),
+            BuildNoHashHasher::default(),
+        );
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -19,6 +19,7 @@ use {
         accounts_db::{AccountStorageEntry, AccountsFileId, AtomicAccountsFileId},
         accounts_file::StorageAccess,
     },
+    solana_nohash_hasher::BuildNoHashHasher,
     solana_sdk::clock::Slot,
     std::{
         collections::HashMap,
@@ -118,7 +119,10 @@ impl SnapshotStorageRebuilder {
         snapshot_from: SnapshotFrom,
         storage_access: StorageAccess,
     ) -> Self {
-        let storage = DashMap::with_capacity(snapshot_storage_lengths.len());
+        let storage = DashMap::with_capacity_and_hasher(
+            snapshot_storage_lengths.len(),
+            BuildNoHashHasher::default(),
+        );
         let storage_paths: DashMap<_, _> = snapshot_storage_lengths
             .iter()
             .map(|(slot, storage_lengths)| {

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7191,6 +7191,7 @@ dependencies = [
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
+ "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
  "solana-program",


### PR DESCRIPTION
#### Problem

`DashMap` uses SipHash by default. `AccountStorageMap` uses `Slot` as a key and therefore it doesn't have any chance of collisions.

#### Summary of Changes

We can skip hashing the key entirely.

Ref #4276
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
