### PR TITLE
Remove BlockVerificationMethod::BlockstoreProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Release channels have their own copy of this changelog:
 
 <a name="edge-channel"></a>
 ## 2.3.0 - Unreleased
-
+* Breaking:
+  * Removed `--block-verification-method blockstore-processor` option from validator.
 
 ## 2.2.0
 * Breaking:

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -56,26 +56,23 @@ $agave_validator --ledger config/ledger exit --force || true
 
 wait $pid
 
-for method in blockstore-processor unified-scheduler
-do
-  rm -rf config/snapshot-ledger
-  $solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" config/snapshot-ledger
-  cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
-  $solana_ledger_tool copy --ledger config/ledger \
-    --target-db config/snapshot-ledger --starting-slot "$snapshot_slot" --ending-slot "$latest_slot"
+rm -rf config/snapshot-ledger
+$solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" config/snapshot-ledger
+cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
+$solana_ledger_tool copy --ledger config/ledger \
+  --target-db config/snapshot-ledger --starting-slot "$snapshot_slot" --ending-slot "$latest_slot"
 
-  set -x
-  $solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
-    |& grep -q "Log Messages:$" && exit 1
+set -x
+$solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
+  |& grep -q "Log Messages:$" && exit 1
 
-  $solana_ledger_tool verify --abort-on-invalid-block \
-    --ledger config/snapshot-ledger --block-verification-method "$method" \
-    --enable-rpc-transaction-history --enable-extended-tx-metadata-storage
+$solana_ledger_tool verify --abort-on-invalid-block \
+  --ledger config/snapshot-ledger --enable-rpc-transaction-history \
+  --enable-extended-tx-metadata-storage
 
-  $solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
-    |& grep -q "Log Messages:$"
-  set +x
-done
+$solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
+  |& grep -q "Log Messages:$"
+set +x
 
 first_simulated_slot=$((latest_slot / 2))
 purge_slot=$((first_simulated_slot + latest_slot / 4))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -165,7 +165,6 @@ const WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT: u64 =
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockVerificationMethod {
-    BlockstoreProcessor,
     #[default]
     UnifiedScheduler,
 }
@@ -992,15 +991,6 @@ impl Validator {
         let banking_tracer_channels = banking_tracer.create_channels(false);
 
         match &config.block_verification_method {
-            BlockVerificationMethod::BlockstoreProcessor => {
-                info!("no scheduler pool is installed for block verification...");
-                if let Some(count) = config.unified_scheduler_handler_threads {
-                    warn!(
-                        "--unified-scheduler-handler-threads={count} is ignored because unified \
-                         scheduler isn't enabled"
-                    );
-                }
-            }
             BlockVerificationMethod::UnifiedScheduler => {
                 let scheduler_pool = DefaultSchedulerPool::new_dyn(
                     config.unified_scheduler_handler_threads,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -367,15 +367,6 @@ pub fn load_and_process_ledger(
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
     match block_verification_method {
-        BlockVerificationMethod::BlockstoreProcessor => {
-            info!("no scheduler pool is installed for block verification...");
-            if let Some(count) = unified_scheduler_handler_threads {
-                warn!(
-                    "--unified-scheduler-handler-threads={count} is ignored because unified \
-                     scheduler isn't enabled"
-                );
-            }
-        }
         BlockVerificationMethod::UnifiedScheduler => {
             let no_replay_vote_sender = None;
             let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));


### PR DESCRIPTION
#### Problem
- blockstore-processor is slower than unified-scheduler
- it blocks SIMD-83 from being activated without significant changes.

#### Summary of Changes
- disable `blockstore-processor` option so that operators cannot run with it

#### Note
There are still many tests which use this path, they will be updated in follow-up PR(s)

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
