### PR TITLE
enable optimizer in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -637,6 +637,11 @@ opt-level = 3
 inherits = "dev"
 debug = "full"
 
+# Enable optimizations for ci unittests to trigger const propagation and inlining
+[profile.ci]
+inherits = "test"
+opt-level = 1
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ ./cargo build
 **Run the test suite:**
 
 ```bash
-$ ./cargo test
+$ ./cargo nextest run --profile ci  --cargo-profile ci --config-file .config/nextest.toml
 ```
 
 ### Starting a local testnet

--- a/ci/stable/run-local-cluster-partially.sh
+++ b/ci/stable/run-local-cluster-partially.sh
@@ -22,6 +22,7 @@ source "$here"/common.sh
 
 _ cargo nextest run \
   --profile ci \
+  --cargo-profile ci \
   --package solana-local-cluster \
   --test local_cluster \
   --partition hash:"$CURRENT/$TOTAL" \

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -25,6 +25,7 @@ source "$here"/common.sh
 
 ARGS=(
   --profile ci
+  --cargo-profile ci
   --workspace
   --tests
   --jobs "$JOBS"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -287,6 +287,11 @@ debug = "line-tables-only"
 inherits = "dev"
 debug = "full"
 
+# Enable basic optimizations for unittests to trigger const propagation and inlining
+[profile.ci]
+inherits = "test"
+opt-level = 1
+
 [profile.release]
 # The test programs are build in release mode
 # Minimize their file size so that they fit into the account size limit


### PR DESCRIPTION
#### Problem
* Unittests are very slow: optimization is not enabled for them at all, so we wait hours for CI to complete
* Unittests do not catch optimizer-induced UB (as optimizer is not enabled) so much of the unsound unsafe code gets through unittests

#### Summary of Changes
* Enable optimizer for unittests



