### PR TITLE
Abstract Repair Service Actions

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -6,7 +6,7 @@ use {
     solana_sdk::clock::DEFAULT_MS_PER_SLOT,
 };
 use {
-    crate::{
+    super::serve_repair::RepairPeers, crate::{
         cluster_info_vote_listener::VerifiedVoteReceiver,
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{
@@ -21,29 +21,17 @@ use {
                 REPAIR_PEERS_CACHE_CAPACITY,
             },
         },
-    },
-    bytes::Bytes,
-    crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender},
-    lru::LruCache,
-    rand::seq::SliceRandom,
-    solana_client::connection_cache::Protocol,
-    solana_gossip::cluster_info::ClusterInfo,
-    solana_ledger::{
+    }, bytes::Bytes, crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender}, lru::LruCache, rand::seq::SliceRandom, solana_client::connection_cache::Protocol, solana_gossip::cluster_info::ClusterInfo, solana_ledger::{
         blockstore::{Blockstore, SlotMeta},
         shred,
-    },
-    solana_measure::measure::Measure,
-    solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache},
-    solana_sdk::{
+    }, solana_measure::measure::Measure, solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache}, solana_sdk::{
         clock::{Slot, DEFAULT_TICKS_PER_SECOND, MS_PER_TICK},
         epoch_schedule::EpochSchedule,
         hash::Hash,
         pubkey::Pubkey,
         signer::keypair::Keypair,
         timing::timestamp,
-    },
-    solana_streamer::sendmmsg::{batch_send, SendPktsError},
-    std::{
+    }, solana_streamer::sendmmsg::{batch_send, SendPktsError}, std::{
         collections::{hash_map::Entry, HashMap, HashSet},
         iter::Iterator,
         net::{SocketAddr, UdpSocket},
@@ -53,8 +41,7 @@ use {
         },
         thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},
-    },
-    tokio::sync::mpsc::Sender as AsyncSender,
+    }, tokio::sync::mpsc::Sender as AsyncSender
 };
 
 // Time to defer repair requests to allow for turbine propagation
@@ -440,6 +427,17 @@ impl RepairServiceChannels {
     }
 }
 
+struct RepairTracker {
+    root_bank_cache: RootBankCache,
+    repair_weight: RepairWeight,
+    serve_repair: ServeRepair,
+    repair_metrics: RepairMetrics,
+    peers_cache: LruCache<u64, RepairPeers>,
+    popular_pruned_forks_requests: HashSet<Slot>,
+    // Maps a repair that may still be outstanding to the timestamp it was requested.
+    outstanding_repairs: HashMap<ShredRepairType, u64>,
+}
+
 pub struct RepairService {
     t_repair: JoinHandle<()>,
     ancestor_hashes_service: AncestorHashesService,
@@ -488,6 +486,215 @@ impl RepairService {
         }
     }
 
