### PR TITLE
Clarify bank's private calculate_fee function

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6902,6 +6902,9 @@ impl TransactionProcessingCallback for Bank {
             .unwrap_or(0)
     }
 
+    // Overrides default TransactionProcessingCallback::calculate_fee() to calculate actual transaction fee;
+    // Checking for `zero_fees_for_test` is done at callsite (eg. transaction_processor) where blockhash_queue's
+    // lamports_per_siganture is checked ` == 0`.
     fn calculate_fee(
         &self,
         message: &impl SVMMessage,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6904,7 +6904,7 @@ impl TransactionProcessingCallback for Bank {
 
     // Overrides default TransactionProcessingCallback::calculate_fee() to calculate actual transaction fee;
     // Checking for `zero_fees_for_test` is done at callsite (eg. transaction_processor) where blockhash_queue's
-    // lamports_per_siganture is checked ` == 0`.
+    // lamports_per_signature is checked ` == 0`.
     fn calculate_fee(
         &self,
         message: &impl SVMMessage,


### PR DESCRIPTION
#### Problem

The private calculate_fee function seems to be a step towards to remove `zero_fees_for_test` flag, it's usage is not obvious to me at first glance. 

#### Summary of Changes
- add comment

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
