### PR TITLE
agave-validator: add args tests for exit

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -64,7 +64,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .global_setting(AppSettings::InferSubcommands)
         .global_setting(AppSettings::UnifiedHelpMessage)
         .global_setting(AppSettings::VersionlessSubcommands)
-        .subcommand(commands::exit::command(default_args))
+        .subcommand(commands::exit::command())
         .subcommand(commands::authorized_voter::command(default_args))
         .subcommand(commands::contact_info::command(default_args))
         .subcommand(commands::repair_shred_from_peer::command())
@@ -432,10 +432,6 @@ pub struct DefaultArgs {
     pub num_quic_endpoints: String,
     pub vote_use_quic: String,
 
-    // Exit subcommand
-    pub exit_min_idle_time: String,
-    pub exit_max_delinquent_stake: String,
-
     pub banking_trace_dir_byte_limit: String,
 
     pub wen_restart_path: String,
@@ -531,8 +527,6 @@ impl DefaultArgs {
             tpu_max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
             rpc_max_request_body_size: MAX_REQUEST_BODY_SIZE.to_string(),
-            exit_min_idle_time: "10".to_string(),
-            exit_max_delinquent_stake: "5".to_string(),
             banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
             wen_restart_path: "wen_restart_progress.proto".to_string(),
             thread_args: DefaultThreadArgs::default(),

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -5,8 +5,10 @@ use {
     std::path::Path,
 };
 
+const COMMAND: &str = "exit";
+
 pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
-    SubCommand::with_name("exit")
+    SubCommand::with_name(COMMAND)
         .about("Send an exit request to the validator")
         .arg(
             Arg::with_name("force")

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{admin_rpc_service, commands},
+    crate::{
+        admin_rpc_service,
+        commands::{monitor, wait_for_restart_window, FromClapArgMatches},
+    },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
     std::path::Path,
@@ -9,6 +12,29 @@ const COMMAND: &str = "exit";
 
 const DEFAULT_MIN_IDLE_TIME: &str = "10";
 const DEFAULT_MAX_DELINQUENT_STAKE: &str = "5";
+
+#[derive(Debug, PartialEq)]
+pub struct ExitArgs {
+    pub force: bool,
+    pub monitor: bool,
+    pub min_idle_time: usize,
+    pub max_delinquent_stake: u8,
+    pub skip_new_snapshot_check: bool,
+    pub skip_health_check: bool,
+}
+
+impl FromClapArgMatches for ExitArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+        Ok(ExitArgs {
+            force: matches.is_present("force"),
+            monitor: matches.is_present("monitor"),
+            min_idle_time: value_t_or_exit!(matches, "min_idle_time", usize),
+            max_delinquent_stake: value_t_or_exit!(matches, "max_delinquent_stake", u8),
+            skip_new_snapshot_check: matches.is_present("skip_new_snapshot_check"),
+            skip_health_check: matches.is_present("skip_health_check"),
+        })
+    }
+}
 
 pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name(COMMAND)
@@ -62,21 +88,16 @@ pub fn command<'a>() -> App<'a, 'a> {
 }
 
 pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
-    let min_idle_time = value_t_or_exit!(matches, "min_idle_time", usize);
-    let force = matches.is_present("force");
-    let monitor = matches.is_present("monitor");
-    let skip_new_snapshot_check = matches.is_present("skip_new_snapshot_check");
-    let skip_health_check = matches.is_present("skip_health_check");
-    let max_delinquent_stake = value_t_or_exit!(matches, "max_delinquent_stake", u8);
+    let exit_args = ExitArgs::from_clap_arg_match(matches)?;
 
-    if !force {
-        commands::wait_for_restart_window::wait_for_restart_window(
+    if !exit_args.force {
+        wait_for_restart_window::wait_for_restart_window(
             ledger_path,
             None,
-            min_idle_time,
-            max_delinquent_stake,
-            skip_new_snapshot_check,
-            skip_health_check,
+            exit_args.min_idle_time,
+            exit_args.max_delinquent_stake,
+            exit_args.skip_new_snapshot_check,
+            exit_args.skip_health_check,
         )
         .map_err(|err| format!("error waiting for restart window: {err}"))?;
     }
@@ -87,9 +108,108 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
         .map_err(|err| format!("exit request failed: {err}"))?;
     println!("Exit request sent");
 
-    if monitor {
-        commands::monitor::execute(matches, ledger_path)?;
+    if exit_args.monitor {
+        monitor::execute(matches, ledger_path)?;
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::commands::tests::verify_args_struct_by_command};
+
+    impl Default for ExitArgs {
+        fn default() -> Self {
+            ExitArgs {
+                min_idle_time: DEFAULT_MIN_IDLE_TIME
+                    .parse()
+                    .expect("invalid DEFAULT_MIN_IDLE_TIME"),
+                max_delinquent_stake: DEFAULT_MAX_DELINQUENT_STAKE
+                    .parse()
+                    .expect("invalid DEFAULT_MAX_DELINQUENT_STAKE"),
+                force: false,
+                monitor: false,
+                skip_new_snapshot_check: false,
+                skip_health_check: false,
+            }
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_default() {
+        verify_args_struct_by_command(command(), vec![COMMAND], ExitArgs::default());
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_force() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--force"],
+            ExitArgs {
+                force: true,
+                ..ExitArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_monitor() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--monitor"],
+            ExitArgs {
+                monitor: true,
+                ..ExitArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_min_idle_time() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--min-idle-time", "60"],
+            ExitArgs {
+                min_idle_time: 60,
+                ..ExitArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_max_delinquent_stake() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--max-delinquent-stake", "10"],
+            ExitArgs {
+                max_delinquent_stake: 10,
+                ..ExitArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_skip_new_snapshot_check() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--skip-new-snapshot-check"],
+            ExitArgs {
+                skip_new_snapshot_check: true,
+                ..ExitArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_exit_with_skip_health_check() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--skip-health-check"],
+            ExitArgs {
+                skip_health_check: true,
+                ..ExitArgs::default()
+            },
+        );
+    }
 }

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands},
+    crate::{admin_rpc_service, commands},
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
     std::path::Path,
@@ -7,7 +7,10 @@ use {
 
 const COMMAND: &str = "exit";
 
-pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
+const DEFAULT_MIN_IDLE_TIME: &str = "10";
+const DEFAULT_MAX_DELINQUENT_STAKE: &str = "5";
+
+pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name(COMMAND)
         .about("Send an exit request to the validator")
         .arg(
@@ -32,7 +35,7 @@ pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .value_name("MINUTES")
-                .default_value(&default_args.exit_min_idle_time)
+                .default_value(DEFAULT_MIN_IDLE_TIME)
                 .help(
                     "Minimum time that the validator should not be leader before restarting",
                 ),
@@ -42,7 +45,7 @@ pub fn command(default_args: &DefaultArgs) -> App<'_, '_> {
                 .long("max-delinquent-stake")
                 .takes_value(true)
                 .validator(is_valid_percentage)
-                .default_value(&default_args.exit_max_delinquent_stake)
+                .default_value(DEFAULT_MAX_DELINQUENT_STAKE)
                 .value_name("PERCENT")
                 .help("The maximum delinquent stake % permitted for an exit"),
         )


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/issues/4082

#### Summary of Changes

- added const COMMAND
- moved default args into the exit command
- extracted clap args and added tests