### PR TITLE
Stops ABS in wen_restart when generating a snapshot

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1551,6 +1551,7 @@ impl Validator {
                     WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT,
                 snapshot_config: config.snapshot_config.clone(),
                 accounts_background_request_sender: accounts_background_request_sender.clone(),
+                abs_status: accounts_background_service.status().clone(),
                 genesis_config_hash: genesis_config.hash(),
                 exit: exit.clone(),
             })?;


### PR DESCRIPTION
#### Problem

When wen_restart generates a snapshot, AccountsBackgroundService is still running. The accounts-db background tasks (flush/clean/shrink) cannot run concurrent with each other, but since ABS is still running (and generating a snapshot calls flush & clean), this invariant is broken. We observe asserts on larger tests indicating as such.


#### Summary of Changes

Stop ABS before wen-restart generates a snapshot.

Note to reviewers: I recommend ignoring whitespace in the diff view.