### PR TITLE
Revert "Remove ignored default-features key from Cargo.toml (#4878)

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -45,7 +45,7 @@ zstd = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-hash = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, default-features = false }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-pod = { workspace = true }
 

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -11,7 +11,9 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
-solana-pubkey = { workspace = true, features = ["bytemuck"] }
+solana-pubkey = { workspace = true, default-features = false, features = [
+    "bytemuck",
+] }
 
 [lib]
 crate-type = ["lib"]

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -33,7 +33,7 @@ solana-keypair = { workspace = true, optional = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode"] }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, default-features = false }
 solana-rayon-threadlimit = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -24,7 +24,7 @@ solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, default-features = false }
 solana-quic-definitions = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-signer = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -49,7 +49,7 @@ jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, default-features = false }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -39,7 +39,7 @@ solana-message = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-precompiles = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, default-features = false }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -20,7 +20,7 @@ solana-account-decoder-client-types = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-message = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, default-features = false }
 solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
This reverts commit 9059d9d428e81e6a992c1b0bed71b5004a5d41ad.

#### Problem
This is reverting #4878. In discussion of the v2.2 BP (#4962), we determined that the warnings could be addressed in a cleaner way. #4962 has some discussion about what the better approach is; I'll do that in a PR on top of this one

#### Summary of Changes
Backing out the commit, will followup with another PR to address the warnings
