### PR TITLE
Report gossip streamer stats

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -15,9 +15,7 @@
 
 use {
     crate::{
-        cluster_info_metrics::{
-            submit_gossip_stats, Counter, GossipStats, ScopedTimer, TimedGuard,
-        },
+        cluster_info_metrics::{Counter, GossipStats, ScopedTimer, TimedGuard},
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, SnapshotHashes, Vote},
@@ -167,7 +165,7 @@ pub struct ClusterInfo {
     outbound_budget: DataBudget,
     my_contact_info: RwLock<ContactInfo>,
     ping_cache: Mutex<PingCache>,
-    stats: GossipStats,
+    pub(crate) stats: GossipStats,
     local_message_pending_push_queue: Mutex<Vec<CrdsValue>>,
     contact_debug_interval: u64, // milliseconds, 0 = disabled
     contact_save_interval: u64,  // milliseconds, 0 = disabled
@@ -2213,13 +2211,11 @@ impl ClusterInfo {
         receiver: &Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         response_sender: &PacketBatchSender,
         thread_pool: &ThreadPool,
-        last_print: &mut Instant,
         should_check_duplicate_instance: bool,
         packet_buf: &mut VecDeque<Vec<(/*from:*/ SocketAddr, Protocol)>>,
     ) -> Result<(), GossipError> {
         let _st = ScopedTimer::from(&self.stats.gossip_listen_loop_time);
         const RECV_TIMEOUT: Duration = Duration::from_secs(1);
-        const SUBMIT_GOSSIP_STATS_INTERVAL: Duration = Duration::from_secs(2);
         let mut num_packets = 0;
         for pkts in receiver
             .recv_timeout(RECV_TIMEOUT)
@@ -2256,10 +2252,6 @@ impl ClusterInfo {
             should_check_duplicate_instance,
         )?;
         packet_buf.clear();
-        if last_print.elapsed() > SUBMIT_GOSSIP_STATS_INTERVAL {
-            submit_gossip_stats(&self.stats, &self.gossip, &stakes);
-            *last_print = Instant::now();
-        }
         self.stats
             .gossip_listen_loop_iterations_since_last_report
             .add_relaxed(1);
@@ -2311,7 +2303,6 @@ impl ClusterInfo {
         should_check_duplicate_instance: bool,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
-        let mut last_print = Instant::now();
         let recycler = PacketBatchRecycler::default();
         let thread_pool = ThreadPoolBuilder::new()
             .num_threads(get_thread_count().min(8))
@@ -2330,7 +2321,6 @@ impl ClusterInfo {
                         &requests_receiver,
                         &response_sender,
                         &thread_pool,
-                        &mut last_print,
                         should_check_duplicate_instance,
                         &mut packet_buf,
                     ) {

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -3,7 +3,9 @@
 use {
     crate::{
         cluster_info::{ClusterInfo, GOSSIP_CHANNEL_CAPACITY},
+        cluster_info_metrics::submit_gossip_stats,
         contact_info::ContactInfo,
+        epoch_specs::EpochSpecs,
     },
     crossbeam_channel::{bounded, Sender},
     rand::{thread_rng, Rng},
@@ -27,10 +29,12 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
         },
-        thread::{self, sleep, JoinHandle},
+        thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
 };
+
+const SUBMIT_GOSSIP_STATS_INTERVAL: Duration = Duration::from_secs(2);
 
 pub struct GossipService {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -54,13 +58,14 @@ impl GossipService {
             gossip_socket.local_addr().unwrap()
         );
         let socket_addr_space = *cluster_info.socket_addr_space();
+        let gossip_receiver_stats = Arc::new(StreamerReceiveStats::new("gossip_receiver"));
         let t_receiver = streamer::receiver(
             "solRcvrGossip".to_string(),
             gossip_socket.clone(),
             exit.clone(),
             request_sender,
             Recycler::default(),
-            Arc::new(StreamerReceiveStats::new("gossip_receiver")),
+            gossip_receiver_stats.clone(),
             Duration::from_millis(1), // coalesce
             false,
             None,
@@ -81,10 +86,12 @@ impl GossipService {
             should_check_duplicate_instance,
             exit.clone(),
         );
-        let t_gossip =
-            cluster_info
-                .clone()
-                .gossip(bank_forks, response_sender, gossip_validators, exit);
+        let t_gossip = cluster_info.clone().gossip(
+            bank_forks.clone(),
+            response_sender,
+            gossip_validators,
+            exit.clone(),
+        );
         let t_responder = streamer::responder(
             "Gossip",
             gossip_socket,
@@ -92,12 +99,33 @@ impl GossipService {
             socket_addr_space,
             stats_reporter_sender,
         );
+        let t_metrics = Builder::new()
+            .name("solGossipMetr".to_string())
+            .spawn({
+                let cluster_info = cluster_info.clone();
+                let mut epoch_specs = bank_forks.map(EpochSpecs::from);
+                move || {
+                    while !exit.load(Ordering::Relaxed) {
+                        sleep(SUBMIT_GOSSIP_STATS_INTERVAL);
+                        let stakes = epoch_specs
+                            .as_mut()
+                            .map(|epoch_specs| epoch_specs.current_epoch_staked_nodes())
+                            .cloned()
+                            .unwrap_or_default();
+
+                        submit_gossip_stats(&cluster_info.stats, &cluster_info.gossip, &stakes);
+                        gossip_receiver_stats.report();
+                    }
+                }
+            })
+            .unwrap();
         let thread_hdls = vec![
             t_receiver,
             t_responder,
             t_socket_consume,
             t_listen,
             t_gossip,
+            t_metrics,
         ];
         Self { thread_hdls }
     }


### PR DESCRIPTION
#### Problem

Since #5104, dropped packets may be recorded in `streamer::recevier`. Though they are _collected_, `streamer::receiver` metrics are not currently _reported_.

#### Summary of Changes

- Wire up the `streamer::receiver` metrics to be reported on the same interval as gossip metrics are currently.
- Move gossip metric reporting outside the `run_listen` loop, and collocate with `streamer::receiver` metric reporting.
