### PR TITLE
allows reading from the socket with no max_wait

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
             s_reader,
             recycler.clone(),
             stats.clone(),
-            Duration::from_millis(1), // coalesce
+            Some(Duration::from_millis(1)), // coalesce
             true,
             None,
             false,

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -33,7 +33,7 @@ use {
 const SINK_REPORT_INTERVAL: Duration = Duration::from_secs(5);
 const SINK_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);
 const SOCKET_RECEIVE_TIMEOUT: Duration = Duration::from_secs(1);
-const COALESCE_TIME: Duration = Duration::from_millis(1);
+const COALESCE_TIME: Option<Duration> = Some(Duration::from_millis(1));
 
 fn sink(
     exit: Arc<AtomicBool>,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -36,7 +36,7 @@ impl FetchStage {
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        coalesce: Duration,
+        coalesce: Option<Duration>,
     ) -> (Self, PacketBatchReceiver, PacketBatchReceiver) {
         let (sender, receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
@@ -72,7 +72,7 @@ impl FetchStage {
         forward_sender: &PacketBatchSender,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        coalesce: Duration,
+        coalesce: Option<Duration>,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
         tpu_enable_udp: bool,
     ) -> Self {
@@ -148,7 +148,7 @@ impl FetchStage {
         forward_sender: &PacketBatchSender,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
-        coalesce: Duration,
+        coalesce: Option<Duration>,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
         tpu_enable_udp: bool,
     ) -> Self {

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -171,10 +171,10 @@ impl AncestorHashesService {
             Arc::new(StreamerReceiveStats::new(
                 "ancestor_hashes_response_receiver",
             )),
-            Duration::from_millis(1), // coalesce
-            false,                    // use_pinned_memory
-            None,                     // in_vote_only_mode
-            false,                    // is_staked_service
+            Some(Duration::from_millis(1)), // coalesce
+            false,                          // use_pinned_memory
+            None,                           // in_vote_only_mode
+            false,                          // is_staked_service
         );
 
         let AncestorHashesChannels {
@@ -1302,7 +1302,7 @@ mod test {
                 requests_sender,
                 Recycler::default(),
                 Arc::new(StreamerReceiveStats::new("repair_request_receiver")),
-                Duration::from_millis(1), // coalesce
+                Some(Duration::from_millis(1)), // coalesce
                 false,
                 None,
                 false,

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -47,10 +47,10 @@ impl ServeRepairService {
             request_sender,
             Recycler::default(),
             Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
-            Duration::from_millis(1), // coalesce
-            false,                    // use_pinned_memory
-            None,                     // in_vote_only_mode
-            false,                    // is_staked_service
+            Some(Duration::from_millis(1)), // coalesce
+            false,                          // use_pinned_memory
+            None,                           // in_vote_only_mode
+            false,                          // is_staked_service
         );
         let t_packet_adapter = Builder::new()
             .name(String::from("solServRAdapt"))

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -31,7 +31,6 @@ use {
     },
 };
 
-const PACKET_COALESCE_DURATION: Duration = Duration::from_millis(1);
 // When running with very short epochs (e.g. for testing), we want to avoid
 // filtering out shreds that we actually need. This value was chosen empirically
 // because it's large enough to protect against observed short epoch problems
@@ -183,6 +182,7 @@ impl ShredFetchStage {
         repair_context: Option<RepairContext>,
         turbine_disabled: Arc<AtomicBool>,
     ) -> (Vec<JoinHandle<()>>, JoinHandle<()>) {
+        const PACKET_COALESCE_DURATION: Option<Duration> = Some(Duration::from_millis(1));
         let (packet_sender, packet_receiver) = unbounded();
         let streamers = sockets
             .into_iter()
@@ -387,6 +387,7 @@ pub(crate) fn receive_quic_datagrams(
     exit: Arc<AtomicBool>,
 ) {
     const RECV_TIMEOUT: Duration = Duration::from_secs(1);
+    const PACKET_COALESCE_DURATION: Duration = Duration::from_millis(1);
     while !exit.load(Ordering::Relaxed) {
         let entry = match quic_datagrams_receiver.recv_timeout(RECV_TIMEOUT) {
             Ok(entry) => entry,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -151,7 +151,7 @@ impl Tpu {
             &forwarded_packet_sender,
             forwarded_packet_receiver,
             poh_recorder,
-            tpu_coalesce,
+            Some(tpu_coalesce),
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
             tpu_enable_udp,
         );

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -66,7 +66,7 @@ impl GossipService {
             request_sender,
             Recycler::default(),
             gossip_receiver_stats.clone(),
-            Duration::from_millis(1), // coalesce
+            Some(Duration::from_millis(1)), // coalesce
             false,
             None,
             false,

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -5,7 +5,7 @@ use {
         socket::SocketAddrSpace,
     },
     std::{
-        io::Result,
+        io::{ErrorKind, Result},
         net::UdpSocket,
         time::{Duration, Instant},
     },
@@ -17,7 +17,14 @@ pub use {
     },
 };
 
-pub fn recv_from(batch: &mut PacketBatch, socket: &UdpSocket, max_wait: Duration) -> Result<usize> {
+pub(crate) fn recv_from(
+    batch: &mut PacketBatch,
+    socket: &UdpSocket,
+    // If max_wait is None, reads from the socket until either:
+    //   * 64 packets are read (NUM_RCVMMSGS == PACKETS_PER_BATCH == 64), or
+    //   * There are no more data available to read from the socket.
+    max_wait: Option<Duration>,
+) -> Result<usize> {
     let mut i = 0;
     //DOCUMENTED SIDE-EFFECT
     //Performance out of the IO without poll
@@ -27,15 +34,16 @@ pub fn recv_from(batch: &mut PacketBatch, socket: &UdpSocket, max_wait: Duration
     //  * set it back to blocking before returning
     socket.set_nonblocking(false)?;
     trace!("receiving on {}", socket.local_addr().unwrap());
-    let start = Instant::now();
+    let should_wait = max_wait.is_some();
+    let start = should_wait.then(Instant::now);
     loop {
         batch.resize(
             std::cmp::min(i + NUM_RCVMMSGS, PACKETS_PER_BATCH),
             Packet::default(),
         );
         match recv_mmsg(socket, &mut batch[i..]) {
-            Err(_) if i > 0 => {
-                if start.elapsed() > max_wait {
+            Err(err) if i > 0 => {
+                if !should_wait && err.kind() == ErrorKind::WouldBlock {
                     break;
                 }
             }
@@ -51,10 +59,13 @@ pub fn recv_from(batch: &mut PacketBatch, socket: &UdpSocket, max_wait: Duration
                 i += npkts;
                 // Try to batch into big enough buffers
                 // will cause less re-shuffling later on.
-                if start.elapsed() > max_wait || i >= PACKETS_PER_BATCH {
+                if i >= PACKETS_PER_BATCH {
                     break;
                 }
             }
+        }
+        if start.as_ref().map(Instant::elapsed) > max_wait {
+            break;
         }
     }
     batch.truncate(i);
@@ -119,7 +130,7 @@ mod tests {
         let recvd = recv_from(
             &mut batch,
             &recv_socket,
-            Duration::from_millis(1), // max_wait
+            Some(Duration::from_millis(1)), // max_wait
         )
         .unwrap();
         assert_eq!(recvd, batch.len());
@@ -177,7 +188,7 @@ mod tests {
         let recvd = recv_from(
             &mut batch,
             &recv_socket,
-            Duration::from_millis(100), // max_wait
+            Some(Duration::from_millis(100)), // max_wait
         )
         .unwrap();
         // Check we only got PACKETS_PER_BATCH packets

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -116,7 +116,7 @@ fn recv_loop(
     packet_batch_sender: &PacketBatchSender,
     recycler: &PacketBatchRecycler,
     stats: &StreamerReceiveStats,
-    coalesce: Duration,
+    coalesce: Option<Duration>,
     use_pinned_memory: bool,
     in_vote_only_mode: Option<Arc<AtomicBool>>,
     is_staked_service: bool,
@@ -178,7 +178,7 @@ pub fn receiver(
     packet_batch_sender: PacketBatchSender,
     recycler: PacketBatchRecycler,
     stats: Arc<StreamerReceiveStats>,
-    coalesce: Duration,
+    coalesce: Option<Duration>,
     use_pinned_memory: bool,
     in_vote_only_mode: Option<Arc<AtomicBool>>,
     is_staked_service: bool,
@@ -504,7 +504,7 @@ mod test {
             s_reader,
             Recycler::default(),
             stats.clone(),
-            Duration::from_millis(1), // coalesce
+            Some(Duration::from_millis(1)), // coalesce
             true,
             None,
             false,


### PR DESCRIPTION

#### Problem
Reading from the socket with `max_wait` either adds latency and overhead or returns too early while there are data still available to read.

#### Summary of Changes
The commit allows to read from the socket until either:
  * 64 packets are read (`NUM_RCVMMSGS == PACKETS_PER_BATCH == 64`).
  * There are no data available to read from the socket.

A large `max_wait` will _not_ achieve the same behavior because it will keep retrying read from the socket until `max_wait` is passed which adds both overhead and latency.
