### PR TITLE
Update C Makefile to support SBPFv1 and SBPFv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Release channels have their own copy of this changelog:
 #### Changes
 * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
 * SBFPv1 and SBPFv2 are also available for Anza's C compiler toolchain.
-  * In order to build a C program for SBPFv1 or SBPFv2, use the existing Makefile in platform tools and set the `SBPF_CPU` environment variable to `SBPF_CPU=v1` or `SBPF_CPU=v2`.
 * SBPFv3 will be only available for the Rust toolchain. The C toolchain will no longer be supported for SBPFv3 onwards.
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Release channels have their own copy of this changelog:
 
 #### Changes
 * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
+* SBFPv1 and SBPFv2 are also available for Anza's C compiler toolchain.
+  * In order to build a C program for SBPFv1 or SBPFv2, use the existing Makefile in platform tools and set the `SBPF_CPU` environment variable to `SBPF_CPU=v1` or `SBPF_CPU=v2`.
+* SBPFv3 will be only available for the Rust toolchain. The C toolchain will no longer be supported for SBPFv3 onwards.
 
 ## 2.2.0
 

--- a/platform-tools-sdk/sbf/c/sbf.mk
+++ b/platform-tools-sdk/sbf/c/sbf.mk
@@ -15,11 +15,21 @@ OUT_DIR ?= ./out
 OS := $(shell uname)
 
 LLVM_DIR = $(LOCAL_PATH)../dependencies/platform-tools/llvm
-LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/17/include
-COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/platform-tools/rust/lib/rustlib/sbf-solana-solana/lib
-STD_INC_DIRS := $(LLVM_DIR)/include
-STD_LIB_DIRS := $(LLVM_DIR)/lib
+LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/18/include
 
+ifeq "$(SBPF_CPU)" "v1"
+TARGET_NAME := sbpfv1
+else ifeq "$(SBPF_CPU)" "v2"
+TARGET_NAME := sbpfv2
+else
+TARGET_NAME := sbpf
+endif
+
+LLVM_TARGET := $(TARGET_NAME)-solana-solana
+
+COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/platform-tools/rust/lib/rustlib/$(LLVM_TARGET)/lib
+STD_INC_DIRS := $(LLVM_DIR)/$(TARGET_NAME)/include
+STD_LIB_DIRS := $(LLVM_DIR)/lib/$(TARGET_NAME)
 ifdef LLVM_DIR
 CC := $(LLVM_DIR)/bin/clang
 CXX := $(LLVM_DIR)/bin/clang++
@@ -65,6 +75,24 @@ SBF_CXX_FLAGS := \
   -fno-asynchronous-unwind-tables \
   -fno-unwind-tables
 
+ifeq "$(SBPF_CPU)" "v1"
+SBF_C_FLAGS := \
+  $(SBF_C_FLAGS) \
+  -mcpu=v1
+
+SBF_CXX_FLAGS := \
+  $(SBF_CXX_FLAGS) \
+  -mcpu=v1
+else ifeq "$(SBPF_CPU)" "v2"
+SBF_C_FLAGS := \
+  $(SBF_C_FLAGS) \
+  -mcpu=v2
+
+SBF_CXX_FLAGS := \
+  $(SBF_CXX_FLAGS) \
+  -mcpu=v2
+endif
+
 SBF_LLD_FLAGS := \
   -z notext \
   -shared \
@@ -73,12 +101,6 @@ SBF_LLD_FLAGS := \
   --entry entrypoint \
   -L $(STD_LIB_DIRS) \
   -lc \
-
-ifeq ($(SOL_SBPFV3),1)
-SBF_LLD_FLAGS := \
-  $(SBF_LLD_FLAGS) \
-  --pack-dyn-relocs=relr
-endif
 
 OBJ_DUMP_FLAGS := \
   --source \

--- a/platform-tools-sdk/sbf/c/sbf.mk
+++ b/platform-tools-sdk/sbf/c/sbf.mk
@@ -12,6 +12,7 @@ INC_DIRS ?=
 SRC_DIR ?= ./src
 TEST_PREFIX ?= test_
 OUT_DIR ?= ./out
+SBPF_CPU ?= v0
 OS := $(shell uname)
 
 LLVM_DIR = $(LOCAL_PATH)../dependencies/platform-tools/llvm
@@ -161,6 +162,8 @@ help:
 	@echo '      OUT_DIR=$(OUT_DIR)'
 	@echo '    - Location of LLVM:'
 	@echo '      LLVM_DIR=$(LLVM_DIR)'
+	@echo '    - Version of SBPF (v0, v1 or v2):'
+	@echo '      SBPF_CPU=$(SBPF_CPU)'
 	@echo ''
 	@echo 'Usage:'
 	@echo '  - make help - This help message'


### PR DESCRIPTION
#### Problem

We'll still provide support for C program compiled for SBPFv1 and SBPFv2, but the Makefile we use for compilation hasn't been updated yet.

#### Summary of Changes

Update the Makefile to switch source folder and compilation parameters based on the `SBPF_CPU` environment variable.


This change will allow us to properly run `programs/sbf` C tests for SBPF v1 and v2.
