### PR TITLE
agave-validator: remove unused default args for monitor

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -72,7 +72,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(
             SubCommand::with_name("init").about("Initialize the ledger directory then exit"),
         )
-        .subcommand(commands::monitor::command(default_args))
+        .subcommand(commands::monitor::command())
         .subcommand(SubCommand::with_name("run").about("Run the validator"))
         .subcommand(commands::plugin::command(default_args))
         .subcommand(commands::set_identity::command())

--- a/validator/src/commands/monitor/mod.rs
+++ b/validator/src/commands/monitor/mod.rs
@@ -1,10 +1,10 @@
 use {
-    crate::{cli::DefaultArgs, dashboard::Dashboard},
+    crate::dashboard::Dashboard,
     clap::{App, ArgMatches, SubCommand},
     std::{path::Path, time::Duration},
 };
 
-pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name("monitor").about("Monitor the validator")
 }
 


### PR DESCRIPTION
#### Problem

we removed unused default args for other commands. this one should follow the same rule.

#### Summary of Changes

remove it