### PR TITLE
SchedulerMetrics add num_unschedulable_threads

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -717,7 +717,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
-        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 3);
+        assert_eq!(scheduling_summary.num_unschedulable_threads, 3);
         assert_eq!(collect_work(&work_receivers[0]).1, [vec![5], vec![4]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![0]]);
     }

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -102,7 +102,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         let mut num_scanned: usize = 0;
         let mut num_scheduled: usize = 0;
         let mut num_sent: usize = 0;
-        let mut num_unschedulable: usize = 0;
+        let mut num_unschedulable_conflicts: usize = 0;
+        let mut num_unschedulable_threads: usize = 0;
 
         let mut batches = Batches::new(num_threads, self.config.target_transactions_per_batch);
         while num_scanned < self.config.max_scanned_transactions_per_scheduling_pass
@@ -147,9 +148,12 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     )
                 },
             ) {
-                Err(TransactionSchedulingError::UnschedulableConflicts)
-                | Err(TransactionSchedulingError::UnschedulableThread) => {
-                    num_unschedulable += 1;
+                Err(TransactionSchedulingError::UnschedulableConflicts) => {
+                    num_unschedulable_conflicts += 1;
+                    self.unschedulables.push(id);
+                }
+                Err(TransactionSchedulingError::UnschedulableThread) => {
+                    num_unschedulable_threads += 1;
                     self.unschedulables.push(id);
                 }
                 Ok(TransactionSchedulingInfo {
@@ -201,7 +205,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
 
         Ok(SchedulingSummary {
             num_scheduled,
-            num_unschedulable,
+            num_unschedulable_conflicts,
+            num_unschedulable_threads,
             num_filtered_out: 0,
             filter_time_us: 0,
         })
@@ -545,7 +550,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1, 0]]);
     }
 
@@ -567,7 +572,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 1);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1]]);
     }
 
@@ -589,7 +594,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 1);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1]]);
     }
 
@@ -611,7 +616,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
     }
 
@@ -629,7 +634,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
     }
 
@@ -644,7 +649,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 4);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, [vec![3, 1]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![2, 0]]);
     }
@@ -680,7 +685,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
-        assert_eq!(scheduling_summary.num_unschedulable, 1);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 1);
         assert_eq!(collect_work(&work_receivers[0]).1, [vec![3], vec![0]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![2]]);
     }
@@ -712,7 +717,7 @@ mod test {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
-        assert_eq!(scheduling_summary.num_unschedulable, 3);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 3);
         assert_eq!(collect_work(&work_receivers[0]).1, [vec![5], vec![4]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![0]]);
     }

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -120,12 +120,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             }
         }
         if schedulable_threads.is_empty() {
-            return Ok(SchedulingSummary {
-                num_scheduled: 0,
-                num_unschedulable: 0,
-                num_filtered_out: 0,
-                filter_time_us: 0,
-            });
+            return Ok(SchedulingSummary::default());
         }
 
         let mut batches = Batches::new(num_threads, self.config.target_transactions_per_batch);
@@ -198,7 +193,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         let mut num_scanned: usize = 0;
         let mut num_scheduled: usize = 0;
         let mut num_sent: usize = 0;
-        let mut num_unschedulable: usize = 0;
+        let mut num_unschedulable_conflicts: usize = 0;
+        let mut num_unschedulable_threads: usize = 0;
         while num_scanned < self.config.max_scanned_transactions_per_scheduling_pass {
             // If nothing is in the main-queue of the `PrioGraph` then there's nothing left to schedule.
             if self.prio_graph.is_empty() {
@@ -233,10 +229,13 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                 );
 
                 match maybe_schedule_info {
-                    Err(TransactionSchedulingError::UnschedulableConflicts)
-                    | Err(TransactionSchedulingError::UnschedulableThread) => {
+                    Err(TransactionSchedulingError::UnschedulableConflicts) => {
+                        num_unschedulable_conflicts += 1;
                         unschedulable_ids.push(id);
-                        saturating_add_assign!(num_unschedulable, 1);
+                    }
+                    Err(TransactionSchedulingError::UnschedulableThread) => {
+                        num_unschedulable_threads += 1;
+                        unschedulable_ids.push(id);
                     }
                     Ok(TransactionSchedulingInfo {
                         thread_id,
@@ -314,7 +313,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
 
         Ok(SchedulingSummary {
             num_scheduled,
-            num_unschedulable,
+            num_unschedulable_conflicts,
+            num_unschedulable_threads,
             num_filtered_out,
             filter_time_us: total_filter_time_us,
         })
@@ -783,7 +783,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1, 0]]);
     }
 
@@ -800,7 +800,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
     }
 
@@ -820,7 +820,7 @@ mod tests {
             scheduling_summary.num_scheduled,
             4 * TARGET_NUM_TRANSACTIONS_PER_BATCH
         );
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
 
         let thread0_work_counts: Vec<_> = work_receivers[0]
             .try_iter()
