### PR TITLE
target current leader with votes

### DIFF
--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -20,7 +20,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
 ) -> Vec<SocketAddr> {
     let upcoming_leaders = {
         let poh_recorder = poh_recorder.read().unwrap();
-        (1..=fanout_slots)
+        (0..=fanout_slots)
             .filter_map(|n_slots| poh_recorder.leader_after_n_slots(n_slots))
             .collect_vec()
     };

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -20,7 +20,7 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
 ) -> Vec<SocketAddr> {
     let upcoming_leaders = {
         let poh_recorder = poh_recorder.read().unwrap();
-        (0..=fanout_slots)
+        (0..fanout_slots)
             .filter_map(|n_slots| poh_recorder.leader_after_n_slots(n_slots))
             .collect_vec()
     };

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -122,10 +122,13 @@ impl VotingService {
             trace!("{measure}");
         }
 
-        // Attempt to send our vote transaction to the leaders for the next few slots
-        const UPCOMING_LEADER_FANOUT_SLOTS: u64 = FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET;
+        // Attempt to send our vote transaction to the leaders for the next few
+        // slots. From the current slot to the forwarding slot offset
+        // (inclusive).
+        const UPCOMING_LEADER_FANOUT_SLOTS: u64 =
+            FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET.saturating_add(1);
         #[cfg(test)]
-        static_assertions::const_assert_eq!(UPCOMING_LEADER_FANOUT_SLOTS, 2);
+        static_assertions::const_assert_eq!(UPCOMING_LEADER_FANOUT_SLOTS, 3);
         let upcoming_leader_sockets = upcoming_leader_tpu_vote_sockets(
             cluster_info,
             poh_recorder,


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/1851 for some background
As part of sending votes, we try and identify the current leader we should send to. We currently use our best understanding of the current slot (slot N) and send to leader(s) building the next 2 slots (slots N+1 and N+2). Often N+1 and N+2 are built by the same leader and will be de-duped.

The potential issue occurs when leaders are building the last slot of their 4 slot quartet. If nodes have a fresh view of things, they may observe the current slot being build (N) as the latest, but they will send their vote for N-1 to the next leader that is going to build N+1. It would be good to also try and land this vote in N. This likely explains why we often see the first leader slot overpacked with votes (and conversely, the last slot being lightly packed).

#### Summary of Changes
Change targeting to include the current highest slot as well. This will result in 1 additional vote transaction being sent out per node per leader slot quartet. I.e. an increase of 20% from 5 to 6 votes per quartet.

|Current Slot|Old Target Slots|Old Target Leader(s)|New Target Slots|New Target Leader(s)|
|-|-|-|-|-|
|0|1,2|Leader A|0,1,2|Leader A|
|1|2,3|Leader A|1,2,3|Leader A|
|2|3,4|Leader A,B|2,3,4|Leader A,B|
|3|4,5|Leader B|3,4,5|Leader A,B|
|4|5,6|Leader B|4,5,6|Leader B|
|5|6,7|Leader B|5,6,7|Leader B|
|6|7,8|Leader B,C|6,7,8|Leader B,C|
|7|8,9|Leader C|7,8,9|Leader B,C|