### PR TITLE
Instrument RPC tests with tpu-client-next

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -73,6 +73,7 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
+solana-send-transaction-service = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -466,6 +466,9 @@ impl JsonRpcRequestProcessor {
             );
             ClusterInfo::new(contact_info, keypair, socket_addr_space)
         });
+        // QUIC is the default TPU protocol and is used by ConnectionCache
+        // by default (see `DEFAULT_CONNECTION_CACHE_USE_QUIC`).
+        // Therefore, explicitly specifying QUIC here does not change the test behavior.
         let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let (transaction_sender, transaction_receiver) = unbounded();
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -123,14 +123,12 @@ use {
 };
 #[cfg(test)]
 use {
-    solana_client::connection_cache::ConnectionCache,
     solana_gossip::contact_info::ContactInfo,
     solana_ledger::get_tmp_ledger_path,
     solana_runtime::commitment::CommitmentSlots,
     solana_send_transaction_service::{
         send_transaction_service::Config as SendTransactionServiceConfig,
-        send_transaction_service::SendTransactionService, tpu_info::NullTpuInfo,
-        transaction_client::ConnectionCacheClient,
+        send_transaction_service::SendTransactionService, test_utils::ClientWithCreator,
     },
     solana_streamer::socket::SocketAddrSpace,
 };
@@ -449,10 +447,9 @@ impl JsonRpcRequestProcessor {
     }
 
     #[cfg(test)]
-    pub fn new_from_bank(
+    pub fn new_from_bank<Client: ClientWithCreator>(
         bank: Bank,
         socket_addr_space: SocketAddrSpace,
-        connection_cache: Arc<ConnectionCache>,
     ) -> Self {
         use crate::rpc_service::service_runtime;
 
@@ -469,19 +466,18 @@ impl JsonRpcRequestProcessor {
             );
             ClusterInfo::new(contact_info, keypair, socket_addr_space)
         });
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let (transaction_sender, transaction_receiver) = unbounded();
 
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
-        );
+        let config = JsonRpcConfig::default();
+        let JsonRpcConfig {
+            rpc_threads,
+            rpc_blocking_threads,
+            rpc_niceness_adj,
+            ..
+        } = config;
+        let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
+        let client = Client::create_client(Some(runtime.handle().clone()), my_tpu_address, None, 1);
 
         SendTransactionService::new_with_client(
             &bank_forks,
@@ -500,13 +496,6 @@ impl JsonRpcRequestProcessor {
         let slot = bank.slot();
         let optimistically_confirmed_bank =
             Arc::new(RwLock::new(OptimisticallyConfirmedBank { bank }));
-        let config = JsonRpcConfig::default();
-        let JsonRpcConfig {
-            rpc_threads,
-            rpc_blocking_threads,
-            rpc_niceness_adj,
-            ..
-        } = config;
         Self {
             config,
             snapshot_config: None,
@@ -536,7 +525,7 @@ impl JsonRpcRequestProcessor {
             max_complete_transaction_status_slot: Arc::new(AtomicU64::default()),
             max_complete_rewards_slot: Arc::new(AtomicU64::default()),
             prioritization_fee_cache: Arc::new(PrioritizationFeeCache::default()),
-            runtime: service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj),
+            runtime,
         }
     }
 
@@ -4571,7 +4560,10 @@ pub mod tests {
             },
             vote::state::VoteState,
         },
