### PR TITLE
Bound gossip channels

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -44,7 +44,7 @@ use {
         },
         weighted_shuffle::WeightedShuffle,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError},
     itertools::{Either, Itertools},
     rand::{seq::SliceRandom, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
@@ -118,6 +118,13 @@ const MAX_GOSSIP_TRAFFIC: usize = 128_000_000 / PACKET_DATA_SIZE;
 /// so any extra capacity that may be reserved due to traffic variations will be preserved,
 /// avoiding excessive resizing and re-allocation.
 const CHANNEL_RECV_BUFFER_INITIAL_CAPACITY: usize = MAX_GOSSIP_TRAFFIC.div_ceil(28);
+/// Channel capacity for gossip channels.
+///
+/// It was observed that under extreme load, the channel caps out
+/// around 11k capacity. This rounds that up to the next power of 2
+/// such that load shedding is highly unlikely to occur on the sender
+/// and continues to be done on the receiver side.
+pub(crate) const GOSSIP_CHANNEL_CAPACITY: usize = 16_384; // 2^14
 const GOSSIP_PING_CACHE_CAPACITY: usize = 126976;
 const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
 const GOSSIP_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1280 / 64);
@@ -1357,7 +1364,11 @@ impl ClusterInfo {
         .filter_map(|(addr, data)| make_gossip_packet(addr, &data, &self.stats))
         .for_each(|pkt| packet_batch.push(pkt));
         if !packet_batch.is_empty() {
-            sender.send(packet_batch)?;
+            if let Err(TrySendError::Full(packet_batch)) = sender.try_send(packet_batch) {
+                self.stats
+                    .gossip_transmit_packets_dropped_count
+                    .add_relaxed(packet_batch.len() as u64);
+            }
         }
         self.stats
             .gossip_transmit_loop_iterations_since_last_report
@@ -1599,7 +1610,11 @@ impl ClusterInfo {
         if !requests.is_empty() {
             let response = self.handle_pull_requests(thread_pool, recycler, requests, stakes);
             if !response.is_empty() {
-                let _ = response_sender.send(response);
+                if let Err(TrySendError::Full(response)) = response_sender.try_send(response) {
+                    self.stats
+                        .gossip_packets_dropped_count
+                        .add_relaxed(response.len() as u64);
+                }
             }
         }
     }
@@ -1874,7 +1889,11 @@ impl ClusterInfo {
             .filter_map(|(addr, data)| make_gossip_packet(addr, &data, &self.stats))
             .for_each(|pkt| packet_batch.push(pkt));
         if !packet_batch.is_empty() {
-            let _ = response_sender.send(packet_batch);
+            if let Err(TrySendError::Full(packet_batch)) = response_sender.try_send(packet_batch) {
+                self.stats
+                    .gossip_packets_dropped_count
+                    .add_relaxed(packet_batch.len() as u64);
+            }
         }
     }
 
@@ -2158,7 +2177,7 @@ impl ClusterInfo {
             .map(EpochSpecs::current_epoch_staked_nodes)
             .cloned()
             .unwrap_or_default();
-        let packets: Vec<_> = {
+        let packets_verified: Vec<_> = {
             let _st = ScopedTimer::from(&self.stats.verify_gossip_packets_time);
             thread_pool.install(|| {
                 if packet_buf.len() == 1 {
@@ -2175,8 +2194,15 @@ impl ClusterInfo {
                 }
             })
         };
+        if let Err(TrySendError::Full(_)) = sender.try_send(packets_verified) {
+            self.stats.gossip_packets_dropped_count.add_relaxed(
+                packet_buf
+                    .iter()
+                    .fold(0, |acc, packet_batch| acc + packet_batch.len()) as u64,
+            );
+        }
         packet_buf.clear();
-        Ok(sender.send(packets)?)
+        Ok(())
     }
 
     /// Process messages from the network
@@ -3006,7 +3032,11 @@ fn send_gossip_packets<S: Borrow<SocketAddr>>(
     let pkts = pkts.into_iter();
     if pkts.len() != 0 {
         let pkts = make_gossip_packet_batch(pkts, recycler, stats);
-        let _ = sender.send(pkts);
+        if let Err(TrySendError::Full(pkts)) = sender.try_send(pkts) {
+            stats
+                .gossip_packets_dropped_count
+                .add_relaxed(pkts.len() as u64);
+        }
     }
 }
 

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -111,6 +111,7 @@ pub struct GossipStats {
     pub(crate) gossip_pull_request_sent_bytes: Counter,
     pub(crate) gossip_transmit_loop_iterations_since_last_report: Counter,
     pub(crate) gossip_transmit_loop_time: Counter,
+    pub(crate) gossip_transmit_packets_dropped_count: Counter,
     pub(crate) handle_batch_ping_messages_time: Counter,
     pub(crate) handle_batch_pong_messages_time: Counter,
     pub(crate) handle_batch_prune_messages_time: Counter,
@@ -429,6 +430,11 @@ pub(crate) fn submit_gossip_stats(
         (
             "gossip_transmit_loop_time",
             stats.gossip_transmit_loop_time.clear(),
+            i64
+        ),
+        (
+            "gossip_transmit_packets_dropped_count",
+            stats.gossip_transmit_packets_dropped_count.clear(),
             i64
         ),
         (


### PR DESCRIPTION
#### Problem

The `unbounded` channel uses what is effectively a linked list of "blocks" of 31 slots. As volume surges, it has to dynamically allocate additional blocks to accommodate the extra slots required. It does this on demand, one-by-one, which adds extra synchronization overhead on the sending and receiving side in addition to the time waiting for allocation / deallocation -- this slows down the entire pipeline of packet processing. Contrast this to a `bounded` channel, which uses a single contiguous allocation without any of the block synchronization overhead. 

#### Summary of Changes

Gossip packet buffers now used `bounded` channels, with a fixed, preallocated, capacity. 

It was observed that under extreme load, the channel caps out at around 11k packet batches. The channel capacity introduced here is `16,384` (`2^14`) packet batches, which is the 11k figure rounded up to the next power of 2. This ensures that load shedding is highly unlikely to occur on the sender and continues to be done on the receiver side.

Senders are also updated to use `try_send` and introduce error handling in the event that channels are full. It is highly unlikely that these errors are actually hit in practice given the large capacity of the channels and the draining that is occurring in the receivers. This adjustment is made here for correctness and completeness, and also dovetail with forthcoming updates to load shed at the send site. 

To reiterate, there is no practical change to current load shedding behavior in this branch, save for edge cases that were never observed in load testing and are highly unlikely to be encountered.

Broken out of #5065 