### PR TITLE
Uses ScanOrder in ScanConfig::new()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -126,13 +126,7 @@ impl Default for ScanConfig {
 }
 
 impl ScanConfig {
-    pub fn new(collect_all_unsorted: bool) -> Self {
-        let scan_order = if collect_all_unsorted {
-            ScanOrder::Unsorted
-        } else {
-            ScanOrder::Sorted
-        };
-
+    pub fn new(scan_order: ScanOrder) -> Self {
         Self {
             scan_order,
             ..Default::default()
@@ -4258,8 +4252,7 @@ pub mod tests {
     #[test]
     fn test_scan_config() {
         for scan_order in [ScanOrder::Sorted, ScanOrder::Unsorted] {
-            let collect_all_unsorted = scan_order == ScanOrder::Unsorted;
-            let config = ScanConfig::new(collect_all_unsorted);
+            let config = ScanConfig::new(scan_order);
             assert_eq!(config.scan_order, scan_order);
             assert!(config.abort.is_none()); // not allocated
             assert!(!config.is_aborted());
@@ -4267,7 +4260,7 @@ pub mod tests {
             assert!(!config.is_aborted());
         }
 
-        let config = ScanConfig::new(false);
+        let config = ScanConfig::new(ScanOrder::Sorted);
         assert_eq!(config.scan_order, ScanOrder::Sorted);
         assert!(config.abort.is_none());
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -20,7 +20,10 @@ use {
     log::*,
     serde_derive::Serialize,
     solana_account_decoder::UiAccountEncoding,
-    solana_accounts_db::{accounts_db::CalcAccountsHashDataSource, accounts_index::ScanConfig},
+    solana_accounts_db::{
+        accounts_db::CalcAccountsHashDataSource,
+        accounts_index::{ScanConfig, ScanOrder},
+    },
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
@@ -2173,7 +2176,10 @@ fn main() {
 
                     if remove_stake_accounts {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), &ScanConfig::new(false))
+                            .get_program_accounts(
+                                &stake::program::id(),
+                                &ScanConfig::new(ScanOrder::Sorted),
+                            )
                             .unwrap()
                             .into_iter()
                         {
@@ -2197,7 +2203,10 @@ fn main() {
 
                     if !vote_accounts_to_destake.is_empty() {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), &ScanConfig::new(false))
+                            .get_program_accounts(
+                                &stake::program::id(),
+                                &ScanConfig::new(ScanOrder::Sorted),
+                            )
                             .unwrap()
                             .into_iter()
                         {
@@ -2237,7 +2246,7 @@ fn main() {
                         for (address, mut account) in bank
                             .get_program_accounts(
                                 &solana_vote_program::id(),
-                                &ScanConfig::new(false),
+                                &ScanConfig::new(ScanOrder::Sorted),
                             )
                             .unwrap()
                             .into_iter()

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -8,7 +8,7 @@ use {
     serde::ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     serde_derive::{Deserialize, Serialize},
     solana_account_decoder::{encode_ui_account, UiAccountData, UiAccountEncoding},
-    solana_accounts_db::accounts_index::ScanConfig,
+    solana_accounts_db::accounts_index::{ScanConfig, ScanOrder},
     solana_cli_output::{
         display::writeln_transaction, CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay,
         VerboseDisplay,
@@ -910,7 +910,7 @@ impl AccountsScanner {
             }),
             AccountsOutputMode::Program(program_pubkey) => self
                 .bank
-                .get_program_accounts(program_pubkey, &ScanConfig::new(false))
+                .get_program_accounts(program_pubkey, &ScanConfig::new(ScanOrder::Sorted))
                 .unwrap()
                 .iter()
                 .filter(|(_, account)| self.should_process_account(account))


### PR DESCRIPTION
#### Problem

The `collect_all_unsorted` parameter in ScanConfig::new() is sometimes cumbersome due to (1) it being a bool, and (2) it feeling backwards/negative from its true/false meaning.


#### Summary of Changes

Following on from https://github.com/anza-xyz/agave/pull/4955, use the ScanOrder enum instead. This way it is self documenting.