### PR TITLE
rpc: Store total transaction costs

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -817,6 +817,7 @@ mod test {
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(1234u64),
+            cost_units: Some(5678),
         };
 
         let output = {
@@ -896,6 +897,7 @@ Rewards:
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(2345u64),
+            cost_units: Some(5678),
         };
 
         let output = {

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -1,6 +1,7 @@
 use {
     super::leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
     itertools::Itertools,
+    solana_cost_model::cost_model::CostModel,
     solana_ledger::{
         blockstore_processor::TransactionStatusSender, token_balances::collect_token_balances,
     },
@@ -133,29 +134,45 @@ impl Committer {
         starting_transaction_index: Option<usize>,
     ) {
         if let Some(transaction_status_sender) = &self.transaction_status_sender {
+            let sanitized_transactions = batch.sanitized_transactions();
+
             // Clone `SanitizedTransaction` out of `RuntimeTransaction`, this is
             // done to send over the status sender.
-            let txs = batch
-                .sanitized_transactions()
+            let txs = sanitized_transactions
                 .iter()
                 .map(|tx| tx.as_sanitized_transaction().into_owned())
                 .collect_vec();
+
             let post_balances = bank.collect_balances(batch);
             let post_token_balances =
                 collect_token_balances(bank, batch, &mut pre_balance_info.mint_decimals);
+
             let mut transaction_index = starting_transaction_index.unwrap_or_default();
-            let batch_transaction_indexes: Vec<_> = commit_results
+            let (batch_transaction_indexes, tx_costs): (Vec<_>, Vec<_>) = commit_results
                 .iter()
-                .map(|commit_result| {
-                    if commit_result.was_committed() {
+                .zip(sanitized_transactions.iter())
+                .map(|(commit_result, tx)| {
+                    if let Ok(committed_tx) = commit_result {
                         let this_transaction_index = transaction_index;
                         saturating_add_assign!(transaction_index, 1);
-                        this_transaction_index
+
+                        let tx_cost = Some(
+                            CostModel::calculate_cost_for_executed_transaction(
+                                tx,
+                                committed_tx.executed_units,
+                                committed_tx.loaded_account_stats.loaded_accounts_data_size,
+                                &bank.feature_set,
+                            )
+                            .sum(),
+                        );
+
+                        (this_transaction_index, tx_cost)
                     } else {
-                        0
+                        (0, Some(0))
                     }
                 })
-                .collect();
+                .unzip();
+
             transaction_status_sender.send_transaction_status_batch(
                 bank.slot(),
                 txs,
@@ -168,7 +185,7 @@ impl Committer {
                     std::mem::take(&mut pre_balance_info.token),
                     post_token_balances,
                 ),
-                vec![], // TODO: get actual costs here
+                tx_costs,
                 batch_transaction_indexes,
             );
         }

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -156,6 +156,7 @@ impl Committer {
                     }
                 })
                 .collect();
+            // TODO: pass costs along here
             transaction_status_sender.send_transaction_status_batch(
                 bank.slot(),
                 txs,

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -156,7 +156,6 @@ impl Committer {
                     }
                 })
                 .collect();
-            // TODO: pass costs along here
             transaction_status_sender.send_transaction_status_batch(
                 bank.slot(),
                 txs,
@@ -169,6 +168,7 @@ impl Committer {
                     std::mem::take(&mut pre_balance_info.token),
                     post_token_balances,
                 ),
+                vec![], // TODO: get actual costs here
                 batch_transaction_indexes,
             );
         }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1700,7 +1700,26 @@ mod tests {
         );
         let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
 
-        let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()]);
+        let consumer_output =
+            consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()]);
+        let CommitTransactionDetails::Committed {
+            compute_units,
+            loaded_accounts_data_size,
+        } = consumer_output
+            .execute_and_commit_transactions_output
+            .commit_transactions_result
+            .unwrap()
+            .pop()
+            .unwrap()
+        else {
+            panic!("The transaction was not commited");
+        };
+        let tx_cost = CostModel::calculate_cost_for_executed_transaction(
+            &sanitized_tx,
+            compute_units,
+            loaded_accounts_data_size,
+            &bank.feature_set,
+        );
 
         drop(consumer); // drop/disconnect transaction_status_sender
 
