### PR TITLE
Document paper wallet verify key with "ASK" in place of "prompt://"

### DIFF
--- a/docs/src/cli/wallets/paper.md
+++ b/docs/src/cli/wallets/paper.md
@@ -172,10 +172,10 @@ To verify you control the private key of a paper wallet address, use
 `solana-keygen verify`:
 
 ```bash
-solana-keygen verify <PUBKEY> prompt://
+solana-keygen verify <PUBKEY> ASK
 ```
 
-where `<PUBKEY>` is replaced with the wallet address and the keyword `prompt://`
+where `<PUBKEY>` is replaced with the wallet address and the keyword `ASK`
 tells the command to prompt you for the keypair's seed phrase; `key` and
 `full-path` query-strings accepted. Note that for security reasons, your seed
 phrase will not be displayed as you type. After entering your seed phrase, the


### PR DESCRIPTION
#### Problem

The paper wallet document says to verify the generated public key, seed phrase and passphrase using
`solana-keygen verify <pubkey> prompt://`. The `prompt://` keypath is programmed to fail, not yet implemented at currently `solana-keygen 2.1.14 (src:3ad46824; feat:3271415109, client:Agave)` and on master at, for example,
[`from_seed_and_derivation_path`][fsdp].

[fsdp]: https://github.com/anza-xyz/agave/blob/ae7fa713426d1c3ebbeb3a0c0e0dad191b48c427/zk-token-sdk/src/encryption/auth_encryption.rs#L180

#### Summary of Changes

Document to use the "ASK" keyword in place of the `prompt://` scheme when verifying keys.

[Experimentation demonstrates][so19998] that the "ASK" keypath, `solana-keygen verify <pubkey> ASK` does verify a public key, seed phrase and passphrase generated with the `solana-keygen new` subcommand.

[so19998]: https://solana.stackexchange.com/questions/19998/solana-keygen-error-verification-for-public-key-failed

As an aside, there is currently no way to verify a triplet generated with the `--derivation-path` option of the `solana-keygen new` subcommand. If the `prompt://` scheme is implemented to do that, the symmetry of usage could be made explicit in this document.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
