### PR TITLE
clippy: unnecessary_map_or

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -925,7 +925,7 @@ fn check_for_newer_github_release(
                             if (prerelease_allowed || !prerelease)
                                 && version_filter
                                     .as_ref()
-                                    .map_or(true, |version_filter| version_filter.matches(&version))
+                                    .is_none_or(|version_filter| version_filter.matches(&version))
                             {
                                 return Some(version);
                             }


### PR DESCRIPTION
#### Problem

New clippy lints when upgrading to rust 1.85.0.

```
warning: this `map_or` can be simplified
   --> install/src/command.rs:926:36
    |
926 |   ...                   && version_filter
    |  __________________________^
927 | | ...                       .as_ref()
928 | | ...                       .map_or(true, |version_filter| version_filter.matches(&version))
    | |__________________________________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
help: use is_none_or instead
    |
926 ~                                 && version_filter
927 +                                     .as_ref().is_none_or(|version_filter| version_filter.matches(&version))
    |
```


#### Summary of Changes

```
cargo clippy --fix
```