### PR TITLE
fix(rpc): fix health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9046,6 +9046,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bs58",
+ "chrono",
  "crossbeam-channel",
  "dashmap",
  "itertools 0.12.1",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2579,7 +2579,7 @@ impl Blockstore {
         )
     }
 
-    fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
+    pub fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
         let _lock = self.check_lowest_cleanup_slot(slot)?;
         self.blocktime_cf.get(slot)
     }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -64,6 +64,7 @@ stream-cancel = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "compat"] }
+chrono = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use {
     crate::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     solana_ledger::blockstore::Blockstore,
@@ -99,6 +100,22 @@ impl RpcHealth {
             >= cluster_latest_optimistically_confirmed_slot
                 .saturating_sub(self.health_check_slot_distance)
         {
+            let block_time = match self
+                .blockstore
+                .get_block_time(cluster_latest_optimistically_confirmed_slot)
+            {
+                Ok(Some(block_time)) => block_time,
+                Ok(None) | Err(_) => return RpcHealthStatus::Ok,
+            };
+            let current_time = Utc::now().timestamp();
+            let time_diff = current_time.saturating_sub(block_time);
+            if time_diff > 30 {
+                warn!(
+                    "health check: latest block is too old: block_time={block_time} \
+                    current_time={current_time}"
+                );
+                return RpcHealthStatus::Unknown;
+            }
             RpcHealthStatus::Ok
         } else {
             let num_slots = cluster_latest_optimistically_confirmed_slot


### PR DESCRIPTION
#### Problem
Rpc health method currently returns status as ok for a couple seconds right after the ledger is loaded, since the cluster latest optimistically confirmed slot maches the last one that was locally processed (instead of the one received via gossip)

#### Summary of Changes
Added an additional check on block time before returning ok status
