### PR TITLE
opt: account's index map items

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -719,8 +719,7 @@ mod tests {
         // use bins * 2 to get the first half of the range within bin 0
         let bins_2 = bins * 2;
         let binner = crate::pubkey_bins::PubkeyBinCalculator24::new(bins_2);
-        let range2 =
-            binner.lowest_pubkey_from_bin(0, bins_2)..binner.lowest_pubkey_from_bin(1, bins_2);
+        let range2 = binner.lowest_pubkey_from_bin(0)..binner.lowest_pubkey_from_bin(1);
         let range2_inclusive = range2.start..=range2.end;
         assert_eq!(0, idx.bin_calculator.bin_from_pubkey(&range2.start));
         assert_eq!(0, idx.bin_calculator.bin_from_pubkey(&range2.end));

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1411,7 +1411,7 @@ mod tests {
                             CalculateHashIntermediate {
                                 hash: AccountHash(Hash::default()),
                                 lamports: 0,
-                                pubkey: binner.lowest_pubkey_from_bin(bin, bins),
+                                pubkey: binner.lowest_pubkey_from_bin(bin),
                             }
                         })
                     })

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -272,7 +272,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .read()
             .unwrap()
             .iter()
-            .filter(|&(k, v)| range.contains(k))
+            .filter(|&(k, _v)| range.contains(k))
             .map(|(k, v)| (*k, Arc::clone(v)))
             .collect();
         self.hold_range_in_memory(range, false);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -272,7 +272,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .read()
             .unwrap()
             .iter()
-            .filter_map(|(k, v)| range.contains(k).then(|| (*k, Arc::clone(v))))
+            .filter(|&(k, v)| range.contains(k))
+            .map(|(k, v)| (*k, Arc::clone(v)))
             .collect();
         self.hold_range_in_memory(range, false);
         Self::update_stat(&self.stats().items, 1);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -6,6 +6,7 @@ use {
         },
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         bucket_map_holder_stats::BucketMapHolderStats,
+        pubkey_bins::PubkeyBinCalculator24,
         waitable_condvar::WaitableCondvar,
     },
     rand::{thread_rng, Rng},
@@ -96,6 +97,8 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     map_internal: RwLock<InMemMap<T>>,
     storage: Arc<BucketMapHolder<T, U>>,
     bin: usize,
+    lowest_pubkey: Pubkey,
+    highest_pubkey: Pubkey,
 
     bucket: Option<Arc<BucketApi<(Slot, U)>>>,
 
