### PR TITLE
Mergify backport v2.2

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -104,51 +104,14 @@ pull_request_rules:
           - automerge
       comment:
         message: automerge label removed due to a CI failure
-  - name: v2.0 feature-gate backport
-    conditions:
-      - label=v2.0
-      - label=feature-gate
-    actions:
-      backport:
-        assignees: &BackportAssignee
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@anza-xyz/community-pr-subscribers')) }}"
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        labels:
-          - feature-gate
-        branches:
-          - v2.0
-  - name: v2.0 non-feature-gate backport
-    conditions:
-      - label=v2.0
-      - label!=feature-gate
-    actions:
-      backport:
-        assignees: *BackportAssignee
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        branches:
-          - v2.0
-  - name: v2.0 backport warning comment
-    conditions:
-      - label=v2.0
-    actions:
-      comment:
-        message: >
-          Backports to the stable branch are to be avoided unless absolutely
-          necessary for fixing bugs, security issues, and perf regressions.
-          Changes intended for backport should be structured such that a
-          minimum effective diff can be committed separately from any
-          refactoring, plumbing, cleanup, etc that are not strictly
-          necessary to achieve the goal. Any of the latter should go only
-          into master and ride the normal stabilization schedule.
   - name: v2.1 feature-gate backport
     conditions:
       - label=v2.1
       - label=feature-gate
     actions:
       backport:
-        assignees: *BackportAssignee
+        assignees: &BackportAssignee
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@anza-xyz/community-pr-subscribers')) }}"
         title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
         ignore_conflicts: true
         labels:
@@ -169,6 +132,43 @@ pull_request_rules:
   - name: v2.1 backport warning comment
     conditions:
       - label=v2.1
+    actions:
+      comment:
+        message: >
+          Backports to the stable branch are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule.
+  - name: v2.2 feature-gate backport
+    conditions:
+      - label=v2.2
+      - label=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        labels:
+          - feature-gate
+        branches:
+          - v2.2
+  - name: v2.2 non-feature-gate backport
+    conditions:
+      - label=v2.2
+      - label!=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        branches:
+          - v2.2
+  - name: v2.2 backport warning comment
+    conditions:
+      - label=v2.2
     actions:
       comment:
         message: >


### PR DESCRIPTION
The release branches have been advanced (beta is v2.2, stable is v2.1, and v2.0 is EOL). This updates the mergify config accordingly

I've created the v2.2 label. I'll delete the v2.0 label after this is merged.