### PR TITLE
validator: Consolidate repeated args in plugin command

### DIFF
--- a/validator/src/commands/plugin/mod.rs
+++ b/validator/src/commands/plugin/mod.rs
@@ -5,6 +5,9 @@ use {
 };
 
 pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+    let name_arg = Arg::with_name("name").required(true).takes_value(true);
+    let config_arg = Arg::with_name("config").required(true).takes_value(true);
+
     SubCommand::with_name("plugin")
         .about("Manage and view geyser plugins")
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -12,28 +15,25 @@ pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
         .subcommand(SubCommand::with_name("list").about("List all current running gesyer plugins"))
         .subcommand(
             SubCommand::with_name("unload")
-                .about(
-                    "Unload a particular gesyer plugin. You must specify the gesyer \
-               plugin name",
-                )
-                .arg(Arg::with_name("name").required(true).takes_value(true)),
+                .about("Unload a particular gesyer plugin. You must specify the gesyer plugin name")
+                .arg(&name_arg),
         )
         .subcommand(
             SubCommand::with_name("reload")
                 .about(
-                    "Reload a particular gesyer plugin. You must specify the gesyer \
-               plugin name and the new config path",
+                    "Reload a particular gesyer plugin. You must specify the gesyer plugin name \
+                     and the new config path",
                 )
-                .arg(Arg::with_name("name").required(true).takes_value(true))
-                .arg(Arg::with_name("config").required(true).takes_value(true)),
+                .arg(&name_arg)
+                .arg(&config_arg),
         )
         .subcommand(
             SubCommand::with_name("load")
                 .about(
                     "Load a new gesyer plugin. You must specify the config path. Fails if \
-               overwriting (use reload)",
+                     overwriting (use reload)",
                 )
-                .arg(Arg::with_name("config").required(true).takes_value(true)),
+                .arg(&config_arg),
         )
 }
 


### PR DESCRIPTION
#### Summary of Changes
The `name` and `config` arguments are each used for multiple commands. Create them once to avoid duplicate code