### PR TITLE
reworks gossip packets-sent metrics

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -6,6 +6,7 @@ use {
     rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator},
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
+        borrow::Borrow,
         io::Read,
         net::SocketAddr,
         ops::{Index, IndexMut},
@@ -73,19 +74,25 @@ impl PacketBatch {
         batch
     }
 
-    pub fn new_unpinned_with_recycler_data_and_dests<T: solana_packet::Encode>(
+    pub fn new_unpinned_with_recycler_data_and_dests<S, T>(
         recycler: &PacketBatchRecycler,
         name: &'static str,
-        dests_and_data: &[(SocketAddr, T)],
-    ) -> Self {
+        dests_and_data: impl IntoIterator<Item = (S, T), IntoIter: ExactSizeIterator>,
+    ) -> Self
+    where
+        S: Borrow<SocketAddr>,
+        T: solana_packet::Encode,
+    {
+        let dests_and_data = dests_and_data.into_iter();
         let mut batch = Self::new_unpinned_with_recycler(recycler, dests_and_data.len(), name);
         batch
             .packets
             .resize(dests_and_data.len(), Packet::default());
 
-        for ((addr, data), packet) in dests_and_data.iter().zip(batch.packets.iter_mut()) {
+        for ((addr, data), packet) in dests_and_data.zip(batch.packets.iter_mut()) {
+            let addr = addr.borrow();
             if !addr.ip().is_unspecified() && addr.port() != 0 {
-                if let Err(e) = Packet::populate_packet(packet, Some(addr), data) {
+                if let Err(e) = Packet::populate_packet(packet, Some(addr), &data) {
                     // TODO: This should never happen. Instead the caller should
                     // break the payload into smaller messages, and here any errors
                     // should be propagated.


### PR DESCRIPTION

#### Problem
A lot of gossip packets are not counted, and for some there are duplicate metrics.

#### Summary of Changes
The commit adds helper methods to count gossip packet every time we create outbound packets.
