### PR TITLE
Add SBPFv1 tests to the CI pipeline

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -55,8 +55,11 @@ test-stable-sbf)
   # Install the platform tools
   _ platform-tools-sdk/sbf/scripts/install.sh
 
-  # SBF program tests
+  # SBPFv0 program tests
   _ make -C programs/sbf test-v0
+
+  # SBPFv1 program tests
+  _ make -C programs/sbf clean-all test-v1
 
   exit 0
   ;;

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -2,13 +2,27 @@ SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/deploy
 
-test-v0: all rust-v0
+clean-all: clean
+	cargo clean
+
+test:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
+
+test-v1:
+	SBPF_CPU=v1 $(MAKE) all ; \
+	$(MAKE) rust-v1 ; \
+	$(MAKE) test
+
+test-v0: all rust-v0 test
 
 rust-v0:
 	cargo +solana build --release --target sbpf-solana-solana --workspace ; \
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
-.PHONY: rust
+rust-v1:
+	cargo +solana build --release --target sbpfv1-solana-solana --workspace ; \
+	cp -r target/sbpfv1-solana-solana/release/* target/deploy
+
+.PHONY: rust-v0
 
 include $(SBF_SDK_PATH)/c/sbf.mk

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -20,7 +20,7 @@ rust-v0:
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
 rust-v1:
-	cargo +solana build --release --target sbpfv1-solana-solana --workspace ; \
+	cargo +solana build --release --target sbpfv1-solana-solana --workspace --features dynamic-frames ; \
 	cp -r target/sbpfv1-solana-solana/release/* target/deploy
 
 .PHONY: rust-v0

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -19,3 +19,6 @@ crate-type = ["cdylib"]
 
 [lints]
 workspace = true
+
+[features]
+dynamic-frames = []

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1482,12 +1482,12 @@ fn process_instruction<'a>(
             #[cfg(feature = "dynamic-frames")]
             // When we have dynamic frames, the stack grows from the higher addresses, so we
             // compare from zero until the beginning of a function frame.
-            // We have 64 * 4096 = 262.144 bytes of stack space, and we consider around 4096
-            // already used by the current function and previous calls. We are considering a
-            // little less than 63 * 4096 = 258.048 bytes to be zeroed.
+            // We have 64 * 4096 = 262.144 bytes of stack space, and we consider around 2 * 4096
+            // already used by the current function and previous calls.
             {
-                assert_eq!(sol_memcmp(stack, &ZEROS, 257900), 0);
-                stack[..257900].fill(42);
+                const ZEROED_BYTES_LENGTH: usize = (MAX_CALL_DEPTH - 2) * STACK_FRAME_SIZE;
+                assert_eq!(sol_memcmp(stack, &ZEROS, ZEROED_BYTES_LENGTH), 0);
+                stack[..ZEROED_BYTES_LENGTH].fill(42);
             }
 
             // Recurse to check that the stack and heap are zeroed.

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1482,8 +1482,6 @@ fn process_instruction<'a>(
             #[cfg(feature = "dynamic-frames")]
             // When we have dynamic frames, the stack grows from the higher addresses, so we
             // compare from zero until the beginning of a function frame.
-            // We have 64 * 4096 = 262.144 bytes of stack space, and we consider around 2 * 4096
-            // already used by the current function and previous calls.
             {
                 const ZEROED_BYTES_LENGTH: usize = (MAX_CALL_DEPTH - 2) * STACK_FRAME_SIZE;
                 assert_eq!(sol_memcmp(stack, &ZEROS, ZEROED_BYTES_LENGTH), 0);

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(unreachable_code)]
 #![allow(clippy::arithmetic_side_effects)]
 
+#[cfg(feature = "dynamic-frames")]
+use solana_program::program_memory::sol_memcmp;
 use {
     solana_program::{
         account_info::AccountInfo,
@@ -1456,17 +1458,36 @@ fn process_instruction<'a>(
             heap[8..pos].fill(42);
 
             // Check that the stack is zeroed too.
-            //
+            let stack = unsafe {
+                slice::from_raw_parts_mut(
+                    MM_STACK_START as *mut u8,
+                    MAX_CALL_DEPTH * STACK_FRAME_SIZE,
+                )
+            };
+
+            #[cfg(not(feature = "dynamic-frames"))]
             // We don't know in which frame we are now, so we skip a few (10) frames at the start
             // which might have been used by the current call stack. We check that the memory for
             // the 10..MAX_CALL_DEPTH frames is zeroed. Then we write a sentinel value, and in the
             // next nested invocation check that it's been zeroed.
-            let stack =
-                unsafe { slice::from_raw_parts_mut(MM_STACK_START as *mut u8, 0x100000000) };
+            //
+            // When we don't have dynamic stack frames, the stack grows from lower addresses
+            // to higher addresses, so we compare accordingly.
             for i in 10..MAX_CALL_DEPTH {
                 let stack = &mut stack[i * STACK_FRAME_SIZE..][..STACK_FRAME_SIZE];
                 assert!(stack == &ZEROS[..STACK_FRAME_SIZE], "stack not zeroed");
                 stack.fill(42);
+            }
+
+            #[cfg(feature = "dynamic-frames")]
+            // When we have dynamic frames, the stack grows from the higher addresses, so we
+            // compare from zero until the beginning of a function frame.
+            // We have 64 * 4096 = 262.144 bytes of stack space, and we consider around 4096
+            // already used by the current function and previous calls. We are considering a
+            // little less than 63 * 4096 = 258.048 bytes to be zeroed.
+            {
+                assert_eq!(sol_memcmp(stack, &ZEROS, 257900), 0);
+                stack[..257900].fill(42);
             }
 
             // Recurse to check that the stack and heap are zeroed.

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1697,10 +1697,15 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
             );
         } else {
             let (result, _, _, _) = process_transaction_and_record_inner(&bank, tx);
-            assert_eq!(
-                result.unwrap_err(),
-                TransactionError::InstructionError(37, InstructionError::UnsupportedProgramId),
-            );
+            if let TransactionError::InstructionError(instr_no, ty) = result.unwrap_err() {
+                // Asserting the instruction number as an upper bound, since the quantity of
+                // instructions depends on the program size, which in turn depends on the SBPF
+                // versions.
+                assert!(instr_no <= 38);
+                assert_eq!(ty, InstructionError::UnsupportedProgramId);
+            } else {
+                panic!("Invalid error type");
+            }
         }
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1272,10 +1272,10 @@ fn assert_instruction_count() {
             ("noop", 5),
             ("noop++", 5),
             ("relative_call", 210),
-            ("return_data", 980),
+            ("return_data", 982),
             ("sanity", 2377),
             ("sanity++", 2277),
-            ("secp256k1_recover", 25383),
+            ("secp256k1_recover", 25483),
             ("sha", 1355),
             ("struct_pass", 108),
             ("struct_ret", 122),
@@ -1284,20 +1284,20 @@ fn assert_instruction_count() {
     #[cfg(feature = "sbf_rust")]
     {
         programs.extend_from_slice(&[
-            ("solana_sbf_rust_128bit", 1218),
-            ("solana_sbf_rust_alloc", 5077),
-            ("solana_sbf_rust_custom_heap", 398),
+            ("solana_sbf_rust_128bit", 955),
+            ("solana_sbf_rust_alloc", 4784),
+            ("solana_sbf_rust_custom_heap", 270),
             ("solana_sbf_rust_dep_crate", 2),
             ("solana_sbf_rust_iter", 1514),
             ("solana_sbf_rust_many_args", 1289),
-            ("solana_sbf_rust_mem", 2067),
-            ("solana_sbf_rust_membuiltins", 1539),
+            ("solana_sbf_rust_mem", 1207),
+            ("solana_sbf_rust_membuiltins", 292),
             ("solana_sbf_rust_noop", 275),
-            ("solana_sbf_rust_param_passing", 146),
-            ("solana_sbf_rust_rand", 378),
-            ("solana_sbf_rust_sanity", 51953),
-            ("solana_sbf_rust_secp256k1_recover", 91185),
-            ("solana_sbf_rust_sha", 24059),
+            ("solana_sbf_rust_param_passing", 108),
+            ("solana_sbf_rust_rand", 264),
+            ("solana_sbf_rust_sanity", 50084),
+            ("solana_sbf_rust_secp256k1_recover", 89217),
+            ("solana_sbf_rust_sha", 22850),
         ]);
     }
 


### PR DESCRIPTION
#### Problem

There are three new SBPF versions already released in the platform tools that are compatible with the current validator configuration, but we do not test them actively in the CI.

#### Summary of Changes

1. Modify the CI script to test SBPFv1
2. Add a new command to the `programs/sbf` folder Makefile.
3. Revamp tests that failed in SBPFv1.
