### PR TITLE
Directly storing and propagating target_lamports_per_signature, ensuring the same zero-fee test behavior while simplifying fee tracking logic

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2750,7 +2750,9 @@ impl Bank {
 
         self.blockhash_queue.write().unwrap().genesis_hash(
             &genesis_hash,
-            genesis_config.fee_rate_governor.lamports_per_signature,
+            genesis_config
+                .fee_rate_governor
+                .target_lamports_per_signature,
         );
 
         self.hashes_per_tick = genesis_config.hashes_per_tick();
@@ -2990,6 +2992,9 @@ impl Bank {
         // consistent tx check_age handling.
         BankWithScheduler::wait_for_paused_scheduler(self, scheduler);
 
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
+
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.
@@ -3015,7 +3020,10 @@ impl Bank {
         #[cfg(feature = "dev-context-only-utils")]
         let blockhash = blockhash_override.as_ref().unwrap_or(blockhash);
 
-        w_blockhash_queue.register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
+        // lamports_per_signature stored in blockhash_queue is not used for fee calculation
+        // but only for determining zero_fees_for_test mode (lamports_per_signature == 0).
+        // Storing last_lamports_per_signature serves the same purpose.
+        w_blockhash_queue.register_hash(blockhash, last_lamports_per_signature);
         self.update_recent_blockhashes_locked(&w_blockhash_queue);
     }
 
@@ -3034,6 +3042,9 @@ impl Bank {
         blockhash: &Hash,
         lamports_per_signature: Option<u64>,
     ) {
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
+
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.
@@ -3041,8 +3052,7 @@ impl Bank {
         if let Some(lamports_per_signature) = lamports_per_signature {
             w_blockhash_queue.register_hash(blockhash, lamports_per_signature);
         } else {
-            w_blockhash_queue
-                .register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
+            w_blockhash_queue.register_hash(blockhash, last_lamports_per_signature);
         }
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2917,10 +2917,10 @@ fn test_bank_tx_compute_unit_fee() {
     );
 }
 
-#[test]
-fn test_bank_blockhash_fee_structure() {
-    //solana_logger::setup();
-
+#[test_case(0; "zero fees for tests")]
+#[test_case(10000; "default target lamports per signature")]
+#[test_case(1; "random non-zero target lamports per signature")]
+fn test_bank_transaction_fee(target_lamports_per_signature: u64) {
     let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
@@ -2929,115 +2929,46 @@ fn test_bank_blockhash_fee_structure() {
     } = create_genesis_config_with_leader(1_000_000, &leader, 3);
     genesis_config
         .fee_rate_governor
-        .target_lamports_per_signature = 5000;
-    genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
+        .target_lamports_per_signature = target_lamports_per_signature;
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
-    let cheap_blockhash = bank.last_blockhash();
-    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
-    assert_eq!(cheap_lamports_per_signature, 0);
+    let early_blockhash = bank.last_blockhash();
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
-    let expensive_blockhash = bank.last_blockhash();
-    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
-    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
+    let later_blockhash = bank.last_blockhash();
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
-    // Send a transfer using cheap_blockhash
-    let key = solana_pubkey::new_rand();
-    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
-    assert_eq!(bank.process_transaction(&tx), Ok(()));
-    assert_eq!(bank.get_balance(&key), 1);
-    let cheap_fee = calculate_test_fee(
+    // transaction fee for same transaction must be consistent bewteen block hashs; it is
+    // either `0` if set up for zero_fees_for_test, or a non-zeo fee.
+    let tx_fee = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        cheap_lamports_per_signature,
+        target_lamports_per_signature,
         bank.fee_structure(),
     );
-    assert_eq!(
-        bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - cheap_fee
-    );
 
-    // Send a transfer using expensive_blockhash
+    // Send a transfer using early_blockhash
     let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, early_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
-    let expensive_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        expensive_lamports_per_signature,
-        bank.fee_structure(),
-    );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - expensive_fee
+        initial_mint_balance - 1 - tx_fee
     );
-}
 
-#[test]
-fn test_bank_blockhash_compute_unit_fee_structure() {
-    //solana_logger::setup();
-
-    let leader = solana_pubkey::new_rand();
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(1_000_000_000, &leader, 3);
-    genesis_config
-        .fee_rate_governor
-        .target_lamports_per_signature = 1000;
-    genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    goto_end_of_slot(bank.clone());
-    let cheap_blockhash = bank.last_blockhash();
-    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
-    assert_eq!(cheap_lamports_per_signature, 0);
-
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
-    goto_end_of_slot(bank.clone());
-    let expensive_blockhash = bank.last_blockhash();
-    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
-    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
-
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
-
-    // Send a transfer using cheap_blockhash
+    // Send a transfer using later_blockhash
     let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, later_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
-    let cheap_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        cheap_lamports_per_signature,
-        bank.fee_structure(),
-    );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - cheap_fee
-    );
-
-    // Send a transfer using expensive_blockhash
-    let key = solana_pubkey::new_rand();
-    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
-    assert_eq!(bank.process_transaction(&tx), Ok(()));
-    assert_eq!(bank.get_balance(&key), 1);
-    let expensive_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        expensive_lamports_per_signature,
-        bank.fee_structure(),
-    );
-    assert_eq!(
-        bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - expensive_fee
+        initial_mint_balance - 1 - tx_fee
     );
 }
 
