### PR TITLE
Support receiving verified transactions from the vortexor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7573,6 +7573,7 @@ dependencies = [
  "solana-unified-scheduler-logic",
  "solana-unified-scheduler-pool",
  "solana-version",
+ "solana-vortexor-receiver",
  "solana-vote",
  "solana-vote-program",
  "solana-wen-restart",
@@ -11125,6 +11126,15 @@ dependencies = [
  "tokio",
  "url 2.5.4",
  "x509-parser",
+]
+
+[[package]]
+name = "solana-vortexor-receiver"
+version = "2.3.0"
+dependencies = [
+ "assert_matches",
+ "solana-perf",
+ "solana-streamer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ members = [
     "validator",
     "version",
     "vortexor",
+    "vortexor-receiver",
     "vote",
     "watchtower",
     "wen-restart",
@@ -567,6 +568,7 @@ solana-type-overrides = { path = "type-overrides", version = "=2.3.0" }
 solana-udp-client = { path = "udp-client", version = "=2.3.0" }
 solana-validator-exit = "2.2.1"
 solana-version = { path = "version", version = "=2.3.0" }
+solana-vortexor-receiver = { path = "vortexor-receiver", version = "=2.3.0" }
 solana-vote = { path = "vote", version = "=2.3.0" }
 solana-vote-interface = "2.2.4"
 solana-vote-program = { path = "programs/vote", version = "=2.3.0", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -96,6 +96,7 @@ solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
+solana-vortexor-receiver = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-wen-restart = { workspace = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,6 +41,7 @@ mod tpu_entry_notifier;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;
 pub mod validator;
+mod vortexor_receiver_adapter;
 pub mod vote_simulator;
 pub mod voting_service;
 pub mod warm_quic_cache_service;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -100,8 +100,8 @@ pub struct Tpu {
     forwarding_stage: JoinHandle<()>,
     cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
-    tpu_quic_t: thread::JoinHandle<()>,
-    tpu_forwards_quic_t: thread::JoinHandle<()>,
+    tpu_quic_t: Option<thread::JoinHandle<()>>,
+    tpu_forwards_quic_t: Option<thread::JoinHandle<()>>,
     tpu_entry_notifier: Option<TpuEntryNotifier>,
     staked_nodes_updater_service: StakedNodesUpdaterService,
     tracer_thread_hdl: TracerThread,
@@ -214,39 +214,49 @@ impl Tpu {
         )
         .unwrap();
 
-        // Streamer for TPU
-        let SpawnServerResult {
-            endpoints: _,
-            thread: tpu_quic_t,
-            key_updater,
-        } = spawn_server_multi(
-            "solQuicTpu",
-            "quic_streamer_tpu",
-            transactions_quic_sockets,
-            keypair,
-            packet_sender,
-            exit.clone(),
-            staked_nodes.clone(),
-            tpu_quic_server_config,
-        )
-        .unwrap();
+        let (tpu_quic_t, key_updater) = if vortexor_receivers.is_none() {
+            // Streamer for TPU
+            let SpawnServerResult {
+                endpoints: _,
+                thread: tpu_quic_t,
+                key_updater,
+            } = spawn_server_multi(
+                "solQuicTpu",
+                "quic_streamer_tpu",
+                transactions_quic_sockets,
+                keypair,
+                packet_sender,
+                exit.clone(),
+                staked_nodes.clone(),
+                tpu_quic_server_config,
+            )
+            .unwrap();
+            (Some(tpu_quic_t), Some(key_updater))
+        } else {
+            (None, None)
+        };
 
-        // Streamer for TPU forward
-        let SpawnServerResult {
-            endpoints: _,
-            thread: tpu_forwards_quic_t,
-            key_updater: forwards_key_updater,
-        } = spawn_server_multi(
-            "solQuicTpuFwd",
-            "quic_streamer_tpu_forwards",
-            transactions_forwards_quic_sockets,
-            keypair,
-            forwarded_packet_sender,
-            exit.clone(),
-            staked_nodes.clone(),
-            tpu_fwd_quic_server_config,
-        )
-        .unwrap();
+        let (tpu_forwards_quic_t, forwards_key_updater) = if vortexor_receivers.is_none() {
+            // Streamer for TPU forward
+            let SpawnServerResult {
+                endpoints: _,
+                thread: tpu_forwards_quic_t,
+                key_updater: forwards_key_updater,
+            } = spawn_server_multi(
+                "solQuicTpuFwd",
+                "quic_streamer_tpu_forwards",
+                transactions_forwards_quic_sockets,
+                keypair,
+                forwarded_packet_sender,
+                exit.clone(),
+                staked_nodes.clone(),
+                tpu_fwd_quic_server_config,
+            )
+            .unwrap();
+            (Some(tpu_forwards_quic_t), Some(forwards_key_updater))
+        } else {
+            (None, None)
+        };
 
         let (forward_stage_sender, forward_stage_receiver) = bounded(1024);
         let sig_verifier = if let Some(vortexor_receivers) = vortexor_receivers {
@@ -353,6 +363,14 @@ impl Tpu {
             turbine_quic_endpoint_sender,
         );
 
+        let mut key_updaters: Vec<Arc<dyn NotifyKeyUpdate + Send + Sync>> = Vec::new();
+        if let Some(key_updater) = key_updater {
+            key_updaters.push(key_updater);
+        }
+        if let Some(forwards_key_updater) = forwards_key_updater {
+            key_updaters.push(forwards_key_updater);
+        }
+        key_updaters.push(vote_streamer_key_updater);
         (
             Self {
                 fetch_stage,
@@ -369,7 +387,7 @@ impl Tpu {
                 tracer_thread_hdl,
                 tpu_vote_quic_t,
             },
-            vec![key_updater, forwards_key_updater, vote_streamer_key_updater],
+            key_updaters,
         )
     }
 
@@ -382,8 +400,8 @@ impl Tpu {
             self.banking_stage.join(),
             self.forwarding_stage.join(),
             self.staked_nodes_updater_service.join(),
-            self.tpu_quic_t.join(),
-            self.tpu_forwards_quic_t.join(),
+            self.tpu_quic_t.map_or(Ok(()), |t| t.join()),
+            self.tpu_forwards_quic_t.map_or(Ok(()), |t| t.join()),
             self.tpu_vote_quic_t.join(),
         ];
         let broadcast_result = self.broadcast_stage.join();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -267,6 +267,7 @@ impl Tpu {
                 Duration::from_millis(5),
                 tpu_coalesce,
                 non_vote_sender,
+                enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
                 exit.clone(),
             );
             SigVerifier::Remote(adapter)

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -23,6 +23,7 @@ use {
         staked_nodes_updater_service::StakedNodesUpdaterService,
         tpu_entry_notifier::TpuEntryNotifier,
         validator::{BlockProductionMethod, GeneratorConfig, TransactionStructure},
+        vortexor_receiver_adapter::VortexorReceiverAdapter,
     },
     bytes::Bytes,
     crossbeam_channel::{bounded, unbounded, Receiver},
@@ -73,11 +74,26 @@ pub struct TpuSockets {
     pub vote_quic: Vec<UdpSocket>,
     /// Client-side socket for the forwarding votes.
     pub vote_forwards_client: UdpSocket,
+    pub vortexor_receivers: Option<Vec<UdpSocket>>,
+}
+
+enum SigVerifier {
+    Local(SigVerifyStage),
+    Remote(VortexorReceiverAdapter),
+}
+
+impl SigVerifier {
+    fn join(self) -> thread::Result<()> {
+        match self {
+            SigVerifier::Local(sig_verify_stage) => sig_verify_stage.join(),
+            SigVerifier::Remote(vortexor_receiver_adapter) => vortexor_receiver_adapter.join(),
+        }
+    }
 }
 
 pub struct Tpu {
     fetch_stage: FetchStage,
-    sigverify_stage: SigVerifyStage,
+    sig_verifier: SigVerifier,
     vote_sigverify_stage: SigVerifyStage,
     banking_stage: BankingStage,
     forwarding_stage: JoinHandle<()>,
@@ -143,6 +159,7 @@ impl Tpu {
             transactions_forwards_quic: transactions_forwards_quic_sockets,
             vote_quic: tpu_vote_quic_sockets,
             vote_forwards_client: vote_forwards_client_socket,
+            vortexor_receivers,
         } = sockets;
 
         let (packet_sender, packet_receiver) = unbounded();
@@ -231,12 +248,29 @@ impl Tpu {
         .unwrap();
 
         let (forward_stage_sender, forward_stage_receiver) = bounded(1024);
-        let sigverify_stage = {
+        let sig_verifier = if let Some(vortexor_receivers) = vortexor_receivers {
+            info!("starting vortexor adapter");
+            let sockets = vortexor_receivers.into_iter().map(Arc::new).collect();
+            let adapter = VortexorReceiverAdapter::new(
+                sockets,
+                Duration::from_millis(5),
+                tpu_coalesce,
+                non_vote_sender,
+                exit.clone(),
+            );
+            SigVerifier::Remote(adapter)
+        } else {
+            info!("starting regular sigverify stage");
             let verifier = TransactionSigVerifier::new(
                 non_vote_sender,
                 enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
             );
-            SigVerifyStage::new(packet_receiver, verifier, "solSigVerTpu", "tpu-verifier")
+            SigVerifier::Local(SigVerifyStage::new(
+                packet_receiver,
+                verifier,
+                "solSigVerTpu",
+                "tpu-verifier",
+            ))
         };
 
         let vote_sigverify_stage = {
@@ -321,7 +355,7 @@ impl Tpu {
         (
             Self {
                 fetch_stage,
-                sigverify_stage,
+                sig_verifier,
                 vote_sigverify_stage,
                 banking_stage,
                 forwarding_stage,
@@ -341,7 +375,7 @@ impl Tpu {
     pub fn join(self) -> thread::Result<()> {
         let results = vec![
             self.fetch_stage.join(),
-            self.sigverify_stage.join(),
+            self.sig_verifier.join(),
             self.vote_sigverify_stage.join(),
             self.cluster_info_vote_listener.join(),
             self.banking_stage.join(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -77,6 +77,7 @@ pub struct TpuSockets {
     pub vortexor_receivers: Option<Vec<UdpSocket>>,
 }
 
+/// The `SigVerifier` enum is used to determine whether to use a local or remote signature verifier.
 enum SigVerifier {
     Local(SigVerifyStage),
     Remote(VortexorReceiverAdapter),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1580,6 +1580,7 @@ impl Validator {
                 transactions_forwards_quic: node.sockets.tpu_forwards_quic,
                 vote_quic: node.sockets.tpu_vote_quic,
                 vote_forwards_client: node.sockets.tpu_vote_forwards_client,
+                vortexor_receivers: node.sockets.vortexor_receivers,
             },
             &rpc_subscriptions,
             transaction_status_sender,

--- a/core/src/vortexor_receiver_adapter.rs
+++ b/core/src/vortexor_receiver_adapter.rs
@@ -64,11 +64,11 @@ impl VortexorReceiverAdapter {
                     // Send out packet batches
                     match traced_sender.send(packet_batch) {
                         Ok(_) => {
-                            info!("Sent vortexor batch {count} successfully");
+                            trace!("Sent batch: {count} received from vortexor successfully");
                             continue;
                         }
-                        Err(_err) => {
-                            info!("Failed to send batch {count}");
+                        Err(err) => {
+                            debug!("Failed to send batch {count} {err:?}");
                             break;
                         }
                     }

--- a/core/src/vortexor_receiver_adapter.rs
+++ b/core/src/vortexor_receiver_adapter.rs
@@ -1,4 +1,6 @@
-//! Tempory solution to receive from the receiver and forward the packets to banking stage
+//! Vortexor receiver adapter which wraps the VerifiedPacketReceiver
+//! to receive packet batches from the remote and sends the packets to the
+//! banking stage.
 
 use {
     crate::banking_trace::TracedSender,
@@ -83,7 +85,7 @@ impl VortexorReceiverAdapter {
         }
     }
 
-    /// Receives packet batches from sigverify stage with a timeout
+    /// Receives packet batches from VerifiedPacketReceiver with a timeout
     fn receive_until(
         packet_batch_receiver: Receiver<PacketBatch>,
         recv_timeout: Duration,

--- a/core/src/vortexor_receiver_adapter.rs
+++ b/core/src/vortexor_receiver_adapter.rs
@@ -1,0 +1,108 @@
+//! Tempory solution to receive from the receiver and forward the packets to banking stage
+
+use {
+    crate::banking_trace::TracedSender,
+    agave_banking_stage_ingress_types::BankingPacketBatch,
+    crossbeam_channel::{unbounded, Receiver, RecvTimeoutError},
+    solana_perf::packet::PacketBatch,
+    solana_vortexor_receiver::receiver::VerifiedPacketReceiver,
+    std::{
+        net::UdpSocket,
+        sync::{atomic::AtomicBool, Arc},
+        thread::{self, Builder, JoinHandle},
+        time::{Duration, Instant},
+    },
+};
+
+pub struct VortexorReceiverAdapter {
+    thread_hdl: JoinHandle<()>,
+    receiver: VerifiedPacketReceiver,
+}
+
+impl VortexorReceiverAdapter {
+    pub fn new(
+        sockets: Vec<Arc<UdpSocket>>,
+        recv_timeout: Duration,
+        tpu_coalesce: Duration,
+        packets_sender: TracedSender,
+        exit: Arc<AtomicBool>,
+    ) -> Self {
+        let (batch_sender, batch_receiver) = unbounded();
+
+        let receiver =
+            VerifiedPacketReceiver::new(sockets, &batch_sender, tpu_coalesce, None, exit.clone());
+
+        let thread_hdl = Builder::new()
+            .name("vtxRcvAdptr".to_string())
+            .spawn(move || {
+                Self::recv_send(batch_receiver, recv_timeout, 8, packets_sender);
+            })
+            .unwrap();
+        Self {
+            thread_hdl,
+            receiver,
+        }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()?;
+        self.receiver.join()
+    }
+
+    fn recv_send(
+        packet_batch_receiver: Receiver<PacketBatch>,
+        recv_timeout: Duration,
+        batch_size: usize,
+        traced_sender: TracedSender,
+    ) {
+        loop {
+            match Self::receive_until(packet_batch_receiver.clone(), recv_timeout, batch_size) {
+                Ok(packet_batch) => {
+                    let count = packet_batch.len();
+                    // Send out packet batches
+                    match traced_sender.send(packet_batch) {
+                        Ok(_) => {
+                            info!("Sent vortexor batch {count} successfully");
+                            continue;
+                        }
+                        Err(_err) => {
+                            info!("Failed to send batch {count}");
+                            break;
+                        }
+                    }
+                }
+                Err(err) => match err {
+                    RecvTimeoutError::Timeout => {
+                        continue;
+                    }
+                    RecvTimeoutError::Disconnected => {
+                        break;
+                    }
+                },
+            }
+        }
+    }
+
+    /// Receives packet batches from sigverify stage with a timeout
+    fn receive_until(
+        packet_batch_receiver: Receiver<PacketBatch>,
+        recv_timeout: Duration,
+        batch_size: usize,
+    ) -> Result<BankingPacketBatch, RecvTimeoutError> {
+        let start = Instant::now();
+
+        let message = packet_batch_receiver.recv_timeout(recv_timeout)?;
+        let mut packet_batches = Vec::new();
+        packet_batches.push(message);
+
+        while let Ok(message) = packet_batch_receiver.try_recv() {
+            packet_batches.push(message);
+
+            if start.elapsed() >= recv_timeout || packet_batches.len() >= batch_size {
+                break;
+            }
+        }
+
+        Ok(Arc::new(packet_batches))
+    }
+}

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2388,6 +2388,7 @@ pub struct Sockets {
     pub quic_vote_client: UdpSocket,
     /// Client-side socket for RPC/SendTransactionService.
     pub rpc_sts_client: UdpSocket,
+    pub vortexor_receivers: Option<Vec<UdpSocket>>,
 }
 
 pub struct NodeConfig {
@@ -2396,6 +2397,8 @@ pub struct NodeConfig {
     pub bind_ip_addr: IpAddr,
     pub public_tpu_addr: Option<SocketAddr>,
     pub public_tpu_forwards_addr: Option<SocketAddr>,
+    pub vortexor_receiver_addr: Option<SocketAddr>,
+
     /// The number of TVU receive sockets to create
     pub num_tvu_receive_sockets: NonZeroUsize,
     /// The number of TVU retransmit sockets to create
@@ -2558,6 +2561,7 @@ impl Node {
                 quic_forwards_client,
                 quic_vote_client,
                 rpc_sts_client,
+                vortexor_receivers: None,
             },
         }
     }
@@ -2731,6 +2735,7 @@ impl Node {
                 quic_vote_client,
                 quic_forwards_client,
                 rpc_sts_client,
+                vortexor_receivers: None,
             },
         }
     }
@@ -2745,6 +2750,7 @@ impl Node {
             num_tvu_receive_sockets,
             num_tvu_retransmit_sockets,
             num_quic_endpoints,
+            vortexor_receiver_addr,
         } = config;
 
         let (gossip_port, (gossip, ip_echo)) =
@@ -2864,6 +2870,23 @@ impl Node {
         info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
             .unwrap();
 
+        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
+            multi_bind_in_range_with_config(
+                vortexor_receiver_addr.ip(),
+                (
+                    vortexor_receiver_addr.port(),
+                    vortexor_receiver_addr.port() + 1,
+                ),
+                socket_config_reuseport,
+                32,
+            )
+            .unwrap_or_else(|_| {
+                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
+            })
+            .1
+        });
+
+        info!("vortexor_receivers is {vortexor_receivers:?}");
         trace!("new ContactInfo: {:?}", info);
         let sockets = Sockets {
             gossip,
@@ -2888,6 +2911,7 @@ impl Node {
             quic_vote_client,
             quic_forwards_client,
             rpc_sts_client,
+            vortexor_receivers,
         };
         info!("Bound all network sockets as follows: {:#?}", &sockets);
         Node { info, sockets }
@@ -3363,6 +3387,7 @@ mod tests {
             num_tvu_receive_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_tvu_retransmit_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_quic_endpoints: DEFAULT_NUM_QUIC_ENDPOINTS,
+            vortexor_receiver_addr: None,
         };
 
         let node = Node::new_with_external_ip(&solana_pubkey::new_rand(), config);
@@ -3387,6 +3412,7 @@ mod tests {
             num_tvu_receive_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_tvu_retransmit_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_quic_endpoints: DEFAULT_NUM_QUIC_ENDPOINTS,
+            vortexor_receiver_addr: None,
         };
 
         let node = Node::new_with_external_ip(&solana_pubkey::new_rand(), config);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5922,6 +5922,7 @@ dependencies = [
  "solana-turbine",
  "solana-unified-scheduler-pool",
  "solana-version",
+ "solana-vortexor-receiver",
  "solana-vote",
  "solana-vote-program",
  "solana-wen-restart",
@@ -9171,6 +9172,14 @@ dependencies = [
  "serde_derive",
  "solana-sanitize",
  "solana-serde-varint",
+]
+
+[[package]]
+name = "solana-vortexor-receiver"
+version = "2.3.0"
+dependencies = [
+ "solana-perf",
+ "solana-streamer",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5780,6 +5780,7 @@ dependencies = [
  "solana-turbine",
  "solana-unified-scheduler-pool",
  "solana-version",
+ "solana-vortexor-receiver",
  "solana-vote",
  "solana-vote-program",
  "solana-wen-restart",
@@ -8512,6 +8513,14 @@ dependencies = [
  "serde_derive",
  "solana-sanitize",
  "solana-serde-varint",
+]
+
+[[package]]
+name = "solana-vortexor-receiver"
+version = "2.3.0"
+dependencies = [
+ "solana-perf",
+ "solana-streamer",
 ]
 
 [[package]]

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -378,6 +378,14 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("tpu_vortexor_receiver_address")
+            .long("tpu-vortexor-receiver-address")
+            .value_name("HOST:PORT")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host_port)
+            .help("TPU Vortexor Receiver address to which verified transaction packet will be forwarded."),
+    )
+    .arg(
         Arg::with_name("public_rpc_addr")
             .long("public-rpc-address")
             .value_name("HOST:PORT")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -382,6 +382,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("tpu-vortexor-receiver-address")
             .value_name("HOST:PORT")
             .takes_value(true)
+            .hidden(hidden_unless_forced())
             .validator(solana_net_utils::is_host_port)
             .help("TPU Vortexor Receiver address to which verified transaction packet will be forwarded."),
     )

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1140,6 +1140,19 @@ pub fn execute(
         })
         .transpose()?;
 
+    let tpu_vortexor_receiver_address =
+        matches
+            .value_of("tpu_vortexor_receiver_address")
+            .map(|tpu_vortexor_receiver_address| {
+                solana_net_utils::parse_host_port(tpu_vortexor_receiver_address).unwrap_or_else(
+                    |err| {
+                        eprintln!("Failed to parse --tpu-vortexor-receiver-address: {err}");
+                        exit(1);
+                    },
+                )
+            });
+
+    info!("tpu_vortexor_receiver_address is {tpu_vortexor_receiver_address:?}");
     let num_quic_endpoints = value_t_or_exit!(matches, "num_quic_endpoints", NonZeroUsize);
 
     let tpu_max_connections_per_peer =
@@ -1166,6 +1179,7 @@ pub fn execute(
         num_tvu_receive_sockets: tvu_receive_threads,
         num_tvu_retransmit_sockets: tvu_retransmit_threads,
         num_quic_endpoints,
+        vortexor_receiver_addr: tpu_vortexor_receiver_address,
     };
 
     let cluster_entrypoints = entrypoint_addrs

--- a/vortexor-receiver/Cargo.toml
+++ b/vortexor-receiver/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solana-vortexor-receiver"
+description = "Solana TPU Vortexor Receiver"
+documentation = "https://docs.rs/solana-vortexor-receiver"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-perf = { workspace = true }
+solana-streamer = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+
+[lib]
+crate-type = ["lib"]
+name = "solana_vortexor_receiver"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/vortexor-receiver/Readme.md
+++ b/vortexor-receiver/Readme.md
@@ -1,0 +1,48 @@
+The vortexor is a service which can be used to offload receiving transaction from the public, doing signature verifications and deduplications from the core validator which can focus on processing and executing the transactions. The filtered transactions can be forwarded to the validators linked with the vortexor.
+This vortexor makes the TPU transaction ingestion more scalable compared to single node solution.
+
+The archietecture diagram of the Vorexor with the relationship to the validator.
+
+                    +--------------------- VORTEXOR ------------------------+
+                    |                                                       |
+                    |   +-------------+        +--------------------+       |
+        TPU -->     |   | TPU Streamer| -----> | SigVerifier/Dedup  |       |
+        /QUIC       |   +-------------+        +--------------------+       |
+                    |        |                   |                          |
+                    |        v                   v                          |
+                    |  +----------------+     +------------------------+    |
+                    |  | Subscription   |<----| VerifiedPacketForwarder|    |
+                    |  | Management     |     +------------------------+    |
+                    |  +----------------+            |                      |
+                    +--------------------------------|----------------------+
+                                ^                    |
+    heart beat/subscriptions    |                    v
+                    +-------------------- AGAVE VALIDATOR ------------------+
+                    |                                                       |
+                    |  +----------------+      +-----------------------+    |
+Validator Config->  |  | Subscription   |      | VerifiedPacketReceiver|    |
+Admin RPC           |  | Management     |      |                       |    |
+                    |  +----------------+      +-----------------------+    |
+                    |        |                           |                  |
+                    |        |                           v                  |
+                    |        v                      +-----------+           |
+                    |  +--------------------+       | Banking   |           |
+    Gossip <--------|--| Gossip/Contact Info|       | Stage     |           |
+                    |  +--------------------+       +-----------+           |
+                    +-------------------------------------------------------+
+
+
+The Vorexor is a new executable which can be deployed on to different nodes from the core Agave validator.
+It has the following major components:
+
+1. The TPU Streamer -- this is built from the existing QUIC based TPU streamer
+2. The SigVerify/Dedup -- this is built/refactored from the existing SigVerify component
+3. Subscription Management -- This is responsible for managing subscriptions from the validator.
+   Subscriptions action include subscription for transactions and cancel subscriptions.
+4. VerifiedPacketForwarder -- This is responsible for forwarding the verified transaction packets
+   to the subscribed validators. We target use UDP/QUIC to send transactions to the validators
+   The validators can use firewall rules to allow transactions only from the vortexor.
+
+In the validator, there is new component which receives the verified packets sent from the vortexor which directly sends the packets to the banking stage. The validator's Admin RPC is enhanced to configure the peering vortexor. The ContactInfo of the validator is updated with the address of the vortexor when it is linked with the validator. There is periodic heartbeat messages sent from the vortexor to the validator. If there are not transactions sent and no heartbeat messages from the vortexor within configurable timeout window, the validator may decide the vortexor is dead or disconnected it may choose to use another vortexor or use its own native QUI TPU streamer by updating the ContactInfo about TPU address.
+
+This module implements the VerifiedPacketReceiver.

--- a/vortexor-receiver/Readme.md
+++ b/vortexor-receiver/Readme.md
@@ -1,27 +1,53 @@
-The vortexor is a service which can be used to offload receiving transaction from the public, doing signature verifications and deduplications from the core validator which can focus on processing and executing the transactions. The filtered transactions can be forwarded to the validators linked with the vortexor.
-This vortexor makes the TPU transaction ingestion more scalable compared to single node solution.
+# Introduction
+The Vortexor is a service that can offload the tasks of receiving transactions
+from the public, performing signature verifications, and deduplications from the
+core validator, enabling it to focus on processing and executing the
+transactions. The verified and filtered transactions will then be forwarded to
+the validators linked with the Vortexor. This setup makes the TPU transaction
+ingestion and verification more scalable compared to a single-node solution.
 
-The archietecture diagram of the Vorexor with the relationship to the validator.
+This module implements the VerifiedPacketReceiver in the below architecture
+which encapsulates the functionality of receiving the verified packet batches
+from the vortexor. In the first impelementation, we use UDP to receive the
+verified packets from the vortexor. It is designed to support other protocol
+option such as using QUIC.
 
+# Architecture
+Figure 1 describes the architecture diagram of the Vortexor and its
+relationship with the validator.
+
+                     +---------------------+
+                     |   Solana            |
+                     |   RPC / Web Socket  |
+                     |   Service           |
+                     +---------------------+
+                                |
+                                v
                     +--------------------- VORTEXOR ------------------------+
-                    |                                                       |
+                    |           |                                           |
+                    |   +------------------+                                |
+                    |   | StakedKeyUpdater |                                |
+                    |   +------------------+                                |
+                    |           |                                           |
+                    |           v                                           |
                     |   +-------------+        +--------------------+       |
         TPU -->     |   | TPU Streamer| -----> | SigVerifier/Dedup  |       |
         /QUIC       |   +-------------+        +--------------------+       |
-                    |        |                   |                          |
-                    |        v                   v                          |
+                    |        |                          |                   |
+                    |        v                          v                   |
                     |  +----------------+     +------------------------+    |
                     |  | Subscription   |<----| VerifiedPacketForwarder|    |
                     |  | Management     |     +------------------------+    |
                     |  +----------------+            |                      |
                     +--------------------------------|----------------------+
-                                ^                    |
-    heart beat/subscriptions    |                    v
+                                ^                    | (UDP/QUIC)
+    Heartbeat/subscriptions     |                    |
+                                |                    v
                     +-------------------- AGAVE VALIDATOR ------------------+
                     |                                                       |
                     |  +----------------+      +-----------------------+    |
-Validator Config->  |  | Subscription   |      | VerifiedPacketReceiver|    |
-Admin RPC           |  | Management     |      |                       |    |
+          Config->  |  | Subscription   |      | VerifiedPacketReceiver|    |
+      Admin RPC     |  | Management     |      |                       |    |
                     |  +----------------+      +-----------------------+    |
                     |        |                           |                  |
                     |        |                           v                  |
@@ -31,18 +57,5 @@ Admin RPC           |  | Management     |      |                       |    |
                     |  +--------------------+       +-----------+           |
                     +-------------------------------------------------------+
 
+                                       Figure 1.
 
-The Vorexor is a new executable which can be deployed on to different nodes from the core Agave validator.
-It has the following major components:
-
-1. The TPU Streamer -- this is built from the existing QUIC based TPU streamer
-2. The SigVerify/Dedup -- this is built/refactored from the existing SigVerify component
-3. Subscription Management -- This is responsible for managing subscriptions from the validator.
-   Subscriptions action include subscription for transactions and cancel subscriptions.
-4. VerifiedPacketForwarder -- This is responsible for forwarding the verified transaction packets
-   to the subscribed validators. We target use UDP/QUIC to send transactions to the validators
-   The validators can use firewall rules to allow transactions only from the vortexor.
-
-In the validator, there is new component which receives the verified packets sent from the vortexor which directly sends the packets to the banking stage. The validator's Admin RPC is enhanced to configure the peering vortexor. The ContactInfo of the validator is updated with the address of the vortexor when it is linked with the validator. There is periodic heartbeat messages sent from the vortexor to the validator. If there are not transactions sent and no heartbeat messages from the vortexor within configurable timeout window, the validator may decide the vortexor is dead or disconnected it may choose to use another vortexor or use its own native QUI TPU streamer by updating the ContactInfo about TPU address.
-
-This module implements the VerifiedPacketReceiver.

--- a/vortexor-receiver/Readme.md
+++ b/vortexor-receiver/Readme.md
@@ -58,4 +58,3 @@ relationship with the validator.
                     +-------------------------------------------------------+
 
                                        Figure 1.
-

--- a/vortexor-receiver/src/lib.rs
+++ b/vortexor-receiver/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod receiver;

--- a/vortexor-receiver/src/receiver.rs
+++ b/vortexor-receiver/src/receiver.rs
@@ -1,0 +1,58 @@
+/// This is responsible for receiving the verified and deduplicated transactions
+/// from the vortexor and sending down to the banking stage.
+use {
+    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
+    solana_streamer::streamer::{self, PacketBatchSender, StreamerReceiveStats},
+    std::{
+        net::UdpSocket,
+        sync::{atomic::AtomicBool, Arc},
+        thread::{self, JoinHandle},
+        time::Duration,
+    },
+};
+
+pub struct VerifiedPacketReceiver {
+    thread_hdls: Vec<JoinHandle<()>>,
+}
+
+impl VerifiedPacketReceiver {
+    pub fn new(
+        sockets: Vec<Arc<UdpSocket>>,
+        sender: &PacketBatchSender,
+        coalesce: Duration,
+        in_vote_only_mode: Option<Arc<AtomicBool>>,
+        exit: Arc<AtomicBool>,
+    ) -> Self {
+        let recycler: PacketBatchRecycler = Recycler::warmed(1000, 1024);
+
+        let tpu_stats = Arc::new(StreamerReceiveStats::new("vortexor_receiver"));
+
+        let thread_hdls = sockets
+            .into_iter()
+            .enumerate()
+            .map(|(i, socket)| {
+                streamer::receiver(
+                    format!("solVtxRcvr{i:02}"),
+                    socket,
+                    exit.clone(),
+                    sender.clone(),
+                    recycler.clone(),
+                    tpu_stats.clone(),
+                    Some(coalesce),
+                    true,
+                    in_vote_only_mode.clone(),
+                    false, // unstaked connections
+                )
+            })
+            .collect();
+
+        Self { thread_hdls }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        for thread_hdl in self.thread_hdls {
+            thread_hdl.join()?;
+        }
+        Ok(())
+    }
+}

--- a/vortexor-receiver/src/receiver.rs
+++ b/vortexor-receiver/src/receiver.rs
@@ -41,7 +41,7 @@ impl VerifiedPacketReceiver {
                     Some(coalesce),
                     true,
                     in_vote_only_mode.clone(),
-                    false, // unstaked connections
+                    false, // is_staked_service
                 )
             })
             .collect();

--- a/vortexor/src/sender.rs
+++ b/vortexor/src/sender.rs
@@ -83,7 +83,9 @@ impl PacketBatchSender {
                     for batch in &packet_batches {
                         for packet_batch in batch.iter() {
                             for packet in packet_batch {
-                                packets.push(packet.data(0..).unwrap());
+                                if let Some(data) = packet.data(0..) {
+                                    packets.push(data);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
#### Problem

This support receiving verified transactions from the vortexor.

#### Summary of Changes

The additional argument in the validator can start service receiving the verified transactions:

e.g
:
--tpu-vortexor-receiver-address 10.138.0.136:8100

And the validator can use existing TPU customize address to point its TPU addresses to the vortexor:

e.g.
--public-tpu-address 10.138.0.136:9194 --public-tpu-forwards-address 10.138.0.136:9195

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
