### PR TITLE
agave-validator: remove unused default args for contact-info

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -66,7 +66,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .global_setting(AppSettings::VersionlessSubcommands)
         .subcommand(commands::exit::command(default_args))
         .subcommand(commands::authorized_voter::command(default_args))
-        .subcommand(commands::contact_info::command(default_args))
+        .subcommand(commands::contact_info::command())
         .subcommand(commands::repair_shred_from_peer::command())
         .subcommand(commands::repair_whitelist::command())
         .subcommand(

--- a/validator/src/commands/contact_info/mod.rs
+++ b/validator/src/commands/contact_info/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs, commands::FromClapArgMatches},
+    crate::{admin_rpc_service, commands::FromClapArgMatches},
     clap::{App, Arg, ArgMatches, SubCommand},
     solana_cli_output::OutputFormat,
     std::path::Path,
@@ -20,7 +20,7 @@ impl FromClapArgMatches for ContactInfoArgs {
     }
 }
 
-pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name(COMMAND)
         .about("Display the validator's contact info")
         .arg(
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_contact_info_output_json() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, "--output", "json"],
             ContactInfoArgs {
                 output: OutputFormat::Json,
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_contact_info_output_json_compact() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, "--output", "json-compact"],
             ContactInfoArgs {
                 output: OutputFormat::JsonCompact,
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_contact_info_output_default() {
         verify_args_struct_by_command(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND],
             ContactInfoArgs {
                 output: OutputFormat::Display,
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_contact_info_output_invalid() {
         verify_args_struct_by_command_is_error::<ContactInfoArgs>(
-            command(&DefaultArgs::default()),
+            command(),
             vec![COMMAND, "--output", "invalid_output_type"],
         );
     }


### PR DESCRIPTION
#### Problem

we removed unused default args for other commands. this one should follow the same rule.

#### Summary of Changes

remove it