### PR TITLE
ci: add openssh-client into ci Dockerfile

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -41,6 +41,7 @@ RUN \
   gnupg \
   lld \
   cmake \
+  openssh-client \
   # docs
   mscgen \
   # solana compiling


### PR DESCRIPTION
#### Summary of Changes

it's useful if we can have this dep in our ci docker image