### PR TITLE
Remove `calculate-fee` callback from SVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9021,6 +9021,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-feature-set",
+ "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash",

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -3,7 +3,8 @@ pub use solana_program_runtime::execution_budget::{
     MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE,
 };
 use {
-    crate::compute_budget_limits::ComputeBudgetLimits, solana_fee_structure::FeeBudgetLimits,
+    crate::compute_budget_limits::ComputeBudgetLimits,
+    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
 };
 
@@ -241,12 +242,13 @@ impl ComputeBudget {
     pub fn get_compute_budget_and_limits(
         &self,
         compute_budget_limits: &ComputeBudgetLimits,
+        transaction_fee: u64,
     ) -> SVMTransactionExecutionAndFeeBudgetLimits {
         let fee_budget = FeeBudgetLimits::from(compute_budget_limits);
         SVMTransactionExecutionAndFeeBudgetLimits {
             budget: self.to_budget(),
             loaded_accounts_data_size_limit: fee_budget.loaded_accounts_data_size_limit,
-            priority_fee: fee_budget.prioritization_fee,
+            fee_details: FeeDetails::new(transaction_fee, fee_budget.prioritization_fee),
         }
     }
 }

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -3,9 +3,9 @@ pub use solana_program_runtime::execution_budget::{
     MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE,
 };
 use {
-    crate::compute_budget_limits::ComputeBudgetLimits,
-    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
+    crate::compute_budget_limits::ComputeBudgetLimits, solana_fee_structure::FeeDetails,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
+    std::num::NonZeroU32,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -241,14 +241,13 @@ impl ComputeBudget {
 
     pub fn get_compute_budget_and_limits(
         &self,
-        compute_budget_limits: &ComputeBudgetLimits,
-        transaction_fee: u64,
+        loaded_accounts_data_size_limit: NonZeroU32,
+        fee_details: FeeDetails,
     ) -> SVMTransactionExecutionAndFeeBudgetLimits {
-        let fee_budget = FeeBudgetLimits::from(compute_budget_limits);
         SVMTransactionExecutionAndFeeBudgetLimits {
             budget: self.to_budget(),
-            loaded_accounts_data_size_limit: fee_budget.loaded_accounts_data_size_limit,
-            fee_details: FeeDetails::new(transaction_fee, fee_budget.prioritization_fee),
+            loaded_accounts_data_size_limit,
+            fee_details,
         }
     }
 }

--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -6,7 +6,7 @@ pub use solana_program_runtime::execution_budget::{
     MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, MIN_HEAP_FRAME_BYTES,
 };
 use {
-    solana_fee_structure::FeeBudgetLimits,
+    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
     solana_program_runtime::execution_budget::{
         SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionBudget,
     },
@@ -39,10 +39,13 @@ impl Default for ComputeBudgetLimits {
 
 impl ComputeBudgetLimits {
     pub fn default_compute_budget_and_limits() -> SVMTransactionExecutionAndFeeBudgetLimits {
-        Self::get_compute_budget_and_limits(&ComputeBudgetLimits::default())
+        Self::get_compute_budget_and_limits(&ComputeBudgetLimits::default(), 0u64)
     }
 
-    pub fn get_compute_budget_and_limits(&self) -> SVMTransactionExecutionAndFeeBudgetLimits {
+    pub fn get_compute_budget_and_limits(
+        &self,
+        transaction_fee: u64,
+    ) -> SVMTransactionExecutionAndFeeBudgetLimits {
         let fee_budget = FeeBudgetLimits::from(self);
         SVMTransactionExecutionAndFeeBudgetLimits {
             budget: SVMTransactionExecutionBudget {
@@ -51,7 +54,7 @@ impl ComputeBudgetLimits {
                 ..SVMTransactionExecutionBudget::default()
             },
             loaded_accounts_data_size_limit: fee_budget.loaded_accounts_data_size_limit,
-            priority_fee: fee_budget.prioritization_fee,
+            fee_details: FeeDetails::new(transaction_fee, fee_budget.prioritization_fee),
         }
     }
 }

--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -38,24 +38,24 @@ impl Default for ComputeBudgetLimits {
 }
 
 impl ComputeBudgetLimits {
-    pub fn default_compute_budget_and_limits() -> SVMTransactionExecutionAndFeeBudgetLimits {
-        Self::get_compute_budget_and_limits(&ComputeBudgetLimits::default(), 0u64)
-    }
-
     pub fn get_compute_budget_and_limits(
         &self,
-        transaction_fee: u64,
+        loaded_accounts_data_size_limit: NonZeroU32,
+        fee_details: FeeDetails,
     ) -> SVMTransactionExecutionAndFeeBudgetLimits {
-        let fee_budget = FeeBudgetLimits::from(self);
         SVMTransactionExecutionAndFeeBudgetLimits {
             budget: SVMTransactionExecutionBudget {
                 compute_unit_limit: u64::from(self.compute_unit_limit),
                 heap_size: self.updated_heap_bytes,
                 ..SVMTransactionExecutionBudget::default()
             },
-            loaded_accounts_data_size_limit: fee_budget.loaded_accounts_data_size_limit,
-            fee_details: FeeDetails::new(transaction_fee, fee_budget.prioritization_fee),
+            loaded_accounts_data_size_limit,
+            fee_details,
         }
+    }
+
+    pub fn get_prioritization_fee(&self) -> u64 {
+        get_prioritization_fee(self.compute_unit_price, u64::from(self.compute_unit_limit))
     }
 }
 

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -53,20 +53,12 @@ pub fn calculate_fee_details(
     }
 
     FeeDetails::new(
-        calculate_transaction_fee(message, lamports_per_signature, fee_features),
+        calculate_signature_fee(
+            SignatureCounts::from(message),
+            lamports_per_signature,
+            fee_features.enable_secp256r1_precompile,
+        ),
         prioritization_fee,
-    )
-}
-
-pub fn calculate_transaction_fee(
-    message: &impl SVMMessage,
-    lamports_per_signature: u64,
-    fee_features: FeeFeatures,
-) -> u64 {
-    calculate_signature_fee(
-        SignatureCounts::from(message),
-        lamports_per_signature,
-        fee_features.enable_secp256r1_precompile,
     )
 }
 

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -53,12 +53,20 @@ pub fn calculate_fee_details(
     }
 
     FeeDetails::new(
-        calculate_signature_fee(
-            SignatureCounts::from(message),
-            lamports_per_signature,
-            fee_features.enable_secp256r1_precompile,
-        ),
+        calculate_transaction_fee(message, lamports_per_signature, fee_features),
         prioritization_fee,
+    )
+}
+
+pub fn calculate_transaction_fee(
+    message: &impl SVMMessage,
+    lamports_per_signature: u64,
+    fee_features: FeeFeatures,
+) -> u64 {
+    calculate_signature_fee(
+        SignatureCounts::from(message),
+        lamports_per_signature,
+        fee_features.enable_secp256r1_precompile,
     )
 }
 

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -23,6 +23,7 @@ solana-clock = { workspace = true }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-feature-set = { workspace = true }
+solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -1,4 +1,6 @@
-use {solana_program_entrypoint::HEAP_LENGTH, std::num::NonZeroU32};
+use {
+    solana_fee_structure::FeeDetails, solana_program_entrypoint::HEAP_LENGTH, std::num::NonZeroU32,
+};
 
 /// Max instruction stack depth. This is the maximum nesting of instructions that can happen during
 /// a transaction.
@@ -236,7 +238,7 @@ impl SVMTransactionExecutionCost {
 pub struct SVMTransactionExecutionAndFeeBudgetLimits {
     pub budget: SVMTransactionExecutionBudget,
     pub loaded_accounts_data_size_limit: NonZeroU32,
-    pub priority_fee: u64,
+    pub fee_details: FeeDetails,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -245,7 +247,17 @@ impl Default for SVMTransactionExecutionAndFeeBudgetLimits {
         Self {
             budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-            priority_fee: 0,
+            fee_details: FeeDetails::default(),
+        }
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl SVMTransactionExecutionAndFeeBudgetLimits {
+    pub fn with_fee(fee_details: FeeDetails) -> Self {
+        Self {
+            fee_details,
+            ..SVMTransactionExecutionAndFeeBudgetLimits::default()
         }
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7049,6 +7049,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-feature-set",
+ "solana-fee-structure",
  "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6943,25 +6943,6 @@ impl TransactionProcessingCallback for Bank {
             .map(|(stake, _)| (*stake))
             .unwrap_or(0)
     }
-
-    // Overrides default TransactionProcessingCallback::calculate_fee() to calculate actual transaction fee;
-    // Checking for `zero_fees_for_test` is done at callsite (eg. transaction_processor) where blockhash_queue's
-    // lamports_per_signature is checked ` == 0`.
-    fn calculate_fee(
-        &self,
-        message: &impl SVMMessage,
-        lamports_per_signature: u64,
-        prioritization_fee: u64,
-        feature_set: &FeatureSet,
-    ) -> FeeDetails {
-        solana_fee::calculate_fee_details(
-            message,
-            false, /* zero_fees_for_test */
-            lamports_per_signature,
-            prioritization_fee,
-            FeeFeatures::from(feature_set),
-        )
-    }
 }
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7904,6 +7904,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-client",
  "solana-compute-budget",
+ "solana-fee-structure",
  "solana-logger",
  "solana-program-runtime",
  "solana-sdk",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6873,6 +6873,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-feature-set",
+ "solana-fee-structure",
  "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",

--- a/svm/examples/paytube/Cargo.toml
+++ b/svm/examples/paytube/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 solana-bpf-loader-program = { workspace = true }
 solana-client = { workspace = true }
 solana-compute-budget = { workspace = true }
+solana-fee-structure = "=2.2.1"
 solana-logger = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true }

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -3,6 +3,7 @@
 use {
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
+    solana_fee_structure::FeeDetails,
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionBudget,
         loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
@@ -95,11 +96,15 @@ pub(crate) fn get_transaction_check_results(
     len: usize,
     lamports_per_signature: u64,
 ) -> Vec<transaction::Result<CheckedTransactionDetails>> {
+    let compute_budget_limit = ComputeBudgetLimits::default();
     vec![
         transaction::Result::Ok(CheckedTransactionDetails::new(
             None,
             lamports_per_signature,
-            Ok(ComputeBudgetLimits::default_compute_budget_and_limits())
+            Ok(compute_budget_limit.get_compute_budget_and_limits(
+                compute_budget_limit.loaded_accounts_bytes,
+                FeeDetails::default()
+            )),
         ));
         len
     ]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -80,7 +80,7 @@ impl Default for CheckedTransactionDetails {
                 budget: SVMTransactionExecutionBudget::default(),
                 loaded_accounts_data_size_limit: NonZeroU32::new(32)
                     .expect("Failed to set loaded_accounts_bytes"),
-                priority_fee: 0,
+                fee_details: FeeDetails::default(),
             }),
         }
     }

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,8 +1,4 @@
-use {
-    solana_account::AccountSharedData, solana_feature_set::FeatureSet,
-    solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
-    solana_svm_transaction::svm_message::SVMMessage,
-};
+use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
@@ -17,15 +13,6 @@ pub trait TransactionProcessingCallback {
 
     fn get_current_epoch_vote_account_stake(&self, _vote_address: &Pubkey) -> u64 {
         0
-    }
-    fn calculate_fee(
-        &self,
-        _message: &impl SVMMessage,
-        _lamports_per_signature: u64,
-        _prioritization_fee: u64,
-        _feature_set: &FeatureSet,
-    ) -> FeeDetails {
-        FeeDetails::default()
     }
 }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -26,7 +26,7 @@ use {
     },
     solana_clock::{Epoch, Slot},
     solana_feature_set::{remove_accounts_executable_flag_checks, FeatureSet},
-    solana_fee_structure::{FeeDetails, FeeStructure},
+    solana_fee_structure::FeeStructure,
     solana_hash::Hash,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
     solana_log_collector::LogCollector,
@@ -555,7 +555,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let CheckedTransactionDetails {
             nonce,
-            lamports_per_signature,
+            lamports_per_signature: _,
             compute_budget_and_limits,
         } = checked_details;
 
@@ -580,12 +580,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         )
         .rent_amount;
 
-        let fee_details = if lamports_per_signature == 0 {
-            FeeDetails::default()
-        } else {
-            compute_budget_and_limits.fee_details
-        };
-
         let fee_payer_index = 0;
         validate_fee_payer(
             fee_payer_address,
@@ -593,7 +587,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             fee_payer_index,
             error_counters,
             rent_collector,
-            fee_details.total_fee(),
+            compute_budget_and_limits.fee_details.total_fee(),
         )?;
 
         // Capture fee-subtracted fee payer account and next nonce account state
@@ -607,7 +601,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         );
 
         Ok(ValidatedTransactionDetails {
-            fee_details,
+            fee_details: compute_budget_and_limits.fee_details,
             rollback_accounts,
             loaded_accounts_bytes_limit: compute_budget_and_limits.loaded_accounts_data_size_limit,
             compute_budget: compute_budget_and_limits.budget,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -411,12 +411,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         tx,
                         tx_details,
                         &environment.blockhash,
-                        environment.fee_lamports_per_signature,
                         environment
                             .rent_collector
                             .unwrap_or(&RentCollector::default()),
                         &mut error_metrics,
-                        callbacks,
                     )
                 }));
             validate_fees_us = validate_fees_us.saturating_add(single_validate_fees_us);
