### PR TITLE
Remove ignored default-features key from Cargo.toml files

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -45,7 +45,7 @@ zstd = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-hash = { workspace = true }
-solana-program = { workspace = true, default-features = false }
+solana-program = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-pod = { workspace = true }
 

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -11,9 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false, features = [
-    "bytemuck",
-] }
+solana-pubkey = { workspace = true, features = ["bytemuck"] }
 
 [lib]
 crate-type = ["lib"]

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -33,7 +33,7 @@ solana-keypair = { workspace = true, optional = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode"] }
-solana-pubkey = { workspace = true, default-features = false }
+solana-pubkey = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -24,7 +24,7 @@ solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false }
+solana-pubkey = { workspace = true }
 solana-quic-definitions = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-signer = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -49,7 +49,7 @@ jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program = { workspace = true, default-features = false }
+solana-program = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -40,7 +40,7 @@ solana-message = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-precompiles = { workspace = true }
-solana-program = { workspace = true, default-features = false }
+solana-program = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -20,7 +20,7 @@ solana-account-decoder-client-types = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-message = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
-solana-signature = { workspace = true, default-features = false }
+solana-signature = { workspace = true }
 solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
#### Problem

`default-features` is ignored for solana-program, and other sdk dependencies, since `default-features` was not specified for `workspace.dependencies.solana-program`.

#### Summary of Changes

Remove `default-features` key from Cargo.toml files.
