### PR TITLE
Bound gossip packet buffers

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -110,6 +110,7 @@ pub struct GossipStats {
     pub(crate) gossip_pull_request_sent_bytes: Counter,
     pub(crate) gossip_transmit_loop_iterations_since_last_report: Counter,
     pub(crate) gossip_transmit_loop_time: Counter,
+    pub(crate) gossip_transmit_packets_dropped_count: Counter,
     pub(crate) handle_batch_ping_messages_time: Counter,
     pub(crate) handle_batch_pong_messages_time: Counter,
     pub(crate) handle_batch_prune_messages_time: Counter,
@@ -412,6 +413,11 @@ pub(crate) fn submit_gossip_stats(
             stats
                 .gossip_transmit_loop_iterations_since_last_report
                 .clear(),
+            i64
+        ),
+        (
+            "gossip_transmit_packets_dropped_count",
+            stats.gossip_transmit_packets_dropped_count.clear(),
             i64
         ),
         (

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -202,29 +202,6 @@ impl GossipStats {
         .add_relaxed(1);
         Some(protocol)
     }
-
-    // Updates metrics from count of dropped packets.
-    pub(crate) fn record_dropped_packets(&self, counts: &[u64; 7]) -> u64 {
-        let num_packets_dropped = counts.iter().sum::<u64>();
-        if num_packets_dropped > 0u64 {
-            self.gossip_packets_dropped_count
-                .add_relaxed(num_packets_dropped);
-            self.packets_received_pull_requests_count
-                .add_relaxed(counts[0]);
-            self.packets_received_pull_responses_count
-                .add_relaxed(counts[1]);
-            self.packets_received_push_messages_count
-                .add_relaxed(counts[2]);
-            self.packets_received_prune_messages_count
-                .add_relaxed(counts[3]);
-            self.packets_received_ping_messages_count
-                .add_relaxed(counts[4]);
-            self.packets_received_pong_messages_count
-                .add_relaxed(counts[5]);
-            self.packets_received_unknown_count.add_relaxed(counts[6]);
-        }
-        num_packets_dropped
-    }
 }
 
 pub(crate) fn submit_gossip_stats(

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -1,8 +1,11 @@
 //! The `gossip_service` module implements the network control plane.
 
 use {
-    crate::{cluster_info::ClusterInfo, contact_info::ContactInfo},
-    crossbeam_channel::{unbounded, Sender},
+    crate::{
+        cluster_info::{ClusterInfo, MAX_GOSSIP_TRAFFIC_BATCHED},
+        contact_info::ContactInfo,
+    },
+    crossbeam_channel::{bounded, Sender},
     rand::{thread_rng, Rng},
     solana_client::{connection_cache::ConnectionCache, tpu_client::TpuClientWrapper},
     solana_net_utils::DEFAULT_IP_ECHO_SERVER_THREADS,
@@ -44,7 +47,7 @@ impl GossipService {
         stats_reporter_sender: Option<Sender<Box<dyn FnOnce() + Send>>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let (request_sender, request_receiver) = unbounded();
+        let (request_sender, request_receiver) = bounded(MAX_GOSSIP_TRAFFIC_BATCHED);
         let gossip_socket = Arc::new(gossip_socket);
         trace!(
             "GossipService: id: {}, listening on: {:?}",
@@ -64,14 +67,14 @@ impl GossipService {
             None,
             false,
         );
-        let (consume_sender, listen_receiver) = unbounded();
+        let (consume_sender, listen_receiver) = bounded(MAX_GOSSIP_TRAFFIC_BATCHED);
         let t_socket_consume = cluster_info.clone().start_socket_consume_thread(
             bank_forks.clone(),
             request_receiver,
             consume_sender,
             exit.clone(),
         );
-        let (response_sender, response_receiver) = unbounded();
+        let (response_sender, response_receiver) = bounded(MAX_GOSSIP_TRAFFIC_BATCHED);
         let t_listen = cluster_info.clone().listen(
             bank_forks.clone(),
             listen_receiver,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -3,7 +3,9 @@
 use {
     crate::{
         cluster_info::{ClusterInfo, MAX_GOSSIP_TRAFFIC_BATCHED},
+        cluster_info_metrics::submit_gossip_stats,
         contact_info::ContactInfo,
+        epoch_specs::EpochSpecs,
     },
     crossbeam_channel::{bounded, Sender},
     rand::{thread_rng, Rng},
@@ -28,10 +30,12 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
         },
-        thread::{self, sleep, JoinHandle},
+        thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
 };
+
+const SUBMIT_GOSSIP_STATS_INTERVAL: Duration = Duration::from_secs(2);
 
 pub struct GossipService {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -55,13 +59,14 @@ impl GossipService {
             gossip_socket.local_addr().unwrap()
         );
         let socket_addr_space = *cluster_info.socket_addr_space();
+        let gossip_receiver_stats = Arc::new(StreamerReceiveStats::new("gossip_receiver"));
         let t_receiver = streamer::receiver(
             "solRcvrGossip".to_string(),
             gossip_socket.clone(),
             exit.clone(),
             request_sender,
             Recycler::default(),
-            Arc::new(StreamerReceiveStats::new("gossip_receiver")),
+            gossip_receiver_stats.clone(),
             Duration::from_millis(1), // coalesce
             false,
             None,
@@ -82,10 +87,12 @@ impl GossipService {
             should_check_duplicate_instance,
             exit.clone(),
         );
-        let t_gossip =
-            cluster_info
-                .clone()
-                .gossip(bank_forks, response_sender, gossip_validators, exit);
+        let t_gossip = cluster_info.clone().gossip(
+            bank_forks.clone(),
+            response_sender,
+            gossip_validators,
+            exit.clone(),
+        );
         let t_responder = streamer::responder(
             "Gossip",
             gossip_socket,
@@ -93,12 +100,33 @@ impl GossipService {
             socket_addr_space,
             stats_reporter_sender,
         );
+        let t_metrics = Builder::new()
+            .name("solGossipMetr".to_string())
+            .spawn({
+                let cluster_info = cluster_info.clone();
+                let mut epoch_specs = bank_forks.map(EpochSpecs::from);
+                move || {
+                    while !exit.load(Ordering::Relaxed) {
+                        sleep(SUBMIT_GOSSIP_STATS_INTERVAL);
+                        let stakes = epoch_specs
+                            .as_mut()
+                            .map(|epoch_specs| epoch_specs.current_epoch_staked_nodes())
+                            .cloned()
+                            .unwrap_or_default();
+
+                        submit_gossip_stats(&cluster_info.stats, &cluster_info.gossip, &stakes);
+                        gossip_receiver_stats.report();
+                    }
+                }
+            })
+            .unwrap();
         let thread_hdls = vec![
             t_receiver,
             t_responder,
             t_socket_consume,
             t_listen,
             t_gossip,
+            t_metrics,
         ];
         Self { thread_hdls }
     }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -7,7 +7,7 @@ use {
         sendmmsg::{batch_send, SendPktsError},
         socket::SocketAddrSpace,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
     histogram::Histogram,
     itertools::Itertools,
     solana_packet::Packet,
@@ -61,6 +61,7 @@ pub struct StreamerReceiveStats {
     pub packet_batches_count: AtomicUsize,
     pub full_packet_batches_count: AtomicUsize,
     pub max_channel_len: AtomicUsize,
+    pub num_packets_dropped: AtomicUsize,
 }
 
 impl StreamerReceiveStats {
@@ -71,6 +72,7 @@ impl StreamerReceiveStats {
             packet_batches_count: AtomicUsize::default(),
             full_packet_batches_count: AtomicUsize::default(),
             max_channel_len: AtomicUsize::default(),
+            num_packets_dropped: AtomicUsize::default(),
         }
     }
 
@@ -95,6 +97,11 @@ impl StreamerReceiveStats {
             (
                 "channel_len",
                 self.max_channel_len.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "num_packets_dropped",
+                self.num_packets_dropped.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
         );
@@ -153,7 +160,9 @@ fn recv_loop(
                     packet_batch
                         .iter_mut()
                         .for_each(|p| p.meta_mut().set_from_staked_node(is_staked_service));
-                    _ = packet_batch_sender.try_send(packet_batch);
+                    if let Err(TrySendError::Full(_)) = packet_batch_sender.try_send(packet_batch) {
+                        stats.num_packets_dropped.fetch_add(len, Ordering::Relaxed);
+                    }
                 }
                 break;
             }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -153,7 +153,7 @@ fn recv_loop(
                     packet_batch
                         .iter_mut()
                         .for_each(|p| p.meta_mut().set_from_staked_node(is_staked_service));
-                    packet_batch_sender.send(packet_batch)?;
+                    _ = packet_batch_sender.try_send(packet_batch);
                 }
                 break;
             }


### PR DESCRIPTION
#### Problem

The packet buffering components in the gossip service dynamically scale their memory capacity to accommodate surges in packet volume. This includes the outer `unbounded` channels and the intermediate `VecDeque` buffers used in each packet batch processing cycle. This results in frequent memory deallocation and reallocation cycles, reflected in a high volume of `madvise` calls. As a result, gossip consumer threads frequently stall as they are blocked from making progress while memory is being reclaimed, reallocated, or faulted back in.


Profile of `master` under heavy gossip load:

![image](https://github.com/user-attachments/assets/511e5cf5-6226-49e8-9def-cca74c18903c)

Note the white gaps correlated to spikes in `solGossipConsum`. These represent stalls in gossip consumer threads due to memory reclamation. Stalls of up to 200ms have been observed.


#### Summary of Changes

Dynamically allocated channels and buffers are refactored to use fixed-size, preallocated analogs.

Profile of this branch under the same load:

![image](https://github.com/user-attachments/assets/7c139f38-a431-4ee6-b7fa-c2cf8b3db06b)

`madvise` calls are reduced by roughly 6x and stalls are mitigated.

Commits are broken up logically to simplify the review process — details of each below.

<details>
<summary><b>Re-use intermediate buffer in socket consume / listen</b></summary>

##### Problem
Currently, a `VecDeque` is allocated on each batch iteration in both `run_socket_consume` and `run_listen`.

https://github.com/anza-xyz/agave/blob/2cd02bb18ec8874c4d0ec18f5390f93298ebdbb4/gossip/src/cluster_info.rs#L2103
https://github.com/anza-xyz/agave/blob/2cd02bb18ec8874c4d0ec18f5390f93298ebdbb4/gossip/src/cluster_info.rs#L2188

Under high load, these dynamically resize to max capacity (`num_packets > MAX_GOSSIP_TRAFFIC`) and are immediately dropped after processing. This creates significant memory churn.

![Untitled-1](https://github.com/user-attachments/assets/ac8daf52-91de-4d31-9eb5-21462b7a1f49)
_roughly 4.3GiB allocated over 120s_

Additionally, the channel is continuously drained while packets are being received. 

https://github.com/anza-xyz/agave/blob/2cd02bb18ec8874c4d0ec18f5390f93298ebdbb4/gossip/src/cluster_info.rs#L2104-L2119

In principle, nothing prevents the outer loop from running for an extended period if packets keep arriving. However, practically speaking, implicit system conditions (e.g., thread scheduling, crossbeam internal synchronization) will eventually cause it to terminate. This can introduce non-trivial lag time between packets being received and processed. 

##### Summary of Changes

A `Vec` is preallocated outside the batch loops and reused on each iteration. This avoids the allocation / reallocation pressure caused by doing this in each loop. Furthermore, capacity is fixed to `1024` packet batches. This avoids excessive memory pressure from deallocating large sets of packets after processing. 

Additionally, the channel draining loop is explicitly broken after receiving `1024` packet batches. This ensures processing happens regularly rather than relying on implicit system behavior for termination.

</details>

<details>
<summary><b>Use bounded channels in gossip service</b></summary>

##### Problem

The initial gossip channel, sender of which is passed to `streamer::receiver`, is unbounded, and can exhibit similar memory churn to the `VecDeque` outlined in the previous section. Here is a sample of master under high load: 

![image](https://github.com/user-attachments/assets/c527ef5b-3543-4273-b444-b75ad0d52712)


Now, since the previous commit, channel receivers are pulling a fixed amount of packet batches (rather than continuously draining the channel). This shifts the aforementioned memory pressure of the `VecDeque` onto the channel. 

##### Summary of Changes

Gossip packet buffers now used bounded channels, with a fixed, preallocated, capacity of `4096` packet batches. This avoids dynamic allocation and associated memory churn. Additionally, due to the fixed size nature of the channels, packets are now dropped on the sending side of the channels.

</details>

<details>
<summary><b>Record dropped packets in streamer::receiver</b></summary>

Because packets are now dropped on the sending side, an additional metric was added to `streamer::recever` to record dropped packets.

</details>

<details>
<summary><b>Collocate gossip stat submission</b></summary>

While gossip's `streamer::receiver` currently records metrics, it does not report them. This commit adds the associated `report` logic, which submits metrics on the same interval as the rest of the gossip stats. Gossip stat reporting is also moved outside of the `run_listen` loop and collocated with `streamer::receiver` reporting logic in the outer gossip service.

</details>

<details>
<summary><b>Add gossip_transmit_packets_dropped_count</b></summary>

Add dropping metrics to `run_gossip` for completeness.

</details>