### PR TITLE
Removes accounts delta hash from bank hash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2546,14 +2546,19 @@ impl Bank {
     /// recalcuates the bank hash.
     ///
     /// Note that the account state is *not* allowed to change by rehashing.
-    /// If it does, this function will panic.
     /// If modifying accounts in ledger-tool is needed, create a new bank.
     pub fn rehash(&self) {
         let get_delta_hash = || {
-            self.rc
-                .accounts
-                .accounts_db
-                .get_accounts_delta_hash(self.slot())
+            (!self
+                .feature_set
+                .is_active(&feature_set::remove_accounts_delta_hash::id()))
+            .then(|| {
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .get_accounts_delta_hash(self.slot())
+            })
+            .flatten()
         };
 
         let mut hash = self.hash.write().unwrap();
@@ -5220,25 +5225,41 @@ impl Bank {
     ///  of the delta of the ledger since the last vote and up to now
     fn hash_internal_state(&self) -> Hash {
         let measure_total = Measure::start("");
-
         let slot = self.slot();
-        let (accounts_delta_hash, accounts_delta_hash_us) = measure_us!({
-            self.rc
-                .accounts
-                .accounts_db
-                .calculate_accounts_delta_hash_internal(
-                    slot,
-                    None,
-                    self.skipped_rewrites.lock().unwrap().clone(),
-                )
+
+        let delta_hash_info = (!self
+            .feature_set
+            .is_active(&feature_set::remove_accounts_delta_hash::id()))
+        .then(|| {
+            let (hash, us) = measure_us!({
+                self.rc
+                    .accounts
+                    .accounts_db
+                    .calculate_accounts_delta_hash_internal(
+                        slot,
+                        None,
+                        self.skipped_rewrites.lock().unwrap().clone(),
+                    )
+            });
+            let log = format!(" accounts_delta: {}", hash.0);
+            (hash, us, log)
         });
 
-        let mut hash = hashv(&[
-            self.parent_hash.as_ref(),
-            accounts_delta_hash.0.as_ref(),
-            &self.signature_count().to_le_bytes(),
-            self.last_blockhash().as_ref(),
-        ]);
+        let mut hash = if let Some((accounts_delta_hash, _measure, _log)) = delta_hash_info.as_ref()
+        {
+            hashv(&[
+                self.parent_hash.as_ref(),
+                accounts_delta_hash.0.as_ref(),
+                &self.signature_count().to_le_bytes(),
+                self.last_blockhash().as_ref(),
+            ])
+        } else {
+            hashv(&[
+                self.parent_hash.as_ref(),
+                &self.signature_count().to_le_bytes(),
+                self.last_blockhash().as_ref(),
+            ])
+        };
 
         let accounts_hash_info = if self
             .feature_set
@@ -5294,15 +5315,18 @@ impl Bank {
         let bank_hash_stats = self.bank_hash_stats.load();
 
         let total_us = measure_total.end_as_us();
+
+        let (accounts_delta_hash_us, accounts_delta_hash_log) =
+            delta_hash_info.map(|(_hash, us, log)| (us, log)).unzip();
         datapoint_info!(
             "bank-hash_internal_state",
             ("slot", slot, i64),
             ("total_us", total_us, i64),
-            ("accounts_delta_hash_us", accounts_delta_hash_us, i64),
+            ("accounts_delta_hash_us", accounts_delta_hash_us, Option<i64>),
         );
         info!(
-            "bank frozen: {slot} hash: {hash} accounts_delta: {} signature_count: {} last_blockhash: {} capitalization: {}{}, stats: {bank_hash_stats:?}",
-            accounts_delta_hash.0,
+            "bank frozen: {slot} hash: {hash}{} signature_count: {} last_blockhash: {} capitalization: {}{}, stats: {bank_hash_stats:?}",
+            accounts_delta_hash_log.unwrap_or_default(),
             self.signature_count(),
             self.last_blockhash(),
             self.capitalization(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5241,12 +5241,10 @@ impl Bank {
                         self.skipped_rewrites.lock().unwrap().clone(),
                     )
             });
-            let log = format!(" accounts_delta: {}", hash.0);
-            (hash, us, log)
+            (hash, us)
         });
 
-        let mut hash = if let Some((accounts_delta_hash, _measure, _log)) = delta_hash_info.as_ref()
-        {
+        let mut hash = if let Some((accounts_delta_hash, _measure)) = delta_hash_info.as_ref() {
             hashv(&[
                 self.parent_hash.as_ref(),
                 accounts_delta_hash.0.as_ref(),
@@ -5316,8 +5314,9 @@ impl Bank {
 
         let total_us = measure_total.end_as_us();
 
-        let (accounts_delta_hash_us, accounts_delta_hash_log) =
-            delta_hash_info.map(|(_hash, us, log)| (us, log)).unzip();
+        let (accounts_delta_hash_us, accounts_delta_hash_log) = delta_hash_info
+            .map(|(hash, us)| (us, format!(" accounts_delta: {}", hash.0)))
+            .unzip();
         datapoint_info!(
             "bank-hash_internal_state",
             ("slot", slot, i64),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5231,7 +5231,7 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::remove_accounts_delta_hash::id()))
         .then(|| {
-            let (hash, us) = measure_us!({
+            measure_us!({
                 self.rc
                     .accounts
                     .accounts_db
@@ -5240,8 +5240,7 @@ impl Bank {
                         None,
                         self.skipped_rewrites.lock().unwrap().clone(),
                     )
-            });
-            (hash, us)
+            })
         });
 
         let mut hash = if let Some((accounts_delta_hash, _measure)) = delta_hash_info.as_ref() {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3617,6 +3617,10 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
                 .accounts
                 .remove(&feature_set::accounts_lt_hash::id())
                 .unwrap();
+            genesis_config
+                .accounts
+                .remove(&feature_set::remove_accounts_delta_hash::id())
+                .unwrap();
         }
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         assert_eq!(
@@ -13591,11 +13595,22 @@ fn test_bank_epoch_stakes() {
     }
 }
 
-#[test]
-fn test_rehash_good() {
+/// Ensure rehash() does *not* change the bank hash if accounts are unmodified
+#[test_case(true; "with accounts delta hash")]
+#[test_case(false; "without accounts delta hash")]
+fn test_rehash_accounts_unmodified(has_accounts_delta_hash: bool) {
     let ten_sol = 10 * LAMPORTS_PER_SOL;
-    let (genesis_config, _mint) = create_genesis_config(ten_sol);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let mut genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
+    if has_accounts_delta_hash {
+        // Keep the accounts delta hash by removing the 'remove_accounts_delta_hash'
+        // feature account from genesis.
+        genesis_config_info
+            .genesis_config
+            .accounts
+            .remove(&feature_set::remove_accounts_delta_hash::id())
+            .unwrap();
+    }
+    let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
 
     let lamports = 123_456_789;
     let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
@@ -13612,12 +13627,20 @@ fn test_rehash_good() {
     assert_eq!(post_bank_hash, prev_bank_hash);
 }
 
+/// Ensure rehash() *does* change the bank hash if accounts are modified
 #[test]
 #[should_panic(expected = "rehashing is not allowed to change the account state")]
-fn test_rehash_bad() {
+fn test_rehash_accounts_modified() {
     let ten_sol = 10 * LAMPORTS_PER_SOL;
-    let (genesis_config, _mint) = create_genesis_config(ten_sol);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let mut genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
+    // Keep the accounts delta hash by removing the 'remove_accounts_delta_hash'
+    // feature account from genesis.
+    genesis_config_info
+        .genesis_config
+        .accounts
+        .remove(&feature_set::remove_accounts_delta_hash::id())
+        .unwrap();
+    let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
 
     let mut account = AccountSharedData::new(ten_sol, 0, &Pubkey::default());
     let pubkey = Pubkey::new_unique();

--- a/sdk/feature-set/src/lib.rs
+++ b/sdk/feature-set/src/lib.rs
@@ -912,6 +912,10 @@ pub mod snapshots_lt_hash {
     solana_pubkey::declare_id!("LTsNAP8h1voEVVToMNBNqoiNQex4aqfUrbFhRH3mSQ2");
 }
 
+pub mod remove_accounts_delta_hash {
+    solana_pubkey::declare_id!("LTdLt9Ycbyoipz5fLysCi1NnDnASsZfmJLJXts5ZxZz");
+}
+
 pub mod migrate_stake_program_to_core_bpf {
     solana_pubkey::declare_id!("6M4oQ6eXneVhtLoiAr4yRYQY43eVLjrKbiDZDJc892yk");
 }
@@ -1153,6 +1157,7 @@ lazy_static! {
         (disable_account_loader_special_case::id(), "Disable account loader special case #3513"),
         (accounts_lt_hash::id(), "enables lattice-based accounts hash SIMD-0215"),
         (snapshots_lt_hash::id(), "snapshots use lattice-based accounts hash SIMD-0220"),
+        (remove_accounts_delta_hash::id(), "removes accounts delta hash SIMD-0223"),
         (enable_secp256r1_precompile::id(), "Enable secp256r1 precompile SIMD-0075"),
         (migrate_stake_program_to_core_bpf::id(), "Migrate Stake program to Core BPF SIMD-0196 #3655"),
         (deplete_cu_meter_on_vm_failure::id(), "Deplete compute meter for vm errors SIMD-0182 #3993"),


### PR DESCRIPTION
#### Problem

Implement SIMD-223, which removes the accounts delta hash from the bank.


#### Summary of Changes

Remove the accounts delta hash from the bank hash. We check if the feature is enabled, and conditionally calculate the accounts delta hash & mix it into the bank hash.

Note this PR doesn't touch the background account hasher. That'll be addressed in the next PR.

Feature Gate Issue: #4441

