### PR TITLE
Remove unused SBPF tarball

### DIFF
--- a/ci/buildkite-pipeline-in-disk.sh
+++ b/ci/buildkite-pipeline-in-disk.sh
@@ -187,7 +187,6 @@ all_test_steps() {
   - command: "ci/test-stable-sbf.sh"
     name: "stable-sbf"
     timeout_in_minutes: 35
-    artifact_paths: "sbf-dumps.tar.bz2"
     agents:
       queue: "gcp"
 EOF

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -226,7 +226,6 @@ all_test_steps() {
   - command: "ci/docker-run-default-image.sh ci/test-stable-sbf.sh"
     name: "stable-sbf"
     timeout_in_minutes: 35
-    artifact_paths: "sbf-dumps.tar.bz2"
     agents:
       queue: "solana"
 EOF

--- a/ci/buildkite-solana-private.sh
+++ b/ci/buildkite-solana-private.sh
@@ -171,7 +171,6 @@ all_test_steps() {
   - command: "ci/docker-run-default-image.sh ci/test-stable-sbf.sh"
     name: "stable-sbf"
     timeout_in_minutes: 35
-    artifact_paths: "sbf-dumps.tar.bz2"
     agents:
       queue: "default"
 EOF

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -58,16 +58,6 @@ test-stable-sbf)
   # SBF program tests
   _ make -C programs/sbf test-v0
 
-  # SBF program instruction count assertion
-  sbf_target_path=programs/sbf/target
-  _ cargo test \
-    --manifest-path programs/sbf/Cargo.toml \
-    --features=sbf_c,sbf_rust assert_instruction_count \
-    -- --nocapture &> $sbf_target_path/deploy/instruction_counts.txt
-
-  sbf_dump_archive="sbf-dumps.tar.bz2"
-  rm -f "$sbf_dump_archive"
-  tar cjvf "$sbf_dump_archive" $sbf_target_path/deploy/{*.txt,*.so}
   exit 0
   ;;
 test-docs)


### PR DESCRIPTION
#### Problem

When running SBPF tests in the CI, we create a tarball file with the generated objects and the CU consumption, but we do not use it for anything.

#### Summary of Changes

Remove the tarball creation code and upload pipelines.
