### PR TITLE
Include SBPFv3 tests in the CI pipline

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -64,6 +64,9 @@ test-stable-sbf)
   # SBPFv2 program tests
   _ make -C programs/sbf clean-all test-v2
 
+  # SBPFv3 program tests
+  _ make -C programs/sbf clean-all test-v3
+
   exit 0
   ;;
 test-docs)

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -5,10 +5,13 @@ OUT_DIR := target/deploy
 clean-all: clean
 	cargo clean
 
-test:
+test-all:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)
 
-test-v0: all rust-v0 test
+test-rust:
+	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust" $(TEST_ARGS)
+
+test-v0: all rust-v0 test-all
 
 test-v1:
 	VER=v1 $(MAKE) test-version
@@ -16,17 +19,22 @@ test-v1:
 test-v2:
 	VER=v2 $(MAKE) test-version
 
+test-v3:
+	mkdir -p target/deploy ; \
+	VER=v3 $(MAKE) rust-new ; \
+	$(MAKE) test-rust
+
 test-version:
-	SBPF_CPU=$(VER) $(MAKE) all; \
+	SBPF_CPU=$(VER) $(MAKE) all ; \
 	$(MAKE) rust-new ; \
-	$(MAKE) test
+	$(MAKE) test-all
 
 rust-v0:
 	cargo +solana build --release --target sbpf-solana-solana --workspace ; \
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
 rust-new:
-	cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace --features dynamic-frames ; \
+	RUSTFLAGS="-C instrument-coverage=no" cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace --features dynamic-frames ; \
 	cp -r target/sbpf$(VER)-solana-solana/release/* target/deploy
 
 .PHONY: rust-v0

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4121,9 +4121,10 @@ fn test_cpi_invalid_account_info_pointers() {
 
     let mut program_ids: Vec<Pubkey> = Vec::with_capacity(2);
 
+    let mut bank;
     #[cfg(feature = "sbf_rust")]
     {
-        let (_bank, invoke_program_id) = load_program_of_loader_v4(
+        let (new_bank, invoke_program_id) = load_program_of_loader_v4(
             &mut bank_client,
             &bank_forks,
             &mint_keypair,
@@ -4132,11 +4133,15 @@ fn test_cpi_invalid_account_info_pointers() {
         );
         account_metas.push(AccountMeta::new_readonly(invoke_program_id, false));
         program_ids.push(invoke_program_id);
+        #[allow(unused)]
+        {
+            bank = new_bank;
+        }
     }
 
     #[cfg(feature = "sbf_c")]
     {
-        let (_bank, c_invoke_program_id) = load_program_of_loader_v4(
+        let (new_bank, c_invoke_program_id) = load_program_of_loader_v4(
             &mut bank_client,
             &bank_forks,
             &mint_keypair,
@@ -4145,11 +4150,11 @@ fn test_cpi_invalid_account_info_pointers() {
         );
         account_metas.push(AccountMeta::new_readonly(c_invoke_program_id, false));
         program_ids.push(c_invoke_program_id);
+        #[allow(unused)]
+        {
+            bank = new_bank;
+        }
     }
-
-    let bank = bank_client
-        .advance_slot(1, &bank_forks, &Pubkey::default())
-        .expect("Failed to advance the slot");
 
     for invoke_program_id in &program_ids {
         for ix in [

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4121,6 +4121,7 @@ fn test_cpi_invalid_account_info_pointers() {
 
     let mut program_ids: Vec<Pubkey> = Vec::with_capacity(2);
 
+    #[allow(unused_mut)]
     let mut bank;
     #[cfg(feature = "sbf_rust")]
     {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -570,6 +570,7 @@ fn test_program_sbf_invoke_sanity() {
     solana_logger::setup();
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     enum Languages {
         C,
         Rust,
@@ -3348,7 +3349,7 @@ fn test_program_sbf_processed_inner_instruction() {
         &bank_forks,
         &mint_keypair,
         &authority_keypair,
-        "noop",
+        "solana_sbf_rust_noop",
     );
     let (_bank, invoke_and_return_program_id) = load_program_of_loader_v4(
         &mut bank_client,
@@ -4097,7 +4098,6 @@ fn test_cpi_change_account_data_memory_allocation() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
 fn test_cpi_invalid_account_info_pointers() {
     solana_logger::setup();
 
@@ -4112,41 +4112,56 @@ fn test_cpi_invalid_account_info_pointers() {
     let mut bank_client = BankClient::new_shared(bank);
     let authority_keypair = Keypair::new();
 
-    let (_bank, c_invoke_program_id) = load_program_of_loader_v4(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "invoke",
-    );
-    let (bank, invoke_program_id) = load_program_of_loader_v4(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_invoke",
-    );
-
     let account_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
-    let account_metas = vec![
+    let mut account_metas = vec![
         AccountMeta::new(mint_pubkey, true),
         AccountMeta::new(account_keypair.pubkey(), false),
-        AccountMeta::new_readonly(invoke_program_id, false),
-        AccountMeta::new_readonly(c_invoke_program_id, false),
     ];
 
-    for invoke_program_id in [invoke_program_id, c_invoke_program_id] {
+    let mut program_ids: Vec<Pubkey> = Vec::with_capacity(2);
+
+    #[cfg(feature = "sbf_rust")]
+    {
+        let (_bank, invoke_program_id) = load_program_of_loader_v4(
+            &mut bank_client,
+            &bank_forks,
+            &mint_keypair,
+            &authority_keypair,
+            "solana_sbf_rust_invoke",
+        );
+        account_metas.push(AccountMeta::new_readonly(invoke_program_id, false));
+        program_ids.push(invoke_program_id);
+    }
+
+    #[cfg(feature = "sbf_c")]
+    {
+        let (_bank, c_invoke_program_id) = load_program_of_loader_v4(
+            &mut bank_client,
+            &bank_forks,
+            &mint_keypair,
+            &authority_keypair,
+            "invoke",
+        );
+        account_metas.push(AccountMeta::new_readonly(c_invoke_program_id, false));
+        program_ids.push(c_invoke_program_id);
+    }
+
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, &Pubkey::default())
+        .expect("Failed to advance the slot");
+
+    for invoke_program_id in &program_ids {
         for ix in [
             TEST_CPI_INVALID_KEY_POINTER,
             TEST_CPI_INVALID_LAMPORTS_POINTER,
             TEST_CPI_INVALID_OWNER_POINTER,
             TEST_CPI_INVALID_DATA_POINTER,
         ] {
-            let account = AccountSharedData::new(42, 5, &invoke_program_id);
+            let account = AccountSharedData::new(42, 5, invoke_program_id);
             bank.store_account(&account_keypair.pubkey(), &account);
             let instruction = Instruction::new_with_bytes(
-                invoke_program_id,
+                *invoke_program_id,
                 &[ix, 42, 42, 42],
                 account_metas.clone(),
             );


### PR DESCRIPTION
#### Problem

SBPFv3 is now available on `cargo-build-sbf` and the virtual machine, but it is not yet tested in the CI.

#### Summary of Changes

1. Refactor `programs/sbf/tests/programs.rs` to only execute rust programs when the `sbf_rust` feature is enabled.
2. Refactor the makefile to build SBFv3 programs and execute only Rust tests (reminder: we are not providing support for C in SBPFv3.
3. Add SBFv3 to the CI bash script.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
