### PR TITLE
move transaction fee burn config and impl from fee-rate-governor to bank

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6483,14 +6483,14 @@ impl Bank {
 
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
             *self.inflation.write().unwrap() = Inflation::pico();
-            self.fee_rate_governor.burn_percent = 50; // 50% fee burn
+            self.fee_rate_governor.burn_percent = solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT; // 50% fee burn
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
         if !new_feature_activations.is_disjoint(&self.feature_set.full_inflation_features_enabled())
         {
             *self.inflation.write().unwrap() = Inflation::full();
-            self.fee_rate_governor.burn_percent = 50; // 50% fee burn
+            self.fee_rate_governor.burn_percent = solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT; // 50% fee burn
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -80,11 +80,23 @@ impl Bank {
         fee_details: &CollectorFeeDetails,
     ) -> (u64, u64) {
         let (deposit, burn) = if fee_details.transaction_fee != 0 {
-            self.fee_rate_governor.burn(fee_details.transaction_fee)
+            self.burn_transaction_fee(fee_details.transaction_fee)
         } else {
             (0, 0)
         };
         (deposit.saturating_add(fee_details.priority_fee), burn)
+    }
+
+    fn burn_transaction_fee(&self, fees: u64) -> (u64, u64) {
+        let burned = fees * u64::from(self.burn_percent()) / 100;
+        (fees - burned, burned)
+    }
+
+    fn burn_percent(&self) -> u8 {
+        // NOTE: burn percent is statically 50%, in case it needs to change in the future,
+        // burn_percent can be bank property that being passed down from bank to bank, without
+        // needing fee-rate-governor
+        solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT
     }
 
     fn deposit_or_burn_fee(&self, deposit: u64, burn: &mut u64) {
@@ -679,7 +691,7 @@ pub mod tests {
             transaction_fee,
             priority_fee,
         });
-        let (expected_deposit, expected_burn) = bank.fee_rate_governor.burn(transaction_fee);
+        let (expected_deposit, expected_burn) = bank.burn_transaction_fee(transaction_fee);
         let expected_rewards = expected_deposit + priority_fee;
 
         let initial_capitalization = bank.capitalization();

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -88,15 +88,15 @@ impl Bank {
     }
 
     fn burn_transaction_fee(&self, fees: u64) -> (u64, u64) {
-        let burned = fees * u64::from(self.burn_percent()) / 100;
+        let burned = fees * self.burn_percent() / 100;
         (fees - burned, burned)
     }
 
-    fn burn_percent(&self) -> u8 {
+    const fn burn_percent(&self) -> u64 {
         // NOTE: burn percent is statically 50%, in case it needs to change in the future,
         // burn_percent can be bank property that being passed down from bank to bank, without
         // needing fee-rate-governor
-        solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT
+        solana_sdk::fee_calculator::DEFAULT_BURN_PERCENT as u64
     }
 
     fn deposit_or_burn_fee(&self, deposit: u64, burn: &mut u64) {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -750,50 +750,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_distribute_transaction_fee_details_burn_all() {
-        let mut genesis = create_genesis_config(0);
-        genesis.genesis_config.fee_rate_governor.burn_percent = 100;
-        let mut bank = Bank::new_for_tests(&genesis.genesis_config);
-        let transaction_fee = 100;
-        let priority_fee = 200;
-        bank.collector_fee_details = RwLock::new(CollectorFeeDetails {
-            transaction_fee,
-            priority_fee,
-        });
-
-        let initial_capitalization = bank.capitalization();
-        let initial_collector_id_balance = bank.get_balance(bank.collector_id());
-        bank.distribute_transaction_fee_details();
-        let new_collector_id_balance = bank.get_balance(bank.collector_id());
-
-        assert_eq!(
-            initial_collector_id_balance + priority_fee,
-            new_collector_id_balance
-        );
-        assert_eq!(
-            initial_capitalization - transaction_fee,
-            bank.capitalization()
-        );
-        let locked_rewards = bank.rewards.read().unwrap();
-        assert_eq!(
-            locked_rewards.len(),
-            1,
-            "There should be one reward distributed"
-        );
-
-        let reward_info = &locked_rewards[0];
-        assert_eq!(
-            reward_info.1.lamports, priority_fee as i64,
-            "The reward amount should match the expected deposit"
-        );
-        assert_eq!(
-            reward_info.1.reward_type,
-            RewardType::Fee,
-            "The reward type should be Fee"
-        );
-    }
-
-    #[test]
     fn test_distribute_transaction_fee_details_overflow_failure() {
         let genesis = create_genesis_config(0);
         let mut bank = Bank::new_for_tests(&genesis.genesis_config);


### PR DESCRIPTION
#### Problem

`bank.fee_rate_governor` provides two functions: 
1. set `zero-fees-for-test` switch; 
2. impl of transaction fee burning logic.

`burn` rate and logic is stable and simple, moving it into `bank` itself helps to remove `fee_rate_governor` from bank (#3303)

#### Summary of Changes
- move burn_percent const to `bank`
- move `burn()` logic to bank

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
