### PR TITLE
Make hash cache robust to crash and restart

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -364,17 +364,17 @@ impl CacheHashData {
 
     fn save_internal(
         &self,
-        cache_path_full_path: impl AsRef<Path>,
+        in_progress_cache_file_full_path: impl AsRef<Path>,
         data: &SavedTypeSlice,
     ) -> Result<(), std::io::Error> {
         let mut m = Measure::start("save");
-        let _ignored = remove_file(&cache_path_full_path);
+        let _ignored = remove_file(&in_progress_cache_file_full_path);
         let cell_size = std::mem::size_of::<EntryType>() as u64;
         let mut m1 = Measure::start("create save");
         let entries = data.iter().map(Vec::len).sum::<usize>();
         let capacity = cell_size * (entries as u64) + std::mem::size_of::<Header>() as u64;
 
-        let mmap = CacheHashDataFile::new_map(&cache_path_full_path, capacity)?;
+        let mmap = CacheHashDataFile::new_map(&in_progress_cache_file_full_path, capacity)?;
         m1.stop();
         self.stats
             .create_save_us

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -338,7 +338,7 @@ impl CacheHashData {
         let work_in_progress_file_full_path = self
             .cache_dir
             .join(Self::get_work_in_progress_file_name(file_name.as_ref()));
-        Self::save_internal(&work_in_progress_file_full_path, data, self.stats.clone())?;
+        Self::save_internal(&work_in_progress_file_full_path, data, &self.stats)?;
         // Rename the file to remove the ".in-progress" suffix after the file
         // has been successfully written. This is done to ensure that the file is
         // not read before it has been completely written. For example, if the
@@ -356,7 +356,7 @@ impl CacheHashData {
     fn save_internal(
         in_progress_cache_file_full_path: impl AsRef<Path>,
         data: &SavedTypeSlice,
-        stats: Arc<CacheHashDataStats>,
+        stats: &CacheHashDataStats,
     ) -> Result<(), std::io::Error> {
         let mut m = Measure::start("save");
         let _ignored = remove_file(&in_progress_cache_file_full_path);


### PR DESCRIPTION
#### Problem

Hash cache is not robust for validator crash and restart.  When a validator is
stopped or crashed in the middle of the writing the hash cache data, the
following restart will read incomplete cache file and fail.


#### Summary of Changes

Add ".in-progress" hash cache file when saving the data
Commit and rename the cache file only after we have completely written the data.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
