### PR TITLE
geyser: Removes deduplication in notify_account_restore_from_snapshot()

### DIFF
--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -11,7 +11,6 @@ use {
     solana_transaction::sanitized::SanitizedTransaction,
     std::{
         cmp::Reverse,
-        collections::{HashMap, HashSet},
         ops::AddAssign,
         time::{Duration, Instant},
     },
@@ -19,27 +18,16 @@ use {
 
 #[derive(Default)]
 pub struct GeyserPluginNotifyAtSnapshotRestoreStats {
-    pub total_accounts: usize,
-    pub skipped_accounts: usize,
     pub notified_accounts: usize,
-    pub elapsed_filtering: Duration,
     pub elapsed_notifying: Duration,
     pub total_pure_notify: Duration,
-    pub total_pure_bookkeeping: Duration,
 }
 
 impl GeyserPluginNotifyAtSnapshotRestoreStats {
     pub fn report(&self) {
         datapoint_info!(
             "accountsdb_plugin_notify_account_restore_from_snapshot_summary",
-            ("total_accounts", self.total_accounts, i64),
-            ("skipped_accounts", self.skipped_accounts, i64),
             ("notified_accounts", self.notified_accounts, i64),
-            (
-                "elapsed_filtering_us",
-                self.elapsed_filtering.as_micros(),
-                i64
-            ),
             (
                 "elapsed_notifying_us",
                 self.elapsed_notifying.as_micros(),
@@ -50,31 +38,23 @@ impl GeyserPluginNotifyAtSnapshotRestoreStats {
                 self.total_pure_notify.as_micros(),
                 i64
             ),
-            (
-                "total_pure_bookeeping_us",
-                self.total_pure_bookkeeping.as_micros(),
-                i64
-            ),
         );
     }
 }
 
 impl AddAssign for GeyserPluginNotifyAtSnapshotRestoreStats {
     fn add_assign(&mut self, other: Self) {
-        self.total_accounts += other.total_accounts;
-        self.skipped_accounts += other.skipped_accounts;
         self.notified_accounts += other.notified_accounts;
-        self.elapsed_filtering += other.elapsed_filtering;
         self.elapsed_notifying += other.elapsed_notifying;
         self.total_pure_notify += other.total_pure_notify;
-        self.total_pure_bookkeeping += other.total_pure_bookkeeping;
     }
 }
 
 impl AccountsDb {
-    /// Notify the plugins of account data when AccountsDb is restored from a snapshot. The data is streamed
-    /// in the reverse order of the slots so that an account is only streamed once. At a slot, if the accounts is updated
-    /// multiple times only the last write (with highest write_version) is notified.
+    /// Notify the plugins of account data when AccountsDb is restored from a snapshot.
+    ///
+    /// Since accounts may have multiple versions in different slots, plugins must handle
+    /// deduplication by inspected the slot and write version of each account notification.
     pub fn notify_account_restore_from_snapshot(&self) {
         let Some(accounts_update_notifier) = &self.accounts_update_notifier else {
             return;
@@ -83,18 +63,12 @@ impl AccountsDb {
         let mut notify_stats = GeyserPluginNotifyAtSnapshotRestoreStats::default();
         if accounts_update_notifier.snapshot_notifications_enabled() {
             let mut slots = self.storage.all_slots();
-            let mut notified_accounts: HashSet<Pubkey> = HashSet::default();
-
             slots.sort_unstable_by_key(|&slot| Reverse(slot));
             slots
                 .into_iter()
                 .filter_map(|slot| self.storage.get_slot_storage_entry(slot))
                 .map(|storage| {
-                    Self::notify_accounts_in_storage(
-                        accounts_update_notifier.as_ref(),
-                        &storage,
-                        &mut notified_accounts,
-                    )
+                    Self::notify_accounts_in_storage(accounts_update_notifier.as_ref(), &storage)
                 })
                 .for_each(|stats| notify_stats += stats);
         }
@@ -125,46 +99,12 @@ impl AccountsDb {
     fn notify_accounts_in_storage(
         notifier: &dyn AccountsUpdateNotifierInterface,
         storage: &AccountStorageEntry,
-        notified_accounts: &mut HashSet<Pubkey>,
     ) -> GeyserPluginNotifyAtSnapshotRestoreStats {
-        let filtering_start = Instant::now();
-        let mut accounts_duplicate: HashMap<Pubkey, usize> = HashMap::default();
-        let mut pubkeys = HashSet::new();
-
-        // populate `accounts_duplicate` for any pubkeys that are in this storage twice.
-        // Storages cannot return `AccountForGeyser` for more than 1 account at a time, so we have to do 2 passes to make sure
-        // we don't have duplicate pubkeys.
-        let mut i = 0;
-        storage.accounts.scan_pubkeys(|pubkey| {
-            i += 1; // pre-increment to most easily match early returns in next loop
-            if !pubkeys.insert(*pubkey) {
-                accounts_duplicate.insert(*pubkey, i); // remember the highest index entry in this slot
-            }
-        });
-
-        // now, actually notify geyser
         let mut pure_notify_time = Duration::ZERO;
-        let mut pure_bookkeeping_time = Duration::ZERO;
-        let mut num_total_accounts = 0;
-        let mut num_skipped_accounts = 0;
-        let mut num_notified_accounts = 0;
         let mut i = 0;
         let notifying_start = Instant::now();
         storage.accounts.scan_accounts_for_geyser(|account| {
             i += 1;
-            num_total_accounts += 1;
-            if notified_accounts.contains(account.pubkey) {
-                num_skipped_accounts += 1;
-                return;
-            }
-            if let Some(highest_i) = accounts_duplicate.get(account.pubkey) {
-                if highest_i != &i {
-                    // this pubkey is in this storage twice and the current instance is not the last one, so we skip it.
-                    // We only send unique accounts in this slot to `notify_filtered_accounts`
-                    return;
-                }
-            }
-
             // later entries in the same slot are more recent and override earlier accounts for the same pubkey
             // We can pass an incrementing number here for write_version in the future, if the storage does not have a write_version.
             // As long as all accounts for this slot are in 1 append vec that can be iterated oldest to newest.
@@ -173,22 +113,14 @@ impl AccountsDb {
                 i as u64,
                 &account
             ));
-            let (_, bookkeeping_dur) = meas_dur!(notified_accounts.insert(*account.pubkey));
             pure_notify_time += notify_dur;
-            pure_bookkeeping_time += bookkeeping_dur;
-            num_notified_accounts += 1;
         });
         let notifying_time = notifying_start.elapsed();
 
-        let filtering_time = filtering_start.elapsed();
         GeyserPluginNotifyAtSnapshotRestoreStats {
-            total_accounts: num_total_accounts,
-            skipped_accounts: num_skipped_accounts,
-            notified_accounts: num_notified_accounts,
-            elapsed_filtering: filtering_time,
+            notified_accounts: i,
             elapsed_notifying: notifying_time,
             total_pure_notify: pure_notify_time,
-            total_pure_bookkeeping: pure_bookkeeping_time,
         }
     }
 }
@@ -216,7 +148,7 @@ pub mod tests {
 
     #[derive(Debug, Default)]
     struct GeyserTestPlugin {
-        pub accounts_notified: DashMap<Pubkey, Vec<(Slot, AccountSharedData)>>,
+        pub accounts_notified: DashMap<Pubkey, Vec<(Slot, u64, AccountSharedData)>>,
         pub is_startup_done: AtomicBool,
     }
 
@@ -232,12 +164,13 @@ pub mod tests {
             account: &AccountSharedData,
             _txn: &Option<&SanitizedTransaction>,
             pubkey: &Pubkey,
-            _write_version: u64,
+            write_version: u64,
         ) {
-            self.accounts_notified
-                .entry(*pubkey)
-                .or_default()
-                .push((slot, account.clone()));
+            self.accounts_notified.entry(*pubkey).or_default().push((
+                slot,
+                write_version,
+                account.clone(),
+            ));
         }
 
         /// Notified when the AccountsDb is initialized at start when restored
@@ -245,13 +178,13 @@ pub mod tests {
         fn notify_account_restore_from_snapshot(
             &self,
             slot: Slot,
-            _write_version: u64,
+            write_version: u64,
             account: &AccountForGeyser<'_>,
         ) {
             self.accounts_notified
                 .entry(*account.pubkey)
                 .or_default()
-                .push((slot, account.to_account_shared_data()));
+                .push((slot, write_version, account.to_account_shared_data()));
         }
 
         fn notify_end_of_restore_from_snapshot(&self) {
@@ -260,113 +193,64 @@ pub mod tests {
     }
 
     #[test]
-    fn test_notify_account_restore_from_snapshot_once_per_slot() {
+    fn test_notify_account_restore_from_snapshot() {
         let mut accounts = AccountsDb::new_single_for_tests();
-        // Account with key1 is updated twice in the store -- should only get notified once.
-        let key1 = solana_pubkey::new_rand();
-        let mut account1_lamports: u64 = 1;
-        let account1 =
-            AccountSharedData::new(account1_lamports, 1, AccountSharedData::default().owner());
-        let slot0 = 0;
-        accounts.store_uncached(slot0, &[(&key1, &account1)]);
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        let key3 = Pubkey::new_unique();
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
 
-        account1_lamports = 2;
-        let account1 = AccountSharedData::new(account1_lamports, 1, account1.owner());
-        accounts.store_uncached(slot0, &[(&key1, &account1)]);
+        // Account with key1 is updated twice in two different slots, should get notified twice
+        accounts.store_uncached(0, &[(&key1, &account)]);
+        accounts.store_uncached(1, &[(&key1, &account)]);
+
+        // Account with key2 is updated in a single slot, should get notified once
+        accounts.store_uncached(2, &[(&key2, &account)]);
+
+        // Account with key3 is updated twice in a single slot, should get notified twice
+        accounts.store_uncached(3, &[(&key3, &account)]);
+        accounts.store_uncached(3, &[(&key3, &account)]);
+
+        // Do the notification
         let notifier = GeyserTestPlugin::default();
-
-        let key2 = solana_pubkey::new_rand();
-        let account2_lamports: u64 = 100;
-        let account2 =
-            AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-
-        accounts.store_uncached(slot0, &[(&key2, &account2)]);
-
         let notifier = Arc::new(notifier);
         accounts.set_geyser_plugin_notifer(Some(notifier.clone()));
-
         accounts.notify_account_restore_from_snapshot();
 
-        assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 1);
-        assert_eq!(
-            notifier.accounts_notified.get(&key1).unwrap()[0]
-                .1
-                .lamports(),
-            account1_lamports
-        );
-        assert_eq!(notifier.accounts_notified.get(&key1).unwrap()[0].0, slot0);
-        assert_eq!(notifier.accounts_notified.get(&key2).unwrap().len(), 1);
-        assert_eq!(
-            notifier.accounts_notified.get(&key2).unwrap()[0]
-                .1
-                .lamports(),
-            account2_lamports
-        );
-        assert_eq!(notifier.accounts_notified.get(&key2).unwrap()[0].0, slot0);
+        // Ensure key1 was notified twice in different slots
+        {
+            let notified_key1 = notifier.accounts_notified.get(&key1).unwrap();
+            assert_eq!(notified_key1.len(), 2);
+            let (slot, write_version, _account) = &notified_key1[0];
+            assert_eq!(*slot, 1);
+            assert_eq!(*write_version, 1);
+            let (slot, write_version, _account) = &notified_key1[1];
+            assert_eq!(*slot, 0);
+            assert_eq!(*write_version, 1);
+        }
 
-        assert!(notifier.is_startup_done.load(Ordering::Relaxed));
-    }
+        // Ensure key2 was notified once
+        {
+            let notified_key2 = notifier.accounts_notified.get(&key2).unwrap();
+            assert_eq!(notified_key2.len(), 1);
+            let (slot, write_version, _account) = &notified_key2[0];
+            assert_eq!(*slot, 2);
+            assert_eq!(*write_version, 1);
+        }
 
-    #[test]
-    fn test_notify_account_restore_from_snapshot_once_across_slots() {
-        let mut accounts = AccountsDb::new_single_for_tests();
-        // Account with key1 is updated twice in two different slots -- should only get notified once.
-        // Account with key2 is updated slot0, should get notified once
-        // Account with key3 is updated in slot1, should get notified once
-        let key1 = solana_pubkey::new_rand();
-        let mut account1_lamports: u64 = 1;
-        let account1 =
-            AccountSharedData::new(account1_lamports, 1, AccountSharedData::default().owner());
-        let slot0 = 0;
-        accounts.store_uncached(slot0, &[(&key1, &account1)]);
+        // Ensure key3 was notified twice in the same slot
+        {
+            let notified_key3 = notifier.accounts_notified.get(&key3).unwrap();
+            assert_eq!(notified_key3.len(), 2);
+            let (slot, write_version, _account) = &notified_key3[0];
+            assert_eq!(*slot, 3);
+            assert_eq!(*write_version, 1);
+            let (slot, write_version, _account) = &notified_key3[1];
+            assert_eq!(*slot, 3);
+            assert_eq!(*write_version, 2);
+        }
 
-        let key2 = solana_pubkey::new_rand();
-        let account2_lamports: u64 = 200;
-        let account2 =
-            AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_uncached(slot0, &[(&key2, &account2)]);
-
-        account1_lamports = 2;
-        let slot1 = 1;
-        let account1 = AccountSharedData::new(account1_lamports, 1, account1.owner());
-        accounts.store_uncached(slot1, &[(&key1, &account1)]);
-        let notifier = GeyserTestPlugin::default();
-
-        let key3 = solana_pubkey::new_rand();
-        let account3_lamports: u64 = 300;
-        let account3 =
-            AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_uncached(slot1, &[(&key3, &account3)]);
-
-        let notifier = Arc::new(notifier);
-        accounts.set_geyser_plugin_notifer(Some(notifier.clone()));
-
-        accounts.notify_account_restore_from_snapshot();
-
-        assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 1);
-        assert_eq!(
-            notifier.accounts_notified.get(&key1).unwrap()[0]
-                .1
-                .lamports(),
-            account1_lamports
-        );
-        assert_eq!(notifier.accounts_notified.get(&key1).unwrap()[0].0, slot1);
-        assert_eq!(notifier.accounts_notified.get(&key2).unwrap().len(), 1);
-        assert_eq!(
-            notifier.accounts_notified.get(&key2).unwrap()[0]
-                .1
-                .lamports(),
-            account2_lamports
-        );
-        assert_eq!(notifier.accounts_notified.get(&key2).unwrap()[0].0, slot0);
-        assert_eq!(notifier.accounts_notified.get(&key3).unwrap().len(), 1);
-        assert_eq!(
-            notifier.accounts_notified.get(&key3).unwrap()[0]
-                .1
-                .lamports(),
-            account3_lamports
-        );
-        assert_eq!(notifier.accounts_notified.get(&key3).unwrap()[0].0, slot1);
+        // Ensure we were notified that startup is done
         assert!(notifier.is_startup_done.load(Ordering::Relaxed));
     }
 
@@ -409,14 +293,14 @@ pub mod tests {
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 2);
         assert_eq!(
             notifier.accounts_notified.get(&key1).unwrap()[0]
-                .1
+                .2
                 .lamports(),
             account1_lamports1
         );
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap()[0].0, slot0);
         assert_eq!(
             notifier.accounts_notified.get(&key1).unwrap()[1]
-                .1
+                .2
                 .lamports(),
             account1_lamports2
         );
@@ -425,7 +309,7 @@ pub mod tests {
         assert_eq!(notifier.accounts_notified.get(&key2).unwrap().len(), 1);
         assert_eq!(
             notifier.accounts_notified.get(&key2).unwrap()[0]
-                .1
+                .2
                 .lamports(),
             account2_lamports
         );
@@ -433,7 +317,7 @@ pub mod tests {
         assert_eq!(notifier.accounts_notified.get(&key3).unwrap().len(), 1);
         assert_eq!(
             notifier.accounts_notified.get(&key3).unwrap()[0]
-                .1
+                .2
                 .lamports(),
             account3_lamports
         );


### PR DESCRIPTION
#### Problem

Geyser startup is expensive.

Geyser startup is expensive in part because accounts-db promises the geyser plugins that it'll only send a single `notify` per account. Since the current impl is scanning through account storages, it is possible an account can have multiple versions across multiple storages. The current solution is to use a HashMap of *all the accounts* to track the accounts that have already been notified (and then skip the others).

Note that when the validator is running at steady state, the geyser plugin can/will receive multiple updates for an account in different slots. Thus geyser plugins already must manage this deduplication themselves, rendering the startup hashmap unnecessary.

Part of that deduplication is the slot, and the other part is the write version. We now only write an account once per storage, so the write version usually isn't important. However, it is legal for an AppendVec to have multiple version of an account. Again, we have a discrepancy between startup and steady state. At steady state, we *do* pass a write version to the geyser plugins, but at startup we do not (we actually pass a constant of 0, which is safe).


#### Summary of Changes

Removes account deduplication at startup for geyser plugins.


#### Other Pertinent Information

I checked with as many geyser plugin developers as I could to see if this change would break them. All of them said these changes would *not* break them. This includes Triton and the yellowstone geyser plugin.