### PR TITLE
agave-validator: Make whitelist required for repair-whitelist set

### DIFF
--- a/validator/src/commands/repair_whitelist/mod.rs
+++ b/validator/src/commands/repair_whitelist/mod.rs
@@ -160,6 +160,15 @@ mod tests {
     }
 
     #[test]
+    fn verify_args_struct_by_command_repair_whitelist_set_required() {
+        use crate::commands::tests::verify_args_struct_by_command_is_error;
+        verify_args_struct_by_command_is_error::<RepairWhitelistSetArgs>(
+            command(),
+            vec![COMMAND, "set"],
+        );
+    }
+
+    #[test]
     fn verify_args_struct_by_command_repair_whitelist_set_with_single_whitelist() {
         let app = command();
         let matches = app.get_matches_from(vec![

--- a/validator/src/commands/repair_whitelist/mod.rs
+++ b/validator/src/commands/repair_whitelist/mod.rs
@@ -160,15 +160,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_repair_whitelist_set_required() {
-        use crate::commands::tests::verify_args_struct_by_command_is_error;
-        verify_args_struct_by_command_is_error::<RepairWhitelistSetArgs>(
-            command(),
-            vec![COMMAND, "set"],
-        );
-    }
-
-    #[test]
     fn verify_args_struct_by_command_repair_whitelist_set_with_single_whitelist() {
         let app = command();
         let matches = app.get_matches_from(vec![


### PR DESCRIPTION
#### Problem
    The set command adds any specified keys, or no-ops if empty. There could
    be the case where a user wants to clear the list; this is currently done
    with the remove-all subcommand. It could be reasonable to think that
    calling set with an empty list would also clear the list
    
#### Summary of Changes
    To disambiguate, make --whitelist required for the set subcommand

I added a unit test in second commit, and confirmed it passes. However, I then removed the uni test as that erroring is guaranteed by `.required(true)` being set. I don't think it is necessary for us to unit test that
