### PR TITLE
bump version to v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-accounts-hash-cache-tool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "flate2",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-clock",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "atty",
  "bincode",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "clap 2.33.3",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_cmd",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "regex",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "regex",
 ]
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "rdrand"
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "assert_matches",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
@@ -6372,7 +6372,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "fnv",
@@ -6556,7 +6556,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6627,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -6693,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6788,7 +6788,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6988,7 +6988,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "futures-util",
  "rand 0.8.5",
@@ -7074,7 +7074,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "criterion",
  "solana-compute-budget",
@@ -7149,7 +7149,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7199,7 +7199,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-thread-manager",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -7369,7 +7369,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-clock",
@@ -7466,7 +7466,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
@@ -7477,7 +7477,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7584,7 +7584,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -7663,7 +7663,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-feature-set",
  "solana-fee-structure",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7819,7 +7819,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -7830,7 +7830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7964,7 +7964,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -8021,7 +8021,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8090,7 +8090,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -8214,7 +8214,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
 ]
@@ -8315,15 +8315,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-memory-management"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "fast-math",
  "hex",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -8406,7 +8406,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-shaper"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 3.2.23",
  "rand 0.8.5",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "reqwest",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -8618,7 +8618,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -8801,7 +8801,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -8844,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8937,7 +8937,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -8987,7 +8987,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "console",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9144,7 +9144,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -9288,7 +9288,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-transaction-view",
  "ahash 0.8.11",
@@ -9386,7 +9386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -9604,7 +9604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -9751,7 +9751,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -9790,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -9827,7 +9827,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -9840,7 +9840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -9908,7 +9908,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -10033,7 +10033,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-conformance"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -10042,14 +10042,14 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -10080,7 +10080,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10176,7 +10176,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10208,7 +10208,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -10242,7 +10242,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -10251,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "rustls 0.23.23",
  "solana-keypair",
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10296,7 +10296,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-account",
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -10359,7 +10359,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10436,7 +10436,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -10477,7 +10477,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10496,7 +10496,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -10537,7 +10537,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10558,7 +10558,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10602,7 +10602,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "futures 0.3.31",
  "lazy_static",
@@ -10612,7 +10612,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10627,7 +10627,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -10640,7 +10640,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10677,7 +10677,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -10691,7 +10691,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "semver 1.0.25",
  "serde",
