### PR TITLE
Adding counters

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6255,6 +6255,18 @@ impl AccountsDb {
                 i64
             ),
             ("flush_roots_elapsed", flush_roots_elapsed.as_us(), i64),
+            ("num_flushed", flush_stats.num_accounts_flushed.0, i64),
+            ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
+            (
+                "num_accounts_recalimed",
+                flush_stats.num_accounts_reclaimed.0,
+                i64
+            ),
+            (
+                "num_zero_lamport_accounts",
+                flush_stats.num_zero_lamport_accounts_flushed.0,
+                i64
+            ),
             ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
             ("num_accounts_saved", flush_stats.num_accounts_purged.0, i64),
             (

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6258,7 +6258,7 @@ impl AccountsDb {
             ("num_flushed", flush_stats.num_accounts_flushed.0, i64),
             ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
             (
-                "num_accounts_recalimed",
+                "num_accounts_reclaimed",
                 flush_stats.num_accounts_reclaimed.0,
                 i64
             ),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6233,9 +6233,18 @@ impl AccountsDb {
             });
             datapoint_info!(
                 "accounts_db-flush_accounts_cache_aggressively",
-                ("num_flushed", flush_stats.num_accounts_flushed.0, i64),
-                ("num_purged", flush_stats.num_accounts_purged.0, i64),
-                ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
+                (
+                    "num_accounts_flushed",
+                    flush_stats.num_accounts_flushed.0,
+                    i64
+                ),
+                ("num_accounts_saved", flush_stats.num_accounts_purged.0, i64),
+                (
+                    "account_bytes_flushed",
+                    flush_stats.num_bytes_flushed.0,
+                    i64
+                ),
+                ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
                 ("total_cache_size", self.accounts_cache.size(), i64),
                 ("total_frozen_slots", excess_slot_count, i64),
                 ("total_slots", self.accounts_cache.num_slots(), i64),
@@ -6255,16 +6264,14 @@ impl AccountsDb {
                 i64
             ),
             ("flush_roots_elapsed", flush_roots_elapsed.as_us(), i64),
-            ("num_flushed", flush_stats.num_accounts_flushed.0, i64),
-            ("total_flush_size", flush_stats.num_bytes_flushed.0, i64),
             (
-                "num_accounts_reclaimed",
-                flush_stats.num_accounts_reclaimed.0,
+                "account_bytes_flushed",
+                flush_stats.num_bytes_flushed.0,
                 i64
             ),
             (
-                "num_zero_lamport_accounts",
-                flush_stats.num_zero_lamport_accounts_flushed.0,
+                "num_accounts_flushed",
+                flush_stats.num_accounts_flushed.0,
                 i64
             ),
             ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -145,8 +145,6 @@ impl StoreAccountsTiming {
 pub struct FlushStats {
     pub num_accounts_flushed: Saturating<usize>,
     pub num_bytes_flushed: Saturating<u64>,
-    pub num_zero_lamport_accounts_flushed: Saturating<usize>,
-    pub num_accounts_reclaimed: Saturating<usize>,
     pub num_accounts_purged: Saturating<usize>,
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
@@ -156,8 +154,6 @@ pub struct FlushStats {
 impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_accounts_flushed += other.num_accounts_flushed;
-        self.num_zero_lamport_accounts_flushed += other.num_zero_lamport_accounts_flushed;
-        self.num_accounts_reclaimed += other.num_accounts_reclaimed;
         self.num_bytes_flushed += other.num_bytes_flushed;
         self.num_accounts_purged += other.num_accounts_purged;
         self.num_bytes_purged += other.num_bytes_purged;

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -145,6 +145,8 @@ impl StoreAccountsTiming {
 pub struct FlushStats {
     pub num_accounts_flushed: Saturating<usize>,
     pub num_bytes_flushed: Saturating<u64>,
+    pub num_zero_lamport_accounts_flushed: Saturating<usize>,
+    pub num_accounts_reclaimed: Saturating<usize>,
     pub num_accounts_purged: Saturating<usize>,
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
@@ -154,6 +156,8 @@ pub struct FlushStats {
 impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_accounts_flushed += other.num_accounts_flushed;
+        self.num_zero_lamport_accounts_flushed += other.num_zero_lamport_accounts_flushed;
+        self.num_accounts_reclaimed += other.num_accounts_reclaimed;
         self.num_bytes_flushed += other.num_bytes_flushed;
         self.num_accounts_purged += other.num_accounts_purged;
         self.num_bytes_purged += other.num_bytes_purged;


### PR DESCRIPTION
#### Problem
Flush counters are not currently logged unless the cache is flushed aggressively. 

#### Summary of Changes
Logging the counters all the time. 
Added new counters that will be used with dead account sideband structure

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
