### PR TITLE
agave-validator: handle args parsing errors

### DIFF
--- a/validator/src/commands/contact_info/mod.rs
+++ b/validator/src/commands/contact_info/mod.rs
@@ -13,10 +13,10 @@ pub struct ContactInfoArgs {
 }
 
 impl FromClapArgMatches for ContactInfoArgs {
-    fn from_clap_arg_match(matches: &ArgMatches) -> Self {
-        ContactInfoArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+        Ok(ContactInfoArgs {
             output: OutputFormat::from_matches(matches, "output", false),
-        }
+        })
     }
 }
 
@@ -34,7 +34,7 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let contact_info_args = ContactInfoArgs::from_clap_arg_match(matches);
+    let contact_info_args = ContactInfoArgs::from_clap_arg_match(matches)?;
 
     let admin_client = admin_rpc_service::connect(ledger_path);
     let contact_info = admin_rpc_service::runtime()

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -13,7 +13,9 @@ pub mod staked_nodes_overrides;
 pub mod wait_for_restart_window;
 
 pub trait FromClapArgMatches {
-    fn from_clap_arg_match(matches: &clap::ArgMatches) -> Self;
+    fn from_clap_arg_match(matches: &clap::ArgMatches) -> Result<Self, String>
+    where
+        Self: Sized;
 }
 
 #[cfg(test)]
@@ -26,7 +28,8 @@ pub mod tests {
     {
         let matches = app.get_matches_from(vec);
         let result = T::from_clap_arg_match(&matches);
-        assert_eq!(result, expected_arg);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_arg);
     }
 
     pub fn verify_args_struct_by_command_is_error<T>(app: clap::App, vec: Vec<&str>)

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -28,7 +28,6 @@ pub mod tests {
     {
         let matches = app.get_matches_from(vec);
         let result = T::from_clap_arg_match(&matches);
-        assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_arg);
     }
 


### PR DESCRIPTION
#### Problems

I thought we could use some workaround code to get through this transition period. however, it actually makes things more complicated. let’s handle the parsing error in the struct parsing function!

#### Summary of Changes

align to `fn execute` :

```diff
- fn from_clap_arg_match(matches: &clap::ArgMatches) -> Self
+ fn from_clap_arg_match(matches: &clap::ArgMatches) -> Result<Self, String>
```
