### PR TITLE
Update `cargo-build-sbf` to build new SBPF versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Release channels have their own copy of this changelog:
 
 <a name="edge-channel"></a>
 ## 2.3.0 - Unreleased
-
+* Changes:
+  * Platform tools SDK:
+    * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
 
 ## 2.2.0
 * Breaking:

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -56,7 +56,7 @@ test-stable-sbf)
   _ platform-tools-sdk/sbf/scripts/install.sh
 
   # SBF program tests
-  export SBF_OUT_DIR=target/sbf-solana-solana/release
+  export SBF_OUT_DIR=target/sbpf-solana-solana/release
   _ make -C programs/sbf test
 
   # SBF program instruction count assertion
@@ -69,7 +69,7 @@ test-stable-sbf)
 
   sbf_dump_archive="sbf-dumps.tar.bz2"
   rm -f "$sbf_dump_archive"
-  tar cjvf "$sbf_dump_archive" $sbf_target_path/{deploy/*.txt,sbf-solana-solana/release/*.so}
+  tar cjvf "$sbf_dump_archive" $sbf_target_path/{deploy/*.txt,sbpf-solana-solana/release/*.so}
   exit 0
   ;;
 test-docs)

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -73,7 +73,7 @@ impl Default for Config<'_> {
             verbose: false,
             workspace: false,
             jobs: None,
-            arch: "sbfv1",
+            arch: "v0",
         }
     }
 }
@@ -624,7 +624,13 @@ fn build_solana_package(
         .cloned()
         .unwrap_or_else(|| target_directory.join("deploy"));
 
-    let target_build_directory = target_directory.join("sbf-solana-solana").join("release");
+    let target_triple = if config.arch == "v0" {
+        "sbpf-solana-solana".to_string()
+    } else {
+        format!("sbpf{}-solana-solana", config.arch)
+    };
+
+    let target_build_directory = target_directory.join(&target_triple).join("release");
 
     env::set_current_dir(root_package_dir).unwrap_or_else(|err| {
         error!(
@@ -705,10 +711,9 @@ fn build_solana_package(
             exit(1);
         });
     }
-    let target = "sbf-solana-solana";
 
     if config.no_rustup_override {
-        check_solana_target_installed(target);
+        check_solana_target_installed(&target_triple);
     } else {
         link_solana_toolchain(config);
         // RUSTC variable overrides cargo +<toolchain> mechanism of
@@ -734,7 +739,10 @@ fn build_solana_package(
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
 
-    let cargo_target = "CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS";
+    let cargo_target = format!(
+        "CARGO_TARGET_{}_RUSTFLAGS",
+        target_triple.to_uppercase().replace("-", "_")
+    );
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
         warn!(
@@ -743,7 +751,7 @@ fn build_solana_package(
         );
         env::remove_var("RUSTFLAGS")
     }
-    let target_rustflags = env::var(cargo_target).ok();
+    let target_rustflags = env::var(&cargo_target).ok();
     let mut target_rustflags = Cow::Borrowed(target_rustflags.as_deref().unwrap_or_default());
     target_rustflags = Cow::Owned(format!("{} {}", &rustflags, &target_rustflags));
     if config.remap_cwd && !config.debug {
@@ -753,17 +761,14 @@ fn build_solana_package(
         // Replace with -Zsplit-debuginfo=packed when stabilized.
         target_rustflags = Cow::Owned(format!("{} -g", &target_rustflags));
     }
-    if config.arch == "sbfv2" {
-        target_rustflags = Cow::Owned(format!("{} -C target_cpu=sbfv2", &target_rustflags));
-    }
     if let Cow::Owned(flags) = target_rustflags {
-        env::set_var(cargo_target, flags);
+        env::set_var(&cargo_target, flags);
     }
     if config.verbose {
         debug!(
             "{}=\"{}\"",
             cargo_target,
-            env::var(cargo_target).ok().unwrap_or_default(),
+            env::var(&cargo_target).ok().unwrap_or_default(),
         );
     }
 
@@ -773,10 +778,7 @@ fn build_solana_package(
         cargo_build_args.push("+solana");
     };
 
-    cargo_build_args.append(&mut vec!["build", "--release", "--target", target]);
-    if config.arch == "sbfv2" {
-        cargo_build_args.push("-Zbuild-std=std,panic_abort");
-    }
+    cargo_build_args.append(&mut vec!["build", "--release", "--target", &target_triple]);
     if config.no_default_features {
         cargo_build_args.push("--no-default-features");
     }
@@ -911,7 +913,10 @@ fn build_solana_package(
             }
         }
 
-        check_undefined_symbols(config, &program_so);
+        if config.arch != "v3" {
+            // SBPFv3 shall not have any undefined syscall.
+            check_undefined_symbols(config, &program_so);
+        }
 
         info!("To deploy this program:");
         info!("  $ solana program deploy {}", program_so.display());
@@ -1138,8 +1143,8 @@ fn main() {
         .arg(
             Arg::new("arch")
                 .long("arch")
-                .possible_values(["sbfv1", "sbfv2"])
-                .default_value("sbfv1")
+                .possible_values(["v0", "v1", "v2", "v3"])
+                .default_value("v0")
                 .help("Build for the given target architecture"),
         )
         .get_matches_from(args);

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -1,4 +1,5 @@
 use {
+    assert_cmd::assert::Assert,
     predicates::prelude::*,
     std::{
         env, fs,
@@ -141,11 +142,8 @@ fn test_generate_child_script_on_failure() {
     clean_target("fail");
 }
 
-#[test]
-#[ignore]
-#[serial]
-fn test_sbfv2() {
-    run_cargo_build("noop", &["--arch", "sbfv2"], false);
+fn build_noop_and_readelf(arch: &str) -> Assert {
+    run_cargo_build("noop", &["--arch", arch], false);
     let cwd = env::current_dir().expect("Unable to get current working directory");
     let bin = cwd
         .join("tests")
@@ -168,11 +166,53 @@ fn test_sbfv2() {
         .join("llvm")
         .join("bin")
         .join("llvm-readelf");
-    assert_cmd::Command::new(readelf)
-        .args(["-h", bin])
-        .assert()
+
+    assert_cmd::Command::new(readelf).args(["-h", bin]).assert()
+}
+
+#[test]
+#[serial]
+fn test_sbpfv0() {
+    let assert_v0 = build_noop_and_readelf("v0");
+    assert_v0
         .stdout(predicate::str::contains(
-            "Flags:                             0x20",
+            "Flags:                             0x0",
+        ))
+        .success();
+    clean_target("noop");
+}
+
+#[test]
+#[serial]
+fn test_sbpfv1() {
+    let assert_v1 = build_noop_and_readelf("v1");
+    assert_v1
+        .stdout(predicate::str::contains(
+            "Flags:                             0x1",
+        ))
+        .success();
+    clean_target("noop");
+}
+
+#[test]
+#[serial]
+fn test_sbpfv2() {
+    let assert_v1 = build_noop_and_readelf("v2");
+    assert_v1
+        .stdout(predicate::str::contains(
+            "Flags:                             0x2",
+        ))
+        .success();
+    clean_target("noop");
+}
+
+#[test]
+#[serial]
+fn test_sbpfv3() {
+    let assert_v1 = build_noop_and_readelf("v3");
+    assert_v1
+        .stdout(predicate::str::contains(
+            "Flags:                             0x3",
         ))
         .success();
     clean_target("noop");

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -52,7 +52,7 @@ impl Default for Config<'_> {
             verbose: false,
             workspace: false,
             jobs: None,
-            arch: "sbfv1",
+            arch: "v0",
         }
     }
 }
@@ -376,8 +376,8 @@ fn main() {
         .arg(
             Arg::new("arch")
                 .long("arch")
-                .possible_values(["sbfv1", "sbfv2"])
-                .default_value("sbfv1")
+                .possible_values(["v0", "v1", "v2", "v3"])
+                .default_value("v0")
                 .help("Build for the given target architecture"),
         )
         .arg(

--- a/platform-tools-sdk/gen-headers/src/main.rs
+++ b/platform-tools-sdk/gen-headers/src/main.rs
@@ -83,7 +83,7 @@ fn transform(inc: &PathBuf) {
         let func = &caps[2].to_string();
         let args = &caps[3].to_string();
         let warn = format!("/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE {} AND RUN `cargo run --bin gen-headers` */", inc.display());
-        let ifndef = format!("#ifndef SOL_SBFV2\n{ty} {func}({args});");
+        let ifndef = format!("#ifndef SOL_SBPFV3\n{ty} {func}({args});");
         let hash = sys_hash(func);
         let typedef_statement = format!("typedef {ty}(*{func}_pointer_type)({args});");
         let mut arg = 0;

--- a/platform-tools-sdk/sbf/c/sbf.mk
+++ b/platform-tools-sdk/sbf/c/sbf.mk
@@ -41,10 +41,10 @@ C_FLAGS := \
   $(addprefix -I,$(STD_INC_DIRS)) \
   $(addprefix -I,$(INC_DIRS)) \
 
-ifeq ($(SOL_SBFV2),1)
+ifeq ($(SOL_SBPFV3),1)
 C_FLAGS := \
   $(C_FLAGS) \
-  -DSOL_SBFV2=1
+  -DSOL_SBPFV3=1
 endif
 
 CXX_FLAGS := \
@@ -74,7 +74,7 @@ SBF_LLD_FLAGS := \
   -L $(STD_LIB_DIRS) \
   -lc \
 
-ifeq ($(SOL_SBFV2),1)
+ifeq ($(SOL_SBPFV3),1)
 SBF_LLD_FLAGS := \
   $(SBF_LLD_FLAGS) \
   --pack-dyn-relocs=relr

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -1,12 +1,12 @@
 SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
-OUT_DIR := target/sbf-solana-solana/release
+OUT_DIR := target/sbpf-solana-solana/release
 
 test: rust all
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 
 rust:
-	cargo +solana build --release --target sbf-solana-solana --workspace
+	cargo +solana build --release --target sbpf-solana-solana --workspace
 
 .PHONY: rust
 

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -38,7 +38,7 @@ pub fn load_program_from_file(name: &str) -> Vec<u8> {
                 .unwrap(),
         )
     };
-    pathbuf.push("sbf-solana-solana");
+    pathbuf.push("sbpf-solana-solana");
     pathbuf.push("release");
     pathbuf.push(name);
     pathbuf.set_extension("so");


### PR DESCRIPTION
#### Problem

Now that platform tools v1.44 is available we can update the `cargo-build-sbf` and `cargo-test-sbf` commands to be able to build the new SBPF versions.

This PR is a continuation of #5019.

#### Summary of Changes

The `--arch` parameter now supports the options `v0`, `v1`, `v2`, and `v3`. The build folder also changed, so I updated the files accordingly and updated `cargo-build-sbf` the tests in the repository.