### PR TITLE
Add counter to track mmap open files and rename existing counter

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -237,12 +237,17 @@ impl LatestAccountsIndexRootsStats {
             ),
             (
                 "append_vecs_open",
-                APPEND_VEC_STATS.mmap_files_open.load(Ordering::Relaxed),
+                APPEND_VEC_STATS.files_open.load(Ordering::Relaxed),
                 i64
             ),
             (
                 "append_vecs_dirty",
                 APPEND_VEC_STATS.mmap_files_dirty.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "append_vecs_open_as_mmap",
+                APPEND_VEC_STATS.open_as_mmap.load(Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -308,11 +308,12 @@ lazy_static! {
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
-        APPEND_VEC_STATS
-            .mmap_files_open
-            .fetch_sub(1, Ordering::Relaxed);
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap_only) => {
+                APPEND_VEC_STATS
+                    .mmap_files_open
+                    .fetch_sub(1, Ordering::Relaxed);
+
                 if mmap_only.is_dirty.load(Ordering::Acquire) {
                     APPEND_VEC_STATS
                         .mmap_files_dirty
@@ -539,9 +540,6 @@ impl AppendVec {
         #[cfg(unix)]
         // we must use mmap on non-linux
         if storage_access == StorageAccess::File {
-            APPEND_VEC_STATS
-                .mmap_files_open
-                .fetch_add(1, Ordering::Relaxed);
             APPEND_VEC_STATS
                 .open_as_file_io
                 .fetch_add(1, Ordering::Relaxed);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -293,25 +293,29 @@ const fn page_align(size: u64) -> u64 {
 const SCAN_BUFFER_SIZE_WITHOUT_DATA: usize = 1 << 16;
 
 pub struct AppendVecStat {
-    pub mmap_files_open: AtomicU64,
+    pub open_as_mmap: AtomicU64,
     pub mmap_files_dirty: AtomicU64,
     pub open_as_file_io: AtomicU64,
+    pub files_open: AtomicU64,
 }
 
 lazy_static! {
     pub static ref APPEND_VEC_STATS: AppendVecStat = AppendVecStat {
-        mmap_files_open: AtomicU64::new(0),
+        open_as_mmap: AtomicU64::new(0),
         mmap_files_dirty: AtomicU64::new(0),
         open_as_file_io: AtomicU64::new(0),
+        files_open: AtomicU64::new(0),
     };
 }
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
+        APPEND_VEC_STATS.files_open.fetch_sub(1, Ordering::Relaxed);
+
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap_only) => {
                 APPEND_VEC_STATS
-                    .mmap_files_open
+                    .open_as_mmap
                     .fetch_sub(1, Ordering::Relaxed);
 
                 if mmap_only.is_dirty.load(Ordering::Acquire) {
@@ -384,8 +388,10 @@ impl AppendVec {
             );
             std::process::exit(1);
         });
+        APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
+
         APPEND_VEC_STATS
-            .mmap_files_open
+            .open_as_mmap
             .fetch_add(1, Ordering::Relaxed);
 
         AppendVec {
@@ -540,6 +546,8 @@ impl AppendVec {
         #[cfg(unix)]
         // we must use mmap on non-linux
         if storage_access == StorageAccess::File {
+            APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
+
             APPEND_VEC_STATS
                 .open_as_file_io
                 .fetch_add(1, Ordering::Relaxed);
@@ -562,8 +570,11 @@ impl AppendVec {
             }
             result?
         };
+
+        APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
+
         APPEND_VEC_STATS
-            .mmap_files_open
+            .open_as_mmap
             .fetch_add(1, Ordering::Relaxed);
 
         Ok(AppendVec {


### PR DESCRIPTION
#### Problem
File open MMAP counter includes files that are not mmapped. 

#### Summary of Changes
Fix counter to to accurately track mmaped files. 

Other option considered was changing the name of the counter to reflect that it was all opened files in append vecs. I like this method more because it makes it easier to track dirty mmapped files relatively to open. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
