### PR TITLE
tpu-client-next: introduce stake identity

### DIFF
--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -45,7 +45,7 @@ pub enum ConnectionWorkersSchedulerError {
 /// be targeted when sending transactions and connecting.
 ///
 /// Note, that the unit is number of leaders per
-/// [`NUM_CONSECUTIVE_LEADER_SLOTS`]. It means that if the leader schedule is
+/// [`solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS`]. It means that if the leader schedule is
 /// [L1, L1, L1, L1, L1, L1, L1, L1, L2, L2, L2, L2], the leaders per
 /// consecutive leader slots are [L1, L1, L2], so there are 3 of them.
 ///
@@ -91,6 +91,12 @@ pub struct ConnectionWorkersSchedulerConfig {
     pub leaders_fanout: Fanout,
 }
 
+/// The [`StakeIdentity`] structure provides a convenient abstraction for handling
+/// [`Keypair`] when creating a QUIC certificate. Since `Keypair` does not implement
+/// [`Clone`], it cannot be moved in situations where [`ConnectionWorkersSchedulerConfig`]
+/// needs to be transferred. This wrapper structure allows the use of either a `Keypair`
+/// or a `&Keypair` to create a certificate, which is stored internally and later
+/// consumed by [`ConnectionWorkersScheduler`] to create an endpoint.
 pub struct StakeIdentity(QuicClientCertificate);
 
 impl From<Keypair> for StakeIdentity {
@@ -142,7 +148,7 @@ impl ConnectionWorkersScheduler {
     ///
     /// This method is a shorthand for
     /// [`ConnectionWorkersScheduler::run_with_broadcaster`] using
-    /// [`NonblockingBroadcaster`] strategy.
+    /// `NonblockingBroadcaster` strategy.
     ///
     /// Transactions that fail to be delivered to workers due to full channels
     /// will be dropped. The same for transactions that failed to be delivered

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -1,5 +1,5 @@
 //! This module provides [`LeaderUpdater`] trait along with
-//! `create_leader_updater` function to create an instance of this trait.
+//! [`create_leader_updater`] function to create an instance of this trait.
 //!
 //! Currently, the main purpose of [`LeaderUpdater`] is to abstract over leader
 //! updates, hiding the details of how leaders are retrieved and which

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -1,4 +1,4 @@
-//! This module defines `WorkersCache` along with aux struct `WorkerInfo`. These
+//! This module defines [`WorkersCache`] along with aux struct [`WorkerInfo`]. These
 //! structures provide mechanisms for caching workers, sending transaction
 //! batches, and gathering send transaction statistics.
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -45,7 +45,7 @@ use {
 fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
     ConnectionWorkersSchedulerConfig {
         bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
-        stake_identity,
+        stake_identity: stake_identity.map(Into::into),
         num_connections: 1,
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try


### PR DESCRIPTION
#### Problem

When we launch the transaction scheduler, we do it as follows (pseudocode):
```rust
let config = Config { stake_identity: Some(keypair) ... }
tokio_runtime.spawn(Scheduler::run(config));
```

So we move the `config` together with the `stake_identity` which is currently `Keypair`. Keypair doesn't have clone and we are trying to avoid `insecure_clone`. 

#### Summary of Changes

This PR introduces workaround which allows to use `&Keypair` instead. At the end, the `stake_identity` is needed to create `QuicClientCertificate` which will be consumed when creating endpoint. So in this PR we  create and store certificate as part of this config.

Why wrapping QuicClientCertificate with a new type:
* to hide that we are creating certificate from client, otherwise it would require to import additional crate, call function creating certificates
* if something changes in the respect of Keypair and Certificate, we control the new type on the crate level so it is possible to change it's implementation
* to use convenience `into` calls simplifying user experience.

