### PR TITLE
Remove use of Blockstore::destroy() from banking_stage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1236,15 +1236,15 @@ mod tests {
             .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
 
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let entry_receiver = {
             // start a banking_stage to eat verified receiver
             let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-            let blockstore = Arc::new(
-                Blockstore::open(ledger_path.path())
-                    .expect("Expected to be able to open database ledger"),
-            );
             let poh_config = PohConfig {
                 // limit tick count to avoid clearing working_bank at
                 // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -929,7 +929,6 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Arc::new(
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
@@ -962,8 +961,6 @@ mod tests {
             exit.store(true, Ordering::Relaxed);
             banking_stage.join().unwrap();
             poh_service.join().unwrap();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test_case(TransactionStructure::Sdk)]
@@ -987,7 +984,6 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Arc::new(
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
@@ -1036,8 +1032,6 @@ mod tests {
             assert!(entries.verify(&start_hash, &entry::thread_pool_for_tests()));
             assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
             banking_stage.join().unwrap();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     pub fn convert_from_old_verified(
@@ -1073,7 +1067,6 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Arc::new(
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
@@ -1182,8 +1175,6 @@ mod tests {
             assert_eq!(bank.get_balance(&to2), 0);
 
             drop(entry_receiver);
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test_case(TransactionStructure::Sdk)]
@@ -1246,7 +1237,6 @@ mod tests {
             .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let entry_receiver = {
@@ -1313,8 +1303,6 @@ mod tests {
             // entry, then one of the transactions will be rejected, because it drives
             // the account balance below zero before the credit is added.
             assert!(bank.get_balance(&alice.pubkey()) != 3);
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1328,7 +1316,6 @@ mod tests {
         } = create_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
@@ -1381,8 +1368,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     pub(crate) fn create_slow_genesis_config(lamports: u64) -> GenesisConfigInfo {
@@ -1447,7 +1432,6 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Arc::new(
                 Blockstore::open(ledger_path.path())
                     .expect("Expected to be able to open database ledger"),
@@ -1564,7 +1548,5 @@ mod tests {
             banking_stage.join().unwrap();
             exit.store(true, Ordering::Relaxed);
             poh_service.join().unwrap();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -929,38 +929,38 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Arc::new(
-                Blockstore::open(ledger_path.path())
-                    .expect("Expected to be able to open database ledger"),
-            );
-            let (exit, poh_recorder, poh_service, _entry_receiever) =
-                create_test_recorder(bank, blockstore, None, None);
-            let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
-            let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+        let (exit, poh_recorder, poh_service, _entry_receiever) =
+            create_test_recorder(bank, blockstore, None, None);
+        let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
+        let cluster_info = Arc::new(cluster_info);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-            let banking_stage = BankingStage::new(
-                BlockProductionMethod::CentralScheduler,
-                transaction_struct,
-                &cluster_info,
-                &poh_recorder,
-                non_vote_receiver,
-                tpu_vote_receiver,
-                gossip_vote_receiver,
-                None,
-                replay_vote_sender,
-                None,
-                Arc::new(ConnectionCache::new("connection_cache_test")),
-                bank_forks,
-                &Arc::new(PrioritizationFeeCache::new(0u64)),
-                false,
-            );
-            drop(non_vote_sender);
-            drop(tpu_vote_sender);
-            drop(gossip_vote_sender);
-            exit.store(true, Ordering::Relaxed);
-            banking_stage.join().unwrap();
-            poh_service.join().unwrap();
+        let banking_stage = BankingStage::new(
+            BlockProductionMethod::CentralScheduler,
+            transaction_struct,
+            &cluster_info,
+            &poh_recorder,
+            non_vote_receiver,
+            tpu_vote_receiver,
+            gossip_vote_receiver,
+            None,
+            replay_vote_sender,
+            None,
+            Arc::new(ConnectionCache::new("connection_cache_test")),
+            bank_forks,
+            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            false,
+        );
+        drop(non_vote_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        exit.store(true, Ordering::Relaxed);
+        banking_stage.join().unwrap();
+        poh_service.join().unwrap();
     }
 
     #[test_case(TransactionStructure::Sdk)]
@@ -984,54 +984,54 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Arc::new(
-                Blockstore::open(ledger_path.path())
-                    .expect("Expected to be able to open database ledger"),
-            );
-            let poh_config = PohConfig {
-                target_tick_count: Some(bank.max_tick_height() + num_extra_ticks),
-                ..PohConfig::default()
-            };
-            let (exit, poh_recorder, poh_service, entry_receiver) =
-                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
-            let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
-            let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+        let poh_config = PohConfig {
+            target_tick_count: Some(bank.max_tick_height() + num_extra_ticks),
+            ..PohConfig::default()
+        };
+        let (exit, poh_recorder, poh_service, entry_receiver) =
+            create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+        let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
+        let cluster_info = Arc::new(cluster_info);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-            let banking_stage = BankingStage::new(
-                BlockProductionMethod::CentralScheduler,
-                transaction_struct,
-                &cluster_info,
-                &poh_recorder,
-                non_vote_receiver,
-                tpu_vote_receiver,
-                gossip_vote_receiver,
-                None,
-                replay_vote_sender,
-                None,
-                Arc::new(ConnectionCache::new("connection_cache_test")),
-                bank_forks,
-                &Arc::new(PrioritizationFeeCache::new(0u64)),
-                false,
-            );
-            trace!("sending bank");
-            drop(non_vote_sender);
-            drop(tpu_vote_sender);
-            drop(gossip_vote_sender);
-            exit.store(true, Ordering::Relaxed);
-            poh_service.join().unwrap();
-            drop(poh_recorder);
+        let banking_stage = BankingStage::new(
+            BlockProductionMethod::CentralScheduler,
+            transaction_struct,
+            &cluster_info,
+            &poh_recorder,
+            non_vote_receiver,
+            tpu_vote_receiver,
+            gossip_vote_receiver,
+            None,
+            replay_vote_sender,
+            None,
+            Arc::new(ConnectionCache::new("connection_cache_test")),
+            bank_forks,
+            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            false,
+        );
+        trace!("sending bank");
+        drop(non_vote_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        exit.store(true, Ordering::Relaxed);
+        poh_service.join().unwrap();
+        drop(poh_recorder);
 
-            trace!("getting entries");
-            let entries: Vec<_> = entry_receiver
-                .iter()
-                .map(|(_bank, (entry, _tick_height))| entry)
-                .collect();
-            trace!("done");
-            assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
-            assert!(entries.verify(&start_hash, &entry::thread_pool_for_tests()));
-            assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
-            banking_stage.join().unwrap();
+        trace!("getting entries");
+        let entries: Vec<_> = entry_receiver
+            .iter()
+            .map(|(_bank, (entry, _tick_height))| entry)
+            .collect();
+        trace!("done");
+        assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
+        assert!(entries.verify(&start_hash, &entry::thread_pool_for_tests()));
+        assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
+        banking_stage.join().unwrap();
     }
 
     pub fn convert_from_old_verified(
@@ -1067,114 +1067,113 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Arc::new(
-                Blockstore::open(ledger_path.path())
-                    .expect("Expected to be able to open database ledger"),
-            );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
-            let (exit, poh_recorder, poh_service, entry_receiver) =
-                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
-            let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
-            let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+        let poh_config = PohConfig {
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            target_tick_count: Some(bank.max_tick_height() - 1),
+            ..PohConfig::default()
+        };
+        let (exit, poh_recorder, poh_service, entry_receiver) =
+            create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+        let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
+        let cluster_info = Arc::new(cluster_info);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-            let banking_stage = BankingStage::new(
-                block_production_method,
-                transaction_struct,
-                &cluster_info,
-                &poh_recorder,
-                non_vote_receiver,
-                tpu_vote_receiver,
-                gossip_vote_receiver,
-                None,
-                replay_vote_sender,
-                None,
-                Arc::new(ConnectionCache::new("connection_cache_test")),
-                bank_forks.clone(), // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
-                &Arc::new(PrioritizationFeeCache::new(0u64)),
-                false,
-            );
+        let banking_stage = BankingStage::new(
+            block_production_method,
+            transaction_struct,
+            &cluster_info,
+            &poh_recorder,
+            non_vote_receiver,
+            tpu_vote_receiver,
+            gossip_vote_receiver,
+            None,
+            replay_vote_sender,
+            None,
+            Arc::new(ConnectionCache::new("connection_cache_test")),
+            bank_forks.clone(), // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
+            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            false,
+        );
 
-            // fund another account so we can send 2 good transactions in a single batch.
-            let keypair = Keypair::new();
-            let fund_tx =
-                system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, start_hash);
-            bank.process_transaction(&fund_tx).unwrap();
+        // fund another account so we can send 2 good transactions in a single batch.
+        let keypair = Keypair::new();
+        let fund_tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, start_hash);
+        bank.process_transaction(&fund_tx).unwrap();
 
-            // good tx
-            let to = solana_pubkey::new_rand();
-            let tx = system_transaction::transfer(&mint_keypair, &to, 1, start_hash);
+        // good tx
+        let to = solana_pubkey::new_rand();
+        let tx = system_transaction::transfer(&mint_keypair, &to, 1, start_hash);
 
-            // good tx, but no verify
-            let to2 = solana_pubkey::new_rand();
-            let tx_no_ver = system_transaction::transfer(&keypair, &to2, 2, start_hash);
+        // good tx, but no verify
+        let to2 = solana_pubkey::new_rand();
+        let tx_no_ver = system_transaction::transfer(&keypair, &to2, 2, start_hash);
 
-            // bad tx, AccountNotFound
-            let keypair = Keypair::new();
-            let to3 = solana_pubkey::new_rand();
-            let tx_anf = system_transaction::transfer(&keypair, &to3, 1, start_hash);
+        // bad tx, AccountNotFound
+        let keypair = Keypair::new();
+        let to3 = solana_pubkey::new_rand();
+        let tx_anf = system_transaction::transfer(&keypair, &to3, 1, start_hash);
 
-            // send 'em over
-            let packet_batches = to_packet_batches(&[tx_no_ver, tx_anf, tx], 3);
+        // send 'em over
+        let packet_batches = to_packet_batches(&[tx_no_ver, tx_anf, tx], 3);
 
-            // glad they all fit
-            assert_eq!(packet_batches.len(), 1);
+        // glad they all fit
+        assert_eq!(packet_batches.len(), 1);
 
-            let packet_batches = packet_batches
-                .into_iter()
-                .map(|batch| (batch, vec![0u8, 1u8, 1u8]))
+        let packet_batches = packet_batches
+            .into_iter()
+            .map(|batch| (batch, vec![0u8, 1u8, 1u8]))
+            .collect();
+        let packet_batches = convert_from_old_verified(packet_batches);
+        non_vote_sender // no_ver, anf, tx
+            .send(BankingPacketBatch::new(packet_batches))
+            .unwrap();
+
+        drop(non_vote_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        // wait until banking_stage to finish up all packets
+        banking_stage.join().unwrap();
+
+        exit.store(true, Ordering::Relaxed);
+        poh_service.join().unwrap();
+        drop(poh_recorder);
+
+        let mut blockhash = start_hash;
+        let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
+        bank.process_transaction(&fund_tx).unwrap();
+        //receive entries + ticks
+        loop {
+            let entries: Vec<Entry> = entry_receiver
+                .iter()
+                .map(|(_bank, (entry, _tick_height))| entry)
                 .collect();
-            let packet_batches = convert_from_old_verified(packet_batches);
-            non_vote_sender // no_ver, anf, tx
-                .send(BankingPacketBatch::new(packet_batches))
-                .unwrap();
 
-            drop(non_vote_sender);
-            drop(tpu_vote_sender);
-            drop(gossip_vote_sender);
-            // wait until banking_stage to finish up all packets
-            banking_stage.join().unwrap();
-
-            exit.store(true, Ordering::Relaxed);
-            poh_service.join().unwrap();
-            drop(poh_recorder);
-
-            let mut blockhash = start_hash;
-            let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-            bank.process_transaction(&fund_tx).unwrap();
-            //receive entries + ticks
-            loop {
-                let entries: Vec<Entry> = entry_receiver
-                    .iter()
-                    .map(|(_bank, (entry, _tick_height))| entry)
-                    .collect();
-
-                assert!(entries.verify(&blockhash, &entry::thread_pool_for_tests()));
-                if !entries.is_empty() {
-                    blockhash = entries.last().unwrap().hash;
-                    for entry in entries {
-                        bank.process_entry_transactions(entry.transactions)
-                            .iter()
-                            .for_each(|x| assert_eq!(*x, Ok(())));
-                    }
+            assert!(entries.verify(&blockhash, &entry::thread_pool_for_tests()));
+            if !entries.is_empty() {
+                blockhash = entries.last().unwrap().hash;
+                for entry in entries {
+                    bank.process_entry_transactions(entry.transactions)
+                        .iter()
+                        .for_each(|x| assert_eq!(*x, Ok(())));
                 }
-
-                if bank.get_balance(&to) == 1 {
-                    break;
-                }
-
-                sleep(Duration::from_millis(200));
             }
 
-            assert_eq!(bank.get_balance(&to), 1);
-            assert_eq!(bank.get_balance(&to2), 0);
+            if bank.get_balance(&to) == 1 {
+                break;
+            }
 
-            drop(entry_receiver);
+            sleep(Duration::from_millis(200));
+        }
+
+        assert_eq!(bank.get_balance(&to), 1);
+        assert_eq!(bank.get_balance(&to2), 0);
+
+        drop(entry_receiver);
     }
 
     #[test_case(TransactionStructure::Sdk)]
@@ -1237,72 +1236,72 @@ mod tests {
             .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-            let entry_receiver = {
-                // start a banking_stage to eat verified receiver
-                let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-                let blockstore = Arc::new(
-                    Blockstore::open(ledger_path.path())
-                        .expect("Expected to be able to open database ledger"),
-                );
-                let poh_config = PohConfig {
-                    // limit tick count to avoid clearing working_bank at
-                    // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                    target_tick_count: Some(bank.max_tick_height() - 1),
-                    ..PohConfig::default()
-                };
-                let (exit, poh_recorder, poh_service, entry_receiver) =
-                    create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
-                let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
-                let cluster_info = Arc::new(cluster_info);
-                let _banking_stage = BankingStage::new(
-                    BlockProductionMethod::CentralScheduler,
-                    transaction_struct,
-                    &cluster_info,
-                    &poh_recorder,
-                    non_vote_receiver,
-                    tpu_vote_receiver,
-                    gossip_vote_receiver,
-                    None,
-                    replay_vote_sender,
-                    None,
-                    Arc::new(ConnectionCache::new("connection_cache_test")),
-                    bank_forks,
-                    &Arc::new(PrioritizationFeeCache::new(0u64)),
-                    false,
-                );
-
-                // wait for banking_stage to eat the packets
-                while bank.get_balance(&alice.pubkey()) < 1 {
-                    sleep(Duration::from_millis(10));
-                }
-                exit.store(true, Ordering::Relaxed);
-                poh_service.join().unwrap();
-                entry_receiver
+        let entry_receiver = {
+            // start a banking_stage to eat verified receiver
+            let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
+            let blockstore = Arc::new(
+                Blockstore::open(ledger_path.path())
+                    .expect("Expected to be able to open database ledger"),
+            );
+            let poh_config = PohConfig {
+                // limit tick count to avoid clearing working_bank at
+                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
+                target_tick_count: Some(bank.max_tick_height() - 1),
+                ..PohConfig::default()
             };
-            drop(non_vote_sender);
-            drop(tpu_vote_sender);
-            drop(gossip_vote_sender);
+            let (exit, poh_recorder, poh_service, entry_receiver) =
+                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+            let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
+            let cluster_info = Arc::new(cluster_info);
+            let _banking_stage = BankingStage::new(
+                BlockProductionMethod::CentralScheduler,
+                transaction_struct,
+                &cluster_info,
+                &poh_recorder,
+                non_vote_receiver,
+                tpu_vote_receiver,
+                gossip_vote_receiver,
+                None,
+                replay_vote_sender,
+                None,
+                Arc::new(ConnectionCache::new("connection_cache_test")),
+                bank_forks,
+                &Arc::new(PrioritizationFeeCache::new(0u64)),
+                false,
+            );
 
-            // consume the entire entry_receiver, feed it into a new bank
-            // check that the balance is what we expect.
-            let entries: Vec<_> = entry_receiver
-                .iter()
-                .map(|(_bank, (entry, _tick_height))| entry)
-                .collect();
-
-            let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-            for entry in entries {
-                bank.process_entry_transactions(entry.transactions)
-                    .iter()
-                    .for_each(|x| assert_eq!(*x, Ok(())));
+            // wait for banking_stage to eat the packets
+            while bank.get_balance(&alice.pubkey()) < 1 {
+                sleep(Duration::from_millis(10));
             }
+            exit.store(true, Ordering::Relaxed);
+            poh_service.join().unwrap();
+            entry_receiver
+        };
+        drop(non_vote_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
 
-            // Assert the user doesn't hold three lamports. If the stage only outputs one
-            // entry, then one of the transactions will be rejected, because it drives
-            // the account balance below zero before the credit is added.
-            assert!(bank.get_balance(&alice.pubkey()) != 3);
+        // consume the entire entry_receiver, feed it into a new bank
+        // check that the balance is what we expect.
+        let entries: Vec<_> = entry_receiver
+            .iter()
+            .map(|(_bank, (entry, _tick_height))| entry)
+            .collect();
+
+        let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
+        for entry in entries {
+            bank.process_entry_transactions(entry.transactions)
+                .iter()
+                .for_each(|x| assert_eq!(*x, Ok(())));
+        }
+
+        // Assert the user doesn't hold three lamports. If the stage only outputs one
+        // entry, then one of the transactions will be rejected, because it drives
+        // the account balance below zero before the credit is added.
+        assert!(bank.get_balance(&alice.pubkey()) != 3);
     }
 
     #[test]
@@ -1316,58 +1315,56 @@ mod tests {
         } = create_genesis_config(10_000);
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-                // TODO use record_receiver
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                None,
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+            // TODO use record_receiver
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            None,
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-            let pubkey = solana_pubkey::new_rand();
-            let keypair2 = Keypair::new();
-            let pubkey2 = solana_pubkey::new_rand();
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+        let pubkey = solana_pubkey::new_rand();
+        let keypair2 = Keypair::new();
+        let pubkey2 = solana_pubkey::new_rand();
 
-            let txs = vec![
-                system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash())
-                    .into(),
-                system_transaction::transfer(&keypair2, &pubkey2, 1, genesis_config.hash()).into(),
-            ];
+        let txs = vec![
+            system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()).into(),
+            system_transaction::transfer(&keypair2, &pubkey2, 1, genesis_config.hash()).into(),
+        ];
 
-            let _ = recorder.record_transactions(bank.slot(), txs.clone());
-            let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
-            assert_eq!(entry.transactions, txs);
+        let _ = recorder.record_transactions(bank.slot(), txs.clone());
+        let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
+        assert_eq!(entry.transactions, txs);
 
-            // Once bank is set to a new bank (setting bank.slot() + 1 in record_transactions),
-            // record_transactions should throw MaxHeightReached
-            let next_slot = bank.slot() + 1;
-            let RecordTransactionsSummary { result, .. } =
-                recorder.record_transactions(next_slot, txs);
-            assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
-            // Should receive nothing from PohRecorder b/c record failed
-            assert!(entry_receiver.try_recv().is_err());
+        // Once bank is set to a new bank (setting bank.slot() + 1 in record_transactions),
+        // record_transactions should throw MaxHeightReached
+        let next_slot = bank.slot() + 1;
+        let RecordTransactionsSummary { result, .. } = recorder.record_transactions(next_slot, txs);
+        assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
+        // Should receive nothing from PohRecorder b/c record failed
+        assert!(entry_receiver.try_recv().is_err());
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     pub(crate) fn create_slow_genesis_config(lamports: u64) -> GenesisConfigInfo {
@@ -1432,121 +1429,111 @@ mod tests {
             gossip_vote_receiver,
         } = banking_tracer.create_channels(false);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Arc::new(
-                Blockstore::open(ledger_path.path())
-                    .expect("Expected to be able to open database ledger"),
-            );
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at PohRecord then
-                // PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
-            let (exit, poh_recorder, poh_service, _entry_receiver) =
-                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
-            let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
-            let cluster_info = Arc::new(cluster_info);
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+        let poh_config = PohConfig {
+            // limit tick count to avoid clearing working_bank at PohRecord then
+            // PohRecorderError(MaxHeightReached) at BankingStage
+            target_tick_count: Some(bank.max_tick_height() - 1),
+            ..PohConfig::default()
+        };
+        let (exit, poh_recorder, poh_service, _entry_receiver) =
+            create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+        let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
+        let cluster_info = Arc::new(cluster_info);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-            let banking_stage = BankingStage::new(
-                BlockProductionMethod::CentralScheduler,
-                transaction_struct,
-                &cluster_info,
-                &poh_recorder,
-                non_vote_receiver,
-                tpu_vote_receiver,
-                gossip_vote_receiver,
-                None,
-                replay_vote_sender,
-                None,
-                Arc::new(ConnectionCache::new("connection_cache_test")),
-                bank_forks,
-                &Arc::new(PrioritizationFeeCache::new(0u64)),
-                false,
-            );
+        let banking_stage = BankingStage::new(
+            BlockProductionMethod::CentralScheduler,
+            transaction_struct,
+            &cluster_info,
+            &poh_recorder,
+            non_vote_receiver,
+            tpu_vote_receiver,
+            gossip_vote_receiver,
+            None,
+            replay_vote_sender,
+            None,
+            Arc::new(ConnectionCache::new("connection_cache_test")),
+            bank_forks,
+            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            false,
+        );
 
-            let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
-            let vote_keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
-            for keypair in keypairs.iter() {
-                bank.process_transaction(&system_transaction::transfer(
-                    &mint_keypair,
-                    &keypair.pubkey(),
-                    20,
-                    start_hash,
-                ))
-                .unwrap();
-            }
+        let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
+        let vote_keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
+        for keypair in keypairs.iter() {
+            bank.process_transaction(&system_transaction::transfer(
+                &mint_keypair,
+                &keypair.pubkey(),
+                20,
+                start_hash,
+            ))
+            .unwrap();
+        }
 
-            // Send a bunch of votes and transfers
-            let tpu_votes = (0..100_usize)
-                .map(|i| {
-                    new_tower_sync_transaction(
-                        TowerSync::from(vec![
-                            (0, 8),
-                            (1, 7),
-                            (i as u64 + 10, 6),
-                            (i as u64 + 11, 1),
-                        ]),
-                        Hash::new_unique(),
-                        &keypairs[i],
-                        &vote_keypairs[i],
-                        &vote_keypairs[i],
-                        None,
-                    )
-                })
-                .collect_vec();
-            let gossip_votes = (0..100_usize)
-                .map(|i| {
-                    new_tower_sync_transaction(
-                        TowerSync::from(vec![
-                            (0, 9),
-                            (1, 8),
-                            (i as u64 + 5, 6),
-                            (i as u64 + 63, 1),
-                        ]),
-                        Hash::new_unique(),
-                        &keypairs[i],
-                        &vote_keypairs[i],
-                        &vote_keypairs[i],
-                        None,
-                    )
-                })
-                .collect_vec();
-            let txs = (0..100_usize)
-                .map(|i| {
-                    system_transaction::transfer(
-                        &keypairs[i],
-                        &keypairs[(i + 1) % 100].pubkey(),
-                        10,
-                        start_hash,
-                    );
-                })
-                .collect_vec();
-
-            let non_vote_packet_batches = to_packet_batches(&txs, 10);
-            let tpu_packet_batches = to_packet_batches(&tpu_votes, 10);
-            let gossip_packet_batches = to_packet_batches(&gossip_votes, 10);
-
-            // Send em all
-            [
-                (non_vote_packet_batches, non_vote_sender),
-                (tpu_packet_batches, tpu_vote_sender),
-                (gossip_packet_batches, gossip_vote_sender),
-            ]
-            .into_iter()
-            .map(|(packet_batches, sender)| {
-                Builder::new()
-                    .spawn(move || {
-                        sender
-                            .send(BankingPacketBatch::new(packet_batches))
-                            .unwrap()
-                    })
-                    .unwrap()
+        // Send a bunch of votes and transfers
+        let tpu_votes = (0..100_usize)
+            .map(|i| {
+                new_tower_sync_transaction(
+                    TowerSync::from(vec![(0, 8), (1, 7), (i as u64 + 10, 6), (i as u64 + 11, 1)]),
+                    Hash::new_unique(),
+                    &keypairs[i],
+                    &vote_keypairs[i],
+                    &vote_keypairs[i],
+                    None,
+                )
             })
-            .for_each(|handle| handle.join().unwrap());
+            .collect_vec();
+        let gossip_votes = (0..100_usize)
+            .map(|i| {
+                new_tower_sync_transaction(
+                    TowerSync::from(vec![(0, 9), (1, 8), (i as u64 + 5, 6), (i as u64 + 63, 1)]),
+                    Hash::new_unique(),
+                    &keypairs[i],
+                    &vote_keypairs[i],
+                    &vote_keypairs[i],
+                    None,
+                )
+            })
+            .collect_vec();
+        let txs = (0..100_usize)
+            .map(|i| {
+                system_transaction::transfer(
+                    &keypairs[i],
+                    &keypairs[(i + 1) % 100].pubkey(),
+                    10,
+                    start_hash,
+                );
+            })
+            .collect_vec();
 
-            banking_stage.join().unwrap();
-            exit.store(true, Ordering::Relaxed);
-            poh_service.join().unwrap();
+        let non_vote_packet_batches = to_packet_batches(&txs, 10);
+        let tpu_packet_batches = to_packet_batches(&tpu_votes, 10);
+        let gossip_packet_batches = to_packet_batches(&gossip_votes, 10);
+
+        // Send em all
+        [
+            (non_vote_packet_batches, non_vote_sender),
+            (tpu_packet_batches, tpu_vote_sender),
+            (gossip_packet_batches, gossip_vote_sender),
+        ]
+        .into_iter()
+        .map(|(packet_batches, sender)| {
+            Builder::new()
+                .spawn(move || {
+                    sender
+                        .send(BankingPacketBatch::new(packet_batches))
+                        .unwrap()
+                })
+                .unwrap()
+        })
+        .for_each(|handle| handle.join().unwrap());
+
+        banking_stage.join().unwrap();
+        exit.store(true, Ordering::Relaxed);
+        poh_service.join().unwrap();
     }
 }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2152,331 +2152,303 @@ mod tests {
     #[test]
     fn test_consume_buffered_packets() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
-                setup_conflicting_transactions(ledger_path.path());
-            let recorder: TransactionRecorder = poh_recorder.read().unwrap().new_recorder();
-            let num_conflicting_transactions = transactions.len();
-            let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
-            assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
-            let mut buffered_packet_batches =
-                UnprocessedTransactionStorage::new_transaction_storage(
-                    UnprocessedPacketBatches::from_iter(
-                        deserialized_packets,
-                        num_conflicting_transactions,
-                    ),
-                    ThreadType::Transactions,
-                );
+        let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
+            setup_conflicting_transactions(ledger_path.path());
+        let recorder: TransactionRecorder = poh_recorder.read().unwrap().new_recorder();
+        let num_conflicting_transactions = transactions.len();
+        let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
+        assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
+        let mut buffered_packet_batches = UnprocessedTransactionStorage::new_transaction_storage(
+            UnprocessedPacketBatches::from_iter(deserialized_packets, num_conflicting_transactions),
+            ThreadType::Transactions,
+        );
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
-            assert!(!poh_recorder.read().unwrap().has_bank());
-            assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
-            // When the working bank in poh_recorder is Some, all packets should be processed.
-            // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
-            poh_recorder.write().unwrap().set_bank_for_test(bank);
-            let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
-            let banking_stage_stats = BankingStageStats::default();
-            consumer.consume_buffered_packets(
-                &bank_start,
-                &mut buffered_packet_batches,
-                &banking_stage_stats,
-                &mut LeaderSlotMetricsTracker::new(0),
-            );
+        // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
+        assert!(!poh_recorder.read().unwrap().has_bank());
+        assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
+        // When the working bank in poh_recorder is Some, all packets should be processed.
+        // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
+        poh_recorder.write().unwrap().set_bank_for_test(bank);
+        let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
+        let banking_stage_stats = BankingStageStats::default();
+        consumer.consume_buffered_packets(
+            &bank_start,
+            &mut buffered_packet_batches,
+            &banking_stage_stats,
+            &mut LeaderSlotMetricsTracker::new(0),
+        );
 
-            // Check that all packets were processed without retrying
-            assert!(buffered_packet_batches.is_empty());
-            assert_eq!(
-                banking_stage_stats
-                    .consumed_buffered_packets_count
-                    .load(Ordering::Relaxed),
-                num_conflicting_transactions
-            );
-            assert_eq!(
-                banking_stage_stats
-                    .rebuffered_packets_count
-                    .load(Ordering::Relaxed),
-                0
-            );
-            // Use bank to check the number of entries (batches)
-            assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
-            assert_eq!(
-                bank_start.working_bank.transaction_entries_count(),
-                num_conflicting_transactions as u64
-            );
+        // Check that all packets were processed without retrying
+        assert!(buffered_packet_batches.is_empty());
+        assert_eq!(
+            banking_stage_stats
+                .consumed_buffered_packets_count
+                .load(Ordering::Relaxed),
+            num_conflicting_transactions
+        );
+        assert_eq!(
+            banking_stage_stats
+                .rebuffered_packets_count
+                .load(Ordering::Relaxed),
+            0
+        );
+        // Use bank to check the number of entries (batches)
+        assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
+        assert_eq!(
+            bank_start.working_bank.transaction_entries_count(),
+            num_conflicting_transactions as u64
+        );
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
     fn test_consume_buffered_packets_sanitization_error() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let (
-                mut transactions,
-                bank,
-                _bank_forks,
-                poh_recorder,
-                _entry_receiver,
-                _,
-                poh_simulator,
-            ) = setup_conflicting_transactions(ledger_path.path());
-            let duplicate_account_key = transactions[0].message.account_keys[0];
-            transactions[0]
-                .message
-                .account_keys
-                .push(duplicate_account_key); // corrupt transaction
-            let recorder = poh_recorder.read().unwrap().new_recorder();
-            let num_conflicting_transactions = transactions.len();
-            let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
-            assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
-            let mut buffered_packet_batches =
-                UnprocessedTransactionStorage::new_transaction_storage(
-                    UnprocessedPacketBatches::from_iter(
-                        deserialized_packets,
-                        num_conflicting_transactions,
-                    ),
-                    ThreadType::Transactions,
-                );
+        let (mut transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
+            setup_conflicting_transactions(ledger_path.path());
+        let duplicate_account_key = transactions[0].message.account_keys[0];
+        transactions[0]
+            .message
+            .account_keys
+            .push(duplicate_account_key); // corrupt transaction
+        let recorder = poh_recorder.read().unwrap().new_recorder();
+        let num_conflicting_transactions = transactions.len();
+        let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
+        assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
+        let mut buffered_packet_batches = UnprocessedTransactionStorage::new_transaction_storage(
+            UnprocessedPacketBatches::from_iter(deserialized_packets, num_conflicting_transactions),
+            ThreadType::Transactions,
+        );
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            // When the working bank in poh_recorder is None, no packets should be processed
-            assert!(!poh_recorder.read().unwrap().has_bank());
-            assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
-            // When the working bank in poh_recorder is Some, all packets should be processed.
-            // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
-            poh_recorder.write().unwrap().set_bank_for_test(bank);
-            let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
-            consumer.consume_buffered_packets(
-                &bank_start,
-                &mut buffered_packet_batches,
-                &BankingStageStats::default(),
-                &mut LeaderSlotMetricsTracker::new(0),
-            );
-            assert!(buffered_packet_batches.is_empty());
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        // When the working bank in poh_recorder is None, no packets should be processed
+        assert!(!poh_recorder.read().unwrap().has_bank());
+        assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
+        // When the working bank in poh_recorder is Some, all packets should be processed.
+        // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
+        poh_recorder.write().unwrap().set_bank_for_test(bank);
+        let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
+        consumer.consume_buffered_packets(
+            &bank_start,
+            &mut buffered_packet_batches,
+            &BankingStageStats::default(),
+            &mut LeaderSlotMetricsTracker::new(0),
+        );
+        assert!(buffered_packet_batches.is_empty());
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
     fn test_consume_buffered_packets_retryable() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
-                setup_conflicting_transactions(ledger_path.path());
-            let recorder = poh_recorder.read().unwrap().new_recorder();
-            let num_conflicting_transactions = transactions.len();
-            let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
-            assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
-            let retryable_packet = deserialized_packets[0].clone();
-            let mut buffered_packet_batches =
-                UnprocessedTransactionStorage::new_transaction_storage(
-                    UnprocessedPacketBatches::from_iter(
-                        deserialized_packets,
-                        num_conflicting_transactions,
-                    ),
-                    ThreadType::Transactions,
-                );
+        let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
+            setup_conflicting_transactions(ledger_path.path());
+        let recorder = poh_recorder.read().unwrap().new_recorder();
+        let num_conflicting_transactions = transactions.len();
+        let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
+        assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
+        let retryable_packet = deserialized_packets[0].clone();
+        let mut buffered_packet_batches = UnprocessedTransactionStorage::new_transaction_storage(
+            UnprocessedPacketBatches::from_iter(deserialized_packets, num_conflicting_transactions),
+            ThreadType::Transactions,
+        );
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
-            assert!(!poh_recorder.read().unwrap().has_bank());
-            assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
-            // When the working bank in poh_recorder is Some, all packets should be processed
-            // except except for retryable errors. Manually take the lock of a transaction to
-            // simulate another thread processing a transaction with that lock.
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-            let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
+        // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
+        assert!(!poh_recorder.read().unwrap().has_bank());
+        assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
+        // When the working bank in poh_recorder is Some, all packets should be processed
+        // except except for retryable errors. Manually take the lock of a transaction to
+        // simulate another thread processing a transaction with that lock.
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+        let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
 
-            let lock_account = transactions[0].message.account_keys[1];
-            let manual_lock_tx =
-                RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                    &Keypair::new(),
-                    &lock_account,
-                    1,
-                    bank.last_blockhash(),
-                ));
-            let _ = bank_start.working_bank.accounts().lock_accounts(
-                std::iter::once(&manual_lock_tx),
-                bank_start.working_bank.get_transaction_account_lock_limit(),
-            );
+        let lock_account = transactions[0].message.account_keys[1];
+        let manual_lock_tx = RuntimeTransaction::from_transaction_for_tests(
+            system_transaction::transfer(&Keypair::new(), &lock_account, 1, bank.last_blockhash()),
+        );
+        let _ = bank_start.working_bank.accounts().lock_accounts(
+            std::iter::once(&manual_lock_tx),
+            bank_start.working_bank.get_transaction_account_lock_limit(),
+        );
 
-            let banking_stage_stats = BankingStageStats::default();
-            consumer.consume_buffered_packets(
-                &bank_start,
-                &mut buffered_packet_batches,
-                &banking_stage_stats,
-                &mut LeaderSlotMetricsTracker::new(0),
-            );
+        let banking_stage_stats = BankingStageStats::default();
+        consumer.consume_buffered_packets(
+            &bank_start,
+            &mut buffered_packet_batches,
+            &banking_stage_stats,
+            &mut LeaderSlotMetricsTracker::new(0),
+        );
 
-            // Check that all but 1 transaction was processed. And that it was rebuffered.
-            assert_eq!(buffered_packet_batches.len(), 1);
-            assert_eq!(
-                buffered_packet_batches.iter().next().unwrap(),
-                &retryable_packet
-            );
-            assert_eq!(
-                banking_stage_stats
-                    .consumed_buffered_packets_count
-                    .load(Ordering::Relaxed),
-                num_conflicting_transactions - 1,
-            );
-            assert_eq!(
-                banking_stage_stats
-                    .rebuffered_packets_count
-                    .load(Ordering::Relaxed),
-                1
-            );
-            // Use bank to check the number of entries (batches)
-            assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
-            assert_eq!(
-                bank_start.working_bank.transaction_entries_count(),
-                num_conflicting_transactions as u64 - 1
-            );
+        // Check that all but 1 transaction was processed. And that it was rebuffered.
+        assert_eq!(buffered_packet_batches.len(), 1);
+        assert_eq!(
+            buffered_packet_batches.iter().next().unwrap(),
+            &retryable_packet
+        );
+        assert_eq!(
+            banking_stage_stats
+                .consumed_buffered_packets_count
+                .load(Ordering::Relaxed),
+            num_conflicting_transactions - 1,
+        );
+        assert_eq!(
+            banking_stage_stats
+                .rebuffered_packets_count
+                .load(Ordering::Relaxed),
+            1
+        );
+        // Use bank to check the number of entries (batches)
+        assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
+        assert_eq!(
+            bank_start.working_bank.transaction_entries_count(),
+            num_conflicting_transactions as u64 - 1
+        );
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
     fn test_consume_buffered_packets_batch_priority_guard() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let (
-                _,
-                bank,
-                _bank_forks,
-                poh_recorder,
-                _entry_receiver,
-                genesis_config_info,
-                poh_simulator,
-            ) = setup_conflicting_transactions(ledger_path.path());
-            let recorder = poh_recorder.read().unwrap().new_recorder();
+        let (
+            _,
+            bank,
+            _bank_forks,
+            poh_recorder,
+            _entry_receiver,
+            genesis_config_info,
+            poh_simulator,
+        ) = setup_conflicting_transactions(ledger_path.path());
+        let recorder = poh_recorder.read().unwrap().new_recorder();
 
-            // Setup transactions:
-            // [(AB), (BC), (CD)]
-            // (AB) and (BC) are conflicting, and cannot go into the same batch.
-            // (AB) and (CD) are not conflict. However, (CD) should not be able to take locks needed by (BC).
-            let keypair_a = Keypair::new();
-            let keypair_b = Keypair::new();
-            let keypair_c = Keypair::new();
-            let keypair_d = Keypair::new();
-            for keypair in &[&keypair_a, &keypair_b, &keypair_c, &keypair_d] {
-                bank.transfer(5_000, &genesis_config_info.mint_keypair, &keypair.pubkey())
-                    .unwrap();
-            }
+        // Setup transactions:
+        // [(AB), (BC), (CD)]
+        // (AB) and (BC) are conflicting, and cannot go into the same batch.
+        // (AB) and (CD) are not conflict. However, (CD) should not be able to take locks needed by (BC).
+        let keypair_a = Keypair::new();
+        let keypair_b = Keypair::new();
+        let keypair_c = Keypair::new();
+        let keypair_d = Keypair::new();
+        for keypair in &[&keypair_a, &keypair_b, &keypair_c, &keypair_d] {
+            bank.transfer(5_000, &genesis_config_info.mint_keypair, &keypair.pubkey())
+                .unwrap();
+        }
 
-            let make_prioritized_transfer =
-                |from: &Keypair, to, lamports, priority| -> Transaction {
-                    let ixs = vec![
-                        system_instruction::transfer(&from.pubkey(), to, lamports),
-                        compute_budget::ComputeBudgetInstruction::set_compute_unit_price(priority),
-                    ];
-                    let message = Message::new(&ixs, Some(&from.pubkey()));
-                    Transaction::new(&[from], message, bank.last_blockhash())
-                };
-
-            let transactions = vec![
-                make_prioritized_transfer(&keypair_a, &keypair_b.pubkey(), 1, 3),
-                make_prioritized_transfer(&keypair_b, &keypair_c.pubkey(), 1, 2),
-                make_prioritized_transfer(&keypair_c, &keypair_d.pubkey(), 1, 1),
+        let make_prioritized_transfer = |from: &Keypair, to, lamports, priority| -> Transaction {
+            let ixs = vec![
+                system_instruction::transfer(&from.pubkey(), to, lamports),
+                compute_budget::ComputeBudgetInstruction::set_compute_unit_price(priority),
             ];
+            let message = Message::new(&ixs, Some(&from.pubkey()));
+            Transaction::new(&[from], message, bank.last_blockhash())
+        };
 
-            let num_conflicting_transactions = transactions.len();
-            let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
-            assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
-            let mut buffered_packet_batches =
-                UnprocessedTransactionStorage::new_transaction_storage(
-                    UnprocessedPacketBatches::from_iter(
-                        deserialized_packets,
-                        num_conflicting_transactions,
-                    ),
-                    ThreadType::Transactions,
-                );
+        let transactions = vec![
+            make_prioritized_transfer(&keypair_a, &keypair_b.pubkey(), 1, 3),
+            make_prioritized_transfer(&keypair_b, &keypair_c.pubkey(), 1, 2),
+            make_prioritized_transfer(&keypair_c, &keypair_d.pubkey(), 1, 1),
+        ];
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let num_conflicting_transactions = transactions.len();
+        let deserialized_packets = transactions_to_deserialized_packets(&transactions).unwrap();
+        assert_eq!(deserialized_packets.len(), num_conflicting_transactions);
+        let mut buffered_packet_batches = UnprocessedTransactionStorage::new_transaction_storage(
+            UnprocessedPacketBatches::from_iter(deserialized_packets, num_conflicting_transactions),
+            ThreadType::Transactions,
+        );
 
-            // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
-            assert!(!poh_recorder.read().unwrap().has_bank());
-            assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
-            // When the working bank in poh_recorder is Some, all packets should be processed.
-            // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
-            poh_recorder.write().unwrap().set_bank_for_test(bank);
-            let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
-            let banking_stage_stats = BankingStageStats::default();
-            consumer.consume_buffered_packets(
-                &bank_start,
-                &mut buffered_packet_batches,
-                &banking_stage_stats,
-                &mut LeaderSlotMetricsTracker::new(0),
-            );
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            // Check that all packets were processed without retrying
-            assert!(buffered_packet_batches.is_empty());
-            assert_eq!(
-                banking_stage_stats
-                    .consumed_buffered_packets_count
-                    .load(Ordering::Relaxed),
-                num_conflicting_transactions
-            );
-            assert_eq!(
-                banking_stage_stats
-                    .rebuffered_packets_count
-                    .load(Ordering::Relaxed),
-                0
-            );
-            // Use bank to check the number of entries (batches)
-            assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
-            assert_eq!(
-                bank_start.working_bank.transaction_entries_count(),
-                4 + num_conflicting_transactions as u64 // 4 for funding transfers
-            );
+        // When the working bank in poh_recorder is None, no packets should be processed (consume will not be called)
+        assert!(!poh_recorder.read().unwrap().has_bank());
+        assert_eq!(buffered_packet_batches.len(), num_conflicting_transactions);
+        // When the working bank in poh_recorder is Some, all packets should be processed.
+        // Multi-Iterator will process them 1-by-1 if all txs are conflicting.
+        poh_recorder.write().unwrap().set_bank_for_test(bank);
+        let bank_start = poh_recorder.read().unwrap().bank_start().unwrap();
+        let banking_stage_stats = BankingStageStats::default();
+        consumer.consume_buffered_packets(
+            &bank_start,
+            &mut buffered_packet_batches,
+            &banking_stage_stats,
+            &mut LeaderSlotMetricsTracker::new(0),
+        );
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        // Check that all packets were processed without retrying
+        assert!(buffered_packet_batches.is_empty());
+        assert_eq!(
+            banking_stage_stats
+                .consumed_buffered_packets_count
+                .load(Ordering::Relaxed),
+            num_conflicting_transactions
+        );
+        assert_eq!(
+            banking_stage_stats
+                .rebuffered_packets_count
+                .load(Ordering::Relaxed),
+            0
+        );
+        // Use bank to check the number of entries (batches)
+        assert_eq!(bank_start.working_bank.transactions_per_entry_max(), 1);
+        assert_eq!(
+            bank_start.working_bank.transaction_entries_count(),
+            4 + num_conflicting_transactions as u64 // 4 for funding transfers
+        );
+
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2152,7 +2152,6 @@ mod tests {
     #[test]
     fn test_consume_buffered_packets() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
                 setup_conflicting_transactions(ledger_path.path());
             let recorder: TransactionRecorder = poh_recorder.read().unwrap().new_recorder();
@@ -2218,14 +2217,11 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
     fn test_consume_buffered_packets_sanitization_error() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let (
                 mut transactions,
                 bank,
@@ -2281,14 +2277,11 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
     fn test_consume_buffered_packets_retryable() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let (transactions, bank, _bank_forks, poh_recorder, _entry_receiver, _, poh_simulator) =
                 setup_conflicting_transactions(ledger_path.path());
             let recorder = poh_recorder.read().unwrap().new_recorder();
@@ -2377,14 +2370,11 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
     fn test_consume_buffered_packets_batch_priority_guard() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let (
                 _,
                 bank,
@@ -2487,8 +2477,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1092,116 +1092,116 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                commit_transactions_result,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
 
-            assert_eq!(
-                transaction_counts,
-                LeaderProcessedTransactionCounts {
-                    attempted_processing_count: 1,
-                    processed_count: 1,
-                    processed_with_successful_result_count: 1,
-                }
-            );
-            assert!(commit_transactions_result.is_ok());
-
-            // Tick up to max tick height
-            while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() {
-                poh_recorder.write().unwrap().tick();
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
             }
+        );
+        assert!(commit_transactions_result.is_ok());
 
-            let mut done = false;
-            // read entries until I find mine, might be ticks...
-            while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
-                if !entry.is_tick() {
-                    trace!("got entry");
-                    assert_eq!(entry.transactions.len(), transactions.len());
-                    assert_eq!(bank.get_balance(&pubkey), 1);
-                    done = true;
-                }
-                if done {
-                    break;
-                }
+        // Tick up to max tick height
+        while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() {
+            poh_recorder.write().unwrap().tick();
+        }
+
+        let mut done = false;
+        // read entries until I find mine, might be ticks...
+        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
+            if !entry.is_tick() {
+                trace!("got entry");
+                assert_eq!(entry.transactions.len(), transactions.len());
+                assert_eq!(bank.get_balance(&pubkey), 1);
+                done = true;
             }
-            trace!("done ticking");
+            if done {
+                break;
+            }
+        }
+        trace!("done ticking");
 
-            assert!(done);
+        assert!(done);
 
-            let transactions = sanitize_transactions(vec![system_transaction::transfer(
-                &mint_keypair,
-                &pubkey,
-                2,
-                genesis_config.hash(),
-            )]);
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &pubkey,
+            2,
+            genesis_config.hash(),
+        )]);
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                retryable_transaction_indexes,
-                commit_transactions_result,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
-            assert_eq!(
-                transaction_counts,
-                LeaderProcessedTransactionCounts {
-                    attempted_processing_count: 1,
-                    // Transaction was still processed, just wasn't committed, so should be counted here.
-                    processed_count: 1,
-                    processed_with_successful_result_count: 1,
-                }
-            );
-            assert_eq!(retryable_transaction_indexes, vec![0]);
-            assert_matches!(
-                commit_transactions_result,
-                Err(PohRecorderError::MaxHeightReached)
-            );
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            retryable_transaction_indexes,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                // Transaction was still processed, just wasn't committed, so should be counted here.
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert_eq!(retryable_transaction_indexes, vec![0]);
+        assert_matches!(
+            commit_transactions_result,
+            Err(PohRecorderError::MaxHeightReached)
+        );
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
 
-            assert_eq!(bank.get_balance(&pubkey), 1);
+        assert_eq!(bank.get_balance(&pubkey), 1);
     }
 
     #[test]
@@ -1239,125 +1239,125 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::new(false)),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::new(false)),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            fn poh_tick_before_returning_record_response(
-                record_receiver: Receiver<Record>,
-                poh_recorder: Arc<RwLock<PohRecorder>>,
-            ) -> JoinHandle<()> {
-                let is_exited = poh_recorder.read().unwrap().is_exited.clone();
-                let tick_producer = Builder::new()
-                    .name("solana-simulate_poh".to_string())
-                    .spawn(move || loop {
-                        let timeout = Duration::from_millis(10);
-                        let record = record_receiver.recv_timeout(timeout);
-                        if let Ok(record) = record {
-                            let record_response = poh_recorder.write().unwrap().record(
-                                record.slot,
-                                record.mixin,
-                                record.transactions,
-                            );
-                            poh_recorder.write().unwrap().tick();
-                            if record.sender.send(record_response).is_err() {
-                                panic!("Error returning mixin hash");
-                            }
+        fn poh_tick_before_returning_record_response(
+            record_receiver: Receiver<Record>,
+            poh_recorder: Arc<RwLock<PohRecorder>>,
+        ) -> JoinHandle<()> {
+            let is_exited = poh_recorder.read().unwrap().is_exited.clone();
+            let tick_producer = Builder::new()
+                .name("solana-simulate_poh".to_string())
+                .spawn(move || loop {
+                    let timeout = Duration::from_millis(10);
+                    let record = record_receiver.recv_timeout(timeout);
+                    if let Ok(record) = record {
+                        let record_response = poh_recorder.write().unwrap().record(
+                            record.slot,
+                            record.mixin,
+                            record.transactions,
+                        );
+                        poh_recorder.write().unwrap().tick();
+                        if record.sender.send(record_response).is_err() {
+                            panic!("Error returning mixin hash");
                         }
-                        if is_exited.load(Ordering::Relaxed) {
-                            break;
-                        }
-                    });
-                tick_producer.unwrap()
+                    }
+                    if is_exited.load(Ordering::Relaxed) {
+                        break;
+                    }
+                });
+            tick_producer.unwrap()
+        }
+
+        // Simulate a race condition by setting up poh to do the last tick
+        // right before returning the transaction record response so that
+        // bank blockhash queue is updated before transactions are
+        // committed.
+        let poh_simulator =
+            poh_tick_before_returning_record_response(record_receiver, poh_recorder.clone());
+
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+
+        // Tick up to max tick height - 1 so that only one tick remains
+        // before recording transactions to poh
+        while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() - 1 {
+            poh_recorder.write().unwrap().tick();
+        }
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 0,
             }
+        );
+        assert!(commit_transactions_result.is_ok());
 
-            // Simulate a race condition by setting up poh to do the last tick
-            // right before returning the transaction record response so that
-            // bank blockhash queue is updated before transactions are
-            // committed.
-            let poh_simulator =
-                poh_tick_before_returning_record_response(record_receiver, poh_recorder.clone());
+        // Ensure that poh did the last tick after recording transactions
+        assert_eq!(
+            poh_recorder.read().unwrap().tick_height(),
+            bank.max_tick_height()
+        );
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-
-            // Tick up to max tick height - 1 so that only one tick remains
-            // before recording transactions to poh
-            while poh_recorder.read().unwrap().tick_height() != bank.max_tick_height() - 1 {
-                poh_recorder.write().unwrap().tick();
+        let mut done = false;
+        // read entries until I find mine, might be ticks...
+        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
+            if !entry.is_tick() {
+                assert_eq!(entry.transactions.len(), transactions.len());
+                done = true;
+                break;
             }
+        }
+        assert!(done);
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                commit_transactions_result,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
-
-            assert_eq!(
-                transaction_counts,
-                LeaderProcessedTransactionCounts {
-                    attempted_processing_count: 1,
-                    processed_count: 1,
-                    processed_with_successful_result_count: 0,
-                }
-            );
-            assert!(commit_transactions_result.is_ok());
-
-            // Ensure that poh did the last tick after recording transactions
-            assert_eq!(
-                poh_recorder.read().unwrap().tick_height(),
-                bank.max_tick_height()
-            );
-
-            let mut done = false;
-            // read entries until I find mine, might be ticks...
-            while let Ok((_bank, (entry, _tick_height))) = entry_receiver.recv() {
-                if !entry.is_tick() {
-                    assert_eq!(entry.transactions.len(), transactions.len());
-                    done = true;
-                    break;
-                }
-            }
-            assert!(done);
-
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
-
-            // check that the nonce was advanced to the current bank's last blockhash
-            // rather than the current bank's blockhash as would occur had the update
-            // blockhash been queried _after_ transaction recording
-            let expected_nonce = DurableNonce::from_blockhash(&genesis_config.hash());
-            let expected_nonce_hash = expected_nonce.as_hash();
-            let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
-            assert!(verify_nonce_account(&nonce_account, expected_nonce_hash).is_some());
+        // check that the nonce was advanced to the current bank's last blockhash
+        // rather than the current bank's blockhash as would occur had the update
+        // blockhash been queried _after_ transaction recording
+        let expected_nonce = DurableNonce::from_blockhash(&genesis_config.hash());
+        let expected_nonce_hash = expected_nonce.as_hash();
+        let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
+        assert!(verify_nonce_account(&nonce_account, expected_nonce_hash).is_some());
     }
 
     #[test]
@@ -1380,66 +1380,66 @@ mod tests {
         };
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                commit_transactions_result,
-                retryable_transaction_indexes,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            retryable_transaction_indexes,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
 
-            assert_eq!(
-                transaction_counts,
-                LeaderProcessedTransactionCounts {
-                    attempted_processing_count: 1,
-                    processed_count: 0,
-                    processed_with_successful_result_count: 0,
-                }
-            );
-            assert!(retryable_transaction_indexes.is_empty());
-            assert_eq!(
-                commit_transactions_result.ok(),
-                Some(vec![CommitTransactionDetails::NotCommitted; 1])
-            );
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 0,
+                processed_with_successful_result_count: 0,
+            }
+        );
+        assert!(retryable_transaction_indexes.is_empty());
+        assert_eq!(
+            commit_transactions_result.ok(),
+            Some(vec![CommitTransactionDetails::NotCommitted; 1])
+        );
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -1456,145 +1456,144 @@ mod tests {
         let pubkey = solana_pubkey::new_rand();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let get_block_cost = || bank.read_cost_tracker().unwrap().block_cost();
-            let get_tx_count = || bank.read_cost_tracker().unwrap().transaction_count();
-            assert_eq!(get_block_cost(), 0);
-            assert_eq!(get_tx_count(), 0);
+        let get_block_cost = || bank.read_cost_tracker().unwrap().block_cost();
+        let get_tx_count = || bank.read_cost_tracker().unwrap().transaction_count();
+        assert_eq!(get_block_cost(), 0);
+        assert_eq!(get_tx_count(), 0);
 
-            //
-            // TEST: cost tracker's block cost increases when successfully processing a tx
-            //
+        //
+        // TEST: cost tracker's block cost increases when successfully processing a tx
+        //
 
-            let transactions = sanitize_transactions(vec![system_transaction::transfer(
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &pubkey,
+            1,
+            genesis_config.hash(),
+        )]);
+
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
+
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        assert_eq!(transaction_counts.processed_with_successful_result_count, 1);
+        assert!(commit_transactions_result.is_ok());
+
+        let block_cost = get_block_cost();
+        assert_ne!(block_cost, 0);
+        assert_eq!(get_tx_count(), 1);
+
+        // TEST: it's expected that the allocation will execute but the transfer will not
+        // because of a shared write-lock between mint_keypair. Ensure only the first transaction
+        // takes compute units in the block
+        let allocate_keypair = Keypair::new();
+        let transactions = sanitize_transactions(vec![
+            system_transaction::allocate(
                 &mint_keypair,
-                &pubkey,
-                1,
+                &allocate_keypair,
                 genesis_config.hash(),
-            )]);
+                100,
+            ),
+            // this one won't execute in process_and_record_transactions from shared account lock overlap
+            system_transaction::transfer(&mint_keypair, &pubkey, 2, genesis_config.hash()),
+        ]);
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                commit_transactions_result,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
-            assert_eq!(transaction_counts.processed_with_successful_result_count, 1);
-            assert!(commit_transactions_result.is_ok());
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            retryable_transaction_indexes,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        assert_eq!(transaction_counts.processed_with_successful_result_count, 1);
+        assert!(commit_transactions_result.is_ok());
 
-            let block_cost = get_block_cost();
-            assert_ne!(block_cost, 0);
-            assert_eq!(get_tx_count(), 1);
+        // first one should have been committed, second one not committed due to AccountInUse error during
+        // account locking
+        let commit_transactions_result = commit_transactions_result.unwrap();
+        assert_eq!(commit_transactions_result.len(), 2);
+        assert_matches!(
+            commit_transactions_result.first(),
+            Some(CommitTransactionDetails::Committed { .. })
+        );
+        assert_matches!(
+            commit_transactions_result.get(1),
+            Some(CommitTransactionDetails::NotCommitted)
+        );
+        assert_eq!(retryable_transaction_indexes, vec![1]);
 
-            // TEST: it's expected that the allocation will execute but the transfer will not
-            // because of a shared write-lock between mint_keypair. Ensure only the first transaction
-            // takes compute units in the block
-            let allocate_keypair = Keypair::new();
-            let transactions = sanitize_transactions(vec![
-                system_transaction::allocate(
-                    &mint_keypair,
-                    &allocate_keypair,
-                    genesis_config.hash(),
-                    100,
-                ),
-                // this one won't execute in process_and_record_transactions from shared account lock overlap
-                system_transaction::transfer(&mint_keypair, &pubkey, 2, genesis_config.hash()),
-            ]);
-
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
-
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                commit_transactions_result,
-                retryable_transaction_indexes,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
-            assert_eq!(transaction_counts.processed_with_successful_result_count, 1);
-            assert!(commit_transactions_result.is_ok());
-
-            // first one should have been committed, second one not committed due to AccountInUse error during
-            // account locking
-            let commit_transactions_result = commit_transactions_result.unwrap();
-            assert_eq!(commit_transactions_result.len(), 2);
-            assert_matches!(
-                commit_transactions_result.first(),
-                Some(CommitTransactionDetails::Committed { .. })
-            );
-            assert_matches!(
-                commit_transactions_result.get(1),
-                Some(CommitTransactionDetails::NotCommitted)
-            );
-            assert_eq!(retryable_transaction_indexes, vec![1]);
-
-            let expected_block_cost = {
-                let (actual_programs_execution_cost, actual_loaded_accounts_data_size_cost) =
-                    match commit_transactions_result.first().unwrap() {
-                        CommitTransactionDetails::Committed {
-                            compute_units,
-                            loaded_accounts_data_size,
-                        } => (
-                            *compute_units,
-                            CostModel::calculate_loaded_accounts_data_size_cost(
-                                *loaded_accounts_data_size,
-                                &bank.feature_set,
-                            ),
+        let expected_block_cost = {
+            let (actual_programs_execution_cost, actual_loaded_accounts_data_size_cost) =
+                match commit_transactions_result.first().unwrap() {
+                    CommitTransactionDetails::Committed {
+                        compute_units,
+                        loaded_accounts_data_size,
+                    } => (
+                        *compute_units,
+                        CostModel::calculate_loaded_accounts_data_size_cost(
+                            *loaded_accounts_data_size,
+                            &bank.feature_set,
                         ),
-                        CommitTransactionDetails::NotCommitted => {
-                            unreachable!()
-                        }
-                    };
+                    ),
+                    CommitTransactionDetails::NotCommitted => {
+                        unreachable!()
+                    }
+                };
 
-                let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
-                if let TransactionCost::Transaction(ref mut usage_cost) = cost {
-                    usage_cost.programs_execution_cost = actual_programs_execution_cost;
-                    usage_cost.loaded_accounts_data_size_cost =
-                        actual_loaded_accounts_data_size_cost;
-                }
+            let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
+            if let TransactionCost::Transaction(ref mut usage_cost) = cost {
+                usage_cost.programs_execution_cost = actual_programs_execution_cost;
+                usage_cost.loaded_accounts_data_size_cost = actual_loaded_accounts_data_size_cost;
+            }
 
-                block_cost + cost.sum()
-            };
+            block_cost + cost.sum()
+        };
 
-            assert_eq!(get_block_cost(), expected_block_cost);
-            assert_eq!(get_tx_count(), 2);
+        assert_eq!(get_block_cost(), expected_block_cost);
+        assert_eq!(get_tx_count(), 2);
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -1615,64 +1614,64 @@ mod tests {
         ]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let process_transactions_batch_output =
-                consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let process_transactions_batch_output =
+            consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
 
-            let ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                retryable_transaction_indexes,
-                commit_transactions_result,
-                ..
-            } = process_transactions_batch_output.execute_and_commit_transactions_output;
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            retryable_transaction_indexes,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
 
-            assert_eq!(
-                transaction_counts,
-                LeaderProcessedTransactionCounts {
-                    attempted_processing_count: 2,
-                    processed_count: 1,
-                    processed_with_successful_result_count: 1,
-                }
-            );
-            assert_eq!(retryable_transaction_indexes, vec![1]);
-            assert!(commit_transactions_result.is_ok());
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 2,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert_eq!(retryable_transaction_indexes, vec![1]);
+        assert!(commit_transactions_result.is_ok());
     }
 
     #[test]
@@ -1820,61 +1819,61 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
 
-            // Poh Recorder has no working bank, so should throw MaxHeightReached error on
-            // record
-            let recorder = poh_recorder.new_recorder();
+        // Poh Recorder has no working bank, so should throw MaxHeightReached error on
+        // record
+        let recorder = poh_recorder.new_recorder();
 
-            let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
+        let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                None,
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder.clone(), QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            None,
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder.clone(), QosService::new(1), None);
 
-            let process_transactions_summary =
-                consumer.process_transactions(&bank, &Instant::now(), &transactions);
+        let process_transactions_summary =
+            consumer.process_transactions(&bank, &Instant::now(), &transactions);
 
-            let ProcessTransactionsSummary {
-                reached_max_poh_height,
-                transaction_counts,
-                mut retryable_transaction_indexes,
-                ..
-            } = process_transactions_summary;
-            assert!(reached_max_poh_height);
-            assert_eq!(
-                transaction_counts,
-                CommittedTransactionsCounts {
-                    attempted_processing_count: 1,
-                    // MaxHeightReached error does not commit, should be zero here
-                    committed_transactions_count: 0,
-                    committed_transactions_with_successful_result_count: 0,
-                    processed_but_failed_commit: 1,
-                }
-            );
+        let ProcessTransactionsSummary {
+            reached_max_poh_height,
+            transaction_counts,
+            mut retryable_transaction_indexes,
+            ..
+        } = process_transactions_summary;
+        assert!(reached_max_poh_height);
+        assert_eq!(
+            transaction_counts,
+            CommittedTransactionsCounts {
+                attempted_processing_count: 1,
+                // MaxHeightReached error does not commit, should be zero here
+                committed_transactions_count: 0,
+                committed_transactions_with_successful_result_count: 0,
+                processed_but_failed_commit: 1,
+            }
+        );
 
-            retryable_transaction_indexes.sort_unstable();
-            let expected: Vec<usize> = (0..transactions.len()).collect();
-            assert_eq!(retryable_transaction_indexes, expected);
+        retryable_transaction_indexes.sort_unstable();
+        let expected: Vec<usize> = (0..transactions.len()).collect();
+        assert_eq!(retryable_transaction_indexes, expected);
 
-            recorder.is_exited.store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        recorder.is_exited.store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -1917,95 +1916,95 @@ mod tests {
             .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let blockstore = Arc::new(blockstore);
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                blockstore.clone(),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let blockstore = Arc::new(blockstore);
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            blockstore.clone(),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
 
-            let shreds = entries_to_test_shreds(
-                &entries,
-                bank.slot(),
-                0,    // parent_slot
-                true, // is_full_slot
-                0,    // version
-                true, // merkle_variant
-            );
-            blockstore.insert_shreds(shreds, None, false).unwrap();
-            blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
+        let shreds = entries_to_test_shreds(
+            &entries,
+            bank.slot(),
+            0,    // parent_slot
+            true, // is_full_slot
+            0,    // version
+            true, // merkle_variant
+        );
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 
-            let (transaction_status_sender, transaction_status_receiver) = unbounded();
-            let tss_exit = Arc::new(AtomicBool::new(false));
-            let transaction_status_service = TransactionStatusService::new(
-                transaction_status_receiver,
-                Arc::new(AtomicU64::default()),
-                true,
-                None,
-                blockstore.clone(),
-                false,
-                tss_exit.clone(),
-            );
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let tss_exit = Arc::new(AtomicBool::new(false));
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            Arc::new(AtomicU64::default()),
+            true,
+            None,
+            blockstore.clone(),
+            false,
+            tss_exit.clone(),
+        );
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                Some(TransactionStatusSender {
-                    sender: transaction_status_sender,
-                }),
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+            }),
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let _ = consumer.process_and_record_transactions(&bank, &transactions, 0);
+        let _ = consumer.process_and_record_transactions(&bank, &transactions, 0);
 
-            drop(consumer); // drop/disconnect transaction_status_sender
+        drop(consumer); // drop/disconnect transaction_status_sender
 
-            transaction_status_service.quiesce_and_join_for_tests(tss_exit);
+        transaction_status_service.quiesce_and_join_for_tests(tss_exit);
 
-            let confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
-            let actual_tx_results: Vec<_> = confirmed_block
-                .transactions
-                .into_iter()
-                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
-                    (transaction.signatures[0], meta.status)
-                })
-                .collect();
-            let expected_tx_results = vec![
-                (success_signature, Ok(())),
-                (
-                    ix_error_signature,
-                    Err(TransactionError::InstructionError(
-                        0,
-                        InstructionError::Custom(1),
-                    )),
-                ),
-            ];
-            assert_eq!(actual_tx_results, expected_tx_results);
+        let confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
+        let actual_tx_results: Vec<_> = confirmed_block
+            .transactions
+            .into_iter()
+            .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                (transaction.signatures[0], meta.status)
+            })
+            .collect();
+        let expected_tx_results = vec![
+            (success_signature, Ok(())),
+            (
+                ix_error_signature,
+                Err(TransactionError::InstructionError(
+                    0,
+                    InstructionError::Custom(1),
+                )),
+            ),
+        ];
+        assert_eq!(actual_tx_results, expected_tx_results);
 
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]
@@ -2061,93 +2060,93 @@ mod tests {
         bank.transfer(1, &mint_keypair, &keypair.pubkey()).unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger");
-            let blockstore = Arc::new(blockstore);
-            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                Some((4, 4)),
-                bank.ticks_per_slot(),
-                blockstore.clone(),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-                &PohConfig::default(),
-                Arc::new(AtomicBool::default()),
-            );
-            let recorder = poh_recorder.new_recorder();
-            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let blockstore = Arc::new(blockstore);
+        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            blockstore.clone(),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        let recorder = poh_recorder.new_recorder();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
-            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder
-                .write()
-                .unwrap()
-                .set_bank_for_test(bank.clone());
+        poh_recorder
+            .write()
+            .unwrap()
+            .set_bank_for_test(bank.clone());
 
