### PR TITLE
repurpose a dead metric in broadcast stage

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -445,6 +445,8 @@ pub fn broadcast_shreds(
     quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
 ) -> Result<()> {
     let mut result = Ok(());
+
+    // Compute destinations & transmission protocols for each of the shreds to be sent
     let mut shred_select = Measure::start("shred_select");
     let (root_bank, working_bank) = {
         let bank_forks = bank_forks.read().unwrap();
@@ -488,6 +490,8 @@ pub fn broadcast_shreds(
     }
     send_mmsg_time.stop();
     transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();
+
+    let mut quic_send_time = Measure::start("send shreds via quic");
     transmit_stats.total_packets += num_udp_packets + quic_packets.len();
     for (shred, addr) in quic_packets {
         let shred = Bytes::from(shred::Payload::unwrap_or_clone(shred.clone()));
@@ -496,6 +500,9 @@ pub fn broadcast_shreds(
             result = Err(Error::from(err));
         }
     }
+    quic_send_time.stop();
+    transmit_stats.send_quic_elapsed = quic_send_time.as_us();
+
     result
 }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -445,7 +445,6 @@ pub fn broadcast_shreds(
     quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
 ) -> Result<()> {
     let mut result = Ok(());
-
     // Compute destinations & transmission protocols for each of the shreds to be sent
     let mut shred_select = Measure::start("shred_select");
     let (root_bank, working_bank) = {
@@ -478,7 +477,6 @@ pub fn broadcast_shreds(
         .partition_map(std::convert::identity);
     shred_select.stop();
     transmit_stats.shred_select += shred_select.as_us();
-
     let num_udp_packets = packets.len();
     let mut send_mmsg_time = Measure::start("send_mmsg");
     match batch_send(s, packets) {
@@ -490,7 +488,6 @@ pub fn broadcast_shreds(
     }
     send_mmsg_time.stop();
     transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();
-
     let mut quic_send_time = Measure::start("send shreds via quic");
     transmit_stats.total_packets += num_udp_packets + quic_packets.len();
     for (shred, addr) in quic_packets {
@@ -502,7 +499,6 @@ pub fn broadcast_shreds(
     }
     quic_send_time.stop();
     transmit_stats.send_quic_elapsed = quic_send_time.as_us();
-
     result
 }
 

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -15,9 +15,13 @@ pub(crate) struct BroadcastShredBatchInfo {
 
 #[derive(Default, Clone)]
 pub struct TransmitShredsStats {
+    /// microseconds spent for the entire transmit part of broadcast
     pub transmit_elapsed: u64,
+    /// microseconds spent sending UDP packets via mmsg
     pub send_mmsg_elapsed: u64,
-    pub get_peers_elapsed: u64,
+    /// microseconds spent sending packets to quic endpoint
+    pub send_quic_elapsed: u64,
+    /// Time spent figuring out which shreds to send where
     pub shred_select: u64,
     pub num_shreds: usize,
     pub total_packets: usize,
@@ -29,7 +33,7 @@ impl BroadcastStats for TransmitShredsStats {
     fn update(&mut self, new_stats: &TransmitShredsStats) {
         self.transmit_elapsed += new_stats.transmit_elapsed;
         self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
-        self.get_peers_elapsed += new_stats.get_peers_elapsed;
+        self.send_quic_elapsed += new_stats.send_quic_elapsed;
         self.num_shreds += new_stats.num_shreds;
         self.shred_select += new_stats.shred_select;
         self.total_packets += new_stats.total_packets;
@@ -43,7 +47,7 @@ impl BroadcastStats for TransmitShredsStats {
                 ("slot", slot as i64, i64),
                 ("transmit_elapsed", self.transmit_elapsed as i64, i64),
                 ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
-                ("get_peers_elapsed", self.get_peers_elapsed as i64, i64),
+                ("send_quic_elapsed", self.send_quic_elapsed as i64, i64),
                 ("num_shreds", self.num_shreds as i64, i64),
                 ("shred_select", self.shred_select as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
@@ -67,7 +71,7 @@ impl BroadcastStats for TransmitShredsStats {
                 ),
                 ("transmit_elapsed", self.transmit_elapsed as i64, i64),
                 ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
-                ("get_peers_elapsed", self.get_peers_elapsed as i64, i64),
+                ("send_quic_elapsed", self.send_quic_elapsed as i64, i64),
                 ("num_shreds", self.num_shreds as i64, i64),
                 ("shred_select", self.shred_select as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
@@ -217,7 +221,7 @@ mod test {
         slot_broadcast_stats.update(
             &TransmitShredsStats {
                 transmit_elapsed: 1,
-                get_peers_elapsed: 2,
+                send_quic_elapsed: 2,
                 send_mmsg_elapsed: 3,
                 shred_select: 4,
                 num_shreds: 5,
@@ -238,7 +242,7 @@ mod test {
         assert_eq!(slot_0_stats.num_batches, 1);
         assert_eq!(slot_0_stats.num_expected_batches.unwrap(), 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.get_peers_elapsed, 2);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_quic_elapsed, 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 3);
         assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 4);
         assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 5);
@@ -249,7 +253,7 @@ mod test {
         slot_broadcast_stats.update(
             &TransmitShredsStats {
                 transmit_elapsed: 11,
-                get_peers_elapsed: 12,
+                send_quic_elapsed: 12,
                 send_mmsg_elapsed: 13,
                 shred_select: 14,
                 num_shreds: 15,
@@ -265,7 +269,7 @@ mod test {
         assert_eq!(slot_0_stats.num_batches, 1);
         assert_eq!(slot_0_stats.num_expected_batches.unwrap(), 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.get_peers_elapsed, 2);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_quic_elapsed, 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 3);
         assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 4);
         assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 5);
@@ -278,7 +282,7 @@ mod test {
         slot_broadcast_stats.update(
             &TransmitShredsStats {
                 transmit_elapsed: 1,
-                get_peers_elapsed: 1,
+                send_quic_elapsed: 1,
                 send_mmsg_elapsed: 1,
                 shred_select: 1,
                 num_shreds: 1,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -409,9 +409,9 @@ impl StandardBroadcastRun {
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
         let mut transmit_stats = TransmitShredsStats::default();
+
         // Broadcast the shreds
         let mut transmit_time = Measure::start("broadcast_shreds");
-
         broadcast_shreds(
             sock,
             &shreds,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -409,9 +409,9 @@ impl StandardBroadcastRun {
     ) -> Result<()> {
         trace!("Broadcasting {:?} shreds", shreds.len());
         let mut transmit_stats = TransmitShredsStats::default();
-
         // Broadcast the shreds
         let mut transmit_time = Measure::start("broadcast_shreds");
+
         broadcast_shreds(
             sock,
             &shreds,


### PR DESCRIPTION
#### Problem
get_peers_elapsed metric in broadcast stage was unused

#### Summary of Changes
- repurpose it to measure the time used for transmission to the quic endpoint channel

#### Some notes:

- we are not actually measuring the time for packets to land on the wire, but rather time needed to ship them over to quic endpoint. To address this we probably should use a bounded channel to stream to the quic endpoint so we get a better idea of the time needed to send data out. 