### PR TITLE
docs: Remove copied installation commands

### DIFF
--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -156,15 +156,11 @@ installed on your system.
 
 Before building from source, make sure to install the following prerequisites:
 
+#### Rust
+
+For all platforms, check "Install Rust" at [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install) for the latest installation instructions.
+
 #### For Debian and Other Linux Distributions:
-
-Rust Programming Language: Check "Install Rust" at
-[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
-which recommends the following command.
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
 
 Install build dependencies:
 
@@ -205,14 +201,6 @@ Follow the instructions given at the end of the brew install command about
 `PATH` configurations.
 
 #### For Windows:
-
-Rust Programming Language: Check "Install Rust" at
-[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
-which recommends the following command.
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
 
 - Download and install the Build Tools for Visual Studio (2019 or later) from
   the

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -184,7 +184,7 @@ Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`,
 
 #### For macOS:
 
-Check "Install Homebrew" at https://brew.sh/](https://brew.sh/) for the latest installation instruction for Homebrew if not already installed.
+Check "Install Homebrew" at [https://brew.sh/](https://brew.sh/) for the latest installation instruction for Homebrew if not already installed.
 
 Then, install build dependencies with `brew`:
 

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -194,7 +194,7 @@ Install Homebrew (if not already installed), check "Install Homebrew" at
 Install the necessary tools and libraries using Homebrew:
 
 ```bash
-brew install rust pkg-config libudev protobuf llvm coreutils
+brew install pkg-config libudev protobuf llvm coreutils
 ```
 
 Follow the instructions given at the end of the brew install command about

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -184,14 +184,9 @@ Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`,
 
 #### For macOS:
 
-Install Homebrew (if not already installed), check "Install Homebrew" at
-[https://brew.sh/](https://brew.sh/), which recommends the following command:
+Check "Install Homebrew" at https://brew.sh/](https://brew.sh/) for the latest installation instruction for Homebrew if not already installed.
 
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-Install the necessary tools and libraries using Homebrew:
+Then, install build dependencies with `brew`:
 
 ```bash
 brew install pkg-config libudev protobuf llvm coreutils

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -158,7 +158,9 @@ Before building from source, make sure to install the following prerequisites:
 
 #### Rust
 
-For all platforms, check "Install Rust" at [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install) for the latest installation instructions.
+For all platforms, check "Install Rust" at
+[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install)
+for the latest installation instructions.
 
 #### For Debian and Other Linux Distributions:
 
@@ -184,7 +186,8 @@ Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`,
 
 #### For macOS:
 
-Check "Install Homebrew" at [https://brew.sh/](https://brew.sh/) for the latest installation instruction for Homebrew if not already installed.
+Check "Install Homebrew" at [https://brew.sh/](https://brew.sh/) for the latest
+installation instruction for Homebrew if not already installed.
 
 Then, install build dependencies with `brew`:
 


### PR DESCRIPTION
#### Problem
Our installation instruction copy commands from Rust and Homebrew installation instructions. Should those ever change, it is almost guaranteed that our copy would be stale.

#### Summary of Changes
Remove the copied commands in our docs