### PR TITLE
removes redundant data/code partition when making shreds

### DIFF
--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -1,4 +1,5 @@
 use {
+    crate::shred::{Shred, ShredType},
     solana_sdk::clock::Slot,
     std::{
         ops::AddAssign,
@@ -26,8 +27,8 @@ pub struct ProcessShredsStats {
     // When looking up chained merkle root from parent slot fails.
     pub err_unknown_chained_merkle_root: u64,
     pub(crate) data_buffer_residual: usize,
-    pub num_merkle_data_shreds: usize,
-    pub num_merkle_coding_shreds: usize,
+    num_merkle_data_shreds: usize,
+    num_merkle_coding_shreds: usize,
 }
 
 #[derive(Default, Debug, Eq, PartialEq)]
@@ -112,6 +113,15 @@ impl ProcessShredsStats {
         let index = index.saturating_sub(3) as usize;
         let index = index.min(self.num_data_shreds_hist.len() - 1);
         self.num_data_shreds_hist[index] += 1;
+    }
+
+    #[inline]
+    pub fn record_shred(&mut self, shred: &Shred) {
+        let num_shreds = match shred.shred_type() {
+            ShredType::Code => &mut self.num_merkle_coding_shreds,
+            ShredType::Data => &mut self.num_merkle_data_shreds,
+        };
+        *num_shreds += 1;
     }
 }
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -9,7 +9,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::{
         blockstore,
-        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
     },
     solana_sdk::{
         genesis_config::ClusterType, hash::Hash, signature::Keypair, timing::AtomicInterval,
@@ -84,10 +84,10 @@ impl StandardBroadcastRun {
         }
         // Set the reference_tick as if the PoH completed for this slot
         let reference_tick = max_ticks_in_slot;
-        let (mut shreds, coding_shreds) =
+        let shreds: Vec<_> =
             Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
                 .unwrap()
-                .entries_to_shreds(
+                .make_merkle_shreds_from_entries(
                     keypair,
                     &[],  // entries
                     true, // is_last_in_slot,
@@ -95,18 +95,16 @@ impl StandardBroadcastRun {
                         .then_some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
-                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     stats,
-                );
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.index()) {
+                )
+                .inspect(|shred| stats.record_shred(shred))
+                .collect();
+        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
-        stats.num_merkle_data_shreds += shreds.len();
-        stats.num_merkle_coding_shreds += coding_shreds.len();
         self.report_and_reset_stats(/*was_interrupted:*/ true);
         self.completed = true;
-        shreds.extend(coding_shreds);
         shreds
     }
 
@@ -121,17 +119,11 @@ impl StandardBroadcastRun {
         process_stats: &mut ProcessShredsStats,
         max_data_shreds_per_slot: u32,
         max_code_shreds_per_slot: u32,
-    ) -> std::result::Result<
-        (
-            Vec<Shred>, // data shreds
-            Vec<Shred>, // coding shreds
-        ),
-        BroadcastError,
-    > {
-        let (data_shreds, coding_shreds) =
+    ) -> std::result::Result<Vec<Shred>, BroadcastError> {
+        let shreds: Vec<_> =
             Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
                 .unwrap()
-                .entries_to_shreds(
+                .make_merkle_shreds_from_entries(
                     keypair,
                     entries,
                     is_slot_end,
@@ -139,26 +131,28 @@ impl StandardBroadcastRun {
                         .then_some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
-                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     process_stats,
-                );
-        process_stats.num_merkle_data_shreds += data_shreds.len();
-        process_stats.num_merkle_coding_shreds += coding_shreds.len();
-        if let Some(shred) = data_shreds.iter().max_by_key(|shred| shred.index()) {
+                )
+                .inspect(|shred| {
+                    process_stats.record_shred(shred);
+                    let next_index = match shred.shred_type() {
+                        ShredType::Code => &mut self.next_code_index,
+                        ShredType::Data => &mut self.next_shred_index,
+                    };
+                    *next_index = (*next_index).max(shred.index() + 1);
+                })
+                .collect();
+        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
             self.chained_merkle_root = shred.merkle_root().unwrap();
-            self.next_shred_index = shred.index() + 1;
-        };
+        }
         if self.next_shred_index > max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
-        if let Some(index) = coding_shreds.iter().map(Shred::index).max() {
-            self.next_code_index = index + 1;
-        };
         if self.next_code_index > max_code_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
-        Ok((data_shreds, coding_shreds))
+        Ok(shreds)
     }
 
     #[cfg(test)]
@@ -175,10 +169,7 @@ impl StandardBroadcastRun {
         let (bsend, brecv) = unbounded();
         let (ssend, srecv) = unbounded();
         self.process_receive_results(keypair, blockstore, &ssend, &bsend, receive_results)?;
-        //data
-        let _ = self.transmit(&srecv, cluster_info, sock, bank_forks, quic_endpoint_sender);
-        let _ = self.record(&brecv, blockstore);
-        //coding
+        // Data and coding shreds are sent in a single batch.
         let _ = self.transmit(&srecv, cluster_info, sock, bank_forks, quic_endpoint_sender);
         let _ = self.record(&brecv, blockstore);
         Ok(())
@@ -273,7 +264,7 @@ impl StandardBroadcastRun {
         let reference_tick = last_tick_height
             .saturating_add(bank.ticks_per_slot())
             .saturating_sub(bank.max_tick_height());
-        let (data_shreds, coding_shreds) = self
+        let shreds = self
             .entries_to_shreds(
                 keypair,
                 &receive_results.entries,
@@ -294,7 +285,7 @@ impl StandardBroadcastRun {
         // https://github.com/solana-labs/solana/blob/92a0b310c/turbine/src/broadcast_stage/standard_broadcast_run.rs#L132-L142
         // By contrast Self::insert skips the 1st data shred with index zero:
         // https://github.com/solana-labs/solana/blob/92a0b310c/turbine/src/broadcast_stage/standard_broadcast_run.rs#L367-L373
-        if let Some(shred) = data_shreds.first() {
+        if let Some(shred) = shreds.iter().find(|shred| shred.is_data()) {
             if shred.index() == 0 {
                 blockstore
                     .insert_shreds(
@@ -308,15 +299,9 @@ impl StandardBroadcastRun {
         to_shreds_time.stop();
 
         let mut get_leader_schedule_time = Measure::start("broadcast_get_leader_schedule");
-        // Increment by two batches, one for the data batch, one for the coding batch.
-        self.num_batches += 2;
-        let num_expected_batches = {
-            if is_last_in_slot {
-                Some(self.num_batches)
-            } else {
-                None
-            }
-        };
+        // Data and coding shreds are sent in a single batch.
+        self.num_batches += 1;
+        let num_expected_batches = is_last_in_slot.then_some(self.num_batches);
         let batch_info = Some(BroadcastShredBatchInfo {
             slot: bank.slot(),
             num_expected_batches,
@@ -327,19 +312,10 @@ impl StandardBroadcastRun {
 
         let mut coding_send_time = Measure::start("broadcast_coding_send");
 
-        // Send data shreds
-        let data_shreds = Arc::new(data_shreds);
-        debug_assert!(data_shreds.iter().all(|shred| shred.slot() == bank.slot()));
-        socket_sender.send((data_shreds.clone(), batch_info.clone()))?;
-        blockstore_sender.send((data_shreds, batch_info.clone()))?;
-
-        // Send coding shreds
-        let coding_shreds = Arc::new(coding_shreds);
-        debug_assert!(coding_shreds
-            .iter()
-            .all(|shred| shred.slot() == bank.slot()));
-        socket_sender.send((coding_shreds.clone(), batch_info.clone()))?;
-        blockstore_sender.send((coding_shreds, batch_info))?;
+        let shreds = Arc::new(shreds);
+        debug_assert!(shreds.iter().all(|shred| shred.slot() == bank.slot()));
+        socket_sender.send((shreds.clone(), batch_info.clone()))?;
+        blockstore_sender.send((shreds, batch_info))?;
 
         coding_send_time.stop();
 
@@ -662,8 +638,8 @@ mod test {
         assert!(!blockstore.is_full(0));
         // Modify the stats, should reset later
         standard_broadcast_run.process_shreds_stats.receive_elapsed = 10;
-        // Broadcast stats should exist, and 2 batches should have been sent,
-        // one for data, one for coding
+        // Broadcast stats should exist, and 1 batch should have been sent,
+        // for both data and coding shreds.
         assert_eq!(
             standard_broadcast_run
                 .transmit_shreds_stats
@@ -672,7 +648,7 @@ mod test {
                 .get(standard_broadcast_run.slot)
                 .unwrap()
                 .num_batches(),
-            2
+            1
         );
         assert_eq!(
             standard_broadcast_run
@@ -682,7 +658,7 @@ mod test {
                 .get(standard_broadcast_run.slot)
                 .unwrap()
                 .num_batches(),
-            2
+            1
         );
         // Try to fetch ticks from blockstore, nothing should break
         assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), ticks0);
@@ -859,7 +835,9 @@ mod test {
                 1000,
                 1000,
             )
-            .unwrap();
+            .unwrap()
+            .into_iter()
+            .partition::<Vec<_>, _>(Shred::is_data);
         info!("{} {}", data.len(), coding.len());
         assert!(!data.is_empty());
         assert!(!coding.is_empty());


### PR DESCRIPTION

#### Problem
When making shreds from entries, shreds are unnecessarily partitioned into code and data shreds, which only adds overhead: https://github.com/anza-xyz/agave/blob/91befc728/ledger/src/shredder.rs#L112



#### Summary of Changes
The commit instead returns a single iterator for all code and data shreds.
