### PR TITLE
v2.1: CI: Set the spl-token-cli version

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.1.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

v2.1 has become the stable branch, but it doesn't pin a version of spl-token-cli, as is required by `check-install-all.sh`.

#### Summary of changes

Since 5.1.0 is currently the [latest version](https://crates.io/crates/spl-token-cli) at crates.io, use that for the stable branch.