### PR TITLE
Include SBPFv2 tests in the CI pipeline

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -61,6 +61,9 @@ test-stable-sbf)
   # SBPFv1 program tests
   _ make -C programs/sbf clean-all test-v1
 
+  # SBPFv2 program tests
+  _ make -C programs/sbf clean-all test-v2
+
   exit 0
   ;;
 test-docs)

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -9,19 +9,22 @@ test:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 
 test-v1:
-	SBPF_CPU=v1 $(MAKE) all ; \
-	$(MAKE) rust-v1 ; \
-	$(MAKE) test
+	VER=v1 $(MAKE) test-version
 
 test-v0: all rust-v0 test
+
+test-version:
+	SBPF_CPU=$(VER) $(MAKE) all; \
+	$(MAKE) rust-new ; \
+	$(MAKE) test
 
 rust-v0:
 	cargo +solana build --release --target sbpf-solana-solana --workspace ; \
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
-rust-v1:
-	cargo +solana build --release --target sbpfv1-solana-solana --workspace --features dynamic-frames ; \
-	cp -r target/sbpfv1-solana-solana/release/* target/deploy
+rust-new:
+	cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace --features dynamic-frames ; \
+	cp -r target/sbpf$(VER)-solana-solana/release/* target/deploy
 
 .PHONY: rust-v0
 

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -8,10 +8,13 @@ clean-all: clean
 test:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 
+test-v0: all rust-v0 test
+
 test-v1:
 	VER=v1 $(MAKE) test-version
 
-test-v0: all rust-v0 test
+test-v2:
+	VER=v2 $(MAKE) test-version
 
 test-version:
 	SBPF_CPU=$(VER) $(MAKE) all; \

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1266,17 +1266,17 @@ fn assert_instruction_count() {
     #[cfg(feature = "sbf_c")]
     {
         programs.extend_from_slice(&[
-            ("alloc", 14575),
-            ("sbf_to_sbf", 313),
-            ("multiple_static", 208),
-            ("noop", 5),
-            ("noop++", 5),
-            ("relative_call", 210),
-            ("return_data", 982),
-            ("sanity", 2377),
-            ("sanity++", 2277),
+            ("alloc", 19332),
+            ("sbf_to_sbf", 316),
+            ("multiple_static", 210),
+            ("noop", 6),
+            ("noop++", 6),
+            ("relative_call", 212),
+            ("return_data", 1027),
+            ("sanity", 2394),
+            ("sanity++", 2294),
             ("secp256k1_recover", 25483),
-            ("sha", 1355),
+            ("sha", 1447),
             ("struct_pass", 108),
             ("struct_ret", 122),
         ]);
@@ -1285,18 +1285,18 @@ fn assert_instruction_count() {
     {
         programs.extend_from_slice(&[
             ("solana_sbf_rust_128bit", 955),
-            ("solana_sbf_rust_alloc", 4784),
-            ("solana_sbf_rust_custom_heap", 270),
+            ("solana_sbf_rust_alloc", 4940),
+            ("solana_sbf_rust_custom_heap", 286),
             ("solana_sbf_rust_dep_crate", 2),
             ("solana_sbf_rust_iter", 1514),
-            ("solana_sbf_rust_many_args", 1289),
-            ("solana_sbf_rust_mem", 1207),
-            ("solana_sbf_rust_membuiltins", 292),
+            ("solana_sbf_rust_many_args", 1290),
+            ("solana_sbf_rust_mem", 1302),
+            ("solana_sbf_rust_membuiltins", 327),
             ("solana_sbf_rust_noop", 275),
             ("solana_sbf_rust_param_passing", 108),
-            ("solana_sbf_rust_rand", 264),
-            ("solana_sbf_rust_sanity", 50084),
-            ("solana_sbf_rust_secp256k1_recover", 89217),
+            ("solana_sbf_rust_rand", 278),
+            ("solana_sbf_rust_sanity", 51325),
+            ("solana_sbf_rust_secp256k1_recover", 89388),
             ("solana_sbf_rust_sha", 22850),
         ]);
     }
@@ -1701,7 +1701,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
                 // Asserting the instruction number as an upper bound, since the quantity of
                 // instructions depends on the program size, which in turn depends on the SBPF
                 // versions.
-                assert!(instr_no <= 38);
+                assert!(instr_no <= 39);
                 assert_eq!(ty, InstructionError::UnsupportedProgramId);
             } else {
                 panic!("Invalid error type");


### PR DESCRIPTION
#### Problem

SBPFv2 has been officially integrated in the `cargo-build-sbf` tool, but we don't test it yet in the CI.

#### Summary of Changes

1. Modify the CI script to run one more command.
2. Modify the Makefile to build SBPFv2 tests.
3. Patch failing tests.