### PR TITLE
Install the latest supported Win64 OpenSSL v3.4.1

### DIFF
--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -6,7 +6,7 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  choco install openssl --version 3.3.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
+  choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
   export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
   export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
   ;;


### PR DESCRIPTION
#### Problem
The previous version 3.3.2 is not available it seems and causing CI failures


#### Summary of Changes
As per https://slproweb.com/products/Win32OpenSSL.html OpenSSL v3.4.1 is the 'Recommended for software developers by the creators of [OpenSSL](https://www.openssl.org/)'