@@ -10705,7 +10705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10805,7 +10805,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10845,7 +10845,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10880,7 +10880,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -10894,7 +10894,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -10913,7 +10913,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -10967,7 +10967,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
@@ -10987,7 +10987,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ exclude = ["programs/sbf", "svm/examples", "svm/tests/example-programs"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
@@ -172,8 +172,8 @@ check-cfg = [
 [workspace.dependencies]
 Inflector = "0.11.4"
 axum = "0.7.9"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.2.0" }
-agave-transaction-view = { path = "transaction-view", version = "=2.2.0" }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.0" }
+agave-transaction-view = { path = "transaction-view", version = "=2.3.0" }
 aquamarine = "0.6.0"
 aes-gcm-siv = "0.11.1"
 ahash = "0.8.11"
@@ -354,115 +354,115 @@ smpl_jwt = "0.7.1"
 socket2 = "0.5.8"
 soketto = "0.7"
 solana-account = "=2.2.1"
-solana-account-decoder = { path = "account-decoder", version = "=2.2.0" }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.2.0" }
+solana-account-decoder = { path = "account-decoder", version = "=2.3.0" }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.3.0" }
 solana-account-info = "=2.2.1"
-solana-accounts-db = { path = "accounts-db", version = "=2.2.0" }
+solana-accounts-db = { path = "accounts-db", version = "=2.3.0" }
 solana-address-lookup-table-interface = "=2.2.2"
-solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.2.0" }
+solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.3.0" }
 solana-atomic-u64 = "=2.2.1"
-solana-banks-client = { path = "banks-client", version = "=2.2.0" }
-solana-banks-interface = { path = "banks-interface", version = "=2.2.0" }
-solana-banks-server = { path = "banks-server", version = "=2.2.0" }
-solana-bench-tps = { path = "bench-tps", version = "=2.2.0" }
+solana-banks-client = { path = "banks-client", version = "=2.3.0" }
+solana-banks-interface = { path = "banks-interface", version = "=2.3.0" }
+solana-banks-server = { path = "banks-server", version = "=2.3.0" }
+solana-bench-tps = { path = "bench-tps", version = "=2.3.0" }
 solana-big-mod-exp = "=2.2.1"
 solana-bincode = "=2.2.1"
 solana-blake3-hasher = "=2.2.1"
-solana-bloom = { path = "bloom", version = "=2.2.0" }
+solana-bloom = { path = "bloom", version = "=2.3.0" }
 solana-bn254 = "=2.2.1"
 solana-borsh = "=2.2.1"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.2.0" }
-solana-bucket-map = { path = "bucket_map", version = "=2.2.0" }
-solana-builtins = { path = "builtins", version = "=2.2.0" }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.2.0" }
-agave-cargo-registry = { path = "cargo-registry", version = "=2.2.0" }
-agave-thread-manager = { path = "thread-manager", version = "=2.2.0" }
-solana-clap-utils = { path = "clap-utils", version = "=2.2.0" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.2.0" }
-solana-cli = { path = "cli", version = "=2.2.0" }
-solana-cli-config = { path = "cli-config", version = "=2.2.0" }
-solana-cli-output = { path = "cli-output", version = "=2.2.0" }
-solana-client = { path = "client", version = "=2.2.0" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.0" }
+solana-bucket-map = { path = "bucket_map", version = "=2.3.0" }
+solana-builtins = { path = "builtins", version = "=2.3.0" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.3.0" }
+agave-cargo-registry = { path = "cargo-registry", version = "=2.3.0" }
+agave-thread-manager = { path = "thread-manager", version = "=2.3.0" }
+solana-clap-utils = { path = "clap-utils", version = "=2.3.0" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.3.0" }
+solana-cli = { path = "cli", version = "=2.3.0" }
+solana-cli-config = { path = "cli-config", version = "=2.3.0" }
+solana-cli-output = { path = "cli-output", version = "=2.3.0" }
+solana-client = { path = "client", version = "=2.3.0" }
 solana-client-traits = "=2.2.1"
 solana-clock = "=2.2.1"
 solana-cluster-type = "=2.2.1"
 solana-commitment-config = "=2.2.1"
-solana-compute-budget = { path = "compute-budget", version = "=2.2.0" }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.2.0" }
+solana-compute-budget = { path = "compute-budget", version = "=2.3.0" }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.0" }
 solana-compute-budget-interface = "=2.2.1"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.2.0" }
-solana-config-program = { path = "programs/config", version = "=2.2.0" }
-solana-connection-cache = { path = "connection-cache", version = "=2.2.0", default-features = false }
-solana-core = { path = "core", version = "=2.2.0" }
-solana-cost-model = { path = "cost-model", version = "=2.2.0" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.0" }
+solana-config-program = { path = "programs/config", version = "=2.3.0" }
+solana-connection-cache = { path = "connection-cache", version = "=2.3.0", default-features = false }
+solana-core = { path = "core", version = "=2.3.0" }
+solana-cost-model = { path = "cost-model", version = "=2.3.0" }
 solana-cpi = "=2.2.1"
-solana-curve25519 = { path = "curves/curve25519", version = "=2.2.0" }
+solana-curve25519 = { path = "curves/curve25519", version = "=2.3.0" }
 solana-decode-error = "=2.2.1"
 solana-define-syscall = "=2.2.1"
 solana-derivation-path = "=2.2.1"
-solana-download-utils = { path = "download-utils", version = "=2.2.0" }
+solana-download-utils = { path = "download-utils", version = "=2.3.0" }
 solana-ed25519-program = "=2.2.1"
-solana-entry = { path = "entry", version = "=2.2.0" }
+solana-entry = { path = "entry", version = "=2.3.0" }
 solana-program-entrypoint = "=2.2.1"
 solana-epoch-info = "=2.2.1"
 solana-epoch-rewards = "=2.2.1"
 solana-epoch-rewards-hasher = "=2.2.1"
 solana-epoch-schedule = "=2.2.1"
 solana-example-mocks = "=2.2.1"
-solana-faucet = { path = "faucet", version = "=2.2.0" }
+solana-faucet = { path = "faucet", version = "=2.3.0" }
 solana-feature-gate-client = "0.0.2"
 solana-feature-gate-interface = "=2.2.1"
 solana-feature-set = "=2.2.4"
 solana-fee-calculator = "=2.2.1"
-solana-fee = { path = "fee", version = "=2.2.0" }
+solana-fee = { path = "fee", version = "=2.3.0" }
 solana-fee-structure = "=2.2.1"
 solana-frozen-abi = "=2.2.1"
 solana-frozen-abi-macro = "=2.2.1"
-solana-tps-client = { path = "tps-client", version = "=2.2.0" }
+solana-tps-client = { path = "tps-client", version = "=2.3.0" }
 solana-file-download = "=2.2.1"
-solana-genesis = { path = "genesis", version = "=2.2.0" }
+solana-genesis = { path = "genesis", version = "=2.3.0" }
 solana-genesis-config = "=2.2.1"
-solana-genesis-utils = { path = "genesis-utils", version = "=2.2.0" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.0" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.0" }
-solana-gossip = { path = "gossip", version = "=2.2.0" }
+solana-genesis-utils = { path = "genesis-utils", version = "=2.3.0" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.0" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.3.0" }
+solana-gossip = { path = "gossip", version = "=2.3.0" }
 solana-hard-forks = "=2.2.1"
 solana-hash = "=2.2.1"
 solana-inflation = "=2.2.1"
-solana-inline-spl = { path = "inline-spl", version = "=2.2.0" }
+solana-inline-spl = { path = "inline-spl", version = "=2.3.0" }
 solana-instruction = "=2.2.1"
 solana-instructions-sysvar = "=2.2.1"
 solana-keccak-hasher = "=2.2.1"
 solana-keypair = "=2.2.1"
 solana-last-restart-slot = "=2.2.1"
-solana-lattice-hash = { path = "lattice-hash", version = "=2.2.0" }
-solana-ledger = { path = "ledger", version = "=2.2.0" }
+solana-lattice-hash = { path = "lattice-hash", version = "=2.3.0" }
+solana-ledger = { path = "ledger", version = "=2.3.0" }
 solana-loader-v2-interface = "=2.2.1"
 solana-loader-v3-interface = "=3.0.0"
 solana-loader-v4-interface = "=2.2.1"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.2.0" }
-solana-local-cluster = { path = "local-cluster", version = "=2.2.0" }
-solana-log-collector = { path = "log-collector", version = "=2.2.0" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.3.0" }
+solana-local-cluster = { path = "local-cluster", version = "=2.3.0" }
+solana-log-collector = { path = "log-collector", version = "=2.3.0" }
 solana-logger = "=2.2.1"
-solana-measure = { path = "measure", version = "=2.2.0" }
-solana-merkle-tree = { path = "merkle-tree", version = "=2.2.0" }
+solana-measure = { path = "measure", version = "=2.3.0" }
+solana-merkle-tree = { path = "merkle-tree", version = "=2.3.0" }
 solana-message = "=2.2.1"
-solana-metrics = { path = "metrics", version = "=2.2.0" }
+solana-metrics = { path = "metrics", version = "=2.3.0" }
 solana-msg = "=2.2.1"
 solana-native-token = "=2.2.1"
-solana-net-utils = { path = "net-utils", version = "=2.2.0" }
+solana-net-utils = { path = "net-utils", version = "=2.3.0" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "=2.2.1"
 solana-nonce-account = "=2.2.1"
-solana-notifier = { path = "notifier", version = "=2.2.0" }
+solana-notifier = { path = "notifier", version = "=2.3.0" }
 solana-offchain-message = "=2.2.1"
 solana-package-metadata = "=2.2.1"
 solana-package-metadata-macro = "=2.2.1"
 solana-packet = "=2.2.1"
-solana-perf = { path = "perf", version = "=2.2.0" }
-solana-poh = { path = "poh", version = "=2.2.0" }
+solana-perf = { path = "perf", version = "=2.3.0" }
+solana-poh = { path = "poh", version = "=2.3.0" }
 solana-poh-config = "=2.2.1"
-solana-poseidon = { path = "poseidon", version = "=2.2.0" }
+solana-poseidon = { path = "poseidon", version = "=2.3.0" }
 solana-precompile-error = "=2.2.1"
 solana-precompiles = "=2.2.1"
 solana-presigner = "=2.2.1"
@@ -471,14 +471,14 @@ solana-program-error = "=2.2.1"
 solana-program-memory = "=2.2.1"
 solana-program-option = "=2.2.1"
 solana-program-pack = "=2.2.1"
-solana-program-runtime = { path = "program-runtime", version = "=2.2.0" }
-solana-program-test = { path = "program-test", version = "=2.2.0" }
+solana-program-runtime = { path = "program-runtime", version = "=2.3.0" }
+solana-program-test = { path = "program-test", version = "=2.3.0" }
 solana-pubkey = "=2.2.1"
-solana-pubsub-client = { path = "pubsub-client", version = "=2.2.0" }
-solana-quic-client = { path = "quic-client", version = "=2.2.0" }
+solana-pubsub-client = { path = "pubsub-client", version = "=2.3.0" }
+solana-quic-client = { path = "quic-client", version = "=2.3.0" }
 solana-quic-definitions = "=2.2.1"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.0" }
-solana-remote-wallet = { path = "remote-wallet", version = "=2.2.0", default-features = false }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.3.0" }
+solana-remote-wallet = { path = "remote-wallet", version = "=2.3.0", default-features = false }
 solana-rent = "=2.2.1"
 solana-rent-collector = "=2.2.1"
 solana-rent-debits = "=2.2.1"
@@ -497,64 +497,64 @@ solana-signer = "=2.2.1"
 solana-slot-hashes = "=2.2.1"
 solana-slot-history = "=2.2.1"
 solana-time-utils = "=2.2.1"
-solana-timings = { path = "timings", version = "=2.2.0" }
-solana-tls-utils = { path = "tls-utils", version = "=2.2.0" }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.2.0" }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.2.0" }
-solana-rpc = { path = "rpc", version = "=2.2.0" }
-solana-rpc-client = { path = "rpc-client", version = "=2.2.0", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.0" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.0" }
-solana-runtime = { path = "runtime", version = "=2.2.0" }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.0" }
+solana-timings = { path = "timings", version = "=2.3.0" }
+solana-tls-utils = { path = "tls-utils", version = "=2.3.0" }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.0" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.3.0" }
+solana-rpc = { path = "rpc", version = "=2.3.0" }
+solana-rpc-client = { path = "rpc-client", version = "=2.3.0", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=2.3.0" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.0" }
+solana-runtime = { path = "runtime", version = "=2.3.0" }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" }
 solana-sbpf = "=0.10.0"
 solana-sdk = "=2.2.1"
 solana-sdk-ids = "=2.2.1"
 solana-sdk-macro = "=2.2.1"
 solana-secp256k1-program = "=2.2.1"
 solana-secp256k1-recover = "=2.2.1"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.0" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.0" }
 solana-short-vec = "=2.2.1"
 solana-shred-version = "=2.2.1"
 solana-stable-layout = "=2.2.1"
 solana-stake-interface = { version = "1.2.1" }
-solana-stake-program = { path = "programs/stake", version = "=2.2.0" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.0" }
-solana-storage-proto = { path = "storage-proto", version = "=2.2.0" }
-solana-streamer = { path = "streamer", version = "=2.2.0" }
-solana-svm = { path = "svm", version = "=2.2.0" }
-solana-svm-conformance = { path = "svm-conformance", version = "=2.2.0" }
-solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.0" }
-solana-svm-transaction = { path = "svm-transaction", version = "=2.2.0" }
+solana-stake-program = { path = "programs/stake", version = "=2.3.0" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=2.3.0" }
+solana-storage-proto = { path = "storage-proto", version = "=2.3.0" }
+solana-streamer = { path = "streamer", version = "=2.3.0" }
+solana-svm = { path = "svm", version = "=2.3.0" }
+solana-svm-conformance = { path = "svm-conformance", version = "=2.3.0" }
+solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.3.0" }
+solana-svm-transaction = { path = "svm-transaction", version = "=2.3.0" }
 solana-system-interface = "1.0"
-solana-system-program = { path = "programs/system", version = "=2.2.0" }
+solana-system-program = { path = "programs/system", version = "=2.3.0" }
 solana-system-transaction = "=2.2.1"
 solana-sysvar = "=2.2.1"
 solana-sysvar-id = "=2.2.1"
-solana-test-validator = { path = "test-validator", version = "=2.2.0" }
-solana-thin-client = { path = "thin-client", version = "=2.2.0" }
+solana-test-validator = { path = "test-validator", version = "=2.3.0" }
+solana-thin-client = { path = "thin-client", version = "=2.3.0" }
 solana-transaction = "=2.2.1"
 solana-transaction-error = "=2.2.1"
-solana-tpu-client = { path = "tpu-client", version = "=2.2.0", default-features = false }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.0" }
+solana-tpu-client = { path = "tpu-client", version = "=2.3.0", default-features = false }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=2.3.0" }
 solana-transaction-context = "=2.2.1"
-solana-transaction-status = { path = "transaction-status", version = "=2.2.0" }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.0" }
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.0" }
-solana-turbine = { path = "turbine", version = "=2.2.0" }
-solana-type-overrides = { path = "type-overrides", version = "=2.2.0" }
-solana-udp-client = { path = "udp-client", version = "=2.2.0" }
+solana-transaction-status = { path = "transaction-status", version = "=2.3.0" }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.3.0" }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.3.0" }
+solana-turbine = { path = "turbine", version = "=2.3.0" }
+solana-type-overrides = { path = "type-overrides", version = "=2.3.0" }
+solana-udp-client = { path = "udp-client", version = "=2.3.0" }
 solana-validator-exit = "=2.2.1"
-solana-version = { path = "version", version = "=2.2.0" }
-solana-vote = { path = "vote", version = "=2.2.0" }
+solana-version = { path = "version", version = "=2.3.0" }
+solana-vote = { path = "vote", version = "=2.3.0" }
 solana-vote-interface = "=2.2.2"
-solana-vote-program = { path = "programs/vote", version = "=2.2.0", default-features = false }
-solana-wen-restart = { path = "wen-restart", version = "=2.2.0" }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.0" }
-solana-zk-keygen = { path = "zk-keygen", version = "=2.2.0" }
-solana-zk-sdk = { path = "zk-sdk", version = "=2.2.0" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.2.0" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.2.0" }
+solana-vote-program = { path = "programs/vote", version = "=2.3.0", default-features = false }
+solana-wen-restart = { path = "wen-restart", version = "=2.3.0" }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.3.0" }
+solana-zk-keygen = { path = "zk-keygen", version = "=2.3.0" }
+solana-zk-sdk = { path = "zk-sdk", version = "=2.3.0" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.3.0" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.3.0" }
 spl-associated-token-account = "=6.0.0"
 spl-instruction-padding = "0.3"
 spl-memo = "=6.0.0"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-clock",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "affinity",
  "anyhow",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "fnv",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "libsecp256k1 0.6.0",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-borsh",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-thread-manager",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-clock",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-feature-set",
  "solana-fee-structure",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
 ]
@@ -6538,11 +6538,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6605,7 +6605,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6716,7 +6716,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6967,7 +6967,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7029,7 +7029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7054,7 +7054,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -7100,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7309,7 +7309,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "aquamarine",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7433,7 +7433,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-validator",
  "bincode",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-128bit-dep",
@@ -7484,35 +7484,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7521,7 +7521,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7530,7 +7530,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "array-bytes",
  "serde",
@@ -7541,7 +7541,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh 1.5.5",
  "solana-program",
@@ -7549,21 +7549,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-curve25519",
  "solana-program",
@@ -7571,14 +7571,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program",
@@ -7586,28 +7586,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -7618,35 +7618,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoke-dep",
@@ -7656,32 +7656,32 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoked-dep",
@@ -7689,28 +7689,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-many-args-dep",
@@ -7718,14 +7718,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7733,14 +7733,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7748,21 +7748,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-param-passing-dep",
@@ -7770,14 +7770,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "array-bytes",
  "solana-poseidon",
@@ -7786,7 +7786,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7803,14 +7803,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7819,39 +7819,39 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-program",
@@ -7860,7 +7860,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "blake3",
  "solana-program",
@@ -7868,42 +7868,42 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "solana-program",
@@ -7911,21 +7911,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-program",
 ]
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8274,7 +8274,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -8301,7 +8301,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8409,7 +8409,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -8452,14 +8452,14 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -8573,7 +8573,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -8637,7 +8637,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8646,7 +8646,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "rustls 0.23.23",
  "solana-keypair",
@@ -8657,7 +8657,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "log",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8844,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -8884,7 +8884,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8906,7 +8906,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8952,7 +8952,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "semver",
  "serde",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "log",
@@ -9071,7 +9071,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -9085,7 +9085,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
@@ -33,45 +33,45 @@ rand = "0.8"
 serde = "1.0.112"                                                                             # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = "1.0.112"                                                                      # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.56"
-solana-account-decoder = { path = "../../account-decoder", version = "=2.2.0" }
-solana-accounts-db = { path = "../../accounts-db", version = "=2.2.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=2.3.0" }
+solana-accounts-db = { path = "../../accounts-db", version = "=2.3.0" }
 solana-bn254 = "=2.2.1"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.2.0" }
-solana-cli-output = { path = "../../cli-output", version = "=2.2.0" }
-solana-compute-budget = { path = "../../compute-budget", version = "=2.2.0" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.2.0" }
-solana-curve25519 = { path = "../../curves/curve25519", version = "=2.2.0" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.3.0" }
+solana-cli-output = { path = "../../cli-output", version = "=2.3.0" }
+solana-compute-budget = { path = "../../compute-budget", version = "=2.3.0" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.3.0" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=2.3.0" }
 solana-decode-error = "=2.2.1"
 solana-feature-set = "=2.2.4"
-solana-fee = { path = "../../fee", version = "=2.2.0" }
-solana-ledger = { path = "../../ledger", version = "=2.2.0" }
-solana-log-collector = { path = "../../log-collector", version = "=2.2.0" }
+solana-fee = { path = "../../fee", version = "=2.3.0" }
+solana-ledger = { path = "../../ledger", version = "=2.3.0" }
+solana-log-collector = { path = "../../log-collector", version = "=2.3.0" }
 solana-logger = "=2.2.1"
-solana-measure = { path = "../../measure", version = "=2.2.0" }
-solana-poseidon = { path = "../../poseidon/", version = "=2.2.0" }
+solana-measure = { path = "../../measure", version = "=2.3.0" }
+solana-poseidon = { path = "../../poseidon/", version = "=2.3.0" }
 solana-program = "=2.2.1"
-solana-program-runtime = { path = "../../program-runtime", version = "=2.2.0" }
-solana-runtime = { path = "../../runtime", version = "=2.2.0" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.2.0" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.2.0" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.2.0" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.2.0" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.2.0" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.2.0" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.2.0" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.0" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.0" }
+solana-program-runtime = { path = "../../program-runtime", version = "=2.3.0" }
+solana-runtime = { path = "../../runtime", version = "=2.3.0" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.3.0" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.3.0" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.3.0" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.3.0" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.3.0" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.3.0" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.3.0" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.3.0" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.3.0" }
 solana-sdk = "=2.2.1"
 solana-sbpf = "=0.10.0"
 solana-secp256k1-recover = "=2.2.1"
-solana-svm = { path = "../../svm", version = "=2.2.0" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.0" }
-solana-timings = { path = "../../timings", version = "=2.2.0" }
-solana-transaction-status = { path = "../../transaction-status", version = "=2.2.0" }
-solana-type-overrides = { path = "../../type-overrides", version = "=2.2.0" }
-solana-vote = { path = "../../vote", version = "=2.2.0" }
-solana-vote-program = { path = "../../programs/vote", version = "=2.2.0" }
-agave-validator = { path = "../../validator", version = "=2.2.0" }
+solana-svm = { path = "../../svm", version = "=2.3.0" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=2.3.0" }
+solana-timings = { path = "../../timings", version = "=2.3.0" }
+solana-transaction-status = { path = "../../transaction-status", version = "=2.3.0" }
+solana-type-overrides = { path = "../../type-overrides", version = "=2.3.0" }
+solana-vote = { path = "../../vote", version = "=2.3.0" }
+solana-vote-program = { path = "../../programs/vote", version = "=2.3.0" }
+agave-validator = { path = "../../validator", version = "=2.3.0" }
 solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
 

--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -32,7 +32,6 @@ update_solana_dependencies() {
     solana-lattice-hash
     solana-ledger
     solana-log-collector
-    solana-logger
     solana-measure
     solana-merkle-tree
     solana-metrics

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-clock",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "affinity",
  "anyhow",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh 1.5.5",
  "clap",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-server"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "fnv",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5481,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "solana-borsh",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-thread-manager",
@@ -5666,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-feature-set",
  "solana-fee-structure",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "log",
 ]
@@ -6357,11 +6357,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6424,7 +6424,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6505,7 +6505,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6566,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6786,7 +6786,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6919,7 +6919,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "console",
  "dialoguer",
@@ -7003,7 +7003,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "aquamarine",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -7593,7 +7593,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -7620,7 +7620,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "backoff",
  "bincode",
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -7683,7 +7683,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-channel",
  "bytes",
@@ -7728,7 +7728,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -7770,7 +7770,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-example-paytube"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-bpf-loader-program",
  "solana-client",
@@ -7788,14 +7788,14 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -7973,7 +7973,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -7982,7 +7982,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "rustls 0.23.23",
  "solana-keypair",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "log",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8180,7 +8180,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -8220,7 +8220,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8228,7 +8228,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8253,7 +8253,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8288,7 +8288,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "semver",
  "serde",
@@ -8300,7 +8300,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -8349,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "log",
@@ -8380,7 +8380,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "log",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -8420,7 +8420,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8455,7 +8455,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -4,7 +4,7 @@ members = ["json-rpc/client", "json-rpc/server", "paytube"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"

--- a/svm/examples/json-rpc/program/Cargo.toml
+++ b/svm/examples/json-rpc/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-example-program"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [features]

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
#### Summary of Changes

1. `./scripts/increment-cargo-version.sh minor`
2. remove `solana-logger` from the patch list because it's moved to solana-sdk. (https://github.com/anza-xyz/solana-sdk/blob/master/logger/Cargo.toml)