-            let shreds = entries_to_test_shreds(
-                &entries,
-                bank.slot(),
-                0,    // parent_slot
-                true, // is_full_slot
-                0,    // version
-                true, // merkle_variant
-            );
-            blockstore.insert_shreds(shreds, None, false).unwrap();
-            blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
+        let shreds = entries_to_test_shreds(
+            &entries,
+            bank.slot(),
+            0,    // parent_slot
+            true, // is_full_slot
+            0,    // version
+            true, // merkle_variant
+        );
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 
-            let (transaction_status_sender, transaction_status_receiver) = unbounded();
-            let tss_exit = Arc::new(AtomicBool::new(false));
-            let transaction_status_service = TransactionStatusService::new(
-                transaction_status_receiver,
-                Arc::new(AtomicU64::default()),
-                true,
-                None,
-                blockstore.clone(),
-                false,
-                tss_exit.clone(),
-            );
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let tss_exit = Arc::new(AtomicBool::new(false));
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            Arc::new(AtomicU64::default()),
+            true,
+            None,
+            blockstore.clone(),
+            false,
+            tss_exit.clone(),
+        );
 
-            let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-            let committer = Committer::new(
-                Some(TransactionStatusSender {
-                    sender: transaction_status_sender,
-                }),
-                replay_vote_sender,
-                Arc::new(PrioritizationFeeCache::new(0u64)),
-            );
-            let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let committer = Committer::new(
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+            }),
+            replay_vote_sender,
+            Arc::new(PrioritizationFeeCache::new(0u64)),
+        );
+        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-            let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
+        let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
 
