### PR TITLE
create genesis hash straight from genesis config

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2748,10 +2748,10 @@ impl Bank {
         #[cfg(feature = "dev-context-only-utils")]
         let genesis_hash = genesis_hash.unwrap_or(genesis_config.hash());
 
-        self.blockhash_queue
-            .write()
-            .unwrap()
-            .genesis_hash(&genesis_hash, genesis_config.fee_rate_governor.lamports_per_signature);
+        self.blockhash_queue.write().unwrap().genesis_hash(
+            &genesis_hash,
+            genesis_config.fee_rate_governor.lamports_per_signature,
+        );
 
         self.hashes_per_tick = genesis_config.hashes_per_tick();
         self.ticks_per_slot = genesis_config.ticks_per_slot();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2751,7 +2751,7 @@ impl Bank {
         self.blockhash_queue
             .write()
             .unwrap()
-            .genesis_hash(&genesis_hash, self.fee_rate_governor.lamports_per_signature);
+            .genesis_hash(&genesis_hash, genesis_config.fee_rate_governor.lamports_per_signature);
 
         self.hashes_per_tick = genesis_config.hashes_per_tick();
         self.ticks_per_slot = genesis_config.ticks_per_slot();


### PR DESCRIPTION
#### Problem

reduce usage of `bank.fee_rate_governor` to eventually remove it #3303 

#### Summary of Changes
- genesis_hash can be created directly from genesis_config, instead of bank.fee_rate_governor which is cloned from genesis_config

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
