### PR TITLE
Simplify and Refactor pre_lock_filter

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -4,7 +4,7 @@ use {
         prio_graph_scheduler::{
             Batches, PrioGraphScheduler, TransactionSchedulingError, TransactionSchedulingInfo,
         },
-        scheduler::{Scheduler, SchedulingSummary},
+        scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
         transaction_priority_id::TransactionPriorityId,
@@ -82,7 +82,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         &mut self,
         container: &mut S,
         _pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
-        pre_lock_filter: impl Fn(&Tx) -> bool,
+        pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
         let num_threads = self.consume_work_senders.len();
         let target_cu_per_thread = self.config.target_scheduled_cus / num_threads as u64;
@@ -99,7 +99,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         }
 
         // Track metrics on filter.
-        let mut num_filtered_out: usize = 0;
         let mut num_scanned: usize = 0;
         let mut num_scheduled: usize = 0;
         let mut num_sent: usize = 0;
@@ -148,10 +147,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     )
                 },
             ) {
-                Err(TransactionSchedulingError::Filtered) => {
-                    num_filtered_out += 1;
-                    container.remove_by_id(id.id);
-                }
                 Err(TransactionSchedulingError::UnschedulableConflicts)
                 | Err(TransactionSchedulingError::UnschedulableThread) => {
                     num_unschedulable += 1;
@@ -207,7 +202,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         Ok(SchedulingSummary {
             num_scheduled,
             num_unschedulable,
-            num_filtered_out,
+            num_filtered_out: 0,
             filter_time_us: 0,
         })
     }
@@ -348,17 +343,17 @@ impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
 
 fn try_schedule_transaction<Tx: TransactionWithMeta>(
     transaction_state: &mut TransactionState<Tx>,
-    pre_lock_filter: impl Fn(&Tx) -> bool,
+    pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     account_locks: &mut ThreadAwareAccountLocks,
     schedulable_threads: ThreadSet,
     thread_selector: impl Fn(ThreadSet) -> ThreadId,
 ) -> Result<TransactionSchedulingInfo<Tx>, TransactionSchedulingError> {
-    let transaction = &transaction_state.transaction_ttl().transaction;
-    if !pre_lock_filter(transaction) {
-        return Err(TransactionSchedulingError::Filtered);
+    match pre_lock_filter(transaction_state) {
+        PreLockFilterAction::AttemptToSchedule => {}
     }
 
     // Schedule the transaction if it can be.
+    let transaction = &transaction_state.transaction_ttl().transaction;
     let account_keys = transaction.account_keys();
     let write_account_locks = account_keys
         .iter()
@@ -518,8 +513,10 @@ mod test {
         results.fill(true);
     }
 
-    fn test_pre_lock_filter(_tx: &RuntimeTransaction<SanitizedTransaction>) -> bool {
-        true
+    fn test_pre_lock_filter(
+        _tx: &TransactionState<RuntimeTransaction<SanitizedTransaction>>,
+    ) -> PreLockFilterAction {
+        PreLockFilterAction::AttemptToSchedule
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -1,5 +1,8 @@
 use {
-    super::{scheduler_error::SchedulerError, transaction_state_container::StateContainer},
+    super::{
+        scheduler_error::SchedulerError, transaction_state::TransactionState,
+        transaction_state_container::StateContainer,
+    },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
 };
 
@@ -11,7 +14,7 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut S,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
-        pre_lock_filter: impl Fn(&Tx) -> bool,
+        pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError>;
 
     /// Receive completed batches of transactions without blocking.
@@ -20,6 +23,12 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut impl StateContainer<Tx>,
     ) -> Result<(usize, usize), SchedulerError>;
+}
+
+/// Action to be taken by pre-lock filter.
+pub(crate) enum PreLockFilterAction {
+    /// Attempt to schedule the transaction.
+    AttemptToSchedule,
 }
 
 /// Metrics from scheduling transactions.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -4,7 +4,7 @@
 use {
     super::{
         receive_and_buffer::ReceiveAndBuffer,
-        scheduler::Scheduler,
+        scheduler::{PreLockFilterAction, Scheduler},
         scheduler_error::SchedulerError,
         scheduler_metrics::{
             SchedulerCountMetrics, SchedulerLeaderDetectionMetrics, SchedulerTimingMetrics,
@@ -142,7 +142,7 @@ where
                             MAX_PROCESSING_AGE,
                         )
                     },
-                    |_| true // no pre-lock filter for now
+                    |_| PreLockFilterAction::AttemptToSchedule // no pre-lock filter for now
                 )?);
 
                 self.count_metrics.update(|count_metrics| {


### PR DESCRIPTION
#### Problem
- `pre_lock_filter` has been unused so far
- want to change from strict filter to allowing different actions to be taken. for example, skip w/o removing it from map

#### Summary of Changes
- `pre_lock_filter` takes in transaction state
- `pre_lock_filter` returns a `PreLockFilterAction`
- `PreLockFilterAction` currently only supports simple pass-through

#### Future Plans
1. Retry throttling
- Add `PreLockFilterAction::Skip` which allows tx to be skipped, but not removed
- `pre_lock_filter` will use the current bank slot to compare against a (soon to be introduced) latest retry slot to avoid retrying transactions too often

2. IP filtering 
- if IP is sending us enough trash, we can quickly drop the transactions here

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
