### PR TITLE
Remove SVM's dep on compute-budget-instructions crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # repo and would like to avoid introducing dependencies in the meantime.
 /builtins-default-costs/ @anza-xyz/svm
 /compute-budget/ @anza-xyz/svm
-/compute-budget-instruction/ @anza-xyz/svm @anza-xyz/fees
+/compute-budget-instruction/ @anza-xyz/fees
 /fee/ @anza-xyz/fees
 /log-collector/ @anza-xyz/svm
 /program-runtime/ @anza-xyz/svm

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8414,7 +8414,6 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
- "solana-compute-budget-instruction",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-hash",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -21,7 +21,6 @@ solana-account = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-compute-budget-instruction = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -71,6 +70,7 @@ rand0-7 = { workspace = true }
 shuttle = { workspace = true }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true, features = ["dev-context-only-utils"] }
+solana-compute-budget-instruction = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-ed25519-program = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7733,7 +7733,6 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
- "solana-compute-budget-instruction",
  "solana-feature-set",
  "solana-fee-structure",
  "solana-hash",


### PR DESCRIPTION
#### Problem
SVM doesn't need a hard dependency on `solana-compute-budget-instructions` crate. It should be demoted to a `dev-dependency`.

#### Summary of Changes
Demote to `dev-dependency`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
