### PR TITLE
Add timeout in test_banking_stage_entryfication

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1148,16 +1148,14 @@ mod tests {
             );
 
             // wait for banking_stage to eat the packets
-            let mut tries = 0;
-            const MAX_TRIES: usize = 100;
-            while bank.get_balance(&alice.pubkey()) < 1 && tries < MAX_TRIES {
-                tries += 1;
+            const TIMEOUT: Duration = Duration::from_secs(10);
+            let start = Instant::now();
+            while bank.get_balance(&alice.pubkey()) < 1 {
+                if start.elapsed() > TIMEOUT {
+                    panic!("banking stage took too long to process transactions");
+                }
                 sleep(Duration::from_millis(10));
             }
-            assert_ne!(
-                tries, MAX_TRIES,
-                "banking stage took too long to process transactions"
-            );
             exit.store(true, Ordering::Relaxed);
             poh_service.join().unwrap();
             entry_receiver

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1148,9 +1148,16 @@ mod tests {
             );
 
             // wait for banking_stage to eat the packets
-            while bank.get_balance(&alice.pubkey()) < 1 {
+            let mut tries = 0;
+            const MAX_TRIES: usize = 100;
+            while bank.get_balance(&alice.pubkey()) < 1 && tries < MAX_TRIES {
+                tries += 1;
                 sleep(Duration::from_millis(10));
             }
+            assert_ne!(
+                tries, MAX_TRIES,
+                "banking stage took too long to process transactions"
+            );
             exit.store(true, Ordering::Relaxed);
             poh_service.join().unwrap();
             entry_receiver


### PR DESCRIPTION
#### Problem
- This test has been run longing in CI in some caeses
- Potential infinite loop in waiting for balance to change

#### Summary of Changes
- Add a 10s timeout

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
