### PR TITLE
agave-validator: add args tests for set-identity

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -75,7 +75,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(commands::monitor::command(default_args))
         .subcommand(SubCommand::with_name("run").about("Run the validator"))
         .subcommand(commands::plugin::command(default_args))
-        .subcommand(commands::set_identity::command(default_args))
+        .subcommand(commands::set_identity::command())
         .subcommand(commands::set_log_filter::command())
         .subcommand(commands::staked_nodes_overrides::command())
         .subcommand(commands::wait_for_restart_window::command())

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -9,6 +9,7 @@ use {
 const COMMAND: &str = "set-identity";
 
 #[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Default))]
 pub struct SetIdentityArgs {
     pub identity: Option<String>,
     pub require_tower: bool,
@@ -97,14 +98,7 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_set_identity_default() {
-        verify_args_struct_by_command(
-            command(),
-            vec![COMMAND],
-            SetIdentityArgs {
-                identity: None,
-                require_tower: false,
-            },
-        );
+        verify_args_struct_by_command(command(), vec![COMMAND], SetIdentityArgs::default());
     }
 
     #[test]
@@ -120,7 +114,7 @@ mod tests {
             vec![COMMAND, file.to_str().unwrap()],
             SetIdentityArgs {
                 identity: Some(file.to_str().unwrap().to_string()),
-                require_tower: false,
+                ..SetIdentityArgs::default()
             },
         );
     }
@@ -131,8 +125,8 @@ mod tests {
             command(),
             vec![COMMAND, "--require-tower"],
             SetIdentityArgs {
-                identity: None,
                 require_tower: true,
+                ..SetIdentityArgs::default()
             },
         );
     }

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -46,10 +46,12 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let set_identity_args = SetIdentityArgs::from_clap_arg_match(matches)?;
-    let require_tower = set_identity_args.require_tower;
+    let SetIdentityArgs {
+        identity,
+        require_tower,
+    } = SetIdentityArgs::from_clap_arg_match(matches)?;
 
-    if let Some(identity_keypair) = set_identity_args.identity {
+    if let Some(identity_keypair) = identity {
         let identity_keypair = fs::canonicalize(&identity_keypair)
             .map_err(|err| format!("unable to access path {identity_keypair}: {err:?}"))?;
 

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -1,13 +1,29 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs},
+    crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
     clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::is_keypair,
     solana_sdk::signature::{read_keypair, Signer},
     std::{fs, path::Path},
 };
 
