### PR TITLE
validator: Deprecate etcd tower storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Release channels have their own copy of this changelog:
   * Unhide `--accounts-db-access-storages-method` for agave-validator and agave-ledger-tool and change default to `file`
   * Remove tracer stats from banking-trace. `banking-trace` directory should be cleared when restarting on v2.2 for first time. It will not break if not cleared, but the file will be a mix of new/old format. (#4043)
   * Add `--snapshot-zstd-compression-level` to set the compression level when archiving snapshots with zstd.
+  * Deprecate `--tower-storage` and all `--etcd-*` arguments
   * SDK:
     * `cargo-build-sbf`: add `--skip-tools-install` flag to avoid downloading platform tools and `--no-rustup-override` flag to not use rustup when invoking `cargo`. Useful for immutable environments like Nix.
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -213,6 +213,25 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         usage_warning: "The quic server is now enabled by default.",
     );
     // All etcd config is deprecated as of v2.2
+    add_arg!(Arg::with_name("etcd_cacert_file")
+        .long("etcd-cacert-file")
+        .required_if("tower_storage", "etcd")
+        .value_name("FILE")
+        .takes_value(true)
+        .help("verify the TLS certificate of the etcd endpoint using this CA bundle"),);
+    add_arg!(Arg::with_name("etcd_cert_file")
+        .long("etcd-cert-file")
+        .required_if("tower_storage", "etcd")
+        .value_name("FILE")
+        .takes_value(true)
+        .help("TLS certificate to use when establishing a connection to the etcd endpoint"),);
+    add_arg!(Arg::with_name("etcd_domain_name")
+        .long("etcd-domain-name")
+        .required_if("tower_storage", "etcd")
+        .value_name("DOMAIN")
+        .default_value("localhost")
+        .takes_value(true)
+        .help("domain name against which to verify the etcd server’s TLS certificate"),);
     add_arg!(Arg::with_name("etcd_endpoint")
         .long("etcd-endpoint")
         .required_if("tower_storage", "etcd")
@@ -221,31 +240,12 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .multiple(true)
         .validator(solana_net_utils::is_host_port)
         .help("etcd gRPC endpoint to connect with"),);
-    add_arg!(Arg::with_name("etcd_domain_name")
-        .long("etcd-domain-name")
-        .required_if("tower_storage", "etcd")
-        .value_name("DOMAIN")
-        .default_value("localhost")
-        .takes_value(true)
-        .help("domain name against which to verify the etcd server’s TLS certificate"),);
-    add_arg!(Arg::with_name("etcd_cacert_file")
-        .long("etcd-cacert-file")
-        .required_if("tower_storage", "etcd")
-        .value_name("FILE")
-        .takes_value(true)
-        .help("verify the TLS certificate of the etcd endpoint using this CA bundle"),);
     add_arg!(Arg::with_name("etcd_key_file")
         .long("etcd-key-file")
         .required_if("tower_storage", "etcd")
         .value_name("FILE")
         .takes_value(true)
         .help("TLS key file to use when establishing a connection to the etcd endpoint"),);
-    add_arg!(Arg::with_name("etcd_cert_file")
-        .long("etcd-cert-file")
-        .required_if("tower_storage", "etcd")
-        .value_name("FILE")
-        .takes_value(true)
-        .help("TLS certificate to use when establishing a connection to the etcd endpoint"),);
 
     add_arg!(Arg::with_name("minimal_rpc_api")
         .long("minimal-rpc-api")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -212,6 +212,41 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("enable-quic-servers"),
         usage_warning: "The quic server is now enabled by default.",
     );
