### PR TITLE
rpc: Cleanup transaction history enabled check

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1831,12 +1831,10 @@ impl JsonRpcRequestProcessor {
         mut limit: usize,
         config: RpcContextConfig,
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        self.check_if_transaction_history_enabled()?;
+
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
-
-        if !self.config.enable_rpc_transaction_history {
-            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
-        }
 
         let highest_super_majority_root = self
             .block_commitment_cache

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1653,16 +1653,15 @@ impl JsonRpcRequestProcessor {
         signatures: Vec<Signature>,
         config: Option<RpcSignatureStatusConfig>,
     ) -> Result<RpcResponse<Vec<Option<TransactionStatus>>>> {
-        let mut statuses: Vec<Option<TransactionStatus>> = vec![];
-
         let search_transaction_history = config
             .map(|x| x.search_transaction_history)
             .unwrap_or(false);
-        let bank = self.bank(Some(CommitmentConfig::processed()));
-
         if search_transaction_history {
             self.check_if_transaction_history_enabled()?;
         }
+
+        let bank = self.bank(Some(CommitmentConfig::processed()));
+        let mut statuses: Vec<Option<TransactionStatus>> = vec![];
 
         for signature in signatures {
             let status = if let Some(status) = self.get_transaction_status(signature, &bank) {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -284,6 +284,13 @@ impl JsonRpcRequestProcessor {
         Ok(bank)
     }
 
+    fn check_if_transaction_history_enabled(&self) -> Result<()> {
+        if !self.config.enable_rpc_transaction_history {
+            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
+        }
+        Ok(())
+    }
+
     async fn calculate_non_circulating_supply(
         &self,
         bank: &Arc<Bank>,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1297,7 +1297,8 @@ impl JsonRpcRequestProcessor {
         slot: Slot,
         config: Option<RpcEncodingConfigWrapper<RpcBlockConfig>>,
     ) -> Result<Option<UiConfirmedBlock>> {
-        if self.config.enable_rpc_transaction_history {
+        self.check_if_transaction_history_enabled()?;
+
             let config = config
                 .map(|config| config.convert_to_current())
                 .unwrap_or_default();
@@ -1408,9 +1409,7 @@ impl JsonRpcRequestProcessor {
                     return encoded_block_future.await.transpose();
                 }
             }
-        } else {
-            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
-        }
+
         Err(RpcCustomError::BlockNotAvailable { slot }.into())
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1660,14 +1660,14 @@ impl JsonRpcRequestProcessor {
             .unwrap_or(false);
         let bank = self.bank(Some(CommitmentConfig::processed()));
 
-        if search_transaction_history && !self.config.enable_rpc_transaction_history {
-            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
+        if search_transaction_history {
+            self.check_if_transaction_history_enabled()?;
         }
 
         for signature in signatures {
             let status = if let Some(status) = self.get_transaction_status(signature, &bank) {
                 Some(status)
-            } else if self.config.enable_rpc_transaction_history && search_transaction_history {
+            } else if search_transaction_history {
                 if let Some(status) = self
                     .blockstore
                     .get_rooted_transaction_status(signature)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1749,6 +1749,8 @@ impl JsonRpcRequestProcessor {
         signature: Signature,
         config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
     ) -> Result<Option<EncodedConfirmedTransactionWithStatusMeta>> {
+        self.check_if_transaction_history_enabled()?;
+
         let config = config
             .map(|config| config.convert_to_current())
             .unwrap_or_default();
@@ -1757,7 +1759,6 @@ impl JsonRpcRequestProcessor {
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
 
-        if self.config.enable_rpc_transaction_history {
             let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
             let confirmed_transaction = self
                 .runtime
@@ -1818,9 +1819,7 @@ impl JsonRpcRequestProcessor {
                     }
                 }
             }
-        } else {
-            return Err(RpcCustomError::TransactionHistoryNotAvailable.into());
-        }
+
         Ok(None)
     }
 


### PR DESCRIPTION
#### Problem
There are a handful of RPC functions that require transaction history in order to return a result. If tx history is disabled, then the query will return an `Err`.

#### Summary of Changes
Unify the "is-transaction-history-enabled" check into a helper, and move that check as high as possible into the callers. This ensures that we don't do any extra work until we're sure that we might be able to return a non-error.

#### Minor Change of Behavior
Technically speaking, this PR introduced a very subtle change in behavior in `getTransaction` and `getSignaturesForAddress`. Previously, these functions performed an is-commitment-at-least-confirmed check followed by an is-tx-history-enabled check. The PR has swapped the order of these to do the tx-history-enabled check first.

 Supposing that a user issued a query with `processed` commitment to a node that has tx history disabled:
- Old behavior: Error for invalid commitment
- New behavior: Error for tx history disabled

**It should also be noted that `getBlock` currently does tx-history-enabled check prior to is-commitment-at-least-confirmed check**.

So, I adjusted `getTransaction` and `getSignaturesForAddress`. This unifies behavior across the functions and does the cheapest check first. I deemed this to be fine, but open to hear others thoughts