### PR TITLE
adjust tpu coalesce channel size to 250K

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -68,7 +68,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 1_000_000;
+pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 250_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527


### PR DESCRIPTION
#### Problem
Based on further testing of TPU coalescer channel size on the receive performance. Adjust the size to reduce memory usage.

#### Summary of Changes

Found the channel size with 250K has similar performance with the size of 1 million (2.8 M/5s). When the size drops to 100K, it drops to about 2.18 M/5s

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
