### PR TITLE
Refactor: Simplify TransactionState

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -6,7 +6,6 @@ use {
         },
         scheduler_error::SchedulerError,
         thread_aware_account_locks::{ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError},
-        transaction_state::SanitizedTransactionTTL,
     },
     crate::banking_stage::{
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
@@ -159,8 +158,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                 *window_budget = window_budget.saturating_sub(chunk_size);
 
                 ids.iter().for_each(|id| {
-                    let transaction = container.get_transaction_ttl(id.id).unwrap();
-                    txs.push(&transaction.transaction);
+                    let transaction = container.get_transaction(id.id).unwrap();
+                    txs.push(transaction);
                 });
 
                 let (_, filter_us) =
@@ -169,7 +168,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
 
                 for (id, filter_result) in ids.iter().zip(&filter_array[..chunk_size]) {
                     if *filter_result {
-                        let transaction = container.get_transaction_ttl(id.id).unwrap();
+                        let transaction = container.get_transaction(id.id).unwrap();
                         prio_graph.insert_transaction(
                             *id,
                             Self::get_transaction_account_access(transaction),
@@ -345,9 +344,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
 impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
     /// Gets accessed accounts (resources) for use in `PrioGraph`.
     fn get_transaction_account_access(
-        transaction: &SanitizedTransactionTTL<impl SVMMessage>,
+        message: &impl SVMMessage,
     ) -> impl Iterator<Item = (Pubkey, AccessKind)> + '_ {
-        let message = &transaction.transaction;
         message
             .account_keys()
             .iter()
@@ -375,7 +373,7 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
     }
 
     // Check if this transaction conflicts with any blocked transactions
-    let transaction = &transaction_state.transaction_ttl().transaction;
+    let transaction = transaction_state.transaction();
     if !blocking_locks.check_locks(transaction) {
         blocking_locks.take_locks(transaction);
         return Err(TransactionSchedulingError::UnschedulableConflicts);
@@ -409,13 +407,13 @@ fn try_schedule_transaction<Tx: TransactionWithMeta>(
         }
     };
 
-    let sanitized_transaction_ttl = transaction_state.transition_to_pending();
+    let (transaction, max_age) = transaction_state.take_transaction_for_scheduling();
     let cost = transaction_state.cost();
 
     Ok(TransactionSchedulingInfo {
         thread_id,
-        transaction: sanitized_transaction_ttl.transaction,
-        max_age: sanitized_transaction_ttl.max_age,
+        transaction,
+        max_age,
         cost,
     })
 }
@@ -519,13 +517,11 @@ mod tests {
                 lamports,
                 compute_unit_price,
             );
-            let transaction_ttl = SanitizedTransactionTTL {
-                transaction,
-                max_age: MaxAge::MAX,
-            };
+
             const TEST_TRANSACTION_COST: u64 = 5000;
             container.insert_new_transaction(
-                transaction_ttl,
+                transaction,
+                MaxAge::MAX,
                 compute_unit_price,
                 TEST_TRANSACTION_COST,
             );

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -12,9 +12,7 @@ use {
         consumer::Consumer, decision_maker::BufferedPacketsDecision,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         packet_deserializer::PacketDeserializer, packet_filter::MAX_ALLOWED_PRECOMPILE_SIGNATURES,
-        scheduler_messages::MaxAge,
-        transaction_scheduler::transaction_state::SanitizedTransactionTTL,
-        TransactionStateContainer,
+        scheduler_messages::MaxAge, TransactionStateContainer,
     },
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     agave_transaction_view::{
@@ -239,12 +237,8 @@ impl SanitizedTransactionReceiveAndBuffer {
 
                 let (priority, cost) =
                     calculate_priority_and_cost(&transaction, &fee_budget_limits, &working_bank);
-                let transaction_ttl = SanitizedTransactionTTL {
-                    transaction,
-                    max_age,
-                };
 
-                if container.insert_new_transaction(transaction_ttl, priority, cost) {
+                if container.insert_new_transaction(transaction, max_age, priority, cost) {
                     saturating_add_assign!(num_dropped_on_capacity, 1);
                 }
                 saturating_add_assign!(num_buffered, 1);
@@ -409,10 +403,9 @@ impl TransactionViewReceiveAndBuffer {
                 let mut check_results = {
                     let mut transactions = ArrayVec::<_, EXTRA_CAPACITY>::new();
                     transactions.extend(transaction_priority_ids.iter().map(|priority_id| {
-                        &container
-                            .get_transaction_ttl(priority_id.id)
+                        container
+                            .get_transaction(priority_id.id)
                             .expect("transaction must exist")
-                            .transaction
                     }));
                     working_bank.check_transactions::<RuntimeTransaction<_>>(
                         &transactions,
@@ -432,10 +425,9 @@ impl TransactionViewReceiveAndBuffer {
                         container.remove_by_id(priority_id.id);
                         continue;
                     }
-                    let transaction = &container
-                        .get_transaction_ttl(priority_id.id)
-                        .expect("transaction must exist")
-                        .transaction;
+                    let transaction = container
+                        .get_transaction(priority_id.id)
+                        .expect("transaction must exist");
                     if let Err(err) = Consumer::check_fee_payer_unlocked(
                         working_bank,
                         transaction,
@@ -597,14 +589,7 @@ impl TransactionViewReceiveAndBuffer {
         let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
         let (priority, cost) = calculate_priority_and_cost(&view, &fee_budget_limits, working_bank);
 
-        Ok(TransactionState::new(
-            SanitizedTransactionTTL {
-                transaction: view,
-                max_age,
-            },
-            priority,
-            cost,
-        ))
+        Ok(TransactionState::new(view, max_age, priority, cost))
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -734,7 +734,7 @@ mod tests {
     ) {
         let mut actual_length: usize = 0;
         while let Some(id) = container.pop() {
-            let Some(_) = container.get_transaction_ttl(id.id) else {
+            let Some(_) = container.get_transaction(id.id) else {
                 panic!(
                     "transaction in queue position {} with id {} must exist.",
                     actual_length, id.id

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -259,11 +259,9 @@ where
             let sanitized_txs: Vec<_> = chunk
                 .iter()
                 .map(|id| {
-                    &self
-                        .container
-                        .get_transaction_ttl(id.id)
+                    self.container
+                        .get_transaction(id.id)
                         .expect("transaction must exist")
-                        .transaction
                 })
                 .collect();
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,53 +1,32 @@
 use crate::banking_stage::scheduler_messages::MaxAge;
 
-/// Simple wrapper type to tie a sanitized transaction to max age slot.
-pub(crate) struct SanitizedTransactionTTL<Tx> {
-    pub(crate) transaction: Tx,
-    pub(crate) max_age: MaxAge,
-}
-
 /// TransactionState is used to track the state of a transaction in the transaction scheduler
 /// and banking stage as a whole.
 ///
-/// There are two states a transaction can be in:
-///     1. `Unprocessed` - The transaction is available for scheduling.
-///     2. `Pending` - The transaction is currently scheduled or being processed.
-///
-/// Newly received transactions are initially in the `Unprocessed` state.
-/// When a transaction is scheduled, it is transitioned to the `Pending` state,
-///   using the `transition_to_pending` method.
-/// When a transaction finishes processing it may be retryable. If it is retryable,
-///   the transaction is transitioned back to the `Unprocessed` state using the
-///   `transition_to_unprocessed` method. If it is not retryable, the state should
-///   be dropped.
-///
-/// For performance, when a transaction is transitioned to the `Pending` state, the
-///   internal `SanitizedTransaction` is moved out of the `TransactionState` and sent
-///   to the appropriate thread for processing. This is done to avoid cloning the
-///  `SanitizedTransaction`.
-#[allow(clippy::large_enum_variant)]
-pub(crate) enum TransactionState<Tx> {
-    /// The transaction is available for scheduling.
-    Unprocessed {
-        transaction_ttl: SanitizedTransactionTTL<Tx>,
-        priority: u64,
-        cost: u64,
-    },
-    /// The transaction is currently scheduled or being processed.
-    Pending { priority: u64, cost: u64 },
-    /// Only used during transition.
-    Transitioning,
+/// Newly received transactions initially have `Some(transaction)`.
+/// When a transaction is scheduled, the transaction is taken from the Option.
+/// When a transaction finishes processing it may be retryable. If it is
+/// retryable, the transaction is added back into the Option. If it si not
+/// retryable, the state is dropped.
+pub(crate) struct TransactionState<Tx> {
+    /// If `Some`, the transaction is available for scheduling.
+    /// If `None`, the transaction is currently scheduled or being processed.
+    transaction: Option<Tx>,
+    /// Tracks information on the maximum age the transaction's pre-processing
+    /// is valid for.
+    max_age: MaxAge,
+    /// Priority of the transaction.
+    priority: u64,
+    /// Estimated cost of the transaction.
+    cost: u64,
 }
 
 impl<Tx> TransactionState<Tx> {
     /// Creates a new `TransactionState` in the `Unprocessed` state.
-    pub(crate) fn new(
-        transaction_ttl: SanitizedTransactionTTL<Tx>,
-        priority: u64,
-        cost: u64,
-    ) -> Self {
-        Self::Unprocessed {
-            transaction_ttl,
+    pub(crate) fn new(transaction: Tx, max_age: MaxAge, priority: u64, cost: u64) -> Self {
+        Self {
+            transaction: Some(transaction),
+            max_age,
             priority,
             cost,
         }
@@ -57,87 +36,47 @@ impl<Tx> TransactionState<Tx> {
     /// This is *not* the same as the `compute_unit_price` of the transaction.
     /// The priority is used to order transactions for processing.
     pub(crate) fn priority(&self) -> u64 {
-        match self {
-            Self::Unprocessed { priority, .. } => *priority,
-            Self::Pending { priority, .. } => *priority,
-            Self::Transitioning => unreachable!(),
-        }
+        self.priority
     }
 
     /// Return the cost of the transaction.
     pub(crate) fn cost(&self) -> u64 {
-        match self {
-            Self::Unprocessed { cost, .. } => *cost,
-            Self::Pending { cost, .. } => *cost,
-            Self::Transitioning => unreachable!(),
-        }
+        self.cost
     }
 
-    /// Intended to be called when a transaction is scheduled. This method will
-    /// transition the transaction from `Unprocessed` to `Pending` and return the
-    /// `SanitizedTransactionTTL` for processing.
+    /// Intended to be called when a transaction is scheduled. This method
+    /// takes ownership of the transaction from the state.
     ///
     /// # Panics
-    /// This method will panic if the transaction is already in the `Pending` state,
-    ///   as this is an invalid state transition.
-    pub(crate) fn transition_to_pending(&mut self) -> SanitizedTransactionTTL<Tx> {
-        match self.take() {
-            TransactionState::Unprocessed {
-                transaction_ttl,
-                priority,
-                cost,
-            } => {
-                *self = TransactionState::Pending { priority, cost };
-                transaction_ttl
-            }
-            TransactionState::Pending { .. } => {
-                panic!("transaction already pending");
-            }
-            Self::Transitioning => unreachable!(),
-        }
+    /// This method will panic if the transaction has already been scheduled.
+    pub(crate) fn take_transaction_for_scheduling(&mut self) -> (Tx, MaxAge) {
+        let tx = self
+            .transaction
+            .take()
+            .expect("transaction not already pending");
+        (tx, self.max_age)
     }
 
     /// Intended to be called when a transaction is retried. This method will
-    /// transition the transaction from `Pending` to `Unprocessed`.
+    /// return ownership of the transaction to the state.
     ///
     /// # Panics
-    /// This method will panic if the transaction is already in the `Unprocessed`
-    ///   state, as this is an invalid state transition.
-    pub(crate) fn transition_to_unprocessed(
-        &mut self,
-        transaction_ttl: SanitizedTransactionTTL<Tx>,
-    ) {
-        match self.take() {
-            TransactionState::Unprocessed { .. } => panic!("already unprocessed"),
-            TransactionState::Pending { priority, cost } => {
-                *self = Self::Unprocessed {
-                    transaction_ttl,
-                    priority,
-                    cost,
-                }
-            }
-            Self::Transitioning => unreachable!(),
-        }
+    /// This method will panic if the transaction is not pending.
+    pub(crate) fn retry_transaction(&mut self, transaction: Tx) {
+        assert!(
+            self.transaction.replace(transaction).is_none(),
+            "transaction is pending"
+        );
     }
 
-    /// Get a reference to the `SanitizedTransactionTTL` for the transaction.
+    /// Get a reference to the transaction.
     ///
     /// # Panics
     /// This method will panic if the transaction is in the `Pending` state.
-    pub(crate) fn transaction_ttl(&self) -> &SanitizedTransactionTTL<Tx> {
-        match self {
-            Self::Unprocessed {
-                transaction_ttl, ..
-            } => transaction_ttl,
-            Self::Pending { .. } => panic!("transaction is pending"),
-            Self::Transitioning => unreachable!(),
-        }
-    }
-
-    /// Internal helper to transitioning between states.
-    /// Replaces `self` with a dummy state that will immediately be overwritten in transition.
-    fn take(&mut self) -> Self {
-        core::mem::replace(self, Self::Transitioning)
+    pub(crate) fn transaction(&self) -> &Tx {
+        self.transaction
+            .as_ref()
+            .expect("transaction is not pending")
     }
 }
 
@@ -168,70 +107,50 @@ mod tests {
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
         let tx = Transaction::new(&[&from_keypair], message, Hash::default());
 
-        let transaction_ttl = SanitizedTransactionTTL {
-            transaction: RuntimeTransaction::from_transaction_for_tests(tx),
-            max_age: MaxAge::MAX,
-        };
         const TEST_TRANSACTION_COST: u64 = 5000;
-        TransactionState::new(transaction_ttl, compute_unit_price, TEST_TRANSACTION_COST)
+        TransactionState::new(
+            RuntimeTransaction::from_transaction_for_tests(tx),
+            MaxAge::MAX,
+            compute_unit_price,
+            TEST_TRANSACTION_COST,
+        )
     }
 
     #[test]
     #[should_panic(expected = "already pending")]
-    fn test_transition_to_pending_panic() {
+    fn test_take_transaction_for_scheduling_panic() {
         let mut transaction_state = create_transaction_state(0);
-        transaction_state.transition_to_pending();
-        transaction_state.transition_to_pending(); // invalid transition
+        transaction_state.take_transaction_for_scheduling();
+        transaction_state.take_transaction_for_scheduling(); // invalid transition
     }
 
     #[test]
-    fn test_transition_to_pending() {
+    fn test_take_transaction_for_scheduling() {
         let mut transaction_state = create_transaction_state(0);
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
-        let _ = transaction_state.transition_to_pending();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Pending { .. }
-        ));
+        assert!(transaction_state.transaction.is_some());
+        let _ = transaction_state.take_transaction_for_scheduling();
+        assert!(transaction_state.transaction.is_none());
     }
 
     #[test]
-    #[should_panic(expected = "already unprocessed")]
-    fn test_transition_to_unprocessed_panic() {
+    #[should_panic(expected = "transaction is pending")]
+    fn test_retry_transaction_panic() {
         let mut transaction_state = create_transaction_state(0);
-
-        // Manually clone `SanitizedTransactionTTL`
-        let SanitizedTransactionTTL {
-            transaction,
-            max_age,
-        } = transaction_state.transaction_ttl();
-        let transaction_ttl = SanitizedTransactionTTL {
-            transaction: transaction.clone(),
-            max_age: *max_age,
-        };
-        transaction_state.transition_to_unprocessed(transaction_ttl); // invalid transition
+        // invalid transition since transaction is already some
+        assert!(transaction_state.transaction.is_some());
+        let transaction_clone = transaction_state.transaction.as_ref().unwrap().clone();
+        assert!(transaction_state.transaction.is_some());
+        transaction_state.retry_transaction(transaction_clone);
     }
 
     #[test]
-    fn test_transition_to_unprocessed() {
+    fn test_retry_transaction() {
         let mut transaction_state = create_transaction_state(0);
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
-        let transaction_ttl = transaction_state.transition_to_pending();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Pending { .. }
-        ));
-        transaction_state.transition_to_unprocessed(transaction_ttl);
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
+        assert!(transaction_state.transaction.is_some());
+        let (transaction, _max_age) = transaction_state.take_transaction_for_scheduling();
+        assert!(transaction_state.transaction.is_none());
+        transaction_state.retry_transaction(transaction);
+        assert!(transaction_state.transaction.is_some());
     }
 
     #[test]
@@ -241,54 +160,36 @@ mod tests {
         assert_eq!(transaction_state.priority(), priority);
 
         // ensure compute unit price is not lost through state transitions
-        let transaction_ttl = transaction_state.transition_to_pending();
+        let (transaction, _max_age) = transaction_state.take_transaction_for_scheduling();
         assert_eq!(transaction_state.priority(), priority);
-        transaction_state.transition_to_unprocessed(transaction_ttl);
+        transaction_state.retry_transaction(transaction);
         assert_eq!(transaction_state.priority(), priority);
     }
 
     #[test]
-    #[should_panic(expected = "transaction is pending")]
-    fn test_transaction_ttl_panic() {
+    #[should_panic(expected = "transaction is not pending")]
+    fn test_transaction_panic() {
         let mut transaction_state = create_transaction_state(0);
-        let transaction_ttl = transaction_state.transaction_ttl();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
-        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
+        let _transaction = transaction_state.transaction();
+        assert!(transaction_state.transaction.is_some());
 
-        let _ = transaction_state.transition_to_pending();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Pending { .. }
-        ));
-        let _ = transaction_state.transaction_ttl(); // pending state, the transaction ttl is not available
+        let _ = transaction_state.take_transaction_for_scheduling();
+        assert!(transaction_state.transaction.is_none());
+        let _ = transaction_state.transaction(); // pending state, the transaction ttl is not available
     }
 
     #[test]
-    fn test_transaction_ttl() {
+    fn test_transaction() {
         let mut transaction_state = create_transaction_state(0);
-        let transaction_ttl = transaction_state.transaction_ttl();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
-        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
+        let _transaction = transaction_state.transaction();
+        assert!(transaction_state.transaction.is_some());
 
         // ensure transaction_ttl is not lost through state transitions
-        let transaction_ttl = transaction_state.transition_to_pending();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Pending { .. }
-        ));
+        let (transaction, _max_age) = transaction_state.take_transaction_for_scheduling();
+        assert!(transaction_state.transaction.is_none());
 
-        transaction_state.transition_to_unprocessed(transaction_ttl);
-        let transaction_ttl = transaction_state.transaction_ttl();
-        assert!(matches!(
-            transaction_state,
-            TransactionState::Unprocessed { .. }
-        ));
-        assert_eq!(transaction_ttl.max_age, MaxAge::MAX);
+        transaction_state.retry_transaction(transaction);
+        let _transaction = transaction_state.transaction();
+        assert!(transaction_state.transaction.is_some());
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -13,7 +13,8 @@ pub(crate) struct TransactionState<Tx> {
     /// If `None`, the transaction is currently scheduled or being processed.
     transaction: Option<Tx>,
     /// Tracks information on the maximum age the transaction's pre-processing
-    /// is valid for.
+    /// is valid for. This includes sanitization features, as well as resolved
+    /// address lookups.
     max_age: MaxAge,
     /// Priority of the transaction.
     priority: u64,


### PR DESCRIPTION
#### Problem
- `TransactionState` used to contain raw packet information but it makes more sense for the state to be flat w/ a simple internal option now.

#### Summary of Changes
- TransactionState contains all items directly instead of a separate `SanitizedTransactionTTL`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
