### PR TITLE
feat: use base64 instead of base58 for program show --buffers

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1895,16 +1895,16 @@ fn get_buffers(
     authority_pubkey: Option<Pubkey>,
     use_lamports_unit: bool,
 ) -> Result<CliUpgradeableBuffers, Box<dyn std::error::Error>> {
-    let mut filters = vec![RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
+    let mut filters = vec![RpcFilterType::Memcmp(Memcmp::new_base64_encoded(
         0,
         &[1, 0, 0, 0],
     ))];
     if let Some(authority_pubkey) = authority_pubkey {
-        filters.push(RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
+        filters.push(RpcFilterType::Memcmp(Memcmp::new_base64_encoded(
             ACCOUNT_TYPE_SIZE,
             &[1],
         )));
-        filters.push(RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
+        filters.push(RpcFilterType::Memcmp(Memcmp::new_base64_encoded(
             ACCOUNT_TYPE_SIZE + OPTION_SIZE,
             authority_pubkey.as_ref(),
         )));

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -164,6 +164,13 @@ impl Memcmp {
         }
     }
 
+    pub fn new_base64_encoded(offset: usize, bytes: &[u8]) -> Self {
+        Self {
+            offset,
+            bytes: MemcmpEncodedBytes::Base64(BASE64_STANDARD.encode(bytes)),
+        }
+    }
+
     pub fn offset(&self) -> usize {
         self.offset
     }


### PR DESCRIPTION
#### Problem
The fetching of program accounts is too slow due to the usage of `base58` encoding filters. 
closes #5157

#### Summary of Changes

- added `new_base64_encoded` fn for `Memcmp` which encodes filter with `base64`
- used `new_base64_encoded` instead of `new_base58_encoded` in CLI during the execution of `solana program show --buffers` command