### PR TITLE
refactor: move inflation rewards code out of stake program

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -51,6 +51,7 @@ use {
             Bank, RewardCalculationEvent,
         },
         bank_forks::BankForks,
+        inflation_rewards::points::{InflationPointCalculationEvent, PointValue},
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_minimizer::SnapshotMinimizer,
@@ -76,7 +77,7 @@ use {
         system_program,
         transaction::{MessageHash, SimpleAddressLoader},
     },
-    solana_stake_program::{points::PointValue, stake_state},
+    solana_stake_program::stake_state,
     solana_transaction_status::parse_ui_instruction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_vote_program::{
@@ -2751,7 +2752,6 @@ fn main() {
                             new_credits_observed: Option<u64>,
                             skipped_reasons: String,
                         }
-                        use solana_stake_program::points::InflationPointCalculationEvent;
                         let stake_calculation_details: DashMap<Pubkey, CalculationDetail> =
                             DashMap::new();
                         let last_point_value = Arc::new(RwLock::new(None));

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -12,9 +12,8 @@ use {
 };
 
 pub mod config;
+#[deprecated(since = "2.2.0")]
 pub mod points;
-#[doc(hidden)]
-pub mod rewards;
 pub mod stake_instruction;
 pub mod stake_state;
 

--- a/programs/stake/src/points.rs
+++ b/programs/stake/src/points.rs
@@ -1,15 +1,7 @@
 //! Information about points calculation based on stake state.
 //! Used by `solana-runtime`.
 
-use {
-    solana_clock::Epoch,
-    solana_instruction::error::InstructionError,
-    solana_pubkey::Pubkey,
-    solana_stake_interface::state::{Delegation, Stake, StakeStateV2},
-    solana_sysvar::stake_history::StakeHistory,
-    solana_vote_interface::state::VoteState,
-    std::cmp::Ordering,
-};
+use {solana_pubkey::Pubkey, solana_stake_interface::state::Delegation};
 
 /// captures a rewards round as lamports to be awarded
 ///  and the total points over which those lamports
@@ -19,13 +11,6 @@ use {
 pub struct PointValue {
     pub rewards: u64, // lamports to split
     pub points: u128, // over these points
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct CalculatedStakePoints {
-    pub(crate) points: u128,
-    pub(crate) new_credits_observed: u64,
-    pub(crate) force_credits_update_with_skipped_reward: bool,
 }
 
 #[derive(Debug)]
@@ -38,10 +23,6 @@ pub enum InflationPointCalculationEvent {
     Commission(u8),
     CreditsObserved(u64, Option<u64>),
     Skipped(SkippedReason),
-}
-
-pub(crate) fn null_tracer() -> Option<impl Fn(&InflationPointCalculationEvent)> {
-    None::<fn(&_)>
 }
 
 #[derive(Debug)]
@@ -60,188 +41,5 @@ pub enum SkippedReason {
 impl From<SkippedReason> for InflationPointCalculationEvent {
     fn from(reason: SkippedReason) -> Self {
         InflationPointCalculationEvent::Skipped(reason)
-    }
-}
-
-// utility function, used by runtime
-#[doc(hidden)]
-pub fn calculate_points(
-    stake_state: &StakeStateV2,
-    vote_state: &VoteState,
-    stake_history: &StakeHistory,
-    new_rate_activation_epoch: Option<Epoch>,
-) -> Result<u128, InstructionError> {
-    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
-        Ok(calculate_stake_points(
-            stake,
-            vote_state,
-            stake_history,
-            null_tracer(),
-            new_rate_activation_epoch,
-        ))
-    } else {
-        Err(InstructionError::InvalidAccountData)
-    }
-}
-
-fn calculate_stake_points(
-    stake: &Stake,
-    vote_state: &VoteState,
-    stake_history: &StakeHistory,
-    inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    new_rate_activation_epoch: Option<Epoch>,
-) -> u128 {
-    calculate_stake_points_and_credits(
-        stake,
-        vote_state,
-        stake_history,
-        inflation_point_calc_tracer,
-        new_rate_activation_epoch,
-    )
-    .points
-}
-
-/// for a given stake and vote_state, calculate how many
-///   points were earned (credits * stake) and new value
-///   for credits_observed were the points paid
-pub(crate) fn calculate_stake_points_and_credits(
-    stake: &Stake,
-    new_vote_state: &VoteState,
-    stake_history: &StakeHistory,
-    inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    new_rate_activation_epoch: Option<Epoch>,
-) -> CalculatedStakePoints {
-    let credits_in_stake = stake.credits_observed;
-    let credits_in_vote = new_vote_state.credits();
-    // if there is no newer credits since observed, return no point
-    match credits_in_vote.cmp(&credits_in_stake) {
-        Ordering::Less => {
-            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
-            }
-            // Don't adjust stake.activation_epoch for simplicity:
-            //  - generally fast-forwarding stake.activation_epoch forcibly (for
-            //    artificial re-activation with re-warm-up) skews the stake
-            //    history sysvar. And properly handling all the cases
-            //    regarding deactivation epoch/warm-up/cool-down without
-            //    introducing incentive skew is hard.
-            //  - Conceptually, it should be acceptable for the staked SOLs at
-            //    the recreated vote to receive rewards again immediately after
-            //    rewind even if it looks like instant activation. That's
-            //    because it must have passed the required warmed-up at least
-            //    once in the past already
-            //  - Also such a stake account remains to be a part of overall
-            //    effective stake calculation even while the vote account is
-            //    missing for (indefinite) time or remains to be pre-remove
-            //    credits score. It should be treated equally to staking with
-            //    delinquent validator with no differentiation.
-
-            // hint with true to indicate some exceptional credits handling is needed
-            return CalculatedStakePoints {
-                points: 0,
-                new_credits_observed: credits_in_vote,
-                force_credits_update_with_skipped_reward: true,
-            };
-        }
-        Ordering::Equal => {
-            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
-            }
-            // don't hint caller and return current value if credits remain unchanged (= delinquent)
-            return CalculatedStakePoints {
-                points: 0,
-                new_credits_observed: credits_in_stake,
-                force_credits_update_with_skipped_reward: false,
-            };
-        }
-        Ordering::Greater => {}
-    }
-
-    let mut points = 0;
-    let mut new_credits_observed = credits_in_stake;
-
-    for (epoch, final_epoch_credits, initial_epoch_credits) in
-        new_vote_state.epoch_credits().iter().copied()
-    {
-        let stake_amount = u128::from(stake.delegation.stake(
-            epoch,
-            stake_history,
-            new_rate_activation_epoch,
-        ));
-
-        // figure out how much this stake has seen that
-        //   for which the vote account has a record
-        let earned_credits = if credits_in_stake < initial_epoch_credits {
-            // the staker observed the entire epoch
-            final_epoch_credits - initial_epoch_credits
-        } else if credits_in_stake < final_epoch_credits {
-            // the staker registered sometime during the epoch, partial credit
-            final_epoch_credits - new_credits_observed
-        } else {
-            // the staker has already observed or been redeemed this epoch
-            //  or was activated after this epoch
-            0
-        };
-        let earned_credits = u128::from(earned_credits);
-
-        // don't want to assume anything about order of the iterator...
-        new_credits_observed = new_credits_observed.max(final_epoch_credits);
-
-        // finally calculate points for this epoch
-        let earned_points = stake_amount * earned_credits;
-        points += earned_points;
-
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&InflationPointCalculationEvent::CalculatedPoints(
-                epoch,
-                stake_amount,
-                earned_credits,
-                earned_points,
-            ));
-        }
-    }
-
-    CalculatedStakePoints {
-        points,
-        new_credits_observed,
-        force_credits_update_with_skipped_reward: false,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, crate::stake_state::new_stake, solana_native_token::sol_to_lamports};
-
-    #[test]
-    fn test_stake_state_calculate_points_with_typical_values() {
-        let mut vote_state = VoteState::default();
-
-        // bootstrap means fully-vested stake at epoch 0 with
-        //  10_000_000 SOL is a big but not unreasaonable stake
-        let stake = new_stake(
-            sol_to_lamports(10_000_000f64),
-            &Pubkey::default(),
-            &vote_state,
-            u64::MAX,
-        );
-
-        let epoch_slots: u128 = 14 * 24 * 3600 * 160;
-        // put 193,536,000 credits in at epoch 0, typical for a 14-day epoch
-        //  this loop takes a few seconds...
-        for _ in 0..epoch_slots {
-            vote_state.increment_credits(0, 1);
-        }
-
-        // no overflow on points
-        assert_eq!(
-            u128::from(stake.delegation.stake) * epoch_slots,
-            calculate_stake_points(
-                &stake,
-                &vote_state,
-                &StakeHistory::default(),
-                null_tracer(),
-                None
-            )
-        );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -42,6 +42,7 @@ use {
         },
         bank_forks::BankForks,
         epoch_stakes::{split_epoch_stakes, EpochStakes, NodeVoteAccounts, VersionedEpochStakes},
+        inflation_rewards::points::InflationPointCalculationEvent,
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         rent_collector::RentCollectorWithMetrics,
         runtime_config::RuntimeConfig,
@@ -151,7 +152,6 @@ use {
         },
         transaction_context::{TransactionAccount, TransactionReturnData},
     },
