### PR TITLE
tpu-client-next: add client selection to validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9180,6 +9180,7 @@ dependencies = [
  "solana-perf",
  "solana-poh",
  "solana-pubkey",
+ "solana-quic-definitions",
  "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-rpc-client-api",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -90,8 +90,7 @@ use {
         rpc::JsonRpcConfig,
         rpc_completed_slots_service::RpcCompletedSlotsService,
         rpc_pubsub_service::{PubSubConfig, PubSubService},
-        rpc_service::JsonRpcService,
-        rpc_service::JsonRpcServiceBuilder,
+        rpc_service::{JsonRpcService, JsonRpcServiceBuilder},
         rpc_subscriptions::RpcSubscriptions,
         transaction_notifier_interface::TransactionNotifierArc,
         transaction_status_service::TransactionStatusService,
@@ -1165,29 +1164,29 @@ impl Validator {
                 None
             };
 
-            let rpc_builder = JsonRpcServiceBuilder::new(
+            let rpc_builder = JsonRpcServiceBuilder {
                 rpc_addr,
-                config.rpc_config.clone(),
-                Some(config.snapshot_config.clone()),
-                bank_forks.clone(),
-                block_commitment_cache.clone(),
-                blockstore.clone(),
-                cluster_info.clone(),
-                Some(poh_recorder.clone()),
-                genesis_config.hash(),
-                ledger_path,
-                config.validator_exit.clone(),
-                exit.clone(),
-                rpc_override_health_check.clone(),
+                config: config.rpc_config.clone(),
+                snapshot_config: Some(config.snapshot_config.clone()),
+                bank_forks: bank_forks.clone(),
+                block_commitment_cache: block_commitment_cache.clone(),
+                blockstore: blockstore.clone(),
+                cluster_info: cluster_info.clone(),
+                poh_recorder: Some(poh_recorder.clone()),
+                genesis_hash: genesis_config.hash(),
+                ledger_path: ledger_path.to_path_buf(),
+                validator_exit: config.validator_exit.clone(),
+                exit: exit.clone(),
+                override_health_check: rpc_override_health_check.clone(),
                 startup_verification_complete,
-                optimistically_confirmed_bank.clone(),
-                config.send_transaction_service_config.clone(),
-                max_slots.clone(),
-                leader_schedule_cache.clone(),
+                optimistically_confirmed_bank: optimistically_confirmed_bank.clone(),
+                send_transaction_service_config: config.send_transaction_service_config.clone(),
+                max_slots: max_slots.clone(),
+                leader_schedule_cache: leader_schedule_cache.clone(),
                 max_complete_transaction_status_slot,
                 max_complete_rewards_slot,
-                prioritization_fee_cache.clone(),
-            );
+                prioritization_fee_cache: prioritization_fee_cache.clone(),
+            };
             let json_rpc_service = if config.use_tpu_client_next {
                 rpc_builder
                     .build(None, Some(Arc::as_ref(&identity_keypair)))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -90,7 +90,7 @@ use {
         rpc::JsonRpcConfig,
         rpc_completed_slots_service::RpcCompletedSlotsService,
         rpc_pubsub_service::{PubSubConfig, PubSubService},
-        rpc_service::{ClientOption, JsonRpcService, JsonRpcServiceBuilder},
+        rpc_service::{ClientOption, JsonRpcService, JsonRpcServiceConfig},
         rpc_subscriptions::RpcSubscriptions,
         transaction_notifier_interface::TransactionNotifierArc,
         transaction_status_service::TransactionStatusService,
@@ -1164,9 +1164,9 @@ impl Validator {
                 None
             };
 
-            let rpc_builder = JsonRpcServiceBuilder {
+            let rpc_svc_config = JsonRpcServiceConfig {
                 rpc_addr,
-                config: config.rpc_config.clone(),
+                rpc_config: config.rpc_config.clone(),
                 snapshot_config: Some(config.snapshot_config.clone()),
                 bank_forks: bank_forks.clone(),
                 block_commitment_cache: block_commitment_cache.clone(),
@@ -1192,7 +1192,8 @@ impl Validator {
                     ClientOption::ConnectionCache(connection_cache.clone())
                 },
             };
-            let json_rpc_service = rpc_builder.build().map_err(ValidatorError::Other)?;
+            let json_rpc_service =
+                JsonRpcService::new_with_config(rpc_svc_config).map_err(ValidatorError::Other)?;
 
             let pubsub_service = if !config.rpc_config.full_api {
                 None

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -74,6 +74,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        use_tpu_client_next: config.use_tpu_client_next,
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7308,6 +7308,7 @@ dependencies = [
  "solana-perf",
  "solana-poh",
  "solana-pubkey",
+ "solana-quic-definitions",
  "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -43,6 +43,7 @@ solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-quic-definitions = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod block_meta_service;
-mod cluster_tpu_info;
+//TODO(klykov): maybe there is a way to avoid exporting?
+pub mod cluster_tpu_info;
 pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod block_meta_service;
-//TODO(klykov): maybe there is a way to avoid exporting?
-pub mod cluster_tpu_info;
+mod cluster_tpu_info;
 pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7132,6 +7132,7 @@ dependencies = [
  "solana-perf",
  "solana-poh",
  "solana-pubkey",
+ "solana-quic-definitions",
  "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",


### PR DESCRIPTION
#### Problem

This PR adds a flag `use_tpu_client_next` to the validator configuration (without cla for now) which allows to use tpu-client-next instead of ConnectionCache for RPC.

#### Summary of Changes

