### PR TITLE
Refactor `programs/sbf` CI tests

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -56,12 +56,10 @@ test-stable-sbf)
   _ platform-tools-sdk/sbf/scripts/install.sh
 
   # SBF program tests
-  export SBF_OUT_DIR=target/sbpf-solana-solana/release
-  _ make -C programs/sbf test
+  _ make -C programs/sbf test-v0
 
   # SBF program instruction count assertion
   sbf_target_path=programs/sbf/target
-  mkdir -p $sbf_target_path/deploy
   _ cargo test \
     --manifest-path programs/sbf/Cargo.toml \
     --features=sbf_c,sbf_rust assert_instruction_count \
@@ -69,7 +67,7 @@ test-stable-sbf)
 
   sbf_dump_archive="sbf-dumps.tar.bz2"
   rm -f "$sbf_dump_archive"
-  tar cjvf "$sbf_dump_archive" $sbf_target_path/{deploy/*.txt,sbpf-solana-solana/release/*.so}
+  tar cjvf "$sbf_dump_archive" $sbf_target_path/deploy/{*.txt,*.so}
   exit 0
   ;;
 test-docs)

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -1,12 +1,13 @@
 SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
-OUT_DIR := target/sbpf-solana-solana/release
+OUT_DIR := target/deploy
 
-test: rust all
+test-v0: all rust-v0
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 
-rust:
-	cargo +solana build --release --target sbpf-solana-solana --workspace
+rust-v0:
+	cargo +solana build --release --target sbpf-solana-solana --workspace ; \
+	cp -r target/sbpf-solana-solana/release/* target/deploy
 
 .PHONY: rust
 

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -38,8 +38,7 @@ pub fn load_program_from_file(name: &str) -> Vec<u8> {
                 .unwrap(),
         )
     };
-    pathbuf.push("sbpf-solana-solana");
-    pathbuf.push("release");
+    pathbuf.push("deploy");
     pathbuf.push(name);
     pathbuf.set_extension("so");
     let mut file = File::open(&pathbuf).unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem

We want to have tests for every SBPF version in the CI, but it only accommodates SBPFv0 tests today.

#### Summary of Changes

1. Changed the output folder to `target/deploy` to match the output of `cargo-build-sbf`.
2. Renamed the Makefile target to `test-v0`
3. Removed unnecessary variables.