@@ -173,10 +176,15 @@ struct FlushScanResult<T> {
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T, U> {
     pub fn new(storage: &Arc<BucketMapHolder<T, U>>, bin: usize) -> Self {
         let num_ages_to_distribute_flushes = Age::MAX - storage.ages_to_stay_in_cache;
+        let bin_calc = PubkeyBinCalculator24::new(storage.bins);
+        let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
+        let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
         Self {
             map_internal: RwLock::default(),
             storage: Arc::clone(storage),
             bin,
+            lowest_pubkey,
+            highest_pubkey,
             bucket: storage
                 .disk
                 .as_ref()
@@ -231,16 +239,53 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
+        let start = match range.start_bound() {
+            Bound::Included(bound) | Bound::Excluded(bound) => *bound,
+            Bound::Unbounded => Pubkey::from([0; 32]),
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(bound) | Bound::Excluded(bound) => *bound,
+            Bound::Unbounded => Pubkey::from([0xff; 32]),
+        };
+
+        if start > self.highest_pubkey || end < self.lowest_pubkey {
+            // range does not contain any of the keys in this bin. No need to
+            // load and scan the map.
+            // Example:
+            //    |-------------------|  |-------------------|  |-------------------|
+            //       start          end  low               high  start              end
+            return vec![];
+        }
+
         let m = Measure::start("items");
         self.hold_range_in_memory(range, true);
-        let map = self.map_internal.read().unwrap();
-        let mut result = Vec::with_capacity(map.len());
-        map.iter().for_each(|(k, v)| {
-            if range.contains(k) {
-                result.push((*k, Arc::clone(v)));
-            }
-        });
-        drop(map);
+        let result = if start < self.lowest_pubkey && end > self.highest_pubkey {
+            // range contains all keys in this bin. Should return all items in the map.
+            // Example:
+            //    |-------------------|  |-------------------|  |-------------------|
+            //           start           low               high        end
+            self.map_internal
+                .read()
+                .unwrap()
+                .iter()
+                .map(|(k, v)| (*k, Arc::clone(v)))
+                .collect()
+        } else {
+            // range contains some keys in this bin
+            self.map_internal
+                .read()
+                .unwrap()
+                .iter()
+                .filter_map(|(k, v)| {
+                    if range.contains(k) {
+                        Some((*k, Arc::clone(v)))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
         self.hold_range_in_memory(range, false);
         Self::update_stat(&self.stats().items, 1);
         Self::update_time_stat(&self.stats().items_us, m);

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -50,7 +50,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     // used by bg processing to know when any bucket has become dirty
     pub wait_dirty_or_aged: Arc<WaitableCondvar>,
     next_bucket_to_flush: AtomicUsize,
-    bins: usize,
+    pub(crate) bins: usize,
 
     pub threads: usize,
 

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -77,6 +77,63 @@ pub mod tests {
     }
 
     #[test]
+    fn test_pubkey_lowest_highest_bin4() {
+        let calc = PubkeyBinCalculator24::new(4);
+
+        // bin 0
+        let expected_lowest = Pubkey::from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]);
+        let expected_highest = Pubkey::from([
+            0x3F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]);
+        assert_eq!(calc.lowest_pubkey_from_bin(0), expected_lowest);
+        assert_eq!(calc.highest_pubkey_from_bin(0), expected_highest);
+
+        // bin 1
+        let expected_lowest = Pubkey::from([
+            0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let expected_highest = Pubkey::from([
+            0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]);
+        assert_eq!(calc.lowest_pubkey_from_bin(1), expected_lowest,);
+        assert_eq!(calc.highest_pubkey_from_bin(1), expected_highest);
+
+        // bin 2
+        let expected_lowest = Pubkey::from([
+            0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let expected_highest = Pubkey::from([
+            0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]);
+        assert_eq!(calc.lowest_pubkey_from_bin(2), expected_lowest);
+        assert_eq!(calc.highest_pubkey_from_bin(2), expected_highest);
+
+        // bin 3
+        let expected_lowest = Pubkey::from([
+            0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ]);
+        let expected_highest = Pubkey::from([
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]);
+        assert_eq!(calc.lowest_pubkey_from_bin(3), expected_lowest);
+        assert_eq!(calc.highest_pubkey_from_bin(3), expected_highest);
+    }
+
+    #[test]
     fn test_pubkey_bins() {
         for i in 0..=24 {
             let bins = 2u32.pow(i);

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -6,9 +6,9 @@ pub struct PubkeyBinCalculator24 {
     shift_bits: u32,
 }
 
-const MAX_BITS: u32 = 24;
-
 impl PubkeyBinCalculator24 {
+    const MAX_BITS: u32 = 24;
+
     const fn num_bits<T>() -> usize {
         std::mem::size_of::<T>() * 8
     }
@@ -20,17 +20,17 @@ impl PubkeyBinCalculator24 {
 
     pub fn new(bins: usize) -> Self {
         assert!(bins > 0);
-        let max_plus_1 = 1 << MAX_BITS;
+        let max_plus_1 = 1 << Self::MAX_BITS;
         assert!(bins <= max_plus_1);
         assert!(bins.is_power_of_two());
         let bits = Self::log_2(bins as u32);
         Self {
-            shift_bits: MAX_BITS - bits,
+            shift_bits: Self::MAX_BITS - bits,
         }
     }
 
     pub fn bins(&self) -> usize {
-        1 << (MAX_BITS - self.shift_bits)
+        1 << (Self::MAX_BITS - self.shift_bits)
     }
 
     #[inline]


### PR DESCRIPTION
#### Problem

Mapping account index items can be optimized.  The current code checks the range against each items in the account's index when mapping the items. We could optimize this by doing the range check only when it is necessary. 


#### Summary of Changes

1. introduce the pubkey bound for accounts index.
2. use pubkey bound on the index to optimize the mapping of account's index items.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