@@ -512,10 +510,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
         environment_blockhash: &Hash,
-        fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
-        callbacks: &CB,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         // If this is a nonce transaction, validate the nonce info.
         // This must be done for every transaction to support SIMD83 because
@@ -542,10 +538,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             account_loader,
             message,
             checked_details,
-            fee_lamports_per_signature,
             rent_collector,
             error_counters,
-            callbacks,
         )
     }
 
@@ -556,10 +550,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         account_loader: &mut AccountLoader<CB>,
         message: &impl SVMMessage,
         checked_details: CheckedTransactionDetails,
-        fee_lamports_per_signature: u64,
         rent_collector: &dyn SVMRentCollector,
         error_counters: &mut TransactionErrorMetrics,
-        callbacks: &CB,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let CheckedTransactionDetails {
             nonce,
@@ -591,12 +583,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let fee_details = if lamports_per_signature == 0 {
             FeeDetails::default()
         } else {
-            callbacks.calculate_fee(
-                message,
-                fee_lamports_per_signature,
-                compute_budget_and_limits.priority_fee,
-                account_loader.feature_set.as_ref(),
-            )
+            compute_budget_and_limits.fee_details
         };
 
         let fee_payer_index = 0;
@@ -1205,7 +1192,7 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_feature_set::FeatureSet,
         solana_fee_calculator::FeeCalculator,
-        solana_fee_structure::{FeeDetails, FeeStructure},
+        solana_fee_structure::FeeDetails,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
@@ -1296,13 +1283,13 @@ mod tests {
                 .or_default()
                 .push((account, is_writable));
         }
+    }
 
