### PR TITLE
Remove obsolete stat - slots_to_clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -774,7 +774,6 @@ struct GenerateIndexTimings {
     pub num_duplicate_accounts: u64,
     pub populate_duplicate_keys_us: u64,
     pub total_slots: u64,
-    pub slots_to_clean: u64,
     pub par_duplicates_lt_hash_us: AtomicU64,
     pub visit_zero_lamports_us: u64,
     pub num_zero_lamport_single_refs: u64,
@@ -846,7 +845,6 @@ impl GenerateIndexTimings {
                 i64
             ),
             ("total_slots", self.total_slots, i64),
-            ("slots_to_clean", self.slots_to_clean, i64),
             (
                 "copy_data_us",
                 startup_stats.copy_data_us.swap(0, Ordering::Relaxed),


### PR DESCRIPTION
#### Problem

There is no longer a need to collect slots_to_clean for the new clean algorithm. Therefore, 'slots_to_clean' stat is no longer populated. 


#### Summary of Changes

Remove obsolete stats - slots_to_clean


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
