### PR TITLE
Marks `store_uncached` functions as DCOU

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -563,6 +563,7 @@ impl Accounts {
     /// Slow because lock is held for 1 operation instead of many.
     /// WARNING: This noncached version is only to be used for tests/benchmarking
     /// as bypassing the cache in general is not supported
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn store_slow_uncached(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
         self.accounts_db.store_uncached(slot, &[(pubkey, account)]);
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8034,6 +8034,7 @@ impl AccountsDb {
 
     /// Store the account update.
     /// only called by tests
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         let storage = self.find_storage_candidate(slot);
         self.store(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1362,6 +1362,9 @@ impl AccountStorageEntry {
         self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
+    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
+    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
+    #[cfg(feature = "dev-context-only-utils")]
     fn try_available(&self) -> bool {
         let mut count_and_status = self.count_and_status.lock_write();
         let (count, status) = *count_and_status;
@@ -5566,6 +5569,9 @@ impl AccountsDb {
         }
     }
 
+    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
+    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
+    #[cfg(feature = "dev-context-only-utils")]
     fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
         let mut get_slot_stores = Measure::start("get_slot_stores");
         let store = self.storage.get_slot_storage_entry(slot);


### PR DESCRIPTION
#### Problem

Storing accounts and bypassing the write cache is not supported. This behavior is only used in tests, and we should prevent their use in other contexts.


#### Summary of Changes

Mark 'em as DCOU.