### PR TITLE
Fee: only expose calculate_fee_details

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -764,13 +764,14 @@ impl Consumer {
                 .compute_budget_instruction_details()
                 .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)?,
         );
-        let fee = solana_fee::calculate_fee(
+        let fee = solana_fee::calculate_fee_details(
             transaction,
             bank.get_lamports_per_signature() == 0,
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),
-        );
+        )
+        .total_fee();
         let (mut fee_payer_account, _slot) = bank
             .rc
             .accounts

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -23,31 +23,16 @@ impl From<&FeatureSet> for FeeFeatures {
     }
 }
 
-/// Calculate fee for `SanitizedMessage`
-pub fn calculate_fee(
-    message: &impl SVMMessage,
+pub fn calculate_fee_details<'a, T>(
+    message: &'a T,
     zero_fees_for_test: bool,
     lamports_per_signature: u64,
     prioritization_fee: u64,
     fee_features: FeeFeatures,
-) -> u64 {
-    calculate_fee_details(
-        message,
-        zero_fees_for_test,
-        lamports_per_signature,
-        prioritization_fee,
-        fee_features,
-    )
-    .total_fee()
-}
-
-pub fn calculate_fee_details(
-    message: &impl SVMMessage,
-    zero_fees_for_test: bool,
-    lamports_per_signature: u64,
-    prioritization_fee: u64,
-    fee_features: FeeFeatures,
-) -> FeeDetails {
+) -> FeeDetails
+where
+    SignatureCounts: From<&'a T>,
+{
     if zero_fees_for_test {
         return FeeDetails::default();
     }
@@ -82,11 +67,11 @@ fn calculate_signature_fee(
     signature_count.saturating_mul(lamports_per_signature)
 }
 
-struct SignatureCounts {
-    pub num_transaction_signatures: u64,
-    pub num_ed25519_signatures: u64,
-    pub num_secp256k1_signatures: u64,
-    pub num_secp256r1_signatures: u64,
+pub struct SignatureCounts {
+    num_transaction_signatures: u64,
+    num_ed25519_signatures: u64,
+    num_secp256k1_signatures: u64,
+    num_secp256r1_signatures: u64,
 }
 
 impl<Tx: SVMMessage> From<&Tx> for SignatureCounts {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3443,13 +3443,14 @@ fn test_program_fees() {
         )
         .unwrap_or_default(),
     );
-    let expected_normal_fee = solana_fee::calculate_fee(
+    let expected_normal_fee = solana_fee::calculate_fee_details(
         &sanitized_message,
         congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         bank.feature_set.as_ref().into(),
-    );
+    )
+    .total_fee();
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
         .unwrap();
@@ -3476,13 +3477,14 @@ fn test_program_fees() {
         )
         .unwrap_or_default(),
     );
-    let expected_prioritized_fee = solana_fee::calculate_fee(
+    let expected_prioritized_fee = solana_fee::calculate_fee_details(
         &sanitized_message,
         congestion_multiplier == 0,
         fee_structure.lamports_per_signature,
         fee_budget_limits.prioritization_fee,
         bank.feature_set.as_ref().into(),
-    );
+    )
+    .total_fee();
     assert!(expected_normal_fee < expected_prioritized_fee);
 
     bank_client

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2913,13 +2913,14 @@ impl Bank {
             )
             .unwrap_or_default(),
         );
-        solana_fee::calculate_fee(
+        solana_fee::calculate_fee_details(
             message,
             lamports_per_signature == 0,
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),
         )
+        .total_fee()
     }
 
     pub fn get_blockhash_last_valid_block_height(&self, blockhash: &Hash) -> Option<Slot> {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10359,7 +10359,7 @@ fn calculate_test_fee(
         )
         .unwrap_or_default(),
     );
-    solana_fee::calculate_fee(
+    solana_fee::calculate_fee_details(
         message,
         lamports_per_signature == 0,
         fee_structure.lamports_per_signature,
@@ -10368,6 +10368,7 @@ fn calculate_test_fee(
             enable_secp256r1_precompile: true,
         },
     )
+    .total_fee()
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
- Current exposed functions force us to have a resolved transaction
- There are places where we want the fee which we have not yet resolved (forwarding stage)

#### Summary of Changes
- Simplify fee libraries interface:
    - No more boiler plate to just call `.total_fee()`
    - Public function takes something that converts to signature counts

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
