### PR TITLE
ci: timeout tests at the per-test level

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -3,7 +3,7 @@ dir = "target/nextest"
 
 [profile.ci]
 failure-output = "immediate-final"
-fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 1 }
 
 [profile.ci.junit]
 path = "junit.xml"
@@ -27,3 +27,59 @@ threads-required = "num-cpus"
 [[profile.ci.overrides]]
 filter = "package(solana-cargo-build-sbf)"
 threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-cargo-build-sbf)'
+slow-timeout = { period = "60s", terminate-after = 5 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-ledger) & test(/^test_purge_huge$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-ledger) & test(/^shred::merkle::test::test_merkle_tree_round_trip/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_nonce_update_blockhash_queried_before_transaction_record/)'
+slow-timeout = { period = "60s", terminate-after = 8 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_process_and_record_transactions/)'
+slow-timeout = { period = "60s", terminate-after = 8 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_development_expects/)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_testnet_expects/)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_devnet_expects/)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_mainnetbeta_expects/)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-runtime) & test(/^bank_forks::tests::test_bank_forks_new_rw_arc_memory_leak/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-runtime) & test(/^bank::tests::test_race_register_tick_freeze/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-svm) & test(/^execute_fixtures/)'
+slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1347909369844469881

all tests should have a proper default timeout so that we can understand how flaky they are.

#### Summary of Changes

- set 60s as the standard threshold for slow tests (we have ~300 tests exceed 10s. use 60s as a start point)
- use 10m as the default timeout in solana-local-cluster
- use 5m as the default timeout for solana-cargo-build-sbf
- add more exclude rules for particularly slow tests