### PR TITLE
Organize gossip random packet generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2028,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4477,6 +4497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7824,10 +7855,12 @@ dependencies = [
 name = "solana-gossip"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bs58",
  "bv",
+ "cfg-if 1.0.0",
  "clap 2.33.3",
  "criterion",
  "crossbeam-channel",
@@ -7838,6 +7871,7 @@ dependencies = [
  "lru",
  "num-traits",
  "num_cpus",
+ "pcap-file",
  "rand 0.7.3",
  "rand 0.8.5",
  "rand_chacha 0.2.2",
@@ -7847,6 +7881,7 @@ dependencies = [
  "serde-big-array",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "serial_test",
  "siphasher",
  "solana-bloom",
@@ -7857,6 +7892,7 @@ dependencies = [
  "solana-feature-set",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-gossip",
  "solana-ledger",
  "solana-logger",
  "solana-measure",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -10,9 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
+cfg-if = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
 flate2 = { workspace = true }
@@ -21,6 +23,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 num-traits = { workspace = true }
+pcap-file = "2.0.0"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
@@ -28,6 +31,7 @@ serde = { workspace = true }
 serde-big-array = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }
+serde_json = { workspace = true, optional = true }
 siphasher = { workspace = true }
 solana-bloom = { workspace = true }
 solana-clap-utils = { workspace = true }
@@ -62,7 +66,6 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
-
 [dev-dependencies]
 bs58 = { workspace = true }
 criterion = { workspace = true }
@@ -70,10 +73,10 @@ num_cpus = { workspace = true }
 rand0-7 = { workspace = true }
 rand_chacha0-2 = { workspace = true }
 serial_test = { workspace = true }
+solana-gossip = { workspace = true, features = ["dev-context-only-utils"] }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
-
 [features]
 frozen-abi = [
     "dep:solana-frozen-abi",
@@ -88,6 +91,7 @@ frozen-abi = [
     "solana-vote/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]
+dev-context-only-utils = []
 
 [[bench]]
 name = "crds"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -25,6 +25,7 @@ lru = { workspace = true }
 num-traits = { workspace = true }
 pcap-file = "2.0.0"
 rand = { workspace = true }
+rand0-7 = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
@@ -73,7 +74,7 @@ num_cpus = { workspace = true }
 rand0-7 = { workspace = true }
 rand_chacha0-2 = { workspace = true }
 serial_test = { workspace = true }
-solana-gossip = { workspace = true, features = ["dev-context-only-utils"] }
+solana-gossip = { path = ".", features = ["dev-context-only-utils"] }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/gossip/benches/crds.rs
+++ b/gossip/benches/crds.rs
@@ -9,6 +9,7 @@ use {
         crds::{Crds, GossipRoute},
         crds_gossip_pull::{CrdsTimeouts, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS},
         crds_value::CrdsValue,
+        testing_fixtures::FormatValidation,
     },
     solana_pubkey::Pubkey,
     std::{collections::HashMap, time::Duration},

--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -9,6 +9,7 @@ use {
         crds::{Crds, GossipRoute},
         crds_gossip_pull::{CrdsFilter, CrdsGossipPull},
         crds_value::CrdsValue,
+        testing_fixtures::FormatValidation,
     },
     solana_sdk::hash::Hash,
     std::sync::RwLock,

--- a/gossip/benches/crds_shards.rs
+++ b/gossip/benches/crds_shards.rs
@@ -8,6 +8,7 @@ use {
         crds::{Crds, GossipRoute, VersionedCrdsValue},
         crds_shards::CrdsShards,
         crds_value::CrdsValue,
+        testing_fixtures::FormatValidation,
     },
     solana_sdk::timing::timestamp,
     std::iter::repeat_with,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3126,6 +3126,7 @@ mod tests {
             duplicate_shred::tests::new_rand_shred,
             protocol::tests::new_rand_remote_node,
             socketaddr,
+            testing_fixtures::{new_insecure_keypair, FormatValidation},
         },
         bincode::serialize,
         itertools::izip,
@@ -3796,7 +3797,8 @@ mod tests {
     #[test]
     fn test_append_entrypoint_to_pulls() {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
-        let node_keypair = Arc::new(Keypair::new());
+        let mut rng = rand::thread_rng();
+        let node_keypair = Arc::new(new_insecure_keypair(&mut rng));
         let cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -781,7 +781,10 @@ fn should_report_message_signature(signature: &Signature) -> bool {
 mod tests {
     use {
         super::*,
-        crate::crds_data::{new_rand_timestamp, AccountsHashes, NodeInstance},
+        crate::{
+            crds_data::{AccountsHashes, NodeInstance},
+            testing_fixtures::*,
+        },
         rand::{thread_rng, Rng, SeedableRng},
         rand_chacha::ChaChaRng,
         rayon::ThreadPoolBuilder,
@@ -1250,7 +1253,9 @@ mod tests {
     #[test]
     fn test_crds_value_indices() {
         let mut rng = thread_rng();
-        let keypairs: Vec<_> = repeat_with(Keypair::new).take(128).collect();
+        let keypairs: Vec<_> = repeat_with(|| new_insecure_keypair(&mut rng))
+            .take(128)
+            .collect();
         let mut crds = Crds::default();
         let mut num_inserts = 0;
         for k in 0..4096 {
@@ -1301,7 +1306,9 @@ mod tests {
             }
         }
         let mut rng = thread_rng();
-        let keypairs: Vec<_> = repeat_with(Keypair::new).take(128).collect();
+        let keypairs: Vec<_> = repeat_with(|| new_insecure_keypair(&mut rng))
+            .take(128)
+            .collect();
         let mut crds = Crds::default();
         for k in 0..4096 {
             let keypair = &keypairs[rng.gen_range(0..keypairs.len())];
@@ -1400,7 +1407,9 @@ mod tests {
                 .len()
         }
         let mut rng = thread_rng();
-        let keypairs: Vec<_> = repeat_with(Keypair::new).take(64).collect();
+        let keypairs: Vec<_> = repeat_with(|| new_insecure_keypair(&mut rng))
+            .take(64)
+            .collect();
         let stakes = keypairs
             .iter()
             .map(|k| (k.pubkey(), rng.gen_range(0..1000)))

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -65,7 +65,7 @@ mod tests {
         super::*,
         crate::{
             crds::{Crds, GossipRoute},
-            crds_data::new_rand_timestamp,
+            testing_fixtures::*,
         },
         rand::seq::SliceRandom,
         solana_sdk::signature::Keypair,

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -82,7 +82,7 @@ impl solana_sanitize::Sanitize for CrdsFilter {
 }
 
 impl CrdsFilter {
-    #[cfg(test)]
+    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn new_rand(num_items: usize, max_bytes: usize) -> Self {
         let max_bits = (max_bytes * 8) as f64;
         let max_items = Self::max_items(max_bits, FALSE_RATE, KEYS);
@@ -666,6 +666,7 @@ pub(crate) mod tests {
             crds_data::{CrdsData, Vote},
             legacy_contact_info::LegacyContactInfo,
             protocol::Protocol,
+            testing_fixtures::*,
         },
         itertools::Itertools,
         rand::{seq::SliceRandom, SeedableRng},

--- a/gossip/src/crds_shards.rs
+++ b/gossip/src/crds_shards.rs
@@ -137,6 +137,7 @@ mod test {
         crate::{
             crds::{Crds, GossipRoute},
             crds_value::CrdsValue,
+            testing_fixtures::*,
         },
         rand::{thread_rng, Rng},
         solana_sdk::timing::timestamp,

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -46,3 +46,6 @@ extern crate solana_frozen_abi_macro;
 
 #[macro_use]
 extern crate solana_metrics;
+
+#[cfg(feature = "dev-context-only-utils")]
+pub mod format_validation;

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -48,4 +48,4 @@ extern crate solana_frozen_abi_macro;
 extern crate solana_metrics;
 
 #[cfg(feature = "dev-context-only-utils")]
-pub mod format_validation;
+pub mod testing_fixtures;

--- a/gossip/src/testing_fixtures.rs
+++ b/gossip/src/testing_fixtures.rs
@@ -1,0 +1,80 @@
+//! Contains fixtures for tests of gossip code
+//! Some of these are cryptographically unsound and
+//! do not belong in any prod code.
+#[cfg(not(feature = "dev-context-only-utils"))]
+use non_existent_crate_to_make_sure_this_is_never_imported_in_prod;
+use {
+    anyhow::Context,
+    rand::Rng,
+    rand0_7::{CryptoRng as CryptoRng0_7, RngCore as RngCore0_7},
+    solana_pubkey::{Pubkey, PUBKEY_BYTES},
+    solana_sanitize::Sanitize,
+    solana_sdk::{signature::Keypair, timing::timestamp},
+};
+
+pub trait FormatValidation<SourceMaterial = Pubkey>: Sized + Sanitize {
+    /// New random instance for tests and benchmarks.
+    /// Implementations may customize which source material they need to build an instance.
+    fn new_rand<R: Rng>(rng: &mut R, source_material: Option<SourceMaterial>) -> Self;
+
+    /// Run some code that uses/traverses the value in a meaningful way
+    /// This is primarily designed for use in fuzz tests.
+    fn exercise(&self) -> anyhow::Result<()> {
+        self.sanitize().context("Sanitize failed")?;
+        Ok(())
+    }
+}
+
+/// Random gossip timestamp for tests and benchmarks.
+/// With seeded rng can be repeatable
+pub fn new_rand_timestamp<R: Rng>(rng: &mut R) -> u64 {
+    const DELAY: u64 = 10 * 60 * 1000; // 10 minutes
+    timestamp() - DELAY + rng.gen_range(0..2 * DELAY)
+}
+
+/// *Insecurely* generated keypair. Designed for tests and benches.
+/// Unlike a proper keypair generation, this can use any rng.
+/// With seeded rng can be repeatable
+pub fn new_insecure_keypair<R: Rng>(rng: &mut R) -> Keypair {
+    let mut not_crypto_rng = FakeCryptoRng::new(rng);
+    Keypair::generate(&mut not_crypto_rng)
+}
+
+/// Random public key bytes. Designed for tests and benches.
+/// With seeded rng can be repeatable
+pub fn new_random_pubkey<R: Rng>(rng: &mut R) -> Pubkey {
+    let bytes = rng.gen::<[u8; PUBKEY_BYTES]>();
+    Pubkey::from(bytes)
+}
+
+/// Fake crypto RNG that can make signatures using any underlying RNG
+/// Obviously, this is for tests and benchmakrs only
+struct FakeCryptoRng<'r, R: Rng>(&'r mut R);
+/// Marking the `FakeCryptoRng` as crypto RNG for tests only
+impl<R: Rng> CryptoRng0_7 for FakeCryptoRng<'_, R> {}
+
+impl<'r, R: Rng> FakeCryptoRng<'r, R> {
+    //just in case, prevent construction of instances outside of tests
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new(rng: &'r mut R) -> Self {
+        Self(rng)
+    }
+}
+
+impl<R: Rng> RngCore0_7 for FakeCryptoRng<'_, R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand0_7::Error> {
+        self.0.try_fill_bytes(dest).map_err(rand0_7::Error::new)
+    }
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -940,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder 1.5.0",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1441,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,6 +3736,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6187,9 +6218,11 @@ dependencies = [
 name = "solana-gossip"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bv",
+ "cfg-if 1.0.0",
  "clap",
  "crossbeam-channel",
  "flate2",
@@ -6198,6 +6231,8 @@ dependencies = [
  "log",
  "lru",
  "num-traits",
+ "pcap-file",
+ "rand 0.7.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -854,6 +854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1347,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3597,6 +3617,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6007,9 +6038,11 @@ dependencies = [
 name = "solana-gossip"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bv",
+ "cfg-if 1.0.0",
  "clap",
  "crossbeam-channel",
  "flate2",
@@ -6018,6 +6051,8 @@ dependencies = [
  "log",
  "lru",
  "num-traits",
+ "pcap-file",
+ "rand 0.7.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",


### PR DESCRIPTION
#### Problem

Gossip's random packet generation was never designed to be reproducible, and did not cover all variants of all packets. As a result, it is really hard to make reproducible pseudorandom gossip packets for purposes such as wire format validation and to track down possible incompatibilities between implemenations.

Also all of that code was not guarded by dev-context-only-utils feature-gate, making it accidentally usable in prod code.

#### Summary of Changes
All of the changes here concern only the code that runs in tests and benches. 
- Added testing_fixtures.rs to organize the test-related code better
- Added FormatValidation trait to organize the new_rand functions for later use in wire format example generation
- Extended the new_rand implementations where appropriate to cover all variants of all messages

This intended to be the first step to address https://github.com/anza-xyz/agave/issues/4879