### PR TITLE
perf: vote state view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,7 +2048,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10885,6 +10885,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-transaction",
  "solana-vote-interface",
+ "static_assertions",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "solana-type-overrides",
  "solana-unified-scheduler-pool",
  "solana-version",
+ "solana-vote",
  "solana-vote-program",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -522,6 +523,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -2028,6 +2038,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8950,6 +8971,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40db1ff5a0f8aea2c158d78ab5f2cf897848964251d1df42fef78efd3c85b863"
 dependencies = [
+ "arbitrary",
  "borsh 0.10.3",
  "borsh 1.5.5",
  "bs58",
@@ -10837,6 +10859,7 @@ dependencies = [
 name = "solana-vote"
 version = "2.3.0"
 dependencies = [
+ "arbitrary",
  "bincode",
  "itertools 0.12.1",
  "log",
@@ -10855,6 +10878,7 @@ dependencies = [
  "solana-packet",
  "solana-pubkey",
  "solana-sdk-ids",
+ "solana-serialize-utils",
  "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
@@ -10870,6 +10894,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e9f6a1651310a94cd5a1a6b7f33ade01d9e5ea38a2220becb5fd737b756514"
 dependencies = [
+ "arbitrary",
  "bincode",
  "num-derive",
  "num-traits",

--- a/ci/test-miri.sh
+++ b/ci/test-miri.sh
@@ -8,6 +8,11 @@ source ci/rust-version.sh nightly
 # miri is very slow; so only run very few of selective tests!
 _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic
 
+# test big endian branch
+_ cargo "+${rust_nightly}" miri test --target s390x-unknown-linux-gnu -p solana-vote -- "vote_state_view" --skip "arbitrary"
+# test little endian branch for UB
+_ cargo "+${rust_nightly}" miri test -p solana-vote -- "vote_state_view" --skip "arbitrary"
+
 # run intentionally-#[ignored] ub triggering tests for each to make sure they fail
 (! _ cargo "+${rust_nightly}" miri test -p solana-unified-scheduler-logic -- \
   --ignored --exact "utils::tests::test_ub_illegally_created_multiple_tokens")

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -203,7 +203,7 @@ impl AggregateCommitmentService {
                 // Override old vote_state in bank with latest one for my own vote pubkey
                 node_vote_state.clone()
             } else {
-                TowerVoteState::from(account.vote_state().clone())
+                TowerVoteState::from(account.vote_state_view())
             };
             Self::aggregate_commitment_for_vote_account(
                 &mut commitment,
@@ -537,7 +537,7 @@ mod tests {
     fn test_highest_super_majority_root_advance() {
         fn get_vote_state(vote_pubkey: Pubkey, bank: &Bank) -> TowerVoteState {
             let vote_account = bank.get_vote_account(&vote_pubkey).unwrap();
-            TowerVoteState::from(vote_account.vote_state().clone())
+            TowerVoteState::from(vote_account.vote_state_view())
         }
 
         let block_commitment_cache = RwLock::new(BlockCommitmentCache::new_for_tests());

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -406,7 +406,7 @@ impl Tower {
                 continue;
             }
             trace!("{} {} with stake {}", vote_account_pubkey, key, voted_stake);
-            let mut vote_state = TowerVoteState::from(account.vote_state().clone());
+            let mut vote_state = TowerVoteState::from(account.vote_state_view());
             for vote in &vote_state.votes {
                 lockout_intervals
                     .entry(vote.last_locked_out_slot())
@@ -608,8 +608,7 @@ impl Tower {
 
     pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
         let vote_account = bank.get_vote_account(vote_account_pubkey)?;
-        let vote_state = vote_account.vote_state();
-        vote_state.last_voted_slot()
+        vote_account.vote_state_view().last_voted_slot()
     }
 
     pub fn record_bank_vote(&mut self, bank: &Bank) -> Option<Slot> {
@@ -1618,7 +1617,7 @@ impl Tower {
         bank: &Bank,
     ) {
         if let Some(vote_account) = bank.get_vote_account(vote_account_pubkey) {
-            self.vote_state = TowerVoteState::from(vote_account.vote_state().clone());
+            self.vote_state = TowerVoteState::from(vote_account.vote_state_view());
             self.initialize_root(root);
             self.initialize_lockouts(|v| v.slot() > root);
         } else {
@@ -2446,8 +2445,8 @@ pub mod test {
             .unwrap()
             .get_vote_account(&vote_pubkey)
             .unwrap();
-        let state = observed.vote_state();
-        info!("observed tower: {:#?}", state.votes);
+        let state = observed.vote_state_view();
+        info!("observed tower: {:#?}", state.votes_iter().collect_vec());
 
         let num_slots_to_try = 200;
         cluster_votes

--- a/core/src/consensus/tower_vote_state.rs
+++ b/core/src/consensus/tower_vote_state.rs
@@ -1,5 +1,6 @@
 use {
     solana_sdk::clock::Slot,
+    solana_vote::vote_state_view::VoteStateView,
     solana_vote_program::vote_state::{Lockout, VoteState, VoteState1_14_11, MAX_LOCKOUT_HISTORY},
     std::collections::VecDeque,
 };
@@ -102,6 +103,15 @@ impl From<VoteState1_14_11> for TowerVoteState {
         } = vote_state;
 
         Self { votes, root_slot }
+    }
+}
+
+impl From<&VoteStateView> for TowerVoteState {
+    fn from(vote_state: &VoteStateView) -> Self {
+        Self {
+            votes: vote_state.votes_iter().collect(),
+            root_slot: vote_state.root_slot(),
+        }
     }
 }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2512,17 +2512,18 @@ impl ReplayStage {
             }
             Some(vote_account) => vote_account,
         };
-        let vote_state = vote_account.vote_state();
-        if vote_state.node_pubkey != node_keypair.pubkey() {
+        let vote_state_view = vote_account.vote_state_view();
+        if vote_state_view.node_pubkey() != &node_keypair.pubkey() {
             info!(
                 "Vote account node_pubkey mismatch: {} (expected: {}).  Unable to vote",
-                vote_state.node_pubkey,
+                vote_state_view.node_pubkey(),
                 node_keypair.pubkey()
             );
             return GenerateVoteTxResult::HotSpare;
         }
 
-        let Some(authorized_voter_pubkey) = vote_state.get_authorized_voter(bank.epoch()) else {
+        let Some(authorized_voter_pubkey) = vote_state_view.get_authorized_voter(bank.epoch())
+        else {
             warn!(
                 "Vote account {} has no authorized voter for epoch {}.  Unable to vote",
                 vote_account_pubkey,
@@ -2533,7 +2534,7 @@ impl ReplayStage {
 
         let authorized_voter_keypair = match authorized_voter_keypairs
             .iter()
-            .find(|keypair| keypair.pubkey() == authorized_voter_pubkey)
+            .find(|keypair| &keypair.pubkey() == authorized_voter_pubkey)
         {
             None => {
                 warn!(
@@ -3577,7 +3578,7 @@ impl ReplayStage {
         let Some(vote_account) = bank.get_vote_account(my_vote_pubkey) else {
             return;
         };
-        let mut bank_vote_state = TowerVoteState::from(vote_account.vote_state().clone());
+        let mut bank_vote_state = TowerVoteState::from(vote_account.vote_state_view());
         if bank_vote_state.last_voted_slot() <= tower.vote_state.last_voted_slot() {
             return;
         }
@@ -7957,7 +7958,14 @@ pub(crate) mod tests {
         let vote_account = expired_bank_child
             .get_vote_account(&my_vote_pubkey)
             .unwrap();
-        assert_eq!(vote_account.vote_state().tower(), vec![0, 1]);
+        assert_eq!(
+            vote_account
+                .vote_state_view()
+                .votes_iter()
+                .map(|lockout| lockout.slot())
+                .collect_vec(),
+            vec![0, 1]
+        );
         expired_bank_child.fill_bank_with_ticks_for_tests();
         expired_bank_child.freeze();
 

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -103,8 +103,7 @@ impl VoteSimulator {
                     let tower_sync = if let Some(vote_account) =
                         parent_bank.get_vote_account(&keypairs.vote_keypair.pubkey())
                     {
-                        let mut vote_state =
-                            TowerVoteState::from(vote_account.vote_state().clone());
+                        let mut vote_state = TowerVoteState::from(vote_account.vote_state_view());
                         vote_state.process_next_vote_slot(parent);
                         TowerSync::new(
                             vote_state.votes,
@@ -135,8 +134,10 @@ impl VoteSimulator {
                     let vote_account = new_bank
                         .get_vote_account(&keypairs.vote_keypair.pubkey())
                         .unwrap();
-                    let state = vote_account.vote_state();
-                    assert!(state.votes.iter().any(|lockout| lockout.slot() == parent));
+                    let vote_state_view = vote_account.vote_state_view();
+                    assert!(vote_state_view
+                        .votes_iter()
+                        .any(|lockout| lockout.slot() == parent));
                 }
             }
             while new_bank.tick_height() < new_bank.max_tick_height() {

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -57,6 +57,7 @@ solana-transaction-status = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
+solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2176,7 +2176,7 @@ fn supermajority_root_from_vote_accounts(
                 return None;
             }
 
-            Some((account.vote_state().root_slot?, *stake))
+            Some((account.vote_state_view().root_slot()?, *stake))
         })
         .collect();
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9073,8 +9073,10 @@ dependencies = [
 name = "solana-vote"
 version = "2.3.0"
 dependencies = [
+ "bincode",
  "itertools 0.12.1",
  "log",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-account",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9086,6 +9086,7 @@ dependencies = [
  "solana-packet",
  "solana-pubkey",
  "solana-sdk-ids",
+ "solana-serialize-utils",
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1181,32 +1181,24 @@ impl JsonRpcRequestProcessor {
                     }
                 }
 
-                let vote_state = account.vote_state();
-                let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
-                    vote.slot()
-                } else {
-                    0
-                };
-
-                let epoch_credits = vote_state.epoch_credits();
-                let epoch_credits = if epoch_credits.len()
-                    > MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY
-                {
-                    epoch_credits
-                        .iter()
-                        .skip(epoch_credits.len() - MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY)
-                        .cloned()
-                        .collect()
-                } else {
-                    epoch_credits.clone()
-                };
+                let vote_state_view = account.vote_state_view();
+                let last_vote = vote_state_view.last_voted_slot().unwrap_or(0);
+                let num_epoch_credits = vote_state_view.num_epoch_credits();
+                let epoch_credits = vote_state_view
+                    .epoch_credits_iter()
+                    .skip(
+                        num_epoch_credits
+                            .saturating_sub(MAX_RPC_VOTE_ACCOUNT_INFO_EPOCH_CREDITS_HISTORY),
+                    )
+                    .map(Into::into)
+                    .collect();
 
                 Some(RpcVoteAccountInfo {
                     vote_pubkey: vote_pubkey.to_string(),
-                    node_pubkey: vote_state.node_pubkey.to_string(),
+                    node_pubkey: vote_state_view.node_pubkey().to_string(),
                     activated_stake: *activated_stake,
-                    commission: vote_state.commission,
-                    root_slot: vote_state.root_slot.unwrap_or(0),
+                    commission: vote_state_view.commission(),
+                    root_slot: vote_state_view.root_slot().unwrap_or(0),
                     epoch_credits,
                     epoch_vote_account: epoch_vote_accounts.contains_key(vote_pubkey),
                     last_vote,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -132,6 +132,7 @@ dev-context-only-utils = [
     "dep:solana-system-program",
     "solana-svm/dev-context-only-utils",
     "solana-runtime-transaction/dev-context-only-utils",
+    "solana-vote/dev-context-only-utils",
 ]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -372,13 +372,13 @@ impl Bank {
                     if vote_account.owner() != &solana_vote_program {
                         return None;
                     }
-                    let vote_state = vote_account.vote_state();
+                    let vote_state_view = vote_account.vote_state_view();
                     let mut stake_state = *stake_account.stake_state();
 
                     let redeemed = redeem_rewards(
                         rewarded_epoch,
                         &mut stake_state,
-                        vote_state,
+                        vote_state_view,
                         &point_value,
                         stake_history,
                         reward_calc_tracer.as_ref(),
@@ -386,7 +386,7 @@ impl Bank {
                     );
 
                     if let Ok((stakers_reward, voters_reward)) = redeemed {
-                        let commission = vote_state.commission;
+                        let commission = vote_state_view.commission();
 
                         // track voter rewards
                         let mut voters_reward_entry = vote_account_rewards
@@ -484,7 +484,7 @@ impl Bank {
 
                     calculate_points(
                         stake_account.stake_state(),
-                        vote_account.vote_state(),
+                        vote_account.vote_state_view(),
                         stake_history,
                         new_warmup_cooldown_rate_epoch,
                     )

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -100,21 +100,20 @@ impl EpochStakes {
         let epoch_authorized_voters = epoch_vote_accounts
             .iter()
             .filter_map(|(key, (stake, account))| {
-                let vote_state = account.vote_state();
+                let vote_state = account.vote_state_view();
 
                 if *stake > 0 {
-                    if let Some(authorized_voter) = vote_state
-                        .authorized_voters()
-                        .get_authorized_voter(leader_schedule_epoch)
+                    if let Some(authorized_voter) =
+                        vote_state.get_authorized_voter(leader_schedule_epoch)
                     {
                         let node_vote_accounts = node_id_to_vote_accounts
-                            .entry(vote_state.node_pubkey)
+                            .entry(*vote_state.node_pubkey())
                             .or_default();
 
                         node_vote_accounts.total_stake += stake;
                         node_vote_accounts.vote_accounts.push(*key);
 
-                        Some((*key, authorized_voter))
+                        Some((*key, *authorized_voter))
                     } else {
                         None
                     }

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -10,7 +10,7 @@ use {
         sysvar::stake_history::StakeHistory,
     },
     solana_stake_program::stake_state::{Stake, StakeStateV2},
-    solana_vote_program::vote_state::VoteState,
+    solana_vote::vote_state_view::VoteStateView,
 };
 
 pub mod points;
@@ -27,7 +27,7 @@ struct CalculatedStakeRewards {
 pub fn redeem_rewards(
     rewarded_epoch: Epoch,
     stake_state: &mut StakeStateV2,
-    vote_state: &VoteState,
+    vote_state: &VoteStateView,
     point_value: &PointValue,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
@@ -46,7 +46,7 @@ pub fn redeem_rewards(
                 meta.rent_exempt_reserve,
             ));
             inflation_point_calc_tracer(&InflationPointCalculationEvent::Commission(
-                vote_state.commission,
+                vote_state.commission(),
             ));
         }
 
@@ -72,7 +72,7 @@ fn redeem_stake_rewards(
     rewarded_epoch: Epoch,
     stake: &mut Stake,
     point_value: &PointValue,
-    vote_state: &VoteState,
+    vote_state: &VoteStateView,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
@@ -119,7 +119,7 @@ fn calculate_stake_rewards(
     rewarded_epoch: Epoch,
     stake: &Stake,
     point_value: &PointValue,
-    vote_state: &VoteState,
+    vote_state: &VoteStateView,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
@@ -190,7 +190,7 @@ fn calculate_stake_rewards(
         return None;
     }
     let (voter_rewards, staker_rewards, is_split) =
-        commission_split(vote_state.commission, rewards);
+        commission_split(vote_state.commission(), rewards);
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
         inflation_point_calc_tracer(&InflationPointCalculationEvent::SplitRewards(
             rewards,
@@ -255,8 +255,14 @@ fn commission_split(commission: u8, on: u64) -> (u64, u64, bool) {
 #[cfg(test)]
 mod tests {
     use {
-        self::points::null_tracer, super::*, solana_program::stake::state::Delegation,
-        solana_pubkey::Pubkey, solana_sdk::native_token::sol_to_lamports, test_case::test_case,
+        self::points::null_tracer,
+        super::*,
+        solana_program::stake::state::Delegation,
+        solana_pubkey::Pubkey,
+        solana_sdk::native_token::sol_to_lamports,
+        solana_vote_program::vote_state::{VoteState, VoteStateVersions},
+        std::sync::Arc,
+        test_case::test_case,
     };
 
     fn new_stake(
@@ -269,6 +275,12 @@ mod tests {
             delegation: Delegation::new(voter_pubkey, stake, activation_epoch),
             credits_observed: vote_state.credits(),
         }
+    }
+
+    fn into_vote_state_view(vote_state: VoteState) -> VoteStateView {
+        let vote_account_data =
+            bincode::serialize(&VoteStateVersions::new_current(vote_state)).unwrap();
+        VoteStateView::try_new(Arc::new(vote_account_data)).unwrap()
     }
 
     #[test]
@@ -289,7 +301,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -310,7 +322,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -341,7 +353,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -366,7 +378,7 @@ mod tests {
                     rewards: 2,
                     points: 2 // all his
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -388,7 +400,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -413,7 +425,7 @@ mod tests {
                     rewards: 2,
                     points: 2
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -436,7 +448,7 @@ mod tests {
                     rewards: 2,
                     points: 2
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -461,7 +473,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -480,7 +492,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -496,7 +508,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -519,7 +531,7 @@ mod tests {
                     rewards: 0,
                     points: 4
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -542,7 +554,7 @@ mod tests {
                     rewards: 0,
                     points: 4
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -557,7 +569,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -576,7 +588,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -592,7 +604,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -616,7 +628,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -640,7 +652,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -661,7 +673,7 @@ mod tests {
             0,
             &stake,
             &PointValue { rewards, points: 1 },
-            &vote_state,
+            &into_vote_state_view(vote_state.clone()),
             &StakeHistory::default(),
             null_tracer(),
             None,
@@ -691,7 +703,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &vote_state,
+                &into_vote_state_view(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -255,14 +255,9 @@ fn commission_split(commission: u8, on: u64) -> (u64, u64, bool) {
 #[cfg(test)]
 mod tests {
     use {
-        self::points::null_tracer,
-        super::*,
-        solana_program::stake::state::Delegation,
-        solana_pubkey::Pubkey,
-        solana_sdk::native_token::sol_to_lamports,
-        solana_vote_program::vote_state::{VoteState, VoteStateVersions},
-        std::sync::Arc,
-        test_case::test_case,
+        self::points::null_tracer, super::*, solana_program::stake::state::Delegation,
+        solana_pubkey::Pubkey, solana_sdk::native_token::sol_to_lamports,
+        solana_vote_program::vote_state::VoteState, test_case::test_case,
     };
 
     fn new_stake(
@@ -275,12 +270,6 @@ mod tests {
             delegation: Delegation::new(voter_pubkey, stake, activation_epoch),
             credits_observed: vote_state.credits(),
         }
-    }
-
-    fn into_vote_state_view(vote_state: VoteState) -> VoteStateView {
-        let vote_account_data =
-            bincode::serialize(&VoteStateVersions::new_current(vote_state)).unwrap();
-        VoteStateView::try_new(Arc::new(vote_account_data)).unwrap()
     }
 
     #[test]
@@ -301,7 +290,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -322,7 +311,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &into_vote_state_view(vote_state),
+                &VoteStateView::from(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -353,7 +342,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -378,7 +367,7 @@ mod tests {
                     rewards: 2,
                     points: 2 // all his
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -400,7 +389,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -425,7 +414,7 @@ mod tests {
                     rewards: 2,
                     points: 2
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -448,7 +437,7 @@ mod tests {
                     rewards: 2,
                     points: 2
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -473,7 +462,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -492,7 +481,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -508,7 +497,7 @@ mod tests {
                     rewards: 4,
                     points: 4
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -531,7 +520,7 @@ mod tests {
                     rewards: 0,
                     points: 4
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -554,7 +543,7 @@ mod tests {
                     rewards: 0,
                     points: 4
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -569,7 +558,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -588,7 +577,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -604,7 +593,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -628,7 +617,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &into_vote_state_view(vote_state.clone()),
+                &VoteStateView::from(vote_state.clone()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -652,7 +641,7 @@ mod tests {
                     rewards: 1,
                     points: 1
                 },
-                &into_vote_state_view(vote_state),
+                &VoteStateView::from(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
@@ -673,7 +662,7 @@ mod tests {
             0,
             &stake,
             &PointValue { rewards, points: 1 },
-            &into_vote_state_view(vote_state.clone()),
+            &VoteStateView::from(vote_state.clone()),
             &StakeHistory::default(),
             null_tracer(),
             None,
@@ -703,7 +692,7 @@ mod tests {
                     rewards: 1_000_000_000,
                     points: 1
                 },
-                &into_vote_state_view(vote_state),
+                &VoteStateView::from(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -207,10 +207,8 @@ pub(crate) fn calculate_stake_points_and_credits(
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        solana_sdk::native_token::sol_to_lamports,
-        solana_vote_program::vote_state::{VoteState, VoteStateVersions},
-        std::sync::Arc,
+        super::*, solana_sdk::native_token::sol_to_lamports,
+        solana_vote_program::vote_state::VoteState,
     };
 
     fn new_stake(
@@ -223,12 +221,6 @@ mod tests {
             delegation: Delegation::new(voter_pubkey, stake, activation_epoch),
             credits_observed: vote_state.credits(),
         }
-    }
-
-    fn into_vote_state_view(vote_state: VoteState) -> VoteStateView {
-        let vote_account_data =
-            bincode::serialize(&VoteStateVersions::new_current(vote_state)).unwrap();
-        VoteStateView::try_new(Arc::new(vote_account_data)).unwrap()
     }
 
     #[test]
@@ -256,7 +248,7 @@ mod tests {
             u128::from(stake.delegation.stake) * epoch_slots,
             calculate_stake_points(
                 &stake,
-                &into_vote_state_view(vote_state),
+                &VoteStateView::from(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -6,7 +6,7 @@ use {
         clock::Epoch, instruction::InstructionError, sysvar::stake_history::StakeHistory,
     },
     solana_stake_program::stake_state::{Delegation, Stake, StakeStateV2},
-    solana_vote_program::vote_state::VoteState,
+    solana_vote::vote_state_view::VoteStateView,
     std::cmp::Ordering,
 };
 
@@ -64,7 +64,7 @@ impl From<SkippedReason> for InflationPointCalculationEvent {
 
 pub fn calculate_points(
     stake_state: &StakeStateV2,
-    vote_state: &VoteState,
+    vote_state: &VoteStateView,
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> Result<u128, InstructionError> {
@@ -83,7 +83,7 @@ pub fn calculate_points(
 
 fn calculate_stake_points(
     stake: &Stake,
-    vote_state: &VoteState,
+    vote_state: &VoteStateView,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
@@ -103,7 +103,7 @@ fn calculate_stake_points(
 ///   for credits_observed were the points paid
 pub(crate) fn calculate_stake_points_and_credits(
     stake: &Stake,
-    new_vote_state: &VoteState,
+    new_vote_state: &VoteStateView,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
@@ -157,9 +157,8 @@ pub(crate) fn calculate_stake_points_and_credits(
     let mut points = 0;
     let mut new_credits_observed = credits_in_stake;
 
-    for (epoch, final_epoch_credits, initial_epoch_credits) in
-        new_vote_state.epoch_credits().iter().copied()
-    {
+    for epoch_credits_item in new_vote_state.epoch_credits_iter() {
+        let (epoch, final_epoch_credits, initial_epoch_credits) = epoch_credits_item.into();
         let stake_amount = u128::from(stake.delegation.stake(
             epoch,
             stake_history,
@@ -207,7 +206,12 @@ pub(crate) fn calculate_stake_points_and_credits(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_sdk::native_token::sol_to_lamports};
+    use {
+        super::*,
+        solana_sdk::native_token::sol_to_lamports,
+        solana_vote_program::vote_state::{VoteState, VoteStateVersions},
+        std::sync::Arc,
+    };
 
     fn new_stake(
         stake: u64,
@@ -221,12 +225,18 @@ mod tests {
         }
     }
 
+    fn into_vote_state_view(vote_state: VoteState) -> VoteStateView {
+        let vote_account_data =
+            bincode::serialize(&VoteStateVersions::new_current(vote_state)).unwrap();
+        VoteStateView::try_new(Arc::new(vote_account_data)).unwrap()
+    }
+
     #[test]
     fn test_stake_state_calculate_points_with_typical_values() {
         let mut vote_state = VoteState::default();
 
         // bootstrap means fully-vested stake at epoch 0 with
-        //  10_000_000 SOL is a big but not unreasaonable stake
+        //  10_000_000 SOL is a big but not unreasonable stake
         let stake = new_stake(
             sol_to_lamports(10_000_000f64),
             &Pubkey::default(),
@@ -246,7 +256,7 @@ mod tests {
             u128::from(stake.delegation.stake) * epoch_slots,
             calculate_stake_points(
                 &stake,
-                &vote_state,
+                &into_vote_state_view(vote_state),
                 &StakeHistory::default(),
                 null_tracer(),
                 None

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8426,6 +8426,7 @@ dependencies = [
  "solana-packet",
  "solana-pubkey",
  "solana-sdk-ids",
+ "solana-serialize-utils",
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true, optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true, optional = true }
@@ -57,7 +58,7 @@ solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-dev-context-only-utils = ["dep:rand"]
+dev-context-only-utils = ["dep:rand", "dep:bincode"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -53,6 +53,7 @@ solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
+static_assertions = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -30,6 +30,7 @@ solana-keypair = { workspace = true }
 solana-packet = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
+solana-serialize-utils = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-svm-transaction = { workspace = true }
@@ -42,6 +43,7 @@ crate-type = ["lib"]
 name = "solana_vote"
 
 [dev-dependencies]
+arbitrary = { workspace = true }
 bincode = { workspace = true }
 rand = { workspace = true }
 solana-keypair = { workspace = true }
@@ -49,6 +51,7 @@ solana-logger = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
+solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/vote/src/lib.rs
+++ b/vote/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod vote_account;
 pub mod vote_parser;
+pub mod vote_state_view;
 pub mod vote_transaction;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -182,8 +182,8 @@ impl VoteStateFrame {
 
     fn offset(&self, field: Field) -> usize {
         match &self {
-            Self::V1_14_11(frame) => frame.get_field_offset(field),
-            Self::V3(frame) => frame.get_field_offset(field),
+            Self::V1_14_11(frame) => frame.field_offset(field),
+            Self::V3(frame) => frame.field_offset(field),
         }
     }
 
@@ -343,6 +343,10 @@ mod tests {
             assert_eq!(vote_state_view.get_authorized_voter(u64::MAX), None);
         }
 
+        assert_eq!(
+            vote_state_view.num_epoch_credits(),
+            vote_state.epoch_credits.len()
+        );
         let view_credits: Vec<(Epoch, u64, u64)> = vote_state_view
             .epoch_credits_iter()
             .map(Into::into)
@@ -393,6 +397,10 @@ mod tests {
             assert_eq!(vote_state_view.get_authorized_voter(u64::MAX), None);
         }
 
+        assert_eq!(
+            vote_state_view.num_epoch_credits(),
+            vote_state.epoch_credits.len()
+        );
         let view_credits: Vec<(Epoch, u64, u64)> = vote_state_view
             .epoch_credits_iter()
             .map(Into::into)

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -79,11 +79,13 @@ impl VoteStateView {
     }
 
     pub fn last_lockout(&self) -> Option<Lockout> {
-        self.votes_view().last_lockout()
+        self.votes_view().last().map(|item| {
+            Lockout::new_with_confirmation_count(item.slot(), item.confirmation_count())
+        })
     }
 
     pub fn last_voted_slot(&self) -> Option<Slot> {
-        self.last_lockout().map(|v| v.slot())
+        self.votes_view().last().map(|item| item.slot())
     }
 
     pub fn root_slot(&self) -> Option<Slot> {
@@ -103,7 +105,10 @@ impl VoteStateView {
     }
 
     pub fn credits(&self) -> u64 {
-        self.epoch_credits_view().credits()
+        self.epoch_credits_view()
+            .last()
+            .map(|item| item.credits())
+            .unwrap_or(0)
     }
 
     pub fn last_timestamp(&self) -> BlockTimestamp {

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -189,29 +189,29 @@ impl VoteStateFrame {
 
     fn votes_frame(&self) -> VotesFrame {
         match &self {
-            Self::V1_14_11(frame) => VotesFrame::Lockout(frame.votes_frame()),
-            Self::V3(frame) => VotesFrame::Landed(frame.votes_frame()),
+            Self::V1_14_11(frame) => VotesFrame::Lockout(frame.votes_frame),
+            Self::V3(frame) => VotesFrame::Landed(frame.votes_frame),
         }
     }
 
     fn root_slot_frame(&self) -> RootSlotFrame {
         match &self {
-            Self::V1_14_11(vote_frame) => vote_frame.root_slot_frame(),
-            Self::V3(vote_frame) => vote_frame.root_slot_frame(),
+            Self::V1_14_11(vote_frame) => vote_frame.root_slot_frame,
+            Self::V3(vote_frame) => vote_frame.root_slot_frame,
         }
     }
 
     fn authorized_voters_frame(&self) -> AuthorizedVotersListFrame {
         match &self {
-            Self::V1_14_11(frame) => frame.authorized_voters_frame(),
-            Self::V3(frame) => frame.authorized_voters_frame(),
+            Self::V1_14_11(frame) => frame.authorized_voters_frame,
+            Self::V3(frame) => frame.authorized_voters_frame,
         }
     }
 
     fn epoch_credits_frame(&self) -> EpochCreditsListFrame {
         match &self {
-            Self::V1_14_11(frame) => frame.epoch_credits_frame(),
-            Self::V3(frame) => frame.epoch_credits_frame(),
+            Self::V1_14_11(frame) => frame.epoch_credits_frame,
+            Self::V3(frame) => frame.epoch_credits_frame,
         }
     }
 }

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -91,17 +91,17 @@ impl LockoutItem {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LockoutListFrame {
-    len: u8,
+    pub(super) len: u8,
 }
 
 impl LockoutListFrame {
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
-            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
-        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::InvalidVotesLength)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -121,17 +121,17 @@ impl ListFrame for LockoutListFrame {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LandedVotesListFrame {
-    len: u8,
+    pub(super) len: u8,
 }
 
 impl LandedVotesListFrame {
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
-            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
-        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::InvalidVotesLength)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -166,17 +166,18 @@ impl ListFrame for LandedVotesListFrame {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct AuthorizedVotersListFrame {
-    len: u8,
+    pub(super) len: u8,
 }
 
 impl AuthorizedVotersListFrame {
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
-            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
-        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)? as usize;
+        let len =
+            u8::try_from(len).map_err(|_| VoteStateViewError::InvalidAuthorizedVotersLength)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -222,17 +223,17 @@ pub struct EpochCreditsItem {
     prev_credits: [u8; 8],
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct EpochCreditsListFrame {
-    len: u8,
+    pub(super) len: u8,
 }
 
 impl EpochCreditsListFrame {
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
-            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
-        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::InvalidEpochCreditsLength)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -299,10 +300,10 @@ impl RootSlotView<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct RootSlotFrame {
-    has_root_slot: bool,
+    pub(super) has_root_slot: bool,
 }
 
 impl RootSlotFrame {
@@ -319,8 +320,14 @@ impl RootSlotFrame {
     }
 
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
-        let has_root_slot = solana_serialize_utils::cursor::read_bool(cursor)
-            .map_err(|_err| VoteStateViewError::ParseError)?;
+        let byte = solana_serialize_utils::cursor::read_u8(cursor)
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)?;
+        let has_root_slot = match byte {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(VoteStateViewError::InvalidRootSlotOption),
+        }?;
+
         let frame = Self { has_root_slot };
         cursor.consume(frame.size());
         Ok(frame)
@@ -328,36 +335,33 @@ impl RootSlotFrame {
 }
 
 pub(super) struct PriorVotersFrame;
-
-impl ListFrame for PriorVotersFrame {
-    type Item = PriorVotersItem;
-
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<PriorVotersItem>() == 1);
-    };
-
-    fn len(&self) -> usize {
-        const MAX_ITEMS: usize = 32;
-        MAX_ITEMS
-    }
-
-    fn total_size(&self) -> usize {
-        self.total_item_size() +
-            core::mem::size_of::<u64>() /* idx */ +
-            core::mem::size_of::<bool>() /* is_empty */
-    }
-}
-
-#[repr(C)]
-pub(super) struct PriorVotersItem {
-    voter: Pubkey,
-    start_epoch_inclusive: [u8; 8],
-    end_epoch_exclusive: [u8; 8],
-}
-
 impl PriorVotersFrame {
+    pub(super) const fn total_size() -> usize {
+        1545 // see test_prior_voters_total_size
+    }
+
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) {
-        cursor.consume(PriorVotersFrame.total_size());
+        cursor.consume(PriorVotersFrame::total_size());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_vote_interface::state::CircBuf};
+
+    #[test]
+    fn test_prior_voters_total_size() {
+        #[repr(C)]
+        pub(super) struct PriorVotersItem {
+            voter: Pubkey,
+            start_epoch_inclusive: [u8; 8],
+            end_epoch_exclusive: [u8; 8],
+        }
+
+        let prior_voters_len = CircBuf::<()>::default().buf().len();
+        let expected_total_size = prior_voters_len * core::mem::size_of::<PriorVotersItem>() +
+            core::mem::size_of::<u64>() /* idx */ +
+            core::mem::size_of::<bool>() /* is_empty */;
+        assert_eq!(PriorVotersFrame::total_size(), expected_total_size);
     }
 }

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use static_assertions::const_assert;
 use {
     super::{list_view::ListView, Result, VoteStateViewError},
     solana_clock::{Epoch, Slot},

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -49,7 +49,7 @@ impl ListFrame for VotesFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
     };
 
     fn len(&self) -> usize {
@@ -113,7 +113,7 @@ impl ListFrame for LockoutListFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
     };
 
     fn len(&self) -> usize {
@@ -150,7 +150,7 @@ impl ListFrame for LandedVotesListFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
     };
 
     fn len(&self) -> usize {
@@ -194,7 +194,7 @@ impl ListFrame for AuthorizedVotersListFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<AuthorizedVoterItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<AuthorizedVoterItem>() == 1);
     };
 
     fn len(&self) -> usize {
@@ -244,7 +244,7 @@ impl ListFrame for EpochCreditsListFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<EpochCreditsItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<EpochCreditsItem>() == 1);
     };
 
     fn len(&self) -> usize {
@@ -334,7 +334,7 @@ impl ListFrame for PriorVotersFrame {
 
     #[cfg(test)]
     const ASSERT_ITEM_ALIGNMENT: () = {
-        const_assert!(core::mem::align_of::<PriorVotersItem>() == 1);
+        static_assertions::const_assert!(core::mem::align_of::<PriorVotersItem>() == 1);
     };
 
     fn len(&self) -> usize {

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -2,7 +2,6 @@ use {
     super::{list_view::ListView, Result, VoteStateViewError},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    solana_vote_interface::state::Lockout,
     std::io::BufRead,
 };
 
@@ -71,18 +70,17 @@ impl LockoutItem {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LockoutListFrame {
-    len: usize,
+    len: u8,
 }
 
 impl LockoutListFrame {
-    pub(super) const fn new(len: usize) -> Self {
-        Self { len }
-    }
-
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
             .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -93,22 +91,21 @@ impl ListFrame<'_> for LockoutListFrame {
     type Item = LockoutItem;
 
     fn len(&self) -> usize {
-        self.len
+        self.len as usize
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LandedVotesListFrame {
-    len: usize,
+    len: u8,
 }
 
 impl LandedVotesListFrame {
-    pub(super) const fn new(len: usize) -> Self {
-        Self { len }
-    }
-
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
             .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -126,7 +123,7 @@ impl ListFrame<'_> for LandedVotesListFrame {
     type Item = LockoutItem;
 
     fn len(&self) -> usize {
-        self.len
+        self.len as usize
     }
 
     fn item_size(&self) -> usize {
@@ -138,18 +135,17 @@ impl ListFrame<'_> for LandedVotesListFrame {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct AuthorizedVotersListFrame {
-    len: usize,
+    len: u8,
 }
 
 impl AuthorizedVotersListFrame {
-    pub(super) const fn new(len: usize) -> Self {
-        Self { len }
-    }
-
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
             .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -166,7 +162,7 @@ impl ListFrame<'_> for AuthorizedVotersListFrame {
     type Item = AuthorizedVoterItem;
 
     fn len(&self) -> usize {
-        self.len
+        self.len as usize
     }
 }
 
@@ -190,18 +186,17 @@ pub struct EpochCreditsItem {
     prev_credits: [u8; 8],
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct EpochCreditsListFrame {
-    len: usize,
+    len: u8,
 }
 
 impl EpochCreditsListFrame {
-    pub(super) const fn new(len: usize) -> Self {
-        Self { len }
-    }
-
     pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
         let len = solana_serialize_utils::cursor::read_u64(cursor)
             .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let len = u8::try_from(len).map_err(|_| VoteStateViewError::ParseError)?;
         let frame = Self { len };
         cursor.consume(frame.total_item_size());
         Ok(frame)
@@ -212,7 +207,7 @@ impl ListFrame<'_> for EpochCreditsListFrame {
     type Item = EpochCreditsItem;
 
     fn len(&self) -> usize {
-        self.len
+        self.len as usize
     }
 }
 
@@ -263,19 +258,13 @@ impl RootSlotView<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct RootSlotFrame {
     has_root_slot: bool,
 }
 
 impl RootSlotFrame {
-    pub(super) const fn new(has_root_slot: bool) -> Self {
-        Self { has_root_slot }
-    }
-
-    pub(super) fn has_root_slot(&self) -> bool {
-        self.has_root_slot
-    }
-
     pub(super) fn total_size(&self) -> usize {
         1 + self.size()
     }

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -5,8 +5,8 @@ use {
     std::io::BufRead,
 };
 
-pub(super) trait ListFrame<'frame> {
-    type Item: 'frame;
+pub(super) trait ListFrame {
+    type Item;
 
     fn len(&self) -> usize;
     fn item_size(&self) -> usize {
@@ -28,7 +28,7 @@ pub(super) enum VotesFrame {
     Landed(LandedVotesListFrame),
 }
 
-impl ListFrame<'_> for VotesFrame {
+impl ListFrame for VotesFrame {
     type Item = LockoutItem;
 
     fn len(&self) -> usize {
@@ -87,7 +87,7 @@ impl LockoutListFrame {
     }
 }
 
-impl ListFrame<'_> for LockoutListFrame {
+impl ListFrame for LockoutListFrame {
     type Item = LockoutItem;
 
     fn len(&self) -> usize {
@@ -119,7 +119,7 @@ pub(super) struct LandedVoteItem {
     confirmation_count: [u8; 4],
 }
 
-impl ListFrame<'_> for LandedVotesListFrame {
+impl ListFrame for LandedVotesListFrame {
     type Item = LockoutItem;
 
     fn len(&self) -> usize {
@@ -158,7 +158,7 @@ pub(super) struct AuthorizedVoterItem {
     voter: Pubkey,
 }
 
-impl ListFrame<'_> for AuthorizedVotersListFrame {
+impl ListFrame for AuthorizedVotersListFrame {
     type Item = AuthorizedVoterItem;
 
     fn len(&self) -> usize {
@@ -203,7 +203,7 @@ impl EpochCreditsListFrame {
     }
 }
 
-impl ListFrame<'_> for EpochCreditsListFrame {
+impl ListFrame for EpochCreditsListFrame {
     type Item = EpochCreditsItem;
 
     fn len(&self) -> usize {
@@ -288,7 +288,7 @@ impl RootSlotFrame {
 
 pub(super) struct PriorVotersFrame;
 
-impl ListFrame<'_> for PriorVotersFrame {
+impl ListFrame for PriorVotersFrame {
     type Item = PriorVotersItem;
 
     fn len(&self) -> usize {

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -138,20 +138,6 @@ impl ListFrame<'_> for LandedVotesListFrame {
     }
 }
 
-impl<'a, T: ListFrame<'a, Item = LockoutItem>> ListView<'a, T> {
-    pub(super) fn last_lockout(&self) -> Option<Lockout> {
-        if self.len() == 0 {
-            return None;
-        }
-
-        let last_item = self.last().unwrap();
-        Some(Lockout::new_with_confirmation_count(
-            last_item.slot(),
-            last_item.confirmation_count(),
-        ))
-    }
-}
-
 pub(super) struct AuthorizedVotersListFrame {
     len: usize,
 }
@@ -248,12 +234,6 @@ impl EpochCreditsItem {
 impl From<&EpochCreditsItem> for (Epoch, u64, u64) {
     fn from(item: &EpochCreditsItem) -> Self {
         (item.epoch(), item.credits(), item.prev_credits())
-    }
-}
-
-impl ListView<'_, EpochCreditsListFrame> {
-    pub(super) fn credits(self) -> u64 {
-        self.last().map(|item| item.credits()).unwrap_or(0)
     }
 }
 

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use static_assertions::const_assert;
 use {
     super::{list_view::ListView, Result, VoteStateViewError},
     solana_clock::{Epoch, Slot},
@@ -8,16 +10,30 @@ use {
 pub(super) trait ListFrame {
     type Item;
 
+    // SAFETY: Each implementor MUST enforce that `Self::Item` is alignment 1 to
+    // ensure that after casting it won't have alignment issues, any heap
+    // allocated fields, or any assumptions about endianness.
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: ();
+
     fn len(&self) -> usize;
     fn item_size(&self) -> usize {
         core::mem::size_of::<Self::Item>()
     }
+
+    /// This function is safe under the following conditions:
+    /// SAFETY:
+    /// - `Self::Item` is alignment 1
+    /// - The passed `item_data` slice is large enough for the type `Self::Item`
+    /// - `Self::Item` is valid for any sequence of bytes
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
         &*(item_data.as_ptr() as *const Self::Item)
     }
+
     fn total_size(&self) -> usize {
         core::mem::size_of::<u64>() /* len */ + self.total_item_size()
     }
+
     fn total_item_size(&self) -> usize {
         self.len() * self.item_size()
     }
@@ -30,6 +46,11 @@ pub(super) enum VotesFrame {
 
 impl ListFrame for VotesFrame {
     type Item = LockoutItem;
+
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+    };
 
     fn len(&self) -> usize {
         match self {
@@ -90,6 +111,11 @@ impl LockoutListFrame {
 impl ListFrame for LockoutListFrame {
     type Item = LockoutItem;
 
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+    };
+
     fn len(&self) -> usize {
         self.len as usize
     }
@@ -121,6 +147,11 @@ pub(super) struct LandedVoteItem {
 
 impl ListFrame for LandedVotesListFrame {
     type Item = LockoutItem;
+
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<LockoutItem>() == 1);
+    };
 
     fn len(&self) -> usize {
         self.len as usize
@@ -160,6 +191,11 @@ pub(super) struct AuthorizedVoterItem {
 
 impl ListFrame for AuthorizedVotersListFrame {
     type Item = AuthorizedVoterItem;
+
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<AuthorizedVoterItem>() == 1);
+    };
 
     fn len(&self) -> usize {
         self.len as usize
@@ -205,6 +241,11 @@ impl EpochCreditsListFrame {
 
 impl ListFrame for EpochCreditsListFrame {
     type Item = EpochCreditsItem;
+
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<EpochCreditsItem>() == 1);
+    };
 
     fn len(&self) -> usize {
         self.len as usize
@@ -291,6 +332,11 @@ pub(super) struct PriorVotersFrame;
 impl ListFrame for PriorVotersFrame {
     type Item = PriorVotersItem;
 
+    #[cfg(test)]
+    const ASSERT_ITEM_ALIGNMENT: () = {
+        const_assert!(core::mem::align_of::<PriorVotersItem>() == 1);
+    };
+
     fn len(&self) -> usize {
         const MAX_ITEMS: usize = 32;
         MAX_ITEMS
@@ -306,8 +352,8 @@ impl ListFrame for PriorVotersFrame {
 #[repr(C)]
 pub(super) struct PriorVotersItem {
     voter: Pubkey,
-    start_epoch_inclusive: Epoch,
-    end_epoch_exclusive: Epoch,
+    start_epoch_inclusive: [u8; 8],
+    end_epoch_exclusive: [u8; 8],
 }
 
 impl PriorVotersFrame {

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -1,0 +1,281 @@
+use {
+    super::{field_list_view::ListView, Result, VoteStateViewError},
+    solana_clock::{Epoch, Slot},
+    solana_pubkey::Pubkey,
+    solana_vote_interface::state::Lockout,
+    std::io::BufRead,
+};
+
+pub(super) trait ListFrame {
+    fn len(&self) -> usize;
+    fn item_size(&self) -> usize;
+    fn total_size(&self) -> usize {
+        core::mem::size_of::<u64>() /* len */ + self.total_item_size()
+    }
+    fn total_item_size(&self) -> usize {
+        self.len() * self.item_size()
+    }
+}
+
+pub(super) struct VotesListFrame {
+    len: usize,
+    has_latency: bool,
+}
+
+impl VotesListFrame {
+    pub(super) const fn new(len: usize, has_latency: bool) -> Self {
+        Self { len, has_latency }
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>, has_latency: bool) -> Result<Self> {
+        let len = solana_serialize_utils::cursor::read_u64(cursor)
+            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let frame = Self { len, has_latency };
+        cursor.consume(frame.total_item_size());
+        Ok(frame)
+    }
+}
+
+impl ListFrame for VotesListFrame {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn item_size(&self) -> usize {
+        core::mem::size_of::<u64>()
+            + core::mem::size_of::<u32>()
+            + if self.has_latency { 1 } else { 0 }
+    }
+}
+
+impl<'a> ListView<'a, VotesListFrame> {
+    pub(super) fn votes_iter(self) -> impl Iterator<Item = Lockout> + 'a {
+        let has_latency = self.frame().has_latency;
+        self.into_iter().map(move |item| {
+            let mut cursor = std::io::Cursor::new(item);
+            if has_latency {
+                cursor.consume(1)
+            }
+            let slot = solana_serialize_utils::cursor::read_u64(&mut cursor).unwrap();
+            let confirmation_count = solana_serialize_utils::cursor::read_u32(&mut cursor).unwrap();
+            Lockout::new_with_confirmation_count(slot, confirmation_count)
+        })
+    }
+
+    pub(super) fn last_lockout(&self) -> Option<Lockout> {
+        if self.len() == 0 {
+            return None;
+        }
+
+        let last_vote_data = self.last().unwrap();
+        let mut cursor = std::io::Cursor::new(last_vote_data);
+        if self.frame().has_latency {
+            cursor.consume(1);
+        }
+        let slot = solana_serialize_utils::cursor::read_u64(&mut cursor).unwrap();
+        let confirmation_count = solana_serialize_utils::cursor::read_u32(&mut cursor).unwrap();
+        Some(Lockout::new_with_confirmation_count(
+            slot,
+            confirmation_count,
+        ))
+    }
+}
+
+pub(super) struct AuthorizedVotersListFrame {
+    len: usize,
+}
+
+impl AuthorizedVotersListFrame {
+    pub(super) const fn new(len: usize) -> Self {
+        Self { len }
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
+        let len = solana_serialize_utils::cursor::read_u64(cursor)
+            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let frame = Self { len };
+        cursor.consume(frame.total_item_size());
+        Ok(frame)
+    }
+}
+
+#[repr(C)]
+struct AuthorizedVoterItem {
+    epoch: [u8; 8],
+    voter: Pubkey,
+}
+
+impl ListFrame for AuthorizedVotersListFrame {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn item_size(&self) -> usize {
+        core::mem::size_of::<AuthorizedVoterItem>()
+    }
+}
+
+impl<'a> ListView<'a, AuthorizedVotersListFrame> {
+    pub(super) fn get_authorized_voter(self, epoch: Epoch) -> Option<&'a Pubkey> {
+        for item_data in self.into_iter().rev() {
+            let item = unsafe { &*(item_data.as_ptr() as *const AuthorizedVoterItem) };
+            let voter_epoch = u64::from_le_bytes(item.epoch);
+            if voter_epoch <= epoch {
+                return Some(&item.voter);
+            }
+        }
+
+        None
+    }
+}
+
+#[repr(C)]
+pub struct EpochCreditsItem {
+    epoch: [u8; 8],
+    credits: [u8; 8],
+    prev_credits: [u8; 8],
+}
+
+pub(super) struct EpochCreditsListFrame {
+    len: usize,
+}
+
+impl EpochCreditsListFrame {
+    pub(super) const fn new(len: usize) -> Self {
+        Self { len }
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
+        let len = solana_serialize_utils::cursor::read_u64(cursor)
+            .map_err(|_err| VoteStateViewError::ParseError)? as usize;
+        let frame = Self { len };
+        cursor.consume(frame.total_item_size());
+        Ok(frame)
+    }
+}
+
+impl ListFrame for EpochCreditsListFrame {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn item_size(&self) -> usize {
+        core::mem::size_of::<EpochCreditsItem>()
+    }
+}
+
+impl EpochCreditsItem {
+    #[inline]
+    pub fn epoch(&self) -> u64 {
+        u64::from_le_bytes(self.epoch)
+    }
+    #[inline]
+    pub fn credits(&self) -> u64 {
+        u64::from_le_bytes(self.credits)
+    }
+    #[inline]
+    pub fn prev_credits(&self) -> u64 {
+        u64::from_le_bytes(self.prev_credits)
+    }
+}
+
+impl From<&EpochCreditsItem> for (Epoch, u64, u64) {
+    fn from(item: &EpochCreditsItem) -> Self {
+        (item.epoch(), item.credits(), item.prev_credits())
+    }
+}
+
+impl<'a> ListView<'a, EpochCreditsListFrame> {
+    pub(super) fn epoch_credits_iter(self) -> impl Iterator<Item = &'a EpochCreditsItem> + 'a {
+        self.into_iter()
+            .map(|item_data| unsafe { &*(item_data.as_ptr() as *const EpochCreditsItem) })
+    }
+
+    pub(super) fn credits(self) -> u64 {
+        self.last()
+            .map(|item_data| unsafe { &*(item_data.as_ptr() as *const EpochCreditsItem) })
+            .map(|item| item.credits())
+            .unwrap_or(0)
+    }
+}
+
+pub(super) struct RootSlotView<'a> {
+    frame: RootSlotFrame,
+    buffer: &'a [u8],
+}
+
+impl<'a> RootSlotView<'a> {
+    pub(super) fn new(frame: RootSlotFrame, buffer: &'a [u8]) -> Self {
+        Self { frame, buffer }
+    }
+}
+
+impl RootSlotView<'_> {
+    pub(super) fn root_slot(&self) -> Option<Slot> {
+        if !self.frame.has_root_slot {
+            None
+        } else {
+            let root_slot = {
+                let mut cursor = std::io::Cursor::new(self.buffer);
+                cursor.consume(1);
+                solana_serialize_utils::cursor::read_u64(&mut cursor).unwrap()
+            };
+            Some(root_slot)
+        }
+    }
+}
+
+pub(super) struct RootSlotFrame {
+    has_root_slot: bool,
+}
+
+impl RootSlotFrame {
+    pub(super) const fn new(has_root_slot: bool) -> Self {
+        Self { has_root_slot }
+    }
+
+    pub(super) fn has_root_slot(&self) -> bool {
+        self.has_root_slot
+    }
+
+    pub(super) fn total_size(&self) -> usize {
+        1 + self.size()
+    }
+
+    pub(super) fn size(&self) -> usize {
+        if self.has_root_slot {
+            core::mem::size_of::<u64>()
+        } else {
+            0
+        }
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
+        let has_root_slot = solana_serialize_utils::cursor::read_bool(cursor)
+            .map_err(|_err| VoteStateViewError::ParseError)?;
+        let frame = Self { has_root_slot };
+        cursor.consume(frame.size());
+        Ok(frame)
+    }
+}
+
+pub(super) struct PriorVotersFrame;
+impl PriorVotersFrame {
+    pub(super) const fn total_size() -> usize {
+        #[repr(C)]
+        struct PriorVotersItem {
+            pub voter: Pubkey,
+            pub start_epoch_inclusive: Epoch,
+            pub end_epoch_exclusive: Epoch,
+        }
+
+        const MAX_ITEMS: usize = 32;
+        let prior_voter_item_size = core::mem::size_of::<PriorVotersItem>();
+        let total_items_size = MAX_ITEMS * prior_voter_item_size;
+        total_items_size + core::mem::size_of::<u64>() + core::mem::size_of::<bool>()
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) {
+        cursor.consume(Self::total_size());
+    }
+}

--- a/vote/src/vote_state_view/field_list_view.rs
+++ b/vote/src/vote_state_view/field_list_view.rs
@@ -1,0 +1,77 @@
+use super::field_frames::ListFrame;
+
+pub(super) struct ListView<'a, F> {
+    frame: F,
+    item_buffer: &'a [u8],
+}
+
+impl<'a, F: ListFrame> ListView<'a, F> {
+    pub(super) fn new(frame: F, buffer: &'a [u8]) -> Self {
+        let len_offset = core::mem::size_of::<u64>();
+        let item_buffer = &buffer[len_offset..];
+        Self { frame, item_buffer }
+    }
+
+    pub(super) fn frame(&self) -> &F {
+        &self.frame
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.frame.len()
+    }
+
+    pub(super) fn into_iter(self) -> ListViewIter<'a, F>
+    where
+        Self: Sized,
+    {
+        ListViewIter {
+            index: 0,
+            rev_index: 0,
+            view: self,
+        }
+    }
+
+    pub(super) fn last(&self) -> Option<&'a [u8]> {
+        let len = self.len();
+        if len == 0 {
+            return None;
+        }
+        Some(self.item(len - 1))
+    }
+
+    fn item(&self, index: usize) -> &'a [u8] {
+        let offset = index * self.frame.item_size();
+        &self.item_buffer[offset..offset + self.frame.item_size()]
+    }
+}
+
+pub(super) struct ListViewIter<'a, F> {
+    index: usize,
+    rev_index: usize,
+    view: ListView<'a, F>,
+}
+
+impl<'a, F: ListFrame> Iterator for ListViewIter<'a, F> {
+    type Item = &'a [u8];
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.view.len() {
+            let item = self.view.item(self.index);
+            self.index += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
+impl<F: ListFrame> DoubleEndedIterator for ListViewIter<'_, F> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.rev_index < self.view.len() {
+            let item = self.view.item(self.view.len() - self.rev_index - 1);
+            self.rev_index += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}

--- a/vote/src/vote_state_view/frame_v1_14_11.rs
+++ b/vote/src/vote_state_view/frame_v1_14_11.rs
@@ -1,0 +1,109 @@
+use {
+    super::{
+        field_frames::{AuthorizedVotersListFrame, ListFrame, PriorVotersFrame, RootSlotFrame},
+        EpochCreditsListFrame, Field, Result, VoteStateViewError, VotesListFrame,
+    },
+    solana_pubkey::Pubkey,
+    solana_vote_interface::state::BlockTimestamp,
+    std::io::BufRead,
+};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+pub(super) struct VoteStateFrameV1_14_11 {
+    pub(super) num_votes: u8,
+    pub(super) has_root_slot: bool,
+    pub(super) num_authorized_voters: u8,
+    pub(super) num_epoch_credits: u8,
+}
+
+impl VoteStateFrameV1_14_11 {
+    pub(super) fn try_new(bytes: &[u8]) -> Result<Self> {
+        let votes_offset = Self::votes_offset();
+        let mut cursor = std::io::Cursor::new(bytes);
+        cursor.set_position(votes_offset as u64);
+
+        let votes = VotesListFrame::read(&mut cursor, false /* has_latency */)?;
+        let root_slot = RootSlotFrame::read(&mut cursor)?;
+        let authorized_voters = AuthorizedVotersListFrame::read(&mut cursor)?;
+        PriorVotersFrame::read(&mut cursor);
+        let epoch_credits = EpochCreditsListFrame::read(&mut cursor)?;
+        cursor.consume(core::mem::size_of::<BlockTimestamp>());
+        if cursor.position() as usize <= bytes.len() {
+            Ok(Self {
+                num_votes: u8::try_from(votes.len()).map_err(|_| VoteStateViewError::ParseError)?,
+                has_root_slot: root_slot.has_root_slot(),
+                num_authorized_voters: u8::try_from(authorized_voters.len())
+                    .map_err(|_| VoteStateViewError::ParseError)?,
+                num_epoch_credits: u8::try_from(epoch_credits.len())
+                    .map_err(|_| VoteStateViewError::ParseError)?,
+            })
+        } else {
+            Err(VoteStateViewError::ParseError)
+        }
+    }
+
+    pub(super) fn votes_frame(&self) -> VotesListFrame {
+        VotesListFrame::new(self.num_votes as usize, false /* has_latency */)
+    }
+
+    pub(super) fn root_slot_frame(&self) -> RootSlotFrame {
+        RootSlotFrame::new(self.has_root_slot)
+    }
+
+    pub(super) fn authorized_voters_frame(&self) -> AuthorizedVotersListFrame {
+        AuthorizedVotersListFrame::new(self.num_authorized_voters as usize)
+    }
+
+    pub(super) const fn epoch_credits_frame(&self) -> EpochCreditsListFrame {
+        EpochCreditsListFrame::new(self.num_epoch_credits as usize)
+    }
+
+    pub(super) fn get_field_offset(&self, field: Field) -> usize {
+        match field {
+            Field::NodePubkey => Self::node_pubkey_offset(),
+            Field::Commission => Self::commission_offset(),
+            Field::Votes => Self::votes_offset(),
+            Field::RootSlot => self.root_slot_offset(),
+            Field::AuthorizedVoters => self.authorized_voters_offset(),
+            Field::EpochCredits => self.epoch_credits_offset(),
+            Field::LastTimestamp => self.last_timestamp_offset(),
+        }
+    }
+
+    const fn node_pubkey_offset() -> usize {
+        4 // size of version
+    }
+
+    const fn authorized_withdrawer_offset() -> usize {
+        Self::node_pubkey_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn commission_offset() -> usize {
+        Self::authorized_withdrawer_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn votes_offset() -> usize {
+        Self::commission_offset() + core::mem::size_of::<u8>()
+    }
+
+    fn root_slot_offset(&self) -> usize {
+        Self::votes_offset() + self.votes_frame().total_size()
+    }
+
+    fn authorized_voters_offset(&self) -> usize {
+        self.root_slot_offset() + self.root_slot_frame().total_size()
+    }
+
+    fn prior_voters_offset(&self) -> usize {
+        self.authorized_voters_offset() + self.authorized_voters_frame().total_size()
+    }
+
+    fn epoch_credits_offset(&self) -> usize {
+        self.prior_voters_offset() + PriorVotersFrame::total_size()
+    }
+
+    fn last_timestamp_offset(&self) -> usize {
+        self.epoch_credits_offset() + self.epoch_credits_frame().total_size()
+    }
+}

--- a/vote/src/vote_state_view/frame_v1_14_11.rs
+++ b/vote/src/vote_state_view/frame_v1_14_11.rs
@@ -13,10 +13,10 @@ use {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct VoteStateFrameV1_14_11 {
-    pub(super) num_votes: u8,
-    pub(super) has_root_slot: bool,
-    pub(super) num_authorized_voters: u8,
-    pub(super) num_epoch_credits: u8,
+    pub(super) votes_frame: LockoutListFrame,
+    pub(super) root_slot_frame: RootSlotFrame,
+    pub(super) authorized_voters_frame: AuthorizedVotersListFrame,
+    pub(super) epoch_credits_frame: EpochCreditsListFrame,
 }
 
 impl VoteStateFrameV1_14_11 {
@@ -25,42 +25,24 @@ impl VoteStateFrameV1_14_11 {
         let mut cursor = std::io::Cursor::new(bytes);
         cursor.set_position(votes_offset as u64);
 
-        let votes = LockoutListFrame::read(&mut cursor)?;
-        let root_slot = RootSlotFrame::read(&mut cursor)?;
-        let authorized_voters = AuthorizedVotersListFrame::read(&mut cursor)?;
+        let votes_frame = LockoutListFrame::read(&mut cursor)?;
+        let root_slot_frame = RootSlotFrame::read(&mut cursor)?;
+        let authorized_voters_frame = AuthorizedVotersListFrame::read(&mut cursor)?;
         PriorVotersFrame::read(&mut cursor);
-        let epoch_credits = EpochCreditsListFrame::read(&mut cursor)?;
+        let epoch_credits_frame = EpochCreditsListFrame::read(&mut cursor)?;
         cursor.consume(core::mem::size_of::<BlockTimestamp>());
         // trailing bytes are allowed. consistent with default behavior of
         // function bincode::deserialize
         if cursor.position() as usize <= bytes.len() {
             Ok(Self {
-                num_votes: u8::try_from(votes.len()).map_err(|_| VoteStateViewError::ParseError)?,
-                has_root_slot: root_slot.has_root_slot(),
-                num_authorized_voters: u8::try_from(authorized_voters.len())
-                    .map_err(|_| VoteStateViewError::ParseError)?,
-                num_epoch_credits: u8::try_from(epoch_credits.len())
-                    .map_err(|_| VoteStateViewError::ParseError)?,
+                votes_frame,
+                root_slot_frame,
+                authorized_voters_frame,
+                epoch_credits_frame,
             })
         } else {
             Err(VoteStateViewError::ParseError)
         }
-    }
-
-    pub(super) fn votes_frame(&self) -> LockoutListFrame {
-        LockoutListFrame::new(self.num_votes as usize)
-    }
-
-    pub(super) fn root_slot_frame(&self) -> RootSlotFrame {
-        RootSlotFrame::new(self.has_root_slot)
-    }
-
-    pub(super) fn authorized_voters_frame(&self) -> AuthorizedVotersListFrame {
-        AuthorizedVotersListFrame::new(self.num_authorized_voters as usize)
-    }
-
-    pub(super) const fn epoch_credits_frame(&self) -> EpochCreditsListFrame {
-        EpochCreditsListFrame::new(self.num_epoch_credits as usize)
     }
 
     pub(super) fn get_field_offset(&self, field: Field) -> usize {
@@ -92,15 +74,15 @@ impl VoteStateFrameV1_14_11 {
     }
 
     fn root_slot_offset(&self) -> usize {
-        Self::votes_offset() + self.votes_frame().total_size()
+        Self::votes_offset() + self.votes_frame.total_size()
     }
 
     fn authorized_voters_offset(&self) -> usize {
-        self.root_slot_offset() + self.root_slot_frame().total_size()
+        self.root_slot_offset() + self.root_slot_frame.total_size()
     }
 
     fn prior_voters_offset(&self) -> usize {
-        self.authorized_voters_offset() + self.authorized_voters_frame().total_size()
+        self.authorized_voters_offset() + self.authorized_voters_frame.total_size()
     }
 
     fn epoch_credits_offset(&self) -> usize {
@@ -108,6 +90,6 @@ impl VoteStateFrameV1_14_11 {
     }
 
     fn last_timestamp_offset(&self) -> usize {
-        self.epoch_credits_offset() + self.epoch_credits_frame().total_size()
+        self.epoch_credits_offset() + self.epoch_credits_frame.total_size()
     }
 }

--- a/vote/src/vote_state_view/frame_v1_14_11.rs
+++ b/vote/src/vote_state_view/frame_v1_14_11.rs
@@ -45,7 +45,7 @@ impl VoteStateFrameV1_14_11 {
         }
     }
 
-    pub(super) fn get_field_offset(&self, field: Field) -> usize {
+    pub(super) fn field_offset(&self, field: Field) -> usize {
         match field {
             Field::NodePubkey => Self::node_pubkey_offset(),
             Field::Commission => Self::commission_offset(),

--- a/vote/src/vote_state_view/frame_v3.rs
+++ b/vote/src/vote_state_view/frame_v3.rs
@@ -14,10 +14,10 @@ use {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct VoteStateFrameV3 {
-    pub(super) num_votes: u8,
-    pub(super) has_root_slot: bool,
-    pub(super) num_authorized_voters: u8,
-    pub(super) num_epoch_credits: u8,
+    pub(super) votes_frame: LandedVotesListFrame,
+    pub(super) root_slot_frame: RootSlotFrame,
+    pub(super) authorized_voters_frame: AuthorizedVotersListFrame,
+    pub(super) epoch_credits_frame: EpochCreditsListFrame,
 }
 
 impl VoteStateFrameV3 {
@@ -26,42 +26,24 @@ impl VoteStateFrameV3 {
         let mut cursor = std::io::Cursor::new(bytes);
         cursor.set_position(votes_offset as u64);
 
-        let votes = LandedVotesListFrame::read(&mut cursor)?;
-        let root_slot = RootSlotFrame::read(&mut cursor)?;
-        let authorized_voters = AuthorizedVotersListFrame::read(&mut cursor)?;
+        let votes_frame = LandedVotesListFrame::read(&mut cursor)?;
+        let root_slot_frame = RootSlotFrame::read(&mut cursor)?;
+        let authorized_voters_frame = AuthorizedVotersListFrame::read(&mut cursor)?;
         PriorVotersFrame::read(&mut cursor);
-        let epoch_credits = EpochCreditsListFrame::read(&mut cursor)?;
+        let epoch_credits_frame = EpochCreditsListFrame::read(&mut cursor)?;
         cursor.consume(core::mem::size_of::<BlockTimestamp>());
         // trailing bytes are allowed. consistent with default behavior of
         // function bincode::deserialize
         if cursor.position() as usize <= bytes.len() {
             Ok(Self {
-                num_votes: u8::try_from(votes.len()).map_err(|_| VoteStateViewError::ParseError)?,
-                has_root_slot: root_slot.has_root_slot(),
-                num_authorized_voters: u8::try_from(authorized_voters.len())
-                    .map_err(|_| VoteStateViewError::ParseError)?,
-                num_epoch_credits: u8::try_from(epoch_credits.len())
-                    .map_err(|_| VoteStateViewError::ParseError)?,
+                votes_frame,
+                root_slot_frame,
+                authorized_voters_frame,
+                epoch_credits_frame,
             })
         } else {
             Err(VoteStateViewError::ParseError)
         }
-    }
-
-    pub(super) fn votes_frame(&self) -> LandedVotesListFrame {
-        LandedVotesListFrame::new(self.num_votes as usize)
-    }
-
-    pub(super) fn root_slot_frame(&self) -> RootSlotFrame {
-        RootSlotFrame::new(self.has_root_slot)
-    }
-
-    pub(super) fn authorized_voters_frame(&self) -> AuthorizedVotersListFrame {
-        AuthorizedVotersListFrame::new(self.num_authorized_voters as usize)
-    }
-
-    pub(super) const fn epoch_credits_frame(&self) -> EpochCreditsListFrame {
-        EpochCreditsListFrame::new(self.num_epoch_credits as usize)
     }
 
     pub(super) fn get_field_offset(&self, field: Field) -> usize {
@@ -93,15 +75,15 @@ impl VoteStateFrameV3 {
     }
 
     fn root_slot_offset(&self) -> usize {
-        Self::votes_offset() + self.votes_frame().total_size()
+        Self::votes_offset() + self.votes_frame.total_size()
     }
 
     fn authorized_voters_offset(&self) -> usize {
-        self.root_slot_offset() + self.root_slot_frame().total_size()
+        self.root_slot_offset() + self.root_slot_frame.total_size()
     }
 
     fn prior_voters_offset(&self) -> usize {
-        self.authorized_voters_offset() + self.authorized_voters_frame().total_size()
+        self.authorized_voters_offset() + self.authorized_voters_frame.total_size()
     }
 
     fn epoch_credits_offset(&self) -> usize {
@@ -109,6 +91,6 @@ impl VoteStateFrameV3 {
     }
 
     fn last_timestamp_offset(&self) -> usize {
-        self.epoch_credits_offset() + self.epoch_credits_frame().total_size()
+        self.epoch_credits_offset() + self.epoch_credits_frame.total_size()
     }
 }

--- a/vote/src/vote_state_view/frame_v3.rs
+++ b/vote/src/vote_state_view/frame_v3.rs
@@ -11,7 +11,7 @@ use {
     std::io::BufRead,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct VoteStateFrameV3 {
     pub(super) votes_frame: LandedVotesListFrame,
@@ -42,7 +42,7 @@ impl VoteStateFrameV3 {
                 epoch_credits_frame,
             })
         } else {
-            Err(VoteStateViewError::ParseError)
+            Err(VoteStateViewError::AccountDataTooSmall)
         }
     }
 
@@ -87,10 +87,144 @@ impl VoteStateFrameV3 {
     }
 
     fn epoch_credits_offset(&self) -> usize {
-        self.prior_voters_offset() + PriorVotersFrame.total_size()
+        self.prior_voters_offset() + PriorVotersFrame::total_size()
     }
 
     fn last_timestamp_offset(&self) -> usize {
         self.epoch_credits_offset() + self.epoch_credits_frame.total_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_clock::Clock,
+        solana_vote_interface::state::{
+            LandedVote, Lockout, VoteInit, VoteState, VoteStateVersions,
+        },
+    };
+
+    #[test]
+    fn test_try_new_zeroed() {
+        let target_vote_state = VoteState::default();
+        let target_vote_state_versions = VoteStateVersions::Current(Box::new(target_vote_state));
+        let mut bytes = bincode::serialize(&target_vote_state_versions).unwrap();
+
+        for i in 0..bytes.len() {
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes[..i]);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::AccountDataTooSmall)
+            );
+        }
+
+        for has_trailing_bytes in [false, true] {
+            if has_trailing_bytes {
+                bytes.extend_from_slice(&[0; 42]);
+            }
+            assert_eq!(
+                VoteStateFrameV3::try_new(&bytes),
+                Ok(VoteStateFrameV3 {
+                    votes_frame: LandedVotesListFrame { len: 0 },
+                    root_slot_frame: RootSlotFrame {
+                        has_root_slot: false,
+                    },
+                    authorized_voters_frame: AuthorizedVotersListFrame { len: 0 },
+                    epoch_credits_frame: EpochCreditsListFrame { len: 0 },
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_try_new_simple() {
+        let mut target_vote_state = VoteState::new(&VoteInit::default(), &Clock::default());
+        target_vote_state.root_slot = Some(42);
+        target_vote_state.epoch_credits.push((1, 2, 3));
+        target_vote_state.votes.push_back(LandedVote {
+            latency: 0,
+            lockout: Lockout::default(),
+        });
+
+        let target_vote_state_versions = VoteStateVersions::Current(Box::new(target_vote_state));
+        let mut bytes = bincode::serialize(&target_vote_state_versions).unwrap();
+
+        for i in 0..bytes.len() {
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes[..i]);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::AccountDataTooSmall)
+            );
+        }
+
+        for has_trailing_bytes in [false, true] {
+            if has_trailing_bytes {
+                bytes.extend_from_slice(&[0; 42]);
+            }
+            assert_eq!(
+                VoteStateFrameV3::try_new(&bytes),
+                Ok(VoteStateFrameV3 {
+                    votes_frame: LandedVotesListFrame { len: 1 },
+                    root_slot_frame: RootSlotFrame {
+                        has_root_slot: true,
+                    },
+                    authorized_voters_frame: AuthorizedVotersListFrame { len: 1 },
+                    epoch_credits_frame: EpochCreditsListFrame { len: 1 },
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_try_new_invalid_values() {
+        let mut bytes = vec![0; VoteStateFrameV3::votes_offset()];
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidVotesLength)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; core::mem::size_of::<u64>()]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(2u8.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidRootSlotOption)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; 1]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidAuthorizedVotersLength)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; core::mem::size_of::<u64>()]);
+        bytes.extend_from_slice(&[0; PriorVotersFrame::total_size()]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV3::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidEpochCreditsLength)
+            );
+        }
     }
 }

--- a/vote/src/vote_state_view/frame_v3.rs
+++ b/vote/src/vote_state_view/frame_v3.rs
@@ -46,7 +46,7 @@ impl VoteStateFrameV3 {
         }
     }
 
-    pub(super) fn get_field_offset(&self, field: Field) -> usize {
+    pub(super) fn field_offset(&self, field: Field) -> usize {
         match field {
             Field::NodePubkey => Self::node_pubkey_offset(),
             Field::Commission => Self::commission_offset(),

--- a/vote/src/vote_state_view/frame_v3.rs
+++ b/vote/src/vote_state_view/frame_v3.rs
@@ -1,0 +1,112 @@
+use {
+    super::{
+        field_frames::{
+            AuthorizedVotersListFrame, EpochCreditsListFrame, ListFrame, PriorVotersFrame,
+            RootSlotFrame, VotesListFrame,
+        },
+        Field, Result, VoteStateViewError,
+    },
+    solana_pubkey::Pubkey,
+    solana_vote_interface::state::BlockTimestamp,
+    std::io::BufRead,
+};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+pub(super) struct VoteStateFrameV3 {
+    pub(super) num_votes: u8,
+    pub(super) has_root_slot: bool,
+    pub(super) num_authorized_voters: u8,
+    pub(super) num_epoch_credits: u8,
+}
+
+impl VoteStateFrameV3 {
+    pub(super) fn try_new(bytes: &[u8]) -> Result<Self> {
+        let votes_offset = Self::votes_offset();
+        let mut cursor = std::io::Cursor::new(bytes);
+        cursor.set_position(votes_offset as u64);
+
+        let votes = VotesListFrame::read(&mut cursor, true /* has_latency */)?;
+        let root_slot = RootSlotFrame::read(&mut cursor)?;
+        let authorized_voters = AuthorizedVotersListFrame::read(&mut cursor)?;
+        PriorVotersFrame::read(&mut cursor);
+        let epoch_credits = EpochCreditsListFrame::read(&mut cursor)?;
+        cursor.consume(core::mem::size_of::<BlockTimestamp>());
+        if cursor.position() as usize <= bytes.len() {
+            Ok(Self {
+                num_votes: u8::try_from(votes.len()).map_err(|_| VoteStateViewError::ParseError)?,
+                has_root_slot: root_slot.has_root_slot(),
+                num_authorized_voters: u8::try_from(authorized_voters.len())
+                    .map_err(|_| VoteStateViewError::ParseError)?,
+                num_epoch_credits: u8::try_from(epoch_credits.len())
+                    .map_err(|_| VoteStateViewError::ParseError)?,
+            })
+        } else {
+            Err(VoteStateViewError::ParseError)
+        }
+    }
+
+    pub(super) fn votes_frame(&self) -> VotesListFrame {
+        VotesListFrame::new(self.num_votes as usize, true /* has_latency */)
+    }
+
+    pub(super) fn root_slot_frame(&self) -> RootSlotFrame {
+        RootSlotFrame::new(self.has_root_slot)
+    }
+
+    pub(super) fn authorized_voters_frame(&self) -> AuthorizedVotersListFrame {
+        AuthorizedVotersListFrame::new(self.num_authorized_voters as usize)
+    }
+
+    pub(super) const fn epoch_credits_frame(&self) -> EpochCreditsListFrame {
+        EpochCreditsListFrame::new(self.num_epoch_credits as usize)
+    }
+
+    pub(super) fn get_field_offset(&self, field: Field) -> usize {
+        match field {
+            Field::NodePubkey => Self::node_pubkey_offset(),
+            Field::Commission => Self::commission_offset(),
+            Field::Votes => Self::votes_offset(),
+            Field::RootSlot => self.root_slot_offset(),
+            Field::AuthorizedVoters => self.authorized_voters_offset(),
+            Field::EpochCredits => self.epoch_credits_offset(),
+            Field::LastTimestamp => self.last_timestamp_offset(),
+        }
+    }
+
+    const fn node_pubkey_offset() -> usize {
+        4 // size of version
+    }
+
+    const fn authorized_withdrawer_offset() -> usize {
+        Self::node_pubkey_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn commission_offset() -> usize {
+        Self::authorized_withdrawer_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn votes_offset() -> usize {
+        Self::commission_offset() + core::mem::size_of::<u8>()
+    }
+
+    fn root_slot_offset(&self) -> usize {
+        Self::votes_offset() + self.votes_frame().total_size()
+    }
+
+    fn authorized_voters_offset(&self) -> usize {
+        self.root_slot_offset() + self.root_slot_frame().total_size()
+    }
+
+    fn prior_voters_offset(&self) -> usize {
+        self.authorized_voters_offset() + self.authorized_voters_frame().total_size()
+    }
+
+    fn epoch_credits_offset(&self) -> usize {
+        self.prior_voters_offset() + PriorVotersFrame::total_size()
+    }
+
+    fn last_timestamp_offset(&self) -> usize {
+        self.epoch_credits_offset() + self.epoch_credits_frame().total_size()
+    }
+}

--- a/vote/src/vote_state_view/list_view.rs
+++ b/vote/src/vote_state_view/list_view.rs
@@ -5,7 +5,7 @@ pub(super) struct ListView<'a, F> {
     item_buffer: &'a [u8],
 }
 
-impl<'a, F: ListFrame<'a>> ListView<'a, F> {
+impl<'a, F: ListFrame> ListView<'a, F> {
     pub(super) fn new(frame: F, buffer: &'a [u8]) -> Self {
         let len_offset = core::mem::size_of::<u64>();
         let item_buffer = &buffer[len_offset..];
@@ -53,7 +53,10 @@ pub(super) struct ListViewIter<'a, F> {
     view: ListView<'a, F>,
 }
 
-impl<'a, F: ListFrame<'a>> Iterator for ListViewIter<'a, F> {
+impl<'a, F: ListFrame> Iterator for ListViewIter<'a, F>
+where
+    F::Item: 'a,
+{
     type Item = &'a F::Item;
     fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.view.len() {
@@ -66,7 +69,10 @@ impl<'a, F: ListFrame<'a>> Iterator for ListViewIter<'a, F> {
     }
 }
 
-impl<'a, F: ListFrame<'a>> DoubleEndedIterator for ListViewIter<'a, F> {
+impl<'a, F: ListFrame> DoubleEndedIterator for ListViewIter<'a, F>
+where
+    F::Item: 'a,
+{
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.rev_index < self.view.len() {
             let item = self.view.item(self.view.len() - self.rev_index - 1);

--- a/vote/src/vote_state_view/list_view.rs
+++ b/vote/src/vote_state_view/list_view.rs
@@ -43,6 +43,7 @@ impl<'a, F: ListFrame> ListView<'a, F> {
         let offset = index * self.frame.item_size();
         // SAFETY: `item_buffer` is long enough to contain all items
         let item_data = &self.item_buffer[offset..offset + self.frame.item_size()];
+        // SAFETY: `item_data` is long enough to contain an item
         Some(unsafe { self.frame.read_item(item_data) })
     }
 }


### PR DESCRIPTION
#### Problem
The stakes cache stores copies of vote account data so that things like consensus, inflation rewards, and vote timestamp calculation can access the vote account state for all staked validators. Every time when a vote is processed, the vote account entry in the stakes cache is updated and the account data is deserialized and ~1KB is allocated to store the new state. This is all unnecessary because the vote state data the protocol needs can be read on demand directly from the account data byte vector.

#### Summary of Changes
- Introduce new `VoteStateView` type which stores a copy of the vote account's `Arc<Vec<u8>>` and field offset data to speed up vote state field lookups.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