-        fn calculate_fee(
-            &self,
+    impl MockBankCallback {
+        pub fn calculate_fee_details(
             message: &impl SVMMessage,
             lamports_per_signature: u64,
             prioritization_fee: u64,
-            _feature_set: &FeatureSet,
         ) -> FeeDetails {
             let signature_count = message
                 .num_transaction_signatures()
@@ -2178,7 +2165,7 @@ mod tests {
                 compute_unit_limit: 2000,
                 ..SVMTransactionExecutionBudget::default()
             },
-            priority_fee,
+            fee_details: FeeDetails::new(transaction_fee, priority_fee),
             ..SVMTransactionExecutionAndFeeBudgetLimits::default()
         };
         let result =
@@ -2191,10 +2178,8 @@ mod tests {
                     Ok(compute_budget_and_limits),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
-                &mock_bank,
             );
 
         let post_validation_fee_payer_account = {
@@ -2260,7 +2245,9 @@ mod tests {
         let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let compute_budget_and_limits = SVMTransactionExecutionAndFeeBudgetLimits::default();
+        let compute_budget_and_limits = SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
+            MockBankCallback::calculate_fee_details(&message, lamports_per_signature, 0),
+        );
         let result =
             TransactionBatchProcessor::<TestForkGraph>::validate_transaction_nonce_and_fee_payer(
                 &mut account_loader,
@@ -2271,10 +2258,8 @@ mod tests {
                     Ok(compute_budget_and_limits),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
-                &mock_bank,
             );
 
         let post_validation_fee_payer_account = {
@@ -2326,10 +2311,8 @@ mod tests {
                     Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
-                &mock_bank,
             );
 
         assert_eq!(error_counters.account_not_found.0, 1);
@@ -2359,13 +2342,17 @@ mod tests {
                 CheckedTransactionDetails::new(
                     None,
                     lamports_per_signature,
-                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
+                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
+                        MockBankCallback::calculate_fee_details(
+                            &message,
+                            lamports_per_signature,
+                            0,
+                        ),
+                    )),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
-                &mock_bank,
             );
 
         assert_eq!(error_counters.insufficient_funds.0, 1);
@@ -2399,13 +2386,17 @@ mod tests {
                 CheckedTransactionDetails::new(
                     None,
                     lamports_per_signature,
-                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
+                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
+                        MockBankCallback::calculate_fee_details(
+                            &message,
+                            lamports_per_signature,
+                            0,
+                        ),
+                    )),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
-                &mock_bank,
             );
 
         assert_eq!(
@@ -2437,13 +2428,17 @@ mod tests {
                 CheckedTransactionDetails::new(
                     None,
                     lamports_per_signature,
-                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
+                    Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
+                        MockBankCallback::calculate_fee_details(
+                            &message,
+                            lamports_per_signature,
+                            0,
+                        ),
+                    )),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
-                &mock_bank,
             );
 
         assert_eq!(error_counters.invalid_account_for_fee.0, 1);
@@ -2474,10 +2469,8 @@ mod tests {
                     Err(DuplicateInstruction(1)),
                 ),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &RentCollector::default(),
                 &mut error_counters,
-                &mock_bank,
             );
 
         assert_eq!(error_counters.invalid_compute_budget.0, 1);
@@ -2498,13 +2491,13 @@ mod tests {
             Some(&Pubkey::new_unique()),
             &last_blockhash,
         ));
+        let transaction_fee = lamports_per_signature;
         let compute_budget_and_limits = SVMTransactionExecutionAndFeeBudgetLimits {
-            priority_fee: compute_unit_limit,
+            fee_details: FeeDetails::new(transaction_fee, compute_unit_limit),
             ..SVMTransactionExecutionAndFeeBudgetLimits::default()
         };
         let fee_payer_address = message.fee_payer();
         let min_balance = Rent::default().minimum_balance(nonce::state::State::size());
-        let transaction_fee = lamports_per_signature;
         let priority_fee = compute_unit_limit;
 
         // Sufficient Fees
@@ -2550,10 +2543,8 @@ mod tests {
                    &message,
                    tx_details,
                    &environment_blockhash,
-                   FeeStructure::default().lamports_per_signature,
                    &rent_collector,
                    &mut error_counters,
-                   &mock_bank,
                );
 
             let post_validation_fee_payer_account = {
@@ -2611,10 +2602,8 @@ mod tests {
                 &message,
                 CheckedTransactionDetails::new(None, lamports_per_signature, Ok(compute_budget_and_limits)),
                 &Hash::default(),
-                FeeStructure::default().lamports_per_signature,
                 &rent_collector,
                 &mut error_counters,
-                &mock_bank,
                );
 
             assert_eq!(error_counters.insufficient_funds.0, 1);
@@ -2655,13 +2644,13 @@ mod tests {
             CheckedTransactionDetails::new(
                 None,
                 5000,
-                Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
+                Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
+                    MockBankCallback::calculate_fee_details(&message, 5000, 0),
+                )),
             ),
             &Hash::default(),
-            FeeStructure::default().lamports_per_signature,
             &RentCollector::default(),
             &mut TransactionErrorMetrics::default(),
-            &mock_bank,
         )
         .unwrap();
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -9,6 +9,7 @@ use {
     },
     solana_account::PROGRAM_OWNERS,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
