### PR TITLE
chore: update doc to add libclang-dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, pro
 On Ubuntu:
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
+$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler libclang-dev
 ```
 
 On Fedora:
 ```bash
-$ sudo dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang cmake make protobuf-devel protobuf-compiler perl-core
+$ sudo dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang cmake make protobuf-devel protobuf-compiler perl-core libclang-dev
 ```
 
 ## **2. Download the source code.**


### PR DESCRIPTION
#### Problem

When building agave validator on a new box, following the build instructions in README, it failed because of missing dependency of libclang.

```
error: failed to run custom build command for `clang-sys v1.2.2`

Caused by:
  process didn't exit successfully: `/home/sol/src/agave/target/release/build/clang-sys-45a870c72477b337/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at /home/sol/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clang-sys-1.2.2/build/dynamic.rs:211:45:
  called `Result::unwrap()` on an `Err` value: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

It turns out that agave validator build depends on sharedlibs from 'libclang'. However, this dependency, i.e. libclang-dev, is not list the build instruction.


#### Summary of Changes

add `libclang-dev` deps in build instruction.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
