### PR TITLE
remove solana-sdk from accounts-bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6129,9 +6129,12 @@ dependencies = [
  "log",
  "rayon",
  "solana-accounts-db",
+ "solana-clock",
+ "solana-epoch-schedule",
  "solana-logger",
  "solana-measure",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-rent-collector",
  "solana-version",
 ]
 

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -13,9 +13,12 @@ clap = { workspace = true }
 log = { workspace = true }
 rayon = { workspace = true }
 solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
+solana-clock = { workspace = true }
+solana-epoch-schedule = { workspace = true }
 solana-logger = { workspace = true }
 solana-measure = { workspace = true }
-solana-sdk = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent-collector = { workspace = true }
 solana-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -13,10 +13,10 @@ use {
         },
         ancestors::Ancestors,
     },
+    solana_epoch_schedule::EpochSchedule,
     solana_measure::measure::Measure,
-    solana_sdk::{
-        pubkey::Pubkey, rent_collector::RentCollector, sysvar::epoch_schedule::EpochSchedule,
-    },
+    solana_pubkey::Pubkey,
+    solana_rent_collector::RentCollector,
     std::{env, fs, path::PathBuf, sync::Arc},
 };
 
@@ -127,7 +127,7 @@ fn main() {
             let results_store = accounts.accounts_db.update_accounts_hash_with_verify_from(
                 CalcAccountsHashDataSource::Storages,
                 false,
-                solana_sdk::clock::Slot::default(),
+                solana_clock::Slot::default(),
                 &ancestors,
                 None,
                 &EpochSchedule::default(),


### PR DESCRIPTION
#### Problem
This crate no longer needs solana-sdk

#### Summary of Changes
Replace with component crates