+    solana_fee_structure::FeeDetails,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -448,7 +449,11 @@ impl SvmTestEntry {
 
                     let compute_budget = compute_budget_limits.map(|v| {
                         v.get_compute_budget_and_limits(
-                            signature_count.saturating_mul(tx_details.lamports_per_signature),
+                            v.loaded_accounts_bytes,
+                            FeeDetails::new(
+                                signature_count.saturating_mul(tx_details.lamports_per_signature),
+                                v.get_prioritization_fee(),
+                            ),
                         )
                     });
                     CheckedTransactionDetails::new(

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -440,8 +440,17 @@ impl SvmTestEntry {
                         SVMMessage::program_instructions_iter(&message),
                         &FeatureSet::default(),
                     );
-                    let compute_budget =
-                        compute_budget_limits.map(|v| v.get_compute_budget_and_limits());
+                    let signature_count = message
+                        .num_transaction_signatures()
+                        .saturating_add(message.num_ed25519_signatures())
+                        .saturating_add(message.num_secp256k1_signatures())
+                        .saturating_add(message.num_secp256r1_signatures());
+
+                    let compute_budget = compute_budget_limits.map(|v| {
+                        v.get_compute_budget_and_limits(
+                            signature_count.saturating_mul(tx_details.lamports_per_signature),
+                        )
+                    });
                     CheckedTransactionDetails::new(
                         tx_details.nonce,
                         tx_details.lamports_per_signature,

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -110,13 +110,13 @@ impl TransactionProcessingCallback for MockBankCallback {
             .or_default()
             .push((account, is_writable));
     }
+}
 
-    fn calculate_fee(
-        &self,
+impl MockBankCallback {
+    pub fn calculate_fee_details(
         message: &impl SVMMessage,
         lamports_per_signature: u64,
         prioritization_fee: u64,
-        _feature_set: &FeatureSet,
     ) -> FeeDetails {
         let signature_count = message
             .num_transaction_signatures()
@@ -129,9 +129,7 @@ impl TransactionProcessingCallback for MockBankCallback {
             prioritization_fee,
         )
     }
-}
 
-impl MockBankCallback {
     #[allow(unused)]
     pub fn override_feature_set(&mut self, new_set: FeatureSet) {
         self.feature_set = Arc::new(new_set)


### PR DESCRIPTION
#### Problem
SVM's `calculate-fee()` callback is making it difficult to refactor fee interface, and causing circular deps.

#### Summary of Changes
The callback has been removed, and the user of SVM (Bank) calculates the fees before calling SVM. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
