### PR TITLE
Removes unused ScanSlotTracker

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -644,21 +644,6 @@ pub trait ZeroLamport {
     fn is_zero_lamport(&self) -> bool;
 }
 
-#[derive(Debug, Default)]
-pub struct ScanSlotTracker {
-    is_removed: bool,
-}
-
-impl ScanSlotTracker {
-    pub fn is_removed(&self) -> bool {
-        self.is_removed
-    }
-
-    pub fn mark_removed(&mut self) {
-        self.is_removed = true;
-    }
-}
-
 #[derive(Copy, Clone)]
 pub enum AccountsIndexScanResult {
     /// if the entry is not in the in-memory index, do not add it unless the entry becomes dirty


### PR DESCRIPTION
#### Problem

The `accounts_index.rs` file is large, and contains many inner/utility types. These non `AccountsIndex` types make it harder for me to quickly traverse the file and understand the code.

For this PR, `ScanSlotTracker` is unused. It was added in https://github.com/solana-labs/solana/pull/17471, but has never been used.


#### Summary of Changes

Remove `ScanSlotTracker`.