### PR TITLE
Limiting Rocks DB Log Size

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1180,6 +1180,11 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
         options.set_disable_auto_compactions(true);
     }
 
+    // Limit the size and the number of logging files to 10/10MB
+    // 100MB in total
+    options.set_max_log_file_size(10 * 1024 * 1024);
+    options.set_keep_log_file_num(10);
+
     // Allow Rocks to open/keep open as many files as it needs for performance;
     // however, this is also explicitly required for a secondary instance.
     // See https://github.com/facebook/rocksdb/wiki/Secondary-instance

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1182,6 +1182,7 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
 
     // Limit the size and the number of logging files to 10/10MB
     // 100MB in total
+    // Logs grow at ~ 1MB/hour, so this should provide ~ 4 days of logs
     options.set_max_log_file_size(10 * 1024 * 1024);
     options.set_keep_log_file_num(10);
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1180,9 +1180,9 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
         options.set_disable_auto_compactions(true);
     }
 
-    // Limit to (10) 50 MB log files (500 MB total) 
-    // Logs grow at < 5 MB / hour, so this provides several days of logs 
-    options.set_max_log_file_size(50 * 1024 * 1024); 
+    // Limit to (10) 50 MB log files (500 MB total)
+    // Logs grow at < 5 MB / hour, so this provides several days of logs
+    options.set_max_log_file_size(50 * 1024 * 1024);
     options.set_keep_log_file_num(10);
 
     // Allow Rocks to open/keep open as many files as it needs for performance;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1180,10 +1180,9 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
         options.set_disable_auto_compactions(true);
     }
 
-    // Limit the size and the number of logging files to 10/10MB
-    // 100MB in total
-    // Logs grow at ~ 1MB/hour, so this should provide ~ 4 days of logs
-    options.set_max_log_file_size(10 * 1024 * 1024);
+    // Limit to (10) 50 MB log files (500 MB total) 
+    // Logs grow at < 5 MB / hour, so this provides several days of logs 
+    options.set_max_log_file_size(50 * 1024 * 1024); 
     options.set_keep_log_file_num(10);
 
     // Allow Rocks to open/keep open as many files as it needs for performance;


### PR DESCRIPTION
#### Problem
Rocks DB Log Size is unconstrained right now and grow to multiple GB

#### Summary of Changes
Limit to 10 logs of 10MB each. Logs grow ~ 1MB/hour, so should cover 4 days of logging

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
