### PR TITLE
perf: remove redundant deser in rewards calculation

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -84,8 +84,8 @@ impl StakeReward {
             stake_reward_info: RewardInfo {
                 reward_type: solana_reward_info::RewardType::Staking,
                 lamports: reward_lamports,
-                post_balance: 0,  /* unused atm */
-                commission: None, /* unused atm */
+                post_balance: 0,     /* unused atm */
+                commission: Some(0), /* unused but tests require some value */
             },
 
             stake_account: validator_stake_account,

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -47,8 +47,8 @@ mod tests {
 
         let total = stake_rewards
             .iter()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>();
+            .map(|stake_reward| stake_reward.stake_reward)
+            .sum::<u64>();
 
         let stake_rewards_in_bucket =
             hash_rewards_into_partitions(stake_rewards.clone(), &Hash::default(), 5);
@@ -60,8 +60,8 @@ mod tests {
         let total_after_hash_partition = stake_rewards_in_bucket
             .iter()
             .flatten()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>();
+            .map(|stake_reward| stake_reward.stake_reward)
+            .sum::<u64>();
 
         let total_num_after_hash_partition: usize =
             stake_rewards_in_bucket.iter().map(|x| x.len()).sum();
@@ -83,8 +83,8 @@ mod tests {
         let total_after_hash_partition = stake_rewards_in_bucket
             .iter()
             .flatten()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>();
+            .map(|stake_reward| stake_reward.stake_reward)
+            .sum::<u64>();
 
         assert_eq!(total, total_after_hash_partition);
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -26,7 +26,7 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address
     pub stake_pubkey: Pubkey,
@@ -40,7 +40,7 @@ pub(crate) struct PartitionedStakeReward {
 
 type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct StartBlockHeightAndRewards {
     /// the block height of the slot at which rewards distribution began
     pub(crate) distribution_starting_block_height: u64,
@@ -49,7 +49,7 @@ pub(crate) struct StartBlockHeightAndRewards {
 }
 
 /// Represent whether bank is in the reward phase or not.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) enum EpochRewardStatus {
     /// this bank is in the reward phase.
     /// Contents are the start point for epoch reward calculation,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -267,10 +267,7 @@ mod tests {
                     stake_pubkey: stake_reward.stake_pubkey,
                     stake,
                     stake_reward: stake_reward.stake_reward_info.lamports as u64,
-                    commission: stake_reward
-                        .stake_reward_info
-                        .commission
-                        .unwrap_or_default(),
+                    commission: stake_reward.stake_reward_info.commission.unwrap(),
                 })
             } else {
                 None

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -32,10 +32,10 @@ pub(crate) struct PartitionedStakeReward {
     pub stake_pubkey: Pubkey,
     /// `Stake` state to be stored in account
     pub stake: Stake,
-    /// RewardInfo for recording in the Bank on distribution. Most of these
-    /// fields are available on calculation, but RewardInfo::post_balance must
-    /// be updated based on current account state before recording.
-    pub stake_reward_info: RewardInfo,
+    /// Stake reward for recording in the Bank on distribution
+    pub stake_reward: u64,
+    /// Vote commission for recording reward info
+    pub commission: u8,
 }
 
 type PartitionedStakeRewards = Vec<PartitionedStakeReward>;
@@ -266,7 +266,11 @@ mod tests {
                 Some(Self {
                     stake_pubkey: stake_reward.stake_pubkey,
                     stake,
-                    stake_reward_info: stake_reward.stake_reward_info,
+                    stake_reward: stake_reward.stake_reward_info.lamports as u64,
+                    commission: stake_reward
+                        .stake_reward_info
+                        .commission
+                        .unwrap_or_default(),
                 })
             } else {
                 None

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -6,10 +6,7 @@ use {
         PointValue, SkippedReason,
     },
     solana_sdk::{
-        account::{state_traits::StateMut, AccountSharedData, WritableAccount},
-        clock::Epoch,
-        instruction::InstructionError,
-        stake::instruction::StakeError,
+        clock::Epoch, instruction::InstructionError, stake::instruction::StakeError,
         sysvar::stake_history::StakeHistory,
     },
     solana_stake_program::stake_state::{Stake, StakeStateV2},
@@ -29,15 +26,14 @@ struct CalculatedStakeRewards {
 // returns a tuple of (stakers_reward,voters_reward)
 pub fn redeem_rewards(
     rewarded_epoch: Epoch,
-    stake_state: StakeStateV2,
-    stake_account: &mut AccountSharedData,
+    stake_state: &mut StakeStateV2,
     vote_state: &VoteState,
     point_value: &PointValue,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> Result<(u64, u64), InstructionError> {
-    if let StakeStateV2::Stake(meta, mut stake, stake_flags) = stake_state {
+    if let StakeStateV2::Stake(meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(
                 &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
@@ -56,16 +52,13 @@ pub fn redeem_rewards(
 
         if let Some((stakers_reward, voters_reward)) = redeem_stake_rewards(
             rewarded_epoch,
-            &mut stake,
+            stake,
             point_value,
             vote_state,
             stake_history,
             inflation_point_calc_tracer,
             new_rate_activation_epoch,
         ) {
-            stake_account.checked_add_lamports(stakers_reward)?;
-            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))?;
-
             Ok((stakers_reward, voters_reward))
         } else {
             Err(StakeError::NoCreditsToRedeem.into())


### PR DESCRIPTION
#### Problem
When calculating partitioned stake rewards, each stake account is needlessly serialized and then deserialized again.

#### Summary of Changes
- Remove unnecessary serde derivations for some types
- Refactor `PartitionedStakeReward` fields to only include necessary info for reward distribution. Notably, the `post_balance` value within `RewardInfo` was never used.
- Refactor `fn redeem_rewards` to no longer needlessly modify and serialize a stake account. Instead it operates directly on stake state.
- Refactor `calculate_stake_vote_rewards` to no longer re-deserialize stake state needlessly

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
