### PR TITLE
Fixing the svm account serialization for performance

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -455,7 +455,7 @@ fn serialize_parameters_aligned(
     }
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>(); // program id; reserve 32 bytes as extra space to avoid reallocation
+    + size_of::<Pubkey>(); // program id;
 
     let mut s = Serializer::new(size, MM_INPUT_START, true, copy_account_data);
 


### PR DESCRIPTION
#### Problem
Performance issue with svm during serialization of accounts forces resize of memory because the initial size is not correctly calculated. This impact the performance of the svm a lot with current benchmarks and profiling with openbook contract we see the average performance jump up from 6360 tps to 8144 tps. This is around 30 % improvement which can be verified by profiling which spends 30 percent of the time in resizing.

#### Summary of Changes
Correctly calculating the initial size of the memory and adding few extra bytes to capacity to avoid potential memory reallocations.

Another change is making use of the method `AlignedMemory::with_capacity_zeroed(size)` which avoid any calls to resize which makes performance much faster.

* Here is detailed performance improved seen by the changes. 

To benchmark the svm code we use following repository.
https://github.com/godmodegalactus/simulate-svm-contract

This repository creates continuously place order on openbook market and also runs crank instruction from time to time. The figures are generated after running the benchmark program for 500s to get the average tps.

Unoptimized serializer : 
```
second: 500
tps (crank + market orders) : 6449.509284800379
tps (only market orders) : 5605.989915113488
average tps: 6360.181975384049
```

Optimized serialized with preallocated and zeroed memory
```
second: 500
tps (crank + market orders) : 8079.207521273256
tps (only market orders) : 6420.863942369388
average tps: 8144.030127013769
```

Optimized serialize without zeroed memory
```
second: 500
tps (crank + market orders) : 7710.865692534364
tps (only market orders) : 6029.487392405706
average tps: 7622.813683394391
```

Fixes #
No feature gates
