### PR TITLE
add deduper to streamer

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1257,6 +1257,17 @@ async fn handle_chunks(
         return Err(());
     }
 
+    // (1 + 64) + (1 + 1 + 1) + (1 + 32) + 32 + 1 = 134 - no instructions
+    // (32 - program account) + (1 + (1 + 0) + (1 + 0) = 3 - the smallest instruction) = 35
+    // 134 + 35 = 169
+    const MINIMUM_SIGNIFICANT_TRANSACTION_SIZE: usize = 169;
+    if accum.meta.size < MINIMUM_SIGNIFICANT_TRANSACTION_SIZE {
+        stats
+            .total_packets_too_small
+            .fetch_add(1, Ordering::Relaxed);
+        return Err(());
+    }
+
     // done receiving chunks
     let bytes_sent = accum.meta.size;
     let chunks_sent = accum.chunks.len();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -172,6 +172,7 @@ pub struct StreamerStats {
     pub(crate) total_packets_sent_to_consumer: AtomicUsize,
     pub(crate) total_bytes_sent_to_consumer: AtomicUsize,
     pub(crate) total_chunks_processed_by_batcher: AtomicUsize,
+    pub(crate) total_packets_too_small: AtomicUsize,
     pub(crate) total_stream_read_errors: AtomicUsize,
     pub(crate) total_stream_read_timeouts: AtomicUsize,
     pub(crate) num_evictions: AtomicUsize,
@@ -422,6 +423,11 @@ impl StreamerStats {
                 "chunks_processed_by_batcher",
                 self.total_chunks_processed_by_batcher
                     .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_packets_too_small",
+                self.total_packets_too_small.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -173,6 +173,8 @@ pub struct StreamerStats {
     pub(crate) total_bytes_sent_to_consumer: AtomicUsize,
     pub(crate) total_chunks_processed_by_batcher: AtomicUsize,
     pub(crate) total_packets_too_small: AtomicUsize,
+    pub(crate) total_packets_deduped_by_batcher: AtomicUsize,
+    pub(crate) total_chunks_deduped_by_batcher: AtomicUsize,
     pub(crate) total_stream_read_errors: AtomicUsize,
     pub(crate) total_stream_read_timeouts: AtomicUsize,
     pub(crate) num_evictions: AtomicUsize,
@@ -428,6 +430,18 @@ impl StreamerStats {
             (
                 "total_packets_too_small",
                 self.total_packets_too_small.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_packets_deduped_by_batcher",
+                self.total_packets_deduped_by_batcher
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_chunks_deduped_by_batcher",
+                self.total_chunks_deduped_by_batcher
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

x2-x5 txs on tpu port are duplicates

#### Summary of Changes

I’m sure you won’t accept this PR as it is because it adds business logic to the abstract streamer.
Maybe it would be better to pass a closure into the constructor and use it here for such filtering.
So, I just want to demonstrate how to reduce about 10% of the traffic for further processing.

Bench for AHashSet<[u8; 64]>: 678us for 1000 x 64

<img width="530" alt="image" src="https://github.com/user-attachments/assets/af30a78a-539f-443d-a5a5-add183eb1b3a" />

