### PR TITLE
accounts-db: Use AHash in `AccountsCache`

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -1,5 +1,6 @@
 use {
     crate::{accounts_db::AccountsDb, accounts_hash::AccountHash},
+    ahash::RandomState as AHashRandomState,
     dashmap::DashMap,
     seqlock::SeqLock,
     solana_nohash_hasher::BuildNoHashHasher,
@@ -22,7 +23,7 @@ pub type SlotCache = Arc<SlotCacheInner>;
 
 #[derive(Debug)]
 pub struct SlotCacheInner {
-    cache: DashMap<Pubkey, CachedAccount>,
+    cache: DashMap<Pubkey, CachedAccount, AHashRandomState>,
     same_account_writes: AtomicU64,
     same_account_writes_size: AtomicU64,
     unique_account_writes_size: AtomicU64,
@@ -119,7 +120,7 @@ impl SlotCacheInner {
 }
 
 impl Deref for SlotCacheInner {
-    type Target = DashMap<Pubkey, CachedAccount>;
+    type Target = DashMap<Pubkey, CachedAccount, AHashRandomState>;
     fn deref(&self) -> &Self::Target {
         &self.cache
     }


### PR DESCRIPTION
#### Problem

`DashMap` uses SipHash by default.

#### Summary of Changes

 AHash is faster and is safe to use in maps where we don't need strong collision resistance, which is the case with `AccountsCache` and `SlotCacheInner`.

Ref #4276
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
