### PR TITLE
Adds --no-snapshots to disable generating snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Release channels have their own copy of this changelog:
 
 #### Changes
 * Account notifications for Geyser are no longer deduplicated when restorting from a snapshot.
+* Add `--no-snapshots` to disable generating snapshots.
+
+#### Deprecations
+* Using `--snapshot-interval-slots 0` to disable generating snapshots is now deprecated.
 
 ### Platform Tools SDK
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -410,7 +410,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("no-snapshots")
             .takes_value(false)
             .conflicts_with_all(&["no_incremental_snapshots", "snapshot_interval_slots", "full_snapshot_interval_slots"])
-            .help("Disable all snapshots")
+            .help("Disable all snapshot generation")
     )
     .arg(
         Arg::with_name("no_incremental_snapshots")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -430,7 +430,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                 "Number of slots between generating snapshots. \
                  If incremental snapshots are enabled, this sets the incremental snapshot interval. \
                  If incremental snapshots are disabled, this sets the full snapshot interval. \
-                 Setting this to 0 disables all snapshots, but prefer --no-snapshots instead.",
+                 To disable all snapshot generation, see --no-snapshots.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -406,6 +406,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("no_snapshots")
+            .long("no-snapshots")
+            .takes_value(false)
+            .conflicts_with_all(&["no_incremental_snapshots", "snapshot_interval_slots", "full_snapshot_interval_slots"])
+            .help("Disable all snapshots")
+    )
+    .arg(
         Arg::with_name("no_incremental_snapshots")
             .long("no-incremental-snapshots")
             .takes_value(false)
@@ -423,7 +430,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                 "Number of slots between generating snapshots. \
                  If incremental snapshots are enabled, this sets the incremental snapshot interval. \
                  If incremental snapshots are disabled, this sets the full snapshot interval. \
-                 Setting this to 0 disables all snapshots.",
+                 Setting this to 0 disables all snapshots, but prefer --no-snapshots instead.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -928,8 +928,8 @@ pub fn execute(
                 (_, 0) => {
                     // snapshots are disabled
                     warn!(
-                        "Snapshots were disabled with `--snapshot-interval-slots 0`, which is \
-                         now deprecated. Use `--no-snapshots` instead.",
+                        "Snapshots generation was disabled with `--snapshot-interval-slots 0`, \
+                        which is now deprecated. Use `--no-snapshots` instead.",
                     );
                     (
                         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -928,8 +928,8 @@ pub fn execute(
                 (_, 0) => {
                     // snapshots are disabled
                     warn!(
-                        "Snapshots generation was disabled with `--snapshot-interval-slots 0`, \
-                        which is now deprecated. Use `--no-snapshots` instead.",
+                        "Snapshot generation was disabled with `--snapshot-interval-slots 0`, \
+                         which is now deprecated. Use `--no-snapshots` instead.",
                     );
                     (
                         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -913,42 +913,55 @@ pub fn execute(
         .transpose()?
         .unwrap_or(SnapshotVersion::default());
 
-    let (full_snapshot_archive_interval_slots, incremental_snapshot_archive_interval_slots) = match (
-        !matches.is_present("no_incremental_snapshots"),
-        value_t_or_exit!(matches, "snapshot_interval_slots", u64),
-    ) {
-        (_, 0) => {
+    let (full_snapshot_archive_interval_slots, incremental_snapshot_archive_interval_slots) =
+        if matches.is_present("no_snapshots") {
             // snapshots are disabled
             (
                 DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
                 DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
             )
-        }
-        (true, incremental_snapshot_interval_slots) => {
-            // incremental snapshots are enabled
-            // use --snapshot-interval-slots for the incremental snapshot interval
-            (
-                value_t_or_exit!(matches, "full_snapshot_interval_slots", u64),
-                incremental_snapshot_interval_slots,
-            )
-        }
-        (false, full_snapshot_interval_slots) => {
-            // incremental snapshots are *disabled*
-            // use --snapshot-interval-slots for the *full* snapshot interval
-            // also warn if --full-snapshot-interval-slots was specified
-            if matches.occurrences_of("full_snapshot_interval_slots") > 0 {
-                warn!(
-                    "Incremental snapshots are disabled, yet --full-snapshot-interval-slots was specified! \
-                     Note that --full-snapshot-interval-slots is *ignored* when incremental snapshots are disabled. \
-                     Use --snapshot-interval-slots instead.",
-                );
+        } else {
+            match (
+                !matches.is_present("no_incremental_snapshots"),
+                value_t_or_exit!(matches, "snapshot_interval_slots", u64),
+            ) {
+                (_, 0) => {
+                    // snapshots are disabled
+                    warn!(
+                        "Snapshots were disabled with `--snapshot-interval-slots 0`, which is \
+                         now deprecated. Use `--no-snapshots` instead.",
+                    );
+                    (
+                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                    )
+                }
+                (true, incremental_snapshot_interval_slots) => {
+                    // incremental snapshots are enabled
+                    // use --snapshot-interval-slots for the incremental snapshot interval
+                    (
+                        value_t_or_exit!(matches, "full_snapshot_interval_slots", u64),
+                        incremental_snapshot_interval_slots,
+                    )
+                }
+                (false, full_snapshot_interval_slots) => {
+                    // incremental snapshots are *disabled*
+                    // use --snapshot-interval-slots for the *full* snapshot interval
+                    // also warn if --full-snapshot-interval-slots was specified
+                    if matches.occurrences_of("full_snapshot_interval_slots") > 0 {
+                        warn!(
+                            "Incremental snapshots are disabled, yet --full-snapshot-interval-slots was specified! \
+                             Note that --full-snapshot-interval-slots is *ignored* when incremental snapshots are disabled. \
+                             Use --snapshot-interval-slots instead.",
+                        );
+                    }
+                    (
+                        full_snapshot_interval_slots,
+                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                    )
+                }
             }
-            (
-                full_snapshot_interval_slots,
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-            )
-        }
-    };
+        };
 
     validator_config.snapshot_config = SnapshotConfig {
         usage: if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {


### PR DESCRIPTION
#### Problem

Node operators sometimes are confused on how to disable generating snapshots.


#### Summary of Changes

Add `--no-snapshots` to make it obvious.