### PR TITLE
validator: Cleanup deprecated and dead AccountsDb arguments

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -131,6 +131,18 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         (@into-option $v:expr) => { Some($v) };
     }
 
+    // deprecated in v2.1 by PR #2721
+    add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
+        .long("accounts-index-memory-limit-mb")
+        .value_name("MEGABYTES")
+        .validator(is_parsable::<usize>)
+        .takes_value(true)
+        .help(
+            "How much memory the accounts index can consume. If this is exceeded, some \
+         account index entries will be stored on disk.",
+        ),
+        usage_warning: "index memory limit has been deprecated. The limit arg has no effect now.",
+    );
     add_arg!(Arg::with_name("accountsdb_repl_bind_address")
         .long("accountsdb-repl-bind-address")
         .value_name("HOST")
@@ -154,7 +166,8 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Number of threads to use for servicing AccountsDb Replication requests"));
     add_arg!(Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default."));
+        .help("Disable the disk-based accounts index if it is enabled by default.")
+        .conflicts_with("accounts_index_memory_limit_mb"));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -131,12 +131,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         (@into-option $v:expr) => { Some($v) };
     }
 
-    add_arg!(
-        Arg::with_name("accounts_db_skip_shrink")
-            .long("accounts-db-skip-shrink")
-            .help("Enables faster starting of validators by skipping startup clean and shrink."),
-        usage_warning: "Enabled by default",
-    );
     add_arg!(Arg::with_name("accounts_hash_interval_slots")
         .long("accounts-hash-interval-slots")
         .value_name("NUMBER")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -131,18 +131,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         (@into-option $v:expr) => { Some($v) };
     }
 
-    // deprecated in v2.1 by PR #2721
-    add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
-        .long("accounts-index-memory-limit-mb")
-        .value_name("MEGABYTES")
-        .validator(is_parsable::<usize>)
-        .takes_value(true)
-        .help(
-            "How much memory the accounts index can consume. If this is exceeded, some \
-         account index entries will be stored on disk.",
-        ),
-        usage_warning: "index memory limit has been deprecated. The limit arg has no effect now.",
-    );
     add_arg!(Arg::with_name("accountsdb_repl_bind_address")
         .long("accountsdb-repl-bind-address")
         .value_name("HOST")
@@ -166,8 +154,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Number of threads to use for servicing AccountsDb Replication requests"));
     add_arg!(Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default.")
-        .conflicts_with("accounts_index_memory_limit_mb"));
+        .help("Disable the disk-based accounts index if it is enabled by default."));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -131,18 +131,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         (@into-option $v:expr) => { Some($v) };
     }
 
-    add_arg!(Arg::with_name("accounts_hash_interval_slots")
-        .long("accounts-hash-interval-slots")
-        .value_name("NUMBER")
-        .takes_value(true)
-        .help("Number of slots between verifying accounts hash.")
-        .validator(|val| {
-            if val.eq("0") {
-                Err(String::from("Accounts hash interval cannot be zero"))
-            } else {
-                Ok(())
-            }
-        }));
     // deprecated in v2.1 by PR #2721
     add_arg!(Arg::with_name("accounts_index_memory_limit_mb")
         .long("accounts-index-memory-limit-mb")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1373,8 +1373,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("no_skip_initial_accounts_db_clean")
             .long("no-skip-initial-accounts-db-clean")
             .help("Do not skip the initial cleaning of accounts when verifying snapshot bank")
-            .hidden(hidden_unless_forced())
-            .conflicts_with("accounts_db_skip_shrink"),
+            .hidden(hidden_unless_forced()),
     )
     .arg(
         Arg::with_name("accounts_db_squash_storages_method")


### PR DESCRIPTION
#### Summary of Changes
Remove deprecated AccountsDb args from the deprecated list to reduce clutter.

- `--accounts-db-skip-shrink` was deprecated in https://github.com/solana-labs/solana/pull/30710 (v1.17)
- `--accounts-hash-interval-slots` was deprecated in https://github.com/solana-labs/solana/pull/31987 (v1.17)
- ~~`--accounts-index-memory-limit-mb` was deprecated in  https://github.com/anza-xyz/agave/pull/2721 (v2.1)~~

I think the first two are obviously fair game to rip out. ~~I also see the third one as valid to pull out since this change will first land in v2.3 which will have given full v2.1 + full v2.2 cycle for validators to adapt. But, I'm open to opinions on this.~~ EDIT: We'll keep `--accounts-index-memory-limit-mb` in place until v3.0