### PR TITLE
remove redundant timeouts in Gossip

### DIFF
--- a/gossip/src/gossip_error.rs
+++ b/gossip/src/gossip_error.rs
@@ -1,6 +1,6 @@
 use {
     crate::{contact_info, duplicate_shred},
-    crossbeam_channel::{RecvTimeoutError, SendError},
+    crossbeam_channel::{RecvError, SendError},
     std::io,
     thiserror::Error,
 };
@@ -16,7 +16,7 @@ pub enum GossipError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
-    RecvTimeoutError(#[from] RecvTimeoutError),
+    RecvError(#[from] RecvError),
     #[error("send error")]
     SendError,
     #[error("serialization error")]


### PR DESCRIPTION
#### Problem
Unnecessary timeouts in Gossip Consume code. Similar timeouts were previously removed from turbine retransmit stage in https://github.com/anza-xyz/agave/pull/4335 

#### Summary of Changes

- Remove unneeded timeouts, save some CPU. 

##### Partially addresses
https://github.com/anza-xyz/agave/issues/5034

Tested on MNB validator DmCowGH9DUHYCetfGaWzPzYCi455yDxewcycdyWuPLjx  at 2025/03/03 14:50-16:00 UTC

Normal operation of gossip is not affected.
Restarts/shutdowns work ok.
