### PR TITLE
Always use compute-budget specific to loaded transaction for invoke_context

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -941,9 +941,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let lamports_before_tx =
             transaction_accounts_lamports_sum(&transaction_accounts).unwrap_or(0);
 
-        let compute_budget = config
-            .compute_budget
-            .unwrap_or_else(|| ComputeBudget::from(loaded_transaction.compute_budget_limits));
+        let compute_budget = ComputeBudget::from(loaded_transaction.compute_budget_limits);
 
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,


### PR DESCRIPTION
#### Problem

Have question if using bank's global compute-budget, if any, to execute transaction is safe. Proposing to always execute transaction with CB specific to it. Should tests need to override CB limits *and* can't include related compute-budget-instructions, we can do `dev-only` overrides on top of tx's CB.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
