### PR TITLE
Remove duplicate counting of flushed accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6229,7 +6229,7 @@ impl AccountsDb {
                 "accounts_db-flush_accounts_cache_aggressively",
                 ("num_flushed", flush_stats.num_flushed.0, i64),
                 ("num_purged", flush_stats.num_purged.0, i64),
-                ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
+                ("total_flush_size", flush_stats.total_size.0, i64),
                 ("total_cache_size", self.accounts_cache.size(), i64),
                 ("total_frozen_slots", excess_slot_count, i64),
                 ("total_slots", self.accounts_cache.num_slots(), i64),
@@ -6362,8 +6362,7 @@ impl AccountsDb {
                     .map(|should_flush_f| should_flush_f(key))
                     .unwrap_or(true);
                 if should_flush {
-                    flush_stats.num_bytes_flushed +=
-                        aligned_stored_size(account.data().len()) as u64;
+                    flush_stats.total_size += aligned_stored_size(account.data().len()) as u64;
                     flush_stats.num_flushed += 1;
                     Some((key, account))
                 } else {
@@ -6387,11 +6386,8 @@ impl AccountsDb {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
             // will be able to find the account in storage
-            let flushed_store = self.create_and_insert_store(
-                slot,
-                flush_stats.num_bytes_flushed.0,
-                "flush_slot_cache",
-            );
+            let flushed_store =
+                self.create_and_insert_store(slot, flush_stats.total_size.0, "flush_slot_cache");
             let (store_accounts_timing_inner, store_accounts_total_inner_us) =
                 measure_us!(self.store_accounts_frozen((slot, &accounts[..]), &flushed_store,));
             flush_stats.store_accounts_timing = store_accounts_timing_inner;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6174,8 +6174,6 @@ impl AccountsDb {
         // Flush only the roots <= requested_flush_root, so that snapshotting has all
         // the relevant roots in storage.
         let mut flush_roots_elapsed = Measure::start("flush_roots_elapsed");
-        let mut account_bytes_saved = 0;
-        let mut num_accounts_saved = 0;
 
         let _guard = self.active_stats.activate(ActiveStatItem::Flush);
 
@@ -6185,7 +6183,7 @@ impl AccountsDb {
         let (total_new_cleaned_roots, num_cleaned_roots_flushed, mut flush_stats) = self
             .flush_rooted_accounts_cache(
                 requested_flush_root,
-                Some((&mut account_bytes_saved, &mut num_accounts_saved)),
+                true, // should_clean
             );
         flush_roots_elapsed.stop();
 
@@ -6199,9 +6197,9 @@ impl AccountsDb {
                 // Start by flushing the roots
                 //
                 // Cannot do any cleaning on roots past `requested_flush_root` because future
-                // snapshots may need updates from those later slots, hence we pass `None`
+                // snapshots may need updates from those later slots, hence we pass `false`
                 // for `should_clean`.
-                self.flush_rooted_accounts_cache(None, None)
+                self.flush_rooted_accounts_cache(None, false)
             } else {
                 (0, 0, FlushStats::default())
             };
@@ -6231,7 +6229,7 @@ impl AccountsDb {
                 "accounts_db-flush_accounts_cache_aggressively",
                 ("num_flushed", flush_stats.num_flushed.0, i64),
                 ("num_purged", flush_stats.num_purged.0, i64),
-                ("total_flush_size", flush_stats.total_size.0, i64),
+                ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
                 ("total_cache_size", self.accounts_cache.size(), i64),
                 ("total_frozen_slots", excess_slot_count, i64),
                 ("total_slots", self.accounts_cache.num_slots(), i64),
@@ -6251,8 +6249,8 @@ impl AccountsDb {
                 i64
             ),
             ("flush_roots_elapsed", flush_roots_elapsed.as_us(), i64),
-            ("account_bytes_saved", account_bytes_saved, i64),
-            ("num_accounts_saved", num_accounts_saved, i64),
+            ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
+            ("num_accounts_saved", flush_stats.num_purged.0, i64),
             (
                 "store_accounts_total_us",
                 flush_stats.store_accounts_total_us.0,
@@ -6279,31 +6277,28 @@ impl AccountsDb {
     fn flush_rooted_accounts_cache(
         &self,
         requested_flush_root: Option<Slot>,
-        should_clean: Option<(&mut usize, &mut usize)>,
+        should_clean: bool,
     ) -> (usize, usize, FlushStats) {
-        let max_clean_root = should_clean.as_ref().and_then(|_| {
-            // If there is a long running scan going on, this could prevent any cleaning
-            // based on updates from slots > `max_clean_root`.
-            self.max_clean_root(requested_flush_root)
-        });
+        let max_clean_root = should_clean
+            .then(|| {
+                // If there is a long running scan going on, this could prevent any cleaning
+                // based on updates from slots > `max_clean_root`.
+                self.max_clean_root(requested_flush_root)
+            })
+            .flatten();
 
         let mut written_accounts = HashSet::new();
 
-        // If `should_clean` is None, then`should_flush_f` is also None, which will cause
+        // If `should_clean` is false, then`should_flush_f` will be None, which will cause
         // `flush_slot_cache` to flush all accounts to storage without cleaning any accounts.
-        let mut should_flush_f = should_clean.map(|(account_bytes_saved, num_accounts_saved)| {
-            move |&pubkey: &Pubkey, account: &AccountSharedData| {
-                // if not in hashset, then not flushed previously, so flush it
-                let should_flush = written_accounts.insert(pubkey);
-                if !should_flush {
-                    *account_bytes_saved += account.data().len();
-                    *num_accounts_saved += 1;
-                    // If a later root already wrote this account, no point
-                    // in flushing it
-                }
-                should_flush
-            }
-        });
+        let mut should_flush_f = should_clean
+            .then(|| {
+                Some(move |&pubkey: &Pubkey| {
+                    // if not in hashset, then not flushed previously, so flush it
+                    written_accounts.insert(pubkey)
+                })
+            })
+            .flatten();
 
         // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
         let flushed_roots: BTreeSet<Slot> = self.accounts_cache.clear_roots(requested_flush_root);
@@ -6340,7 +6335,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         slot_cache: &SlotCache,
-        mut should_flush_f: Option<&mut impl FnMut(&Pubkey, &AccountSharedData) -> bool>,
+        mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
         max_clean_root: Option<Slot>,
     ) -> FlushStats {
         let mut flush_stats = FlushStats::default();
@@ -6364,16 +6359,19 @@ impl AccountsDb {
                 let account = &iter_item.value().account;
                 let should_flush = should_flush_f
                     .as_mut()
-                    .map(|should_flush_f| should_flush_f(key, account))
+                    .map(|should_flush_f| should_flush_f(key))
                     .unwrap_or(true);
                 if should_flush {
-                    flush_stats.total_size += aligned_stored_size(account.data().len()) as u64;
+                    flush_stats.num_bytes_flushed +=
+                        aligned_stored_size(account.data().len()) as u64;
                     flush_stats.num_flushed += 1;
                     Some((key, account))
                 } else {
                     // If we don't flush, we have to remove the entry from the
                     // index, since it's equivalent to purging
                     pubkey_to_slot_set.push((*key, slot));
+                    flush_stats.num_bytes_purged +=
+                        aligned_stored_size(account.data().len()) as u64;
                     flush_stats.num_purged += 1;
                     None
                 }
@@ -6389,8 +6387,11 @@ impl AccountsDb {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
             // will be able to find the account in storage
-            let flushed_store =
-                self.create_and_insert_store(slot, flush_stats.total_size.0, "flush_slot_cache");
+            let flushed_store = self.create_and_insert_store(
+                slot,
+                flush_stats.num_bytes_flushed.0,
+                "flush_slot_cache",
+            );
             let (store_accounts_timing_inner, store_accounts_total_inner_us) =
                 measure_us!(self.store_accounts_frozen((slot, &accounts[..]), &flushed_store,));
             flush_stats.store_accounts_timing = store_accounts_timing_inner;
@@ -6420,7 +6421,7 @@ impl AccountsDb {
 
     /// flush all accounts in this slot
     fn flush_slot_cache(&self, slot: Slot) -> Option<FlushStats> {
-        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_, &_) -> bool>, None)
+        self.flush_slot_cache_with_clean(slot, None::<&mut fn(&_) -> bool>, None)
     }
 
     /// `should_flush_f` is an optional closure that determines whether a given
@@ -6429,7 +6430,7 @@ impl AccountsDb {
     fn flush_slot_cache_with_clean(
         &self,
         slot: Slot,
-        should_flush_f: Option<&mut impl FnMut(&Pubkey, &AccountSharedData) -> bool>,
+        should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
         max_clean_root: Option<Slot>,
     ) -> Option<FlushStats> {
         if self

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -144,7 +144,7 @@ impl StoreAccountsTiming {
 #[derive(Debug, Default)]
 pub struct FlushStats {
     pub num_flushed: Saturating<usize>,
-    pub num_bytes_flushed: Saturating<u64>,
+    pub total_size: Saturating<u64>,
     pub num_purged: Saturating<usize>,
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
@@ -154,7 +154,7 @@ pub struct FlushStats {
 impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_flushed += other.num_flushed;
-        self.num_bytes_flushed += other.num_bytes_flushed;
+        self.total_size += other.total_size;
         self.num_purged += other.num_purged;
         self.num_bytes_purged += other.num_bytes_purged;
         self.store_accounts_timing

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -144,8 +144,9 @@ impl StoreAccountsTiming {
 #[derive(Debug, Default)]
 pub struct FlushStats {
     pub num_flushed: Saturating<usize>,
+    pub num_bytes_flushed: Saturating<u64>,
     pub num_purged: Saturating<usize>,
-    pub total_size: Saturating<u64>,
+    pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
     pub store_accounts_total_us: Saturating<u64>,
 }
@@ -153,8 +154,9 @@ pub struct FlushStats {
 impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_flushed += other.num_flushed;
+        self.num_bytes_flushed += other.num_bytes_flushed;
         self.num_purged += other.num_purged;
-        self.total_size += other.total_size;
+        self.num_bytes_purged += other.num_bytes_purged;
         self.store_accounts_timing
             .accumulate(&other.store_accounts_timing);
         self.store_accounts_total_us += other.store_accounts_total_us;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4592,16 +4592,9 @@ fn test_accounts_db_cache_clean_max_root_with_cache_limit_hit_and_scan() {
 fn run_flush_rooted_accounts_cache(should_clean: bool) {
     let num_slots = 10;
     let (accounts_db, keys, slots, _) = setup_accounts_db_cache_clean(num_slots, None, None);
-    let mut cleaned_bytes = 0;
-    let mut cleaned_accounts = 0;
-    let should_clean_tracker = if should_clean {
-        Some((&mut cleaned_bytes, &mut cleaned_accounts))
-    } else {
-        None
-    };
 
     // If no cleaning is specified, then flush everything
-    accounts_db.flush_rooted_accounts_cache(None, should_clean_tracker);
+    accounts_db.flush_rooted_accounts_cache(None, should_clean);
     for slot in &slots {
         let slot_accounts = if let ScanStorageResult::Stored(slot_accounts) = accounts_db
             .scan_account_storage(


### PR DESCRIPTION
#### Problem
Flush stats are currently counted in two places. Remove one of the counters.

#### Summary of Changes
Ended up being a larger refactor, because the presence of the counters was used to determine whether flushing should happen or not.
Also matched the flush and purge counters to log the same data. 

Split off from the other PR

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
