### PR TITLE
wire format validation PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,10 +1287,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
+name = "byteorder_slice"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "bytes"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
@@ -2012,6 +2021,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3062,6 +3082,12 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hxdmp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b27f28a7466846baca75f0a5244e546e44178eb7f1c07a3820f413e91c6b0"
 
 [[package]]
 name = "hyper"
@@ -4487,6 +4513,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364fec0df39c49a083c9a8a18a23a6bcfd9af130fe9fe321d18520a0d113e09e"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
@@ -7902,6 +7939,7 @@ dependencies = [
 name = "solana-gossip"
 version = "2.3.0"
 dependencies = [
+ "anyhow",
  "arrayvec",
  "assert_matches",
  "bincode",
@@ -8482,9 +8520,11 @@ dependencies = [
  "bincode",
  "bytes",
  "clap 3.2.23",
+ "hxdmp",
  "itertools 0.12.1",
  "log",
  "nix",
+ "pcap-file",
  "rand 0.8.5",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8186,6 +8186,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.3.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bitflags 2.9.0",
@@ -8231,6 +8232,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -76,12 +76,14 @@ static_assertions = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 num_cpus = { workspace = true }
 rand0-7 = { workspace = true }
 rand_chacha0-2 = { workspace = true }
 serial_test = { workspace = true }
+solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -46,3 +46,5 @@ extern crate solana_frozen_abi_macro;
 
 #[macro_use]
 extern crate solana_metrics;
+
+mod wire_format_tests;

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -4,8 +4,10 @@
 mod tests {
 
     use {
-        crate::protocol::Protocol, serde::Serialize,
-        solana_net_utils::tooling_for_tests::validate_packet_format, solana_sanitize::Sanitize,
+        crate::protocol::Protocol,
+        serde::Serialize,
+        solana_net_utils::tooling_for_tests::{hexdump, validate_packet_format},
+        solana_sanitize::Sanitize,
         std::path::PathBuf,
     };
 
@@ -17,6 +19,18 @@ mod tests {
 
     fn serialize<T: Serialize>(pkt: T) -> Vec<u8> {
         bincode::serialize(&pkt).unwrap()
+    }
+
+    fn find_differences(a: &[u8], b: &[u8]) -> Option<usize> {
+        if a.len() != b.len() {
+            return Some(a.len().min(b.len()));
+        }
+        for (idx, (e1, e2)) in a.iter().zip(b).enumerate() {
+            if e1 != e2 {
+                return Some(idx);
+            }
+        }
+        None
     }
 
     /// Test the ability of gossip parsers to understand and re-serialize a corpus of
@@ -38,7 +52,14 @@ mod tests {
             std::fs::read_dir(path_base).expect("Expecting env var to point to a directory")
         {
             let entry = entry.expect("Expecting a readable file");
-            validate_packet_format(&entry.path(), parse_gossip, serialize).unwrap();
+            validate_packet_format(
+                &entry.path(),
+                parse_gossip,
+                serialize,
+                hexdump,
+                find_differences,
+            )
+            .unwrap();
         }
     }
 }

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -21,20 +21,23 @@ mod tests {
 
     /// Test the ability of gossip parsers to understand and re-serialize a corpus of
     /// packets captured from mainnet.
-    /// You will want to run this in --release mode
+    ///
     /// This test requires external files and is not run by default.
-    /// `cargo test test_gossip_wire_format  -- --nocapture --ignored` to run this test manually
+    /// Export the "GOSSIP_WIRE_FORMAT_PACKETS" variable to run this test
     #[test]
-    #[ignore]
     fn test_gossip_wire_format() {
         solana_logger::setup();
-        let path_base = match std::env::var_os("CARGO_MANIFEST_DIR") {
+        let path_base = match std::env::var_os("GOSSIP_WIRE_FORMAT_PACKETS") {
             Some(p) => PathBuf::from(p),
-            None => panic!("Requires CARGO_MANIFEST_DIR env variable"),
+            None => {
+                eprintln!("Test requires GOSSIP_WIRE_FORMAT_PACKETS env variable, skipping!");
+                return;
+            }
         };
-        let path_base = path_base.join("GOSSIP_PACKETS");
-        for entry in std::fs::read_dir(path_base).unwrap() {
-            let entry = entry.unwrap();
+        for entry in
+            std::fs::read_dir(path_base).expect("Expecting env var to point to a directory")
+        {
+            let entry = entry.expect("Expecting a readable file");
             validate_packet_format(&entry.path(), parse_gossip, serialize).unwrap();
         }
     }

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -1,0 +1,43 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(test)]
+mod tests {
+
+    use {
+        crate::protocol::Protocol, serde::Serialize,
+        solana_net_utils::tooling_for_tests::validate_packet_format, solana_sanitize::Sanitize,
+        std::path::PathBuf,
+    };
+
+    fn parse_gossip(bytes: &[u8]) -> anyhow::Result<Protocol> {
+        let pkt: Protocol = solana_perf::packet::deserialize_from_with_limit(bytes)?;
+        pkt.sanitize()?;
+        Ok(pkt)
+    }
+
+    fn serialize<T: Serialize>(pkt: T) -> Vec<u8> {
+        bincode::serialize(&pkt).unwrap()
+    }
+
+    #[test]
+    fn validate_ping() {
+        solana_logger::setup();
+        let path_base = match std::env::var_os("CARGO_MANIFEST_DIR") {
+            Some(p) => PathBuf::from(p),
+            None => panic!("Requires CARGO_MANIFEST_DIR env variable"),
+        };
+
+        validate_packet_format(
+            &path_base.join("GOSSIP_PACKETS/ping.pcap"),
+            parse_gossip,
+            serialize,
+        )
+        .unwrap();
+        validate_packet_format(
+            &path_base.join("GOSSIP_PACKETS/pull_request.pcap"),
+            parse_gossip,
+            serialize,
+        )
+        .unwrap();
+    }
+}

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -19,25 +19,23 @@ mod tests {
         bincode::serialize(&pkt).unwrap()
     }
 
+    /// Test the ability of gossip parsers to understand and re-serialize a corpus of
+    /// packets captured from mainnet.
+    /// You will want to run this in --release mode
+    /// This test requires external files and is not run by default.
+    /// `cargo test test_gossip_wire_format  -- --nocapture --ignored` to run this test manually
     #[test]
-    fn validate_ping() {
+    #[ignore]
+    fn test_gossip_wire_format() {
         solana_logger::setup();
         let path_base = match std::env::var_os("CARGO_MANIFEST_DIR") {
             Some(p) => PathBuf::from(p),
             None => panic!("Requires CARGO_MANIFEST_DIR env variable"),
         };
-
-        validate_packet_format(
-            &path_base.join("GOSSIP_PACKETS/ping.pcap"),
-            parse_gossip,
-            serialize,
-        )
-        .unwrap();
-        validate_packet_format(
-            &path_base.join("GOSSIP_PACKETS/pull_request.pcap"),
-            parse_gossip,
-            serialize,
-        )
-        .unwrap();
+        let path_base = path_base.join("GOSSIP_PACKETS");
+        for entry in std::fs::read_dir(path_base).unwrap() {
+            let entry = entry.unwrap();
+            validate_packet_format(&entry.path(), parse_gossip, serialize).unwrap();
+        }
     }
 }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
@@ -55,6 +56,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
@@ -95,6 +97,7 @@ bs58 = { workspace = true }
 criterion = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-logger = { workspace = true }
+solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 spl-pod = { workspace = true }
 test-case = { workspace = true }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -51,3 +51,5 @@ extern crate solana_frozen_abi_macro;
 pub mod macro_reexports {
     pub use solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE;
 }
+
+mod wire_format_tests;

--- a/ledger/src/wire_format_tests.rs
+++ b/ledger/src/wire_format_tests.rs
@@ -1,0 +1,93 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(test)]
+mod tests {
+
+    use {
+        crate::shred::Shred,
+        solana_net_utils::tooling_for_tests::{hexdump, validate_packet_format},
+        std::path::PathBuf,
+    };
+
+    fn parse_turbine(bytes: &[u8]) -> anyhow::Result<Shred> {
+        let shred = Shred::new_from_serialized_shred(bytes.to_owned())
+            .map_err(|_e| anyhow::anyhow!("Can not deserialize"))?;
+        shred
+            .sanitize()
+            .map_err(|_e| anyhow::anyhow!("Failed sanitize"))?;
+        Ok(shred)
+    }
+
+    fn serialize(pkt: Shred) -> Vec<u8> {
+        pkt.payload().to_vec()
+    }
+
+    fn find_differences(a: &[u8], b: &[u8]) -> Option<usize> {
+        if a.len() != b.len() {
+            return Some(a.len());
+        }
+        for (idx, (e1, e2)) in a.iter().zip(b).enumerate() {
+            if e1 != e2 {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
+    fn show_packet(bytes: &[u8]) -> anyhow::Result<()> {
+        let shred = parse_turbine(bytes)?;
+        let merkle_root = shred.merkle_root();
+        let chained_merkle_root = shred.chained_merkle_root();
+        let rtx_sign = shred.retransmitter_signature();
+
+        println!("=== {} bytes ===", bytes.len());
+        println!(
+            "Shred ID={ID:?} ErasureSetID={ESI:?}",
+            ID = shred.id(),
+            ESI = shred.erasure_set()
+        );
+        println!(
+            "Shred merkle root {:X?}, chained root {:X?}, rtx_sign {:X?}",
+            merkle_root.map(|v| v.as_ref().to_vec()),
+            chained_merkle_root.map(|v| v.as_ref().to_vec()),
+            rtx_sign.map(|v| v.as_ref().to_vec())
+        );
+        println!(
+            "Data shreds: {:?}, Coding shreds: {:?}",
+            shred.num_data_shreds(),
+            shred.num_coding_shreds()
+        );
+        hexdump(bytes)?;
+        println!("===");
+        Ok(())
+    }
+    /// Test the ability of gossip parsers to understand and re-serialize a corpus of
+    /// packets captured from mainnet.
+    ///
+    /// This test requires external files and is not run by default.
+    /// Export the "GOSSIP_WIRE_FORMAT_PACKETS" variable to run this test
+    #[test]
+    fn test_turbine_wire_format() {
+        solana_logger::setup();
+        let path_base = match std::env::var_os("TURBINE_WIRE_FORMAT_PACKETS") {
+            Some(p) => PathBuf::from(p),
+            None => {
+                eprintln!("Test requires TURBINE_WIRE_FORMAT_PACKETS env variable, skipping!");
+                return;
+            }
+        };
+        for entry in
+            std::fs::read_dir(path_base).expect("Expecting env var to point to a directory")
+        {
+            let entry = entry.expect("Expecting a readable file");
+            validate_packet_format(
+                &entry.path(),
+                parse_turbine,
+                serialize,
+                show_packet,
+                find_differences,
+            )
+            .unwrap();
+        }
+    }
+}

--- a/ledger/src/wire_format_tests.rs
+++ b/ledger/src/wire_format_tests.rs
@@ -2,7 +2,6 @@
 
 #[cfg(test)]
 mod tests {
-
     use {
         crate::shred::Shred,
         solana_net_utils::tooling_for_tests::{hexdump, validate_packet_format},
@@ -61,11 +60,12 @@ mod tests {
         println!("===");
         Ok(())
     }
-    /// Test the ability of gossip parsers to understand and re-serialize a corpus of
+
+    /// Test the ability of turbine parser to understand and re-serialize a corpus of
     /// packets captured from mainnet.
     ///
     /// This test requires external files and is not run by default.
-    /// Export the "GOSSIP_WIRE_FORMAT_PACKETS" variable to run this test
+    /// Export the "TURBINE_WIRE_FORMAT_PACKETS" env variable to run this test.
     #[test]
     fn test_turbine_wire_format() {
         solana_logger::setup();

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -27,6 +27,8 @@ solana-serde = { workspace = true }
 solana-version = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
+hxdmp = {version="0.2.1", optional=true}
+pcap-file = {version="2.0.0", optional=true}
 
 [dev-dependencies]
 solana-logger = { workspace = true }
@@ -34,7 +36,7 @@ solana-logger = { workspace = true }
 [features]
 default = []
 clap = ["dep:clap", "dep:solana-logger", "dep:solana-version"]
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:pcap-file", "dep:hxdmp"]
 
 [lib]
 name = "solana_net_utils"

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -15,9 +15,11 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"], optional = true }
+hxdmp = { version = "0.2.1", optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true, features = ["socket"] }
+pcap-file = { version = "2.0.0", optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
@@ -27,8 +29,6 @@ solana-serde = { workspace = true }
 solana-version = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
-hxdmp = {version="0.2.1", optional=true}
-pcap-file = {version="2.0.0", optional=true}
 
 [dev-dependencies]
 solana-logger = { workspace = true }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -2,6 +2,9 @@
 mod ip_echo_client;
 mod ip_echo_server;
 
+#[cfg(feature = "dev-context-only-utils")]
+pub mod tooling_for_tests;
+
 pub use ip_echo_server::{
     ip_echo_server, IpEchoServer, DEFAULT_IP_ECHO_SERVER_THREADS, MAX_PORT_COUNT_PER_MESSAGE,
     MINIMUM_IP_ECHO_SERVER_THREADS,

--- a/net-utils/src/tooling_for_tests.rs
+++ b/net-utils/src/tooling_for_tests.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    anyhow::Context,
+    log::{debug, error, info},
+    pcap_file::pcapng::PcapNgReader,
+    std::{fs::File, io::Write, path::PathBuf},
+};
+
+/// Prints a hexdump of a given byte buffer into stdout
+pub fn hexdump(bytes: &[u8]) -> anyhow::Result<()> {
+    hxdmp::hexdump(bytes, &mut std::io::stderr())?;
+    std::io::stderr().write_all(b"\n")?;
+    Ok(())
+}
+
+/// Reads all packets from PCAPNG file
+pub struct PcapReader {
+    reader: PcapNgReader<File>,
+}
+impl PcapReader {
+    pub fn new(filename: &PathBuf) -> anyhow::Result<Self> {
+        let file_in = File::open(filename).with_context(|| format!("opening file {filename:?}"))?;
+        let reader = PcapNgReader::new(file_in).context("pcap reader creation")?;
+
+        Ok(PcapReader { reader })
+    }
+}
+
+impl Iterator for PcapReader {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let block = match self.reader.next_block() {
+                Some(block) => block.ok()?,
+                None => return None,
+            };
+            let data = match block {
+                pcap_file::pcapng::Block::Packet(ref block) => {
+                    &block.data[0..block.original_len as usize]
+                }
+                pcap_file::pcapng::Block::SimplePacket(ref block) => {
+                    &block.data[0..block.original_len as usize]
+                }
+                pcap_file::pcapng::Block::EnhancedPacket(ref block) => {
+                    &block.data[0..block.original_len as usize]
+                }
+                _ => {
+                    debug!("Skipping unknown block in pcap file");
+                    continue;
+                }
+            };
+
+            let pkt_payload = data;
+            // Check if IP header is present, if it is we can safely skip it
+            // let pkt_payload = if data[0] == 69 {
+            //     &data[20 + 8..]
+            // } else {
+            //     &data[0..]
+            // };
+            //return Some(data.to_vec().into_boxed_slice());
+            return Some(pkt_payload.to_vec());
+        }
+    }
+}
+
+pub fn validate_packet_format<T, P, S>(
+    filename: &PathBuf,
+    parse_packet: P,
+    serialize_packet: S,
+) -> anyhow::Result<usize>
+where
+    P: Fn(&[u8]) -> anyhow::Result<T>,
+    S: Fn(T) -> Vec<u8>,
+{
+    info!(
+        "Validating packet format for {} using samples from {filename:?}",
+        std::any::type_name::<T>()
+    );
+    let reader = PcapReader::new(filename)?;
+    let mut number = 0;
+    for data in reader.into_iter() {
+        number += 1;
+        match parse_packet(&data) {
+            Ok(pkt) => {
+                let reconstructed_bytes = serialize_packet(pkt);
+                if reconstructed_bytes != data {
+                    error!("Reserialization failed for packet {number} in {filename:?}!");
+                    error!("Original packet bytes:");
+                    hexdump(&data)?;
+                    error!("Reserialized bytes:");
+                    hexdump(&reconstructed_bytes)?;
+                    break;
+                }
+            }
+            Err(e) => {
+                error!("Found packet {number} that failed to parse with error {e}");
+                error!("Problematic packet bytes:");
+                hexdump(&data)?;
+            }
+        }
+    }
+    info!("Packet format checks passed for {number} packets");
+    Ok(number)
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6463,6 +6463,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.3.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bitflags 2.9.0",
@@ -6503,6 +6504,7 @@ dependencies = [
  "solana-feature-set",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6286,6 +6286,7 @@ dependencies = [
 name = "solana-ledger"
 version = "2.3.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bincode",
  "bitflags 2.9.0",
@@ -6326,6 +6327,7 @@ dependencies = [
  "solana-feature-set",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-perf",
  "solana-program-runtime",
  "solana-pubkey",


### PR DESCRIPTION
#### Problem

- No wire format validation for network packets in CI

#### Summary of Changes

- Add logic that loads packets from PCAP file and checks if parser can deal with them correctly

Fixes #
  https://github.com/anza-xyz/agave/issues/4879
