### PR TITLE
ci: use ssl 3.4.1 for Windows

### DIFF
--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -6,7 +6,7 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  choco install openssl --version 3.3.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
+  choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
   export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
   export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
   ;;

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -13,6 +13,9 @@ on:
       - "**.rs"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".github/scripts/install-all-deps.sh"
+      - ".github/scripts/install-openssl.sh"
+      - ".github/scripts/install-proto.sh"
       - ".github/scripts/cargo-clippy-before-script.sh"
       - ".github/workflows/cargo.yml"
 


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/560503042458517505/1339129798223728701

```
openssl v3.3.2 [Approved]
openssl package files install completed. Performing other installation steps.
Attempt to get headers for https://slproweb.com/download/Win64OpenSSL-3_3_2.exe failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_3_2.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
Downloading openssl 64 bit
  from 'https://slproweb.com/download/Win64OpenSSL-3_3_2.exe'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_3_2.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found." 
This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
The install of openssl was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\openssl\tools\chocolateyinstall.ps1'.
 See log for details.
```

#### Summary of Changes

1. took credit from @ksolana (#4943)
2. fix ci scripts for triggering the Windows build

Close #4943