-    solana_stake_program::points::InflationPointCalculationEvent,
     solana_svm::{
         account_loader::{collect_rent_from_account, LoadedTransaction},
         account_overrides::AccountOverrides,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -11,6 +11,10 @@ use {
             PrevEpochInflationRewards, RewardCalcTracer, RewardCalculationEvent, RewardsMetrics,
             VoteAccount, VoteReward, VoteRewards,
         },
+        inflation_rewards::{
+            points::{calculate_points, PointValue},
+            redeem_rewards,
+        },
         stake_account::StakeAccount,
         stakes::Stakes,
     },
@@ -31,7 +35,6 @@ use {
         stake::state::{Delegation, StakeStateV2},
         sysvar::epoch_rewards::EpochRewards,
     },
-    solana_stake_program::points::PointValue,
     std::sync::atomic::{AtomicU64, Ordering::Relaxed},
 };
 
@@ -378,7 +381,7 @@ impl Bank {
 
                     let pre_lamport = stake_account.lamports();
 
-                    let redeemed = solana_stake_program::rewards::redeem_rewards(
+                    let redeemed = redeem_rewards(
                         rewarded_epoch,
                         stake_state,
                         &mut stake_account,
@@ -434,7 +437,7 @@ impl Bank {
                         });
                     } else {
                         debug!(
-                            "solana_stake_program::rewards::redeem_rewards() failed for {}: {:?}",
+                            "redeem_rewards() failed for {}: {:?}",
                             stake_pubkey, redeemed
                         );
                     }
@@ -499,7 +502,7 @@ impl Bank {
                         return 0;
                     }
 
-                    solana_stake_program::points::calculate_points(
+                    calculate_points(
                         stake_account.stake_state(),
                         vote_account.vote_state(),
                         stake_history,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -231,12 +231,15 @@ impl Bank {
 mod tests {
     use {
         super::*,
-        crate::bank::{
-            partitioned_epoch_rewards::{
-                epoch_rewards_hasher::hash_rewards_into_partitions, tests::convert_rewards,
-                REWARD_CALCULATION_NUM_BLOCKS,
+        crate::{
+            bank::{
+                partitioned_epoch_rewards::{
+                    epoch_rewards_hasher::hash_rewards_into_partitions, tests::convert_rewards,
+                    REWARD_CALCULATION_NUM_BLOCKS,
+                },
+                tests::create_genesis_config,
             },
-            tests::create_genesis_config,
+            inflation_rewards::points::PointValue,
         },
         rand::Rng,
         solana_accounts_db::stake_rewards::StakeReward,
@@ -254,7 +257,7 @@ mod tests {
             },
             sysvar,
         },
-        solana_stake_program::{points::PointValue, stake_state},
+        solana_stake_program::stake_state,
         solana_vote_program::vote_state,
     };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -5,7 +5,10 @@ mod sysvar;
 
 use {
     super::Bank,
-    crate::{stake_account::StakeAccount, stake_history::StakeHistory},
+    crate::{
+        inflation_rewards::points::PointValue, stake_account::StakeAccount,
+        stake_history::StakeHistory,
+    },
     solana_accounts_db::{
         partitioned_rewards::PartitionedEpochRewardsConfig, stake_rewards::StakeReward,
     },
@@ -15,7 +18,6 @@ use {
         reward_info::RewardInfo,
         stake::state::{Delegation, Stake},
     },
-    solana_stake_program::points::PointValue,
     solana_vote::vote_account::VoteAccounts,
     std::sync::Arc,
 };

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -1,11 +1,11 @@
 use {
     super::Bank,
+    crate::inflation_rewards::points::PointValue,
     log::info,
     solana_sdk::{
         account::{create_account_shared_data_with_fields as create_account, from_account},
         sysvar,
     },
-    solana_stake_program::points::PointValue,
 };
 
 impl Bank {

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -5,11 +5,11 @@ use super::Bank;
 mod tests {
     use {
         super::*,
+        crate::inflation_rewards::points::PointValue,
         solana_sdk::{
             genesis_config::create_genesis_config, pubkey::Pubkey,
             sysvar::epoch_rewards::EpochRewards,
         },
-        solana_stake_program::points::PointValue,
         std::sync::Arc,
     };
 

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -1,0 +1,256 @@
+//! Information about points calculation based on stake state.
+
+use {
+    solana_pubkey::Pubkey,
+    solana_sdk::{
+        clock::Epoch, instruction::InstructionError, sysvar::stake_history::StakeHistory,
+    },
+    solana_stake_program::stake_state::{Delegation, Stake, StakeStateV2},
+    solana_vote_program::vote_state::VoteState,
+    std::cmp::Ordering,
+};
+
+/// captures a rewards round as lamports to be awarded
+///  and the total points over which those lamports
+///  are to be distributed
+//  basically read as rewards/points, but in integers instead of as an f64
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PointValue {
+    pub rewards: u64, // lamports to split
+    pub points: u128, // over these points
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CalculatedStakePoints {
+    pub(crate) points: u128,
+    pub(crate) new_credits_observed: u64,
+    pub(crate) force_credits_update_with_skipped_reward: bool,
+}
+
+#[derive(Debug)]
+pub enum InflationPointCalculationEvent {
+    CalculatedPoints(u64, u128, u128, u128),
+    SplitRewards(u64, u64, u64, PointValue),
+    EffectiveStakeAtRewardedEpoch(u64),
+    RentExemptReserve(u64),
+    Delegation(Delegation, Pubkey),
+    Commission(u8),
+    CreditsObserved(u64, Option<u64>),
+    Skipped(SkippedReason),
+}
+
+pub(crate) fn null_tracer() -> Option<impl Fn(&InflationPointCalculationEvent)> {
+    None::<fn(&_)>
+}
+
+#[derive(Debug)]
+pub enum SkippedReason {
+    DisabledInflation,
+    JustActivated,
+    TooEarlyUnfairSplit,
+    ZeroPoints,
+    ZeroPointValue,
+    ZeroReward,
+    ZeroCreditsAndReturnZero,
+    ZeroCreditsAndReturnCurrent,
+    ZeroCreditsAndReturnRewinded,
+}
+
+impl From<SkippedReason> for InflationPointCalculationEvent {
+    fn from(reason: SkippedReason) -> Self {
+        InflationPointCalculationEvent::Skipped(reason)
+    }
+}
+
+pub fn calculate_points(
+    stake_state: &StakeStateV2,
+    vote_state: &VoteState,
+    stake_history: &StakeHistory,
+    new_rate_activation_epoch: Option<Epoch>,
+) -> Result<u128, InstructionError> {
+    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
+        Ok(calculate_stake_points(
+            stake,
+            vote_state,
+            stake_history,
+            null_tracer(),
+            new_rate_activation_epoch,
+        ))
+    } else {
+        Err(InstructionError::InvalidAccountData)
+    }
+}
+
+fn calculate_stake_points(
+    stake: &Stake,
+    vote_state: &VoteState,
+    stake_history: &StakeHistory,
+    inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
+    new_rate_activation_epoch: Option<Epoch>,
+) -> u128 {
+    calculate_stake_points_and_credits(
+        stake,
+        vote_state,
+        stake_history,
+        inflation_point_calc_tracer,
+        new_rate_activation_epoch,
+    )
+    .points
+}
+
+/// for a given stake and vote_state, calculate how many
+///   points were earned (credits * stake) and new value
+///   for credits_observed were the points paid
+pub(crate) fn calculate_stake_points_and_credits(
+    stake: &Stake,
+    new_vote_state: &VoteState,
+    stake_history: &StakeHistory,
+    inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
+    new_rate_activation_epoch: Option<Epoch>,
+) -> CalculatedStakePoints {
+    let credits_in_stake = stake.credits_observed;
+    let credits_in_vote = new_vote_state.credits();
+    // if there is no newer credits since observed, return no point
+    match credits_in_vote.cmp(&credits_in_stake) {
+        Ordering::Less => {
+            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnRewinded.into());
+            }
+            // Don't adjust stake.activation_epoch for simplicity:
+            //  - generally fast-forwarding stake.activation_epoch forcibly (for
+            //    artificial re-activation with re-warm-up) skews the stake
+            //    history sysvar. And properly handling all the cases
+            //    regarding deactivation epoch/warm-up/cool-down without
+            //    introducing incentive skew is hard.
+            //  - Conceptually, it should be acceptable for the staked SOLs at
+            //    the recreated vote to receive rewards again immediately after
+            //    rewind even if it looks like instant activation. That's
+            //    because it must have passed the required warmed-up at least
+            //    once in the past already
+            //  - Also such a stake account remains to be a part of overall
+            //    effective stake calculation even while the vote account is
+            //    missing for (indefinite) time or remains to be pre-remove
+            //    credits score. It should be treated equally to staking with
+            //    delinquent validator with no differentiation.
+
+            // hint with true to indicate some exceptional credits handling is needed
+            return CalculatedStakePoints {
+                points: 0,
+                new_credits_observed: credits_in_vote,
+                force_credits_update_with_skipped_reward: true,
+            };
+        }
+        Ordering::Equal => {
+            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+                inflation_point_calc_tracer(&SkippedReason::ZeroCreditsAndReturnCurrent.into());
+            }
+            // don't hint caller and return current value if credits remain unchanged (= delinquent)
+            return CalculatedStakePoints {
+                points: 0,
+                new_credits_observed: credits_in_stake,
+                force_credits_update_with_skipped_reward: false,
+            };
+        }
+        Ordering::Greater => {}
+    }
+
+    let mut points = 0;
+    let mut new_credits_observed = credits_in_stake;
+
+    for (epoch, final_epoch_credits, initial_epoch_credits) in
+        new_vote_state.epoch_credits().iter().copied()
+    {
+        let stake_amount = u128::from(stake.delegation.stake(
+            epoch,
+            stake_history,
+            new_rate_activation_epoch,
+        ));
+
+        // figure out how much this stake has seen that
+        //   for which the vote account has a record
+        let earned_credits = if credits_in_stake < initial_epoch_credits {
+            // the staker observed the entire epoch
+            final_epoch_credits - initial_epoch_credits
+        } else if credits_in_stake < final_epoch_credits {
+            // the staker registered sometime during the epoch, partial credit
+            final_epoch_credits - new_credits_observed
+        } else {
+            // the staker has already observed or been redeemed this epoch
+            //  or was activated after this epoch
+            0
+        };
+        let earned_credits = u128::from(earned_credits);
+
+        // don't want to assume anything about order of the iterator...
+        new_credits_observed = new_credits_observed.max(final_epoch_credits);
+
+        // finally calculate points for this epoch
+        let earned_points = stake_amount * earned_credits;
+        points += earned_points;
+
+        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            inflation_point_calc_tracer(&InflationPointCalculationEvent::CalculatedPoints(
+                epoch,
+                stake_amount,
+                earned_credits,
+                earned_points,
+            ));
+        }
+    }
+
+    CalculatedStakePoints {
+        points,
+        new_credits_observed,
+        force_credits_update_with_skipped_reward: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_sdk::native_token::sol_to_lamports};
+
+    fn new_stake(
+        stake: u64,
+        voter_pubkey: &Pubkey,
+        vote_state: &VoteState,
+        activation_epoch: Epoch,
+    ) -> Stake {
+        Stake {
+            delegation: Delegation::new(voter_pubkey, stake, activation_epoch),
+            credits_observed: vote_state.credits(),
+        }
+    }
+
+    #[test]
+    fn test_stake_state_calculate_points_with_typical_values() {
+        let mut vote_state = VoteState::default();
+
+        // bootstrap means fully-vested stake at epoch 0 with
+        //  10_000_000 SOL is a big but not unreasaonable stake
+        let stake = new_stake(
+            sol_to_lamports(10_000_000f64),
+            &Pubkey::default(),
+            &vote_state,
+            u64::MAX,
+        );
+
+        let epoch_slots: u128 = 14 * 24 * 3600 * 160;
+        // put 193,536,000 credits in at epoch 0, typical for a 14-day epoch
+        //  this loop takes a few seconds...
+        for _ in 0..epoch_slots {
+            vote_state.increment_credits(0, 1);
+        }
+
+        // no overflow on points
+        assert_eq!(
+            u128::from(stake.delegation.stake) * epoch_slots,
+            calculate_stake_points(
+                &stake,
+                &vote_state,
+                &StakeHistory::default(),
+                null_tracer(),
+                None
+            )
+        );
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bank_utils;
 pub mod commitment;
 pub mod epoch_stakes;
 pub mod genesis_utils;
+pub mod inflation_rewards;
 pub mod installed_scheduler_pool;
 pub mod loader_utils;
 pub mod non_circulating_supply;


### PR DESCRIPTION
#### Problem
I want to create a new runtime defined `VoteStateView` struct to make vote state deserialization more efficient in the runtime. This new struct should be used in inflation rewards code as well but that code lives in the `solana-stake-program` crate. In order to avoid adding a `solana-runtime` dependency to the `solana-stake-program`, I propose moving inflation rewards code into the runtime (where I think it should belong anyways).

#### Summary of Changes
Move `rewards` and `points` modules from the `solana-stake-program` into the new `solana_runtime::inflation_rewards` module.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
