### PR TITLE
chore: remove useless must_use attributes

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -56,9 +56,6 @@ pub(crate) struct ScopedTimer<'a> {
 }
 
 impl<'a> From<&'a Counter> for ScopedTimer<'a> {
-    // Output should be assigned to a *named* variable, otherwise it is
-    // immediately dropped.
-    #[must_use]
     fn from(counter: &'a Counter) -> Self {
         Self {
             clock: Instant::now(),

--- a/runtime/src/accounts_background_service/stats.rs
+++ b/runtime/src/accounts_background_service/stats.rs
@@ -102,7 +102,6 @@ impl Stats {
 }
 
 impl Default for Stats {
-    #[must_use]
     fn default() -> Self {
         Self {
             num_iterations: 0,


### PR DESCRIPTION
#### Problem
`must_use` attribute does nothing in trait functions with default impl

https://doc.rust-lang.org/reference/attributes/diagnostics.html#r-attributes.diagnostics.must_use.trait-impl-function

#### Summary of Changes

remove attributes where appropriate

Fixes #
build using latest nightly compiler