+const COMMAND: &str = "set-identity";
+
+#[derive(Debug, PartialEq)]
+pub struct SetIdentityArg {
+    pub identity: Option<String>,
+    pub require_tower: bool,
+}
+
+impl FromClapArgMatches for SetIdentityArg {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+        Ok(SetIdentityArg {
+            identity: value_t!(matches, "identity", String).ok(),
+            require_tower: matches.is_present("require_tower"),
+        })
+    }
+}
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
-    SubCommand::with_name("set-identity")
+    SubCommand::with_name(COMMAND)
         .about("Set the validator identity")
         .arg(
             Arg::with_name("identity")
@@ -30,9 +46,10 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let require_tower = matches.is_present("require_tower");
+    let set_identity_arg = SetIdentityArg::from_clap_arg_match(matches)?;
+    let require_tower = set_identity_arg.require_tower;
 
-    if let Ok(identity_keypair) = value_t!(matches, "identity", String) {
+    if let Some(identity_keypair) = set_identity_arg.identity {
         let identity_keypair = fs::canonicalize(&identity_keypair)
             .map_err(|err| format!("unable to access path {identity_keypair}: {err:?}"))?;
 
@@ -66,5 +83,52 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
                     .await
             })
             .map_err(|err| format!("set identity request failed: {err}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::commands::tests::verify_args_struct_by_command};
+
+    #[test]
+    fn verify_args_struct_by_command_set_identity_default() {
+        verify_args_struct_by_command(
+            command(&DefaultArgs::default()),
+            vec![COMMAND],
+            SetIdentityArg {
+                identity: None,
+                require_tower: false,
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_set_identity_with_identity_file() {
+        // generate a keypair
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_path = tmp_dir.path().join("id.json");
+        let keypair_string = "[99,66,147,169,175,95,166,214,27,255,19,64,81,255,101,39,10,24,205,48,226,191,98,234,210,86,174,34,2,121,173,223,9,36,145,159,1,95,129,252,249,189,217,191,13,169,231,216,4,181,124,105,193,20,61,251,197,68,44,240,205,70,115,226]";
+        std::fs::write(&tmp_path, keypair_string).unwrap();
+
+        verify_args_struct_by_command(
+            command(&DefaultArgs::default()),
+            vec![COMMAND, tmp_path.to_str().unwrap()],
+            SetIdentityArg {
+                identity: Some(tmp_path.to_str().unwrap().to_string()),
+                require_tower: false,
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_set_identity_with_require_tower() {
+        verify_args_struct_by_command(
+            command(&DefaultArgs::default()),
+            vec![COMMAND, "--require-tower"],
+            SetIdentityArg {
+                identity: None,
+                require_tower: true,
+            },
+        );
     }
 }

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -9,14 +9,14 @@ use {
 const COMMAND: &str = "set-identity";
 
 #[derive(Debug, PartialEq)]
-pub struct SetIdentityArg {
+pub struct SetIdentityArgs {
     pub identity: Option<String>,
     pub require_tower: bool,
 }
 
-impl FromClapArgMatches for SetIdentityArg {
+impl FromClapArgMatches for SetIdentityArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
-        Ok(SetIdentityArg {
+        Ok(SetIdentityArgs {
             identity: value_t!(matches, "identity", String).ok(),
             require_tower: matches.is_present("require_tower"),
         })
@@ -46,10 +46,10 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let set_identity_arg = SetIdentityArg::from_clap_arg_match(matches)?;
-    let require_tower = set_identity_arg.require_tower;
+    let set_identity_args = SetIdentityArgs::from_clap_arg_match(matches)?;
+    let require_tower = set_identity_args.require_tower;
 
-    if let Some(identity_keypair) = set_identity_arg.identity {
+    if let Some(identity_keypair) = set_identity_args.identity {
         let identity_keypair = fs::canonicalize(&identity_keypair)
             .map_err(|err| format!("unable to access path {identity_keypair}: {err:?}"))?;
 
@@ -95,7 +95,7 @@ mod tests {
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
             vec![COMMAND],
-            SetIdentityArg {
+            SetIdentityArgs {
                 identity: None,
                 require_tower: false,
             },
@@ -113,7 +113,7 @@ mod tests {
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
             vec![COMMAND, tmp_path.to_str().unwrap()],
-            SetIdentityArg {
+            SetIdentityArgs {
                 identity: Some(tmp_path.to_str().unwrap().to_string()),
                 require_tower: false,
             },
@@ -125,7 +125,7 @@ mod tests {
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
             vec![COMMAND, "--require-tower"],
-            SetIdentityArg {
+            SetIdentityArgs {
                 identity: None,
                 require_tower: true,
             },

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
+    crate::{admin_rpc_service, commands::FromClapArgMatches},
     clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::is_keypair,
     solana_sdk::signature::{read_keypair, Signer},
@@ -22,7 +22,7 @@ impl FromClapArgMatches for SetIdentityArgs {
         })
     }
 }
-pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name(COMMAND)
         .about("Set the validator identity")
         .arg(
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_set_identity_default() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND],
             SetIdentityArgs {
                 identity: None,
@@ -116,7 +116,7 @@ mod tests {
         solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
 
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, file.to_str().unwrap()],
             SetIdentityArgs {
                 identity: Some(file.to_str().unwrap().to_string()),
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_set_identity_with_require_tower() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, "--require-tower"],
             SetIdentityArgs {
                 identity: None,

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -90,7 +90,10 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::commands::tests::verify_args_struct_by_command};
+    use {
+        super::*, crate::commands::tests::verify_args_struct_by_command,
+        solana_sdk::signature::Keypair,
+    };
 
     #[test]
     fn verify_args_struct_by_command_set_identity_default() {
@@ -108,15 +111,15 @@ mod tests {
     fn verify_args_struct_by_command_set_identity_with_identity_file() {
         // generate a keypair
         let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path().join("id.json");
-        let keypair_string = "[99,66,147,169,175,95,166,214,27,255,19,64,81,255,101,39,10,24,205,48,226,191,98,234,210,86,174,34,2,121,173,223,9,36,145,159,1,95,129,252,249,189,217,191,13,169,231,216,4,181,124,105,193,20,61,251,197,68,44,240,205,70,115,226]";
-        std::fs::write(&tmp_path, keypair_string).unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = Keypair::new();
+        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
 
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
-            vec![COMMAND, tmp_path.to_str().unwrap()],
+            vec![COMMAND, file.to_str().unwrap()],
             SetIdentityArgs {
-                identity: Some(tmp_path.to_str().unwrap().to_string()),
+                identity: Some(file.to_str().unwrap().to_string()),
                 require_tower: false,
             },
         );


### PR DESCRIPTION
#### Problem

#4082 

#### Summary of Changes

extracting args parsing logic and adding tests

