### PR TITLE
removes max_wait when reading from the socket in shred-fetch-stage

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -182,7 +182,6 @@ impl ShredFetchStage {
         repair_context: Option<RepairContext>,
         turbine_disabled: Arc<AtomicBool>,
     ) -> (Vec<JoinHandle<()>>, JoinHandle<()>) {
-        const PACKET_COALESCE_DURATION: Option<Duration> = Some(Duration::from_millis(1));
         let (packet_sender, packet_receiver) = unbounded();
         let streamers = sockets
             .into_iter()
@@ -195,10 +194,10 @@ impl ShredFetchStage {
                     packet_sender.clone(),
                     recycler.clone(),
                     Arc::new(StreamerReceiveStats::new("packet_modifier")),
-                    PACKET_COALESCE_DURATION,
-                    true, // use_pinned_memory
-                    None, // in_vote_only_mode
-                    false,
+                    None,  // coalesce
+                    true,  // use_pinned_memory
+                    None,  // in_vote_only_mode
+                    false, // is_staked_service
                 )
             })
             .collect();


### PR DESCRIPTION
#### Problem

There are ~3000 shreds in each block. If the streamer unnecessarily
blocks 1ms for just 1% of shreds, that is 30ms latency within the block
which compounds as we get further hops away from the leader.

On the other hand if the streamer returns early while there are still
shreds available to read from the socket, there will be more overhead
and overall the throughput gets worse and average latency will increase.



#### Summary of Changes
The commit removes max_wait when reading from the socket, so that it
reads from the socket until either:
  * 64 shreds are read (NUM_RCVMMSGS == PACKETS_PER_BATCH == 64), or
  * There are no more shreds available to read from the socket.

