### PR TITLE
clippy: useless_conversion

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -448,7 +448,6 @@ impl BanksClient {
             .await?
             .map(|x| x.0)
             .ok_or(BanksClientError::ClientError("valid blockhash not found"))
-            .map_err(Into::into)
     }
 
     pub async fn get_latest_blockhash_with_commitment(

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -1,11 +1,8 @@
 use {
-    crate::cli::CliError,
-    solana_commitment_config::CommitmentConfig,
-    solana_message::Message,
-    solana_native_token::lamports_to_sol,
-    solana_pubkey::Pubkey,
+    crate::cli::CliError, solana_commitment_config::CommitmentConfig, solana_message::Message,
+    solana_native_token::lamports_to_sol, solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_rpc_client_api::client_error::{Error as ClientError, Result as ClientResult},
+    solana_rpc_client_api::client_error::Result as ClientResult,
 };
 
 pub fn check_account_for_fee(

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -96,9 +96,7 @@ pub fn check_account_for_spend_and_fee_with_commitment(
         account_pubkey,
         required_balance,
         commitment,
-    )
-    .map_err(Into::<ClientError>::into)?
-    {
+    )? {
         if balance > 0 {
             return Err(CliError::InsufficientFundsForSpendAndFee(
                 lamports_to_sol(balance),

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -341,8 +341,7 @@ where
         src_addr,
         n_bytes,
         resize_area,
-    )
-    .map_err(EbpfError::from)?;
+    )?;
     let mut dst_chunk_iter = MemoryChunkIterator::new(
         memory_mapping,
         accounts,
@@ -350,8 +349,7 @@ where
         dst_addr,
         n_bytes,
         resize_area,
-    )
-    .map_err(EbpfError::from)?;
+    )?;
 
     let mut src_chunk = None;
     let mut dst_chunk = None;


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.85.0.

```
warning: useless conversion to the same type: `solana_sbpf::error::EbpfError`
   --> programs/bpf_loader/src/syscalls/mem_ops.rs:344:6
    |
344 |       )
    |  ______^
345 | |     .map_err(EbpfError::from)?;
    | |_____________________________^ help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default
```


#### Summary of Changes

```
cargo clippy --fix
```