### PR TITLE
agave-validator: add args tests for repair-shred-from-peer

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -67,7 +67,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(commands::exit::command(default_args))
         .subcommand(commands::authorized_voter::command(default_args))
         .subcommand(commands::contact_info::command(default_args))
-        .subcommand(commands::repair_shred_from_peer::command(default_args))
+        .subcommand(commands::repair_shred_from_peer::command())
         .subcommand(commands::repair_whitelist::command(default_args))
         .subcommand(
             SubCommand::with_name("init").about("Initialize the ledger directory then exit"),

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -6,8 +6,10 @@ use {
     std::path::Path,
 };
 
+const COMMAND: &str = "repair-shred-from-peer";
+
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
-    SubCommand::with_name("repair-shred-from-peer")
+    SubCommand::with_name(COMMAND)
         .about("Request a repair from the specified validator")
         .arg(
             Arg::with_name("pubkey")

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
+    crate::{admin_rpc_service, commands::FromClapArgMatches},
     clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_pubkey},
     solana_sdk::pubkey::Pubkey,
@@ -25,7 +25,7 @@ impl FromClapArgMatches for RepairShredFromPeerArgs {
     }
 }
 
-pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name(COMMAND)
         .about("Request a repair from the specified validator")
         .arg(
@@ -79,8 +79,7 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_repair_shred_from_peer_missing_slot() {
-        let default_args = DefaultArgs::default();
-        let app = command(&default_args);
+        let app = command();
         let matches = app.get_matches_from(vec![COMMAND]);
         let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
         assert_eq!(args, Err("slot is not a valid number".to_string()));
@@ -88,8 +87,7 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_repair_shred_from_peer_missing_shred() {
-        let default_args = DefaultArgs::default();
-        let app = command(&default_args);
+        let app = command();
         let matches = app.get_matches_from(vec![COMMAND, "--slot", "1"]);
         let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
         assert_eq!(args, Err("shred is not a valid number".to_string()));
@@ -98,7 +96,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_repair_shred_from_peer_missing_pubkey() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, "--slot", "1", "--shred", "2"],
             RepairShredFromPeerArgs {
                 pubkey: None,
@@ -111,7 +109,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_repair_shred_from_peer_with_pubkey() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![
                 COMMAND,
                 "--slot",

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -1,12 +1,29 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs},
-    clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand},
+    crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
+    clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_pubkey},
     solana_sdk::pubkey::Pubkey,
     std::path::Path,
 };
 
 const COMMAND: &str = "repair-shred-from-peer";
+
+#[derive(Debug, PartialEq)]
+pub struct RepairShredFromPeerArgs {
+    pub pubkey: Option<Pubkey>,
+    pub slot: u64,
+    pub shred: u64,
+}
+
+impl FromClapArgMatches for RepairShredFromPeerArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+        Ok(RepairShredFromPeerArgs {
+            pubkey: value_t!(matches, "pubkey", Pubkey).ok(),
+            slot: value_t!(matches, "slot", u64).map_err(|_| "slot is not a valid number")?,
+            shred: value_t!(matches, "shred", u64).map_err(|_| "shred is not a valid number")?,
+        })
+    }
+}
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name(COMMAND)
@@ -39,16 +56,78 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let pubkey = value_t!(matches, "pubkey", Pubkey).ok();
-    let slot = value_t_or_exit!(matches, "slot", u64);
-    let shred_index = value_t_or_exit!(matches, "shred", u64);
+    let RepairShredFromPeerArgs {
+        pubkey,
+        slot,
+        shred,
+    } = RepairShredFromPeerArgs::from_clap_arg_match(matches)?;
+
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime()
         .block_on(async move {
             admin_client
                 .await?
-                .repair_shred_from_peer(pubkey, slot, shred_index)
+                .repair_shred_from_peer(pubkey, slot, shred)
                 .await
         })
         .map_err(|err| format!("repair shred from peer request failed: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::commands::tests::verify_args_struct_by_command, std::str::FromStr};
+
+    #[test]
+    fn verify_args_struct_by_command_repair_shred_from_peer_missing_slot() {
+        let default_args = DefaultArgs::default();
+        let app = command(&default_args);
+        let matches = app.get_matches_from(vec![COMMAND]);
+        let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
+        assert_eq!(args, Err("slot is not a valid number".to_string()));
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_repair_shred_from_peer_missing_shred() {
+        let default_args = DefaultArgs::default();
+        let app = command(&default_args);
+        let matches = app.get_matches_from(vec![COMMAND, "--slot", "1"]);
+        let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
+        assert_eq!(args, Err("shred is not a valid number".to_string()));
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_repair_shred_from_peer_missing_pubkey() {
+        verify_args_struct_by_command(
+            command(&DefaultArgs::default()),
+            vec![COMMAND, "--slot", "1", "--shred", "2"],
+            RepairShredFromPeerArgs {
+                pubkey: None,
+                slot: 1,
+                shred: 2,
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_repair_shred_from_peer_with_pubkey() {
+        verify_args_struct_by_command(
+            command(&DefaultArgs::default()),
+            vec![
+                COMMAND,
+                "--slot",
+                "1",
+                "--shred",
+                "2",
+                "--pubkey",
+                "ch1do11111111111111111111111111111111111111",
+            ],
+            RepairShredFromPeerArgs {
+                pubkey: Some(
+                    Pubkey::from_str("ch1do11111111111111111111111111111111111111").unwrap(),
+                ),
+                slot: 1,
+                shred: 2,
+            },
+        );
+    }
 }


### PR DESCRIPTION
#### Problem

#4082 

#### Summary of Changes

- extracting args parsing logic and adding tests
- same as https://github.com/anza-xyz/agave/pull/4923. I replaced `value_t_or_exit !` with other functions and moved the exit logic to the `fn execute`