### PR TITLE
ci: use exec in ci/docker-run-default-image.sh

### DIFF
--- a/ci/docker-run-default-image.sh
+++ b/ci/docker-run-default-image.sh
@@ -7,4 +7,4 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$here/docker/env.sh"
 
-"$here/docker-run.sh" "${CI_DOCKER_IMAGE:?}" "$@"
+exec "$here/docker-run.sh" "${CI_DOCKER_IMAGE:?}" "$@"


### PR DESCRIPTION
#### Problem

I don't handle the SIGTERM correctly

#### Summary of Changes

use exec to pass the signal
