### PR TITLE
disable coalesce for gossip

### DIFF
--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -66,7 +66,7 @@ impl GossipService {
             request_sender,
             Recycler::default(),
             gossip_receiver_stats.clone(),
-            Some(Duration::from_millis(1)), // coalesce
+            None, // coalesce
             false,
             None,
             false,


### PR DESCRIPTION
#### Problem

* solRcvrGossip is using over 80% of a core (just pulling packets from a socket)
* https://github.com/anza-xyz/agave/pull/5213 enables a more efficient way to drain sockets 
* 
#### Summary of Changes

- Remove the coalesce from the streamer in solRcvrGossip

Result is 20% core use by solRcvrGossip (4x reduction) and increases amount of batches sent to downstream code by 4x (left part before the gap is master, right part after gap is this PR)
<img width="671" alt="Näyttökuva 2025-03-17 kello 0 21 02" src="https://github.com/user-attachments/assets/da478b6e-9c56-4ad6-a7ee-5f3fdaa25c2f" />

Overall, it is a good question if we want fewer batches or lower CPU load of solRcvrGossip thread in particular.

Fixes #
https://github.com/anza-xyz/agave/issues/5034
