### PR TITLE
geyser: Includes write_version in notify_account_restore_from_snapshot()

### DIFF
--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -20,7 +20,12 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when the AccountsDb is initialized at start when restored
     /// from a snapshot.
-    fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta);
+    fn notify_account_restore_from_snapshot(
+        &self,
+        slot: Slot,
+        write_version: u64,
+        account: &StoredAccountMeta,
+    );
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);


### PR DESCRIPTION
#### Problem

Geyser startup is expensive.

Geyser startup is expensive in part because accounts-db promises the geyser plugins that it'll only send a single `notify` per account. Since the current impl is scanning through account storages, it is possible an account can have multiple versions across multiple storages. The current solution is to use a HashMap of *all the accounts* to track the accounts that have already been notified (and then skip the others).

Note that when the validator is running at steady state, the geyser plugin can/will receive multiple updates for an account in different slots. Thus geyser plugins already must manage this deduplication themselves, rendering the startup hashmap unnecessary.

Part of that deduplication is the slot, and the other part is the write version. We now only write an account once per storage, so the write version usually isn't important. However, it is legal for an AppendVec to have multiple version of an account. Again, we have a discrepancy between startup and steady state. At steady state, we *do* pass a write version to the geyser plugins, but at startup we do not (we actually pass a constant of 0, which is safe).

This PR is solving the problem where startup does not pass a write version to the geyser plugins. We want to be consistent between startup and steady state, and we want to remove the big HashMap above. We need to ensure geyser plugins get sufficient information in order to do the account deduplication correctly at startup.


#### Summary of Changes

Add `write_version` as a parameter to `notify_account_restore_from_snapshot()`, so that the geyser plugins can get a proper write version value for account notifications at startup.