### PR TITLE
Remove unnecessary svm-internal features from crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,11 +6811,9 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
- "qualifier_attr",
  "rand 0.8.5",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
- "solana-builtins-default-costs",
  "solana-compute-budget-program",
  "solana-config-program",
  "solana-feature-set",
@@ -7267,7 +7265,6 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.3.0"
 dependencies = [
- "qualifier_attr",
  "solana-program-runtime",
 ]
 

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -13,16 +13,15 @@ edition = { workspace = true }
 ahash = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-qualifier_attr = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }
-solana-bpf-loader-program = { workspace = true, features = ["svm-internal"] }
-solana-compute-budget-program = { workspace = true, features = ["svm-internal"] }
+solana-bpf-loader-program = { workspace = true }
+solana-compute-budget-program = { workspace = true }
 solana-config-program = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-loader-v4-program = { workspace = true, features = ["svm-internal"] }
+solana-loader-v4-program = { workspace = true, features = ["agave-internal"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-stake-program = { workspace = true }
@@ -36,7 +35,6 @@ name = "solana_builtins_default_costs"
 
 [dev-dependencies]
 rand = "0.8.5"
-solana-builtins-default-costs = { path = ".", features = ["svm-internal"] }
 static_assertions = { workspace = true }
 
 [package.metadata.docs.rs]
@@ -48,7 +46,6 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 dev-context-only-utils = []
-svm-internal = []
 
 [lints]
 workspace = true

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -21,7 +21,7 @@ solana-feature-set = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-loader-v4-program = { workspace = true, features = ["agave-internal"] }
+solana-loader-v4-program = { workspace = true, features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-stake-program = { workspace = true }

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
-#[cfg(feature = "svm-internal")]
-use qualifier_attr::qualifiers;
 use {
     ahash::AHashMap,
     lazy_static::lazy_static,
@@ -15,8 +13,7 @@ use {
 };
 
 #[derive(Clone)]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-struct MigratingBuiltinCost {
+pub struct MigratingBuiltinCost {
     native_cost: u64,
     core_bpf_migration_feature: Pubkey,
     // encoding positional information explicitly for migration feature item,
@@ -27,8 +24,7 @@ struct MigratingBuiltinCost {
 }
 
 #[derive(Clone)]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-struct NotMigratingBuiltinCost {
+pub struct NotMigratingBuiltinCost {
     native_cost: u64,
 }
 
@@ -39,8 +35,7 @@ struct NotMigratingBuiltinCost {
 /// When migration completed, eg the feature gate is enabled everywhere, please
 /// remove that builtin entry from MIGRATING_BUILTINS_COSTS.
 #[derive(Clone)]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-enum BuiltinCost {
+pub enum BuiltinCost {
     Migrating(MigratingBuiltinCost),
     NotMigrating(NotMigratingBuiltinCost),
 }
@@ -53,7 +48,6 @@ impl BuiltinCost {
         }
     }
 
-    #[cfg(feature = "svm-internal")]
     fn core_bpf_migration_feature(&self) -> Option<&Pubkey> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -64,7 +58,6 @@ impl BuiltinCost {
         }
     }
 
-    #[cfg(feature = "svm-internal")]
     fn position(&self) -> Option<usize> {
         match self {
             BuiltinCost::Migrating(MigratingBuiltinCost { position, .. }) => Some(*position),
@@ -116,8 +109,7 @@ static_assertions::const_assert_eq!(
     TOTAL_COUNT_BUILTINS
 );
 
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
+pub const MIGRATING_BUILTINS_COSTS: &[(Pubkey, BuiltinCost)] = &[
     (
         stake::id(),
         BuiltinCost::Migrating(MigratingBuiltinCost {
@@ -223,17 +215,13 @@ pub fn get_builtin_instruction_cost<'a>(
         .map(|builtin_cost| builtin_cost.native_cost())
 }
 
-#[cfg(feature = "svm-internal")]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-enum BuiltinMigrationFeatureIndex {
+pub enum BuiltinMigrationFeatureIndex {
     NotBuiltin,
     BuiltinNoMigrationFeature,
     BuiltinWithMigrationFeature(usize),
 }
 
-#[cfg(feature = "svm-internal")]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
+pub fn get_builtin_migration_feature_index(program_id: &Pubkey) -> BuiltinMigrationFeatureIndex {
     BUILTIN_INSTRUCTION_COSTS.get(program_id).map_or(
         BuiltinMigrationFeatureIndex::NotBuiltin,
         |builtin_cost| {
@@ -266,9 +254,7 @@ const _: () = validate_position(MIGRATING_BUILTINS_COSTS);
 
 /// Helper function to return ref of migration feature Pubkey at position `index`
 /// from MIGRATING_BUILTINS_COSTS
-#[cfg(feature = "svm-internal")]
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-pub(crate) fn get_migration_feature_id(index: usize) -> &'static Pubkey {
+pub fn get_migration_feature_id(index: usize) -> &'static Pubkey {
     MIGRATING_BUILTINS_COSTS
         .get(index)
         .expect("valid index of MIGRATING_BUILTINS_COSTS")

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 [dependencies]
 log = { workspace = true }
 solana-borsh = { workspace = true }
-solana-builtins-default-costs = { workspace = true, features = ["svm-internal"] }
+solana-builtins-default-costs = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true, features = ["borsh"] }
 solana-feature-set = { workspace = true }
@@ -32,7 +32,7 @@ name = "solana_compute_budget_instruction"
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { workspace = true, features = ["dev-context-only-utils", "svm-internal"] }
+solana-builtins-default-costs = { workspace = true, features = ["dev-context-only-utils"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -10,15 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-qualifier_attr = { workspace = true }
 solana-program-runtime = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
 name = "solana_compute_budget_program"
-
-[features]
-svm-internal = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,9 +1,6 @@
-#[cfg(feature = "svm-internal")]
-use qualifier_attr::qualifiers;
 use solana_program_runtime::declare_process_instruction;
 
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
-const DEFAULT_COMPUTE_UNITS: u64 = 150;
+pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
 
 declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |_invoke_context| {
     // Do nothing, compute budget instructions handled by the runtime

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -40,6 +40,7 @@ name = "solana_loader_v4_program"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+agave-internal = []
 shuttle-test = [
     "solana-type-overrides/shuttle-test",
     "solana-program-runtime/shuttle-test",

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -40,7 +40,7 @@ name = "solana_loader_v4_program"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-agave-internal = []
+agave-unstable-api = []
 shuttle-test = [
     "solana-type-overrides/shuttle-test",
     "solana-program-runtime/shuttle-test",

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "agave-internal")]
+#[cfg(feature = "agave-unstable-api")]
 use qualifier_attr::qualifiers;
 use {
     solana_bincode::limited_deserialize,
@@ -26,7 +26,7 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
-#[cfg_attr(feature = "agave-internal", qualifiers(pub))]
+#[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
 const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
 
 pub fn get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "svm-internal")]
+#[cfg(feature = "agave-internal")]
 use qualifier_attr::qualifiers;
 use {
     solana_bincode::limited_deserialize,
@@ -26,7 +26,7 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
-#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
+#[cfg_attr(feature = "agave-internal", qualifiers(pub))]
 const DEFAULT_COMPUTE_UNITS: u64 = 2_000;
 
 pub fn get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5522,7 +5522,6 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
- "qualifier_attr",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -5761,7 +5760,6 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.3.0"
 dependencies = [
- "qualifier_attr",
  "solana-program-runtime",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5380,7 +5380,6 @@ dependencies = [
  "ahash 0.8.11",
  "lazy_static",
  "log",
- "qualifier_attr",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -5619,7 +5618,6 @@ dependencies = [
 name = "solana-compute-budget-program"
 version = "2.3.0"
 dependencies = [
- "qualifier_attr",
  "solana-program-runtime",
 ]
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2498,7 +2498,7 @@ mod tests {
     fn test_validate_transaction_fee_payer_is_nonce() {
         let lamports_per_signature = 5000;
         let rent_collector = RentCollector::default();
-        let compute_unit_limit = 2 * solana_loader_v4_program::DEFAULT_COMPUTE_UNITS;
+        let compute_unit_limit = 1000u64;
         let last_blockhash = Hash::new_unique();
         let message = new_unchecked_sanitized_message(Message::new_with_blockhash(
             &[

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2498,7 +2498,7 @@ mod tests {
     fn test_validate_transaction_fee_payer_is_nonce() {
         let lamports_per_signature = 5000;
         let rent_collector = RentCollector::default();
-        let compute_unit_limit = 2 * solana_compute_budget_program::DEFAULT_COMPUTE_UNITS;
+        let compute_unit_limit = 2 * solana_loader_v4_program::DEFAULT_COMPUTE_UNITS;
         let last_blockhash = Hash::new_unique();
         let message = new_unchecked_sanitized_message(Message::new_with_blockhash(
             &[


### PR DESCRIPTION
#### Problem
The following crates are no longer internal to SVM, and should not use `svm-internal` feature to export or consume internal APIs.
1. `builtins-default-costs`
2. `compute-budget-instruction`
3. `programs/compute-budget`

#### Summary of Changes
Remove the feature and its usage from these crates.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
