### PR TITLE
perf: Hide `to_packet_batches` behind `dev-context-only-utils` feature

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -219,6 +219,7 @@ impl From<PacketBatch> for Vec<Packet> {
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn to_packet_batches<T: Serialize>(items: &[T], chunk_size: usize) -> Vec<PacketBatch> {
     items
         .chunks(chunk_size)

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -12,9 +12,7 @@ use {
 };
 pub use {
     solana_packet::{Meta, Packet, PACKET_DATA_SIZE},
-    solana_perf::packet::{
-        to_packet_batches, PacketBatch, PacketBatchRecycler, NUM_PACKETS, PACKETS_PER_BATCH,
-    },
+    solana_perf::packet::{PacketBatch, PacketBatchRecycler, NUM_PACKETS, PACKETS_PER_BATCH},
 };
 
 pub(crate) fn recv_from(


### PR DESCRIPTION
#### Problem

`to_packet_batches` is not used outside tests and benchmarks.

#### Summary of Changes

Hide it behind `dev-context-only-utils` feature.