@@ -1721,6 +1740,7 @@ mod tests {
                 rewards: Some(vec![]),
                 loaded_addresses: sanitized_tx.get_loaded_addresses(),
                 compute_units_consumed: Some(0),
+                cost_units: Some(tx_cost.sum()),
                 ..TransactionStatusMeta::default()
             }
         );

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8145,6 +8145,7 @@ pub mod tests {
                     post_balances.push(i as u64 * 11);
                 }
                 let compute_units_consumed = Some(12345);
+                let cost_units = Some(6789);
                 let signature = transaction.signatures[0];
                 let status = TransactionStatusMeta {
                     status: Ok(()),
@@ -8159,6 +8160,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
+                    cost_units,
                 }
                 .into();
                 blockstore
@@ -8178,6 +8180,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
+                    cost_units,
                 }
                 .into();
                 blockstore
@@ -8197,6 +8200,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
+                    cost_units,
                 }
                 .into();
                 blockstore
@@ -8218,6 +8222,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data: Some(TransactionReturnData::default()),
                         compute_units_consumed,
+                        cost_units,
                     },
                 }
             })
@@ -8341,7 +8346,9 @@ pub mod tests {
             data: vec![1, 2, 3],
         };
         let compute_units_consumed_1 = Some(3812649u64);
+        let cost_units_1 = Some(1234);
         let compute_units_consumed_2 = Some(42u64);
+        let cost_units_2 = Some(5678);
 
         // result not found
         assert!(transaction_status_cf
@@ -8363,6 +8370,7 @@ pub mod tests {
             loaded_addresses: test_loaded_addresses.clone(),
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_1,
+            cost_units: cost_units_1,
         }
         .into();
         assert!(transaction_status_cf
@@ -8383,6 +8391,7 @@ pub mod tests {
             loaded_addresses,
             return_data,
             compute_units_consumed,
+            cost_units,
         } = transaction_status_cf
             .get_protobuf((Signature::default(), 0))
             .unwrap()
@@ -8401,6 +8410,7 @@ pub mod tests {
         assert_eq!(loaded_addresses, test_loaded_addresses);
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_1);
+        assert_eq!(cost_units, cost_units_1);
 
         // insert value
         let status = TransactionStatusMeta {
@@ -8416,6 +8426,7 @@ pub mod tests {
             loaded_addresses: test_loaded_addresses.clone(),
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_2,
+            cost_units: cost_units_2,
         }
         .into();
         assert!(transaction_status_cf
@@ -8436,6 +8447,7 @@ pub mod tests {
             loaded_addresses,
             return_data,
             compute_units_consumed,
+            cost_units,
         } = transaction_status_cf
             .get_protobuf((Signature::from([2u8; 64]), 9))
             .unwrap()
@@ -8456,6 +8468,7 @@ pub mod tests {
         assert_eq!(loaded_addresses, test_loaded_addresses);
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_2);
+        assert_eq!(cost_units, cost_units_2);
     }
 
     #[test]
@@ -8552,6 +8565,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
+            cost_units: Some(1234),
         }
         .into();
 
@@ -8728,6 +8742,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
+            cost_units: Some(1234),
         }
         .into();
 
@@ -8855,6 +8870,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
+            cost_units: Some(1234),
         }
         .into();
 
@@ -9024,6 +9040,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42),
+                    cost_units: Some(1234),
                 }
                 .into();
                 blockstore
@@ -9045,6 +9062,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data,
                         compute_units_consumed: Some(42),
+                        cost_units: Some(1234),
                     },
                 }
             })
@@ -9146,6 +9164,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42u64),
+                    cost_units: Some(1234),
                 }
                 .into();
                 blockstore
@@ -9167,6 +9186,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data,
                         compute_units_consumed: Some(42u64),
+                        cost_units: Some(1234),
                     },
                 }
             })
@@ -9843,6 +9863,7 @@ pub mod tests {
                 loaded_addresses: LoadedAddresses::default(),
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: None,
+                cost_units: None,
             }
             .into();
             transaction_status_cf
