### PR TITLE
add rust-version 1.83 to net-utils

### DIFF
--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.83.0"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
#### Problem
solana-net-utils uses const unwrap, which requires rust >= 1.83 https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html

If you try to build this crate with an older rust version you will get a less helpful error:
```
`std::option::Option::<T>::unwrap` is not yet stable as a const fn
```

I ran into this when trying to upgrade the token-2022 deps: https://github.com/solana-program/token-2022/pull/204

#### Summary of Changes
Specify in the Cargo.toml that this requires at least 1.83