### PR TITLE
changelog: Geyser account notifications at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ Release channels have their own copy of this changelog:
 
 <a name="edge-channel"></a>
 ## 2.3.0 - Unreleased
-* Changes:
-  * Platform tools SDK:
-    * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
+
+### Validator
+
+#### Changes
+* Account notifications for Geyser are no longer deduplicated when restorting from a snapshot.
+
+### Platform Tools SDK
+
+#### Changes
+* `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
 
 ## 2.2.0
 


### PR DESCRIPTION
Note in the changelog that geyser no longer deduplicates account notifications when restoring from a snapshot.

See #5083 for more information.