@@ -10649,6 +10670,7 @@ pub mod tests {
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(23456),
+            cost_units: Some(5678),
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -18,7 +18,7 @@ use {
         accounts_db::AccountsDbConfig, accounts_update_notifier_interface::AccountsUpdateNotifier,
         epoch_accounts_hash::EpochAccountsHash,
     },
-    solana_cost_model::cost_model::CostModel,
+    solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::entry::{
         self, create_ticks, Entry, EntrySlice, EntryType, EntryVerificationStatus, VerifyRecyclers,
     },
@@ -176,12 +176,12 @@ pub fn execute_batch<'a>(
     //   Some(_) => unified scheduler block production path
     //   None    => block verification path(s)
     let block_verification = extra_pre_commit_callback.is_none();
-    let record_token_balances = transaction_status_sender.is_some();
+    let record_transaction_meta = transaction_status_sender.is_some();
 
     let mut transaction_indexes = Cow::from(transaction_indexes);
     let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
 
-    let pre_token_balances = if record_token_balances {
+    let pre_token_balances = if record_transaction_meta {
         collect_token_balances(bank, batch, &mut mint_decimals)
     } else {
         vec![]
@@ -234,9 +234,31 @@ pub fn execute_batch<'a>(
             pre_commit_callback,
         )?;
 
-    if block_verification {
-        check_block_cost_limits_with_timing(batch, bank, timings, &commit_results)?;
-    }
+    let mut check_block_costs_elapsed = Measure::start("check_block_costs");
+    let tx_costs = if block_verification {
+        // Block verification (including unified scheduler) case;
+        // collect and check transaction costs
+        let tx_costs = get_transaction_costs(bank, &commit_results, batch.sanitized_transactions());
+        check_block_cost_limits(bank, &tx_costs).map(|_| tx_costs)
+    } else {
+        // Unified scheduler block production case;
+        // collect transaction costs if we are recording transaction metadata
+        if record_transaction_meta {
+            Ok(get_transaction_costs(
+                bank,
+                &commit_results,
+                batch.sanitized_transactions(),
+            ))
+        } else {
+            Ok(vec![])
+        }
+    };
+    check_block_costs_elapsed.stop();
+    timings.saturating_add_in_place(
+        ExecuteTimingType::CheckBlockLimitsUs,
+        check_block_costs_elapsed.as_us(),
+    );
+    let tx_costs = tx_costs?;
 
     bank_utils::find_and_send_votes(
         batch.sanitized_transactions(),
@@ -256,7 +278,7 @@ pub fn execute_batch<'a>(
             .iter()
             .map(|tx| tx.as_sanitized_transaction().into_owned())
             .collect();
-        let post_token_balances = if record_token_balances {
+        let post_token_balances = if record_transaction_meta {
             collect_token_balances(bank, batch, &mut mint_decimals)
         } else {
             vec![]
@@ -265,13 +287,21 @@ pub fn execute_batch<'a>(
         let token_balances =
             TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
 
-        // TODO: pass costs along here
+        // The length of costs vector needs to be consistent with all other
+        // vectors that are sent over (such as `transactions`). So, replace the
+        // None elements with Some(0)
+        let tx_costs = tx_costs
+            .into_iter()
+            .map(|tx_cost_option| tx_cost_option.map(|tx_cost| tx_cost.sum()).or(Some(0)))
+            .collect();
+
         transaction_status_sender.send_transaction_status_batch(
             bank.slot(),
             transactions,
             commit_results,
             balances,
             token_balances,
+            tx_costs,
             transaction_indexes.into_owned(),
         );
     }
@@ -279,20 +309,18 @@ pub fn execute_batch<'a>(
     Ok(())
 }
 
-// collect transactions actual execution costs, subject to block limits;
-// block will be marked as dead if exceeds cost limits, details will be
-// reported to metric `replay-stage-mark_dead_slot`
-fn check_block_cost_limits(
+// Get actual transaction execution costs from transaction commit results
+fn get_transaction_costs<'a, Tx: TransactionWithMeta>(
     bank: &Bank,
     commit_results: &[TransactionCommitResult],
-    sanitized_transactions: &[impl TransactionWithMeta],
-) -> Result<()> {
+    sanitized_transactions: &'a [Tx],
+) -> Vec<Option<TransactionCost<'a, Tx>>> {
     assert_eq!(sanitized_transactions.len(), commit_results.len());
 
-    let tx_costs_with_actual_execution_units: Vec<_> = commit_results
+    commit_results
         .iter()
         .zip(sanitized_transactions)
-        .filter_map(|(commit_result, tx)| {
+        .map(|(commit_result, tx)| {
             if let Ok(committed_tx) = commit_result {
                 Some(CostModel::calculate_cost_for_executed_transaction(
                     tx,
@@ -304,34 +332,21 @@ fn check_block_cost_limits(
                 None
             }
         })
-        .collect();
-
-    {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        for tx_cost in &tx_costs_with_actual_execution_units {
-            cost_tracker
-                .try_add(tx_cost)
-                .map_err(TransactionError::from)?;
-        }
-    }
-    Ok(())
+        .collect()
 }
 
-fn check_block_cost_limits_with_timing(
-    batch: &TransactionBatch<impl TransactionWithMeta>,
+fn check_block_cost_limits<Tx: TransactionWithMeta>(
     bank: &Bank,
-    timings: &mut ExecuteTimings,
-    commit_results: &[TransactionCommitResult],
+    tx_costs: &[Option<TransactionCost<'_, Tx>>],
 ) -> Result<()> {
-    let (check_block_cost_limits_result, check_block_cost_limits_us) = measure_us!(
-        check_block_cost_limits(bank, commit_results, batch.sanitized_transactions())
-    );
+    let mut cost_tracker = bank.write_cost_tracker().unwrap();
+    for tx_cost in tx_costs.iter().flatten() {
+        cost_tracker
+            .try_add(tx_cost)
+            .map_err(TransactionError::from)?;
+    }
 
-    timings.saturating_add_in_place(
-        ExecuteTimingType::CheckBlockLimitsUs,
-        check_block_cost_limits_us,
-    );
-    check_block_cost_limits_result
+    Ok(())
 }
 
 #[derive(Default)]
@@ -2211,6 +2226,7 @@ pub struct TransactionStatusBatch {
     pub commit_results: Vec<TransactionCommitResult>,
     pub balances: TransactionBalancesSet,
     pub token_balances: TransactionTokenBalancesSet,
+    pub costs: Vec<Option<u64>>,
     pub transaction_indexes: Vec<usize>,
 }
 
@@ -2227,6 +2243,7 @@ impl TransactionStatusSender {
         commit_results: Vec<TransactionCommitResult>,
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
+        costs: Vec<Option<u64>>,
         transaction_indexes: Vec<usize>,
     ) {
         if let Err(e) = self
@@ -2237,6 +2254,7 @@ impl TransactionStatusSender {
                 commit_results,
                 balances,
                 token_balances,
+                costs,
                 transaction_indexes,
             }))
         {
@@ -2330,23 +2348,17 @@ pub mod tests {
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             epoch_schedule::EpochSchedule,
-            fee::FeeDetails,
             hash::Hash,
             instruction::{Instruction, InstructionError},
             native_token::LAMPORTS_PER_SOL,
             pubkey::Pubkey,
-            rent_debits::RentDebits,
             signature::{Keypair, Signer},
             signer::SeedDerivable,
             system_instruction::SystemError,
             system_transaction,
             transaction::{Transaction, TransactionError},
         },
-        solana_svm::{
-            transaction_commit_result::CommittedTransaction,
-            transaction_execution_result::TransactionLoadedAccountsStats,
-            transaction_processor::ExecutionRecordingConfig,
-        },
+        solana_svm::transaction_processor::ExecutionRecordingConfig,
         solana_vote::{vote_account::VoteAccount, vote_transaction},
         solana_vote_program::{
             self,
@@ -5313,32 +5325,19 @@ pub mod tests {
             );
         // set block-limit to be able to just have one transaction
         let block_limit = tx_cost.sum();
-
         bank.write_cost_tracker()
             .unwrap()
             .set_limits(u64::MAX, block_limit, u64::MAX);
-        let txs = vec![tx.clone(), tx];
-        let commit_results = vec![
-            Ok(CommittedTransaction {
-                status: Ok(()),
-                log_messages: None,
-                inner_instructions: None,
-                return_data: None,
-                executed_units: actual_execution_cu,
-                fee_details: FeeDetails::default(),
-                rent_debits: RentDebits::default(),
-                loaded_account_stats: TransactionLoadedAccountsStats {
-                    loaded_accounts_data_size: actual_loaded_accounts_data_size,
-                    loaded_accounts_count: 2,
-                },
-            }),
-            Err(TransactionError::AccountNotFound),
-        ];
 
-        assert!(check_block_cost_limits(&bank, &commit_results, &txs).is_ok());
+        let tx_costs = vec![None, Some(tx_cost), None];
+        // The transaction will fit when added the first time
+        assert!(check_block_cost_limits(&bank, &tx_costs).is_ok());
+        // But adding a second time will exceed the block limit
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
-            check_block_cost_limits(&bank, &commit_results, &txs)
+            check_block_cost_limits(&bank, &tx_costs)
         );
+        // Adding another None will noop (even though the block is already full)
+        assert!(check_block_cost_limits(&bank, &tx_costs[0..1]).is_ok());
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -240,18 +240,18 @@ pub fn execute_batch<'a>(
         // collect and check transaction costs
         let tx_costs = get_transaction_costs(bank, &commit_results, batch.sanitized_transactions());
         check_block_cost_limits(bank, &tx_costs).map(|_| tx_costs)
-    } else {
+    } else if record_transaction_meta {
         // Unified scheduler block production case;
-        // collect transaction costs if we are recording transaction metadata
-        if record_transaction_meta {
-            Ok(get_transaction_costs(
-                bank,
-                &commit_results,
-                batch.sanitized_transactions(),
-            ))
-        } else {
-            Ok(vec![])
-        }
+        // the scheduler will track costs elsewhere but costs are recalculated
+        // here so they can be recorded with other transaction metadata
+        Ok(get_transaction_costs(
+            bank,
+            &commit_results,
+            batch.sanitized_transactions(),
+        ))
+    } else {
+        // Unified scheduler block production wihout metadata recording
+        Ok(vec![])
     };
     check_block_costs_elapsed.stop();
     timings.saturating_add_in_place(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -265,6 +265,7 @@ pub fn execute_batch<'a>(
         let token_balances =
             TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances);
 
+        // TODO: pass costs along here
         transaction_status_sender.send_transaction_status_batch(
             bank.slot(),
             transactions,

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -199,6 +199,7 @@ impl RpcSender for MockSender {
                             loaded_addresses: OptionSerializer::Skip,
                             return_data: OptionSerializer::Skip,
                             compute_units_consumed: OptionSerializer::Skip,
+                            cost_units: OptionSerializer::Skip,
                         }),
                 },
                 block_time: Some(1628633791),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -176,6 +176,8 @@ impl TransactionStatusService {
                         loaded_addresses,
                         return_data,
                         compute_units_consumed: Some(executed_units),
+                        // TODO: populate me later
+                        cost_units: None,
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -107,6 +107,7 @@ impl TransactionStatusService {
                 commit_results,
                 balances,
                 token_balances,
+                costs,
                 transaction_indexes,
             }) => {
                 let mut status_and_memos_batch = blockstore.get_write_batch()?;
@@ -118,6 +119,7 @@ impl TransactionStatusService {
                     post_balances,
                     pre_token_balances,
                     post_token_balances,
+                    cost,
                     transaction_index,
                 ) in izip!(
                     transactions,
@@ -126,6 +128,7 @@ impl TransactionStatusService {
                     balances.post_balances,
                     token_balances.pre_token_balances,
                     token_balances.post_token_balances,
+                    costs,
                     transaction_indexes,
                 ) {
                     let Ok(committed_tx) = commit_result else {
@@ -176,8 +179,7 @@ impl TransactionStatusService {
                         loaded_addresses,
                         return_data,
                         compute_units_consumed: Some(executed_units),
-                        // TODO: populate me later
-                        cost_units: None,
+                        cost_units: cost,
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
@@ -440,6 +442,7 @@ pub(crate) mod tests {
             commit_results: vec![commit_result],
             balances,
             token_balances,
+            costs: vec![Some(123)],
             transaction_indexes: vec![transaction_index],
         };
 
@@ -543,6 +546,7 @@ pub(crate) mod tests {
             commit_results: vec![commit_result.clone(), commit_result],
             balances: balances.clone(),
             token_balances,
+            costs: vec![Some(123), Some(456)],
             transaction_indexes: vec![transaction_index1, transaction_index2],
         };
 

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1025,6 +1025,7 @@ mod tests {
                 loaded_addresses: LoadedAddresses::default(),
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: Some(1234),
+                cost_units: Some(5678),
             },
         });
         let expected_block = ConfirmedBlock {
@@ -1085,6 +1086,7 @@ mod tests {
                 meta.rewards = None; // Legacy bincode implementation does not support rewards
                 meta.return_data = None; // Legacy bincode implementation does not support return data
                 meta.compute_units_consumed = None; // Legacy bincode implementation does not support CU consumed
+                meta.cost_units = None; // Legacy bincode implementation does not support CU
             }
             assert_eq!(block, bincode_block.into());
         } else {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -257,6 +257,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data: None,
             compute_units_consumed: None,
+            cost_units: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -65,6 +65,8 @@ message TransactionStatusMeta {
     // Available since Solana v1.10.35 / v1.11.6.
     // Set to `None` for txs executed on earlier versions.
     optional uint64 compute_units_consumed = 16;
+    // Total transaction cost
+    optional uint64 cost_units = 17;
 }
 
 message TransactionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -407,6 +407,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
+            cost_units,
         } = value;
         let err = match status {
             Ok(()) => None,
@@ -467,6 +468,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data,
             return_data_none,
             compute_units_consumed,
+            cost_units,
         }
     }
 }
@@ -499,6 +501,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             return_data_none,
             compute_units_consumed,
+            cost_units,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -568,6 +571,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
+            cost_units,
         })
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -178,6 +178,8 @@ pub struct StoredTransactionStatusMeta {
     pub return_data: Option<TransactionReturnData>,
     #[serde(deserialize_with = "default_on_eof")]
     pub compute_units_consumed: Option<u64>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub cost_units: Option<u64>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -194,6 +196,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             rewards,
             return_data,
             compute_units_consumed,
+            cost_units,
         } = value;
         Self {
             status,
@@ -211,6 +214,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data,
             compute_units_consumed,
+            cost_units,
         }
     }
 }
@@ -231,6 +235,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
+            cost_units,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -256,6 +261,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
                 .map(|rewards| rewards.into_iter().map(|reward| reward.into()).collect()),
             return_data,
             compute_units_consumed,
+            cost_units,
         })
     }
 }

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -275,6 +275,11 @@ pub struct UiTransactionStatusMeta {
         skip_serializing_if = "OptionSerializer::should_skip"
     )]
     pub compute_units_consumed: OptionSerializer<u64>,
