### PR TITLE
enable retries in nextest

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -4,6 +4,7 @@ dir = "target/nextest"
 [profile.ci]
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
+retries = { backoff = "exponential", count = 3, delay = "5s" }
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/nextest.toml
+++ b/nextest.toml
@@ -4,7 +4,7 @@ dir = "target/nextest"
 [profile.ci]
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
-retries = { backoff = "exponential", count = 3, delay = "5s" }
+retries = { count = 3 }
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
#### Problem
retries for one flaky test restart entire test batch that takes 15 min

#### Summary of Changes

add retries inside nextest runs. This means when one test flakes we do not need to restart the entire partition immediately.