@@ -839,7 +839,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 4);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, [vec![3, 1]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![2, 0]]);
     }
@@ -880,7 +880,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 4);
-        assert_eq!(scheduling_summary.num_unschedulable, 2);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 2);
         let (thread_0_work, thread_0_ids) = collect_work(&work_receivers[0]);
         assert_eq!(thread_0_ids, [vec![0], vec![2]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![1], vec![3]]);
@@ -890,7 +890,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 0);
-        assert_eq!(scheduling_summary.num_unschedulable, 2);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 2);
 
         // Complete batch on thread 0. Remaining txs can be scheduled onto thread 1
         finished_work_sender
@@ -904,7 +904,7 @@ mod tests {
             .schedule(&mut container, test_pre_graph_filter, test_pre_lock_filter)
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
 
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![4], vec![5]]);
     }
@@ -934,7 +934,7 @@ mod tests {
                 .max_scanned_transactions_per_scheduling_pass,
         );
         assert_eq!(scheduling_summary.num_scheduled, expected_num_scheduled);
-        assert_eq!(scheduling_summary.num_unschedulable, 0);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
 
         let mut post_schedule_remaining_ids = 0;
         while let Some(_p) = container.pop() {

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -37,7 +37,9 @@ pub(crate) struct SchedulingSummary {
     /// Number of transactions scheduled.
     pub num_scheduled: usize,
     /// Number of transactions that were not scheduled due to conflicts.
-    pub num_unschedulable: usize,
+    pub num_unschedulable_conflicts: usize,
+    /// Number of transactions that were skipped due to thread capacity.
+    pub num_unschedulable_threads: usize,
     /// Number of transactions that were dropped due to filter.
     pub num_filtered_out: usize,
     /// Time spent filtering transactions

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -152,7 +152,7 @@ where
                     );
                     saturating_add_assign!(
                         count_metrics.num_unschedulable,
-                        scheduling_summary.num_unschedulable
+                        scheduling_summary.num_unschedulable_conflicts
                     );
                     saturating_add_assign!(
                         count_metrics.num_schedule_filtered_out,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -151,8 +151,12 @@ where
                         scheduling_summary.num_scheduled
                     );
                     saturating_add_assign!(
-                        count_metrics.num_unschedulable,
+                        count_metrics.num_unschedulable_conflicts,
                         scheduling_summary.num_unschedulable_conflicts
+                    );
+                    saturating_add_assign!(
+                        count_metrics.num_unschedulable_threads,
+                        scheduling_summary.num_unschedulable_threads
                     );
                     saturating_add_assign!(
                         count_metrics.num_schedule_filtered_out,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -51,8 +51,10 @@ pub struct SchedulerCountMetricsInner {
 
     /// Number of transactions scheduled.
     pub num_scheduled: usize,
-    /// Number of transactions that were unschedulable.
-    pub num_unschedulable: usize,
+    /// Number of transactions that were unschedulable due to multiple conflicts.
+    pub num_unschedulable_conflicts: usize,
+    /// Number of transactions that were unschedulable due to thread capacity.
+    pub num_unschedulable_threads: usize,
     /// Number of transactions that were filtered out during scheduling.
     pub num_schedule_filtered_out: usize,
     /// Number of completed transactions received from workers.
@@ -114,7 +116,8 @@ impl SchedulerCountMetricsInner {
             ("num_received", self.num_received, i64),
             ("num_buffered", self.num_buffered, i64),
             ("num_scheduled", self.num_scheduled, i64),
-            ("num_unschedulable", self.num_unschedulable, i64),
+            ("num_unschedulable_conflicts", self.num_unschedulable_conflicts, i64),
+            ("num_unschedulable_threads", self.num_unschedulable_threads, i64),
             (
                 "num_schedule_filtered_out",
                 self.num_schedule_filtered_out,
@@ -158,7 +161,8 @@ impl SchedulerCountMetricsInner {
         self.num_received != 0
             || self.num_buffered != 0
             || self.num_scheduled != 0
-            || self.num_unschedulable != 0
+            || self.num_unschedulable_conflicts != 0
+            || self.num_unschedulable_threads != 0
             || self.num_schedule_filtered_out != 0
             || self.num_finished != 0
             || self.num_retryable != 0
@@ -175,7 +179,8 @@ impl SchedulerCountMetricsInner {
         self.num_received = 0;
         self.num_buffered = 0;
         self.num_scheduled = 0;
-        self.num_unschedulable = 0;
+        self.num_unschedulable_conflicts = 0;
+        self.num_unschedulable_threads = 0;
         self.num_schedule_filtered_out = 0;
         self.num_finished = 0;
         self.num_retryable = 0;


### PR DESCRIPTION
#### Problem
- Scheduler metric currently reports a single count for unschedulable transactions even though there are multiple reasons a transaction may be unschedulable at some time

#### Summary of Changes
- Separate metrics for unschedulable due to conflicts and unschedulable due to thread capacity

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