+    #[serde(
+        default = "OptionSerializer::skip",
+        skip_serializing_if = "OptionSerializer::should_skip"
+    )]
+    pub cost_units: OptionSerializer<u64>,
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
@@ -304,6 +309,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
                 meta.return_data.map(|return_data| return_data.into()),
             ),
             compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
+            cost_units: OptionSerializer::or_skip(meta.cost_units),
         }
     }
 }
@@ -547,6 +553,7 @@ pub struct TransactionStatusMeta {
     pub loaded_addresses: LoadedAddresses,
     pub return_data: Option<TransactionReturnData>,
     pub compute_units_consumed: Option<u64>,
+    pub cost_units: Option<u64>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -564,6 +571,7 @@ impl Default for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data: None,
             compute_units_consumed: None,
+            cost_units: None,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -187,6 +187,7 @@ fn build_simple_ui_transaction_status_meta(
         loaded_addresses: OptionSerializer::Skip,
         return_data: OptionSerializer::Skip,
         compute_units_consumed: OptionSerializer::Skip,
+        cost_units: OptionSerializer::Skip,
     }
 }
 
@@ -225,6 +226,7 @@ fn parse_ui_transaction_status_meta(
             meta.return_data.map(|return_data| return_data.into()),
         ),
         compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
+        cost_units: OptionSerializer::or_skip(meta.cost_units),
     }
 }
 
@@ -876,6 +878,7 @@ mod test {
             },
             return_data: None,
             compute_units_consumed: None,
+            cost_units: None,
         };
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
             "{\


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/4815 for more context, but the TLDR is would like the total CU usage for transactions to be available in long term storage / in RPC queries.

Similar in structure to a previous PR that added a new field: https://github.com/solana-labs/solana/pull/26528

#### Summary of Changes
- Plumb a new field, `cost_units`, through the Blockstore and BigTable types
- Refactor to pass costs along to `transaction_status_sender` on both replay and leader side
