### PR TITLE
Fix flaky banking stage tests

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -950,14 +950,8 @@ mod tests {
             Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger"),
         );
-        let poh_config = PohConfig {
-            // limit tick count to avoid clearing working_bank at PohRecord then
-            // PohRecorderError(MaxHeightReached) at BankingStage
-            target_tick_count: Some(bank.max_tick_height() - 1),
-            ..PohConfig::default()
-        };
         let (exit, poh_recorder, poh_service, entry_receiver) =
-            create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+            create_test_recorder(bank.clone(), blockstore, None, None);
         let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
         let cluster_info = Arc::new(cluster_info);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -1122,14 +1116,8 @@ mod tests {
         let entry_receiver = {
             // start a banking_stage to eat verified receiver
             let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-            let poh_config = PohConfig {
-                // limit tick count to avoid clearing working_bank at
-                // PohRecord then PohRecorderError(MaxHeightReached) at BankingStage
-                target_tick_count: Some(bank.max_tick_height() - 1),
-                ..PohConfig::default()
-            };
             let (exit, poh_recorder, poh_service, entry_receiver) =
-                create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+                create_test_recorder(bank.clone(), blockstore, None, None);
             let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
             let cluster_info = Arc::new(cluster_info);
             let _banking_stage = BankingStage::new(
@@ -1258,7 +1246,7 @@ mod tests {
         );
 
         // For these tests there's only 1 slot, don't want to run out of ticks
-        config_info.genesis_config.ticks_per_slot *= 8;
+        config_info.genesis_config.ticks_per_slot *= 1024;
         config_info
     }
 
@@ -1308,14 +1296,8 @@ mod tests {
             Blockstore::open(ledger_path.path())
                 .expect("Expected to be able to open database ledger"),
         );
-        let poh_config = PohConfig {
-            // limit tick count to avoid clearing working_bank at PohRecord then
-            // PohRecorderError(MaxHeightReached) at BankingStage
-            target_tick_count: Some(bank.max_tick_height() - 1),
-            ..PohConfig::default()
-        };
         let (exit, poh_recorder, poh_service, _entry_receiver) =
-            create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
+            create_test_recorder(bank.clone(), blockstore, None, None);
         let (_, cluster_info) = new_test_cluster_info(/*keypair:*/ None);
         let cluster_info = Arc::new(cluster_info);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();


### PR DESCRIPTION
#### Problem
Some banking stage tests try to process some transactions within the first block of a cluster with slow poh. If for some reason the transaction isn't included before poh ticks to the 2nd to last tick in the first block (takes about ~3.2s (8 * 400ms)), the test will never end because the poh loop stops recording transaction mixins.

#### Summary of Changes
- Make slow poh even slower by increase ticks per slot by a factor of 1024 (blocks will be over 6min long)
- Exit low power poh loop as soon as exit is set

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
