### PR TITLE
validator: Use error propagation over exit()

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -410,14 +410,11 @@ fn main() {
         },
     );
     let dashboard = if output == Output::Dashboard {
-        Some(
-            Dashboard::new(
-                &ledger_path,
-                Some(&validator_log_symlink),
-                Some(&mut genesis.validator_exit.write().unwrap()),
-            )
-            .unwrap(),
-        )
+        Some(Dashboard::new(
+            &ledger_path,
+            Some(&validator_log_symlink),
+            Some(&mut genesis.validator_exit.write().unwrap()),
+        ))
     } else {
         None
     };

--- a/validator/src/commands/authorized_voter/mod.rs
+++ b/validator/src/commands/authorized_voter/mod.rs
@@ -3,7 +3,7 @@ use {
     clap::{value_t, App, AppSettings, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::is_keypair,
     solana_sdk::signature::{read_keypair, Signer},
-    std::{fs, path::Path, process::exit},
+    std::{fs, path::Path},
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -38,17 +38,17 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
     match matches.subcommand() {
         ("add", Some(subcommand_matches)) => {
             if let Ok(authorized_voter_keypair) =
                 value_t!(subcommand_matches, "authorized_voter_keypair", String)
             {
                 let authorized_voter_keypair = fs::canonicalize(&authorized_voter_keypair)
-                    .unwrap_or_else(|err| {
-                        println!("Unable to access path: {authorized_voter_keypair}: {err:?}");
-                        exit(1);
-                    });
+                    .map_err(|err| {
+                        format!("unable to access path {authorized_voter_keypair}: {err:?}")
+                    })?;
+
                 println!(
                     "Adding authorized voter path: {}",
                     authorized_voter_keypair.display()
@@ -62,16 +62,11 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
                             .add_authorized_voter(authorized_voter_keypair.display().to_string())
                             .await
                     })
-                    .unwrap_or_else(|err| {
-                        println!("addAuthorizedVoter request failed: {err}");
-                        exit(1);
-                    });
+                    .map_err(|err| format!("add authorized voter request failed: {err}"))?;
             } else {
                 let mut stdin = std::io::stdin();
-                let authorized_voter_keypair = read_keypair(&mut stdin).unwrap_or_else(|err| {
-                    println!("Unable to read JSON keypair from stdin: {err:?}");
-                    exit(1);
-                });
+                let authorized_voter_keypair = read_keypair(&mut stdin)
+                    .map_err(|err| format!("unable to read json keypair from stdin: {err:?}"))?;
                 println!(
                     "Adding authorized voter: {}",
                     authorized_voter_keypair.pubkey()
@@ -87,22 +82,18 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
                             ))
                             .await
                     })
-                    .unwrap_or_else(|err| {
-                        println!("addAuthorizedVoterFromBytes request failed: {err}");
-                        exit(1);
-                    });
+                    .map_err(|err| format!("add authorized voter request failed: {err}"))?;
             }
         }
         ("remove-all", _) => {
             let admin_client = admin_rpc_service::connect(ledger_path);
             admin_rpc_service::runtime()
                 .block_on(async move { admin_client.await?.remove_all_authorized_voters().await })
-                .unwrap_or_else(|err| {
-                    println!("removeAllAuthorizedVoters request failed: {err}");
-                    exit(1);
-                });
+                .map_err(|err| format!("remove all authorized voters request failed: {err}"))?;
             println!("All authorized voters removed");
         }
         _ => unreachable!(),
     }
+
+    Ok(())
 }

--- a/validator/src/commands/monitor/mod.rs
+++ b/validator/src/commands/monitor/mod.rs
@@ -8,11 +8,13 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
     SubCommand::with_name("monitor").about("Monitor the validator")
 }
 
