### PR TITLE
backoff config is required for nextest

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -4,7 +4,7 @@ dir = "target/nextest"
 [profile.ci]
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
-retries = { count = 3 }
+retries = { backoff = "fixed", count = 3, delay = "1s" }
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
#### Problem

assuming fields are not required can break CI (https://github.com/anza-xyz/agave/pull/5238)

#### Summary of Changes

put back the required field.