### PR TITLE
validator: Cleanup output format parsing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clap-utils",
  "solana-cli-config",
+ "solana-cli-output",
  "solana-core",
  "solana-download-utils",
  "solana-entry",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clap-utils",
  "solana-cli-config",
+ "solana-cli-output",
  "solana-core",
  "solana-download-utils",
  "solana-entry",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -36,6 +36,7 @@ serde_yaml = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
+solana-cli-output = { workspace = true }
 solana-core = { workspace = true }
 solana-download-utils = { workspace = true }
 solana-entry = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -133,6 +133,8 @@ impl Display for AdminRpcContactInfo {
         writeln!(f, "Shred Version: {}", self.shred_version)
     }
 }
+impl solana_cli_output::VerboseDisplay for AdminRpcContactInfo {}
+impl solana_cli_output::QuietDisplay for AdminRpcContactInfo {}
 
 impl Display for AdminRpcRepairWhitelist {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -141,6 +141,8 @@ impl Display for AdminRpcRepairWhitelist {
         writeln!(f, "Repair whitelist: {:?}", &self.whitelist)
     }
 }
+impl solana_cli_output::VerboseDisplay for AdminRpcRepairWhitelist {}
+impl solana_cli_output::QuietDisplay for AdminRpcRepairWhitelist {}
 
 #[rpc]
 pub trait AdminRpc {

--- a/validator/src/commands/contact_info/mod.rs
+++ b/validator/src/commands/contact_info/mod.rs
@@ -44,7 +44,10 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
             exit(1);
         });
 
-    println!("{}", contact_info_args.output.formatted_string(&contact_info));
+    println!(
+        "{}",
+        contact_info_args.output.formatted_string(&contact_info)
+    );
 }
 
 #[cfg(test)]
@@ -83,7 +86,9 @@ mod tests {
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
             vec![COMMAND],
-            ContactInfoArgs { output: OutputFormat::Display },
+            ContactInfoArgs {
+                output: OutputFormat::Display,
+            },
         );
     }
 

--- a/validator/src/commands/contact_info/mod.rs
+++ b/validator/src/commands/contact_info/mod.rs
@@ -1,6 +1,7 @@
 use {
     crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
     clap::{App, Arg, ArgMatches, SubCommand},
+    solana_cli_output::OutputFormat,
     std::{path::Path, process::exit},
 };
 
@@ -8,13 +9,13 @@ const COMMAND: &str = "contact-info";
 
 #[derive(Debug, PartialEq)]
 pub struct ContactInfoArgs {
-    pub output: Option<String>,
+    pub output: OutputFormat,
 }
 
 impl FromClapArgMatches for ContactInfoArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Self {
         ContactInfoArgs {
-            output: matches.value_of("output").map(String::from),
+            output: OutputFormat::from_matches(matches, "output", false),
         }
     }
 }
@@ -42,15 +43,8 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
             eprintln!("Contact info query failed: {err}");
             exit(1);
         });
-    if let Some(mode) = contact_info_args.output {
-        match mode.as_str() {
-            "json" => println!("{}", serde_json::to_string_pretty(&contact_info).unwrap()),
-            "json-compact" => print!("{}", serde_json::to_string(&contact_info).unwrap()),
-            _ => unreachable!(),
-        }
-    } else {
-        print!("{contact_info}");
-    }
+
+    println!("{}", contact_info_args.output.formatted_string(&contact_info));
 }
 
 #[cfg(test)]
@@ -68,7 +62,7 @@ mod tests {
             command(&DefaultArgs::default()),
             vec![COMMAND, "--output", "json"],
             ContactInfoArgs {
-                output: Some("json".to_string()),
+                output: OutputFormat::Json,
             },
         );
     }
@@ -79,7 +73,7 @@ mod tests {
             command(&DefaultArgs::default()),
             vec![COMMAND, "--output", "json-compact"],
             ContactInfoArgs {
-                output: Some("json-compact".to_string()),
+                output: OutputFormat::JsonCompact,
             },
         );
     }
@@ -89,7 +83,7 @@ mod tests {
         verify_args_struct_by_command(
             command(&DefaultArgs::default()),
             vec![COMMAND],
-            ContactInfoArgs { output: None },
+            ContactInfoArgs { output: OutputFormat::Display },
         );
     }
 


### PR DESCRIPTION
#### Summary of Changes
Use the existing OutputFormat enum to reduce duplicate code

Follow on to https://github.com/anza-xyz/agave/pull/4893#discussion_r1953629699

I manually tested this out and compared to current tip of master. The differences:

##### --output not set
There is now a newline after the last line of the output which I think is a win
```
// Old
$ agave-validator contact-info
...
Shred Version: 50093
$

// New
...
$ agave-validator contact-info
Shred Version: 50093

$
```
##### --output json
No changes

##### --output json-compact
There is now a newline at the end which prevent some ugly output, also a win I think. Also, 
```
// Old - note the cursor is same line as output
$ agave-validator contact-info --output json-compact
{...,"shred_version":50093}$ 

// New
$ agave-validator contact-info --output json-compact
{...,"shred_version":50093}
$
```