### PR TITLE
Fixes log when snapshots are disabled

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1141,16 +1141,16 @@ pub fn main() {
     );
 
     info!(
-        "Snapshot configuration: full snapshot interval: {} slots, incremental snapshot interval: {} slots",
+        "Snapshot configuration: full snapshot interval: {}, incremental snapshot interval: {}",
         if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
             "disabled".to_string()
         } else {
-            full_snapshot_archive_interval_slots.to_string()
+            format!("{full_snapshot_archive_interval_slots} slots")
         },
         if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
             "disabled".to_string()
         } else {
-            incremental_snapshot_archive_interval_slots.to_string()
+            format!("{incremental_snapshot_archive_interval_slots} slots")
         },
     );
 


### PR DESCRIPTION
#### Problem

If snapshots are disabled, the log that prints the snapshot configuration looks like this:

```
[2025-02-06T20:43:00.085015000Z INFO  agave_validator] Snapshot configuration: full snapshot interval: disabled slots, incremental snapshot interval: disabled slots
```

Notice the "disabled slots". That's not proper english 😅 


#### Summary of Changes

If snapshots are disabled, don't add "slots" afterwards. Here's what it looks like with this PR:

```
[2025-02-06T20:52:16.582203000Z INFO  agave_validator] Snapshot configuration: full snapshot interval: disabled, incremental snapshot interval: disabled
```