### PR TITLE
gate create_executor_jit_compile_us comparison on os and arch

### DIFF
--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2666,14 +2666,18 @@ fn svm_metrics_accumulation() {
             &env.processing_config,
         );
 
-        assert_ne!(
-            result
-                .execute_timings
-                .details
-                .create_executor_jit_compile_us
-                .0,
-            0
-        );
+        // jit compilation only happens on non-windows && x86_64
+        #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+        {
+            assert_ne!(
+                result
+                    .execute_timings
+                    .details
+                    .create_executor_jit_compile_us
+                    .0,
+                0
+            );
+        }
         assert_ne!(
             result.execute_timings.details.create_executor_load_elf_us.0,
             0


### PR DESCRIPTION
#### Problem
- jit compilation only happens for specifc os & arch
	- https://github.com/anza-xyz/agave/blob/master/program-runtime/src/loaded_programs.rs#L397
- for other os/arch this test will fail due to `create_executor_jit_compile_us` being zero
- ^ if you run tests on a m-series mac, the test currently fails

#### Summary of Changes
- use same cfg conditions for the jit time comparison

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
