### PR TITLE
Clean up and fix PER stats

### DIFF
--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -22,6 +22,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) redeem_rewards_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_vote_accounts_us: AtomicU64,
+    pub(crate) hash_partition_rewards_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -89,6 +90,11 @@ pub(crate) fn report_new_epoch_metrics(
         (
             "store_vote_accounts_us",
             metrics.store_vote_accounts_us.load(Relaxed),
+            i64
+        ),
+        (
+            "hash_partition_rewards_us",
+            metrics.hash_partition_rewards_us,
             i64
         ),
     );

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -18,13 +18,10 @@ pub(crate) struct NewEpochTimings {
 
 #[derive(Debug, Default)]
 pub(crate) struct RewardsMetrics {
-    pub(crate) load_vote_and_stake_accounts_us: AtomicU64,
     pub(crate) calculate_points_us: AtomicU64,
     pub(crate) redeem_rewards_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_vote_accounts_us: AtomicU64,
-    pub(crate) vote_accounts_cache_miss_count: usize,
-    pub(crate) hash_partition_rewards_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -79,11 +76,6 @@ pub(crate) fn report_new_epoch_metrics(
             i64
         ),
         (
-            "load_vote_and_stake_accounts_us",
-            metrics.load_vote_and_stake_accounts_us.load(Relaxed),
-            i64
-        ),
-        (
             "calculate_points_us",
             metrics.calculate_points_us.load(Relaxed),
             i64
@@ -97,16 +89,6 @@ pub(crate) fn report_new_epoch_metrics(
         (
             "store_vote_accounts_us",
             metrics.store_vote_accounts_us.load(Relaxed),
-            i64
-        ),
-        (
-            "vote_accounts_cache_miss_count",
-            metrics.vote_accounts_cache_miss_count,
-            i64
-        ),
-        (
-            "hash_partition_rewards_us",
-            metrics.hash_partition_rewards_us,
             i64
         ),
     );

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -22,6 +22,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) redeem_rewards_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_vote_accounts_us: AtomicU64,
+    pub(crate) vote_accounts_cache_miss_count: AtomicU64,
     pub(crate) hash_partition_rewards_us: u64,
 }
 
@@ -90,6 +91,11 @@ pub(crate) fn report_new_epoch_metrics(
         (
             "store_vote_accounts_us",
             metrics.store_vote_accounts_us.load(Relaxed),
+            i64
+        ),
+        (
+            "vote_accounts_cache_miss_count",
+            metrics.vote_accounts_cache_miss_count.load(Relaxed),
             i64
         ),
         (

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -346,6 +346,7 @@ impl Bank {
             // already have been cached in cached_vote_accounts; so the code
             // below is only for sanity checking, and can be removed once
             // the cache is deemed to be reliable.
+            metrics.vote_accounts_cache_miss_count.fetch_add(1, Relaxed);
             let account = self.get_account_with_fixed_root(vote_pubkey)?;
             VoteAccount::try_from(account).ok()
         };

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -238,11 +238,12 @@ impl Bank {
             .parent()
             .expect("Partitioned rewards calculation must still have access to parent Bank.")
             .last_blockhash();
-        let stake_rewards_by_partition = hash_rewards_into_partitions(
+        let (stake_rewards_by_partition, hash_us) = measure_us!(hash_rewards_into_partitions(
             std::mem::take(&mut stake_rewards.stake_rewards),
             &parent_blockhash,
             num_partitions as usize,
-        );
+        ));
+        metrics.hash_partition_rewards_us += hash_us;
 
         PartitionedRewardsCalculation {
             vote_account_rewards,


### PR DESCRIPTION
#### Problem

Now we enabled PER and deleted the old ER code path. There are a few stats that are missing from the PER code path.

load_vote_and_stake_accounts_us, hash reward partition timing  and vote_accounts_cache_miss_count stats are not hooked up in PER code path.

#### Summary of Changes

- Remove stale PER stat - load_vote_and_stake_accounts_us (no longer applicable)
- fix hash reward partition timing stat
- add back vote_accounts_cache_miss_count


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
