### PR TITLE
script: fetch-core-bpf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ log-*/
 /solana.iml
 /.vscode/
 
+# fetch-core-bpf.sh artifacts
+/core-bpf-genesis-args.sh
+/core_bpf_*.so
+
 # fetch-spl.sh artifacts
 /spl-genesis-args.sh
 /spl_*.so

--- a/fetch-core-bpf.sh
+++ b/fetch-core-bpf.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Fetches the latest Core BPF programs and produces the solana-genesis
+# command-line arguments needed to install them
+#
+
+set -e
+
+upgradeableLoader=BPFLoaderUpgradeab1e11111111111111111111111
+
+fetch_program() {
+  declare name=$1
+  declare version=$2
+  declare address=$3
+
+  declare so=core_bpf_$name-$version.so
+
+  genesis_args+=(--upgradeable-program "$address" "$upgradeableLoader" "$so" none)
+
+  if [[ -r $so ]]; then
+    return
+  fi
+
+  if [[ -r ~/.cache/solana-core-bpf/$so ]]; then
+    cp ~/.cache/solana-core-bpf/"$so" "$so"
+  else
+    echo "Downloading $name $version"
+    so_name="solana_${name//-/_}_program.so"
+    (
+      set -x
+      curl -L --retry 5 --retry-delay 2 --retry-connrefused \
+        -o "$so" \
+        "https://github.com/solana-program/$name/releases/download/program%40$version/$so_name"
+    )
+
+    mkdir -p ~/.cache/solana-core-bpf
+    cp "$so" ~/.cache/solana-core-bpf/"$so"
+  fi
+
+}
+
+fetch_program address-lookup-table 3.0.0 AddressLookupTab1e1111111111111111111111111
+fetch_program config 3.0.0 Config1111111111111111111111111111111111111
+fetch_program feature-gate 0.0.1 Feature111111111111111111111111111111111111
+
+echo "${genesis_args[@]}" > core-bpf-genesis-args.sh
+
+echo
+echo "Available SPL programs:"
+ls -l core_bpf_*.so
+
+echo
+echo "solana-genesis command-line arguments (core-bpf-genesis-args.sh):"
+cat core-bpf-genesis-args.sh

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -41,6 +41,14 @@ args=(
                         "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
 )
 
+"$SOLANA_ROOT"/fetch-core-bpf.sh
+if [[ -r core-bpf-genesis-args.sh ]]; then
+  CORE_BPF_GENESIS_ARGS=$(cat "$SOLANA_ROOT"/core-bpf-genesis-args.sh)
+  #shellcheck disable=SC2207
+  #shellcheck disable=SC2206
+  args+=($CORE_BPF_GENESIS_ARGS)
+fi
+
 "$SOLANA_ROOT"/fetch-spl.sh
 if [[ -r spl-genesis-args.sh ]]; then
   SPL_GENESIS_ARGS=$(cat "$SOLANA_ROOT"/spl-genesis-args.sh)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -71,6 +71,11 @@ fi
 if [[ -e "$ledgerDir"/genesis.bin || -e "$ledgerDir"/genesis.tar.bz2 ]]; then
   echo "Use existing genesis"
 else
+  ./fetch-core-bpf.sh
+  if [[ -r core-bpf-genesis-args.sh ]]; then
+    CORE_BPF_GENESIS_ARGS=$(cat core-bpf-genesis-args.sh)
+  fi
+
   ./fetch-spl.sh
   if [[ -r spl-genesis-args.sh ]]; then
     SPL_GENESIS_ARGS=$(cat spl-genesis-args.sh)
@@ -86,6 +91,7 @@ else
       "$validator_stake_account" \
     --ledger "$ledgerDir" \
     --cluster-type "$SOLANA_RUN_SH_CLUSTER_TYPE" \
+    $CORE_BPF_GENESIS_ARGS \
     $SPL_GENESIS_ARGS \
     $SOLANA_RUN_SH_GENESIS_ARGS
 fi


### PR DESCRIPTION
#### Problem
Similar to `fetch-spl.sh`, developers would appreciate a helper script that can fetch the latest versions of Core BPF programs, in case they wish to use the BPF versions instead of the builtins.

#### Summary of Changes
Literally copy-paste `fetch-spl.sh` as a new `fetch-core-bpf.sh` script and tweak values like prefix and url to mimic the same behavior as `fetch-spl.sh`, but for Core BPF programs.