### PR TITLE
perf: Introduce InstructionMeta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
@@ -2622,18 +2622,18 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
+checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_core"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
+checksum = "9b2a72055cd9cffc40c9f75f1e5810c80559e158796cf2202292ce4745889588"
 
 [[package]]
 name = "fixedbitset"
@@ -5278,7 +5278,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5762,7 +5762,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
@@ -5821,7 +5821,7 @@ dependencies = [
  "rustls 0.23.25",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5846,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -13844,11 +13844,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -13864,9 +13864,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
@@ -2622,18 +2622,18 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a72055cd9cffc40c9f75f1e5810c80559e158796cf2202292ce4745889588"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "fixedbitset"
@@ -5278,7 +5278,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -5762,7 +5762,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.0",
  "subtle",
  "zeroize",
 ]
@@ -5821,7 +5821,7 @@ dependencies = [
  "rustls 0.23.25",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.0",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5846,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -13844,11 +13844,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -13864,9 +13864,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -343,7 +343,7 @@ impl QosService {
                 );
                 saturating_add_assign!(
                     batched_transaction_details.costs.batched_data_bytes_cost,
-                    cost.data_bytes_cost()
+                    u64::from(cost.data_bytes_cost())
                 );
                 saturating_add_assign!(
                     batched_transaction_details
@@ -961,7 +961,7 @@ mod tests {
         // should only accumulate half of the costs that are OK
         let expected_signatures = signature_cost * (num_txs / 2);
         let expected_write_locks = write_lock_cost * (num_txs / 2);
-        let expected_data_bytes = data_bytes_cost * (num_txs / 2);
+        let expected_data_bytes = u64::from(data_bytes_cost) * (num_txs / 2);
         let expected_programs_execution_costs = programs_execution_cost * (num_txs / 2);
         let batched_transaction_details =
             QosService::accumulate_batched_transaction_costs(tx_cost_results.iter());

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -42,11 +42,7 @@ impl CostModel {
             TransactionCost::SimpleVote { transaction }
         } else {
             let (programs_execution_cost, loaded_accounts_data_size_cost, data_bytes_cost) =
-                Self::get_transaction_cost(
-                    transaction,
-                    transaction.program_instructions_iter(),
-                    feature_set,
-                );
+                Self::get_transaction_cost(transaction, feature_set);
             Self::calculate_non_vote_transaction_cost(
                 transaction,
                 transaction.program_instructions_iter(),
@@ -74,8 +70,7 @@ impl CostModel {
                 actual_loaded_accounts_data_size_bytes,
                 feature_set,
             );
-            let instructions_data_cost =
-                Self::get_instructions_data_cost(transaction.program_instructions_iter());
+            let instructions_data_cost = Self::get_instructions_data_cost(transaction);
 
             Self::calculate_non_vote_transaction_cost(
                 transaction,
@@ -103,7 +98,7 @@ impl CostModel {
             return TransactionCost::SimpleVote { transaction };
         }
         let (programs_execution_cost, loaded_accounts_data_size_cost, data_bytes_cost) =
-            Self::get_transaction_cost(transaction, instructions.clone(), feature_set);
+            Self::get_transaction_cost(transaction, feature_set);
         Self::calculate_non_vote_transaction_cost(
             transaction,
             instructions,
@@ -187,12 +182,8 @@ impl CostModel {
     }
 
     /// Return (programs_execution_cost, loaded_accounts_data_size_cost, data_bytes_cost)
-    fn get_transaction_cost<'a>(
-        meta: &impl StaticMeta,
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
-        feature_set: &FeatureSet,
-    ) -> (u64, u64, u64) {
-        let data_bytes_cost = Self::get_instructions_data_cost(instructions);
+    fn get_transaction_cost(meta: &impl StaticMeta, feature_set: &FeatureSet) -> (u64, u64, u64) {
+        let data_bytes_cost = Self::get_instructions_data_cost(meta);
         let (programs_execution_cost, loaded_accounts_data_size_cost) =
             Self::get_estimated_execution_cost(meta, feature_set);
         (
@@ -227,14 +218,8 @@ impl CostModel {
     }
 
     /// Return the instruction data bytes cost.
-    fn get_instructions_data_cost<'a>(
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
-    ) -> u64 {
-        let ix_data_bytes_len_total: u64 = instructions
-            .map(|(_, instruction)| instruction.data.len() as u64)
-            .sum();
-
-        ix_data_bytes_len_total / INSTRUCTION_DATA_BYTES_COST
+    fn get_instructions_data_cost(transaction: &impl StaticMeta) -> u64 {
+        transaction.instruction_data_len() / INSTRUCTION_DATA_BYTES_COST
     }
 
     pub fn calculate_loaded_accounts_data_size_cost(
@@ -539,11 +524,7 @@ mod tests {
         let feature_set = FeatureSet::default();
         let expected_execution_cost = u64::from(MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT);
         let (program_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
-            CostModel::get_transaction_cost(
-                &simple_transaction,
-                simple_transaction.program_instructions_iter(),
-                &feature_set,
-            );
+            CostModel::get_transaction_cost(&simple_transaction, &feature_set);
 
         assert_eq!(expected_execution_cost, program_execution_cost);
     }
@@ -573,11 +554,7 @@ mod tests {
             ),
         ] {
             let (program_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
-                CostModel::get_transaction_cost(
-                    &token_transaction,
-                    token_transaction.program_instructions_iter(),
-                    &feature_set,
-                );
+                CostModel::get_transaction_cost(&token_transaction, &feature_set);
 
             assert_eq!(expected_execution_cost, program_execution_cost);
             assert_eq!(0, data_bytes_cost);
@@ -630,11 +607,7 @@ mod tests {
             (FeatureSet::all_enabled(), expected_cu_limit as u64),
         ] {
             let (program_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
-                CostModel::get_transaction_cost(
-                    &token_transaction,
-                    token_transaction.program_instructions_iter(),
-                    &feature_set,
-                );
+                CostModel::get_transaction_cost(&token_transaction, &feature_set);
 
             assert_eq!(expected_execution_cost, program_execution_cost);
             assert_eq!(1, data_bytes_cost);
@@ -674,11 +647,7 @@ mod tests {
 
         for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
             let (program_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
-                CostModel::get_transaction_cost(
-                    &token_transaction,
-                    token_transaction.program_instructions_iter(),
-                    &feature_set,
-                );
+                CostModel::get_transaction_cost(&token_transaction, &feature_set);
             assert_eq!(0, program_execution_cost);
         }
     }
@@ -702,7 +671,7 @@ mod tests {
         let feature_set = FeatureSet::default();
         let expected_execution_cost = 2 * u64::from(MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT);
         let (programs_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
-            CostModel::get_transaction_cost(&tx, tx.program_instructions_iter(), &feature_set);
+            CostModel::get_transaction_cost(&tx, &feature_set);
         assert_eq!(expected_execution_cost, programs_execution_cost);
         assert_eq!(6, data_bytes_cost);
     }
@@ -741,7 +710,7 @@ mod tests {
             ),
         ] {
             let (program_execution_cost, _loaded_accounts_data_size_cost, data_bytes_cost) =
-                CostModel::get_transaction_cost(&tx, tx.program_instructions_iter(), &feature_set);
+                CostModel::get_transaction_cost(&tx, &feature_set);
             assert_eq!(expected_cost, program_execution_cost);
             assert_eq!(0, data_bytes_cost);
         }
@@ -859,11 +828,7 @@ mod tests {
         let expected_execution_cost = u64::from(MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT)
             + u64::from(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT);
         let (programs_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
-            CostModel::get_transaction_cost(
-                &transaction,
-                transaction.program_instructions_iter(),
-                &feature_set,
-            );
+            CostModel::get_transaction_cost(&transaction, &feature_set);
 
         assert_eq!(expected_execution_cost, programs_execution_cost);
     }
@@ -887,11 +852,7 @@ mod tests {
         let expected_execution_cost = cu_limit as u64;
 
         let (programs_execution_cost, _loaded_accounts_data_size_cost, _data_bytes_cost) =
-            CostModel::get_transaction_cost(
-                &transaction,
-                transaction.program_instructions_iter(),
-                &feature_set,
-            );
+            CostModel::get_transaction_cost(&transaction, &feature_set);
 
         assert_eq!(expected_execution_cost, programs_execution_cost);
     }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -90,7 +90,7 @@ impl CostModel {
     /// - `num_write_locks` - number of requested write locks
     pub fn estimate_cost<'a, Tx: StaticMeta>(
         transaction: &'a Tx,
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
+        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
@@ -112,7 +112,7 @@ impl CostModel {
 
     fn calculate_non_vote_transaction_cost<'a, Tx: StaticMeta>(
         transaction: &'a Tx,
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
+        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
         programs_execution_cost: u64,
         loaded_accounts_data_size_cost: u64,

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -116,7 +116,7 @@ impl CostModel {
         num_write_locks: u64,
         programs_execution_cost: u64,
         loaded_accounts_data_size_cost: u64,
-        data_bytes_cost: u64,
+        data_bytes_cost: u16,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
         let signature_cost = Self::get_signature_cost(transaction, feature_set);
@@ -182,7 +182,7 @@ impl CostModel {
     }
 
     /// Return (programs_execution_cost, loaded_accounts_data_size_cost, data_bytes_cost)
-    fn get_transaction_cost(meta: &impl StaticMeta, feature_set: &FeatureSet) -> (u64, u64, u64) {
+    fn get_transaction_cost(meta: &impl StaticMeta, feature_set: &FeatureSet) -> (u64, u64, u16) {
         let data_bytes_cost = Self::get_instructions_data_cost(meta);
         let (programs_execution_cost, loaded_accounts_data_size_cost) =
             Self::get_estimated_execution_cost(meta, feature_set);
@@ -218,8 +218,8 @@ impl CostModel {
     }
 
     /// Return the instruction data bytes cost.
-    fn get_instructions_data_cost(transaction: &impl StaticMeta) -> u64 {
-        transaction.instruction_data_len() / INSTRUCTION_DATA_BYTES_COST
+    fn get_instructions_data_cost(transaction: &impl StaticMeta) -> u16 {
+        transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16)
     }
 
     pub fn calculate_loaded_accounts_data_size_cost(

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -276,6 +276,10 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
     fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
         unimplemented!("WritableKeysTransaction::compute_budget_instruction_details")
     }
+
+    fn instruction_data_len(&self) -> u64 {
+        unimplemented!("WritableKeysTransaction::instruction_data_len")
+    }
 }
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -59,7 +59,7 @@ impl<Tx> TransactionCost<'_, Tx> {
         }
     }
 
-    pub fn data_bytes_cost(&self) -> u64 {
+    pub fn data_bytes_cost(&self) -> u16 {
         match self {
             Self::SimpleVote { .. } => 0,
             Self::Transaction(usage_cost) => usage_cost.data_bytes_cost,
@@ -158,7 +158,7 @@ pub struct UsageCostDetails<'a, Tx> {
     pub transaction: &'a Tx,
     pub signature_cost: u64,
     pub write_lock_cost: u64,
-    pub data_bytes_cost: u64,
+    pub data_bytes_cost: u16,
     pub programs_execution_cost: u64,
     pub loaded_accounts_data_size_cost: u64,
     pub allocated_accounts_data_size: u64,
@@ -168,7 +168,7 @@ impl<Tx> UsageCostDetails<'_, Tx> {
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)
-            .saturating_add(self.data_bytes_cost)
+            .saturating_add(u64::from(self.data_bytes_cost))
             .saturating_add(self.programs_execution_cost)
             .saturating_add(self.loaded_accounts_data_size_cost)
     }
@@ -277,7 +277,7 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
         unimplemented!("WritableKeysTransaction::compute_budget_instruction_details")
     }
 
-    fn instruction_data_len(&self) -> u64 {
+    fn instruction_data_len(&self) -> u16 {
         unimplemented!("WritableKeysTransaction::instruction_data_len")
     }
 }

--- a/runtime-transaction/src/instruction_data_len.rs
+++ b/runtime-transaction/src/instruction_data_len.rs
@@ -2,15 +2,15 @@ use {solana_pubkey::Pubkey, solana_svm_transaction::instruction::SVMInstruction}
 
 #[derive(Default)]
 pub struct InstructionDataLenBuilder {
-    value: u64,
+    value: u16,
 }
 
 impl InstructionDataLenBuilder {
     pub fn process_instruction(&mut self, _program_id: &Pubkey, instruction: &SVMInstruction) {
-        self.value = self.value.saturating_add(instruction.data.len() as u64);
+        self.value = self.value.saturating_add(instruction.data.len() as u16);
     }
 
-    pub fn build(self) -> u64 {
+    pub fn build(self) -> u16 {
         self.value
     }
 }

--- a/runtime-transaction/src/instruction_data_len.rs
+++ b/runtime-transaction/src/instruction_data_len.rs
@@ -1,0 +1,16 @@
+use {solana_pubkey::Pubkey, solana_svm_transaction::instruction::SVMInstruction};
+
+#[derive(Default)]
+pub struct InstructionDataLenBuilder {
+    value: u64,
+}
+
+impl InstructionDataLenBuilder {
+    pub fn process_instruction(&mut self, _program_id: &Pubkey, instruction: &SVMInstruction) {
+        self.value = self.value.saturating_add(instruction.data.len() as u64);
+    }
+
+    pub fn build(self) -> u64 {
+        self.value
+    }
+}

--- a/runtime-transaction/src/instruction_meta.rs
+++ b/runtime-transaction/src/instruction_meta.rs
@@ -1,5 +1,8 @@
 use {
-    crate::signature_details::{PrecompileSignatureDetails, PrecompileSignatureDetailsBuilder},
+    crate::{
+        instruction_data_len::InstructionDataLenBuilder,
+        signature_details::{PrecompileSignatureDetails, PrecompileSignatureDetailsBuilder},
+    },
     solana_pubkey::Pubkey,
     solana_svm_transaction::instruction::SVMInstruction,
     solana_transaction_error::TransactionError,
@@ -7,6 +10,7 @@ use {
 
 pub struct InstructionMeta {
     pub precompile_signature_details: PrecompileSignatureDetails,
+    pub instruction_data_len: u64,
 }
 
 impl InstructionMeta {
@@ -14,12 +18,15 @@ impl InstructionMeta {
         instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
     ) -> Result<Self, TransactionError> {
         let mut precompile_signature_details_builder = PrecompileSignatureDetailsBuilder::default();
+        let mut instruction_data_len_builder = InstructionDataLenBuilder::default();
         for (program_id, instruction) in instructions {
-            precompile_signature_details_builder.process_instruction(program_id, instruction);
+            precompile_signature_details_builder.process_instruction(program_id, &instruction);
+            instruction_data_len_builder.process_instruction(program_id, &instruction);
         }
 
         Ok(Self {
             precompile_signature_details: precompile_signature_details_builder.build(),
+            instruction_data_len: instruction_data_len_builder.build(),
         })
     }
 }

--- a/runtime-transaction/src/instruction_meta.rs
+++ b/runtime-transaction/src/instruction_meta.rs
@@ -10,7 +10,7 @@ use {
 
 pub struct InstructionMeta {
     pub precompile_signature_details: PrecompileSignatureDetails,
-    pub instruction_data_len: u64,
+    pub instruction_data_len: u16,
 }
 
 impl InstructionMeta {

--- a/runtime-transaction/src/instruction_meta.rs
+++ b/runtime-transaction/src/instruction_meta.rs
@@ -1,0 +1,25 @@
+use {
+    crate::signature_details::{PrecompileSignatureDetails, PrecompileSignatureDetailsBuilder},
+    solana_pubkey::Pubkey,
+    solana_svm_transaction::instruction::SVMInstruction,
+    solana_transaction_error::TransactionError,
+};
+
+pub struct InstructionMeta {
+    pub precompile_signature_details: PrecompileSignatureDetails,
+}
+
+impl InstructionMeta {
+    pub fn try_new<'a>(
+        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+    ) -> Result<Self, TransactionError> {
+        let mut precompile_signature_details_builder = PrecompileSignatureDetailsBuilder::default();
+        for (program_id, instruction) in instructions {
+            precompile_signature_details_builder.process_instruction(program_id, instruction);
+        }
+
+        Ok(Self {
+            precompile_signature_details: precompile_signature_details_builder.build(),
+        })
+    }
+}

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
+pub(crate) mod instruction_meta;
 pub mod runtime_transaction;
 pub mod signature_details;
 pub mod transaction_meta;

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
+mod instruction_data_len;
 pub(crate) mod instruction_meta;
 pub mod runtime_transaction;
 pub mod signature_details;

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -48,7 +48,7 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
         &self.meta.compute_budget_instruction_details
     }
-    fn instruction_data_len(&self) -> u64 {
+    fn instruction_data_len(&self) -> u16 {
         self.meta.instruction_data_len
     }
 }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -48,6 +48,9 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
         &self.meta.compute_budget_instruction_details
     }
+    fn instruction_data_len(&self) -> u64 {
+        self.meta.instruction_data_len
+    }
 }
 
 impl<T: SVMMessage> DynamicMeta for RuntimeTransaction<T> {}

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -32,6 +32,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
 
         let InstructionMeta {
             precompile_signature_details,
+            instruction_data_len: _,
         } = InstructionMeta::try_new(
             sanitized_versioned_tx
                 .get_message()

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -1,7 +1,7 @@
 use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
-        signature_details::get_precompile_signature_details,
+        instruction_meta::InstructionMeta,
         transaction_meta::{StaticMeta, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
@@ -30,12 +30,14 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
         let is_simple_vote_tx = is_simple_vote_tx
             .unwrap_or_else(|| is_simple_vote_transaction(&sanitized_versioned_tx));
 
-        let precompile_signature_details = get_precompile_signature_details(
+        let InstructionMeta {
+            precompile_signature_details,
+        } = InstructionMeta::try_new(
             sanitized_versioned_tx
                 .get_message()
                 .program_instructions_iter()
                 .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
-        );
+        )?;
         let signature_details = TransactionSignatureDetails::new(
             u64::from(
                 sanitized_versioned_tx

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -32,7 +32,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
 
         let InstructionMeta {
             precompile_signature_details,
-            instruction_data_len: _,
+            instruction_data_len,
         } = InstructionMeta::try_new(
             sanitized_versioned_tx
                 .get_message()
@@ -65,6 +65,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
                 is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,
                 compute_budget_instruction_details,
+                instruction_data_len,
             },
         })
     }

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -53,6 +53,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
 
         let InstructionMeta {
             precompile_signature_details,
+            instruction_data_len: _,
         } = InstructionMeta::try_new(transaction.program_instructions_iter())?;
 
         let signature_details = TransactionSignatureDetails::new(

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -1,7 +1,7 @@
 use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
-        signature_details::get_precompile_signature_details,
+        instruction_meta::InstructionMeta,
         transaction_meta::{StaticMeta, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
@@ -51,8 +51,10 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
         let is_simple_vote_tx =
             is_simple_vote_tx.unwrap_or_else(|| is_simple_vote_transaction(&transaction));
 
-        let precompile_signature_details =
-            get_precompile_signature_details(transaction.program_instructions_iter());
+        let InstructionMeta {
+            precompile_signature_details,
+        } = InstructionMeta::try_new(transaction.program_instructions_iter())?;
+
         let signature_details = TransactionSignatureDetails::new(
             u64::from(transaction.num_required_signatures()),
             precompile_signature_details.num_secp256k1_instruction_signatures,

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -53,7 +53,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
 
         let InstructionMeta {
             precompile_signature_details,
-            instruction_data_len: _,
+            instruction_data_len,
         } = InstructionMeta::try_new(transaction.program_instructions_iter())?;
 
         let signature_details = TransactionSignatureDetails::new(
@@ -72,6 +72,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
                 is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,
                 compute_budget_instruction_details,
+                instruction_data_len,
             },
         })
     }

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -10,42 +10,64 @@ pub struct PrecompileSignatureDetails {
     pub num_secp256r1_instruction_signatures: u64,
 }
 
-/// Get transaction signature details.
-pub fn get_precompile_signature_details<'a>(
-    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
-) -> PrecompileSignatureDetails {
-    let mut filter = SignatureDetailsFilter::new();
+pub(crate) struct PrecompileSignatureDetailsBuilder {
+    filter: SignatureDetailsFilter,
+    value: PrecompileSignatureDetails,
+}
 
-    // Wrapping arithmetic is safe below because the maximum number of signatures
-    // per instruction is 255, and the maximum number of instructions per transaction
-    // is low enough that the sum of all signatures will not overflow a u64.
-    let mut num_secp256k1_instruction_signatures: u64 = 0;
-    let mut num_ed25519_instruction_signatures: u64 = 0;
-    let mut num_secp256r1_instruction_signatures: u64 = 0;
-    for (program_id, instruction) in instructions {
+impl Default for PrecompileSignatureDetailsBuilder {
+    fn default() -> Self {
+        Self {
+            filter: SignatureDetailsFilter::new(),
+            value: PrecompileSignatureDetails {
+                num_secp256k1_instruction_signatures: 0,
+                num_ed25519_instruction_signatures: 0,
+                num_secp256r1_instruction_signatures: 0,
+            },
+        }
+    }
+}
+
+impl PrecompileSignatureDetailsBuilder {
+    pub fn process_instruction(&mut self, program_id: &Pubkey, instruction: SVMInstruction) {
         let program_id_index = instruction.program_id_index;
-        match filter.is_signature(program_id_index, program_id) {
+        match self.filter.is_signature(program_id_index, program_id) {
             ProgramIdStatus::NotSignature => {}
             ProgramIdStatus::Secp256k1 => {
-                num_secp256k1_instruction_signatures = num_secp256k1_instruction_signatures
+                self.value.num_secp256k1_instruction_signatures = self
+                    .value
+                    .num_secp256k1_instruction_signatures
                     .wrapping_add(get_num_signatures_in_instruction(&instruction));
             }
             ProgramIdStatus::Ed25519 => {
-                num_ed25519_instruction_signatures = num_ed25519_instruction_signatures
+                self.value.num_ed25519_instruction_signatures = self
+                    .value
+                    .num_ed25519_instruction_signatures
                     .wrapping_add(get_num_signatures_in_instruction(&instruction));
             }
             ProgramIdStatus::Secp256r1 => {
-                num_secp256r1_instruction_signatures = num_secp256r1_instruction_signatures
+                self.value.num_secp256r1_instruction_signatures = self
+                    .value
+                    .num_secp256r1_instruction_signatures
                     .wrapping_add(get_num_signatures_in_instruction(&instruction));
             }
         }
     }
 
-    PrecompileSignatureDetails {
-        num_secp256k1_instruction_signatures,
-        num_ed25519_instruction_signatures,
-        num_secp256r1_instruction_signatures,
+    pub fn build(self) -> PrecompileSignatureDetails {
+        self.value
     }
+}
+
+/// Get transaction signature details.
+pub fn get_precompile_signature_details<'a>(
+    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+) -> PrecompileSignatureDetails {
+    let mut builder = PrecompileSignatureDetailsBuilder::default();
+    for (program_id, instruction) in instructions {
+        builder.process_instruction(program_id, instruction);
+    }
+    builder.build()
 }
 
 #[inline]

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -29,7 +29,7 @@ impl Default for PrecompileSignatureDetailsBuilder {
 }
 
 impl PrecompileSignatureDetailsBuilder {
-    pub fn process_instruction(&mut self, program_id: &Pubkey, instruction: SVMInstruction) {
+    pub fn process_instruction(&mut self, program_id: &Pubkey, instruction: &SVMInstruction) {
         let program_id_index = instruction.program_id_index;
         match self.filter.is_signature(program_id_index, program_id) {
             ProgramIdStatus::NotSignature => {}
@@ -37,19 +37,19 @@ impl PrecompileSignatureDetailsBuilder {
                 self.value.num_secp256k1_instruction_signatures = self
                     .value
                     .num_secp256k1_instruction_signatures
-                    .wrapping_add(get_num_signatures_in_instruction(&instruction));
+                    .wrapping_add(get_num_signatures_in_instruction(instruction));
             }
             ProgramIdStatus::Ed25519 => {
                 self.value.num_ed25519_instruction_signatures = self
                     .value
                     .num_ed25519_instruction_signatures
-                    .wrapping_add(get_num_signatures_in_instruction(&instruction));
+                    .wrapping_add(get_num_signatures_in_instruction(instruction));
             }
             ProgramIdStatus::Secp256r1 => {
                 self.value.num_secp256r1_instruction_signatures = self
                     .value
                     .num_secp256r1_instruction_signatures
-                    .wrapping_add(get_num_signatures_in_instruction(&instruction));
+                    .wrapping_add(get_num_signatures_in_instruction(instruction));
             }
         }
     }
@@ -65,7 +65,7 @@ pub fn get_precompile_signature_details<'a>(
 ) -> PrecompileSignatureDetails {
     let mut builder = PrecompileSignatureDetailsBuilder::default();
     for (program_id, instruction) in instructions {
-        builder.process_instruction(program_id, instruction);
+        builder.process_instruction(program_id, &instruction);
     }
     builder.build()
 }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -23,7 +23,7 @@ pub trait StaticMeta {
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
     fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails;
-    fn instruction_data_len(&self) -> u64;
+    fn instruction_data_len(&self) -> u16;
 }
 
 /// Statically loaded meta is a supertrait of Dynamically loaded meta, when
@@ -40,5 +40,5 @@ pub struct TransactionMeta {
     pub(crate) is_simple_vote_transaction: bool,
     pub(crate) signature_details: TransactionSignatureDetails,
     pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
-    pub(crate) instruction_data_len: u64,
+    pub(crate) instruction_data_len: u16,
 }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -23,6 +23,7 @@ pub trait StaticMeta {
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
     fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails;
+    fn instruction_data_len(&self) -> u64;
 }
 
 /// Statically loaded meta is a supertrait of Dynamically loaded meta, when
@@ -39,4 +40,5 @@ pub struct TransactionMeta {
     pub(crate) is_simple_vote_transaction: bool,
     pub(crate) signature_details: TransactionSignatureDetails,
     pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
+    pub(crate) instruction_data_len: u64,
 }


### PR DESCRIPTION
#### Problem
- Iterating over instructions is expensive (see #5264)
- We currently iterate because there are a bunch of different ways we process instructions that are spread across the code

#### Summary of Changes
- Introduce `InstructionMeta` which contains all instruction-based meta we calculate, and a function to calculate all of it in a single iteration over instructions.
- Add instruction data length to static meta, and remove an iteration from cost-model as an example

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
