### PR TITLE
Bump platform tools version

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -21,7 +21,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.44";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.45";
 
 #[derive(Debug)]
 struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.44"
+tools-version = "v1.45"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -21,4 +21,4 @@ crate-type = ["cdylib"]
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.44"
+tools-version = "v1.45"

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.44
+version=v1.45
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1274,8 +1274,8 @@ fn assert_instruction_count() {
             ("noop++", 6),
             ("relative_call", 212),
             ("return_data", 1027),
-            ("sanity", 2394),
-            ("sanity++", 2294),
+            ("sanity", 2396),
+            ("sanity++", 2296),
             ("secp256k1_recover", 25483),
             ("sha", 1447),
             ("struct_pass", 108),
@@ -1285,7 +1285,7 @@ fn assert_instruction_count() {
     #[cfg(feature = "sbf_rust")]
     {
         programs.extend_from_slice(&[
-            ("solana_sbf_rust_128bit", 955),
+            ("solana_sbf_rust_128bit", 967),
             ("solana_sbf_rust_alloc", 4940),
             ("solana_sbf_rust_custom_heap", 286),
             ("solana_sbf_rust_dep_crate", 2),


### PR DESCRIPTION
#### Problem

Platform tools version v1.44 caused a regression on the build pipeline used in `cargo-build-sbf`, whereby the `llvm-objcopy` command run after the build would create invalid binary file for our ELF loader.

This problem was undetected because https://github.com/anza-xyz/agave/pull/1581 removed all integration tests with `cargo-build-sbf`. Since it was merged, we do not build and test any program with `cargo-build-sbf` in the CI.

#### Summary of Changes

The new version fixes the issue and reduces program size for SBPFv2 and SBPFv3.

PS: I'll add sanity tests for `cargo-build-sbf` to the CI in a follow up PR.
