### PR TITLE
Test cargo-build-sbf in CI

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -17,7 +17,9 @@ cargo_build_sbf_sanity() {
 
   pushd programs/sbf
   # Generate the sanity programs list
-  cargo test --features="sbf_rust,sbf_sanity_list" --test programs test_program_sbf_sanity
+  if [ ! -f sanity_programs.txt ]; then
+    cargo test --features="sbf_rust,sbf_sanity_list" --test programs test_program_sbf_sanity
+  fi
   mapfile -t rust_programs < <(cat sanity_programs.txt)
 
   pushd rust

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -14,17 +14,15 @@ annotate() {
 
 cargo_build_sbf_sanity() {
   cargo_build_sbf="$(realpath ./cargo-build-sbf)"
-  # These programs must match those available on the list:
-  # https://github.com/anza-xyz/agave/blob/e12e6fbf76a0a3ba6acc85c3ef43467a7f90f38b/programs/sbf/tests/programs.rs#L149-L169
-  local sanity_programs=("128bit" "alloc" "alt_bn128" "alt_bn128_compression" "curve25519" "custom_heap" "dep_crate"
-  "external_spend" "iter" "many_args" "mem" "membuiltins" "noop" "panic" "param_passing" "poseidon" "rand"
-  "remaining_compute_units" "sanity" "secp256k1_recover" "sha")
 
   pushd programs/sbf
+  # Generate the sanity programs list
+  cargo test --features="sbf_rust,sbf_sanity_list" --test programs test_program_sbf_sanity
+  mapfile -t rust_programs < <(cat sanity_programs.txt)
 
   pushd rust
   # This is done in a loop to mock how developers invoke `cargo-build-sbf`
-  for program in "${sanity_programs[@]}"
+  for program in "${rust_programs[@]}"
   do
     pushd "$program"
     $cargo_build_sbf --arch "$1"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -82,22 +82,22 @@ test-stable-sbf)
   # SBPFv0 program tests
   _ make -C programs/sbf test-v0
   _ make -C programs/sbf clean-all
-  cargo_build_sbf_sanity "v0"
+  _ cargo_build_sbf_sanity "v0"
 
   # SBPFv1 program tests
   _ make -C programs/sbf clean-all test-v1
   _ make -C programs/sbf clean-all
-  cargo_build_sbf_sanity "v1"
+  _ cargo_build_sbf_sanity "v1"
 
   # SBPFv2 program tests
   _ make -C programs/sbf clean-all test-v2
   _ make -C programs/sbf clean-all
-  cargo_build_sbf_sanity "v2"
+  _ cargo_build_sbf_sanity "v2"
 
   # SBPFv3 program tests
   _ make -C programs/sbf clean-all test-v3
   _ make -C programs/sbf clean-all
-  cargo_build_sbf_sanity "v3"
+  _ cargo_build_sbf_sanity "v3"
 
   exit 0
   ;;

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -97,7 +97,8 @@ strip = true
 [features]
 sbf_c = []
 sbf_rust = []
-dummy-for-ci-check = ["sbf_c", "sbf_rust"]
+sbf_sanity_list = []
+dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list"]
 # This was needed for ci
 frozen-abi = []
 

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -2,6 +2,19 @@ SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/deploy
 
+test-v3:
+	mkdir -p target/deploy ; \
+	VER=v3 $(MAKE) rust-new ; \
+	$(MAKE) test-rust
+
+test-v2:
+	VER=v2 $(MAKE) test-version
+
+test-v1:
+	VER=v1 $(MAKE) test-version
+
+test-v0: all rust-v0 test-all
+
 clean-all:
 	rm -rf target/deploy target/sbpf*
 
@@ -10,19 +23,6 @@ test-all:
 
 test-rust:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust" $(TEST_ARGS)
-
-test-v0: all rust-v0 test-all
-
-test-v1:
-	VER=v1 $(MAKE) test-version
-
-test-v2:
-	VER=v2 $(MAKE) test-version
-
-test-v3:
-	mkdir -p target/deploy ; \
-	VER=v3 $(MAKE) rust-new ; \
-	$(MAKE) test-rust
 
 test-version:
 	SBPF_CPU=$(VER) $(MAKE) all ; \
@@ -37,6 +37,6 @@ rust-new:
 	RUSTFLAGS="-C instrument-coverage=no" cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace --features dynamic-frames ; \
 	cp -r target/sbpf$(VER)-solana-solana/release/* target/deploy
 
-.PHONY: rust-v0
+.PHONY: test-v3
 
 include $(SBF_SDK_PATH)/c/sbf.mk

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -2,8 +2,8 @@ SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/deploy
 
-clean-all: clean
-	cargo clean
+clean-all:
+	rm -rf target/deploy target/sbpf*
 
 test-all:
 	SBF_OUT_DIR=$(OUT_DIR) cargo test --features="sbf_rust,sbf_c" $(TEST_ARGS)

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4095,6 +4095,7 @@ fn test_cpi_change_account_data_memory_allocation() {
 }
 
 #[test]
+#[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 fn test_cpi_invalid_account_info_pointers() {
     solana_logger::setup();
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -170,6 +170,20 @@ fn test_program_sbf_sanity() {
         ]);
     }
 
+    #[cfg(all(feature = "sbf_rust", feature = "sbf_sanity_list"))]
+    {
+        // This code generates the list of sanity programs for a CI job to build with
+        // cargo-build-sbf and ensure it is working correctly.
+        use std::{env, fs::File, io::Write};
+        let current_dir = env::current_dir().unwrap();
+        let mut file = File::create(current_dir.join("sanity_programs.txt")).unwrap();
+        for program in programs.iter() {
+            writeln!(file, "{}", program.0.trim_start_matches("solana_sbf_rust_"))
+                .expect("Failed to write to file");
+        }
+    }
+
+    #[cfg(not(feature = "sbf_sanity_list"))]
     for program in programs.iter() {
         println!("Test program: {:?}", program.0);
 


### PR DESCRIPTION
#### Problem

There was a regression with `cargo-build-sbf` fixed in #5267 that went undetected because #1581 removed integration tests with `cargo-build-sbf`.

#### Summary of Changes

The `stable-sbf` job now runs sanity tests for `cargo-build-sbf`.