### PR TITLE
Removes InMemMap type alias

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -27,8 +27,6 @@ use {
 type K = Pubkey;
 type CacheRangesHeld = RwLock<Vec<RangeInclusive<Pubkey>>>;
 
-type InMemMap<T> = HashMap<Pubkey, AccountMapEntry<T>, ahash::RandomState>;
-
 #[derive(Debug, Default)]
 pub struct StartupStats {
     pub copy_data_us: AtomicU64,
@@ -94,7 +92,7 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     last_age_flushed: AtomicAge,
 
     // backing store
-    map_internal: RwLock<InMemMap<T>>,
+    map_internal: RwLock<HashMap<Pubkey, AccountMapEntry<T>, ahash::RandomState>>,
     storage: Arc<BucketMapHolder<T, U>>,
     bin: usize,
     lowest_pubkey: Pubkey,


### PR DESCRIPTION
#### Problem

The `InMemMap` alias is only used in a single place, so it is exclusively adding an indirection for understanding the underlying type of the internal in-memory map.


#### Summary of Changes

Remove the alias and use the type directly.