### PR TITLE
geyser: Uses scan_accounts_for_geyser() at startup

### DIFF
--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -1,6 +1,8 @@
 use {
-    crate::account_storage::meta::StoredAccountMeta, solana_account::AccountSharedData,
-    solana_clock::Slot, solana_pubkey::Pubkey, solana_transaction::sanitized::SanitizedTransaction,
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_clock::{Epoch, Slot},
+    solana_pubkey::Pubkey,
+    solana_transaction::sanitized::SanitizedTransaction,
     std::sync::Arc,
 };
 
@@ -24,7 +26,7 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
         &self,
         slot: Slot,
         write_version: u64,
-        account: &StoredAccountMeta,
+        account: &AccountForGeyser<'_>,
     );
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
@@ -32,3 +34,32 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 }
 
 pub type AccountsUpdateNotifier = Arc<dyn AccountsUpdateNotifierInterface + Sync + Send>;
+
+/// Account type with only the fields necessary for Geyser
+#[derive(Debug, Clone)]
+pub struct AccountForGeyser<'a> {
+    pub pubkey: &'a Pubkey,
+    pub lamports: u64,
+    pub owner: &'a Pubkey,
+    pub executable: bool,
+    pub rent_epoch: Epoch,
+    pub data: &'a [u8],
+}
+
+impl ReadableAccount for AccountForGeyser<'_> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &[u8] {
+        self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}


### PR DESCRIPTION
#### Problem

Geyser startup is expensive.

Geyser startup is expensive in part because accounts-db promises the geyser plugins that it'll only send a single `notify` per account. Since the current impl is scanning through account storages, it is possible an account can have multiple versions across multiple storages. The current solution is to use a HashMap of *all the accounts* to track the accounts that have already been notified (and then skip the others).

Note that when the validator is running at steady state, the geyser plugin can/will receive multiple updates for an account in different slots. Thus geyser plugins already must manage this deduplication themselves, rendering the startup hashmap unnecessary.

Part of that deduplication is the slot, and the other part is the write version. We now only write an account once per storage, so the write version usually isn't important. However, it is legal for an AppendVec to have multiple version of an account. Again, we have a discrepancy between startup and steady state. At steady state, we *do* pass a write version to the geyser plugins, but at startup we do not (we actually pass a constant of 0, which is safe).

This PR is solving the problem where startup scans through the storages and passes a `StoredAccountMeta` back through to the plugin manager. We want to remove use of the StoredAccountMeta, because it requires reading data from storages and creating a structure with fields that we may not want or need. We should only pass to Geyser the fields needed by Geyser.


#### Summary of Changes

Add a `scan_accounts_for_geyser()` method to `AccountsFile` and use that when notifying geyser plugins of account updates at startup.

Related to #5064 