### PR TITLE
Removes AccountStorageReference

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -22,7 +22,7 @@ mod tests {
             stakes::{SerdeStakesToStakeFormat, Stakes, StakesEnum},
         },
         solana_accounts_db::{
-            account_storage::{AccountStorageMap, AccountStorageReference},
+            account_storage::AccountStorageMap,
             accounts_db::{
                 get_temp_accounts_paths, AccountStorageEntry, AccountsDb, AccountsDbConfig,
                 AtomicAccountsFileId, ACCOUNTS_DB_CONFIG_FOR_TESTING,
@@ -79,13 +79,7 @@ mod tests {
                 num_accounts,
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
-            storage.insert(
-                new_storage_entry.slot(),
-                AccountStorageReference {
-                    id: new_storage_entry.id(),
-                    storage: Arc::new(new_storage_entry),
-                },
-            );
+            storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));
         }
 
         Ok(StorageAndNextAccountsFileId {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -13,7 +13,7 @@ mod serde_snapshot_tests {
         log::info,
         rand::{thread_rng, Rng},
         solana_accounts_db::{
-            account_storage::{AccountStorageMap, AccountStorageReference},
+            account_storage::AccountStorageMap,
             accounts::Accounts,
             accounts_db::{
                 get_temp_accounts_paths, test_utils::create_test_accounts, AccountStorageEntry,
@@ -159,13 +159,7 @@ mod serde_snapshot_tests {
                 num_accounts,
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
-            storage.insert(
-                new_storage_entry.slot(),
-                AccountStorageReference {
-                    id: new_storage_entry.id(),
-                    storage: Arc::new(new_storage_entry),
-                },
-            );
+            storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));
         }
 
         Ok(StorageAndNextAccountsFileId {

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -15,8 +15,8 @@ use {
     },
     regex::Regex,
     solana_accounts_db::{
-        account_storage::{AccountStorageMap, AccountStorageReference},
-        accounts_db::{AccountStorageEntry, AccountsFileId, AtomicAccountsFileId},
+        account_storage::AccountStorageMap,
+        accounts_db::{AccountsFileId, AtomicAccountsFileId},
         accounts_file::StorageAccess,
     },
     solana_nohash_hasher::BuildNoHashHasher,
@@ -342,10 +342,9 @@ impl SnapshotStorageRebuilder {
                     )?,
                 };
 
-                Ok((storage_entry.id(), storage_entry))
+                Ok(storage_entry)
             })
-            .collect::<Result<HashMap<AccountsFileId, Arc<AccountStorageEntry>>, SnapshotError>>(
-            )?;
+            .collect::<Result<Vec<_>, SnapshotError>>()?;
 
         if slot_stores.len() != 1 {
             return Err(SnapshotError::RebuildStorages(format!(
@@ -355,10 +354,9 @@ impl SnapshotStorageRebuilder {
         }
         // SAFETY: The check above guarantees there is one item in slot_stores,
         // so `.next()` will always return `Some`
-        let (id, storage) = slot_stores.into_iter().next().unwrap();
+        let storage = slot_stores.into_iter().next().unwrap();
 
-        self.storage
-            .insert(slot, AccountStorageReference { id, storage });
+        self.storage.insert(slot, storage);
         Ok(())
     }
 


### PR DESCRIPTION
#### Problem

AccountStorageReference was created to bypass an atomic read when needing the ID of an account storage entry. The ID used to be atomic to allow interior mutability. This was required back when the storages were recycled and their IDs needed to change. Storage recycling has been removed for a few versions now, and the ID also is now non-atomic. Thus the original reason for creating AccountStorageReference no longer applies, and we can remove AccountStorageReference entirely.


#### Summary of Changes

Replace uses of AccountStorageReference with `Arc<AccountStorageEntry>` and remove AccountStorageReference.