### PR TITLE
chore: Use jemalloc in all bench crates and modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,6 +6728,7 @@ dependencies = [
  "solana-version",
  "spl-generic-token",
  "spl-token",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -6818,6 +6819,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -6968,6 +6970,7 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-version",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -7034,6 +7037,7 @@ dependencies = [
  "spl-instruction-padding",
  "tempfile",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -7057,6 +7061,7 @@ dependencies = [
  "solana-transaction",
  "solana-version",
  "solana-vote-program",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -9258,6 +9263,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "test-case",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -9291,6 +9297,7 @@ dependencies = [
  "solana-time-utils",
  "solana-transaction",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -44,6 +44,9 @@ solana-version = { workspace = true }
 spl-generic-token = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
 [dev-dependencies]
 solana-accounts-db = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -47,6 +47,10 @@ use {
     },
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 pub const MAX_RPC_CALL_RETRIES: usize = 5;
 
 pub fn poll_slot_height(client: &RpcClient) -> Slot {

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -134,6 +134,9 @@ strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 test-case = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
+jemallocator = { workspace = true }
+
 [[bench]]
 name = "bench_accounts_file"
 harness = false

--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -31,6 +31,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn new_accounts_db(account_paths: Vec<PathBuf>) -> AccountsDb {
     AccountsDb::new_with_config(
         account_paths,

--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -16,6 +16,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[bench]
 fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_PUBKEYS: usize = 10_000;

--- a/accounts-db/benches/append_vec.rs
+++ b/accounts-db/benches/append_vec.rs
@@ -20,6 +20,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 /// Copy the account metadata, account and hash to the internal buffer.
 /// Return the starting offset of the account metadata.
 /// After the account is appended, the internal `current_len` is updated.

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -19,6 +19,10 @@ use {
 
 mod utils;
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const ACCOUNTS_COUNTS: [usize; 4] = [
     1,      // the smallest count; will bench overhead
     100,    // lower range of accounts written per slot on mnb

--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -10,6 +10,10 @@ use {
     solana_pubkey::Pubkey,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const KB: usize = 1024;
 const MB: usize = KB * KB;
 

--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -12,6 +12,10 @@ use {
     std::sync::Arc,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 // simultaneous transactions locked
 const BATCH_SIZES: [usize; 3] = [1, 32, 64];
 

--- a/accounts-db/benches/bench_serde.rs
+++ b/accounts-db/benches/bench_serde.rs
@@ -7,6 +7,10 @@ use {
     std::mem,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const KB: usize = 1024;
 const MB: usize = KB * KB;
 

--- a/accounts-db/benches/read_only_accounts_cache.rs
+++ b/accounts-db/benches/read_only_accounts_cache.rs
@@ -16,6 +16,10 @@ use {
 };
 mod utils;
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 /// Sizes of accounts.
 ///
 /// - No data.

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -17,3 +17,6 @@ crossbeam-channel = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-streamer = { workspace = true }
 solana-version = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -23,6 +23,10 @@ use {
     },
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn producer(dest_addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<usize> {
     let send = bind_to_unspecified().unwrap();
 

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -70,6 +70,9 @@ solana-version = { workspace = true }
 spl-instruction-padding = { version = "=0.3.0", features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 serial_test = { workspace = true }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -30,6 +30,10 @@ use {
     },
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 /// Number of signatures for all transactions in ~1 week at ~100K TPS
 pub const NUM_SIGNATURES_FOR_TXS: u64 = 100_000 * 60 * 60 * 24 * 7;
 

--- a/bench-vote/Cargo.toml
+++ b/bench-vote/Cargo.toml
@@ -29,3 +29,6 @@ solana-streamer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -38,6 +38,10 @@ use {
     },
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const SINK_REPORT_INTERVAL: Duration = Duration::from_secs(5);
 const SINK_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);
 const SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -82,6 +82,9 @@ solana-logger = { workspace = true }
 solana-perf = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
+jemallocator = { workspace = true }
+
 [[bench]]
 name = "sigverify"
 

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -13,6 +13,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM: usize = 4096;
 
 fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -7,6 +7,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM: usize = 1000;
 
 #[bench]

--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -7,6 +7,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const N: usize = 1_000_000;
 
 // test bench_reset1 ... bench:     436,240 ns/iter (+/- 176,714)

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -13,6 +13,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM_PACKETS: usize = 1024 * 4;
 
 fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -14,6 +14,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM: usize = 256;
 const LARGE_BATCH_PACKET_COUNT: usize = 128;
 

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -51,6 +51,9 @@ solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
+jemallocator = { workspace = true }
+
 [[bench]]
 name = "poh"
 

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -25,6 +25,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM_HASHES: u64 = 30_000; // Should require ~10ms on a 2017 MacBook Pro
 
 #[bench]

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -11,6 +11,10 @@ use {
     test::Bencher,
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 const NUM_HASHES: u64 = 400;
 const NUM_ENTRIES: usize = 800;
 


### PR DESCRIPTION
To make the benchmark results closer to what's happening on validators, make sure that benchmarks, especially the multithreaded ones, are using jemalloc.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
