### PR TITLE
agave-validator: add args tests for plugin

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -74,7 +74,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         )
         .subcommand(commands::monitor::command(default_args))
         .subcommand(SubCommand::with_name("run").about("Run the validator"))
-        .subcommand(commands::plugin::command(default_args))
+        .subcommand(commands::plugin::command())
         .subcommand(commands::set_identity::command())
         .subcommand(commands::set_log_filter::command())
         .subcommand(commands::staked_nodes_overrides::command())

--- a/validator/src/commands/plugin/mod.rs
+++ b/validator/src/commands/plugin/mod.rs
@@ -4,11 +4,13 @@ use {
     std::path::Path,
 };
 
+const COMMAND: &str = "plugin";
+
 pub fn command<'a>() -> App<'a, 'a> {
     let name_arg = Arg::with_name("name").required(true).takes_value(true);
     let config_arg = Arg::with_name("config").required(true).takes_value(true);
 
-    SubCommand::with_name("plugin")
+    SubCommand::with_name(COMMAND)
         .about("Manage and view geyser plugins")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .setting(AppSettings::InferSubcommands)

--- a/validator/src/commands/plugin/mod.rs
+++ b/validator/src/commands/plugin/mod.rs
@@ -1,10 +1,10 @@
 use {
-    crate::{admin_rpc_service, cli::DefaultArgs},
+    crate::admin_rpc_service,
     clap::{value_t, App, AppSettings, Arg, ArgMatches, SubCommand},
     std::path::Path,
 };
 
-pub fn command(_default_args: &DefaultArgs) -> App<'_, '_> {
+pub fn command<'a>() -> App<'a, 'a> {
     let name_arg = Arg::with_name("name").required(true).takes_value(true);
     let config_arg = Arg::with_name("config").required(true).takes_value(true);
 

--- a/validator/src/commands/plugin/mod.rs
+++ b/validator/src/commands/plugin/mod.rs
@@ -141,13 +141,14 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, crate::commands::tests::verify_args_struct_by_command_is_error};
 
     #[test]
     fn verify_args_struct_by_command_plugin_unload_default() {
-        let app = command();
-        let matches = app.get_matches_from_safe(vec![COMMAND, "unload"]);
-        assert!(matches.is_err());
+        verify_args_struct_by_command_is_error::<PluginUnloadArgs>(
+            command(),
+            vec![COMMAND, "unload"],
+        );
     }
 
     #[test]
@@ -166,9 +167,7 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_plugin_load_default() {
-        let app = command();
-        let matches = app.get_matches_from_safe(vec![COMMAND, "load"]);
-        assert!(matches.is_err());
+        verify_args_struct_by_command_is_error::<PluginLoadArgs>(command(), vec![COMMAND, "load"]);
     }
 
     #[test]
@@ -187,16 +186,18 @@ mod tests {
 
     #[test]
     fn verify_args_struct_by_command_plugin_reload_default() {
-        let app = command();
-        let matches = app.get_matches_from_safe(vec![COMMAND, "reload"]);
-        assert!(matches.is_err());
+        verify_args_struct_by_command_is_error::<PluginReloadArgs>(
+            command(),
+            vec![COMMAND, "reload"],
+        );
     }
 
     #[test]
     fn verify_args_struct_by_command_plugin_reload_with_name() {
-        let app = command();
-        let matches = app.get_matches_from_safe(vec![COMMAND, "reload", "testname"]);
-        assert!(matches.is_err());
+        verify_args_struct_by_command_is_error::<PluginReloadArgs>(
+            command(),
+            vec![COMMAND, "reload", "testname"],
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/issues/4082

#### Summary of Changes

- removed unused default args
- added const command
- extracted clap args and added tests