### PR TITLE
Refactor - CLI program-v4

### DIFF
--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -12,7 +12,7 @@ use {
     serde_derive::{Deserialize, Serialize},
     serde_json::from_slice,
     sha2::{Digest, Sha256},
-    solana_cli::program_v4::{process_deploy_program, process_dump},
+    solana_cli::program_v4::{process_deploy_program, process_dump, AdditionalCliConfig},
     solana_keypair::Keypair,
     solana_pubkey::Pubkey,
     solana_signer::{EncodableKey, Signer},
@@ -126,13 +126,12 @@ impl Program {
         process_deploy_program(
             client.rpc_client.clone(),
             &client.get_cli_config(),
+            &AdditionalCliConfig::default(),
             &client.authority_signer_index,
             &signer.pubkey(),
             &program_data,
             None..None,
             Some(signer),
-            false,
-            None,
         )
         .map_err(|e| {
             error!("Failed to deploy the program: {}", e);

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -107,6 +107,8 @@ impl Program {
         if self.id != signer.pubkey() {
             return Err("Signer doesn't match program ID".into());
         }
+        let mut cli_config = client.get_cli_config();
+        cli_config.signers.push(signer);
 
         let mut file = fs::File::open(&self.path)
             .map_err(|err| format!("Unable to open program file: {err}"))?;
@@ -125,13 +127,13 @@ impl Program {
 
         process_deploy_program(
             client.rpc_client.clone(),
-            &client.get_cli_config(),
+            &cli_config,
             &AdditionalCliConfig::default(),
             &client.authority_signer_index,
             &signer.pubkey(),
             &program_data,
             None..None,
-            Some(signer),
+            Some(&2),
         )
         .map_err(|e| {
             error!("Failed to deploy the program: {}", e);

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -793,13 +793,11 @@ pub fn process_deploy_program(
         final_messages,
         buffer_signer,
         lamports_required.saturating_sub(existing_lamports),
-    )?;
-
-    let program_id = CliProgramId {
-        program_id: program_address.to_string(),
-        signature: None,
-    };
-    Ok(config.output_format.formatted_string(&program_id))
+        config.output_format.formatted_string(&CliProgramId {
+            program_id: program_address.to_string(),
+            signature: None,
+        }),
+    )
 }
 
 fn process_close_program(
@@ -841,13 +839,11 @@ fn process_close_program(
         Vec::default(),
         None,
         0,
-    )?;
-
-    let program_id = CliProgramId {
-        program_id: program_address.to_string(),
-        signature: None,
-    };
-    Ok(config.output_format.formatted_string(&program_id))
+        config.output_format.formatted_string(&CliProgramId {
+            program_id: program_address.to_string(),
+            signature: None,
+        }),
+    )
 }
 
 fn process_transfer_authority_of_program(
@@ -876,13 +872,11 @@ fn process_transfer_authority_of_program(
         Vec::default(),
         None,
         0,
-    )?;
-
-    let program_id = CliProgramId {
-        program_id: program_address.to_string(),
-        signature: None,
-    };
-    Ok(config.output_format.formatted_string(&program_id))
+        config.output_format.formatted_string(&CliProgramId {
+            program_id: program_address.to_string(),
+            signature: None,
+        }),
+    )
 }
 
 fn process_finalize_program(
@@ -911,13 +905,11 @@ fn process_finalize_program(
         Vec::default(),
         None,
         0,
-    )?;
-
-    let program_id = CliProgramId {
-        program_id: program_address.to_string(),
-        signature: None,
-    };
-    Ok(config.output_format.formatted_string(&program_id))
+        config.output_format.formatted_string(&CliProgramId {
+            program_id: program_address.to_string(),
+            signature: None,
+        }),
+    )
 }
 
 fn process_show(
@@ -992,6 +984,7 @@ pub fn process_dump(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn send_messages(
     rpc_client: Arc<RpcClient>,
     config: &CliConfig,
@@ -1002,7 +995,8 @@ fn send_messages(
     final_messages: Vec<Vec<Instruction>>,
     program_signer: Option<&dyn Signer>,
     balance_needed: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
+    ok_result: String,
+) -> ProcessResult {
     let payer_pubkey = config.signers[0].pubkey();
     let blockhash = rpc_client.get_latest_blockhash()?;
     let compute_unit_config = ComputeUnitConfig {
@@ -1149,7 +1143,7 @@ fn send_messages(
         )?;
     }
 
-    Ok(())
+    Ok(ok_result)
 }
 
 fn build_retract_instruction(


### PR DESCRIPTION
#### Problem
Preparation to support two step deployment and offline signing, split off from #5195.

#### Summary of Changes
- Refactors code to have all blockhash and simulation related code closer to the signing.
- Fixes a bug where `use_rpc` was defaulted to `true`, even though it should be `false`.
- Fixes the required lamports check on deployments (but not on redeployments).