### PR TITLE
v2.2 Remove solana-logger from the patch list

### DIFF
--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -32,7 +32,6 @@ update_solana_dependencies() {
     solana-lattice-hash
     solana-ledger
     solana-log-collector
-    solana-logger
     solana-measure
     solana-merkle-tree
     solana-metrics


### PR DESCRIPTION
#### Problem
v2.2 CI is failing:
```
    error: failed to select a version for the requirement `solana-logger = "^2.2.2"`
```
