### PR TITLE
Add metric for tracking gossip packet_buf capacity

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2129,6 +2129,9 @@ impl ClusterInfo {
         self.stats
             .packets_received_count
             .add_relaxed(num_packets as u64 + num_packets_dropped);
+        self.stats
+            .socket_consume_packet_buf_capacity
+            .max_relaxed(packet_buf.capacity() as u64);
         fn verify_packet(
             packet: &Packet,
             stakes: &HashMap<Pubkey, u64>,
@@ -2212,6 +2215,9 @@ impl ClusterInfo {
                 num_packets -= num;
             }
         }
+        self.stats
+            .listen_packet_buf_capacity
+            .max_relaxed(packet_buf.capacity() as u64);
         let stakes = epoch_specs
             .as_mut()
             .map(|epoch_specs| epoch_specs.current_epoch_staked_nodes())

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -13,6 +13,21 @@ use {
     },
 };
 
+/// A metric that records the maximum value between reporting intervals.
+#[derive(Default)]
+pub(crate) struct Max(AtomicU64);
+
+impl Max {
+    /// Max the given value against the current maximum, retaining the greater of the two.
+    pub(crate) fn max_relaxed(&self, x: u64) {
+        self.0.fetch_max(x, Ordering::Relaxed);
+    }
+
+    fn clear(&self) -> u64 {
+        self.0.swap(0, Ordering::Relaxed)
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct Counter(AtomicU64);
 
@@ -117,6 +132,7 @@ pub struct GossipStats {
     pub(crate) handle_batch_pull_requests_time: Counter,
     pub(crate) handle_batch_pull_responses_time: Counter,
     pub(crate) handle_batch_push_messages_time: Counter,
+    pub(crate) listen_packet_buf_capacity: Max,
     pub(crate) new_pull_requests: Counter,
     pub(crate) new_push_requests2: Counter,
     pub(crate) new_push_requests: Counter,
@@ -161,6 +177,7 @@ pub struct GossipStats {
     pub(crate) skip_pull_response_shred_version: Counter,
     pub(crate) skip_pull_shred_version: Counter,
     pub(crate) skip_push_message_shred_version: Counter,
+    pub(crate) socket_consume_packet_buf_capacity: Max,
     pub(crate) trim_crds_table: Counter,
     pub(crate) trim_crds_table_failed: Counter,
     pub(crate) trim_crds_table_purged_values_count: Counter,
@@ -602,6 +619,16 @@ pub(crate) fn submit_gossip_stats(
         (
             "trim_crds_table_purged_values_count",
             stats.trim_crds_table_purged_values_count.clear(),
+            i64
+        ),
+        (
+            "listen_packet_buf_capacity",
+            stats.listen_packet_buf_capacity.clear(),
+            i64
+        ),
+        (
+            "socket_consume_packet_buf_capacity",
+            stats.socket_consume_packet_buf_capacity.clear(),
             i64
         ),
     );


### PR DESCRIPTION
#### Problem
Follow up of #5101, we want to track the capacity of `run_socket_consume` and `run_listen` packet buffers.

#### Summary of Changes

- Adds a new metric type `Max` (similar to `Counter`) that records the max value seen over the reporting interval.
- Includes two new metrics, `socket_consume_packet_buf_capacity` and `listen_packet_buf_capacity`, which use the new `Max` type to record the capacity of `run_socket_consume` and `run_listen` packet buffers, respectively.