### PR TITLE
Change multiline logs to single line

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1202,11 +1202,11 @@ fn main() {
                 .takes_value(true)
                 .value_name("BYTES")
                 .help(
-                    "Every `n` batches, create a batch of close transactions for
-                    the earliest remaining batch of accounts created.
-                    Note: Should be > 1 to avoid situations where the close \
-                    transactions will be submitted before the corresponding \
-                    create transactions have been confirmed",
+                    "Every `n` batches, create a batch of close transactions for \
+                     the earliest remaining batch of accounts created. \
+                     Note: Should be > 1 to avoid situations where the close \
+                     transactions will be submitted before the corresponding \
+                     create transactions have been confirmed",
                 ),
         )
         .arg(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5677,8 +5677,8 @@ impl AccountsDb {
     pub fn purge_slot(&self, slot: Slot, bank_id: BankId, is_serialized_with_abs: bool) {
         if self.is_bank_drop_callback_enabled.load(Ordering::Acquire) && !is_serialized_with_abs {
             panic!(
-                "bad drop callpath detected; Bank::drop() must run serially with other logic in
-                ABS like clean_accounts()"
+                "bad drop callpath detected; Bank::drop() must run serially with other logic in \
+                 ABS like clean_accounts()"
             )
         }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -576,7 +576,7 @@ impl Tower {
         if let Some(last_voted_slot) = self.last_vote.last_voted_slot() {
             if heaviest_slot_on_same_fork <= last_voted_slot {
                 warn!(
-                    "Trying to refresh timestamp for vote on {last_voted_slot}
+                    "Trying to refresh timestamp for vote on {last_voted_slot} \
                      using smaller heaviest bank {heaviest_slot_on_same_fork}"
                 );
                 return;
@@ -588,8 +588,8 @@ impl Tower {
             self.last_vote.set_timestamp(Some(timestamp));
         } else {
             warn!(
-                "Trying to refresh timestamp for last vote on heaviest bank on same fork
-                   {heaviest_slot_on_same_fork}, but there is no vote to refresh"
+                "Trying to refresh timestamp for last vote on heaviest bank on same fork \
+                 {heaviest_slot_on_same_fork}, but there is no vote to refresh"
             );
         }
     }
@@ -1115,8 +1115,8 @@ impl Tower {
                             last_vote_ancestors,
                         )
                         .expect(
-                            "candidate_slot and switch_slot exist in descendants map,
-                        so they must exist in ancestors map",
+                            "candidate_slot and switch_slot exist in descendants map, \
+                             so they must exist in ancestors map",
                         )
                 }
             {

--- a/core/src/consensus/fork_choice.rs
+++ b/core/src/consensus/fork_choice.rs
@@ -144,16 +144,13 @@ fn recheck_fork_decision_failed_switch_threshold(
     // then there will be no blocks to include the votes for slot 4, and the network halts
     // because 90% of validators can't vote
     info!(
-        "Waiting to switch vote to {},
-        resetting to slot {:?} for now,
-        switch proof stake: {},
-        threshold stake: {},
-        total stake: {}",
-        heaviest_bank_slot,
+        "Waiting to switch vote to {heaviest_bank_slot}, \
+        resetting to slot {:?} for now, \
+        switch proof stake: {switch_proof_stake}, \
+        threshold stake: {}, \
+        total stake: {total_stake}",
         reset_bank.as_ref().map(|b| b.slot()),
-        switch_proof_stake,
         total_stake as f64 * SWITCH_FORK_THRESHOLD,
-        total_stake
     );
     failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
         heaviest_bank_slot,

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -1033,10 +1033,8 @@ impl HeaviestSubtreeForkChoice {
                     {
                         assert!(if new_vote_slot == old_latest_vote_slot {
                             warn!(
-                                "Got a duplicate vote for
-                                    validator: {},
-                                    slot_hash: {:?}",
-                                pubkey, new_vote_slot_hash
+                                "Got a duplicate vote for validator: {pubkey}, \
+                                 slot_hash: {new_vote_slot_hash:?}",
                             );
                             // If the slots are equal, then the new
                             // vote must be for a smaller hash

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -400,18 +400,17 @@ impl ProgressMap {
     pub fn log_propagated_stats(&self, slot: Slot, bank_forks: &RwLock<BankForks>) {
         if let Some(stats) = self.get_propagated_stats(slot) {
             info!(
-                "Propagated stats:
-                total staked: {},
-                observed staked: {},
-                vote pubkeys: {:?},
-                node_pubkeys: {:?},
-                slot: {},
-                epoch: {:?}",
+                "Propagated stats: \
+                 total staked: {}, \
+                 observed staked: {}, \
+                 vote pubkeys: {:?}, \
+                 node_pubkeys: {:?}, \
+                 slot: {slot}, \
+                 epoch: {:?}",
                 stats.total_epoch_stake,
                 stats.propagated_validators_stake,
                 stats.propagated_validators,
                 stats.propagated_node_ids,
-                slot,
                 bank_forks.read().unwrap().get(slot).map(|x| x.epoch()),
             );
         }

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -107,26 +107,21 @@ impl OptimisticConfirmationVerifier {
                     .unwrap_or(0);
 
                 error!(
-                    "{},
-                    hash: {},
-                    epoch: {},
-                    voted keys: {:?},
-                    root: {},
-                    root bank hash: {},
-                    voted stake: {},
-                    total epoch stake: {},
-                    pct: {}",
+                    "{}, \
+                     hash: {hash}, \
+                     epoch: {epoch}, \
+                     voted keys: {:?}, \
+                     root: {root}, \
+                     root bank hash: {}, \
+                     voted stake: {voted_stake}, \
+                     total epoch stake: {total_epoch_stake}, \
+                     pct: {}",
                     Self::format_optimistic_confirmed_slot_violation_log(*optimistic_slot),
-                    hash,
-                    epoch,
                     r_slot_tracker
                         .as_ref()
                         .and_then(|s| s.optimistic_votes_tracker(hash))
                         .map(|s| s.voted()),
-                    root,
                     root_bank.hash(),
-                    voted_stake,
-                    total_epoch_stake,
                     voted_stake as f64 / total_epoch_stake as f64,
                 );
                 voted_stake

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -740,9 +740,8 @@ impl AncestorHashesService {
 
         for (slot, request_type) in potential_slot_requests.take(number_of_allowed_requests) {
             warn!(
-                "Cluster froze slot: {}, but we marked it as {}.
+                "Cluster froze slot: {slot}, but we marked it as {}. \
                  Initiating protocol to sample cluster for dead slot ancestors.",
-                slot,
                 if request_type.is_pruned() {
                     "pruned"
                 } else {

--- a/core/src/repair/cluster_slot_state_verifier.rs
+++ b/core/src/repair/cluster_slot_state_verifier.rs
@@ -434,9 +434,8 @@ fn check_epoch_slots_hash_against_bank_status(
         BankStatus::Frozen(bank_frozen_hash) => {
             // The epoch slots hash does not match our frozen hash.
             warn!(
-                "EpochSlots sample returned slot {} with hash {}, but our version
-                has hash {:?}",
-                slot, epoch_slots_frozen_hash, bank_frozen_hash
+                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, \
+                 but our version has hash {bank_frozen_hash:?}",
             );
             if !is_popular_pruned {
                 // If the slot is not already pruned notify fork choice to mark as invalid
@@ -446,8 +445,8 @@ fn check_epoch_slots_hash_against_bank_status(
         BankStatus::Dead => {
             // Cluster sample found a hash for our dead slot, we must have the wrong version
             warn!(
-                "EpochSlots sample returned slot {} with hash {}, but we marked slot dead",
-                slot, epoch_slots_frozen_hash
+                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, \
+                 but we marked slot dead",
             );
         }
         BankStatus::Unprocessed => {
@@ -456,8 +455,8 @@ fn check_epoch_slots_hash_against_bank_status(
             assert!(is_popular_pruned);
             // The cluster sample found the troublesome slot which caused this fork to be pruned
             warn!(
-                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, but \
-                 we have pruned it due to incorrect ancestry"
+                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, \
+                 but we have pruned it due to incorrect ancestry"
             );
         }
     }
@@ -644,9 +643,8 @@ fn on_epoch_slots_frozen(
         if let Some(duplicate_confirmed_hash) = duplicate_confirmed_hash {
             if epoch_slots_frozen_hash != duplicate_confirmed_hash {
                 warn!(
-                    "EpochSlots sample returned slot {} with hash {}, but we already saw \
-                     duplicate confirmation on hash: {:?}",
-                    slot, epoch_slots_frozen_hash, duplicate_confirmed_hash
+                    "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, \
+                     but we already saw duplicate confirmation on hash: {duplicate_confirmed_hash:?}",
                 );
             }
             return vec![];
@@ -778,9 +776,9 @@ fn get_duplicate_confirmed_hash(
         (Some(local_duplicate_confirmed_hash), Some(duplicate_confirmed_hash)) => {
             if local_duplicate_confirmed_hash != duplicate_confirmed_hash {
                 error!(
-                    "For slot {}, the gossip duplicate confirmed hash {}, is not equal
-                to the confirmed hash we replayed: {}",
-                    slot, duplicate_confirmed_hash, local_duplicate_confirmed_hash
+                    "For slot {slot}, the gossip duplicate confirmed hash: \
+                     {duplicate_confirmed_hash} is not equal to the confirmed hash we replayed: \
+                     {local_duplicate_confirmed_hash}",
                 );
             }
             Some(local_duplicate_confirmed_hash)

--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -473,10 +473,10 @@ impl AncestorRequestStatus {
                 // replay dump then repair to fix.
 
                 warn!(
-                    "Blockstore is missing frozen hash for slot {},
-                which the cluster claims is an ancestor of dead slot {}. Potentially
-                our version of the dead slot chains to the wrong fork!",
-                    ancestor_slot, self.requested_mismatched_slot
+                    "Blockstore is missing frozen hash for slot {ancestor_slot}, \
+                     which the cluster claims is an ancestor of dead slot {}. Potentially \
+                     our version of the dead slot chains to the wrong fork!",
+                    self.requested_mismatched_slot
                 );
             }
             last_ancestor = *ancestor_slot;

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -503,8 +503,8 @@ impl ServeRepair {
                     error!("Unexpected legacy request: {request:?}");
                     debug_assert!(
                         false,
-                        "Legacy requests should have been filtered out during signature
-                        verification. {request:?}"
+                        "Legacy requests should have been filtered out during signature \
+                         verification. {request:?}"
                     );
                     (None, "Legacy")
                 }
@@ -958,8 +958,8 @@ impl ServeRepair {
                     error!("Unexpected legacy request: {request:?}");
                     debug_assert!(
                         false,
-                        "Legacy requests should have been filtered out during signature
-                        verification. {request:?}"
+                        "Legacy requests should have been filtered out during signature \
+                         verification. {request:?}"
                     );
                     None
                 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3582,10 +3582,10 @@ impl ReplayStage {
             return;
         }
         info!(
-            "Frozen bank vote state slot {:?}
-             is newer than our local vote state slot {:?},
-             adopting the bank vote state as our own.
-             Bank votes: {:?}, root: {:?},
+            "Frozen bank vote state slot {:?} \
+             is newer than our local vote state slot {:?}, \
+             adopting the bank vote state as our own. \
+             Bank votes: {:?}, root: {:?}, \
              Local votes: {:?}, root: {:?}",
             bank_vote_state.last_voted_slot(),
             tower.vote_state.last_voted_slot(),
@@ -3609,7 +3609,7 @@ impl ReplayStage {
                     .votes
                     .retain(|lockout| lockout.slot() > local_root);
                 info!(
-                    "Local root is larger than on chain root,
+                    "Local root is larger than on chain root, \
                      overwrote bank root {:?} and updated votes {:?}",
                     bank_vote_state.root_slot, bank_vote_state.votes
                 );

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3833,9 +3833,8 @@ impl Blockstore {
         let results = self.check_last_fec_set(slot);
         let Ok(results) = results else {
             warn!(
-                "Unable to check the last fec set for slot {} {},
+                "Unable to check the last fec set for slot {slot} {bank_hash}, \
                  marking as dead: {results:?}",
-                slot, bank_hash,
             );
             if feature_set.is_active(&solana_sdk::feature_set::vote_only_full_fec_sets::id()) {
                 return Err(BlockstoreProcessorError::IncompleteFinalFecSet);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -170,9 +170,8 @@ impl Blockstore {
                     .put_in_batch(&mut write_batch, parent_slot, &parent_slot_meta)?;
             } else {
                 error!(
-                    "Parent slot meta {} for child {} is missing  or cleaned up.
-                       Falling back to orphan repair to remedy the situation",
-                    parent_slot, slot
+                    "Parent slot meta {parent_slot} for child {slot} is missing or cleaned up. \
+                     Falling back to orphan repair to remedy the situation",
                 );
             }
         }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1761,8 +1761,8 @@ fn test_optimistic_confirmation_violation_detection() {
 
         // Wait for this node to make a fork that doesn't include the `optimistically_confirmed_slot``
         info!(
-            "Looking for slot not equal to {optimistically_confirmed_slot}
-            with parent {optimistically_confirmed_slot_parent}"
+            "Looking for slot not equal to {optimistically_confirmed_slot} \
+             with parent {optimistically_confirmed_slot_parent}"
         );
         let start = Instant::now();
         let new_fork_slot;
@@ -3435,13 +3435,9 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         let elapsed = now.elapsed();
         assert!(
             elapsed <= Duration::from_secs(30),
-            "C failed to create a fork past {} in {} seconds
-            last_vote {},
-            votes_on_c_fork: {:?}",
-            base_slot,
+            "C failed to create a fork past {base_slot} in {} seconds, \
+             last_vote {last_vote}, votes_on_c_fork: {votes_on_c_fork:?}",
             elapsed.as_secs(),
-            last_vote,
-            votes_on_c_fork,
         );
         sleep(Duration::from_millis(100));
 
@@ -3458,7 +3454,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         }
     }
     assert!(!votes_on_c_fork.is_empty());
-    info!("Collected validator C's votes: {:?}", votes_on_c_fork);
+    info!("Collected validator C's votes: {votes_on_c_fork:?}");
 
     // Step 4:
     // verify whether there was violation or not
@@ -4827,11 +4823,9 @@ fn test_duplicate_with_pruned_ancestor() {
         let elapsed = now.elapsed();
         assert!(
             elapsed <= Duration::from_secs(30),
-            "Majority validator failed to vote on a slot >= {} in {} secs,
-            majority validator last vote: {}",
-            fork_slot,
+            "Majority validator failed to vote on a slot >= {fork_slot} in {} secs, \
+             majority validator last vote: {last_majority_vote}",
             elapsed.as_secs(),
-            last_majority_vote,
         );
         sleep(Duration::from_millis(100));
 
@@ -4843,7 +4837,7 @@ fn test_duplicate_with_pruned_ancestor() {
         }
     }
 
-    info!("Killing majority validator, waiting for minority fork to reach a depth of at least 15",);
+    info!("Killing majority validator, waiting for minority fork to reach a depth of at least 15");
     let mut majority_validator_info = cluster.exit_node(&majority_pubkey);
 
     let now = Instant::now();
@@ -4852,11 +4846,9 @@ fn test_duplicate_with_pruned_ancestor() {
         let elapsed = now.elapsed();
         assert!(
             elapsed <= Duration::from_secs(30),
-            "Minority validator failed to create a fork of depth >= {} in {} secs,
-            last_minority_vote: {}",
-            15,
+            "Minority validator failed to create a fork of depth >= {} in 15 secs, \
+             last_minority_vote: {last_minority_vote}",
             elapsed.as_secs(),
-            last_minority_vote,
         );
 
         if let Some((last_vote, _)) = last_vote_in_tower(&minority_ledger_path, &minority_pubkey) {
@@ -4904,11 +4896,10 @@ fn test_duplicate_with_pruned_ancestor() {
         let elapsed = now.elapsed();
         assert!(
             elapsed <= Duration::from_secs(60),
-            "Majority validator failed to root something > {} in {} secs,
-            last majority validator vote: {},",
+            "Majority validator failed to root something > {} in {} secs, \
+             last majority validator vote: {last_majority_vote}",
             fork_slot + fork_length + majority_fork_buffer,
             elapsed.as_secs(),
-            last_majority_vote,
         );
         sleep(Duration::from_millis(100));
 
@@ -4921,8 +4912,8 @@ fn test_duplicate_with_pruned_ancestor() {
         wait_for_last_vote_in_tower_to_land_in_ledger(&majority_ledger_path, &majority_pubkey)
             .unwrap();
     info!(
-        "Creating duplicate block built off of pruned branch for our node.
-           Last majority vote {last_majority_vote}, Last minority vote {last_minority_vote}"
+        "Creating duplicate block built off of pruned branch for our node. \
+         Last majority vote {last_majority_vote}, Last minority vote {last_minority_vote}"
     );
     {
         {
@@ -5532,14 +5523,10 @@ fn test_duplicate_shreds_switch_failure() {
     ) = (validators[0], validators[1], validators[2], validators[3]);
 
     info!(
-        "duplicate_fork_validator1_pubkey: {},
-        duplicate_fork_validator2_pubkey: {},
-        target_switch_fork_validator_pubkey: {},
-        duplicate_leader_validator_pubkey: {}",
-        duplicate_fork_validator1_pubkey,
-        duplicate_fork_validator2_pubkey,
-        target_switch_fork_validator_pubkey,
-        duplicate_leader_validator_pubkey
+        "duplicate_fork_validator1_pubkey: {duplicate_fork_validator1_pubkey}, \
+         duplicate_fork_validator2_pubkey: {duplicate_fork_validator2_pubkey}, \
+         target_switch_fork_validator_pubkey: {target_switch_fork_validator_pubkey}, \
+         duplicate_leader_validator_pubkey: {duplicate_leader_validator_pubkey}",
     );
 
     let validator_to_slots = vec![

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -417,11 +417,7 @@ impl BankForks {
         let new_epoch = root_bank.epoch();
         if old_epoch != new_epoch {
             info!(
-                "Root entering
-                    epoch: {},
-                    next_epoch_start_slot: {},
-                    epoch_stakes: {:#?}",
-                new_epoch,
+                "Root entering epoch: {new_epoch}, next_epoch_start_slot: {}, epoch_stakes: {:#?}",
                 root_bank
                     .epoch_schedule()
                     .get_first_slot_in_epoch(new_epoch + 1),


### PR DESCRIPTION
#### Problem
Some logs (unintentionally?) output multiple lines instead of a single line and this can make parsing validator logs more challenging.


#### Summary of Changes
An LLM helped me create this crazy regex to look for odd numbers of `"` and exclude false positives

```
grep -P '^(([^"]*"[^"]*")*[^"]*"[^"]*$)(?<!\\)' --include="*.rs" -r . | grep -E -v '.*"#?\)?,?;?$' | grep -E -v 'r#?"' > output
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
