### PR TITLE
remove vec allocation in CRDS deserialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7902,6 +7902,7 @@ dependencies = [
 name = "solana-gossip"
 version = "2.3.0"
 dependencies = [
+ "arrayvec",
  "assert_matches",
  "bincode",
  "bs58",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+arrayvec = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bv = { workspace = true, features = ["serde"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6264,6 +6264,7 @@ dependencies = [
 name = "solana-gossip"
 version = "2.3.0"
 dependencies = [
+ "arrayvec",
  "assert_matches",
  "bincode",
  "bv",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6087,6 +6087,7 @@ dependencies = [
 name = "solana-gossip"
 version = "2.3.0"
 dependencies = [
+ "arrayvec",
  "assert_matches",
  "bincode",
  "bv",


### PR DESCRIPTION
#### Problem
* Unnecessary Vec allocation for every CrdsValue deserialization

#### Summary of Changes
* Use stack-allocated array instead

Fixes #
partially addresses https://github.com/anza-xyz/agave/issues/5034