-pub fn execute(_matches: &ArgMatches, ledger_path: &Path) {
-    monitor_validator(ledger_path);
+pub fn execute(_matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+    monitor_validator(ledger_path)
 }
 
-pub fn monitor_validator(ledger_path: &Path) {
+pub fn monitor_validator(ledger_path: &Path) -> Result<(), String> {
     let dashboard = Dashboard::new(ledger_path, None, None);
     dashboard.run(Duration::from_secs(2));
+
+    Ok(())
 }

--- a/validator/src/commands/monitor/mod.rs
+++ b/validator/src/commands/monitor/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{cli::DefaultArgs, dashboard::Dashboard},
     clap::{App, ArgMatches, SubCommand},
-    std::{path::Path, process::exit, time::Duration},
+    std::{path::Path, time::Duration},
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -13,13 +13,6 @@ pub fn execute(_matches: &ArgMatches, ledger_path: &Path) {
 }
 
 pub fn monitor_validator(ledger_path: &Path) {
-    let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
-        println!(
-            "Error: Unable to connect to validator at {}: {:?}",
-            ledger_path.display(),
-            err,
-        );
-        exit(1);
-    });
+    let dashboard = Dashboard::new(ledger_path, None, None);
     dashboard.run(Duration::from_secs(2));
 }

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -3,7 +3,7 @@ use {
     clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_pubkey},
     solana_sdk::pubkey::Pubkey,
-    std::{path::Path, process::exit},
+    std::path::Path,
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -36,7 +36,7 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
     let pubkey = value_t!(matches, "pubkey", Pubkey).ok();
     let slot = value_t_or_exit!(matches, "slot", u64);
     let shred_index = value_t_or_exit!(matches, "shred", u64);
@@ -48,8 +48,5 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
                 .repair_shred_from_peer(pubkey, slot, shred_index)
                 .await
         })
-        .unwrap_or_else(|err| {
-            println!("repair shred from peer failed: {err}");
-            exit(1);
-        });
+        .map_err(|err| format!("repair shred from peer request failed: {err}"))
 }

--- a/validator/src/commands/repair_whitelist/mod.rs
+++ b/validator/src/commands/repair_whitelist/mod.rs
@@ -4,7 +4,7 @@ use {
     solana_clap_utils::input_validators::is_pubkey,
     solana_cli_output::OutputFormat,
     solana_sdk::pubkey::Pubkey,
-    std::{collections::HashSet, path::Path, process::exit},
+    std::{collections::HashSet, path::Path},
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -50,17 +50,14 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
     match matches.subcommand() {
         ("get", Some(subcommand_matches)) => {
             let output = OutputFormat::from_matches(subcommand_matches, "output", false);
             let admin_client = admin_rpc_service::connect(ledger_path);
             let repair_whitelist = admin_rpc_service::runtime()
                 .block_on(async move { admin_client.await?.repair_whitelist().await })
-                .unwrap_or_else(|err| {
-                    eprintln!("Repair whitelist query failed: {err}");
-                    exit(1);
-                });
+                .map_err(|err| format!("get repair whitelist request failed: {err}"))?;
 
             println!("{}", output.formatted_string(&repair_whitelist));
         }
@@ -72,35 +69,22 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
                         .collect();
                 validators_set.into_iter().collect::<Vec<_>>()
             } else {
-                return;
+                return Ok(());
             };
-            set_repair_whitelist(ledger_path, whitelist).unwrap_or_else(|err| {
-                eprintln!("{err}");
-                exit(1);
-            });
+            set_repair_whitelist(ledger_path, whitelist)?;
         }
         ("remove-all", _) => {
-            set_repair_whitelist(ledger_path, Vec::default()).unwrap_or_else(|err| {
-                eprintln!("{err}");
-                exit(1);
-            });
+            set_repair_whitelist(ledger_path, Vec::default())?;
         }
         _ => unreachable!(),
     }
+
+    Ok(())
 }
 
-fn set_repair_whitelist(
-    ledger_path: &Path,
-    whitelist: Vec<Pubkey>,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn set_repair_whitelist(ledger_path: &Path, whitelist: Vec<Pubkey>) -> Result<(), String> {
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime()
         .block_on(async move { admin_client.await?.set_repair_whitelist(whitelist).await })
-        .map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("setRepairWhitelist request failed: {err}"),
-            )
-        })?;
-    Ok(())
+        .map_err(|err| format!("set repair whitelist request failed: {err}"))
 }

--- a/validator/src/commands/set_log_filter/mod.rs
+++ b/validator/src/commands/set_log_filter/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{admin_rpc_service, cli::DefaultArgs},
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
-    std::{path::Path, process::exit},
+    std::path::Path,
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -16,13 +16,10 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         .after_help("Note: the new filter only applies to the currently running validator instance")
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
     let filter = value_t_or_exit!(matches, "filter", String);
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime()
         .block_on(async move { admin_client.await?.set_log_filter(filter).await })
