### PR TITLE
Cleanup write cache flush counters

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -144,6 +144,8 @@ impl StoreAccountsTiming {
 #[derive(Debug, Default)]
 pub struct FlushStats {
     pub num_flushed: Saturating<usize>,
+    pub num_zero_lamport: Saturating<usize>,
+    pub num_reclaimed: Saturating<usize>,
     pub num_purged: Saturating<usize>,
     pub total_size: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
@@ -154,6 +156,8 @@ impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_flushed += other.num_flushed;
         self.num_purged += other.num_purged;
+        self.num_reclaimed += other.num_reclaimed;
+        self.num_zero_lamport += other.num_zero_lamport;
         self.total_size += other.total_size;
         self.store_accounts_timing
             .accumulate(&other.store_accounts_timing);

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4592,10 +4592,9 @@ fn test_accounts_db_cache_clean_max_root_with_cache_limit_hit_and_scan() {
 fn run_flush_rooted_accounts_cache(should_clean: bool) {
     let num_slots = 10;
     let (accounts_db, keys, slots, _) = setup_accounts_db_cache_clean(num_slots, None, None);
-    let mut cleaned_bytes = 0;
     let mut cleaned_accounts = 0;
     let should_clean_tracker = if should_clean {
-        Some((&mut cleaned_bytes, &mut cleaned_accounts))
+        Some(&mut cleaned_accounts)
     } else {
         None
     };


### PR DESCRIPTION
#### Problem
Number of slots flushed is only saved when aggressively flush is used.
Purged/saved counter is counted in two counters

#### Summary of Changes
Added most counters under aggressively flush to the normal flush counter
Removed the duplicate purge/save counter
Added some new counters that will be used during dead_account tracking updates.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
