### PR TITLE
Remove legacy shreds from code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8190,6 +8190,7 @@ dependencies = [
  "solana-feature-set",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-ledger",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -94,6 +94,7 @@ features = ["lz4"]
 bs58 = { workspace = true }
 criterion = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 spl-pod = { workspace = true }

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -123,11 +123,11 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(0, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(0, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(1, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(2, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(2, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         assert_eq!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -217,6 +217,7 @@ impl LastFECSetCheckResults {
     }
 }
 
+#[derive(Debug)]
 pub struct InsertResults {
     completed_data_set_infos: Vec<CompletedDataSetInfo>,
     duplicate_shreds: Vec<PossibleDuplicateShred>,
@@ -1415,6 +1416,7 @@ impl Blockstore {
             None, // (reed_solomon_cache, retransmit_sender)
             &mut BlockstoreInsertionMetrics::default(),
         )?;
+        dbg!(&insert_results);
         Ok(insert_results.completed_data_set_infos)
     }
 
@@ -7214,14 +7216,9 @@ pub mod tests {
 
         let entries = create_ticks(100, 0, Hash::default());
         let mut shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
-        assert!(shreds.len() > 2);
-        shreds.drain(2..);
-
         const ONE: u64 = 1;
         const OTHER: u64 = 4;
-
-        shreds[0].set_index(ONE as u32);
-        shreds[1].set_index(OTHER as u32);
+        let shreds = vec![shreds.remove(OTHER as usize), shreds.remove(ONE as usize)];
 
         // Insert one shred at index = first_index
         blockstore.insert_shreds(shreds, None, false).unwrap();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5966,45 +5966,6 @@ pub mod tests {
         );
     }
 
-    // This test seems to be unnecessary with introduction of data shreds. There are no
-    // guarantees that a particular shred index contains a complete entry
-    #[test]
-    #[ignore]
-    pub fn test_get_slot_entries2() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        // Write entries
-        let num_slots = 5_u64;
-        let mut index = 0;
-        for slot in 0..num_slots {
-            let entries = create_ticks(slot + 1, 0, Hash::default());
-            let last_entry = entries.last().unwrap().clone();
-            let mut shreds = entries_to_test_shreds(
-                &entries,
-                slot,
-                slot.saturating_sub(1),
-                false,
-                0,
-                true, // merkle_variant
-            );
-            for b in shreds.iter_mut() {
-                b.set_index(index);
-                b.set_slot(slot);
-                index += 1;
-            }
-            blockstore
-                .insert_shreds(shreds, None, false)
-                .expect("Expected successful write of shreds");
-            assert_eq!(
-                blockstore
-                    .get_slot_entries(slot, u64::from(index - 1))
-                    .unwrap(),
-                vec![last_entry],
-            );
-        }
-    }
-
     #[test]
     fn test_get_slot_entries3() {
         // Test inserting/fetching shreds which contain multiple entries per shred

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -620,7 +620,6 @@ pub mod tests {
                 x.saturating_sub(1), // parent_slot
                 true,                // is_full_slot
                 0,                   // version
-                true,                // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature = entries
@@ -661,7 +660,6 @@ pub mod tests {
                 x.saturating_sub(1), // parent_slot
                 true,                // is_full_slot
                 0,                   // version
-                true,                // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature = entries
@@ -703,7 +701,6 @@ pub mod tests {
                 slot.saturating_sub(1),
                 true, // is_full_slot
                 0,    // version
-                true, // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -953,7 +950,6 @@ pub mod tests {
             slot - 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -1106,9 +1102,9 @@ pub mod tests {
 
         let (shreds, _) = make_many_slot_entries(0, 10, 5);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (slot_11, _) = make_slot_entries(11, 4, 5, true);
+        let (slot_11, _) = make_slot_entries(11, 4, 5);
         blockstore.insert_shreds(slot_11, None, false).unwrap();
-        let (slot_12, _) = make_slot_entries(12, 5, 5, true);
+        let (slot_12, _) = make_slot_entries(12, 5, 5);
         blockstore.insert_shreds(slot_12, None, false).unwrap();
 
         blockstore.purge_slot_cleanup_chaining(5).unwrap();

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -453,7 +453,7 @@ mod tests {
 
         // Write a shred into slot 2 that chains to slot 1,
         // but slot 1 is empty so should not be skipped
-        let (shreds, _) = make_slot_entries(2, 1, 1, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(2, 1, 1);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert_eq!(
             cache
@@ -464,7 +464,7 @@ mod tests {
         );
 
         // Write a shred into slot 1
-        let (shreds, _) = make_slot_entries(1, 0, 1, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 1);
 
         // Check that slot 1 and 2 are skipped
         blockstore.insert_shreds(shreds, None, false).unwrap();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -389,10 +389,6 @@ impl Shred {
     dispatch!(pub fn payload(&self) -> &Payload);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
 
-    // Only for tests.
-    dispatch!(pub fn set_index(&mut self, index: u32));
-    dispatch!(pub fn set_slot(&mut self, slot: Slot));
-
     pub fn copy_to_packet(&self, packet: &mut Packet) {
         let payload = self.payload();
         let size = payload.len();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -437,14 +437,6 @@ impl Shred {
         Payload: From<T>,
     {
         Ok(match layout::get_shred_variant(shred.as_ref())? {
-            ShredVariant::LegacyCode => {
-                let shred = legacy::ShredCode::from_payload(shred)?;
-                Self::from(ShredCode::from(shred))
-            }
-            ShredVariant::LegacyData => {
-                let shred = legacy::ShredData::from_payload(shred)?;
-                Self::from(ShredData::from(shred))
-            }
             ShredVariant::MerkleCode { .. } => {
                 let shred = merkle::ShredCode::from_payload(shred)?;
                 Self::from(ShredCode::from(shred))
@@ -452,6 +444,9 @@ impl Shred {
             ShredVariant::MerkleData { .. } => {
                 let shred = merkle::ShredData::from_payload(shred)?;
                 Self::from(ShredData::from(shred))
+            }
+            _ => {
+                return Err(Error::InvalidShredVariant);
             }
         })
     }
@@ -745,9 +740,9 @@ impl TryFrom<u8> for ShredVariant {
     #[inline]
     fn try_from(shred_variant: u8) -> Result<Self, Self::Error> {
         if shred_variant == u8::from(ShredType::Code) {
-            Ok(ShredVariant::LegacyCode)
+            Err(Error::InvalidShredVariant)
         } else if shred_variant == u8::from(ShredType::Data) {
-            Ok(ShredVariant::LegacyData)
+            Err(Error::InvalidShredVariant)
         } else {
             let proof_size = shred_variant & 0x0F;
             match shred_variant & 0xF0 {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -2,45 +2,6 @@
 //! network. There are two types of shreds: data and coding. Data shreds contain entry information
 //! while coding shreds provide redundancy to protect against dropped network packets (erasures).
 //!
-//! +---------------------------------------------------------------------------------------------+
-//! | Data Shred                                                                                  |
-//! +---------------------------------------------------------------------------------------------+
-//! | common       | data       | payload                                                         |
-//! | header       | header     |                                                                 |
-//! |+---+---+---  |+---+---+---|+----------------------------------------------------------+----+|
-//! || s | s | .   || p | f | s || data (ie ledger entries)                                 | r  ||
-//! || i | h | .   || a | l | i ||                                                          | e  ||
-//! || g | r | .   || r | a | z || See notes immediately after shred diagrams for an        | s  ||
-//! || n | e |     || e | g | e || explanation of the "restricted" section in this payload  | t  ||
-//! || a | d |     || n | s |   ||                                                          | r  ||
-//! || t |   |     || t |   |   ||                                                          | i  ||
-//! || u | t |     ||   |   |   ||                                                          | c  ||
-//! || r | y |     || o |   |   ||                                                          | t  ||
-//! || e | p |     || f |   |   ||                                                          | e  ||
-//! ||   | e |     || f |   |   ||                                                          | d  ||
-//! |+---+---+---  |+---+---+---+|----------------------------------------------------------+----+|
-//! +---------------------------------------------------------------------------------------------+
-//!
-//! +---------------------------------------------------------------------------------------------+
-//! | Coding Shred                                                                                |
-//! +---------------------------------------------------------------------------------------------+
-//! | common       | coding     | payload                                                         |
-//! | header       | header     |                                                                 |
-//! |+---+---+---  |+---+---+---+----------------------------------------------------------------+|
-//! || s | s | .   || n | n | p || data (encoded data shred data)                                ||
-//! || i | h | .   || u | u | o ||                                                               ||
-//! || g | r | .   || m | m | s ||                                                               ||
-//! || n | e |     ||   |   | i ||                                                               ||
-//! || a | d |     || d | c | t ||                                                               ||
-//! || t |   |     ||   |   | i ||                                                               ||
-//! || u | t |     || s | s | o ||                                                               ||
-//! || r | y |     || h | h | n ||                                                               ||
-//! || e | p |     || r | r |   ||                                                               ||
-//! ||   | e |     || e | e |   ||                                                               ||
-//! ||   |   |     || d | d |   ||                                                               ||
-//! |+---+---+---  |+---+---+---+|+--------------------------------------------------------------+|
-//! +---------------------------------------------------------------------------------------------+
-//!
 //! Notes:
 //! a) Coding shreds encode entire data shreds: both of the headers AND the payload.
 //! b) Coding shreds require their own headers for identification and etc.
@@ -374,8 +335,6 @@ use dispatch;
 
 impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
-    #[cfg(feature = "dev-context-only-utils")]
-    dispatch!(fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(fn set_signature(&mut self, signature: Signature));
     dispatch!(fn signed_data(&self) -> Result<SignedData, Error>);
 
@@ -398,17 +357,15 @@ impl Shred {
         packet.meta_mut().size = size;
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn set_slot(&mut self, slot: u64) {
-        self.common_header_mut().slot = slot;
+    pub fn set_slot(&mut self, _slot: u64) {
+        unreachable!("This function should not be used anymore");
+    }
+
+    pub fn set_index(&mut self, _index: u32) {
+        unreachable!("This function should not be used anymore");
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn set_index(&mut self, index: u32) {
-        self.common_header_mut().index = index;
-    }
-
-    // TODO: Should this sanitize output?
     pub fn new_from_data(
         slot: Slot,
         index: u32,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -374,6 +374,8 @@ use dispatch;
 
 impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
+    #[cfg(feature = "dev-context-only-utils")]
+    dispatch!(fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(fn set_signature(&mut self, signature: Signature));
     dispatch!(fn signed_data(&self) -> Result<SignedData, Error>);
 
@@ -394,6 +396,16 @@ impl Shred {
         let size = payload.len();
         packet.buffer_mut()[..size].copy_from_slice(&payload[..]);
         packet.meta_mut().size = size;
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_slot(&mut self, slot: u64) {
+        self.common_header_mut().slot = slot;
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_index(&mut self, index: u32) {
+        self.common_header_mut().index = index;
     }
 
     // TODO: Should this sanitize output?

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -50,32 +50,6 @@ macro_rules! impl_shred_common {
             self.payload[..SIZE_OF_SIGNATURE].copy_from_slice(signature.as_ref());
             self.common_header.signature = signature;
         }
-
-        // Only for tests.
-        fn set_index(&mut self, index: u32) {
-            match self.common_header.shred_variant {
-                ShredVariant::LegacyCode | ShredVariant::LegacyData => {
-                    self.common_header.index = index;
-                    bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
-                }
-                ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. } => {
-                    panic!("Not Implemented!");
-                }
-            }
-        }
-
-        // Only for tests.
-        fn set_slot(&mut self, slot: Slot) {
-            match self.common_header.shred_variant {
-                ShredVariant::LegacyCode | ShredVariant::LegacyData => {
-                    self.common_header.slot = slot;
-                    bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
-                }
-                ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. } => {
-                    panic!("Not Implemented!");
-                }
-            }
-        }
     };
 }
 

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -35,6 +35,12 @@ macro_rules! impl_shred_common {
             &self.common_header
         }
 
+        #[cfg(feature = "dev-context-only-utils")]
+        #[inline]
+        fn common_header_mut(&mut self) -> &mut ShredCommonHeader {
+            &mut self.common_header
+        }
+
         #[inline]
         fn payload(&self) -> &Payload {
             &self.payload

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -35,12 +35,6 @@ macro_rules! impl_shred_common {
             &self.common_header
         }
 
-        #[cfg(feature = "dev-context-only-utils")]
-        #[inline]
-        fn common_header_mut(&mut self) -> &mut ShredCommonHeader {
-            &mut self.common_header
-        }
-
         #[inline]
         fn payload(&self) -> &Payload {
             &self.payload

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -1,12 +1,35 @@
 use std::{
+    fmt::{Debug, Write},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq)]
 pub enum Payload {
     Shared(Arc<Vec<u8>>),
     Unique(Vec<u8>),
+}
+
+impl Debug for Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let buf: &[u8] = match self {
+            Payload::Shared(items) => {
+                f.write_str("Shared {\n")?;
+                items.as_ref()
+            }
+            Payload::Unique(items) => {
+                f.write_str("Unique {\n")?;
+                items.as_ref()
+            }
+        };
+        for chunk in buf.chunks(32) {
+            for b in chunk {
+                write!(f, "{:02x}", b)?;
+            }
+            f.write_char('\n')?;
+        }
+        f.write_str("}\n")
+    }
 }
 
 macro_rules! make_mut {

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -36,10 +36,6 @@ impl ShredCode {
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
-    // Only for tests.
-    dispatch!(pub(super) fn set_index(&mut self, index: u32));
-    dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
-
     pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -28,8 +28,6 @@ impl ShredCode {
     dispatch!(fn coding_header(&self) -> &CodingShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
-    #[cfg(feature = "dev-context-only-utils")]
-    dispatch!(pub(super) fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -28,6 +28,8 @@ impl ShredCode {
     dispatch!(fn coding_header(&self) -> &CodingShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
+    #[cfg(feature = "dev-context-only-utils")]
+    dispatch!(pub(super) fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -21,8 +21,6 @@ impl ShredData {
     dispatch!(fn data_header(&self) -> &DataShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
-    #[cfg(feature = "dev-context-only-utils")]
-    dispatch!(pub(super) fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn into_payload(self) -> Payload);
@@ -62,7 +60,7 @@ impl ShredData {
         version: u16,
         fec_set_index: u32,
     ) -> Self {
-        Self::from(legacy::ShredData::new_from_data(
+        Self::from(merkle::ShredData::new_from_data(
             slot,
             index,
             parent_offset,

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -29,10 +29,6 @@ impl ShredData {
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
-    // Only for tests.
-    dispatch!(pub(super) fn set_index(&mut self, index: u32));
-    dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
-
     pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -21,6 +21,8 @@ impl ShredData {
     dispatch!(fn data_header(&self) -> &DataShredHeader);
 
     dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
+    #[cfg(feature = "dev-context-only-utils")]
+    dispatch!(pub(super) fn common_header_mut(&mut self) -> &mut ShredCommonHeader);
     dispatch!(pub(super) fn erasure_shard(&self) -> Result<&[u8], Error>);
     dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
     dispatch!(pub(super) fn into_payload(self) -> Payload);

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -32,10 +32,6 @@ pub(super) trait Shred<'a>: Sized {
 
     // Portion of the payload which is signed.
     fn signed_data(&'a self) -> Result<Self::SignedData, Error>;
-
-    // Only for tests.
-    fn set_index(&mut self, index: u32);
-    fn set_slot(&mut self, slot: Slot);
 }
 
 pub(super) trait ShredData: for<'a> Shred<'a> {

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -18,8 +18,6 @@ pub(super) trait Shred<'a>: Sized {
     where
         Payload: From<T>;
     fn common_header(&self) -> &ShredCommonHeader;
-    #[cfg(feature = "dev-context-only-utils")]
-    fn common_header_mut(&mut self) -> &mut ShredCommonHeader;
 
     fn sanitize(&self) -> Result<(), Error>;
 

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -18,6 +18,9 @@ pub(super) trait Shred<'a>: Sized {
     where
         Payload: From<T>;
     fn common_header(&self) -> &ShredCommonHeader;
+    #[cfg(feature = "dev-context-only-utils")]
+    fn common_header_mut(&mut self) -> &mut ShredCommonHeader;
+
     fn sanitize(&self) -> Result<(), Error>;
 
     fn set_signature(&mut self, signature: Signature);

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -804,7 +804,6 @@ mod tests {
                     chained.then(|| Hash::new_from_array(rng.gen())),
                     rng.gen_range(0..2671), // next_shred_index
                     rng.gen_range(0..2781), // next_code_index
-                    rng.gen(),              // merkle_variant,
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -21,14 +21,7 @@ fn test_multiple_threads_insert_shred() {
         let threads: Vec<_> = (0..num_threads)
             .map(|i| {
                 let entries = entry::create_ticks(1, 0, Hash::default());
-                let shreds = blockstore::entries_to_test_shreds(
-                    &entries,
-                    i + 1,
-                    0,
-                    false,
-                    0,
-                    true, // merkle_variant
-                );
+                let shreds = blockstore::entries_to_test_shreds(&entries, i + 1, 0, false, 0);
                 let blockstore_ = blockstore.clone();
                 Builder::new()
                     .name("blockstore-writer".to_string())

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -55,10 +55,9 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
         &keypair,
         &entries,
         is_last_in_slot,
-        None,  // chained_merkle_root
-        0,     // next_shred_index
-        0,     // next_code_index
-        false, // merkle_variant
+        None, // chained_merkle_root
+        0,    // next_shred_index
+        0,    // next_code_index
         &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
@@ -235,7 +234,6 @@ fn setup_different_sized_fec_blocks(
             None, // chained_merkle_root
             next_shred_index,
             next_code_index,
-            false, // merkle_variant
             &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4467,7 +4467,6 @@ pub fn populate_blockstore_for_tests(
         parent_slot,
         true,
         0,
-        true, // merkle_variant
     );
     blockstore.insert_shreds(shreds, None, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 bs58 = { workspace = true }
+solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -563,9 +563,8 @@ pub mod test {
             true, // is_last_in_slot
             // chained_merkle_root
             Some(Hash::new_from_array(rand::thread_rng().gen())),
-            0,    // next_shred_index,
-            0,    // next_code_index
-            true, // merkle_variant
+            0, // next_shred_index,
+            0, // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -184,7 +184,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             Some(self.chained_merkle_root),
             self.next_shred_index,
             self.next_code_index,
-            true, // merkle_variant
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
@@ -204,7 +203,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
-                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );
@@ -218,7 +216,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
-                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -79,7 +79,6 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             Some(chained_merkle_root),
             next_shred_index,
             self.next_code_index,
-            true, // merkle_variant
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
@@ -101,7 +100,6 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             Some(chained_merkle_root),
             next_shred_index,
             self.next_code_index,
-            true, // merkle_variant
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -103,7 +103,6 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             Some(self.chained_merkle_root),
             self.next_shred_index,
             self.next_code_index,
-            true, // merkle_variant
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
@@ -123,7 +122,6 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
                 Some(self.chained_merkle_root),
                 self.next_shred_index,
                 self.next_code_index,
-                true, // merkle_variant
                 &self.reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             );
@@ -137,7 +135,6 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
                 Some(self.chained_merkle_root),
                 self.next_shred_index,
                 self.next_code_index,
-                true, // merkle_variant
                 &self.reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             );

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -515,6 +515,7 @@ mod tests {
             0xc0de,
         );
         shred.sign(&leader_keypair);
+        dbg!(&shred);
         batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
         batches[0][0].meta_mut().size = shred.payload().len();
 
@@ -530,6 +531,7 @@ mod tests {
         );
         let wrong_keypair = Keypair::new();
         shred.sign(&wrong_keypair);
+        dbg!(&shred);
         batches[0][1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
         batches[0][1].meta_mut().size = shred.payload().len();
 


### PR DESCRIPTION
#### Problem
Legacy shreds are no longer present in the cluster (MNB) so there is no point supporting them in the code.

#### Summary of Changes

- Remove the key mechanisms for instantiation of LegacyData and LegacyCode shred types
- Remove usages in tests etc

Out of scope: cleaning up the code in ledger/shred/*.rs , it will be subject of another PR. 