### PR TITLE
Recreate connection cache after restart

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -201,6 +201,13 @@ impl LocalCluster {
         let quic_connection_cache_config = config.tpu_use_quic.then(|| {
             let client_keypair: Keypair = Keypair::new();
             let stake = DEFAULT_NODE_STAKE;
+
+            for validator_config in config.validator_configs.iter_mut() {
+                let mut overrides = HashMap::new();
+                overrides.insert(client_keypair.pubkey(), stake);
+                validator_config.staked_nodes_overrides = Arc::new(RwLock::new(overrides));
+            }
+
             let total_stake = config.node_stakes.iter().sum::<u64>();
             let stakes = HashMap::from([
                 (client_keypair.pubkey(), stake),
@@ -211,11 +218,6 @@ impl LocalCluster {
                 HashMap::<Pubkey, u64>::default(), // overrides
             )));
 
-            for validator_config in config.validator_configs.iter_mut() {
-                let mut overrides = HashMap::new();
-                overrides.insert(client_keypair.pubkey(), stake);
-                validator_config.staked_nodes_overrides = Arc::new(RwLock::new(overrides));
-            }
             QuicConnectionCacheConfig {
                 client_keypair,
                 staked_nodes,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -199,7 +199,7 @@ impl LocalCluster {
         assert_eq!(config.validator_configs.len(), config.node_stakes.len());
 
         let quic_connection_cache_config = config.tpu_use_quic.then(|| {
-            let client_keypair: Keypair = Keypair::new();
+            let client_keypair = Keypair::new();
             let stake = DEFAULT_NODE_STAKE;
 
             for validator_config in config.validator_configs.iter_mut() {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -1084,7 +1084,9 @@ impl Cluster for LocalCluster {
         );
         self.add_node(pubkey, cluster_validator_info);
 
-        // reset the connection cache as we are connecting to the new nodes
+        // Recreate the connection cache as we are connecting to the nodes
+        // after restart. It can make connections faster without waiting for
+        // the existing connections to time out.
         self.connection_cache = create_connection_cache(
             &self.quic_connection_cache_config,
             self.tpu_connection_pool_size,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -144,6 +144,13 @@ impl Default for ClusterConfig {
     }
 }
 
+struct QuicConnectionCacheConfig {
+    stake: u64,
+    total_stake: u64,
+    client_keypair: Keypair,
+    staked_nodes: Arc<RwLock<StakedNodes>>,
+}
+
 pub struct LocalCluster {
     /// Keypair with funding to participate in the network
     pub funding_keypair: Keypair,
@@ -152,6 +159,8 @@ pub struct LocalCluster {
     pub validators: HashMap<Pubkey, ClusterValidatorInfo>,
     pub genesis_config: GenesisConfig,
     pub connection_cache: Arc<ConnectionCache>,
+    quic_connection_cache_config: Option<QuicConnectionCacheConfig>,
+    tpu_connection_pool_size: usize,
 }
 
 impl LocalCluster {
@@ -191,21 +200,9 @@ impl LocalCluster {
     pub fn new(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
         assert_eq!(config.validator_configs.len(), config.node_stakes.len());
 
-        let connection_cache = if config.tpu_use_quic {
-            let client_keypair = Keypair::new();
+        let quic_connection_cache_config = if config.tpu_use_quic {
+            let client_keypair: Keypair = Keypair::new();
             let stake = DEFAULT_NODE_STAKE;
-
-            for validator_config in config.validator_configs.iter_mut() {
-                let mut overrides = HashMap::new();
-                overrides.insert(client_keypair.pubkey(), stake);
-                validator_config.staked_nodes_overrides = Arc::new(RwLock::new(overrides));
-            }
-
-            assert!(
-                config.tpu_use_quic,
-                "no support for staked override forwarding without quic"
-            );
-
             let total_stake = config.node_stakes.iter().sum::<u64>();
             let stakes = HashMap::from([
                 (client_keypair.pubkey(), stake),
@@ -216,19 +213,25 @@ impl LocalCluster {
                 HashMap::<Pubkey, u64>::default(), // overrides
             )));
 
-            Arc::new(ConnectionCache::new_with_client_options(
-                "connection_cache_local_cluster_quic_staked",
-                config.tpu_connection_pool_size,
-                None,
-                Some((&client_keypair, IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))),
-                Some((&staked_nodes, &client_keypair.pubkey())),
-            ))
+            for validator_config in config.validator_configs.iter_mut() {
+                let mut overrides = HashMap::new();
+                overrides.insert(client_keypair.pubkey(), stake);
+                validator_config.staked_nodes_overrides = Arc::new(RwLock::new(overrides));
+            }
+            Some(QuicConnectionCacheConfig {
+                stake,
+                total_stake,
+                client_keypair,
+                staked_nodes,
+            })
         } else {
-            Arc::new(ConnectionCache::with_udp(
-                "connection_cache_local_cluster_udp",
-                config.tpu_connection_pool_size,
-            ))
+            None
         };
+
+        let connection_cache = create_connection_cache(
+            &quic_connection_cache_config,
+            config.tpu_connection_pool_size,
+        );
 
         let mut validator_keys = {
             if let Some(ref keys) = config.validator_keys {
@@ -379,6 +382,8 @@ impl LocalCluster {
             validators,
             genesis_config,
             connection_cache,
+            quic_connection_cache_config,
+            tpu_connection_pool_size: config.tpu_connection_pool_size,
         };
 
         let node_pubkey_to_vote_key: HashMap<Pubkey, Arc<Keypair>> = keys_in_genesis
@@ -973,6 +978,30 @@ impl LocalCluster {
     }
 }
 
+fn create_connection_cache(
+    quic_connection_cache_config: &Option<QuicConnectionCacheConfig>,
+    tpu_connection_pool_size: usize,
+) -> Arc<ConnectionCache> {
+    let connection_cache = if let Some(config) = quic_connection_cache_config {
+        Arc::new(ConnectionCache::new_with_client_options(
+            "connection_cache_local_cluster_quic_staked",
+            tpu_connection_pool_size,
+            None,
+            Some((
+                &config.client_keypair,
+                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            )),
+            Some((&config.staked_nodes, &config.client_keypair.pubkey())),
+        ))
+    } else {
+        Arc::new(ConnectionCache::with_udp(
+            "connection_cache_local_cluster_udp",
+            tpu_connection_pool_size,
+        ))
+    };
+    connection_cache
+}
+
 impl Cluster for LocalCluster {
     fn get_node_pubkeys(&self) -> Vec<Pubkey> {
         self.validators.keys().cloned().collect()
@@ -1059,6 +1088,12 @@ impl Cluster for LocalCluster {
             socket_addr_space,
         );
         self.add_node(pubkey, cluster_validator_info);
+
+        // reset the connection cache as we are connecting to the new nodes
+        self.connection_cache = create_connection_cache(
+            &self.quic_connection_cache_config,
+            self.tpu_connection_pool_size,
+        );
     }
 
     fn add_node(&mut self, pubkey: &Pubkey, cluster_validator_info: ClusterValidatorInfo) {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -978,7 +978,7 @@ fn create_connection_cache(
     quic_connection_cache_config: &Option<QuicConnectionCacheConfig>,
     tpu_connection_pool_size: usize,
 ) -> Arc<ConnectionCache> {
-    let connection_cache = if let Some(config) = quic_connection_cache_config {
+    if let Some(config) = quic_connection_cache_config {
         Arc::new(ConnectionCache::new_with_client_options(
             "connection_cache_local_cluster_quic_staked",
             tpu_connection_pool_size,
@@ -994,8 +994,7 @@ fn create_connection_cache(
             "connection_cache_local_cluster_udp",
             tpu_connection_pool_size,
         ))
-    };
-    connection_cache
+    }
 }
 
 impl Cluster for LocalCluster {


### PR DESCRIPTION
#### Problem

The connection cache might hold connections to the validators before the restart which can make the test slow as it has to wait for the existing defunct connection to timeout. 

The tests under local-cluster/tests can all be impacted if it involved restart. For example

cargo test test_snapshots_restart_validity 

This is exposed when we tried to increase the QUIC connection idle timeout value for example to 60 seconds.

#### Summary of Changes

Recreate the connection cache after a restart.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
