### PR TITLE
CI - Bump platform tools to v1.44

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -21,7 +21,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.43";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.44";
 
 #[derive(Debug)]
 struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -142,6 +142,7 @@ fn test_generate_child_script_on_failure() {
 }
 
 #[test]
+#[ignore]
 #[serial]
 fn test_sbfv2() {
     run_cargo_build("noop", &["--arch", "sbfv2"], false);

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.43"
+tools-version = "v1.44"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -21,4 +21,4 @@ crate-type = ["cdylib"]
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.43"
+tools-version = "v1.44"

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.43
+version=v1.44
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1699,7 +1699,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
             let (result, _, _, _) = process_transaction_and_record_inner(&bank, tx);
             assert_eq!(
                 result.unwrap_err(),
-                TransactionError::InstructionError(38, InstructionError::UnsupportedProgramId),
+                TransactionError::InstructionError(37, InstructionError::UnsupportedProgramId),
             );
         }
     }
@@ -3956,7 +3956,7 @@ fn test_cpi_deprecated_loader_realloc() {
         if direct_mapping {
             assert_eq!(
                 result.unwrap_err().unwrap(),
-                TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
+                TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
             );
         } else {
             assert_eq!(


### PR DESCRIPTION
#### Problem

Platform tools v1.43 doesn't contain the necessary changes for new SBPF versions and is inefficient in lowering memory operations.

#### Summary of Changes

Tools v1.44 brings in improvements in memory operations, enables the store-imm instruction class for SBPFv0 and starts emitting jumps with less than. These changes enhance code generation and decrease program size.

It also comes with the new targets to generate code for the new SBPF versions.


PS: Changes to the `cargo-build-sbf` commands to build for new SBPF versions will come in separate PRs. In the meantime, I commented out the `sbpfv2` test in the repo, since it won't work anymore.
