### PR TITLE
Fix musl build, add it to CI

### DIFF
--- a/.github/scripts/install-all-deps.sh
+++ b/.github/scripts/install-all-deps.sh
@@ -29,8 +29,7 @@ case "$os_name" in
       linux-headers \
       llvm-dev \
       musl-dev \
-      perl \
-      zlib-static
+      perl
   else
     sudo apt update
     sudo apt install -y libclang-dev

--- a/.github/scripts/install-all-deps.sh
+++ b/.github/scripts/install-all-deps.sh
@@ -19,8 +19,26 @@ case "$os_name" in
   export LIBCLANG_PATH
   ;;
 "Linux")
-  sudo apt update
-  sudo apt install -y libclang-dev
+  if grep "Alpine" /etc/os-release ; then
+    apk update
+    apk add \
+      build-base \
+      clang19-libclang \
+      eudev-dev \
+      hidapi-dev \
+      linux-headers \
+      llvm19-dev \
+      musl-dev \
+      perl \
+      zlib-static
+    LIBCLANG_PATH="/usr/lib/llvm19/lib"
+    export LIBCLANG_PATH
+    PATH="/usr/lib/llvm19/bin:$PATH"
+    export PATH
+  else
+    sudo apt update
+    sudo apt install -y libclang-dev
+  fi
   ;;
 *)
   echo "Unknown Operating System"

--- a/.github/scripts/install-all-deps.sh
+++ b/.github/scripts/install-all-deps.sh
@@ -23,18 +23,14 @@ case "$os_name" in
     apk update
     apk add \
       build-base \
-      clang19-libclang \
+      clang-libclang \
       eudev-dev \
       hidapi-dev \
       linux-headers \
-      llvm19-dev \
+      llvm-dev \
       musl-dev \
       perl \
       zlib-static
-    LIBCLANG_PATH="/usr/lib/llvm19/lib"
-    export LIBCLANG_PATH
-    PATH="/usr/lib/llvm19/bin:$PATH"
-    export PATH
   else
     sudo apt update
     sudo apt install -y libclang-dev

--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -11,7 +11,11 @@ case "$os_name" in
   export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
   ;;
 "macOS") ;;
-"Linux") ;;
+"Linux")
+  if grep "Alpine" /etc/os-release ; then
+    apk add openssl-dev openssl-libs-static
+  fi
+  ;;
 *)
   echo "Unknown Operating System"
   ;;

--- a/.github/scripts/install-proto.sh
+++ b/.github/scripts/install-proto.sh
@@ -12,7 +12,11 @@ case "$os_name" in
 "macOS")
   brew install protobuf
   ;;
-"Linux") ;;
+"Linux")
+  if grep "Alpine" /etc/os-release ; then
+    apk add protoc
+  fi
+  ;;
 *)
   echo "Unknown Operating System"
   ;;

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -34,10 +34,25 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+          - os: macos-latest
+          # musl with dynamic linking
+          - os: ubuntu-latest
+            container: docker.io/rust:1-alpine
+            rustflags: -C target-feature=-crt-static
+    runs-on: ${{ matrix.os.os }}
+    container:
+      image: ${{ matrix.os.container }}
+    env:
+      RUSTFLAGS: ${{ matrix.os.rustflags }}
     steps:
+      # Alpine container needs:
+      # * `bash`, to run the scripts.
+      # * `git`, to run the `checkout` action.
+      - if: ${{ contains(matrix.os.container, 'alpine') }}
+        run: |
+          apk update
+          apk add bash git
+
       - uses: actions/checkout@v4
 
       - uses: mozilla-actions/sccache-action@v0.0.9
@@ -53,6 +68,7 @@ jobs:
 
       - shell: bash
         run: |
+          git config --global --add safe.directory "$(pwd)"
           source .github/scripts/install-all-deps.sh ${{ runner.os }}
           source ci/rust-version.sh nightly
           rustup component add clippy --toolchain "$rust_nightly"

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -39,6 +39,7 @@ jobs:
           - os: ubuntu-latest
             container: docker.io/rust:1-alpine
             rustflags: -C target-feature=-crt-static
