### PR TITLE
Codegen-units=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ lto = false                # Preserve the 'thin local LTO' for this build.
 [profile.release]
 split-debuginfo = "unpacked"
 lto = "thin"
+codegen-units = 1
 
 [workspace]
 members = [


### PR DESCRIPTION
#### Problem
Use codegen-units=1 for better performance with lto builds.

#### Summary of Changes
Fixes #5085 
