### PR TITLE
ci: private pipeline use default queue

### DIFF
--- a/ci/buildkite-solana-private.sh
+++ b/ci/buildkite-solana-private.sh
@@ -109,7 +109,7 @@ command_step() {
     timeout_in_minutes: $3
     artifact_paths: "log-*.txt"
     agents:
-      queue: "sol-private"
+      queue: "default"
 EOF
 }
 
@@ -138,7 +138,7 @@ all_test_steps() {
   wait_step
 
   # Full test suite
-  .buildkite/scripts/build-stable.sh sol-private >> "$output_file"
+  .buildkite/scripts/build-stable.sh default >> "$output_file"
 
   # Docs tests
   if affects \
@@ -174,7 +174,7 @@ all_test_steps() {
     timeout_in_minutes: 35
     artifact_paths: "sbf-dumps.tar.bz2"
     agents:
-      queue: "sol-private"
+      queue: "default"
 EOF
   else
     annotate --style info \
@@ -198,7 +198,7 @@ EOF
              ^ci/downstream-projects \
              .buildkite/scripts/build-downstream-projects.sh \
       ; then
-    .buildkite/scripts/build-downstream-projects.sh sol-private >> "$output_file"
+    .buildkite/scripts/build-downstream-projects.sh default >> "$output_file"
   else
     annotate --style info \
       "downstream-projects skipped as no relevant files were modified"


### PR DESCRIPTION
#### Problem

I reorganized our Buildkite agents

#### Summary of Changes

get private pipeline use `default` agents