### PR TITLE
CLI - loader v3 to v4 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6833,6 +6833,7 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-loader-v4-program",
  "solana-logger",

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2468,6 +2468,25 @@ impl fmt::Display for CliUpgradeableProgramExtended {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliUpgradeableProgramMigrated {
+    pub program_id: String,
+}
+impl QuietDisplay for CliUpgradeableProgramMigrated {}
+impl VerboseDisplay for CliUpgradeableProgramMigrated {}
+impl fmt::Display for CliUpgradeableProgramMigrated {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln!(
+            f,
+            "Migrated Program Id {} from loader-v3 to loader-v4",
+            &self.program_id,
+        )?;
+        Ok(())
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliUpgradeableBuffer {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ solana-feature-set = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
+solana-loader-v3-interface = { workspace = true }
 solana-loader-v4-interface = { workspace = true }
 solana-loader-v4-program = { workspace = true }
 solana-logger = { workspace = true }


### PR DESCRIPTION
#### Problem
Split off from https://github.com/anza-xyz/agave/pull/4661 as requested (https://github.com/anza-xyz/agave/pull/4661#pullrequestreview-2601818441).

#### Summary of Changes
Adds a CLI subcommand for migrating loader-v3 programs to loader-v4.