### PR TITLE
Moves AccountMapEntry types to submodule

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,3 +1,4 @@
+mod account_map_entry;
 pub(crate) mod in_mem_accounts_index;
 mod roots_tracker;
 use {
@@ -5,12 +6,13 @@ use {
         accounts_index_storage::{AccountsIndexStorage, Startup},
         accounts_partition::RentPayingAccountsByPartition,
         ancestors::Ancestors,
-        bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+        bucket_map_holder::Age,
         contains::Contains,
         pubkey_bins::PubkeyBinCalculator24,
         rolling_bit_field::RollingBitField,
         secondary_index::*,
     },
+    account_map_entry::{AccountMapEntry, AccountMapEntryInner, PreAllocatedAccountMapEntry},
     in_mem_accounts_index::{InMemAccountsIndex, InsertNewEntryResults, StartupStats},
     log::*,
     rand::{thread_rng, Rng},
@@ -170,8 +172,6 @@ pub enum ScanOrder {
     Sorted,
 }
 
-pub(crate) type AccountMapEntry<T> = Arc<AccountMapEntryInner<T>>;
-
 pub trait IsCached {
     fn is_cached(&self) -> bool;
 }
@@ -260,186 +260,6 @@ impl AccountSecondaryIndexes {
         match &self.keys {
             Some(options) => options.exclude ^ options.keys.contains(key),
             None => true, // include all keys
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-/// data per entry in in-mem accounts index
-/// used to keep track of consistency with disk index
-pub struct AccountMapEntryMeta {
-    /// true if entry in in-mem idx has changes and needs to be written to disk
-    pub dirty: AtomicBool,
-    /// 'age' at which this entry should be purged from the cache (implements lru)
-    pub age: AtomicAge,
-}
-
-impl AccountMapEntryMeta {
-    pub fn new_dirty<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
-        storage: &Arc<BucketMapHolder<T, U>>,
-        is_cached: bool,
-    ) -> Self {
-        AccountMapEntryMeta {
-            dirty: AtomicBool::new(true),
-            age: AtomicAge::new(storage.future_age_to_flush(is_cached)),
-        }
-    }
-    pub fn new_clean<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
-        storage: &Arc<BucketMapHolder<T, U>>,
-    ) -> Self {
-        AccountMapEntryMeta {
-            dirty: AtomicBool::new(false),
-            age: AtomicAge::new(storage.future_age_to_flush(false)),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-/// one entry in the in-mem accounts index
-/// Represents the value for an account key in the in-memory accounts index
-pub struct AccountMapEntryInner<T> {
-    /// number of alive slots that contain >= 1 instances of account data for this pubkey
-    /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
-    ref_count: AtomicU64,
-    /// list of slots in which this pubkey was updated
-    /// Note that 'clean' removes outdated entries (ie. older roots) from this slot_list
-    /// purge_slot() also removes non-rooted slots from this list
-    pub slot_list: RwLock<SlotList<T>>,
-    /// synchronization metadata for in-memory state since last flush to disk accounts index
-    pub meta: AccountMapEntryMeta,
-}
-
-impl<T: IndexValue> AccountMapEntryInner<T> {
-    pub fn new(slot_list: SlotList<T>, ref_count: RefCount, meta: AccountMapEntryMeta) -> Self {
-        Self {
-            slot_list: RwLock::new(slot_list),
-            ref_count: AtomicU64::new(ref_count),
-            meta,
-        }
-    }
-    pub fn ref_count(&self) -> RefCount {
-        self.ref_count.load(Ordering::Acquire)
-    }
-
-    pub fn addref(&self) {
-        self.ref_count.fetch_add(1, Ordering::Release);
-        self.set_dirty(true);
-    }
-
-    /// decrement the ref count
-    /// return the refcount prior to subtracting 1
-    /// 0 indicates an under refcounting error in the system.
-    pub fn unref(&self) -> RefCount {
-        let previous = self.ref_count.fetch_sub(1, Ordering::Release);
-        self.set_dirty(true);
-        if previous == 0 {
-            inc_new_counter_info!("accounts_index-deref_from_0", 1);
-        }
-        previous
-    }
-
-    pub fn dirty(&self) -> bool {
-        self.meta.dirty.load(Ordering::Acquire)
-    }
-
-    pub fn set_dirty(&self, value: bool) {
-        self.meta.dirty.store(value, Ordering::Release)
-    }
-
-    /// set dirty to false, return true if was dirty
-    pub fn clear_dirty(&self) -> bool {
-        self.meta
-            .dirty
-            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-    }
-
-    pub fn age(&self) -> Age {
-        self.meta.age.load(Ordering::Acquire)
-    }
-
-    pub fn set_age(&self, value: Age) {
-        self.meta.age.store(value, Ordering::Release)
-    }
-
-    /// set age to 'next_age' if 'self.age' is 'expected_age'
-    pub fn try_exchange_age(&self, next_age: Age, expected_age: Age) {
-        let _ = self.meta.age.compare_exchange(
-            expected_age,
-            next_age,
-            Ordering::AcqRel,
-            Ordering::Relaxed,
-        );
-    }
-}
-
-/// can be used to pre-allocate structures for insertion into accounts index outside of lock
-pub enum PreAllocatedAccountMapEntry<T: IndexValue> {
-    Entry(AccountMapEntry<T>),
-    Raw((Slot, T)),
-}
-
-impl<T: IndexValue> ZeroLamport for PreAllocatedAccountMapEntry<T> {
-    fn is_zero_lamport(&self) -> bool {
-        match self {
-            PreAllocatedAccountMapEntry::Entry(entry) => {
-                entry.slot_list.read().unwrap()[0].1.is_zero_lamport()
-            }
-            PreAllocatedAccountMapEntry::Raw(raw) => raw.1.is_zero_lamport(),
-        }
-    }
-}
-
-impl<T: IndexValue> From<PreAllocatedAccountMapEntry<T>> for (Slot, T) {
-    fn from(source: PreAllocatedAccountMapEntry<T>) -> (Slot, T) {
-        match source {
-            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list.read().unwrap()[0],
-            PreAllocatedAccountMapEntry::Raw(raw) => raw,
-        }
-    }
-}
-
-impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
-    /// create an entry that is equivalent to this process:
-    /// 1. new empty (refcount=0, slot_list={})
-    /// 2. update(slot, account_info)
-    ///
-    /// This code is called when the first entry [ie. (slot,account_info)] for a pubkey is inserted into the index.
-    pub fn new<U: DiskIndexValue + From<T> + Into<T>>(
-        slot: Slot,
-        account_info: T,
-        storage: &Arc<BucketMapHolder<T, U>>,
-        store_raw: bool,
-    ) -> PreAllocatedAccountMapEntry<T> {
-        if store_raw {
-            Self::Raw((slot, account_info))
-        } else {
-            Self::Entry(Self::allocate(slot, account_info, storage))
-        }
-    }
-
-    fn allocate<U: DiskIndexValue + From<T> + Into<T>>(
-        slot: Slot,
-        account_info: T,
-        storage: &Arc<BucketMapHolder<T, U>>,
-    ) -> AccountMapEntry<T> {
-        let is_cached = account_info.is_cached();
-        let ref_count = u64::from(!is_cached);
-        let meta = AccountMapEntryMeta::new_dirty(storage, is_cached);
-        Arc::new(AccountMapEntryInner::new(
-            vec![(slot, account_info)],
-            ref_count,
-            meta,
-        ))
-    }
-
-    pub fn into_account_map_entry<U: DiskIndexValue + From<T> + Into<T>>(
-        self,
-        storage: &Arc<BucketMapHolder<T, U>>,
-    ) -> AccountMapEntry<T> {
-        match self {
-            Self::Entry(entry) => entry,
-            Self::Raw((slot, account_info)) => Self::allocate(slot, account_info, storage),
         }
     }
 }
@@ -2078,6 +1898,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 pub mod tests {
     use {
         super::*,
+        crate::bucket_map_holder::{AtomicAge, BucketMapHolder},
+        account_map_entry::AccountMapEntryMeta,
         solana_account::{AccountSharedData, WritableAccount},
         solana_inline_spl::token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET,
         solana_pubkey::PUBKEY_BYTES,
@@ -2503,7 +2325,7 @@ pub mod tests {
 
         for (i, key) in [key0, key1].iter().enumerate() {
             let entry = index.get_cloned(key).unwrap();
-            assert_eq!(entry.ref_count.load(Ordering::Relaxed), 1);
+            assert_eq!(entry.ref_count(), 1);
             assert_eq!(
                 entry.slot_list.read().unwrap().as_slice(),
                 &[(slot0, account_infos[i])],

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -1,0 +1,192 @@
+use {
+    super::{DiskIndexValue, IndexValue, RefCount, SlotList, ZeroLamport},
+    crate::bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+    log::*,
+    solana_clock::Slot,
+    std::sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+};
+
+pub type AccountMapEntry<T> = Arc<AccountMapEntryInner<T>>;
+
+/// one entry in the in-mem accounts index
+/// Represents the value for an account key in the in-memory accounts index
+#[derive(Debug, Default)]
+pub struct AccountMapEntryInner<T> {
+    /// number of alive slots that contain >= 1 instances of account data for this pubkey
+    /// where alive represents a slot that has not yet been removed by clean via AccountsDB::clean_stored_dead_slots() for containing no up to date account information
+    ref_count: AtomicU64,
+    /// list of slots in which this pubkey was updated
+    /// Note that 'clean' removes outdated entries (ie. older roots) from this slot_list
+    /// purge_slot() also removes non-rooted slots from this list
+    pub slot_list: RwLock<SlotList<T>>,
+    /// synchronization metadata for in-memory state since last flush to disk accounts index
+    pub meta: AccountMapEntryMeta,
+}
+
+impl<T: IndexValue> AccountMapEntryInner<T> {
+    pub fn new(slot_list: SlotList<T>, ref_count: RefCount, meta: AccountMapEntryMeta) -> Self {
+        Self {
+            slot_list: RwLock::new(slot_list),
+            ref_count: AtomicU64::new(ref_count),
+            meta,
+        }
+    }
+    pub fn ref_count(&self) -> RefCount {
+        self.ref_count.load(Ordering::Acquire)
+    }
+
+    pub fn addref(&self) {
+        self.ref_count.fetch_add(1, Ordering::Release);
+        self.set_dirty(true);
+    }
+
+    /// decrement the ref count
+    /// return the refcount prior to subtracting 1
+    /// 0 indicates an under refcounting error in the system.
+    pub fn unref(&self) -> RefCount {
+        let previous = self.ref_count.fetch_sub(1, Ordering::Release);
+        self.set_dirty(true);
+        if previous == 0 {
+            inc_new_counter_info!("accounts_index-deref_from_0", 1);
+        }
+        previous
+    }
+
+    pub fn dirty(&self) -> bool {
+        self.meta.dirty.load(Ordering::Acquire)
+    }
+
+    pub fn set_dirty(&self, value: bool) {
+        self.meta.dirty.store(value, Ordering::Release)
+    }
+
+    /// set dirty to false, return true if was dirty
+    pub fn clear_dirty(&self) -> bool {
+        self.meta
+            .dirty
+            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    pub fn age(&self) -> Age {
+        self.meta.age.load(Ordering::Acquire)
+    }
+
+    pub fn set_age(&self, value: Age) {
+        self.meta.age.store(value, Ordering::Release)
+    }
+
+    /// set age to 'next_age' if 'self.age' is 'expected_age'
+    pub fn try_exchange_age(&self, next_age: Age, expected_age: Age) {
+        let _ = self.meta.age.compare_exchange(
+            expected_age,
+            next_age,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        );
+    }
+}
+
+/// data per entry in in-mem accounts index
+/// used to keep track of consistency with disk index
+#[derive(Debug, Default)]
+pub struct AccountMapEntryMeta {
+    /// true if entry in in-mem idx has changes and needs to be written to disk
+    pub dirty: AtomicBool,
+    /// 'age' at which this entry should be purged from the cache (implements lru)
+    pub age: AtomicAge,
+}
+
+impl AccountMapEntryMeta {
+    pub fn new_dirty<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
+        storage: &Arc<BucketMapHolder<T, U>>,
+        is_cached: bool,
+    ) -> Self {
+        AccountMapEntryMeta {
+            dirty: AtomicBool::new(true),
+            age: AtomicAge::new(storage.future_age_to_flush(is_cached)),
+        }
+    }
+    pub fn new_clean<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
+        storage: &Arc<BucketMapHolder<T, U>>,
+    ) -> Self {
+        AccountMapEntryMeta {
+            dirty: AtomicBool::new(false),
+            age: AtomicAge::new(storage.future_age_to_flush(false)),
+        }
+    }
+}
+
+/// can be used to pre-allocate structures for insertion into accounts index outside of lock
+pub enum PreAllocatedAccountMapEntry<T: IndexValue> {
+    Entry(AccountMapEntry<T>),
+    Raw((Slot, T)),
+}
+
+impl<T: IndexValue> ZeroLamport for PreAllocatedAccountMapEntry<T> {
+    fn is_zero_lamport(&self) -> bool {
+        match self {
+            PreAllocatedAccountMapEntry::Entry(entry) => {
+                entry.slot_list.read().unwrap()[0].1.is_zero_lamport()
+            }
+            PreAllocatedAccountMapEntry::Raw(raw) => raw.1.is_zero_lamport(),
+        }
+    }
+}
+
+impl<T: IndexValue> From<PreAllocatedAccountMapEntry<T>> for (Slot, T) {
+    fn from(source: PreAllocatedAccountMapEntry<T>) -> (Slot, T) {
+        match source {
+            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list.read().unwrap()[0],
+            PreAllocatedAccountMapEntry::Raw(raw) => raw,
+        }
+    }
+}
+
+impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
+    /// create an entry that is equivalent to this process:
+    /// 1. new empty (refcount=0, slot_list={})
+    /// 2. update(slot, account_info)
+    ///
+    /// This code is called when the first entry [ie. (slot,account_info)] for a pubkey is inserted into the index.
+    pub fn new<U: DiskIndexValue + From<T> + Into<T>>(
+        slot: Slot,
+        account_info: T,
+        storage: &Arc<BucketMapHolder<T, U>>,
+        store_raw: bool,
+    ) -> PreAllocatedAccountMapEntry<T> {
+        if store_raw {
+            Self::Raw((slot, account_info))
+        } else {
+            Self::Entry(Self::allocate(slot, account_info, storage))
+        }
+    }
+
+    fn allocate<U: DiskIndexValue + From<T> + Into<T>>(
+        slot: Slot,
+        account_info: T,
+        storage: &Arc<BucketMapHolder<T, U>>,
+    ) -> AccountMapEntry<T> {
+        let is_cached = account_info.is_cached();
+        let ref_count = u64::from(!is_cached);
+        let meta = AccountMapEntryMeta::new_dirty(storage, is_cached);
+        Arc::new(AccountMapEntryInner::new(
+            vec![(slot, account_info)],
+            ref_count,
+            meta,
+        ))
+    }
+
+    pub fn into_account_map_entry<U: DiskIndexValue + From<T> + Into<T>>(
+        self,
+        storage: &Arc<BucketMapHolder<T, U>>,
+    ) -> AccountMapEntry<T> {
+        match self {
+            Self::Entry(entry) => entry,
+            Self::Raw((slot, account_info)) => Self::allocate(slot, account_info, storage),
+        }
+    }
+}

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1,8 +1,11 @@
 use {
     crate::{
         accounts_index::{
-            AccountMapEntry, AccountMapEntryInner, AccountMapEntryMeta, DiskIndexValue, IndexValue,
-            PreAllocatedAccountMapEntry, RefCount, SlotList, UpsertReclaim, ZeroLamport,
+            account_map_entry::{
+                AccountMapEntry, AccountMapEntryInner, AccountMapEntryMeta,
+                PreAllocatedAccountMapEntry,
+            },
+            DiskIndexValue, IndexValue, RefCount, SlotList, UpsertReclaim, ZeroLamport,
         },
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         bucket_map_holder_stats::BucketMapHolderStats,


### PR DESCRIPTION
#### Problem

The `accounts_index.rs` file is large, and contains many inner/utility types. These non `AccountsIndex` types make it harder for me to quickly traverse the file and understand the code.


#### Summary of Changes

Move inner/utility types out, into their own submodule as a separate file.

For this PR, move out `AccountMapEntry` and friends.
