### PR TITLE
Scheduler: Add common struct and implementation

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -48,6 +48,21 @@ pub struct GreedyScheduler<Tx: TransactionWithMeta> {
     config: GreedySchedulerConfig,
 }
 
+impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
+    pub(crate) fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+        config: GreedySchedulerConfig,
+    ) -> Self {
+        Self {
+            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
+            working_account_set: ReadWriteAccountSet::default(),
+            unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
+            config,
+        }
+    }
+}
+
 impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
     fn schedule<S: StateContainer<Tx>>(
         &mut self,
@@ -187,21 +202,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
 
     fn scheduling_common_mut(&mut self) -> &mut SchedulingCommon<Tx> {
         &mut self.common
-    }
-}
-
-impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
-    pub(crate) fn new(
-        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-        config: GreedySchedulerConfig,
-    ) -> Self {
-        Self {
-            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
-            working_account_set: ReadWriteAccountSet::default(),
-            unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
-            config,
-        }
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -1,26 +1,22 @@
 use {
     super::{
-        in_flight_tracker::InFlightTracker,
         scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
+        scheduler_common::{
+            select_thread, Batches, SchedulingCommon, TransactionSchedulingError,
+            TransactionSchedulingInfo,
+        },
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
         transaction_priority_id::TransactionPriorityId,
-        transaction_state::{SanitizedTransactionTTL, TransactionState},
+        transaction_state::TransactionState,
         transaction_state_container::StateContainer,
     },
     crate::banking_stage::{
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         read_write_account_set::ReadWriteAccountSet,
-        scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
-        transaction_scheduler::{
-            scheduler_common::{
-                select_thread, Batches, TransactionSchedulingError, TransactionSchedulingInfo,
-            },
-            thread_aware_account_locks::MAX_THREADS,
-        },
+        scheduler_messages::{ConsumeWork, FinishedConsumeWork},
     },
-    crossbeam_channel::{Receiver, Sender, TryRecvError},
-    itertools::izip,
+    crossbeam_channel::{Receiver, Sender},
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_sdk::saturating_add_assign,
@@ -46,37 +42,10 @@ impl Default for GreedySchedulerConfig {
 /// in priority order, scheduling anything that can be immediately
 /// scheduled, up to the limits.
 pub struct GreedyScheduler<Tx: TransactionWithMeta> {
-    in_flight_tracker: InFlightTracker,
-    account_locks: ThreadAwareAccountLocks,
-    consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-    finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+    common: SchedulingCommon<Tx>,
     working_account_set: ReadWriteAccountSet,
     unschedulables: Vec<TransactionPriorityId>,
     config: GreedySchedulerConfig,
-}
-
-impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
-    pub(crate) fn new(
-        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-        config: GreedySchedulerConfig,
-    ) -> Self {
-        let num_threads = consume_work_senders.len();
-        assert!(num_threads > 0, "must have at least one worker");
-        assert!(
-            num_threads <= MAX_THREADS,
-            "cannot have more than {MAX_THREADS} workers"
-        );
-        Self {
-            in_flight_tracker: InFlightTracker::new(num_threads),
-            account_locks: ThreadAwareAccountLocks::new(num_threads),
-            consume_work_senders,
-            finished_consume_work_receiver,
-            working_account_set: ReadWriteAccountSet::default(),
-            unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
-            config,
-        }
-    }
 }
 
 impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
@@ -86,12 +55,13 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         _pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
-        let num_threads = self.consume_work_senders.len();
+        let num_threads = self.common.consume_work_senders.len();
         let target_cu_per_thread = self.config.target_scheduled_cus / num_threads as u64;
 
         let mut schedulable_threads = ThreadSet::any(num_threads);
         for thread_id in 0..num_threads {
-            if self.in_flight_tracker.cus_in_flight_per_thread()[thread_id] >= target_cu_per_thread
+            if self.common.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
+                >= target_cu_per_thread
             {
                 schedulable_threads.remove(thread_id);
             }
@@ -130,22 +100,24 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                 .check_locks(&transaction_state.transaction_ttl().transaction)
             {
                 self.working_account_set.clear();
-                num_sent += self.send_batches(&mut batches)?;
+                num_sent += self
+                    .common
+                    .send_batches(&mut batches, self.config.target_transactions_per_batch)?;
             }
 
             // Now check if the transaction can actually be scheduled.
             match try_schedule_transaction(
                 transaction_state,
                 &pre_lock_filter,
-                &mut self.account_locks,
+                &mut self.common.account_locks,
                 schedulable_threads,
                 |thread_set| {
                     select_thread(
                         thread_set,
                         &batches.total_cus,
-                        self.in_flight_tracker.cus_in_flight_per_thread(),
+                        self.common.in_flight_tracker.cus_in_flight_per_thread(),
                         &batches.transactions,
-                        self.in_flight_tracker.num_in_flight_per_thread(),
+                        self.common.in_flight_tracker.num_in_flight_per_thread(),
                     )
                 },
             ) {
@@ -173,12 +145,15 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     // If target batch size is reached, send all the batches
                     if batches.ids[thread_id].len() >= self.config.target_transactions_per_batch {
                         self.working_account_set.clear();
-                        num_sent += self.send_batches(&mut batches)?;
+                        num_sent += self.common.send_batches(
+                            &mut batches,
+                            self.config.target_transactions_per_batch,
+                        )?;
                     }
 
                     // if the thread is at target_cu_per_thread, remove it from the schedulable threads
                     // if there are no more schedulable threads, stop scheduling.
-                    if self.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
+                    if self.common.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
                         + batches.total_cus[thread_id]
                         >= target_cu_per_thread
                     {
@@ -192,7 +167,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         }
 
         self.working_account_set.clear();
-        num_sent += self.send_batches(&mut batches)?;
+        // Use zero here to avoid allocating since we are done with `Batches`.
+        num_sent += self.common.send_batches(&mut batches, 0)?;
         assert_eq!(
             num_scheduled, num_sent,
             "number of scheduled and sent transactions must match"
@@ -209,137 +185,23 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         })
     }
 
-    /// Receive completed batches of transactions without blocking.
-    /// Returns (num_transactions, num_retryable_transactions) on success.
-    fn receive_completed(
-        &mut self,
-        container: &mut impl StateContainer<Tx>,
-    ) -> Result<(usize, usize), SchedulerError> {
-        let mut total_num_transactions: usize = 0;
-        let mut total_num_retryable: usize = 0;
-        loop {
-            let (num_transactions, num_retryable) = self.try_receive_completed(container)?;
-            if num_transactions == 0 {
-                break;
-            }
-            saturating_add_assign!(total_num_transactions, num_transactions);
-            saturating_add_assign!(total_num_retryable, num_retryable);
-        }
-        Ok((total_num_transactions, total_num_retryable))
+    fn scheduling_common_mut(&mut self) -> &mut SchedulingCommon<Tx> {
+        &mut self.common
     }
 }
 
 impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
-    /// Receive completed batches of transactions.
-    /// Returns `Ok((num_transactions, num_retryable))` if a batch was received, `Ok((0, 0))` if no batch was received.
-    fn try_receive_completed(
-        &mut self,
-        container: &mut impl StateContainer<Tx>,
-    ) -> Result<(usize, usize), SchedulerError> {
-        match self.finished_consume_work_receiver.try_recv() {
-            Ok(FinishedConsumeWork {
-                work:
-                    ConsumeWork {
-                        batch_id,
-                        ids,
-                        transactions,
-                        max_ages,
-                    },
-                retryable_indexes,
-            }) => {
-                let num_transactions = ids.len();
-                let num_retryable = retryable_indexes.len();
-
-                // Free the locks
-                self.complete_batch(batch_id, &transactions);
-
-                // Retryable transactions should be inserted back into the container
-                let mut retryable_iter = retryable_indexes.into_iter().peekable();
-                for (index, (id, transaction, max_age)) in
-                    izip!(ids, transactions, max_ages).enumerate()
-                {
-                    if let Some(retryable_index) = retryable_iter.peek() {
-                        if *retryable_index == index {
-                            container.retry_transaction(
-                                id,
-                                SanitizedTransactionTTL {
-                                    transaction,
-                                    max_age,
-                                },
-                            );
-                            retryable_iter.next();
-                            continue;
-                        }
-                    }
-                    container.remove_by_id(id);
-                }
-
-                Ok((num_transactions, num_retryable))
-            }
-            Err(TryRecvError::Empty) => Ok((0, 0)),
-            Err(TryRecvError::Disconnected) => Err(SchedulerError::DisconnectedRecvChannel(
-                "finished consume work",
-            )),
+    pub(crate) fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+        config: GreedySchedulerConfig,
+    ) -> Self {
+        Self {
+            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
+            working_account_set: ReadWriteAccountSet::default(),
+            unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
+            config,
         }
-    }
-
-    /// Mark a given `TransactionBatchId` as completed.
-    /// This will update the internal tracking, including account locks.
-    fn complete_batch(&mut self, batch_id: TransactionBatchId, transactions: &[Tx]) {
-        let thread_id = self.in_flight_tracker.complete_batch(batch_id);
-        for transaction in transactions {
-            let account_keys = transaction.account_keys();
-            let write_account_locks = account_keys
-                .iter()
-                .enumerate()
-                .filter_map(|(index, key)| transaction.is_writable(index).then_some(key));
-            let read_account_locks = account_keys
-                .iter()
-                .enumerate()
-                .filter_map(|(index, key)| (!transaction.is_writable(index)).then_some(key));
-            self.account_locks
-                .unlock_accounts(write_account_locks, read_account_locks, thread_id);
-        }
-    }
-
-    /// Send all batches of transactions to the worker threads.
-    /// Returns the number of transactions sent.
-    fn send_batches(&mut self, batches: &mut Batches<Tx>) -> Result<usize, SchedulerError> {
-        (0..self.consume_work_senders.len())
-            .map(|thread_index| self.send_batch(batches, thread_index))
-            .sum()
-    }
-
-    /// Send a batch of transactions to the given thread's `ConsumeWork` channel.
-    /// Returns the number of transactions sent.
-    fn send_batch(
-        &mut self,
-        batches: &mut Batches<Tx>,
-        thread_index: usize,
-    ) -> Result<usize, SchedulerError> {
-        if batches.ids[thread_index].is_empty() {
-            return Ok(0);
-        }
-
-        let (ids, transactions, max_ages, total_cus) =
-            batches.take_batch(thread_index, self.config.target_transactions_per_batch);
-
-        let batch_id = self
-            .in_flight_tracker
-            .track_batch(ids.len(), total_cus, thread_index);
-
-        let num_scheduled = ids.len();
-        let work = ConsumeWork {
-            batch_id,
-            ids,
-            transactions,
-            max_ages,
-        };
-        self.consume_work_senders[thread_index]
-            .send(work)
-            .map_err(|_| SchedulerError::DisconnectedSendChannel("consume work sender"))?;
-
-        Ok(num_scheduled)
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -1,9 +1,6 @@
 use {
     super::{
         in_flight_tracker::InFlightTracker,
-        prio_graph_scheduler::{
-            Batches, PrioGraphScheduler, TransactionSchedulingError, TransactionSchedulingInfo,
-        },
         scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
@@ -15,7 +12,12 @@ use {
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         read_write_account_set::ReadWriteAccountSet,
         scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
-        transaction_scheduler::thread_aware_account_locks::MAX_THREADS,
+        transaction_scheduler::{
+            scheduler_common::{
+                select_thread, Batches, TransactionSchedulingError, TransactionSchedulingInfo,
+            },
+            thread_aware_account_locks::MAX_THREADS,
+        },
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     itertools::izip,
@@ -138,7 +140,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                 &mut self.account_locks,
                 schedulable_threads,
                 |thread_set| {
-                    PrioGraphScheduler::<Tx>::select_thread(
+                    select_thread(
                         thread_set,
                         &batches.total_cus,
                         self.in_flight_tracker.cus_in_flight_per_thread(),

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -4,6 +4,7 @@ mod in_flight_tracker;
 pub(crate) mod prio_graph_scheduler;
 pub(crate) mod receive_and_buffer;
 pub(crate) mod scheduler;
+pub(crate) mod scheduler_common;
 pub(crate) mod scheduler_controller;
 pub(crate) mod scheduler_error;
 mod scheduler_metrics;

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -67,6 +67,20 @@ pub(crate) struct PrioGraphScheduler<Tx> {
     config: PrioGraphSchedulerConfig,
 }
 
+impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
+    pub(crate) fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+        config: PrioGraphSchedulerConfig,
+    ) -> Self {
+        Self {
+            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
+            prio_graph: PrioGraph::new(passthrough_priority),
+            config,
+        }
+    }
+}
+
 impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
     /// Schedule transactions from the given `StateContainer` to be
     /// consumed by the worker threads. Returns summary of scheduling, or an
@@ -320,18 +334,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
 }
 
 impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
-    pub(crate) fn new(
-        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-        config: PrioGraphSchedulerConfig,
-    ) -> Self {
-        Self {
-            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
-            prio_graph: PrioGraph::new(passthrough_priority),
-            config,
-        }
-    }
-
     /// Gets accessed accounts (resources) for use in `PrioGraph`.
     fn get_transaction_account_access(
         transaction: &SanitizedTransactionTTL<impl SVMMessage>,

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -1,8 +1,9 @@
 use {
     super::{
-        in_flight_tracker::InFlightTracker,
         scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
-        scheduler_common::{TransactionSchedulingError, TransactionSchedulingInfo},
+        scheduler_common::{
+            SchedulingCommon, TransactionSchedulingError, TransactionSchedulingInfo,
+        },
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
         transaction_state::SanitizedTransactionTTL,
@@ -10,7 +11,7 @@ use {
     crate::banking_stage::{
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         read_write_account_set::ReadWriteAccountSet,
-        scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
+        scheduler_messages::{ConsumeWork, FinishedConsumeWork},
         transaction_scheduler::{
             scheduler_common::{select_thread, Batches},
             transaction_priority_id::TransactionPriorityId,
@@ -18,8 +19,7 @@ use {
             transaction_state_container::StateContainer,
         },
     },
-    crossbeam_channel::{Receiver, Sender, TryRecvError},
-    itertools::izip,
+    crossbeam_channel::{Receiver, Sender},
     prio_graph::{AccessKind, GraphNode, PrioGraph},
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_measure::measure_us,
@@ -62,30 +62,9 @@ impl Default for PrioGraphSchedulerConfig {
 }
 
 pub(crate) struct PrioGraphScheduler<Tx> {
-    in_flight_tracker: InFlightTracker,
-    account_locks: ThreadAwareAccountLocks,
-    consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-    finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+    common: SchedulingCommon<Tx>,
     prio_graph: SchedulerPrioGraph,
     config: PrioGraphSchedulerConfig,
-}
-
-impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
-    pub(crate) fn new(
-        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-        config: PrioGraphSchedulerConfig,
-    ) -> Self {
-        let num_threads = consume_work_senders.len();
-        Self {
-            in_flight_tracker: InFlightTracker::new(num_threads),
-            account_locks: ThreadAwareAccountLocks::new(num_threads),
-            consume_work_senders,
-            finished_consume_work_receiver,
-            prio_graph: PrioGraph::new(passthrough_priority),
-            config,
-        }
-    }
 }
 
 impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
@@ -111,12 +90,14 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
-        let num_threads = self.consume_work_senders.len();
+        let num_threads = self.common.consume_work_senders.len();
         let max_cu_per_thread = self.config.max_scheduled_cus / num_threads as u64;
 
         let mut schedulable_threads = ThreadSet::any(num_threads);
         for thread_id in 0..num_threads {
-            if self.in_flight_tracker.cus_in_flight_per_thread()[thread_id] >= max_cu_per_thread {
+            if self.common.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
+                >= max_cu_per_thread
+            {
                 schedulable_threads.remove(thread_id);
             }
         }
@@ -194,7 +175,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         chunked_pops(container, &mut self.prio_graph, &mut window_budget);
 
         let mut unblock_this_batch = Vec::with_capacity(
-            self.consume_work_senders.len() * self.config.target_transactions_per_batch,
+            self.common.consume_work_senders.len() * self.config.target_transactions_per_batch,
         );
         let mut num_scanned: usize = 0;
         let mut num_scheduled: usize = 0;
@@ -220,15 +201,15 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                     transaction_state,
                     &pre_lock_filter,
                     &mut blocking_locks,
-                    &mut self.account_locks,
+                    &mut self.common.account_locks,
                     num_threads,
                     |thread_set| {
                         select_thread(
                             thread_set,
                             &batches.total_cus,
-                            self.in_flight_tracker.cus_in_flight_per_thread(),
+                            self.common.in_flight_tracker.cus_in_flight_per_thread(),
                             &batches.transactions,
-                            self.in_flight_tracker.num_in_flight_per_thread(),
+                            self.common.in_flight_tracker.num_in_flight_per_thread(),
                         )
                     },
                 );
@@ -256,13 +237,17 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                         {
                             saturating_add_assign!(
                                 num_sent,
-                                self.send_batch(&mut batches, thread_id)?
+                                self.common.send_batch(
+                                    &mut batches,
+                                    thread_id,
+                                    self.config.target_transactions_per_batch
+                                )?
                             );
                         }
 
                         // if the thread is at max_cu_per_thread, remove it from the schedulable threads
                         // if there are no more schedulable threads, stop scheduling.
-                        if self.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
+                        if self.common.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
                             + batches.total_cus[thread_id]
                             >= max_cu_per_thread
                         {
@@ -280,7 +265,11 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             }
 
             // Send all non-empty batches
-            saturating_add_assign!(num_sent, self.send_batches(&mut batches)?);
+            saturating_add_assign!(
+                num_sent,
+                self.common
+                    .send_batches(&mut batches, self.config.target_transactions_per_batch)?
+            );
 
             // Refresh window budget and do chunked pops
             saturating_add_assign!(window_budget, unblock_this_batch.len());
@@ -293,7 +282,11 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         }
 
         // Send batches for any remaining transactions
-        saturating_add_assign!(num_sent, self.send_batches(&mut batches)?);
+        saturating_add_assign!(
+            num_sent,
+            self.common
+                .send_batches(&mut batches, self.config.target_transactions_per_batch)?
+        );
 
         // Push unschedulable ids back into the container
         container.push_ids_into_queue(unschedulable_ids.into_iter());
@@ -321,137 +314,22 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         })
     }
 
-    /// Receive completed batches of transactions without blocking.
-    /// Returns (num_transactions, num_retryable_transactions) on success.
-    fn receive_completed(
-        &mut self,
-        container: &mut impl StateContainer<Tx>,
-    ) -> Result<(usize, usize), SchedulerError> {
-        let mut total_num_transactions: usize = 0;
-        let mut total_num_retryable: usize = 0;
-        loop {
-            let (num_transactions, num_retryable) = self.try_receive_completed(container)?;
-            if num_transactions == 0 {
-                break;
-            }
-            saturating_add_assign!(total_num_transactions, num_transactions);
-            saturating_add_assign!(total_num_retryable, num_retryable);
-        }
-        Ok((total_num_transactions, total_num_retryable))
+    fn scheduling_common_mut(&mut self) -> &mut SchedulingCommon<Tx> {
+        &mut self.common
     }
 }
 
 impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
-    /// Receive completed batches of transactions.
-    /// Returns `Ok((num_transactions, num_retryable))` if a batch was received, `Ok((0, 0))` if no batch was received.
-    fn try_receive_completed(
-        &mut self,
-        container: &mut impl StateContainer<Tx>,
-    ) -> Result<(usize, usize), SchedulerError> {
-        match self.finished_consume_work_receiver.try_recv() {
-            Ok(FinishedConsumeWork {
-                work:
-                    ConsumeWork {
-                        batch_id,
-                        ids,
-                        transactions,
-                        max_ages,
-                    },
-                retryable_indexes,
-            }) => {
-                let num_transactions = ids.len();
-                let num_retryable = retryable_indexes.len();
-
-                // Free the locks
-                self.complete_batch(batch_id, &transactions);
-
-                // Retryable transactions should be inserted back into the container
-                let mut retryable_iter = retryable_indexes.into_iter().peekable();
-                for (index, (id, transaction, max_age)) in
-                    izip!(ids, transactions, max_ages).enumerate()
-                {
-                    if let Some(retryable_index) = retryable_iter.peek() {
-                        if *retryable_index == index {
-                            container.retry_transaction(
-                                id,
-                                SanitizedTransactionTTL {
-                                    transaction,
-                                    max_age,
-                                },
-                            );
-                            retryable_iter.next();
-                            continue;
-                        }
-                    }
-                    container.remove_by_id(id);
-                }
-
-                Ok((num_transactions, num_retryable))
-            }
-            Err(TryRecvError::Empty) => Ok((0, 0)),
-            Err(TryRecvError::Disconnected) => Err(SchedulerError::DisconnectedRecvChannel(
-                "finished consume work",
-            )),
+    pub(crate) fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+        config: PrioGraphSchedulerConfig,
+    ) -> Self {
+        Self {
+            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
+            prio_graph: PrioGraph::new(passthrough_priority),
+            config,
         }
-    }
-
-    /// Mark a given `TransactionBatchId` as completed.
-    /// This will update the internal tracking, including account locks.
-    fn complete_batch(&mut self, batch_id: TransactionBatchId, transactions: &[Tx]) {
-        let thread_id = self.in_flight_tracker.complete_batch(batch_id);
-        for transaction in transactions {
-            let account_keys = transaction.account_keys();
-            let write_account_locks = account_keys
-                .iter()
-                .enumerate()
-                .filter_map(|(index, key)| transaction.is_writable(index).then_some(key));
-            let read_account_locks = account_keys
-                .iter()
-                .enumerate()
-                .filter_map(|(index, key)| (!transaction.is_writable(index)).then_some(key));
-            self.account_locks
-                .unlock_accounts(write_account_locks, read_account_locks, thread_id);
-        }
-    }
-
-    /// Send all batches of transactions to the worker threads.
-    /// Returns the number of transactions sent.
-    fn send_batches(&mut self, batches: &mut Batches<Tx>) -> Result<usize, SchedulerError> {
-        (0..self.consume_work_senders.len())
-            .map(|thread_index| self.send_batch(batches, thread_index))
-            .sum()
-    }
-
-    /// Send a batch of transactions to the given thread's `ConsumeWork` channel.
-    /// Returns the number of transactions sent.
-    fn send_batch(
-        &mut self,
-        batches: &mut Batches<Tx>,
-        thread_index: usize,
-    ) -> Result<usize, SchedulerError> {
-        if batches.ids[thread_index].is_empty() {
-            return Ok(0);
-        }
-
-        let (ids, transactions, max_ages, total_cus) =
-            batches.take_batch(thread_index, self.config.target_transactions_per_batch);
-
-        let batch_id = self
-            .in_flight_tracker
-            .track_batch(ids.len(), total_cus, thread_index);
-
-        let num_scheduled = ids.len();
-        let work = ConsumeWork {
-            batch_id,
-            ids,
-            transactions,
-            max_ages,
-        };
-        self.consume_work_senders[thread_index]
-            .send(work)
-            .map_err(|_| SchedulerError::DisconnectedSendChannel("consume work sender"))?;
-
-        Ok(num_scheduled)
     }
 
     /// Gets accessed accounts (resources) for use in `PrioGraph`.

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -1,7 +1,8 @@
 use {
     super::{
         in_flight_tracker::InFlightTracker,
-        scheduler::{PreLockFilterAction, Scheduler},
+        scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
+        scheduler_common::{TransactionSchedulingError, TransactionSchedulingInfo},
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
         transaction_state::SanitizedTransactionTTL,
@@ -9,12 +10,12 @@ use {
     crate::banking_stage::{
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         read_write_account_set::ReadWriteAccountSet,
-        scheduler_messages::{
-            ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
-        },
+        scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
         transaction_scheduler::{
-            scheduler::SchedulingSummary, transaction_priority_id::TransactionPriorityId,
-            transaction_state::TransactionState, transaction_state_container::StateContainer,
+            scheduler_common::{select_thread, Batches},
+            transaction_priority_id::TransactionPriorityId,
+            transaction_state::TransactionState,
+            transaction_state_container::StateContainer,
         },
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},
@@ -222,7 +223,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                     &mut self.account_locks,
                     num_threads,
                     |thread_set| {
-                        Self::select_thread(
+                        select_thread(
                             thread_set,
                             &batches.total_cus,
                             self.in_flight_tracker.cus_in_flight_per_thread(),
@@ -453,36 +454,6 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
         Ok(num_scheduled)
     }
 
-    /// Given the schedulable `thread_set`, select the thread with the least amount
-    /// of work queued up.
-    /// Currently, "work" is just defined as the number of transactions.
-    ///
-    /// If the `chain_thread` is available, this thread will be selected, regardless of
-    /// load-balancing.
-    ///
-    /// Panics if the `thread_set` is empty. This should never happen, see comment
-    /// on `ThreadAwareAccountLocks::try_lock_accounts`.
-    pub(crate) fn select_thread(
-        thread_set: ThreadSet,
-        batch_cus_per_thread: &[u64],
-        in_flight_cus_per_thread: &[u64],
-        batches_per_thread: &[Vec<Tx>],
-        in_flight_per_thread: &[usize],
-    ) -> ThreadId {
-        thread_set
-            .contained_threads_iter()
-            .map(|thread_id| {
-                (
-                    thread_id,
-                    batch_cus_per_thread[thread_id] + in_flight_cus_per_thread[thread_id],
-                    batches_per_thread[thread_id].len() + in_flight_per_thread[thread_id],
-                )
-            })
-            .min_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
-            .map(|(thread_id, _, _)| thread_id)
-            .unwrap()
-    }
-
     /// Gets accessed accounts (resources) for use in `PrioGraph`.
     fn get_transaction_account_access(
         transaction: &SanitizedTransactionTTL<impl SVMMessage>,
@@ -500,66 +471,6 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
                 }
             })
     }
-}
-
-pub(crate) struct Batches<Tx> {
-    pub ids: Vec<Vec<TransactionId>>,
-    pub transactions: Vec<Vec<Tx>>,
-    pub max_ages: Vec<Vec<MaxAge>>,
-    pub total_cus: Vec<u64>,
-}
-
-impl<Tx> Batches<Tx> {
-    pub(crate) fn new(num_threads: usize, target_num_transactions_per_batch: usize) -> Self {
-        Self {
-            ids: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
-
-            transactions: (0..num_threads)
-                .map(|_| Vec::with_capacity(target_num_transactions_per_batch))
-                .collect(),
-            max_ages: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
-            total_cus: vec![0; num_threads],
-        }
-    }
-
-    pub(crate) fn take_batch(
-        &mut self,
-        thread_id: ThreadId,
-        target_num_transactions_per_batch: usize,
-    ) -> (Vec<TransactionId>, Vec<Tx>, Vec<MaxAge>, u64) {
-        (
-            core::mem::replace(
-                &mut self.ids[thread_id],
-                Vec::with_capacity(target_num_transactions_per_batch),
-            ),
-            core::mem::replace(
-                &mut self.transactions[thread_id],
-                Vec::with_capacity(target_num_transactions_per_batch),
-            ),
-            core::mem::replace(
-                &mut self.max_ages[thread_id],
-                Vec::with_capacity(target_num_transactions_per_batch),
-            ),
-            core::mem::replace(&mut self.total_cus[thread_id], 0),
-        )
-    }
-}
-
-/// A transaction has been scheduled to a thread.
-pub(crate) struct TransactionSchedulingInfo<Tx> {
-    pub thread_id: ThreadId,
-    pub transaction: Tx,
-    pub max_age: MaxAge,
-    pub cost: u64,
-}
-
-/// Error type for reasons a transaction could not be scheduled.
-pub(crate) enum TransactionSchedulingError {
-    /// Transaction cannot be scheduled due to conflicts, or
-    /// higher priority conflicting transactions are unschedulable.
-    UnschedulableConflicts,
-    /// Thread is not allowed to be scheduled on at this time.
-    UnschedulableThread,
 }
 
 fn try_schedule_transaction<Tx: TransactionWithMeta>(
@@ -624,7 +535,10 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
 mod tests {
     use {
         super::*,
-        crate::banking_stage::transaction_scheduler::transaction_state_container::TransactionStateContainer,
+        crate::banking_stage::{
+            scheduler_messages::{MaxAge, TransactionId},
+            transaction_scheduler::transaction_state_container::TransactionStateContainer,
+        },
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -1,0 +1,94 @@
+use {
+    super::thread_aware_account_locks::{ThreadId, ThreadSet},
+    crate::banking_stage::scheduler_messages::{MaxAge, TransactionId},
+};
+
+pub struct Batches<Tx> {
+    pub ids: Vec<Vec<TransactionId>>,
+    pub transactions: Vec<Vec<Tx>>,
+    pub max_ages: Vec<Vec<MaxAge>>,
+    pub total_cus: Vec<u64>,
+}
+
+impl<Tx> Batches<Tx> {
+    pub fn new(num_threads: usize, target_num_transactions_per_batch: usize) -> Self {
+        Self {
+            ids: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
+
+            transactions: (0..num_threads)
+                .map(|_| Vec::with_capacity(target_num_transactions_per_batch))
+                .collect(),
+            max_ages: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
+            total_cus: vec![0; num_threads],
+        }
+    }
+
+    pub fn take_batch(
+        &mut self,
+        thread_id: ThreadId,
+        target_num_transactions_per_batch: usize,
+    ) -> (Vec<TransactionId>, Vec<Tx>, Vec<MaxAge>, u64) {
+        (
+            core::mem::replace(
+                &mut self.ids[thread_id],
+                Vec::with_capacity(target_num_transactions_per_batch),
+            ),
+            core::mem::replace(
+                &mut self.transactions[thread_id],
+                Vec::with_capacity(target_num_transactions_per_batch),
+            ),
+            core::mem::replace(
+                &mut self.max_ages[thread_id],
+                Vec::with_capacity(target_num_transactions_per_batch),
+            ),
+            core::mem::replace(&mut self.total_cus[thread_id], 0),
+        )
+    }
+}
+
+/// A transaction has been scheduled to a thread.
+pub struct TransactionSchedulingInfo<Tx> {
+    pub thread_id: ThreadId,
+    pub transaction: Tx,
+    pub max_age: MaxAge,
+    pub cost: u64,
+}
+
+/// Error type for reasons a transaction could not be scheduled.
+pub enum TransactionSchedulingError {
+    /// Transaction cannot be scheduled due to conflicts, or
+    /// higher priority conflicting transactions are unschedulable.
+    UnschedulableConflicts,
+    /// Thread is not allowed to be scheduled on at this time.
+    UnschedulableThread,
+}
+
+/// Given the schedulable `thread_set`, select the thread with the least amount
+/// of work queued up.
+/// Currently, "work" is just defined as the number of transactions.
+///
+/// If the `chain_thread` is available, this thread will be selected, regardless of
+/// load-balancing.
+///
+/// Panics if the `thread_set` is empty. This should never happen, see comment
+/// on `ThreadAwareAccountLocks::try_lock_accounts`.
+pub fn select_thread<Tx>(
+    thread_set: ThreadSet,
+    batch_cus_per_thread: &[u64],
+    in_flight_cus_per_thread: &[u64],
+    batches_per_thread: &[Vec<Tx>],
+    in_flight_per_thread: &[usize],
+) -> ThreadId {
+    thread_set
+        .contained_threads_iter()
+        .map(|thread_id| {
+            (
+                thread_id,
+                batch_cus_per_thread[thread_id] + in_flight_cus_per_thread[thread_id],
+                batches_per_thread[thread_id].len() + in_flight_per_thread[thread_id],
+            )
+        })
+        .min_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
+        .map(|(thread_id, _, _)| thread_id)
+        .unwrap()
+}

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -6,8 +6,11 @@ use {
         transaction_state::SanitizedTransactionTTL,
         transaction_state_container::StateContainer,
     },
-    crate::banking_stage::scheduler_messages::{
-        ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
+    crate::banking_stage::{
+        scheduler_messages::{
+            ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
+        },
+        transaction_scheduler::thread_aware_account_locks::MAX_THREADS,
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     itertools::izip,
@@ -106,10 +109,10 @@ pub fn select_thread<Tx>(
 
 /// Common scheduler communication structure.
 pub(crate) struct SchedulingCommon<Tx> {
-    consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
-    finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
-    in_flight_tracker: InFlightTracker,
-    account_locks: ThreadAwareAccountLocks,
+    pub(crate) consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+    pub(crate) finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+    pub(crate) in_flight_tracker: InFlightTracker,
+    pub(crate) account_locks: ThreadAwareAccountLocks,
 }
 
 impl<Tx> SchedulingCommon<Tx> {
@@ -118,6 +121,11 @@ impl<Tx> SchedulingCommon<Tx> {
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
     ) -> Self {
         let num_threads = consume_work_senders.len();
+        assert!(num_threads > 0, "must have at least one worker");
+        assert!(
+            num_threads <= MAX_THREADS,
+            "cannot have more than {MAX_THREADS} workers"
+        );
         Self {
             consume_work_senders,
             finished_consume_work_receiver,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -1,6 +1,17 @@
 use {
-    super::thread_aware_account_locks::{ThreadId, ThreadSet},
-    crate::banking_stage::scheduler_messages::{MaxAge, TransactionId},
+    super::{
+        in_flight_tracker::InFlightTracker,
+        scheduler_error::SchedulerError,
+        thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet},
+        transaction_state::SanitizedTransactionTTL,
+        transaction_state_container::StateContainer,
+    },
+    crate::banking_stage::scheduler_messages::{
+        ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
+    },
+    crossbeam_channel::{Receiver, Sender, TryRecvError},
+    itertools::izip,
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
 };
 
 pub struct Batches<Tx> {
@@ -91,4 +102,148 @@ pub fn select_thread<Tx>(
         .min_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
         .map(|(thread_id, _, _)| thread_id)
         .unwrap()
+}
+
+/// Common scheduler communication structure.
+pub(crate) struct SchedulingCommon<Tx> {
+    consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+    finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+    in_flight_tracker: InFlightTracker,
+    account_locks: ThreadAwareAccountLocks,
+}
+
+impl<Tx> SchedulingCommon<Tx> {
+    pub fn new(
+        consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+        finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+    ) -> Self {
+        let num_threads = consume_work_senders.len();
+        Self {
+            consume_work_senders,
+            finished_consume_work_receiver,
+            in_flight_tracker: InFlightTracker::new(num_threads),
+            account_locks: ThreadAwareAccountLocks::new(num_threads),
+        }
+    }
+
+    /// Send a batch of transactions to the given thread's `ConsumeWork` channel.
+    /// Returns the number of transactions sent.
+    pub fn send_batch(
+        &mut self,
+        batches: &mut Batches<Tx>,
+        thread_index: usize,
+        target_transactions_per_batch: usize,
+    ) -> Result<usize, SchedulerError> {
+        if batches.ids[thread_index].is_empty() {
+            return Ok(0);
+        }
+
+        let (ids, transactions, max_ages, total_cus) =
+            batches.take_batch(thread_index, target_transactions_per_batch);
+
+        let batch_id = self
+            .in_flight_tracker
+            .track_batch(ids.len(), total_cus, thread_index);
+
+        let num_scheduled = ids.len();
+        let work = ConsumeWork {
+            batch_id,
+            ids,
+            transactions,
+            max_ages,
+        };
+        self.consume_work_senders[thread_index]
+            .send(work)
+            .map_err(|_| SchedulerError::DisconnectedSendChannel("consume work sender"))?;
+
+        Ok(num_scheduled)
+    }
+
+    /// Send all batches of transactions to the worker threads.
+    /// Returns the number of transactions sent.
+    pub fn send_batches(
+        &mut self,
+        batches: &mut Batches<Tx>,
+        target_transactions_per_batch: usize,
+    ) -> Result<usize, SchedulerError> {
+        (0..self.consume_work_senders.len())
+            .map(|thread_index| {
+                self.send_batch(batches, thread_index, target_transactions_per_batch)
+            })
+            .sum()
+    }
+}
+
+impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
+    /// Receive completed batches of transactions.
+    /// Returns `Ok((num_transactions, num_retryable))` if a batch was received, `Ok((0, 0))` if no batch was received.
+    pub fn try_receive_completed(
+        &mut self,
+        container: &mut impl StateContainer<Tx>,
+    ) -> Result<(usize, usize), SchedulerError> {
+        match self.finished_consume_work_receiver.try_recv() {
+            Ok(FinishedConsumeWork {
+                work:
+                    ConsumeWork {
+                        batch_id,
+                        ids,
+                        transactions,
+                        max_ages,
+                    },
+                retryable_indexes,
+            }) => {
+                let num_transactions = ids.len();
+                let num_retryable = retryable_indexes.len();
+
+                // Free the locks
+                self.complete_batch(batch_id, &transactions);
+
+                // Retryable transactions should be inserted back into the container
+                let mut retryable_iter = retryable_indexes.into_iter().peekable();
+                for (index, (id, transaction, max_age)) in
+                    izip!(ids, transactions, max_ages).enumerate()
+                {
+                    if let Some(retryable_index) = retryable_iter.peek() {
+                        if *retryable_index == index {
+                            container.retry_transaction(
+                                id,
+                                SanitizedTransactionTTL {
+                                    transaction,
+                                    max_age,
+                                },
+                            );
+                            retryable_iter.next();
+                            continue;
+                        }
+                    }
+                    container.remove_by_id(id);
+                }
+
+                Ok((num_transactions, num_retryable))
+            }
+            Err(TryRecvError::Empty) => Ok((0, 0)),
+            Err(TryRecvError::Disconnected) => Err(SchedulerError::DisconnectedRecvChannel(
+                "finished consume work",
+            )),
+        }
+    }
+
+    /// Mark a given `TransactionBatchId` as completed.
+    /// This will update the internal tracking, including account locks.
+    fn complete_batch(&mut self, batch_id: TransactionBatchId, transactions: &[Tx]) {
+        let thread_id = self.in_flight_tracker.complete_batch(batch_id);
+        for transaction in transactions {
+            let account_keys = transaction.account_keys();
+            let write_account_locks = account_keys
+                .iter()
+                .enumerate()
+                .filter_map(|(index, key)| transaction.is_writable(index).then_some(key));
+            let read_account_locks = account_keys
+                .iter()
+                .enumerate()
+                .filter_map(|(index, key)| (!transaction.is_writable(index)).then_some(key));
+            self.account_locks
+                .unlock_accounts(write_account_locks, read_account_locks, thread_id);
+        }
+    }
 }


### PR DESCRIPTION
#### Problem
- `PrioGraphScheduler` and `GreedyScheduler` have quite a bit of duplicate fields and code

#### Summary of Changes
- create `scheduler_common.rs` to host common data and functions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