-        solana_send_transaction_service::tpu_info::NullTpuInfo,
+        solana_send_transaction_service::{
+            tpu_info::NullTpuInfo,
+            transaction_client::{ConnectionCacheClient, TpuClientNextClient},
+        },
         solana_transaction_status::{
             EncodedConfirmedBlock, EncodedTransaction, EncodedTransactionWithStatusMeta,
             TransactionDetails,
@@ -4959,17 +4951,12 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_rpc_request_processor_new() {
+    fn rpc_request_processor_new<Client: ClientWithCreator>() {
         let bob_pubkey = solana_pubkey::new_rand();
         let genesis = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
-            bank,
-            SocketAddrSpace::Unspecified,
-            connection_cache,
-        );
+        let meta =
+            JsonRpcRequestProcessor::new_from_bank::<Client>(bank, SocketAddrSpace::Unspecified);
 
         let bank = meta.bank_forks.read().unwrap().root_bank();
         bank.transfer(20, &genesis.mint_keypair, &bob_pubkey)
@@ -4982,17 +4969,23 @@ pub mod tests {
         );
     }
 
+    // we cannot use async tests because the JsonRpcRequestProcessor owns runtime
     #[test]
-    fn test_rpc_get_balance() {
+    fn test_rpc_request_processor_new_connection_cache() {
+        rpc_request_processor_new::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_request_processor_new_tpu_client_next() {
+        rpc_request_processor_new::<TpuClientNextClient<NullTpuInfo>>();
+    }
+
+    fn rpc_get_balance<Client: ClientWithCreator>() {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
-            bank,
-            SocketAddrSpace::Unspecified,
-            connection_cache,
-        );
+        let meta =
+            JsonRpcRequestProcessor::new_from_bank::<Client>(bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
         io.extend_with(rpc_minimal::MinimalImpl.to_delegate());
@@ -5015,16 +5008,21 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_get_balance_via_client() {
+    fn test_rpc_get_balance_new_connection_cache() {
+        rpc_get_balance::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_get_balance_new_tpu_client_next() {
+        rpc_get_balance::<TpuClientNextClient<NullTpuInfo>>();
+    }
+
+    fn rpc_get_balance_via_client<Client: ClientWithCreator>() {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
-            bank,
-            SocketAddrSpace::Unspecified,
-            connection_cache,
-        );
+        let meta =
+            JsonRpcRequestProcessor::new_from_bank::<Client>(bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
         io.extend_with(rpc_minimal::MinimalImpl.to_delegate());
@@ -5046,6 +5044,16 @@ pub mod tests {
         };
         let (response, _) = futures::executor::block_on(fut);
         assert_eq!(response, 20);
+    }
+
+    #[test]
+    fn test_rpc_get_balance_via_client_connection_cache() {
+        rpc_get_balance_via_client::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_get_balance_via_client_tpu_client_next() {
+        rpc_get_balance_via_client::<TpuClientNextClient<NullTpuInfo>>();
     }
 
     #[test]
@@ -5142,17 +5150,12 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_get_tx_count() {
+    fn rpc_get_tx_count<Client: ClientWithCreator>() {
         let bob_pubkey = solana_pubkey::new_rand();
         let genesis = create_genesis_config(10);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
-            bank,
-            SocketAddrSpace::Unspecified,
-            connection_cache,
-        );
+        let meta =
+            JsonRpcRequestProcessor::new_from_bank::<Client>(bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
         io.extend_with(rpc_minimal::MinimalImpl.to_delegate());
@@ -5176,6 +5179,16 @@ pub mod tests {
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_rpc_get_tx_count_connection_cache() {
+        rpc_get_tx_count::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_get_tx_count_tpu_client_next() {
+        rpc_get_tx_count::<TpuClientNextClient<NullTpuInfo>>();
     }
 
     #[test]
@@ -6613,16 +6626,11 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_send_bad_tx() {
+    fn rpc_send_bad_tx<Client: ClientWithCreator>() {
         let genesis = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let meta = JsonRpcRequestProcessor::new_from_bank(
-            bank,
-            SocketAddrSpace::Unspecified,
-            connection_cache,
-        );
+        let meta =
+            JsonRpcRequestProcessor::new_from_bank::<Client>(bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
         io.extend_with(rpc_full::FullImpl.to_delegate());
@@ -6635,7 +6643,16 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_send_transaction_preflight() {
+    fn test_rpc_send_bad_tx_connection_cache() {
+        rpc_send_bad_tx::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_send_bad_tx_tpu_client_next() {
+        rpc_send_bad_tx::<TpuClientNextClient<NullTpuInfo>>();
+    }
+
+    fn rpc_send_transaction_preflight<Client: ClientWithCreator>() {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(exit.clone());
         let ledger_path = get_tmp_ledger_path!();
@@ -6661,11 +6678,7 @@ pub mod tests {
             );
             ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
         });
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let config = JsonRpcConfig::default();
         let JsonRpcConfig {
             rpc_threads,
@@ -6673,6 +6686,7 @@ pub mod tests {
             rpc_niceness_adj,
             ..
         } = config;
+        let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
         let (meta, receiver) = JsonRpcRequestProcessor::new(
             config,
             None,
@@ -6691,15 +6705,13 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
-            service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj),
+            runtime.clone(),
         );
 
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
+        let client = Client::create_client(Some(runtime.handle().clone()), my_tpu_address, None, 1);
+        assert!(
+            client.protocol() == Protocol::QUIC,
+            "UDP is not supported by this test."
         );
         SendTransactionService::new_with_client(
             &bank_forks,
@@ -6815,6 +6827,16 @@ pub mod tests {
     }
 
     #[test]
+    fn test_rpc_send_transaction_preflight_with_connection_cache() {
+        rpc_send_transaction_preflight::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_send_transaction_preflight_with_tpu_client_next() {
+        rpc_send_transaction_preflight::<TpuClientNextClient<NullTpuInfo>>();
+    }
+
+    #[test]
     fn test_rpc_verify_filter() {
         let filter = RpcFilterType::Memcmp(Memcmp::new(
             0,                                                                                      // offset
@@ -6926,8 +6948,7 @@ pub mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_rpc_processor_get_block_commitment() {
+    fn rpc_processor_get_block_commitment<Client: ClientWithCreator>() {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(exit.clone());
         let bank_forks = new_bank_forks().0;
@@ -6950,11 +6971,7 @@ pub mod tests {
         )));
 
         let cluster_info = Arc::new(new_test_cluster_info());
-        let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
-        let tpu_address = cluster_info
-            .my_contact_info()
-            .tpu(connection_cache.protocol())
-            .unwrap();
+        let my_tpu_address = cluster_info.my_contact_info().tpu(Protocol::QUIC).unwrap();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let config = JsonRpcConfig::default();
@@ -6964,6 +6981,8 @@ pub mod tests {
             rpc_niceness_adj,
             ..
         } = config;
+        let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
+        let client = Client::create_client(Some(runtime.handle().clone()), my_tpu_address, None, 1);
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             None,
@@ -6982,16 +7001,9 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
-            service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj),
+            runtime,
         );
 
-        let client = ConnectionCacheClient::<NullTpuInfo>::new(
-            connection_cache.clone(),
-            tpu_address,
-            None,
-            None,
-            1,
-        );
         SendTransactionService::new_with_client(
             &bank_forks,
             receiver,
@@ -7025,6 +7037,16 @@ pub mod tests {
                 total_stake: 42,
             }
         );
+    }
+
+    #[test]
+    fn test_rpc_processor_get_block_commitment_with_connection_cache() {
+        rpc_processor_get_block_commitment::<ConnectionCacheClient<NullTpuInfo>>();
+    }
+
+    #[test]
+    fn test_rpc_processor_get_block_commitment_with_tpu_client_next() {
+        rpc_processor_get_block_commitment::<TpuClientNextClient<NullTpuInfo>>();
     }
 
     #[test]

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -16,7 +16,7 @@ use {
 // `maybe_runtime` argument is introduced to be able to use runtime from test
 // for the TpuClientNext, while ConnectionCache uses runtime created internally
 // in the quic-client module and it is impossible to pass test runtime there.
-pub trait CreateClient: TransactionClient {
+pub trait CreateClient: TransactionClient + Clone {
     fn create_client(
         maybe_runtime: Option<Handle>,
         my_tpu_address: SocketAddr,
@@ -27,12 +27,11 @@ pub trait CreateClient: TransactionClient {
 
 impl CreateClient for ConnectionCacheClient<NullTpuInfo> {
     fn create_client(
-        maybe_runtime: Option<Handle>,
+        _maybe_runtime: Option<Handle>,
         my_tpu_address: SocketAddr,
         tpu_peers: Option<Vec<SocketAddr>>,
         leader_forward_count: u64,
     ) -> Self {
-        assert!(maybe_runtime.is_none());
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
         ConnectionCacheClient::new(
             connection_cache,


### PR DESCRIPTION
#### Problem

Currently RPC tests are setup to use only `ConnectionCache`, this PR introduces tpu-client-next to be used as well.

#### Summary of Changes