-            drop(consumer); // drop/disconnect transaction_status_sender
+        drop(consumer); // drop/disconnect transaction_status_sender
 
-            transaction_status_service.quiesce_and_join_for_tests(tss_exit);
+        transaction_status_service.quiesce_and_join_for_tests(tss_exit);
 
-            let mut confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
-            assert_eq!(confirmed_block.transactions.len(), 1);
+        let mut confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
+        assert_eq!(confirmed_block.transactions.len(), 1);
 
-            let recorded_meta = confirmed_block.transactions.pop().unwrap().meta;
-            assert_eq!(
-                recorded_meta,
-                TransactionStatusMeta {
-                    status: Ok(()),
-                    pre_balances: vec![1, 0, 0],
-                    post_balances: vec![1, 0, 0],
-                    pre_token_balances: Some(vec![]),
-                    post_token_balances: Some(vec![]),
-                    rewards: Some(vec![]),
-                    loaded_addresses: sanitized_tx.get_loaded_addresses(),
-                    compute_units_consumed: Some(0),
-                    ..TransactionStatusMeta::default()
-                }
-            );
-            poh_recorder
-                .read()
-                .unwrap()
-                .is_exited
-                .store(true, Ordering::Relaxed);
-            let _ = poh_simulator.join();
+        let recorded_meta = confirmed_block.transactions.pop().unwrap().meta;
+        assert_eq!(
+            recorded_meta,
+            TransactionStatusMeta {
+                status: Ok(()),
+                pre_balances: vec![1, 0, 0],
+                post_balances: vec![1, 0, 0],
+                pre_token_balances: Some(vec![]),
+                post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
+                loaded_addresses: sanitized_tx.get_loaded_addresses(),
+                compute_units_consumed: Some(0),
+                ..TransactionStatusMeta::default()
+            }
+        );
+        poh_recorder
+            .read()
+            .unwrap()
+            .is_exited
+            .store(true, Ordering::Relaxed);
+        let _ = poh_simulator.join();
     }
 
     #[test]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1092,7 +1092,6 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
