### PR TITLE
ledger: Propagate error for unable to replay bank 0

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -9194,7 +9194,8 @@ pub(crate) mod tests {
             &recyclers,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         // Mark block 1, 3, 4, 5 as duplicate
         blockstore.store_duplicate_slot(1, vec![], vec![]).unwrap();

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -58,6 +58,9 @@ pub enum BankForksUtilsError {
         path: PathBuf,
     },
 
+    #[error("failed to process blockstore from genesis: {0}")]
+    ProcessBlockstoreFromGenesis(#[source] BlockstoreProcessorError),
+
     #[error("failed to process blockstore from root: {0}")]
     ProcessBlockstoreFromRoot(#[source] BlockstoreProcessorError),
 }
@@ -196,7 +199,7 @@ pub fn load_bank_forks(
                 accounts_update_notifier,
                 exit,
             )
-            .map_err(BankForksUtilsError::ProcessBlockstoreFromRoot)?;
+            .map_err(BankForksUtilsError::ProcessBlockstoreFromGenesis)?;
             bank_forks
                 .read()
                 .unwrap()

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -195,7 +195,8 @@ pub fn load_bank_forks(
                 entry_notification_sender,
                 accounts_update_notifier,
                 exit,
-            );
+            )
+            .map_err(BankForksUtilsError::ProcessBlockstoreFromRoot)?;
             bank_forks
                 .read()
                 .unwrap()


### PR DESCRIPTION
#### Summary of Changes
We currently .expect() which panics and reports a datapoint which adds noise to the list of panics when looking at metrics. These can be filtered out, but propagating the error is more proper anyways