### PR TITLE
Refactor - Remove use-sites of `TransactionContext::get_account_at_index()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -744,9 +744,9 @@ macro_rules! with_mock_invoke_context {
                 {
                     callback(
                         $transaction_context
-                            .get_account_at_index(index)
+                            .accounts()
+                            .try_borrow(index)
                             .unwrap()
-                            .borrow()
                             .data(),
                     );
                 }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -761,9 +761,9 @@ mod tests {
                         .unwrap();
                     let account = invoke_context
                         .transaction_context
-                        .get_account_at_index(index_in_transaction)
-                        .unwrap()
-                        .borrow();
+                        .accounts()
+                        .try_borrow(index_in_transaction)
+                        .unwrap();
                     assert_eq!(account.lamports(), account_info.lamports());
                     assert_eq!(account.data(), &account_info.data.borrow()[..]);
                     assert_eq!(account.owner(), account_info.owner);
@@ -915,9 +915,9 @@ mod tests {
                     .unwrap();
                 let account = invoke_context
                     .transaction_context
-                    .get_account_at_index(index_in_transaction)
-                    .unwrap()
-                    .borrow();
+                    .accounts()
+                    .try_borrow(index_in_transaction)
+                    .unwrap();
                 assert_eq!(account.lamports(), account_info.lamports());
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
@@ -951,9 +951,9 @@ mod tests {
             {
                 let account = invoke_context
                     .transaction_context
-                    .get_account_at_index(index_in_transaction as IndexOfAccount)
-                    .unwrap()
-                    .borrow();
+                    .accounts()
+                    .try_borrow(index_in_transaction as IndexOfAccount)
+                    .unwrap();
                 assert_eq!(&*account, original_account);
             }
 
@@ -965,9 +965,9 @@ mod tests {
                 .set_owner(bpf_loader_deprecated::id());
             invoke_context
                 .transaction_context
-                .get_account_at_index(0)
+                .accounts()
+                .try_borrow_mut(0)
                 .unwrap()
-                .borrow_mut()
                 .set_owner(bpf_loader_deprecated::id());
 
             let (mut serialized, regions, account_lengths) = serialize_parameters(
@@ -998,9 +998,9 @@ mod tests {
                     .unwrap();
                 let account = invoke_context
                     .transaction_context
-                    .get_account_at_index(index_in_transaction)
-                    .unwrap()
-                    .borrow();
+                    .accounts()
+                    .try_borrow(index_in_transaction)
+                    .unwrap();
                 assert_eq!(account.lamports(), account_info.lamports());
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
@@ -1021,9 +1021,9 @@ mod tests {
             {
                 let account = invoke_context
                     .transaction_context
-                    .get_account_at_index(index_in_transaction as IndexOfAccount)
-                    .unwrap()
-                    .borrow();
+                    .accounts()
+                    .try_borrow(index_in_transaction as IndexOfAccount)
+                    .unwrap();
                 assert_eq!(&*account, original_account);
             }
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1787,9 +1787,9 @@ mod test_utils {
         for index in 0..num_accounts {
             let account = invoke_context
                 .transaction_context
-                .get_account_at_index(index)
-                .expect("Failed to get the account")
-                .borrow();
+                .accounts()
+                .try_borrow(index)
+                .expect("Failed to get the account");
 
             let owner = account.owner();
             if check_loader_id(owner) {

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -2212,9 +2212,9 @@ mod tests {
         {
             let mut account = invoke_context
                 .transaction_context
-                .get_account_at_index(1)
-                .unwrap()
-                .borrow_mut();
+                .accounts()
+                .try_borrow_mut(1)
+                .unwrap();
             account.set_data(b"baz".to_vec());
         }
 

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -1129,9 +1129,9 @@ mod test {
         assert_matches!(
             verify_nonce_account(
                 &transaction_context
-                    .get_account_at_index(NONCE_ACCOUNT_INDEX)
-                    .unwrap()
-                    .borrow(),
+                    .accounts()
+                    .try_borrow(NONCE_ACCOUNT_INDEX)
+                    .unwrap(),
                 DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
                     .as_hash(),
             ),
@@ -1151,9 +1151,9 @@ mod test {
         assert_eq!(
             verify_nonce_account(
                 &transaction_context
-                    .get_account_at_index(NONCE_ACCOUNT_INDEX)
-                    .unwrap()
-                    .borrow(),
+                    .accounts()
+                    .try_borrow(NONCE_ACCOUNT_INDEX)
+                    .unwrap(),
                 &Hash::default(),
             ),
             None
@@ -1191,9 +1191,9 @@ mod test {
         assert_eq!(
             verify_nonce_account(
                 &transaction_context
-                    .get_account_at_index(NONCE_ACCOUNT_INDEX)
-                    .unwrap()
-                    .borrow(),
+                    .accounts()
+                    .try_borrow(NONCE_ACCOUNT_INDEX)
+                    .unwrap(),
                 DurableNonce::from_blockhash(&invoke_context.environment_config.blockhash)
                     .as_hash(),
             ),

--- a/svm-rent-collector/src/svm_rent_collector.rs
+++ b/svm-rent-collector/src/svm_rent_collector.rs
@@ -44,9 +44,9 @@ pub trait SVMRentCollector {
                     .get_key_of_account_at_index(index)
                     .expect(expect_msg),
                 &transaction_context
-                    .get_account_at_index(index)
-                    .expect(expect_msg)
-                    .borrow(),
+                    .accounts()
+                    .try_borrow(index)
+                    .expect(expect_msg),
                 index,
             )?;
         }

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -36,9 +36,9 @@ pub(crate) fn process_message(
         {
             let mut mut_account_ref = invoke_context
                 .transaction_context
-                .get_account_at_index(account_index)
-                .map_err(|_| TransactionError::InvalidAccountIndex)?
-                .borrow_mut();
+                .accounts()
+                .try_borrow_mut(account_index)
+                .map_err(|_| TransactionError::InvalidAccountIndex)?;
             instructions::store_current_index(
                 mut_account_ref.data_as_mut_slice(),
                 instruction_index as u16,
@@ -264,17 +264,17 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             transaction_context
-                .get_account_at_index(0)
+                .accounts()
+                .try_borrow(0)
                 .unwrap()
-                .borrow()
                 .lamports(),
             100
         );
         assert_eq!(
             transaction_context
-                .get_account_at_index(1)
+                .accounts()
+                .try_borrow(1)
                 .unwrap()
-                .borrow()
                 .lamports(),
             0
         );
@@ -572,26 +572,22 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             transaction_context
-                .get_account_at_index(0)
+                .accounts()
+                .try_borrow(0)
                 .unwrap()
-                .borrow()
                 .lamports(),
             80
         );
         assert_eq!(
             transaction_context
-                .get_account_at_index(1)
+                .accounts()
+                .try_borrow(1)
                 .unwrap()
-                .borrow()
                 .lamports(),
             20
         );
         assert_eq!(
-            transaction_context
-                .get_account_at_index(0)
-                .unwrap()
-                .borrow()
-                .data(),
+            transaction_context.accounts().try_borrow(0).unwrap().data(),
             &vec![42]
         );
     }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -21,11 +21,10 @@ impl TransactionAccountStateInfo {
         (0..message.account_keys().len())
             .map(|i| {
                 let rent_state = if message.is_writable(i) {
-                    let state = if let Ok(account) =
-                        transaction_context.get_account_at_index(i as IndexOfAccount)
+                    let state = if let Ok(account) = transaction_context
+                        .accounts()
+                        .try_borrow(i as IndexOfAccount)
                     {
-                        let account = account.borrow();
-
                         // Native programs appear to be RentPaying because they carry low lamport
                         // balances; however they will never be loaded as writable
                         debug_assert!(!native_loader::check_id(account.owner()));


### PR DESCRIPTION
#### Problem
There should be no direct mutable / write accesses to `AccountSharedData` in the SVM and built-in programs.
All data changes should pass through `BorrowedAccount::make_data_mut()`.

#### Summary of Changes
Replaces all use-sites of `TransactionContext::get_account_at_index()` with `TransactionAccounts::try_borrow()` or `TransactionAccounts::try_borrow_mut()`.

Not included in this PR: The two remaining use-sites `TransactionAccounts::try_borrow_mut()` must be replaced with `BorrowedAccount`.