### PR TITLE
clippy: precedence

### DIFF
--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -31,7 +31,7 @@ impl PubkeyBinCalculator24 {
     #[inline]
     pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
         let as_ref = pubkey.as_ref();
-        ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
+        (((as_ref[0] as usize) << 16) | ((as_ref[1] as usize) << 8) | (as_ref[2] as usize))
             >> self.shift_bits
     }
 

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -242,7 +242,7 @@ impl LedgerWallet {
             {
                 return Err(RemoteWalletError::Protocol("Unexpected chunk header"));
             }
-            let seq = (chunk[3] as usize) << 8 | (chunk[4] as usize);
+            let seq = ((chunk[3] as usize) << 8) | (chunk[4] as usize);
             if seq != chunk_index {
                 return Err(RemoteWalletError::Protocol("Unexpected chunk header"));
             }
@@ -253,7 +253,7 @@ impl LedgerWallet {
                 if chunk_size < 7 {
                     return Err(RemoteWalletError::Protocol("Unexpected chunk header"));
                 }
-                message_size = (chunk[5] as usize) << 8 | (chunk[6] as usize);
+                message_size = ((chunk[5] as usize) << 8) | (chunk[6] as usize);
                 offset += 2;
             }
             message.extend_from_slice(&chunk[offset..chunk_size]);
@@ -266,7 +266,7 @@ impl LedgerWallet {
             return Err(RemoteWalletError::Protocol("No status word"));
         }
         let status =
-            (message[message.len() - 2] as usize) << 8 | (message[message.len() - 1] as usize);
+            ((message[message.len() - 2] as usize) << 8) | (message[message.len() - 1] as usize);
         trace!("Read status {:x}", status);
         Self::parse_status(status)?;
         let new_len = message.len() - 2;

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -53,13 +53,13 @@ mod transaction_builder;
 const fn feature_u64(feature: &Pubkey) -> u64 {
     let feature_id = feature.to_bytes();
     feature_id[0] as u64
-        | (feature_id[1] as u64) << 8
-        | (feature_id[2] as u64) << 16
-        | (feature_id[3] as u64) << 24
-        | (feature_id[4] as u64) << 32
-        | (feature_id[5] as u64) << 40
-        | (feature_id[6] as u64) << 48
-        | (feature_id[7] as u64) << 56
+        | ((feature_id[1] as u64) << 8)
+        | ((feature_id[2] as u64) << 16)
+        | ((feature_id[3] as u64) << 24)
+        | ((feature_id[4] as u64) << 32)
+        | ((feature_id[5] as u64) << 40)
+        | ((feature_id[6] as u64) << 48)
+        | ((feature_id[7] as u64) << 56)
 }
 
 lazy_static! {


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.85.0.

```
warning: operator precedence can trip the unwary
  --> accounts-db/src/pubkey_bins.rs:34:10
   |
34 |         ((as_ref[0] as usize) << 16 | (as_ref[1] as usize) << 8 | (as_ref[2] as usize))
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `((as_ref[0] as usize) << 16) | ((as_ref[1] as usize) << 8)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
   = note: `#[warn(clippy::precedence)]` on by default
```


#### Summary of Changes

```
cargo clippy --fix
```