### PR TITLE
Reduce timeout on spl CI jobs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -40,6 +40,7 @@ jobs:
   check:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         programs:
@@ -77,6 +78,7 @@ jobs:
   test_cli:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         programs:
@@ -106,6 +108,7 @@ jobs:
   cargo-test-sbf:
     if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         programs:


### PR DESCRIPTION
#### Problem
Two reports in one day of jobs getting stuck for multiple hours in CI.

![Screenshot from 2025-03-07 14-45-14](https://github.com/user-attachments/assets/13f08d0d-1f83-4350-8026-fe401ca708a8)


#### Summary of Changes

This PR adds timeout config to the three jobs in the `Downstream Project - SPL` workflow 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
