### PR TITLE
ff cleanup: enable_tower_sync_ix

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -622,37 +622,18 @@ impl Tower {
             // here that this is our leader bank.
             Hash::default()
         });
-        self.record_bank_vote_and_update_lockouts(
-            bank.slot(),
-            bank.hash(),
-            bank.feature_set
-                .is_active(&solana_feature_set::enable_tower_sync_ix::id()),
-            block_id,
-        )
+        self.record_bank_vote_and_update_lockouts(bank.slot(), bank.hash(), block_id)
     }
 
     /// If we've recently updated the vote state by applying a new vote
     /// or syncing from a bank, generate the proper last_vote.
-    pub(crate) fn update_last_vote_from_vote_state(
-        &mut self,
-        vote_hash: Hash,
-        enable_tower_sync_ix: bool,
-        block_id: Hash,
-    ) {
-        let mut new_vote = if enable_tower_sync_ix {
-            VoteTransaction::from(TowerSync::new(
-                self.vote_state.votes.clone(),
-                self.vote_state.root_slot,
-                vote_hash,
-                block_id,
-            ))
-        } else {
-            VoteTransaction::from(VoteStateUpdate::new(
-                self.vote_state.votes.clone(),
-                self.vote_state.root_slot,
-                vote_hash,
-            ))
-        };
+    pub(crate) fn update_last_vote_from_vote_state(&mut self, vote_hash: Hash, block_id: Hash) {
+        let mut new_vote = VoteTransaction::from(TowerSync::new(
+            self.vote_state.votes.clone(),
+            self.vote_state.root_slot,
+            vote_hash,
+            block_id,
+        ));
 
         new_vote.set_timestamp(self.maybe_timestamp(self.last_voted_slot().unwrap_or_default()));
         self.last_vote = new_vote;
@@ -662,7 +643,6 @@ impl Tower {
         &mut self,
         vote_slot: Slot,
         vote_hash: Hash,
-        enable_tower_sync_ix: bool,
         block_id: Hash,
     ) -> Option<Slot> {
         if let Some(last_voted_slot) = self.vote_state.last_voted_slot() {
@@ -680,7 +660,7 @@ impl Tower {
         let old_root = self.root();
 
         self.vote_state.process_next_vote_slot(vote_slot);
-        self.update_last_vote_from_vote_state(vote_hash, enable_tower_sync_ix, block_id);
+        self.update_last_vote_from_vote_state(vote_hash, block_id);
 
         let new_root = self.root();
 
@@ -698,7 +678,7 @@ impl Tower {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        self.record_bank_vote_and_update_lockouts(slot, hash, true, Hash::default())
+        self.record_bank_vote_and_update_lockouts(slot, hash, Hash::default())
     }
 
     #[cfg(feature = "dev-context-only-utils")]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3718,8 +3718,6 @@ impl ReplayStage {
             progress
                 .get_hash(last_voted_slot)
                 .expect("Must exist for us to have frozen descendant"),
-            bank.feature_set
-                .is_active(&solana_feature_set::enable_tower_sync_ix::id()),
             block_id,
         );
         // Since we are updating our tower we need to update associated caches for previously computed

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -134,9 +134,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if invoke_context
                 .get_feature_set()
                 .is_active(&feature_set::deprecate_legacy_vote_ixs::id())
-                && invoke_context
-                    .get_feature_set()
-                    .is_active(&feature_set::enable_tower_sync_ix::id())
             {
                 return Err(InstructionError::InvalidInstructionData);
             }
@@ -158,9 +155,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if invoke_context
                 .get_feature_set()
                 .is_active(&feature_set::deprecate_legacy_vote_ixs::id())
-                && invoke_context
-                    .get_feature_set()
-                    .is_active(&feature_set::enable_tower_sync_ix::id())
             {
                 return Err(InstructionError::InvalidInstructionData);
             }
@@ -181,9 +175,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if invoke_context
                 .get_feature_set()
                 .is_active(&feature_set::deprecate_legacy_vote_ixs::id())
-                && invoke_context
-                    .get_feature_set()
-                    .is_active(&feature_set::enable_tower_sync_ix::id())
             {
                 return Err(InstructionError::InvalidInstructionData);
             }
@@ -201,12 +192,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::TowerSync(tower_sync)
         | VoteInstruction::TowerSyncSwitch(tower_sync, _) => {
-            if !invoke_context
-                .get_feature_set()
-                .is_active(&feature_set::enable_tower_sync_ix::id())
-            {
-                return Err(InstructionError::InvalidInstructionData);
-            }
             let sysvar_cache = invoke_context.get_sysvar_cache();
             let slot_hashes = sysvar_cache.get_slot_hashes()?;
             let clock = sysvar_cache.get_clock()?;


### PR DESCRIPTION
Feature has been activated on all clusters
```
Feature                                      | Status                  | Activation Slot | Description
tSynMCspg4xFiCj1v3TDb4c7crMR5tSBhLz4sF7rrNA  | active since epoch 749  | 323568000       | Enable tower sync vote instruction
```

Closes #2902 