### PR TITLE
ForwardingStage: unfiltered dataless packet should panic

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -199,10 +199,10 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
                 .filter(|p| initial_packet_meta_filter(p.meta()))
             {
                 let Some(packet_data) = packet.data(..) else {
-                    // should never occur since we've already checked the
-                    // packet is not marked for discard.
-                    datapoint_error!("forward_stage_packet_discard_error", ("count", 1, i64));
-                    continue;
+                    unreachable!(
+                        "packet.meta().discard() was already checked. \
+                         If not discarded, packet MUST have data"
+                    );
                 };
 
                 let vote_count = usize::from(is_tpu_vote_batch);

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -201,6 +201,7 @@ impl<F: ForwardAddressGetter> ForwardingStage<F> {
                 let Some(packet_data) = packet.data(..) else {
                     // should never occur since we've already checked the
                     // packet is not marked for discard.
+                    datapoint_error!("forward_stage_packet_discard_error", ("count", 1, i64));
                     continue;
                 };
 


### PR DESCRIPTION
#### Problem
- Packets marked as `discard` will have `.data(..)` return `None`
- Comment in code implies this branch should never happen because of the previous check
- If this is not the case, there is a serious bug

#### Summary of Changes
- Mark branch as `unreachable` since it cannot occur due to previous checks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