+    // All etcd config is deprecated as of v2.2
+    add_arg!(Arg::with_name("etcd_endpoint")
+        .long("etcd-endpoint")
+        .required_if("tower_storage", "etcd")
+        .value_name("HOST:PORT")
+        .takes_value(true)
+        .multiple(true)
+        .validator(solana_net_utils::is_host_port)
+        .help("etcd gRPC endpoint to connect with"),);
+    add_arg!(Arg::with_name("etcd_domain_name")
+        .long("etcd-domain-name")
+        .required_if("tower_storage", "etcd")
+        .value_name("DOMAIN")
+        .default_value("localhost")
+        .takes_value(true)
+        .help("domain name against which to verify the etcd server’s TLS certificate"),);
+    add_arg!(Arg::with_name("etcd_cacert_file")
+        .long("etcd-cacert-file")
+        .required_if("tower_storage", "etcd")
+        .value_name("FILE")
+        .takes_value(true)
+        .help("verify the TLS certificate of the etcd endpoint using this CA bundle"),);
+    add_arg!(Arg::with_name("etcd_key_file")
+        .long("etcd-key-file")
+        .required_if("tower_storage", "etcd")
+        .value_name("FILE")
+        .takes_value(true)
+        .help("TLS key file to use when establishing a connection to the etcd endpoint"),);
+    add_arg!(Arg::with_name("etcd_cert_file")
+        .long("etcd-cert-file")
+        .required_if("tower_storage", "etcd")
+        .value_name("FILE")
+        .takes_value(true)
+        .help("TLS certificate to use when establishing a connection to the etcd endpoint"),);
+
     add_arg!(Arg::with_name("minimal_rpc_api")
         .long("minimal-rpc-api")
         .takes_value(false)
@@ -296,6 +331,17 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(false)
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
+    );
+    // Deprecated as of v2.2
+    add_arg!(
+        Arg::with_name("tower_storage")
+            .long("tower-storage")
+            .possible_values(&["file", "etcd"])
+            .default_value("file")
+            .takes_value(true)
+            .help("Where to store the tower"),
+        usage_warning: "\"etcd\" is no longer supported, and the functionality from setting \
+            \"file\" will be become the sole behavior",
     );
 
     res

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -332,57 +332,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Use DIR as file tower storage location [default: --ledger value]"),
     )
     .arg(
-        Arg::with_name("tower_storage")
-            .long("tower-storage")
-            .possible_values(&["file", "etcd"])
-            .default_value(&default_args.tower_storage)
-            .takes_value(true)
-            .help("Where to store the tower"),
-    )
-    .arg(
-        Arg::with_name("etcd_endpoint")
-            .long("etcd-endpoint")
-            .required_if("tower_storage", "etcd")
-            .value_name("HOST:PORT")
-            .takes_value(true)
-            .multiple(true)
-            .validator(solana_net_utils::is_host_port)
-            .help("etcd gRPC endpoint to connect with"),
-    )
-    .arg(
-        Arg::with_name("etcd_domain_name")
-            .long("etcd-domain-name")
-            .required_if("tower_storage", "etcd")
-            .value_name("DOMAIN")
-            .default_value(&default_args.etcd_domain_name)
-            .takes_value(true)
-            .help("domain name against which to verify the etcd server’s TLS certificate"),
-    )
-    .arg(
-        Arg::with_name("etcd_cacert_file")
-            .long("etcd-cacert-file")
-            .required_if("tower_storage", "etcd")
-            .value_name("FILE")
-            .takes_value(true)
-            .help("verify the TLS certificate of the etcd endpoint using this CA bundle"),
-    )
-    .arg(
-        Arg::with_name("etcd_key_file")
-            .long("etcd-key-file")
-            .required_if("tower_storage", "etcd")
-            .value_name("FILE")
-            .takes_value(true)
-            .help("TLS key file to use when establishing a connection to the etcd endpoint"),
-    )
-    .arg(
-        Arg::with_name("etcd_cert_file")
-            .long("etcd-cert-file")
-            .required_if("tower_storage", "etcd")
-            .value_name("FILE")
-            .takes_value(true)
-            .help("TLS certificate to use when establishing a connection to the etcd endpoint"),
-    )
-    .arg(
         Arg::with_name("gossip_port")
             .long("gossip-port")
             .value_name("PORT")


### PR DESCRIPTION
#### Problem
`etcd` is unused by the operator community. Approaches like what is described below has become "best practive":
https://pumpkins-pool.gitbook.io/pumpkins-pool

In accordance, we are looking to update our docs and move away from `etcd`. The docs updates should land in one of these already open PR's or a subsequent one:
- https://github.com/anza-xyz/agave/pull/3683
- https://github.com/anza-xyz/agave/pull/4689

#### Summary of Changes
Make all `etcd` args deprecated, and add an entry to changelog
