### PR TITLE
Fix - loader-v4 deployment buffer funds retrieval

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -18,7 +18,9 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_sbpf::{declare_builtin_function, memory_region::MemoryMapping},
-    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
+    solana_sdk_ids::{
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, system_program,
+    },
     solana_transaction_context::{BorrowedAccount, InstructionContext},
     solana_type_overrides::sync::{atomic::Ordering, Arc},
     std::{cell::RefCell, rc::Rc},
@@ -341,6 +343,7 @@ fn process_instruction_deploy(invoke_context: &mut InvokeContext) -> Result<(), 
         source_program.set_data_length(0)?;
         source_program.checked_sub_lamports(transfer_lamports)?;
         program.checked_add_lamports(transfer_lamports)?;
+        source_program.set_owner(&system_program::id().to_bytes())?;
     }
     let state = get_state_mut(program.get_data_mut()?)?;
     state.slot = current_slot;

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -336,13 +336,12 @@ fn process_instruction_deploy(invoke_context: &mut InvokeContext) -> Result<(), 
     );
 
     if let Some(mut source_program) = source_program {
-        let rent = invoke_context.get_sysvar_cache().get_rent()?;
-        let required_lamports = rent.minimum_balance(source_program.get_data().len());
-        let transfer_lamports = required_lamports.saturating_sub(program.get_lamports());
         program.set_data_from_slice(source_program.get_data())?;
         source_program.set_data_length(0)?;
-        source_program.checked_sub_lamports(transfer_lamports)?;
-        program.checked_add_lamports(transfer_lamports)?;
+        let dst_lamports = program.get_lamports();
+        let src_lamports = source_program.get_lamports();
+        source_program.set_lamports(dst_lamports)?;
+        program.set_lamports(src_lamports)?;
         source_program.set_owner(&system_program::id().to_bytes())?;
     }
     let state = get_state_mut(program.get_data_mut()?)?;
@@ -1335,20 +1334,14 @@ mod tests {
             &[(0, false, true), (1, true, false), (2, false, true)],
             Ok(()),
         );
-        transaction_accounts[0].1 = accounts[0].clone();
         assert_eq!(
             accounts[0].data().len(),
             transaction_accounts[2].1.data().len(),
         );
         assert_eq!(accounts[2].data().len(), 0,);
-        assert_eq!(
-            accounts[2].lamports(),
-            transaction_accounts[2].1.lamports().saturating_sub(
-                accounts[0]
-                    .lamports()
-                    .saturating_sub(transaction_accounts[0].1.lamports())
-            ),
-        );
+        assert_eq!(accounts[0].lamports(), transaction_accounts[2].1.lamports());
+        assert_eq!(accounts[2].lamports(), transaction_accounts[0].1.lamports());
+        transaction_accounts[0].1 = accounts[0].clone();
 
         // Error: Program was deployed recently, cooldown still in effect
         process_instruction(


### PR DESCRIPTION
#### Problem
See https://github.com/solana-foundation/solana-improvement-documents/pull/167#discussion_r1947381572. Currently redeployments using a source program account (buffer account) requires some unnecessary extra steps such as reopening and immediately closing the source program account to retrieve its funds.

#### Summary of Changes
- Assigns the source program account (buffer account) back to the system program after the deployment. This way the funds can be transferred out without additional loader instructions.
- Swaps the funds of the source program account (buffer account) and the program account. This way the correct amount for rent exemption (as it was calculated for the source program account) remains with the program account and the rest is deposited into the source program account to be retrieved. This mechanism is simple and works with programs growing, staying the same size or shrinking.