### PR TITLE
Revert - Feature gate of `disable_new_loader_v3_deployments`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1387,15 +1387,10 @@ fn process_program_deploy(
         fetch_feature_set(&rpc_client)?
     };
 
-    if !skip_feature_verification {
-        if feature_set.is_active(&solana_feature_set::enable_loader_v4::id()) {
-            warn!("Loader-v4 is available now. Please migrate your program.");
-        }
-        if do_initial_deploy
-            && feature_set.is_active(&solana_feature_set::disable_new_loader_v3_deployments::id())
-        {
-            return Err("No new programs can be deployed on loader-v3. Please use the program-v4 subcommand instead.".into());
-        }
+    if !skip_feature_verification
+        && feature_set.is_active(&solana_feature_set::enable_loader_v4::id())
+    {
+        warn!("Loader-v4 is available now. Please migrate your program.");
     }
 
     let (program_data, program_len, buffer_program_data) =

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -14,7 +14,7 @@ use {
     solana_client::rpc_config::RpcSendTransactionConfig,
     solana_commitment_config::CommitmentConfig,
     solana_faucet::faucet::run_local_faucet,
-    solana_feature_set::{disable_new_loader_v3_deployments, enable_alt_bn128_syscall},
+    solana_feature_set::enable_alt_bn128_syscall,
     solana_rpc::rpc::JsonRpcConfig,
     solana_rpc_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient},
     solana_rpc_client_api::config::RpcTransactionConfig,
@@ -54,8 +54,7 @@ fn test_validator_genesis(mint_keypair: Keypair) -> TestValidatorGenesis {
             exemption_threshold: 1.0,
             ..Rent::default()
         })
-        .faucet_addr(Some(run_local_faucet(mint_keypair, None)))
-        .deactivate_features(&[disable_new_loader_v3_deployments::id()]);
+        .faucet_addr(Some(run_local_faucet(mint_keypair, None)));
     genesis
 }
 
@@ -2926,7 +2925,6 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
             exemption_threshold: 1.0,
             ..Rent::default()
         })
-        .deactivate_features(&[disable_new_loader_v3_deployments::id()])
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,
             faucet_addr: Some(faucet_addr),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -10,9 +10,8 @@ use {
     solana_bincode::limited_deserialize,
     solana_clock::Slot,
     solana_feature_set::{
-        bpf_account_data_direct_mapping, disable_new_loader_v3_deployments,
-        enable_bpf_loader_set_authority_checked_ix, enable_loader_v4,
-        remove_accounts_executable_flag_checks,
+        bpf_account_data_direct_mapping, enable_bpf_loader_set_authority_checked_ix,
+        enable_loader_v4, remove_accounts_executable_flag_checks,
     },
     solana_instruction::{error::InstructionError, AccountMeta},
     solana_loader_v3_interface::{
@@ -568,14 +567,6 @@ fn process_loader_upgradeable_instruction(
             )?;
         }
         UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
-            if invoke_context
-                .get_feature_set()
-                .is_active(&disable_new_loader_v3_deployments::id())
-            {
-                ic_logger_msg!(log_collector, "Unsupported instruction");
-                return Err(InstructionError::InvalidInstructionData);
-            }
-
             instruction_context.check_number_of_instruction_accounts(4)?;
             let payer_key = *transaction_context.get_key_of_account_at_index(
                 instruction_context.get_index_of_instruction_account_in_transaction(0)?,
@@ -1867,9 +1858,6 @@ mod tests {
             expected_result,
             Entrypoint::vm,
             |invoke_context| {
-                let mut feature_set = invoke_context.get_feature_set().clone();
-                feature_set.deactivate(&disable_new_loader_v3_deployments::id());
-                invoke_context.mock_set_feature_set(Arc::new(feature_set));
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1459,13 +1459,10 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
     solana_logger::setup();
 
     let GenesisConfigInfo {
-        mut genesis_config,
+        genesis_config,
         mint_keypair,
         ..
     } = get_stable_genesis_config();
-    genesis_config
-        .accounts
-        .remove(&feature_set::disable_new_loader_v3_deployments::id());
     let bank = Bank::new_for_tests(&genesis_config);
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(bank.clone());

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7182,7 +7182,6 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let (genesis_config, mint_keypair) = create_genesis_config_no_tx_fee(1_000_000_000);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
-    bank.deactivate_feature(&solana_feature_set::disable_new_loader_v3_deployments::id());
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let mut bank_client = BankClient::new_shared(bank.clone());
 


### PR DESCRIPTION
#### Problem

See #5189. Because this feature is activated by default in the test validator, lots of dApp devs have trouble because the CLI program subcommand only throws an error message and does not automatically forward to the replacement program-v4 subcommand. Doing this forwarding turned out much more challenging than originally anticipated, so I decided to remove this feature gate until we have the changes in the CLI ready.

#### Summary of Changes

Partial revert of #4666. The feature set part will stay as it currently resides in the SDK repository and the feature gate will be added back in later anyway.
