### PR TITLE
Fix flaky gossip ping test

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3224,6 +3224,7 @@ mod tests {
         );
         let remote_nodes: Vec<(Keypair, SocketAddr)> =
             repeat_with(|| new_rand_remote_node(&mut rng))
+                .filter(|(_, socket)| socket.port() != 0)
                 .take(128)
                 .collect();
         let pings: Vec<_> = remote_nodes


### PR DESCRIPTION
#### Problem
Randomly generated socket addresses in the gossip ping test sometimes get generated with port 0 which causes packets to be discarded and the test to fail

#### Summary of Changes
Skip generated socket addresses with port 0

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
