### PR TITLE
store-histogram: Refactors pad()

### DIFF
--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -14,12 +14,9 @@ struct Bin {
     avg: usize,
 }
 
+/// Creates a string of spaces (` `) of length `width`
 fn pad(width: usize) -> String {
-    let mut s = String::new();
-    for _i in 0..width {
-        s = format!("{s} ");
-    }
-    s
+    " ".repeat(width)
 }
 
 fn get_stars(x: usize, max: usize, width: usize) -> String {


### PR DESCRIPTION
#### Problem

Using `format!()` in a for-loop to create a string filled with spaces made me sad :(


#### Summary of Changes

Use [`str::repeat()`](https://doc.rust-lang.org/std/primitive.str.html#method.repeat) instead.