### PR TITLE
Set default-features = false for several dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,14 +466,14 @@ solana-poseidon = { path = "poseidon", version = "=2.3.0" }
 solana-precompile-error = "=2.2.1"
 solana-precompiles = "=2.2.1"
 solana-presigner = "=2.2.1"
-solana-program = "=2.2.1"
+solana-program = { version = "=2.2.1", default-features = false }
 solana-program-error = "=2.2.1"
 solana-program-memory = "=2.2.1"
 solana-program-option = "=2.2.1"
 solana-program-pack = "=2.2.1"
 solana-program-runtime = { path = "program-runtime", version = "=2.3.0" }
 solana-program-test = { path = "program-test", version = "=2.3.0" }
-solana-pubkey = "=2.2.1"
+solana-pubkey = { version = "=2.2.1", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.3.0" }
 solana-quic-client = { path = "quic-client", version = "=2.3.0" }
 solana-quic-definitions = "=2.2.1"
@@ -492,7 +492,7 @@ solana-serde = "=2.2.1"
 solana-serde-varint = "=2.2.1"
 solana-serialize-utils = "=2.2.1"
 solana-sha256-hasher = "=2.2.1"
-solana-signature = "=2.2.1"
+solana-signature = { version = "=2.2.1", default-features = false }
 solana-signer = "=2.2.1"
 solana-slot-hashes = "=2.2.1"
 solana-slot-history = "=2.2.1"


### PR DESCRIPTION
#### Problem
```
$ cargo build
warning: /Users/steviez/src/solana/account-decoder/Cargo.toml: `default-features` is ignored for solana-program, since `default-features` was not specified for `workspace.dependencies.solana-program`, this could become a hard error in the future
warning: /Users/steviez/src/solana/quic-client/Cargo.toml: `default-features` is ignored for solana-pubkey, since `default-features` was not specified for `workspace.dependencies.solana-pubkey`, this could become a hard error in the future
warning: /Users/steviez/src/solana/perf/Cargo.toml: `default-features` is ignored for solana-pubkey, since `default-features` was not specified for `workspace.dependencies.solana-pubkey`, this could become a hard error in the future
warning: /Users/steviez/src/solana/svm/Cargo.toml: `default-features` is ignored for solana-program, since `default-features` was not specified for `workspace.dependencies.solana-program`, this could become a hard error in the future
warning: /Users/steviez/src/solana/inline-spl/Cargo.toml: `default-features` is ignored for solana-pubkey, since `default-features` was not specified for `workspace.dependencies.solana-pubkey`, this could become a hard error in the future
warning: /Users/steviez/src/solana/rpc-client/Cargo.toml: `default-features` is ignored for solana-program, since `default-features` was not specified for `workspace.dependencies.solana-program`, this could become a hard error in the future
warning: /Users/steviez/src/solana/transaction-status-client-types/Cargo.toml: `default-features` is ignored for solana-signature, since `default-features` was not specified for `workspace.dependencies.solana-signature`, this could become a hard error in the future
```

#### Summary of Changes
Add ` default-features = false` to several workspace dependency declarations. 

See https://github.com/anza-xyz/agave/pull/5153 for the papertrail