+          - os: windows-latest
     runs-on: ${{ matrix.os.os }}
     container:
       image: ${{ matrix.os.container }}

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 use std::ffi::{CStr, CString};
 use {
     crate::{
@@ -936,7 +936,7 @@ pub(crate) fn remap_append_vec_file(
     next_append_vec_id: &AtomicAccountsFileId,
     num_collisions: &AtomicUsize,
 ) -> io::Result<(AccountsFileId, PathBuf)> {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     let append_vec_path_cstr = cstring_from_path(append_vec_path)?;
 
     let mut remapped_append_vec_path = append_vec_path.to_path_buf();
@@ -1283,7 +1283,7 @@ fn rename_no_replace(src: &CStr, dest: &CStr) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 fn cstring_from_path(path: &Path) -> io::Result<CString> {
     // It is better to allocate here than use the stack. Jemalloc is going to give us a chunk of a
     // preallocated small arena anyway. Instead if we used the stack since PATH_MAX=4096 it would

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -3,7 +3,10 @@ use {
         route::Router,
         umem::{Frame, FrameOffset},
     },
-    libc::{ifreq, mmap, munmap, xdp_ring_offset, IF_NAMESIZE, SIOCGIFADDR, SIOCGIFHWADDR},
+    libc::{
+        ifreq, mmap, munmap, syscall, xdp_ring_offset, SYS_ioctl, IF_NAMESIZE, SIOCGIFADDR,
+        SIOCGIFHWADDR,
+    },
     std::{
         ffi::{c_char, CStr, CString},
         io::{self, ErrorKind},
@@ -86,8 +89,7 @@ impl NetworkDevice {
             );
         }
 
-        let result =
-            unsafe { libc::syscall(libc::SYS_ioctl, fd.as_raw_fd(), SIOCGIFHWADDR, &mut req) };
+        let result = unsafe { syscall(SYS_ioctl, fd.as_raw_fd(), SIOCGIFHWADDR, &mut req) };
         if result < 0 {
             return Err(io::Error::last_os_error());
         }
@@ -119,8 +121,7 @@ impl NetworkDevice {
             );
         }
 
-        let result =
-            unsafe { libc::syscall(libc::SYS_ioctl, fd.as_raw_fd(), SIOCGIFADDR, &mut req) };
+        let result = unsafe { syscall(SYS_ioctl, fd.as_raw_fd(), SIOCGIFADDR, &mut req) };
         if result < 0 {
             return Err(io::Error::last_os_error());
         }

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -3,7 +3,7 @@ use {
         route::Router,
         umem::{Frame, FrameOffset},
     },
-    libc::{ifreq, ioctl, mmap, munmap, xdp_ring_offset, IF_NAMESIZE, SIOCGIFADDR, SIOCGIFHWADDR},
+    libc::{ifreq, mmap, munmap, xdp_ring_offset, IF_NAMESIZE, SIOCGIFADDR, SIOCGIFHWADDR},
     std::{
         ffi::{c_char, CStr, CString},
         io::{self, ErrorKind},
@@ -86,7 +86,8 @@ impl NetworkDevice {
             );
         }
 
-        let result = unsafe { ioctl(fd.as_raw_fd(), SIOCGIFHWADDR, &mut req) };
+        let result =
+            unsafe { libc::syscall(libc::SYS_ioctl, fd.as_raw_fd(), SIOCGIFHWADDR, &mut req) };
         if result < 0 {
             return Err(io::Error::last_os_error());
         }
@@ -118,7 +119,8 @@ impl NetworkDevice {
             );
         }
 
-        let result = unsafe { libc::ioctl(fd.as_raw_fd(), SIOCGIFADDR, &mut req) };
+        let result =
+            unsafe { libc::syscall(libc::SYS_ioctl, fd.as_raw_fd(), SIOCGIFADDR, &mut req) };
         if result < 0 {
             return Err(io::Error::last_os_error());
         }


### PR DESCRIPTION
#### Problem

Before this change, `solana-runtime` and `solana-xdp` weren't musl-compatible.

#### Summary of Changes

Guard glibc-specific code and imports with `cfg(target_env = "gnu")`

Call `ioctl` using `libc::syscall` instead of `libc::ioctl`. Different libc implementations use different integer types for the `op` parameter. glibc uses `u64`/`unsigned long int`[0], musl uses `i32`/`int`[1]. Linux kernel uses `u32`/`unsigned int` when handling `ioctl` internally.[2]

In Agave, We use `u64` constants that come from the `libc` crate, however, all of them fit in `u32` just fine. Issuing a raw syscall is the least painful solution doesn't require explicit type conversions or guarding with `cfg`.

Add musl build to CI to make sure it doesn't regress again.

Unfortunately, this change still doesn't yet allow **static** linking of Agave crates, the musl support works only with **dynamic** linking done the following way:

```
RUSTFLAGS="-C target-feature=-crt-static" ./cargo build
```

Possibility of static linking is blocked by https://github.com/KyleMayes/clang-sys/issues/189 and the unreleased fix https://github.com/KyleMayes/clang-sys/pull/190. This bug makes a static build of `librocksdb-sys` impossible.

[0] https://elixir.bootlin.com/glibc/glibc-2.41.9000/source/misc/sys/ioctl.h#L42
[1] https://elixir.bootlin.com/musl/v1.2.5/source/include/sys/ioctl.h#L115
[2] https://elixir.bootlin.com/linux/v6.14.4/source/include/net/sock.h#L1243
