### PR TITLE
increases minimum number of retransmit threads

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -408,9 +408,9 @@ impl RetransmitStage {
         let mut shred_deduper = ShredDeduper::new(&mut rng, DEDUPER_NUM_BITS);
 
         let thread_pool = {
-            // Using clamp will panic if less than 8 sockets are provided
+            // std::cmp::Ord::clamp will panic if min > max.
             #[allow(clippy::manual_clamp)]
-            let num_threads = get_thread_count().min(8).max(retransmit_sockets.len());
+            let num_threads = get_thread_count().min(16).max(retransmit_sockets.len());
             ThreadPoolBuilder::new()
                 .num_threads(num_threads)
                 .thread_name(|i| format!("solRetransmit{i:02}"))


### PR DESCRIPTION

#### Problem
Current minimum number of retransmit threads were set a very long time ago and is no longer suitable especially when there are very large blocks to propagate.


#### Summary of Changes
The commit increases minimum number of retransmit threads.