### PR TITLE
ledger-tool: Allow dead slots for slot command when metadata absent

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -586,7 +586,11 @@ pub fn output_slot(
         Err(_) => {
             // Transaction metadata could be missing, try to fetch just the
             // entries and leave the metadata fields empty
-            let entries = blockstore.get_slot_entries(slot, /*shred_start_index:*/ 0)?;
+            let (entries, _, _) = blockstore.get_slot_entries_with_shred_info(
+                slot,
+                /*shred_start_index:*/ 0,
+                allow_dead_slots,
+            )?;
 
             let blockhash = entries
                 .last()


### PR DESCRIPTION
#### Problem
The slot command will reject dead slots by default. This behavior can be overridden by passing --allow-dead-slots. Additionally, in the event that transaction metadata is missing or the slot is incomplete in the blockstore, a best effort attempt will be made to get as much data out as possible.

#### Summary of Changes
This fallback case did not have the allow dead slots parameter plumbed through, so hook it up to allow fetching dead, partial slots