### PR TITLE
tpu-client-next: use in ForwardingStage (draft to show the overal idea)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,6 +7484,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "assert_matches",
+ "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -7564,6 +7565,7 @@ dependencies = [
  "solana-timings",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction-status",
  "solana-turbine",
  "solana-unified-scheduler-logic",
@@ -7582,6 +7584,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util 0.7.13",
  "trees",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7584,7 +7584,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.12",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.14",
  "trees",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ edition = { workspace = true }
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
 [dependencies]
+async-trait = { workspace = true }
 agave-banking-stage-ingress-types = { workspace = true }
 agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
@@ -71,6 +72,7 @@ solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-tpu-client-next = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -107,6 +107,7 @@ sys-info = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 trees = { workspace = true }
 
 [dev-dependencies]

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -44,9 +44,8 @@ mod packet_container;
 /// [`ForwardingClientOption`] enum represents the available client types for TPU
 /// communication:
 /// * [`ConnectionCacheClient`]: Uses a shared [`ConnectionCache`] to manage
-///       connections efficiently.
-/// * [`TpuClientNextClient`]: Relies on the `tpu-client-next` crate and
-///       requires a reference to a [`Keypair`].
+///       connections.
+/// * [`TpuClientNextClient`]: Relies on the `tpu-client-next` crate.
 pub enum ForwardingClientOption<'a> {
     ConnectionCache(Arc<ConnectionCache>),
     TpuClientNext((&'a Keypair, UdpSocket, RuntimeHandle)),

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -264,9 +264,10 @@ where
             let leader_updater = ForwardingStageLeaderUpdater {
                 forward_address_getter: forward_address_getter.clone(),
             };
+            // TODO(klykov): move these constants to some named consts on top of module with comments.
             let config = ConnectionWorkersSchedulerConfig {
                 bind: SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
-                stake_identity: validator_identity, // In CC, do we send with identity?
+                stake_identity: validator_identity,
                 num_connections: 1,
                 skip_check_transaction_age: false,
                 worker_channel_size: 2,

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -80,6 +80,6 @@ pub(crate) fn next_leaders(
 
     leader_pubkeys
         .iter()
-        .map(|leader_pubkey| cluster_info.lookup_contact_info(&leader_pubkey, &port_selector)?)
+        .map(|leader_pubkey| cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?)
         .collect()
 }

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -6,9 +6,8 @@ use {
         contact_info::{ContactInfoQuery, Protocol},
     },
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{
-        clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS},
-        pubkey::Pubkey,
+    solana_sdk::clock::{
+        FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS,
     },
     std::{net::SocketAddr, sync::RwLock},
 };
@@ -39,35 +38,12 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .collect()
 }
 
-pub(crate) fn next_leader_tpu_vote(
-    cluster_info: &impl LikeClusterInfo,
-    poh_recorder: &RwLock<PohRecorder>,
-) -> Option<(Pubkey, SocketAddr)> {
-    next_leader(cluster_info, poh_recorder, |node| {
-        node.tpu_vote(Protocol::UDP)
-    })
-}
-
-pub(crate) fn next_leader(
-    cluster_info: &impl LikeClusterInfo,
-    poh_recorder: &RwLock<PohRecorder>,
-    port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
-) -> Option<(Pubkey, SocketAddr)> {
-    let leader_pubkey = poh_recorder
-        .read()
-        .unwrap()
-        .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET)?;
-    cluster_info
-        .lookup_contact_info(&leader_pubkey, port_selector)?
-        .map(|addr| (leader_pubkey, addr))
-}
-
 pub(crate) fn next_leaders(
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
     max_count: u64,
     port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
-) -> Vec<Option<SocketAddr>> {
+) -> Vec<SocketAddr> {
     let recorder = poh_recorder.read().unwrap();
     let leader_pubkeys: Vec<_> = (0..max_count)
         .filter_map(|i| {
@@ -80,6 +56,8 @@ pub(crate) fn next_leaders(
 
     leader_pubkeys
         .iter()
-        .map(|leader_pubkey| cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?)
+        .filter_map(|leader_pubkey| {
+            cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?
+        })
         .collect()
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -21,7 +21,9 @@ use {
             VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
-        forwarding_stage::{spawn_forwarding_stage, SpawnForwardingStageResult},
+        forwarding_stage::{
+            spawn_forwarding_stage, ForwardAddressGetter, SpawnForwardingStageResult,
+        },
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -376,7 +378,7 @@ impl Tpu {
             forward_stage_receiver,
             client,
             RootBankCache::new(bank_forks.clone()),
-            (cluster_info.clone(), poh_recorder.clone()),
+            ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),
             DataBudget::default(),
         );
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -75,6 +75,8 @@ pub struct TpuSockets {
     pub transactions_quic: Vec<UdpSocket>,
     pub transactions_forwards_quic: Vec<UdpSocket>,
     pub vote_quic: Vec<UdpSocket>,
+    /// Client-side socket for the forwarding votes.
+    pub vote_forwards_client: UdpSocket,
 }
 
 pub struct Tpu {
@@ -231,6 +233,8 @@ impl Tpu {
             transactions_quic: transactions_quic_sockets,
             transactions_forwards_quic: transactions_forwards_quic_sockets,
             vote_quic: tpu_vote_quic_sockets,
+            vote_forwards_client: vote_forwards_client_socket,
+            ..
         } = sockets;
 
         let (packet_sender, packet_receiver) = unbounded();
@@ -377,6 +381,7 @@ impl Tpu {
         } = spawn_forwarding_stage(
             forward_stage_receiver,
             client,
+            vote_forwards_client_socket,
             RootBankCache::new(bank_forks.clone()),
             ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),
             DataBudget::default(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -17,7 +17,7 @@ use {
             VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
-        forwarding_stage::ForwardingStage,
+        forwarding_stage::spawn_with_connection_cache,
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -280,7 +280,7 @@ impl Tpu {
             prioritization_fee_cache,
         );
 
-        let forwarding_stage = ForwardingStage::spawn(
+        let forwarding_stage = spawn_with_connection_cache(
             forward_stage_receiver,
             connection_cache.clone(),
             RootBankCache::new(bank_forks.clone()),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -591,7 +591,7 @@ pub struct Validator {
     repair_quic_endpoints_join_handle: Option<repair::quic_endpoint::AsyncTryJoinHandle>,
     // This runtime is used when tpu-client-next is used instead of
     // ConnectionCache. The former has it's own runtime.
-    tpu_client_next_runtime: Option<TokioRuntime>,
+    _tpu_client_next_runtime: Option<TokioRuntime>,
 }
 
 impl Validator {
@@ -1657,8 +1657,8 @@ impl Validator {
                 key_notifies.push(json_rpc_service.get_client_key_updater())
             }
         }
-        // add connection_cache because it is still used in Forwarder.
-        key_notifies.push(connection_cache);
+        // Don't add connection_cache to key_notifiers here because it is added
+        // once in tpu.rs.
 
         *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
             bank_forks: bank_forks.clone(),
@@ -1705,7 +1705,7 @@ impl Validator {
             repair_quic_endpoints,
             repair_quic_endpoints_runtime,
             repair_quic_endpoints_join_handle,
-            tpu_client_next_runtime,
+            _tpu_client_next_runtime: tpu_client_next_runtime,
         })
     }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1586,6 +1586,7 @@ impl Validator {
                 .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
             ForwardingClientOption::TpuClientNext((
                 Arc::as_ref(&identity_keypair),
+                node.sockets.tpu_transactions_forwards_client,
                 runtime_handle.clone(),
             ))
         } else {
@@ -1605,6 +1606,7 @@ impl Validator {
                 transactions_quic: node.sockets.tpu_quic,
                 transactions_forwards_quic: node.sockets.tpu_forwards_quic,
                 vote_quic: node.sockets.tpu_vote_quic,
+                vote_forwards_client: node.sockets.tpu_vote_forwards_client,
             },
             &rpc_subscriptions,
             transaction_status_sender,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5883,6 +5883,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "assert_matches",
+ "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -5949,6 +5950,7 @@ dependencies = [
  "solana-timings",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction-status",
  "solana-turbine",
  "solana-unified-scheduler-pool",
@@ -5963,6 +5965,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util 0.7.14",
  "trees",
 ]
 

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -8,7 +8,7 @@ use {
     solana_measure::measure::Measure,
     solana_sdk::quic::NotifyKeyUpdate,
     solana_tpu_client_next::{
-        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
+        connection_workers_scheduler::{BindTarget, ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::LeaderUpdater,
         transaction_batch::TransactionBatch,
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
@@ -287,8 +287,9 @@ impl TpuClientNextClient {
         stake_identity: Option<&Keypair>,
         leader_forward_count: usize,
     ) -> ConnectionWorkersSchedulerConfig {
+        let address = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);
         ConnectionWorkersSchedulerConfig {
-            bind: SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0),
+            bind: BindTarget::Address(address),
             stake_identity: stake_identity.map(Into::into),
             num_connections: MAX_CONNECTIONS,
             skip_check_transaction_age: true,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5738,6 +5738,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "assert_matches",
+ "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -5804,6 +5805,7 @@ dependencies = [
  "solana-timings",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction-status",
  "solana-turbine",
  "solana-unified-scheduler-pool",
@@ -5818,6 +5820,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util 0.7.14",
  "trees",
 ]
 

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -16,7 +16,10 @@ use {
     log::*,
     quinn::Endpoint,
     solana_keypair::Keypair,
-    std::{net::SocketAddr, sync::Arc},
+    std::{
+        net::{SocketAddr, UdpSocket},
+        sync::Arc,
+    },
     thiserror::Error,
     tokio::sync::mpsc,
     tokio_util::sync::CancellationToken,
@@ -72,7 +75,7 @@ pub struct Fanout {
 /// behavior related to transaction handling.
 pub struct ConnectionWorkersSchedulerConfig {
     /// The local address to bind the scheduler to.
-    pub bind: SocketAddr,
+    pub bind: BindTarget,
 
     /// Optional stake identity keypair used in the endpoint certificate for
     /// identifying the sender.
@@ -94,6 +97,13 @@ pub struct ConnectionWorkersSchedulerConfig {
 
     /// Configures the number of leaders to connect to and send transactions to.
     pub leaders_fanout: Fanout,
+}
+
+/// The [`BindTarget`] structure defines how the UDP socket should be bound:
+/// either by providing a [`SocketAddr`] or an existing [`UdpSocket`].
+pub enum BindTarget {
+    Address(SocketAddr),
+    Socket(UdpSocket),
 }
 
 /// The [`StakeIdentity`] structure provides a convenient abstraction for handling
@@ -266,7 +276,7 @@ impl ConnectionWorkersScheduler {
 
     /// Sets up the QUIC endpoint for the scheduler to handle connections.
     fn setup_endpoint(
-        bind: SocketAddr,
+        bind: BindTarget,
         stake_identity: Option<StakeIdentity>,
     ) -> Result<Endpoint, ConnectionWorkersSchedulerError> {
         let client_certificate = match stake_identity {

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -15,7 +15,7 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
-        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
+        connection_workers_scheduler::{BindTarget, ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::create_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
         transaction_batch::TransactionBatch,
@@ -40,8 +40,9 @@ use {
 };
 
 fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
+    let address = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0);
     ConnectionWorkersSchedulerConfig {
-        bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
+        bind: BindTarget::Address(address),
         stake_identity: stake_identity.map(Into::into),
         num_connections: 1,
         skip_check_transaction_age: false,


### PR DESCRIPTION
#### Problem

This PR is to show the scope of changes needed to use tpu-client-next in the ForwardingStage (replacement of Forwarder). Later, these changes should be delivered in a series of PRs.

It lacks one feature from the client: support of the identity keypair update. This feature is, however, implemented in the other similar client in https://github.com/anza-xyz/agave/blob/master/send-transaction-service/src/transaction_client.rs#L366 . 