+    fn run_repair_iteration(
+        blockstore: &Blockstore,
+        repair_channels: &RepairChannels,
+        repair_info: &RepairInfo,
+        repair_tracker: &mut RepairTracker,
+        outstanding_requests: &RwLock<OutstandingShredRepairs>,
+        repair_socket: &UdpSocket,
+    ) {
+        let RepairChannels {
+            repair_request_quic_sender,
+            verified_vote_receiver,
+            dumped_slots_receiver,
+            popular_pruned_forks_sender,
+            ..
+        } = repair_channels;
+
+        let RepairTracker {
+            root_bank_cache,
+            repair_weight,
+            serve_repair,
+            repair_metrics,
+            peers_cache,
+            popular_pruned_forks_requests,
+            outstanding_repairs,
+        } = repair_tracker;
+
+        let mut set_root_elapsed;
+        let mut dump_slots_elapsed;
+        let mut get_votes_elapsed;
+        let mut add_votes_elapsed;
+        let mut purge_outstanding_repairs;
+        let mut handle_popular_pruned_forks;
+
+        let root_bank = root_bank_cache.root_bank();
+        let repair_protocol = serve_repair::get_repair_protocol(root_bank.cluster_type());
+        let repairs = {
+            let new_root = root_bank.slot();
+
+            // Purge outdated slots from the weighting heuristic
+            set_root_elapsed = Measure::start("set_root_elapsed");
+            repair_weight.set_root(new_root);
+            set_root_elapsed.stop();
+
+            // Remove dumped slots from the weighting heuristic
+            dump_slots_elapsed = Measure::start("dump_slots_elapsed");
+            dumped_slots_receiver
+                .try_iter()
+                .for_each(|slot_hash_keys_to_dump| {
+                    // Currently we don't use the correct_hash in repair. Since this dumped
+                    // slot is DuplicateConfirmed, we have a >= 52% chance on receiving the
+                    // correct version.
+                    for (slot, _correct_hash) in slot_hash_keys_to_dump {
+                        // `slot` is dumped in blockstore wanting to be repaired, we orphan it along with
+                        // descendants while copying the weighting heuristic so that it can be
+                        // repaired with correct ancestor information
+                        //
+                        // We still check to see if this slot is too old, as bank forks root
+                        // might have been updated in between the send and our receive. If that
+                        // is the case we can safely ignore this dump request as the slot in
+                        // question would have already been purged in `repair_weight.set_root`
+                        // and there is no chance of it being part of the rooted path.
+                        if slot >= repair_weight.root() {
+                            let dumped_slots = repair_weight.split_off(slot);
+                            // Remove from outstanding ancestor hashes requests. Also clean any
+                            // requests that might have been since fixed
+                            popular_pruned_forks_requests.retain(|slot| {
+                                !dumped_slots.contains(slot) && repair_weight.is_pruned(*slot)
+                            });
+                        }
+                    }
+                });
+            dump_slots_elapsed.stop();
+
+            // Add new votes to the weighting heuristic
+            get_votes_elapsed = Measure::start("get_votes_elapsed");
+            let mut slot_to_vote_pubkeys: HashMap<Slot, Vec<Pubkey>> = HashMap::new();
+            verified_vote_receiver
+                .try_iter()
+                .for_each(|(vote_pubkey, vote_slots)| {
+                    for slot in vote_slots {
+                        slot_to_vote_pubkeys
+                            .entry(slot)
+                            .or_default()
+                            .push(vote_pubkey);
+                    }
+                });
+            get_votes_elapsed.stop();
+
+            add_votes_elapsed = Measure::start("add_votes");
+            repair_weight.add_votes(
+                blockstore,
+                slot_to_vote_pubkeys.into_iter(),
+                root_bank.epoch_stakes_map(),
+                root_bank.epoch_schedule(),
+            );
+            add_votes_elapsed.stop();
+
+            purge_outstanding_repairs = Measure::start("purge_outstanding_repairs");
+            // Purge old entries. They've either completed or need to be retried.
+            outstanding_repairs.retain(|_repair_request, time| {
+                timestamp().saturating_sub(*time) < REPAIR_REQUEST_TIMEOUT_MS
+            });
+            purge_outstanding_repairs.stop();
+
+            let repairs = match repair_info.wen_restart_repair_slots.clone() {
+                Some(slots_to_repair) => Self::generate_repairs_for_wen_restart(
+                    blockstore,
+                    MAX_REPAIR_LENGTH,
+                    &slots_to_repair.read().unwrap(),
+                    outstanding_repairs,
+                ),
+                None => repair_weight.get_best_weighted_repairs(
+                    blockstore,
+                    root_bank.epoch_stakes_map(),
+                    root_bank.epoch_schedule(),
+                    MAX_ORPHANS,
+                    MAX_REPAIR_LENGTH,
+                    MAX_UNKNOWN_LAST_INDEX_REPAIRS,
+                    MAX_CLOSEST_COMPLETION_REPAIRS,
+                    repair_metrics,
+                    outstanding_repairs,
+                ),
+            };
+
+            handle_popular_pruned_forks = Measure::start("handle_popular_pruned_forks");
+            let mut popular_pruned_forks = repair_weight.get_popular_pruned_forks(
+                root_bank.epoch_stakes_map(),
+                root_bank.epoch_schedule(),
+            );
+            // Check if we've already sent a request along this pruned fork
+            popular_pruned_forks.retain(|slot| {
+                if popular_pruned_forks_requests
+                    .iter()
+                    .any(|prev_req_slot| repair_weight.same_tree(*slot, *prev_req_slot))
+                {
+                    false
+                } else {
+                    popular_pruned_forks_requests.insert(*slot);
+                    true
+                }
+            });
+            if !popular_pruned_forks.is_empty() {
+                warn!(
+                    "Notifying repair of popular pruned forks {:?}",
+                    popular_pruned_forks
+                );
+                popular_pruned_forks_sender
+                    .send(popular_pruned_forks)
+                    .unwrap_or_else(|err| error!("failed to send popular pruned forks {err}"));
+            }
+            handle_popular_pruned_forks.stop();
+
+            repairs
+        };
+
+        let identity_keypair: &Keypair = &repair_info.cluster_info.keypair().clone();
+
+        let mut build_repairs_batch_elapsed = Measure::start("build_repairs_batch_elapsed");
+        let batch: Vec<(Vec<u8>, SocketAddr)> = {
+            let mut outstanding_requests = outstanding_requests.write().unwrap();
+            repairs
+                .into_iter()
+                .filter_map(|repair_request| {
+                    let (to, req) = serve_repair
+                        .repair_request(
+                            &repair_info.cluster_slots,
+                            repair_request,
+                            peers_cache,
+                            &mut repair_metrics.stats,
+                            &repair_info.repair_validators,
+                            &mut outstanding_requests,
+                            identity_keypair,
+                            repair_request_quic_sender,
+                            repair_protocol,
+                        )
+                        .ok()??;
+                    Some((req, to))
+                })
+                .collect()
+        };
+        build_repairs_batch_elapsed.stop();
+
+        let mut batch_send_repairs_elapsed = Measure::start("batch_send_repairs_elapsed");
+        if !batch.is_empty() {
+            let num_pkts = batch.len();
+            let batch = batch.iter().map(|(bytes, addr)| (bytes, addr));
+            match batch_send(repair_socket, batch) {
+                Ok(()) => (),
+                Err(SendPktsError::IoError(err, num_failed)) => {
+                    error!(
+                        "{} batch_send failed to send {num_failed}/{num_pkts} packets first error {err:?}", repair_info.cluster_info.id()
+                    );
+                }
+            }
+        }
+        batch_send_repairs_elapsed.stop();
+
+        repair_metrics.timing.update(
+            set_root_elapsed.as_us(),
+            dump_slots_elapsed.as_us(),
+            get_votes_elapsed.as_us(),
+            add_votes_elapsed.as_us(),
+            purge_outstanding_repairs.as_us(),
+            handle_popular_pruned_forks.as_us(),
+            build_repairs_batch_elapsed.as_us(),
+            batch_send_repairs_elapsed.as_us(),
+        );
+    }
+
     fn run(
         blockstore: &Blockstore,
         exit: &AtomicBool,
@@ -497,211 +704,30 @@ impl RepairService {
         outstanding_requests: &RwLock<OutstandingShredRepairs>,
     ) {
         let mut root_bank_cache = RootBankCache::new(repair_info.bank_forks.clone());
-        let mut repair_weight = RepairWeight::new(root_bank_cache.root_bank().slot());
-        let serve_repair = ServeRepair::new(
-            repair_info.cluster_info.clone(),
-            repair_info.bank_forks.clone(),
-            repair_info.repair_whitelist.clone(),
-        );
-        let id = repair_info.cluster_info.id();
-        let mut repair_metrics = RepairMetrics::default();
-
-        let mut peers_cache = LruCache::new(REPAIR_PEERS_CACHE_CAPACITY);
-        let mut popular_pruned_forks_requests = HashSet::new();
-        // Maps a repair that may still be outstanding to the timestamp it was requested.
-        let mut outstanding_repairs = HashMap::new();
-
-        let RepairChannels {
-            repair_request_quic_sender,
-            verified_vote_receiver,
-            dumped_slots_receiver,
-            popular_pruned_forks_sender,
-            ..
-        } = repair_channels;
+        let mut repair_tracker = RepairTracker {
+            root_bank_cache: RootBankCache::new(repair_info.bank_forks.clone()),
+            repair_weight: RepairWeight::new(root_bank_cache.root_bank().slot()),
+            serve_repair: ServeRepair::new(
+                repair_info.cluster_info.clone(),
+                repair_info.bank_forks.clone(),
+                repair_info.repair_whitelist.clone(),
+            ),
+            repair_metrics: RepairMetrics::default(),
+            peers_cache: LruCache::new(REPAIR_PEERS_CACHE_CAPACITY),
+            popular_pruned_forks_requests: HashSet::new(),
+            outstanding_repairs: HashMap::new(),
+        };
 
         while !exit.load(Ordering::Relaxed) {
-            let mut set_root_elapsed;
-            let mut dump_slots_elapsed;
-            let mut get_votes_elapsed;
-            let mut add_votes_elapsed;
-            let mut purge_outstanding_repairs;
-            let mut handle_popular_pruned_forks;
-
-            let root_bank = root_bank_cache.root_bank();
-            let repair_protocol = serve_repair::get_repair_protocol(root_bank.cluster_type());
-            let repairs = {
-                let new_root = root_bank.slot();
-
-                // Purge outdated slots from the weighting heuristic
-                set_root_elapsed = Measure::start("set_root_elapsed");
-                repair_weight.set_root(new_root);
-                set_root_elapsed.stop();
-
-                // Remove dumped slots from the weighting heuristic
-                dump_slots_elapsed = Measure::start("dump_slots_elapsed");
-                dumped_slots_receiver
-                    .try_iter()
-                    .for_each(|slot_hash_keys_to_dump| {
-                        // Currently we don't use the correct_hash in repair. Since this dumped
-                        // slot is DuplicateConfirmed, we have a >= 52% chance on receiving the
-                        // correct version.
-                        for (slot, _correct_hash) in slot_hash_keys_to_dump {
-                            // `slot` is dumped in blockstore wanting to be repaired, we orphan it along with
-                            // descendants while copying the weighting heuristic so that it can be
-                            // repaired with correct ancestor information
-                            //
-                            // We still check to see if this slot is too old, as bank forks root
-                            // might have been updated in between the send and our receive. If that
-                            // is the case we can safely ignore this dump request as the slot in
-                            // question would have already been purged in `repair_weight.set_root`
-                            // and there is no chance of it being part of the rooted path.
-                            if slot >= repair_weight.root() {
-                                let dumped_slots = repair_weight.split_off(slot);
-                                // Remove from outstanding ancestor hashes requests. Also clean any
-                                // requests that might have been since fixed
-                                popular_pruned_forks_requests.retain(|slot| {
-                                    !dumped_slots.contains(slot) && repair_weight.is_pruned(*slot)
-                                });
-                            }
-                        }
-                    });
-                dump_slots_elapsed.stop();
-
-                // Add new votes to the weighting heuristic
-                get_votes_elapsed = Measure::start("get_votes_elapsed");
-                let mut slot_to_vote_pubkeys: HashMap<Slot, Vec<Pubkey>> = HashMap::new();
-                verified_vote_receiver
-                    .try_iter()
-                    .for_each(|(vote_pubkey, vote_slots)| {
-                        for slot in vote_slots {
-                            slot_to_vote_pubkeys
-                                .entry(slot)
-                                .or_default()
-                                .push(vote_pubkey);
-                        }
-                    });
-                get_votes_elapsed.stop();
-
-                add_votes_elapsed = Measure::start("add_votes");
-                repair_weight.add_votes(
-                    blockstore,
-                    slot_to_vote_pubkeys.into_iter(),
-                    root_bank.epoch_stakes_map(),
-                    root_bank.epoch_schedule(),
-                );
-                add_votes_elapsed.stop();
-
-                purge_outstanding_repairs = Measure::start("purge_outstanding_repairs");
-                // Purge old entries. They've either completed or need to be retried.
-                outstanding_repairs.retain(|_repair_request, time| {
-                    timestamp().saturating_sub(*time) < REPAIR_REQUEST_TIMEOUT_MS
-                });
-                purge_outstanding_repairs.stop();
-
-                let repairs = match repair_info.wen_restart_repair_slots.clone() {
-                    Some(slots_to_repair) => Self::generate_repairs_for_wen_restart(
-                        blockstore,
-                        MAX_REPAIR_LENGTH,
-                        &slots_to_repair.read().unwrap(),
-                        &mut outstanding_repairs,
-                    ),
-                    None => repair_weight.get_best_weighted_repairs(
-                        blockstore,
-                        root_bank.epoch_stakes_map(),
-                        root_bank.epoch_schedule(),
-                        MAX_ORPHANS,
-                        MAX_REPAIR_LENGTH,
-                        MAX_UNKNOWN_LAST_INDEX_REPAIRS,
-                        MAX_CLOSEST_COMPLETION_REPAIRS,
-                        &mut repair_metrics,
-                        &mut outstanding_repairs,
-                    ),
-                };
-
-                handle_popular_pruned_forks = Measure::start("handle_popular_pruned_forks");
-                let mut popular_pruned_forks = repair_weight.get_popular_pruned_forks(
-                    root_bank.epoch_stakes_map(),
-                    root_bank.epoch_schedule(),
-                );
-                // Check if we've already sent a request along this pruned fork
-                popular_pruned_forks.retain(|slot| {
-                    if popular_pruned_forks_requests
-                        .iter()
-                        .any(|prev_req_slot| repair_weight.same_tree(*slot, *prev_req_slot))
-                    {
-                        false
-                    } else {
-                        popular_pruned_forks_requests.insert(*slot);
-                        true
-                    }
-                });
-                if !popular_pruned_forks.is_empty() {
-                    warn!(
-                        "Notifying repair of popular pruned forks {:?}",
-                        popular_pruned_forks
-                    );
-                    popular_pruned_forks_sender
-                        .send(popular_pruned_forks)
-                        .unwrap_or_else(|err| error!("failed to send popular pruned forks {err}"));
-                }
-                handle_popular_pruned_forks.stop();
-
-                repairs
-            };
-
-            let identity_keypair: &Keypair = &repair_info.cluster_info.keypair().clone();
-
-            let mut build_repairs_batch_elapsed = Measure::start("build_repairs_batch_elapsed");
-            let batch: Vec<(Vec<u8>, SocketAddr)> = {
-                let mut outstanding_requests = outstanding_requests.write().unwrap();
-                repairs
-                    .into_iter()
-                    .filter_map(|repair_request| {
-                        let (to, req) = serve_repair
-                            .repair_request(
-                                &repair_info.cluster_slots,
-                                repair_request,
-                                &mut peers_cache,
-                                &mut repair_metrics.stats,
-                                &repair_info.repair_validators,
-                                &mut outstanding_requests,
-                                identity_keypair,
-                                &repair_request_quic_sender,
-                                repair_protocol,
-                            )
-                            .ok()??;
-                        Some((req, to))
-                    })
-                    .collect()
-            };
-            build_repairs_batch_elapsed.stop();
-
-            let mut batch_send_repairs_elapsed = Measure::start("batch_send_repairs_elapsed");
-            if !batch.is_empty() {
-                let num_pkts = batch.len();
-                let batch = batch.iter().map(|(bytes, addr)| (bytes, addr));
-                match batch_send(repair_socket, batch) {
-                    Ok(()) => (),
-                    Err(SendPktsError::IoError(err, num_failed)) => {
-                        error!(
-                            "{id} batch_send failed to send {num_failed}/{num_pkts} packets first error {err:?}"
-                        );
-                    }
-                }
-            }
-            batch_send_repairs_elapsed.stop();
-
-            repair_metrics.timing.update(
-                set_root_elapsed.as_us(),
-                dump_slots_elapsed.as_us(),
-                get_votes_elapsed.as_us(),
-                add_votes_elapsed.as_us(),
-                purge_outstanding_repairs.as_us(),
-                handle_popular_pruned_forks.as_us(),
-                build_repairs_batch_elapsed.as_us(),
-                batch_send_repairs_elapsed.as_us(),
+            Self::run_repair_iteration(
+                blockstore,
+                &repair_channels,
+                &repair_info,
+                &mut repair_tracker,
+                outstanding_requests,
+                repair_socket,
             );
-            repair_metrics.maybe_report();
+            repair_tracker.repair_metrics.maybe_report();
             sleep(Duration::from_millis(REPAIR_MS));
         }
     }


### PR DESCRIPTION
#### Problem
`fn run` in `RepairService` is over 200 lines and super hard to understand the first time. It would be a little easier to understand things by abstracting away the large chunks of actions that are happening.

Given we have plans to improve the repair algorithm, making it easier for more people to understand seems worthwhile.

#### Summary of Changes

This list maps to the commits to help make it easier to digest
1. Add repair iteration function to abstract everything happening inside the run loop (except reporting stats/sleeping)
2. cleanup a few things and un-nest the stuff that was under `let repair = {`. Not sure why we ever needed that...
3. Sub-function for update weighting heuristic
4. Sub-function for handle popular pruned forks
5. Sub-function for build and send repair
6. Sub-function for identify repairs
7. Cleanup some places where we are using an intermediate var when it's not necessary