### PR TITLE
Fix - Invoke non program account owned by a builtin

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8427,7 +8427,7 @@ fn test_invoke_non_program_account_owned_by_a_builtin() {
         bank.process_transaction(&tx),
         Err(TransactionError::InstructionError(
             0,
-            InstructionError::ExternalAccountDataModified
+            InstructionError::UnsupportedProgramId
         ))
     );
 }
@@ -13596,7 +13596,7 @@ fn test_loader_v3_to_v4_migration() {
             finalized_migration_transaction.clone(),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::InvalidInstructionData,
+                InstructionError::UnsupportedProgramId,
             )),
         ),
         (
@@ -13604,7 +13604,7 @@ fn test_loader_v3_to_v4_migration() {
             finalized_migration_transaction.clone(),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::InvalidInstructionData,
+                InstructionError::UnsupportedProgramId,
             )),
         ),
         (

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8393,6 +8393,46 @@ fn test_program_is_native_loader() {
 }
 
 #[test]
+fn test_invoke_non_program_account_owned_by_a_builtin() {
+    let (genesis_config, mint_keypair) = create_genesis_config(10000000);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    bank.activate_feature(&feature_set::remove_accounts_executable_flag_checks::id());
+    let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
+
+    let bogus_program = Pubkey::new_unique();
+    bank.transfer(
+        genesis_config.rent.minimum_balance(0),
+        &mint_keypair,
+        &bogus_program,
+    )
+    .unwrap();
+
+    let created_account_keypair = Keypair::new();
+    let mut ix = system_instruction::create_account(
+        &mint_keypair.pubkey(),
+        &created_account_keypair.pubkey(),
+        genesis_config.rent.minimum_balance(0),
+        0,
+        &system_program::id(),
+    );
+    // Calling an account owned by the system program, instead of calling the system program itself
+    ix.program_id = bogus_program;
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&mint_keypair.pubkey()),
+        &[&mint_keypair, &created_account_keypair],
+        bank.last_blockhash(),
+    );
+    assert_eq!(
+        bank.process_transaction(&tx),
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::ExternalAccountDataModified
+        ))
+    );
+}
+
+#[test]
 fn test_debug_bank() {
     let (genesis_config, _mint_keypair) = create_genesis_config(50000);
     let mut bank = Bank::new_for_tests(&genesis_config);


### PR DESCRIPTION
#### Problem
Currently there is a slight bug once `remove_accounts_executable_flag_checks` is active:
One can invoke a built-in program by invoking any account owned by it instead. This leads to the built-in running as a different pubkey, thus all ownership checks fail and the built-in has no write access to anything.

This is benign as it only allows invoking built-in programs in a strange nonsensical way. But, it is still a stupid thing to support and would hinder future protocol changes such as [these in the account loader](https://github.com/anza-xyz/agave/blob/30c95ff6e82c4437946a8753c247144504dfbfdb/svm/src/account_loader.rs#L500-L515).

About rekeying: Well see [Discord discussion](https://discord.com/channels/428295358100013066/910937142182682656/1346924137418854432).

#### Summary of Changes
Blocks the execution of any non loader owned or non built-in account and adds `test_invoke_non_program_account_owned_by_a_builtin()` to demonstrate the change in behavior.

Feature Gate Issue: https://github.com/anza-xyz/feature-gate-tracker/issues/69