### PR TITLE
Cleanup bench-streamer

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -23,7 +23,7 @@ use {
 fn producer(dest_addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<usize> {
     let send = bind_to_unspecified().unwrap();
 
-    let batch_size = 10;
+    let batch_size = 1024;
     let payload = [0u8; PACKET_DATA_SIZE];
     let packet = {
         let mut packet = Packet::default();

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -99,13 +99,6 @@ fn main() -> Result<()> {
 
     let port = 0;
     let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-    let mut addr = SocketAddr::new(ip_addr, 0);
-
-    let exit = Arc::new(AtomicBool::new(false));
-
-    let mut read_channels = Vec::new();
-    let mut read_threads = Vec::new();
-    let recycler = PacketBatchRecycler::default();
     let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
@@ -113,7 +106,14 @@ fn main() -> Result<()> {
         num_sockets,
     )
     .unwrap();
+
+    let mut addr = SocketAddr::new(ip_addr, 0);
+    let mut read_channels = Vec::new();
+    let mut read_threads = Vec::new();
+    let recycler = PacketBatchRecycler::default();
+    let exit = Arc::new(AtomicBool::new(false));
     let stats = Arc::new(StreamerReceiveStats::new("bench-streamer-test"));
+
     for read in read_sockets {
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
 

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<()> {
                 .long("num-producers")
                 .value_name("NUM")
                 .takes_value(true)
+                .default_value("4")
                 .help("Use this many producer threads."),
         )
         .arg(
@@ -97,7 +98,7 @@ fn main() -> Result<()> {
         .get_matches();
 
     let num_sockets = value_t_or_exit!(matches, "num-recv-sockets", usize);
-    let num_producers: u64 = matches.value_of_t("num-producers").unwrap_or(4);
+    let num_producers = value_t_or_exit!(matches, "num-producers", usize);
     let duration_secs = value_t_or_exit!(matches, "duration", u64);
     let duration = Duration::new(duration_secs, 0);
 

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -108,31 +108,35 @@ fn main() -> Result<()> {
     .unwrap();
 
     let mut addr = SocketAddr::new(ip_addr, 0);
-    let mut read_channels = Vec::new();
-    let mut read_threads = Vec::new();
     let recycler = PacketBatchRecycler::default();
     let exit = Arc::new(AtomicBool::new(false));
     let stats = Arc::new(StreamerReceiveStats::new("bench-streamer-test"));
 
-    for read in read_sockets {
-        read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
+    let (read_threads, read_channels): (Vec<_>, Vec<_>) = read_sockets
+        .into_iter()
+        .map(|read_socket| {
+            read_socket
+                .set_read_timeout(Some(Duration::new(1, 0)))
+                .unwrap();
+            addr = read_socket.local_addr().unwrap();
 
-        addr = read.local_addr().unwrap();
-        let (s_reader, r_reader) = unbounded();
-        read_channels.push(r_reader);
-        read_threads.push(receiver(
-            "solRcvrBenStrmr".to_string(),
-            Arc::new(read),
-            exit.clone(),
-            s_reader,
-            recycler.clone(),
-            stats.clone(),
-            Some(Duration::from_millis(1)), // coalesce
-            true,
-            None,
-            false,
-        ));
-    }
+            let (packet_sender, packet_receiver) = unbounded();
+            let receiver = receiver(
+                "solRcvrBenStrmr".to_string(),
+                Arc::new(read_socket),
+                exit.clone(),
+                packet_sender,
+                recycler.clone(),
+                stats.clone(),
+                Some(Duration::from_millis(1)), // coalesce
+                true,
+                None,
+                false,
+            );
+
+            (receiver, packet_receiver)
+        })
+        .unzip();
 
     let producer_threads: Vec<_> = (0..num_producers)
         .map(|_| producer(&addr, exit.clone()))
@@ -154,6 +158,7 @@ fn main() -> Result<()> {
     let ftime = (time as f64) / 10_000_000_000_f64;
     let fcount = (end_val - start_val) as f64;
     println!("performance: {:?}", fcount / ftime);
+
     exit.store(true, Ordering::Relaxed);
 
     for t_reader in read_threads {

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -10,7 +10,6 @@ use {
         streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
     },
     std::{
-        cmp::max,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -65,8 +64,6 @@ fn sink(exit: Arc<AtomicBool>, rvs: Arc<AtomicUsize>, r: PacketBatchReceiver) ->
 }
 
 fn main() -> Result<()> {
-    let mut num_sockets = 1usize;
-
     let matches = Command::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -75,6 +72,7 @@ fn main() -> Result<()> {
                 .long("num-recv-sockets")
                 .value_name("NUM")
                 .takes_value(true)
+                .default_value("1")
                 .help("Use NUM receive sockets"),
         )
         .arg(
@@ -94,9 +92,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    if let Some(n) = matches.value_of("num-recv-sockets") {
-        num_sockets = max(num_sockets, n.to_string().parse().expect("integer"));
-    }
+    let num_sockets = value_t_or_exit!(matches, "num-recv-sockets", usize);
     let num_producers: u64 = matches.value_of_t("num-producers").unwrap_or(4);
     let duration_secs = value_t_or_exit!(matches, "duration", u64);
     let duration = Duration::new(duration_secs, 0);


### PR DESCRIPTION
#### Summary of Changes
- Use `sendmmsg()` to minimize system calls
- Use the builtin CLAP `.default_value()` method
- Reorder + group variables logically
- Make producers track how many packets they create + print it
- Add a CLI flag to control duration