### PR TITLE
disable in-packet parallel processing for gossip

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2294,7 +2294,7 @@ impl ClusterInfo {
                     return None;
                 }
             }
-            protocol.par_verify().then(|| {
+            protocol.verify().then(|| {
                 stats.packets_received_verified_count.add_relaxed(1);
                 (packet.meta().socket_addr(), protocol)
             })

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -7,7 +7,6 @@ use {
         ping_pong::{self, Pong},
     },
     bincode::serialize,
-    rayon::prelude::*,
     serde::Serialize,
     solana_perf::packet::PACKET_DATA_SIZE,
     solana_sanitize::{Sanitize, SanitizeError},
@@ -92,11 +91,11 @@ impl Protocol {
 
     // Returns true if all signatures verify.
     #[must_use]
-    pub(crate) fn par_verify(&self) -> bool {
+    pub(crate) fn verify(&self) -> bool {
         match self {
             Self::PullRequest(_, caller) => caller.verify(),
-            Self::PullResponse(_, data) => data.par_iter().all(CrdsValue::verify),
-            Self::PushMessage(_, data) => data.par_iter().all(CrdsValue::verify),
+            Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),
+            Self::PushMessage(_, data) => data.iter().all(CrdsValue::verify),
             Self::PruneMessage(_, data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),


### PR DESCRIPTION
#### Problem
Verifying signatures for individual CRDS values within a packet is not very useful as we do not have unlimited CPU cores, and there is already parallel processing on a per-packet level.

#### Summary of Changes

- Disable parallel processing within a gossip packet


