### PR TITLE
Use `Arc<Keypair>` instead of `&Keypair` in update `NotifyKeyUpdate`

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -46,10 +46,10 @@ pub enum NonblockingClientConnection {
 }
 
 impl NotifyKeyUpdate for ConnectionCache {
-    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+    fn update_key(&self, key: Arc<Keypair>) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Self::Udp(_) => Ok(()),
-            Self::Quic(backend) => backend.update_key(key),
+            Self::Quic(backend) => backend.update_key(key.as_ref()),
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -137,8 +137,8 @@ pub struct EndpointKeyUpdater {
 }
 
 impl NotifyKeyUpdate for EndpointKeyUpdater {
-    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        let (config, _) = configure_server(key)?;
+    fn update_key(&self, key: Arc<Keypair>) -> Result<(), Box<dyn std::error::Error>> {
+        let (config, _) = configure_server(key.as_ref())?;
         for endpoint in &self.endpoints {
             endpoint.set_server_config(Some(config.clone()));
         }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -718,16 +718,15 @@ impl AdminRpcImpl {
                     })?;
             }
 
+            let identity_keypair = Arc::new(identity_keypair);
             for n in post_init.notifies.iter() {
-                if let Err(err) = n.update_key(&identity_keypair) {
+                if let Err(err) = n.update_key(identity_keypair.clone()) {
                     error!("Error updating network layer keypair: {err}");
                 }
             }
 
             solana_metrics::set_host_id(identity_keypair.pubkey().to_string());
-            post_init
-                .cluster_info
-                .set_keypair(Arc::new(identity_keypair));
+            post_init.cluster_info.set_keypair(identity_keypair);
             warn!("Identity set to {}", post_init.cluster_info.id());
             Ok(())
         })

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -43,10 +43,10 @@ impl KeyUpdateNotifier {
 }
 
 impl NotifyKeyUpdate for KeyUpdateNotifier {
-    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+    fn update_key(&self, key: Arc<Keypair>) -> Result<(), Box<dyn std::error::Error>> {
         let updaters = self.key_updaters.lock().unwrap();
         for updater in updaters.iter() {
-            updater.update_key(key)?
+            updater.update_key(key.clone())?
         }
         Ok(())
     }


### PR DESCRIPTION
#### Problem

The current trait definition restricts a structure implementing `NotifyKeyUpdate` from moving `&Keypair`, as it is required to be used in another thread. But if we use `Arc<Keypair>` this problem is resolved.
This breaks public API so unclear if these changes are feasible to add.

#### Summary of Changes

