### PR TITLE
check zero-fee-for-test with blockhash-queue

### DIFF
--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -63,7 +63,8 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
-        let (_last_hash, last_lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
             last_lamports_per_signature == 0,

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -63,9 +63,10 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
+        let (_last_hash, last_lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
-            self.get_lamports_per_signature() == 0,
+            last_lamports_per_signature == 0,
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),


### PR DESCRIPTION
#### Problem

To reduce uses of bank's `fee_rate_governor`, eventually to #3303.

Theoretically `bank.fee_rate_governor` can have different value as `last_lamports_per_signature`, but the value will never flips between `zero` and `non-zero`, due to `feeRateGovernor::new_derived()` logic. Therefore it is safe and consistent to use last bank's `lamports_per_signature` for `zero-fee-for-test`.

#### Summary of Changes
- remove one call site to `bank.fee-rate-governor` to test if should set zero-fee for tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
