### PR TITLE
ledger: Hide `copy_to_packet` behind `dev-context-only-utils` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8287,6 +8287,7 @@ dependencies = [
  "solana-feature-set",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-ledger",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -95,6 +95,8 @@ features = ["lz4"]
 bs58 = { workspace = true }
 criterion = { workspace = true }
 solana-account-decoder = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-ledger = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 spl-pod = { workspace = true }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -393,6 +393,7 @@ impl Shred {
     dispatch!(pub fn set_index(&mut self, index: u32));
     dispatch!(pub fn set_slot(&mut self, slot: Slot));
 
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn copy_to_packet(&self, packet: &mut Packet) {
         let payload = self.payload();
         let size = payload.len();


### PR DESCRIPTION
#### Problem

`Shred::copy_to_packet` is not used outside tests and benchmarks.

#### Summary of Changes

Hide it behind `dev-context-only-utils` feature.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
