### PR TITLE
try bounded channel for sigverify-retransmit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8452,6 +8452,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
+ "solana-streamer",
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -21,7 +21,7 @@ use {
         window_service::{WindowService, WindowServiceChannels},
     },
     bytes::Bytes,
-    crossbeam_channel::{unbounded, Receiver, Sender},
+    crossbeam_channel::{bounded, unbounded, Receiver, Sender},
     solana_client::connection_cache::ConnectionCache,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::{
@@ -191,7 +191,7 @@ impl Tvu {
         );
 
         let (verified_sender, verified_receiver) = unbounded();
-        let (retransmit_sender, retransmit_receiver) = unbounded();
+        let (retransmit_sender, retransmit_receiver) = bounded(1024); //Allow for a max of 1024 batches of 1024 packets each (according to MAX_IOV).
         let shred_sigverify = solana_turbine::sigverify_shreds::spawn_shred_sigverify(
             cluster_info.clone(),
             bank_forks.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -191,7 +191,7 @@ impl Tvu {
         );
 
         let (verified_sender, verified_receiver) = unbounded();
-        let (retransmit_sender, retransmit_receiver) = bounded(1024); //Allow for a max of 1024 batches of 1024 packets each (according to MAX_IOV).
+        let (retransmit_sender, retransmit_receiver) = bounded(2048); //Allow for a max of 2048 batches of up to 1024 packets each (according to MAX_IOV). In reality this holds about 15K shreds since most batches are never full.
         let shred_sigverify = solana_turbine::sigverify_shreds::spawn_shred_sigverify(
             cluster_info.clone(),
             bank_forks.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -57,10 +57,12 @@ use {
     tokio::sync::mpsc::Sender as AsyncSender,
 };
 
-// Allow for a max of 16k batches of up to 64 packets each (NUM_RCVMMSGS).
-// This translates to about 1 GB of RAM for packet storage in the worst case.
-// In reality this means about 200K shreds since most batches are not full.
-const CHANNEL_SIZE_SIGVERIFY_TO_RETRANSMIT: usize = 16 * 1024;
+/// Sets the upper bound on the number of batches stored in the retransmit
+/// stage ingress channel.
+/// Allows for a max of 16k batches of up to 64 packets each (NUM_RCVMMSGS).
+/// This translates to about 1 GB of RAM for packet storage in the worst case.
+/// In reality this means about 200K shreds since most batches are not full.
+const CHANNEL_SIZE_RETRANSMIT_INGRESS: usize = 16 * 1024;
 
 pub struct Tvu {
     fetch_stage: ShredFetchStage,
@@ -199,7 +201,7 @@ impl Tvu {
         let (verified_sender, verified_receiver) = unbounded();
 
         let (retransmit_sender, retransmit_receiver) =
-            EvictingSender::new_bounded(CHANNEL_SIZE_SIGVERIFY_TO_RETRANSMIT);
+            EvictingSender::new_bounded(CHANNEL_SIZE_RETRANSMIT_INGRESS);
 
         let shred_sigverify = solana_turbine::sigverify_shreds::spawn_shred_sigverify(
             cluster_info.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -191,7 +191,10 @@ impl Tvu {
         );
 
         let (verified_sender, verified_receiver) = unbounded();
-        let (retransmit_sender, retransmit_receiver) = bounded(2048); //Allow for a max of 2048 batches of up to 1024 packets each (according to MAX_IOV). In reality this holds about 15K shreds since most batches are never full.
+        // Allow for a max of 2048 batches of up to 1024 packets each (according to MAX_IOV).
+        // In reality this holds about 20K shreds since most batches are not full.
+        let (retransmit_sender, retransmit_receiver) = bounded(2048);
+
         let shred_sigverify = solana_turbine::sigverify_shreds::spawn_shred_sigverify(
             cluster_info.clone(),
             bank_forks.clone(),

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -67,6 +67,7 @@ solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-storage-proto = { workspace = true }
+solana-streamer = { workspace = true }
 solana-svm = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-timings = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
+ "solana-streamer",
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6394,6 +6394,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
+ "solana-streamer",
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -269,7 +269,7 @@ fn run_shred_sigverify<const K: usize>(
     if let Err(send_err) = retransmit_sender.try_send(shreds.clone()) {
         match send_err {
             crossbeam_channel::TrySendError::Full(v) => {
-                stats.num_retransmit_stage_overflow += v.len();
+                stats.num_retransmit_stage_overflow_shreds += v.len();
             }
             _ => unreachable!("EvictingSender holds on to both ends of the channel"),
         }
@@ -434,7 +434,7 @@ struct ShredSigVerifyStats {
     num_invalid_retransmitter: AtomicUsize,
     num_retranmitter_signature_skipped: AtomicUsize,
     num_retranmitter_signature_verified: AtomicUsize,
-    num_retransmit_stage_overflow: usize,
+    num_retransmit_stage_overflow_shreds: usize,
     num_retransmit_shreds: usize,
     num_unknown_slot_leader: AtomicUsize,
     num_unknown_turbine_parent: AtomicUsize,
@@ -458,7 +458,7 @@ impl ShredSigVerifyStats {
             num_invalid_retransmitter: AtomicUsize::default(),
             num_retranmitter_signature_skipped: AtomicUsize::default(),
             num_retranmitter_signature_verified: AtomicUsize::default(),
-            num_retransmit_stage_overflow: 0,
+            num_retransmit_stage_overflow_shreds: 0usize,
             num_retransmit_shreds: 0usize,
             num_unknown_slot_leader: AtomicUsize::default(),
             num_unknown_turbine_parent: AtomicUsize::default(),
@@ -498,8 +498,8 @@ impl ShredSigVerifyStats {
                 i64
             ),
             (
-                "num_retransmit_stage_overflow",
-                self.num_retransmit_stage_overflow,
+                "num_retransmit_stage_overflow_shreds",
+                self.num_retransmit_stage_overflow_shreds,
                 i64
             ),
             ("num_retransmit_shreds", self.num_retransmit_shreds, i64),


### PR DESCRIPTION
#### Problem
 * Retransmit stage has been observed to have stalls which result in unbounded growth of the channel from sigverify stage
 * Bounded channels have better performance overall

#### Summary of Changes
 * Change to bounded channel with enough capacity to effectively never overflow (16K batches of up to 64 shreds) = up to 1 Gbyte of packet data. Channel itself occupies about 500KB
 * add metric  "num_retransmit_stage_overflow_shreds"  to keep an eye on the number of shreds that do not fit
