### PR TITLE
Vote cu bench for Authorize, CompactUpdate, TowerSync

### DIFF
--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -19,8 +19,8 @@ use {
         vote_processor::Entrypoint,
         vote_state::{
             create_account, create_account_with_authorized, Vote, VoteAuthorize,
-            VoteAuthorizeWithSeedArgs, VoteInit, VoteState, VoteStateUpdate, VoteStateVersions,
-            MAX_LOCKOUT_HISTORY,
+            VoteAuthorizeCheckedWithSeedArgs, VoteAuthorizeWithSeedArgs, VoteInit, VoteState,
+            VoteStateUpdate, VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
     std::sync::Arc,
@@ -692,7 +692,6 @@ impl BenchAuthorizeWithSeed {
     fn new() -> Self {
         let vote_pubkey = Pubkey::new_unique();
         let voter_base_key = Pubkey::new_unique();
-        let vote_account = AccountSharedData::new(100, VoteState::size_of(), &id());
         let voter_owner = Pubkey::new_unique();
         let voter_seed = String::from("VOTER_SEED");
         let new_voter_pubkey = Pubkey::new_unique();
@@ -701,6 +700,25 @@ impl BenchAuthorizeWithSeed {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
+        let withdrawer_base_key = Pubkey::new_unique();
+        let withdrawer_owner = Pubkey::new_unique();
+        let withdrawer_seed = String::from("WITHDRAWER_SEED");
+
+        let authorized_voter =
+            Pubkey::create_with_seed(&voter_base_key, voter_seed.as_str(), &voter_owner).unwrap();
+        let authorized_withdrawer = Pubkey::create_with_seed(
+            &withdrawer_base_key,
+            withdrawer_seed.as_str(),
+            &withdrawer_owner,
+        )
+        .unwrap();
+        let vote_account = create_account_with_authorized(
+            &Pubkey::new_unique(),
+            &authorized_voter,
+            &authorized_withdrawer,
+            0,
+            100,
+        );
         let clock_account = account::create_account_shared_data_for_test(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
@@ -745,7 +763,105 @@ impl BenchAuthorizeWithSeed {
         }
     }
     fn run(&self) {
-        let _accounts = process_deprecated_instruction(
+        let _accounts = process_instruction(
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+        );
+    }
+}
+
+struct BenchAuthorizeCheckedWithSeed {
+    instruction_data: Vec<u8>,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+}
+
+impl BenchAuthorizeCheckedWithSeed {
+    fn new() -> Self {
+        let authorization_type: VoteAuthorize = VoteAuthorize::Voter;
+        let vote_pubkey = Pubkey::new_unique();
+        let current_authority_base_key = Pubkey::new_unique();
+        let current_authority_owner = Pubkey::new_unique();
+        let current_authority_seed = String::from("VOTER_SEED");
+        let withdrawer_base_key = Pubkey::new_unique();
+        let withdrawer_owner = Pubkey::new_unique();
+        let withdrawer_seed = String::from("WITHDRAWER_SEED");
+        let authorized_voter = Pubkey::create_with_seed(
+            &current_authority_base_key,
+            current_authority_seed.as_str(),
+            &current_authority_owner,
+        )
+        .unwrap();
+        let authorized_withdrawer = Pubkey::create_with_seed(
+            &withdrawer_base_key,
+            withdrawer_seed.as_str(),
+            &withdrawer_owner,
+        )
+        .unwrap();
+        let vote_account = create_account_with_authorized(
+            &Pubkey::new_unique(),
+            &authorized_voter,
+            &authorized_withdrawer,
+            0,
+            100,
+        );
+        let new_authority_pubkey = Pubkey::new_unique();
+        let clock = Clock {
+            epoch: 1,
+            leader_schedule_epoch: 2,
+            ..Clock::default()
+        };
+        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::clock::id(), clock_account),
+            (current_authority_base_key, AccountSharedData::default()),
+            (new_authority_pubkey, AccountSharedData::default()),
+        ];
+        let instruction_accounts = vec![
+            AccountMeta {
+                // `[Write]` Vote account to be updated
+                pubkey: vote_pubkey,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                // `[]` Clock sysvar
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                // `[SIGNER]` Base key of current Voter or Withdrawer authority's derived key
+                pubkey: current_authority_base_key,
+                is_signer: true,
+                is_writable: false,
+            },
+            AccountMeta {
+                // `[SIGNER]` New vote or withdraw authority
+                pubkey: new_authority_pubkey,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+        let instruction_data = serialize(&VoteInstruction::AuthorizeCheckedWithSeed(
+            VoteAuthorizeCheckedWithSeedArgs {
+                authorization_type,
+                current_authority_derived_key_owner: current_authority_owner,
+                current_authority_derived_key_seed: current_authority_seed,
+            },
+        ))
+        .unwrap();
+        Self {
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+        }
+    }
+    fn run(&self) {
+        let _accounts = process_instruction(
             &self.instruction_data,
             self.transaction_accounts.clone(),
             self.instruction_accounts.clone(),
@@ -831,6 +947,13 @@ fn bench_authorize_with_seed(c: &mut Criterion) {
     });
 }
 
+fn bench_authorize_checked_with_seed(c: &mut Criterion) {
+    let test_setup = BenchAuthorizeCheckedWithSeed::new();
+    c.bench_function("vote_authorize_checked_with_seed", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
 criterion_group!(
     benches,
     bench_initialize_account,
@@ -844,5 +967,6 @@ criterion_group!(
     bench_update_vote_state,
     bench_update_vote_state_switch,
     bench_authorize_with_seed,
+    bench_authorize_checked_with_seed,
 );
 criterion_main!(benches);

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -870,6 +870,62 @@ impl BenchAuthorizeCheckedWithSeed {
     }
 }
 
+struct BenchCompactUpdateVoteState {
+    instruction_data: Vec<u8>,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+}
+
+impl BenchCompactUpdateVoteState {
+    fn new() -> Self {
+        let (vote_pubkey, vote_account) = create_test_account();
+        let vote = Vote::new(vec![1], Hash::default());
+        let vote_state_update = VoteStateUpdate::from(vec![(1, 1)]);
+        let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
+        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey,
+                is_signer: true,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: sysvar::slot_hashes::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+        ];
+
+        let instruction_data =
+            serialize(&VoteInstruction::CompactUpdateVoteState(vote_state_update)).unwrap();
+
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account.clone()),
+            (sysvar::slot_hashes::id(), slot_hashes_account.clone()),
+            (sysvar::clock::id(), create_default_clock_account()),
+        ];
+
+        Self {
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+        }
+    }
+    fn run(&self) {
+        let _accounts = process_deprecated_instruction(
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+        );
+    }
+}
+
 fn bench_initialize_account(c: &mut Criterion) {
     let test_setup = BenchInitializeAccount::new();
     c.bench_function("vote_instruction_initialize_account", |bencher| {
@@ -954,6 +1010,13 @@ fn bench_authorize_checked_with_seed(c: &mut Criterion) {
     });
 }
 
+fn bench_compact_update_vote_state(c: &mut Criterion) {
+    let test_setup = BenchCompactUpdateVoteState::new();
+    c.bench_function("vote_compact_update_vote_state", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
 criterion_group!(
     benches,
     bench_initialize_account,
@@ -968,5 +1031,6 @@ criterion_group!(
     bench_update_vote_state_switch,
     bench_authorize_with_seed,
     bench_authorize_checked_with_seed,
+    bench_compact_update_vote_state,
 );
 criterion_main!(benches);

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -18,8 +18,9 @@ use {
         vote_instruction::VoteInstruction,
         vote_processor::Entrypoint,
         vote_state::{
-            create_account, create_account_with_authorized, Vote, VoteAuthorize, VoteInit,
-            VoteState, VoteStateUpdate, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+            create_account, create_account_with_authorized, Vote, VoteAuthorize,
+            VoteAuthorizeWithSeedArgs, VoteInit, VoteState, VoteStateUpdate, VoteStateVersions,
+            MAX_LOCKOUT_HISTORY,
         },
     },
     std::sync::Arc,
@@ -681,6 +682,78 @@ impl BenchUpdateVoteState {
     }
 }
 
+struct BenchAuthorizeWithSeed {
+    instruction_data: Vec<u8>,
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+}
+
+impl BenchAuthorizeWithSeed {
+    fn new() -> Self {
+        let vote_pubkey = Pubkey::new_unique();
+        let voter_base_key = Pubkey::new_unique();
+        let vote_account = AccountSharedData::new(100, VoteState::size_of(), &id());
+        let voter_owner = Pubkey::new_unique();
+        let voter_seed = String::from("VOTER_SEED");
+        let new_voter_pubkey = Pubkey::new_unique();
+        let clock = Clock {
+            epoch: 1,
+            leader_schedule_epoch: 2,
+            ..Clock::default()
+        };
+        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::clock::id(), clock_account),
+            (voter_base_key, AccountSharedData::default()),
+        ];
+        let instruction_accounts = vec![
+            AccountMeta {
+                // `[Write]` Vote account to be updated
+                pubkey: vote_pubkey,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                // `[]` Clock sysvar
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                // `[SIGNER]` Base key of current Voter or Withdrawer authority's derived key
+                pubkey: voter_base_key,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+
+        let authorization_type = VoteAuthorize::Voter;
+        let instruction_data = serialize(&VoteInstruction::AuthorizeWithSeed(
+            VoteAuthorizeWithSeedArgs {
+                authorization_type,
+                current_authority_derived_key_owner: voter_owner,
+                current_authority_derived_key_seed: voter_seed,
+                new_authority: new_voter_pubkey,
+            },
+        ))
+        .unwrap();
+        Self {
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+        }
+    }
+    fn run(&self) {
+        let _accounts = process_deprecated_instruction(
+            &self.instruction_data,
+            self.transaction_accounts.clone(),
+            self.instruction_accounts.clone(),
+            Ok(()),
+        );
+    }
+}
+
 fn bench_initialize_account(c: &mut Criterion) {
     let test_setup = BenchInitializeAccount::new();
     c.bench_function("vote_instruction_initialize_account", |bencher| {
@@ -751,6 +824,13 @@ fn bench_update_vote_state_switch(c: &mut Criterion) {
     });
 }
 
+fn bench_authorize_with_seed(c: &mut Criterion) {
+    let test_setup = BenchAuthorizeWithSeed::new();
+    c.bench_function("vote_authorize_with_seed", |bencher| {
+        bencher.iter(|| test_setup.run())
+    });
+}
+
 criterion_group!(
     benches,
     bench_initialize_account,
@@ -763,5 +843,6 @@ criterion_group!(
     bench_authorize_checked,
     bench_update_vote_state,
     bench_update_vote_state_switch,
+    bench_authorize_with_seed,
 );
 criterion_main!(benches);


### PR DESCRIPTION
#### Problem
Part of: https://github.com/anza-xyz/agave/issues/3364

#### Summary of Changes
AuthorizeWithSeed
AuthorizeCheckedWithSeed
CompactUpdateVoteState
CompactUpdateVoteStateSwitch
TowerSync
TowerSyncSwitch

```
vote_authorize_with_seed
                        time:   [19.008 µs 19.032 µs 19.058 µs]
                        change: [+0.0734% +0.6310% +0.9501%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

vote_authorize_checked_with_seed
                        time:   [18.860 µs 18.868 µs 18.877 µs]
                        change: [+0.5467% +0.6135% +0.6776%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

vote_compact_update_vote_state
                        time:   [22.220 µs 22.247 µs 22.284 µs]
                        change: [-0.2787% -0.1999% -0.1157%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

vote_compact_update_vote_state_switch
                        time:   [22.429 µs 22.436 µs 22.443 µs]
                        change: [-1.0326% -0.9583% -0.8881%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

vote_tower_sync         time:   [22.410 µs 22.423 µs 22.437 µs]
                        change: [+0.5608% +0.7428% +0.9066%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

vote_tower_sync_switch  time:   [22.652 µs 22.665 µs 22.677 µs]
                        change: [-0.9113% -0.7565% -0.6192%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```