@@ -5784,7 +5715,12 @@ fn test_nonce_fee_calculator_updates() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    assert_ne!(stored_fee_calculator, fee_calculator);
+    // stored lamports_per_signature isn't used to calculate transaction fee, but to determine if
+    // zero_fees_for_test, only assess if the flag is same.
+    assert_eq!(
+        stored_fee_calculator.lamports_per_signature == 0,
+        fee_calculator.lamports_per_signature == 0
+    );
 }
 
 #[test]
@@ -5833,7 +5769,8 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
     );
     bank.process_transaction(&nonce_tx).unwrap();
 
-    // Grab the new hash and fee_calculator; both should be updated
+    // Grab the new hash and fee_calculator; hash shoudl be updated, and lamports_per_signature
+    // should remain same in respect to zero_fees_for_test
     let (nonce_hash, fee_calculator) = bank
         .get_account(&nonce_pubkey)
         .and_then(|acc| {
@@ -5848,7 +5785,10 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    assert_ne!(stored_fee_calculator, fee_calculator);
+    assert_eq!(
+        stored_fee_calculator.lamports_per_signature == 0,
+        fee_calculator.lamports_per_signature == 0
+    );
 }
 
 #[test]
@@ -6527,26 +6467,27 @@ fn test_bank_hash_consistency() {
         if bank.slot == 0 {
             assert_eq!(
                 bank.hash().to_string(),
-                "Hn2FoJuoFWXVFVnwcQ6peuT24mUPmhDtXHXVjKD7M4yP",
+                "2ggpD1h3XTdGnYYQUdsZxMmXzpvcNBjahPHWyvL2QdsS",
             );
         }
 
         if bank.slot == 32 {
             assert_eq!(
                 bank.hash().to_string(),
-                "Hdrk5wqzRZbofSgZMC3ztfNimrFu6DeYp751JWvtabo"
+                "GhNtDfGcKTN1h1aTE13y2Xg4c6ojLUubyiyUYeLkJVR8"
             );
         }
+
         if bank.slot == 64 {
             assert_eq!(
                 bank.hash().to_string(),
-                "4EcAFkTxymwwPGeCgadhkrkg2hqfAPzuQZoN2NFqPzyg"
+                "J8mmPaZyBp4ckfdbLr8RWzYBaXj6n2WV9z6S7nYU2PhD"
             );
         }
         if bank.slot == 128 {
             assert_eq!(
                 bank.hash().to_string(),
-                "4BK3VANr5mhyRyrwbUHYb2kmM5m76PBGkhmKMrQ2aq7L"
+                "E2ueZJ73FbM6eE7MwPzk2TxkJiHTVQnv5t4Q44KmUm3v"
             );
             break;
         }


### PR DESCRIPTION
#### Problem

##### Understanding `lamports_per_signature` in blockhash_queue

The `lamports_per_signature` value stored in `blockhash_queue` (and also in nonce accounts) is not used for transaction fee calculation. Instead, transaction fees are determined by `bank.fee_structure.lamport_per_signature`, which is a constant `5_000`.

The primary function of `lamports_per_signature` in the `blockhash_queue` is to enable the `zero_fees_for_test` mode—this happens when its value is set to zero.

In tests, "zero-fee" mode is expressed by setting target_lamports_per_signature = 0 in `genesis_config` ([reference](https://github.com/anza-xyz/agave/blob/master/runtime/src/genesis_utils.rs#L126)).

##### Current Behavior of `fee_rate_governor` in `Bank` wrt blockhash_queue

The bank currently uses `fee_rate_governor` to adjust `lamports_per_signature` dynamically for each block based on cluster throughput. This adjustment stays within 50% to 1000% of target_lamports_per_signature.

A key property of fee_rate_governor's adjustment is:

- If `target_lamports_per_signature` is zero, then all future banks will have `lamports_per_signature = 0`.
- Otherwise, lamports_per_signature will never be zero.

Tests rely on this behavior to ensure zero transaction fees in specific scenarios.

##### Proposed Change

The current logic of deriving `fee_rate_governor` from the parent bank and storing it with blockhash to determine if `lamports_per_signature == 0` is unnecessary. Instead, we can:

- Store the `target_lamports_per_signature` from genesis_config in the blockhash, when creating genesis bank;
- Copy `lamports_per_signature` from the parent bank when deriving a new bank.

This preserves the existing behavior while simplifying fee tracking and allowing the eventual removal of `fee_rate_governor` (#3303).

#### Summary of Changes
- Clarify that `lamports_per_signature` in blockhash_queue and nonce_account is not used for fee calculation but only for determining zero_fees_for_test mode (lamports_per_signature == 0).
- When creating a bank from genesis_config, store its `target_lamports_per_signature` in the blockhash.
- For non-genesis banks, copy the parent's lamports_per_signature into the blockhash queue.
- Update tests accordingly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