@@ -1203,8 +1202,6 @@ mod tests {
             let _ = poh_simulator.join();
 
             assert_eq!(bank.get_balance(&pubkey), 1);
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1242,7 +1239,6 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
@@ -1362,8 +1358,6 @@ mod tests {
             let expected_nonce_hash = expected_nonce.as_hash();
             let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
             assert!(verify_nonce_account(&nonce_account, expected_nonce_hash).is_some());
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1386,7 +1380,6 @@ mod tests {
         };
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
@@ -1447,8 +1440,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1465,7 +1456,6 @@ mod tests {
         let pubkey = solana_pubkey::new_rand();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
@@ -1605,8 +1595,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1627,7 +1615,6 @@ mod tests {
         ]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
@@ -1686,8 +1673,6 @@ mod tests {
             );
             assert_eq!(retryable_transaction_indexes, vec![1]);
             assert!(commit_transactions_result.is_ok());
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1835,7 +1820,6 @@ mod tests {
         )]);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
@@ -1891,9 +1875,6 @@ mod tests {
 
             recorder.is_exited.store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -1936,7 +1917,6 @@ mod tests {
             .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let blockstore = Arc::new(blockstore);
@@ -2026,8 +2006,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]
@@ -2083,7 +2061,6 @@ mod tests {
         bank.transfer(1, &mint_keypair, &keypair.pubkey()).unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        {
             let blockstore = Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger");
             let blockstore = Arc::new(blockstore);
@@ -2171,8 +2148,6 @@ mod tests {
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
-        }
-        Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
A caller can use `Blockstore::destroy()` to remove the blockstore files at the given path. In unit tests that create a blockstore, calling destroy at the end of a test is a good step to avoid "junk" from accumulating.

However, there might be other items that get created for a test, such as a `genesis.bin`. And, remembering to call `Blockstore::destroy()` is annoying. So instead, we added a macro that creates a self-deleting directory suitable for any ledger stuff (blockstore, genesis, etc). Using this macro gives us RAII-like qualities
https://github.com/anza-xyz/agave/blob/d221ad409157f67f8d545d2af21743ee18ccfd25/ledger/src/blockstore.rs#L5008-L5013

Using this macro means it is not necessary to call `Blockstore::destroy()`

#### Summary of Changes
Remove the manual invocation of `Blockstore::destroy()` and let the convenience macro to its' job.

The diff for this one is massive because of whitespace. I remove the calls and now useless brackets in separate commits, and then ran `cargo fmt` in separate commits. So, either viewing commit by commit or by hiding whitespace should make reviewing sane