### PR TITLE
v2.1: fix ci audit issues

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -92,6 +92,27 @@ cargo_audit_ignores=(
   # Dependency tree:
   # openssl 0.10.68
   --ignore RUSTSEC-2025-0004
+
+  # Crate:     ring
+  # Version:   0.16.20
+  # Title:     Some AES functions may panic when overflow checking is enabled.
+  # Date:      2025-03-06
+  # ID:        RUSTSEC-2025-0009
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
+  # Solution:  Upgrade to >=0.17.12
+  # Dependency tree:
+  # ring 0.16.20
+  #
+  # Crate:     ring
+  # Version:   0.17.3
+  # Title:     Some AES functions may panic when overflow checking is enabled.
+  # Date:      2025-03-06
+  # ID:        RUSTSEC-2025-0009
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
+  # Solution:  Upgrade to >=0.17.12
+  # Dependency tree:
+  # ring 0.17.3
+  --ignore RUSTSEC-2025-0009
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

```
Crate:     ring
Version:   0.16.20
Title:     Some AES functions may panic when overflow checking is enabled.
Date:      2025-03-06
ID:        RUSTSEC-2025-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
Solution:  Upgrade to >=0.17.12
Dependency tree:
ring 0.16.20

Crate:     ring
Version:   0.17.3
Title:     Some AES functions may panic when overflow checking is enabled.
Date:      2025-03-06
ID:        RUSTSEC-2025-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
Solution:  Upgrade to >=0.17.12
Dependency tree:
ring 0.17.3
```

the related upstream PR is https://github.com/anza-xyz/agave/pull/5181

#### Summary of Changes

ignore it