### PR TITLE
removes redundant allocations when generating new gossip pull/push messages

### DIFF
--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -214,7 +214,7 @@ impl CrdsGossip {
         ping_cache: &Mutex<PingCache>,
         pings: &mut Vec<(SocketAddr, Ping)>,
         socket_addr_space: &SocketAddrSpace,
-    ) -> Result<Vec<(ContactInfo, Vec<CrdsFilter>)>, CrdsGossipError> {
+    ) -> Result<impl Iterator<Item = (SocketAddr, CrdsFilter)> + Clone, CrdsGossipError> {
         self.pull.new_pull_request(
             thread_pool,
             &self.crds,


### PR DESCRIPTION

#### Problem

Instead of collecting the intermediate values into vectors:
https://github.com/anza-xyz/agave/blob/2b0966de4/gossip/src/cluster_info.rs#L1311-L1318
https://github.com/anza-xyz/agave/blob/2b0966de4/gossip/src/cluster_info.rs#L1257-L1268
https://github.com/anza-xyz/agave/blob/2b0966de4/gossip/src/crds_gossip_pull.rs#L292-L302

gossip `new_{push,pull}_requests` can just return an iterator. This iterator can then be written directly to a PacketBatch, bypassing the unnecessary vector allocations.


#### Summary of Changes
The commit reduces allocation for new gossip pull/push messages by holding on to iterators and bypassing intermediate vector allocations.