### PR TITLE
filter old retransmit shreds

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -319,7 +319,9 @@ fn retransmit_shred(
 )> {
     let key = shred::layout::get_shred_id(shred.as_ref())?;
     let (slot_leader, cluster_nodes) = cache.get(&key.slot())?;
-    if shred_deduper.dedup(key, shred.as_ref(), MAX_DUPLICATE_COUNT) {
+    if key.slot() < root_bank.slot()
+        || shred_deduper.dedup(key, shred.as_ref(), MAX_DUPLICATE_COUNT)
+    {
         stats.num_shreds_skipped.fetch_add(1, Ordering::Relaxed);
         return None;
     }


### PR DESCRIPTION
#### Problem
It's possible for retransmit to fall way behind - especially during extreme load.

This was first discovered running private cluster with huge amount of load (15k-20k txs per block), but it looks like it occasionally pops up on mainnet as well.

Over the last 7 days, I see 188 unique identities reporting spending >20 seconds on a single retransmit iteration. A couple dozen of these had at least 1 iteration w/ >500k shreds to process.

The only potential problem I could foresee is if discarding these shreds impacted downstream nodes' ability to construct blocks. However, if we have had time to root the block already, these shreds would be so old that the other node would have recovered the shreds or requested repairs long ago. Sending the shreds at this point just causes unnecessary ingress and processing for downstream nodes.

#### Summary of Changes
Filter out any shred for a slot older than the root bank slot.

#### Testing
![image](https://github.com/user-attachments/assets/c5f12653-9058-4ea3-8c5e-be26434741f7)
Graph above shows old behavior on the left and new behavior on the right.

With the old behavior, we fall into this bad snowball effect where each iteration has more shreds to process, takes more time, which allows more shreds to build up and consume more memory, etc.

With the new behavior, we can quickly toss out shreds when we fall behind, so the number of shreds, time, and memory flatline