### PR TITLE
stop unstaked nodes from pushing EpochSlots into the cluster

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -106,13 +106,16 @@ impl ClusterSlotsService {
                     .get(&node_id)
                     .cloned()
                     .unwrap_or_default();
-                // only staked nodes should push EpochSlots into CRDS to save gossip bandwidth
+                // staked node should push EpochSlots into CRDS to save gossip bandwidth
                 if my_stake > 0 {
                     Self::process_cluster_slots_updates(
                         slots,
                         &cluster_slots_update_receiver,
                         &cluster_info,
                     );
+                } else {
+                    // drain the channel dropping the updates
+                    while cluster_slots_update_receiver.try_recv().is_ok() {}
                 }
             }
             let root_bank = bank_forks.read().unwrap().root_bank();

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -99,15 +99,15 @@ impl ClusterSlotsService {
             let mut process_cluster_slots_updates_elapsed =
                 Measure::start("process_cluster_slots_updates_elapsed");
 
-            let node_id = cluster_info.id();
-            let my_stake = epoch_specs
-                .current_epoch_staked_nodes()
-                .get(&node_id)
-                .cloned()
-                .unwrap_or_default();
-            // only staked nodes should push EpochSlots into CRDS to save gossip bandwidth
-            if my_stake > 0 {
-                if let Some(slots) = slots {
+            if let Some(slots) = slots {
+                let node_id = cluster_info.id();
+                let my_stake = epoch_specs
+                    .current_epoch_staked_nodes()
+                    .get(&node_id)
+                    .cloned()
+                    .unwrap_or_default();
+                // only staked nodes should push EpochSlots into CRDS to save gossip bandwidth
+                if my_stake > 0 {
                     Self::process_cluster_slots_updates(
                         slots,
                         &cluster_slots_update_receiver,

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -15,7 +15,7 @@ use {
 
 // Caches epoch specific information which stay fixed throughout the epoch.
 // Refreshes only if the root bank has moved to a new epoch.
-pub(crate) struct EpochSpecs {
+pub struct EpochSpecs {
     epoch: Epoch, // when fields were last updated.
     epoch_schedule: EpochSchedule,
     root: ReadOnlyAtomicSlot, // updated by bank-forks.
@@ -26,13 +26,13 @@ pub(crate) struct EpochSpecs {
 
 impl EpochSpecs {
     #[inline]
-    pub(crate) fn current_epoch_staked_nodes(&mut self) -> &Arc<HashMap<Pubkey, /*stake:*/ u64>> {
+    pub fn current_epoch_staked_nodes(&mut self) -> &Arc<HashMap<Pubkey, /*stake:*/ u64>> {
         self.maybe_refresh();
         &self.current_epoch_staked_nodes
     }
 
     #[inline]
-    pub(crate) fn epoch_duration(&mut self) -> Duration {
+    pub fn epoch_duration(&mut self) -> Duration {
         self.maybe_refresh();
         self.epoch_duration
     }

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -32,7 +32,7 @@ impl EpochSpecs {
     }
 
     #[inline]
-    pub fn epoch_duration(&mut self) -> Duration {
+    pub(crate) fn epoch_duration(&mut self) -> Duration {
         self.maybe_refresh();
         self.epoch_duration
     }

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -18,7 +18,7 @@ pub mod duplicate_shred;
 pub mod duplicate_shred_handler;
 pub mod duplicate_shred_listener;
 pub mod epoch_slots;
-mod epoch_specs;
+pub mod epoch_specs;
 pub mod gossip_error;
 pub mod gossip_service;
 #[macro_use]


### PR DESCRIPTION
#### Problem
* EpochSlots is 70% of gossip traffic
* Unstaked nodes do not need to send it

#### Summary of Changes
* Prevent them from sending the message

Fixes #
Partially https://github.com/anza-xyz/agave/issues/5034
