### PR TITLE
Use test_assert for debug_asserts that are used for failing tests

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -6,6 +6,7 @@
 //! Otherwise, an ancient append vec is the same as any other append vec
 use {
     crate::{
+        test_assert,
         account_storage::ShrinkInProgress,
         accounts_db::{
             stats::{ShrinkAncientStats, ShrinkStatsSub},
@@ -1199,7 +1200,7 @@ pub fn is_ancient(storage: &AccountsFile) -> bool {
 /// Debug builds check this invariant, and will panic if broken.
 fn div_ceil(x: u64, y: NonZeroU64) -> u64 {
     let y = y.get();
-    debug_assert!(
+    test_assert!(
         x.checked_add(y).is_some(),
         "x + y must not overflow! x: {x}, y: {y}",
     );

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -1,7 +1,10 @@
 use {
-    crate::tiered_storage::{
+    crate::{
+        test_assert,
+        tiered_storage::{
         file::TieredWritableFile, footer::TieredStorageFooter, mmap_utils::get_pod,
         TieredStorageResult,
+        },
     },
     bytemuck::{Pod, Zeroable},
     memmap2::Mmap,
@@ -85,13 +88,13 @@ impl IndexBlockFormat {
     ) -> TieredStorageResult<&'a Pubkey> {
         let offset = match self {
             Self::AddressesThenOffsets => {
-                debug_assert!(index_offset.0 < footer.account_entry_count);
+                test_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * (index_offset.0 as usize)
             }
         };
 
-        debug_assert!(
+        test_assert!(
             offset.saturating_add(std::mem::size_of::<Pubkey>())
                 <= footer.owners_block_offset as usize,
             "reading IndexOffset ({}) would exceed index block boundary ({}).",
@@ -112,14 +115,14 @@ impl IndexBlockFormat {
     ) -> TieredStorageResult<Offset> {
         let offset = match self {
             Self::AddressesThenOffsets => {
-                debug_assert!(index_offset.0 < footer.account_entry_count);
+                test_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
                     + std::mem::size_of::<Offset>() * index_offset.0 as usize
             }
         };
 
-        debug_assert!(
+        test_assert!(
             offset.saturating_add(std::mem::size_of::<Offset>())
                 <= footer.owners_block_offset as usize,
             "reading IndexOffset ({}) would exceed index block boundary ({}).",

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -14,6 +14,14 @@ use {
 pub const ACCOUNTS_RUN_DIR: &str = "run";
 pub const ACCOUNTS_SNAPSHOT_DIR: &str = "snapshot";
 
+#[macro_export]
+macro_rules! test_assert {
+    ($($tt: tt)*) => {
+        #[cfg(test)]
+        assert!($($tt)*)
+    }
+}
+
 /// For all account_paths, create the run/ and snapshot/ sub directories.
 /// If an account_path directory does not exist, create it.
 /// It returns (account_run_paths, account_snapshot_paths) or error


### PR DESCRIPTION
#### Problem
These tests fail in release mode because they use debug_assert to trigger a panic.

#### Summary of Changes
Add a test_assert that only triggers in test and not dependent on debug/release.

Fixes: #5316
