### PR TITLE
scheduler: gate retry on slot

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -122,6 +122,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         self.metrics.has_data.store(true, Ordering::Relaxed);
 
         self.consumed_sender.send(FinishedConsumeWork {
+            slot: Some(bank.slot()),
             work,
             retryable_indexes: output
                 .execute_and_commit_transactions_output
@@ -164,6 +165,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             .fetch_add(num_retryable, Ordering::Relaxed);
         self.metrics.has_data.store(true, Ordering::Relaxed);
         self.consumed_sender.send(FinishedConsumeWork {
+            slot: None,
             work,
             retryable_indexes,
         })?;

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -46,7 +46,7 @@ pub struct ConsumeWork<Tx> {
 /// Message: [Worker -> Scheduler]
 /// Processed transactions.
 pub struct FinishedConsumeWork<Tx> {
-    /// Slot that work was attempted on. `None` if sent back wthout attempt.
+    /// Slot that work was attempted on. `None` if sent back without attempt.
     pub slot: Option<Slot>,
     pub work: ConsumeWork<Tx>,
     pub retryable_indexes: Vec<usize>,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -46,6 +46,8 @@ pub struct ConsumeWork<Tx> {
 /// Message: [Worker -> Scheduler]
 /// Processed transactions.
 pub struct FinishedConsumeWork<Tx> {
+    /// Slot that work was attempted on. `None` if sent back wthout attempt.
+    pub slot: Option<Slot>,
     pub work: ConsumeWork<Tx>,
     pub retryable_indexes: Vec<usize>,
 }

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -694,6 +694,7 @@ mod tests {
         // Complete batch on thread 0. Remaining txs can be scheduled onto thread 1
         finished_work_sender
             .send(FinishedConsumeWork {
+                slot: None,
                 work: thread_0_work.into_iter().next().unwrap(),
                 retryable_indexes: vec![],
             })

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -48,6 +48,8 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
 pub(crate) enum PreLockFilterAction {
     /// Attempt to schedule the transaction.
     AttemptToSchedule,
+    /// Skip the transaction but do not drop it.
+    SkipAndRetain,
 }
 
 /// Metrics from scheduling transactions.
@@ -64,6 +66,8 @@ pub(crate) struct SchedulingSummary {
     pub num_unschedulable_conflicts: usize,
     /// Number of transactions that were skipped due to thread capacity.
     pub num_unschedulable_threads: usize,
+    /// Number of transactions that were skipped due too recently attempted.
+    pub num_skipped_retry: usize,
     /// Number of transactions that were dropped due to filter.
     pub num_filtered_out: usize,
     /// Time spent filtering transactions

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -74,6 +74,8 @@ pub enum TransactionSchedulingError {
     UnschedulableConflicts,
     /// Thread is not allowed to be scheduled on at this time.
     UnschedulableThread,
+    /// Transaction was skipped by pre-filter logic.
+    Skipped,
 }
 
 /// Given the schedulable `thread_set`, select the thread with the least amount

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -198,6 +198,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         max_ages: _,
                     },
                 retryable_indexes,
+                slot: _,
             }) => {
                 let num_transactions = ids.len();
                 let num_retryable = retryable_indexes.len();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -198,7 +198,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         max_ages: _,
                     },
                 retryable_indexes,
-                slot: _,
+                slot,
             }) => {
                 let num_transactions = ids.len();
                 let num_retryable = retryable_indexes.len();
@@ -211,7 +211,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                 for (index, (id, transaction)) in izip!(ids, transactions).enumerate() {
                     if let Some(retryable_index) = retryable_iter.peek() {
                         if *retryable_index == index {
-                            container.retry_transaction(id, transaction);
+                            container.retry_transaction(slot, id, transaction);
                             retryable_iter.next();
                             continue;
                         }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -147,7 +147,13 @@ where
                             MAX_PROCESSING_AGE,
                         )
                     },
-                    |_| PreLockFilterAction::AttemptToSchedule // no pre-lock filter for now
+                    |state| {
+                        if state.last_tried_slot() == Some(bank_start.working_bank.slot()) {
+                            PreLockFilterAction::SkipAndRetain
+                        } else {
+                            PreLockFilterAction::AttemptToSchedule
+                        }
+                    }
                 )?);
 
                 self.count_metrics.update(|count_metrics| {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -543,6 +543,7 @@ mod tests {
 
         finished_consume_work_sender
             .send(FinishedConsumeWork {
+                slot: None,
                 work: ConsumeWork {
                     batch_id: TransactionBatchId::new(0),
                     ids: vec![],
@@ -881,6 +882,7 @@ mod tests {
         // Complete the batch - marking the second transaction as retryable
         finished_consume_work_sender
             .send(FinishedConsumeWork {
+                slot: None,
                 work: consume_work,
                 retryable_indexes: vec![1],
             })

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -419,6 +419,7 @@ pub struct SchedulingDetails {
     pub sum_num_scheduled: usize,
     pub sum_unschedulable_conflicts: usize,
     pub sum_unschedulable_threads: usize,
+    pub sum_skipped_retry: usize,
 }
 
 impl Default for SchedulingDetails {
@@ -435,6 +436,7 @@ impl Default for SchedulingDetails {
             sum_num_scheduled: 0,
             sum_unschedulable_conflicts: 0,
             sum_unschedulable_threads: 0,
+            sum_skipped_retry: 0,
         }
     }
 }
@@ -458,6 +460,7 @@ impl SchedulingDetails {
             .max_starting_buffer_size
             .max(scheduling_summary.starting_buffer_size);
         self.sum_starting_buffer_size += scheduling_summary.starting_buffer_size;
+        self.sum_skipped_retry += scheduling_summary.num_skipped_retry;
 
         self.sum_num_scheduled += scheduling_summary.num_scheduled;
         self.sum_unschedulable_conflicts += scheduling_summary.num_unschedulable_conflicts;
@@ -502,6 +505,7 @@ impl SchedulingDetails {
                         self.sum_unschedulable_threads,
                         i64
                     ),
+                    ("num_skipped_retry", self.sum_skipped_retry, i64),
                 );
                 *self = Self {
                     last_report: now,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,4 +1,4 @@
-use crate::banking_stage::scheduler_messages::MaxAge;
+use {crate::banking_stage::scheduler_messages::MaxAge, solana_sdk::clock::Slot};
 
 /// TransactionState is used to track the state of a transaction in the transaction scheduler
 /// and banking stage as a whole.
@@ -20,6 +20,8 @@ pub(crate) struct TransactionState<Tx> {
     priority: u64,
     /// Estimated cost of the transaction.
     cost: u64,
+    /// Last slot transaction attempted execution on.
+    last_tried_slot: Option<Slot>,
 }
 
 impl<Tx> TransactionState<Tx> {
@@ -30,6 +32,7 @@ impl<Tx> TransactionState<Tx> {
             max_age,
             priority,
             cost,
+            last_tried_slot: None,
         }
     }
 
@@ -56,6 +59,16 @@ impl<Tx> TransactionState<Tx> {
             .take()
             .expect("transaction not already pending");
         (tx, self.max_age)
+    }
+
+    /// Return the last tried slot.
+    pub(crate) fn last_tried_slot(&self) -> Option<Slot> {
+        self.last_tried_slot
+    }
+
+    /// Set a new last tried slot.
+    pub(crate) fn set_last_tried_slot(&mut self, slot: Option<Slot>) {
+        self.last_tried_slot = slot;
     }
 
     /// Intended to be called when a transaction is retried. This method will


### PR DESCRIPTION
#### Problem
- scheduler may retry transactions in the same slot unnecessarily. in edge case this could potentially lead to attempting same transactions many times

#### Summary of Changes
- track most recent slot attempted processing
- wait at least until next slot to retry

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