-        .unwrap_or_else(|err| {
-            println!("set log filter failed: {err}");
-            exit(1);
-        });
+        .map_err(|err| format!("set log filter request failed: {err}"))
 }

--- a/validator/src/commands/staked_nodes_overrides/mod.rs
+++ b/validator/src/commands/staked_nodes_overrides/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{admin_rpc_service, cli::DefaultArgs},
     clap::{App, Arg, ArgMatches, SubCommand},
-    std::{path::Path, process::exit},
+    std::path::Path,
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
@@ -21,13 +21,8 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
-    if !matches.is_present("path") {
-        println!("staked-nodes-overrides requires argument of location of the configuration");
-        exit(1);
-    }
-
-    let path = matches.value_of("path").unwrap();
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+    let path = matches.value_of("path").expect("path is required");
 
     let admin_client = admin_rpc_service::connect(ledger_path);
     admin_rpc_service::runtime()
@@ -37,8 +32,5 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) {
                 .set_staked_nodes_overrides(path.to_string())
                 .await
         })
-        .unwrap_or_else(|err| {
-            println!("setStakedNodesOverrides request failed: {err}");
-            exit(1);
-        });
+        .map_err(|err| format!("set staked nodes override request failed: {err}"))
 }

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -12,7 +12,6 @@ use {
         pubkey::Pubkey,
     },
     std::{
-        io,
         net::SocketAddr,
         path::{Path, PathBuf},
         sync::{
@@ -35,7 +34,7 @@ impl Dashboard {
         ledger_path: &Path,
         log_path: Option<&Path>,
         validator_exit: Option<&mut Exit>,
-    ) -> Result<Self, io::Error> {
+    ) -> Self {
         println_name_value("Ledger location:", &format!("{}", ledger_path.display()));
         if let Some(log_path) = log_path {
             println_name_value("Log:", &format!("{}", log_path.display()));
@@ -50,11 +49,11 @@ impl Dashboard {
             validator_exit.register_exit(Box::new(move || exit.store(true, Ordering::Relaxed)));
         }
 
-        Ok(Self {
+        Self {
             exit,
             ledger_path: ledger_path.to_path_buf(),
             progress_bar,
-        })
+        }
     }
 
     pub fn run(self, refresh_interval: Duration) {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -69,8 +69,7 @@ pub fn main() {
             Ok(())
         }
         ("set-log-filter", Some(subcommand_matches)) => {
-            commands::set_log_filter::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::set_log_filter::execute(subcommand_matches, &ledger_path)
         }
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             commands::wait_for_restart_window::execute(subcommand_matches, &ledger_path);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -79,7 +79,7 @@ pub fn main() {
         _ => unreachable!(),
     }
     .unwrap_or_else(|err| {
-        println!("Validator command failed: {err}");
+        eprintln!("Validator command failed: {err}");
         exit(1);
     })
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -74,8 +74,7 @@ pub fn main() {
             commands::repair_whitelist::execute(repair_whitelist_subcommand_matches, &ledger_path)
         }
         ("set-public-address", Some(subcommand_matches)) => {
-            commands::set_public_address::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::set_public_address::execute(subcommand_matches, &ledger_path)
         }
         _ => unreachable!(),
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -79,7 +79,7 @@ pub fn main() {
         _ => unreachable!(),
     }
     .unwrap_or_else(|err| {
-        eprintln!("Validator command failed: {err}");
+        println!("Validator command failed: {err}");
         exit(1);
     })
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,7 +7,7 @@ use {
         commands,
     },
     solana_streamer::socket::SocketAddrSpace,
-    std::path::PathBuf,
+    std::{path::PathBuf, process::exit},
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -44,7 +44,11 @@ pub fn main() {
             );
         }
         ("authorized-voter", Some(authorized_voter_subcommand_matches)) => {
-            commands::authorized_voter::execute(authorized_voter_subcommand_matches, &ledger_path);
+            commands::authorized_voter::execute(authorized_voter_subcommand_matches, &ledger_path)
+                .unwrap_or_else(|err| {
+                    println!("Error: {err}");
+                    exit(1);
+                });
         }
         ("plugin", Some(plugin_subcommand_matches)) => {
             commands::plugin::execute(plugin_subcommand_matches, &ledger_path);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -52,8 +52,7 @@ pub fn main() {
             commands::plugin::execute(plugin_subcommand_matches, &ledger_path)
         }
         ("contact-info", Some(subcommand_matches)) => {
-            commands::contact_info::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::contact_info::execute(subcommand_matches, &ledger_path)
         }
         ("exit", Some(subcommand_matches)) => {
             commands::exit::execute(subcommand_matches, &ledger_path)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -63,8 +63,7 @@ pub fn main() {
             Ok(())
         }
         ("set-identity", Some(subcommand_matches)) => {
-            commands::set_identity::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::set_identity::execute(subcommand_matches, &ledger_path)
         }
         ("set-log-filter", Some(subcommand_matches)) => {
             commands::set_log_filter::execute(subcommand_matches, &ledger_path)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -59,8 +59,7 @@ pub fn main() {
         }
         ("monitor", _) => commands::monitor::execute(&matches, &ledger_path),
         ("staked-nodes-overrides", Some(subcommand_matches)) => {
-            commands::staked_nodes_overrides::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::staked_nodes_overrides::execute(subcommand_matches, &ledger_path)
         }
         ("set-identity", Some(subcommand_matches)) => {
             commands::set_identity::execute(subcommand_matches, &ledger_path)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -57,7 +57,10 @@ pub fn main() {
             commands::contact_info::execute(subcommand_matches, &ledger_path);
         }
         ("exit", Some(subcommand_matches)) => {
-            commands::exit::execute(subcommand_matches, &ledger_path);
+            commands::exit::execute(subcommand_matches, &ledger_path).unwrap_or_else(|err| {
+                println!("Error: {err}");
+                exit(1);
+            });
         }
         ("monitor", _) => {
             commands::monitor::execute(&matches, &ledger_path).unwrap_or_else(|err| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -68,8 +68,7 @@ pub fn main() {
             commands::set_log_filter::execute(subcommand_matches, &ledger_path)
         }
         ("wait-for-restart-window", Some(subcommand_matches)) => {
-            commands::wait_for_restart_window::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::wait_for_restart_window::execute(subcommand_matches, &ledger_path)
         }
         ("repair-shred-from-peer", Some(subcommand_matches)) => {
             commands::repair_shred_from_peer::execute(subcommand_matches, &ledger_path)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,8 +49,7 @@ pub fn main() {
             commands::authorized_voter::execute(authorized_voter_subcommand_matches, &ledger_path)
         }
         ("plugin", Some(plugin_subcommand_matches)) => {
-            commands::plugin::execute(plugin_subcommand_matches, &ledger_path);
-            Ok(())
+            commands::plugin::execute(plugin_subcommand_matches, &ledger_path)
         }
         ("contact-info", Some(subcommand_matches)) => {
             commands::contact_info::execute(subcommand_matches, &ledger_path);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -33,6 +33,7 @@ pub fn main() {
                 &ledger_path,
                 commands::run::execute::Operation::Initialize,
             );
+            Ok(())
         }
         ("", _) | ("run", _) => {
             commands::run::execute(
@@ -42,53 +43,55 @@ pub fn main() {
                 &ledger_path,
                 commands::run::execute::Operation::Run,
             );
+            Ok(())
         }
         ("authorized-voter", Some(authorized_voter_subcommand_matches)) => {
             commands::authorized_voter::execute(authorized_voter_subcommand_matches, &ledger_path)
-                .unwrap_or_else(|err| {
-                    println!("Error: {err}");
-                    exit(1);
-                });
         }
         ("plugin", Some(plugin_subcommand_matches)) => {
             commands::plugin::execute(plugin_subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("contact-info", Some(subcommand_matches)) => {
             commands::contact_info::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("exit", Some(subcommand_matches)) => {
-            commands::exit::execute(subcommand_matches, &ledger_path).unwrap_or_else(|err| {
-                println!("Error: {err}");
-                exit(1);
-            });
+            commands::exit::execute(subcommand_matches, &ledger_path)
         }
-        ("monitor", _) => {
-            commands::monitor::execute(&matches, &ledger_path).unwrap_or_else(|err| {
-                println!("Error: {err}");
-                exit(1);
-            });
-        }
+        ("monitor", _) => commands::monitor::execute(&matches, &ledger_path),
         ("staked-nodes-overrides", Some(subcommand_matches)) => {
             commands::staked_nodes_overrides::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("set-identity", Some(subcommand_matches)) => {
             commands::set_identity::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("set-log-filter", Some(subcommand_matches)) => {
             commands::set_log_filter::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             commands::wait_for_restart_window::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("repair-shred-from-peer", Some(subcommand_matches)) => {
             commands::repair_shred_from_peer::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("repair-whitelist", Some(repair_whitelist_subcommand_matches)) => {
             commands::repair_whitelist::execute(repair_whitelist_subcommand_matches, &ledger_path);
+            Ok(())
         }
         ("set-public-address", Some(subcommand_matches)) => {
             commands::set_public_address::execute(subcommand_matches, &ledger_path);
+            Ok(())
         }
         _ => unreachable!(),
-    };
+    }
+    .unwrap_or_else(|err| {
+        println!("Error: {err}");
+        exit(1);
+    })
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -79,8 +79,7 @@ pub fn main() {
             commands::repair_shred_from_peer::execute(subcommand_matches, &ledger_path)
         }
         ("repair-whitelist", Some(repair_whitelist_subcommand_matches)) => {
-            commands::repair_whitelist::execute(repair_whitelist_subcommand_matches, &ledger_path);
-            Ok(())
+            commands::repair_whitelist::execute(repair_whitelist_subcommand_matches, &ledger_path)
         }
         ("set-public-address", Some(subcommand_matches)) => {
             commands::set_public_address::execute(subcommand_matches, &ledger_path);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -60,7 +60,10 @@ pub fn main() {
             commands::exit::execute(subcommand_matches, &ledger_path);
         }
         ("monitor", _) => {
-            commands::monitor::execute(&matches, &ledger_path);
+            commands::monitor::execute(&matches, &ledger_path).unwrap_or_else(|err| {
+                println!("Error: {err}");
+                exit(1);
+            });
         }
         ("staked-nodes-overrides", Some(subcommand_matches)) => {
             commands::staked_nodes_overrides::execute(subcommand_matches, &ledger_path);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -76,8 +76,7 @@ pub fn main() {
             Ok(())
         }
         ("repair-shred-from-peer", Some(subcommand_matches)) => {
-            commands::repair_shred_from_peer::execute(subcommand_matches, &ledger_path);
-            Ok(())
+            commands::repair_shred_from_peer::execute(subcommand_matches, &ledger_path)
         }
         ("repair-whitelist", Some(repair_whitelist_subcommand_matches)) => {
             commands::repair_whitelist::execute(repair_whitelist_subcommand_matches, &ledger_path);

--- a/validator/tests/cli.rs
+++ b/validator/tests/cli.rs
@@ -31,6 +31,6 @@ fn test_use_the_same_path_for_accounts_and_snapshots() {
         temp_dir_str,
     ]);
     cmd.assert().failure().stderr(predicates::str::contains(
-        "The --accounts and --snapshots paths must be unique",
+        "the --accounts and --snapshots paths must be unique",
     ));
 }


### PR DESCRIPTION
#### Problem
The various `agave-validator` commands are littered with blocks like this:
```rust
let x = some_func().unwrap_or_else(|err| {
    println!("some_func failed: {err}");
    exit(1);
|;
```
We really should propagate errors instead; we can then handle errors in a uniform manner in a single location. Additionally, actually passing up errors will enable things like unit testing this code (one of the goals of https://github.com/anza-xyz/agave/issues/4082)

#### Summary of Changes
- Remove `exit(1)` from commands in favor of propagating errors


#### Sample Output
Setting a known illegal value for `--acounts-shrink-ratio` (2.0), I see:
```
[2025-02-19T04:44:41.236325631Z ERROR agave_validator] Failed to start validator: the specified account-shrink-ratio is invalid, it must be between 0. and 1.0 inclusive: 2
```
Likewise, if I start the validator in a way such that output would be printed to the screen (not typical with our script + systemd setup), I see the following:
```
/home/sol/src/agave/target/release/agave-validator ... --accounts-shrink-ratio 2.0
log file: /home/sol/logs/solana-validator.log
Validator command failed: the specified account-shrink-ratio is invalid, it must be between 0. and 1.0 inclusive: 2
```
