### PR TITLE
Enable codegen-units = 1 for better optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ debug = true
 split-debuginfo = "packed"
 lto = false                # Preserve the 'thin local LTO' for this build.
 
-[profile.release]
+[profile.release-with-lto]
+inherits = "release"
 split-debuginfo = "unpacked"
 lto = "thin"
+codegen-units = 1
 
 [workspace]
 members = [

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -53,6 +53,10 @@ while [[ -n $1 ]]; do
       buildProfileArg='--profile release-with-debug'
       buildProfile='release-with-debug'
       shift
+    elif [[ $1 = --release-with-lto ]]; then
+      buildProfileArg='--profile release-with-lto'
+      buildProfile='release-with-lto'
+      shift
     elif [[ $1 = --validator-only ]]; then
       validatorOnly=true
       shift


### PR DESCRIPTION
#### Problem

#5085

#### Summary of Changes
Enable codegen-units = 1 for lto builds

