### PR TITLE
Fix support for nightly builds in `solana-unified-scheduler-pool`

### DIFF
--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -12,6 +12,8 @@
 //! Refer to [`PooledScheduler`] doc comment for general overview of scheduler state transitions
 //! regarding to pooling and the actual use.
 
+use std::ops::DerefMut;
+
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
@@ -387,9 +389,8 @@ where
                     //
                     // Note that this critical section could block the latency-sensitive replay
                     // code-path via ::take_scheduler().
-                    #[allow(unstable_name_collisions)]
                     idle_inners.extend(MakeExtractIf::extract_if(
-                        &mut *scheduler_inners,
+                        scheduler_inners.deref_mut(),
                         |(_inner, pooled_at)| now.duration_since(*pooled_at) > max_pooling_duration,
                     ));
                     drop(scheduler_inners);
@@ -419,9 +420,8 @@ where
                     let Ok(mut timeout_listeners) = scheduler_pool.timeout_listeners.lock() else {
                         break;
                     };
-                    #[allow(unstable_name_collisions)]
                     expired_listeners.extend(MakeExtractIf::extract_if(
-                        &mut *timeout_listeners,
+                        timeout_listeners.deref_mut(),
                         |(_callback, registered_at)| {
                             now.duration_since(*registered_at) > timeout_duration
                         },

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -388,9 +388,10 @@ where
                     // Note that this critical section could block the latency-sensitive replay
                     // code-path via ::take_scheduler().
                     #[allow(unstable_name_collisions)]
-                    idle_inners.extend(scheduler_inners.extract_if(|(_inner, pooled_at)| {
-                        now.duration_since(*pooled_at) > max_pooling_duration
-                    }));
+                    idle_inners.extend(MakeExtractIf::extract_if(
+                        &mut *scheduler_inners,
+                        |(_inner, pooled_at)| now.duration_since(*pooled_at) > max_pooling_duration,
+                    ));
                     drop(scheduler_inners);
 
                     let idle_inner_count = idle_inners.len();
@@ -419,7 +420,8 @@ where
                         break;
                     };
                     #[allow(unstable_name_collisions)]
-                    expired_listeners.extend(timeout_listeners.extract_if(
+                    expired_listeners.extend(MakeExtractIf::extract_if(
+                        &mut *timeout_listeners,
                         |(_callback, registered_at)| {
                             now.duration_since(*registered_at) > timeout_duration
                         },

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -12,8 +12,6 @@
 //! Refer to [`PooledScheduler`] doc comment for general overview of scheduler state transitions
 //! regarding to pooling and the actual use.
 
-use std::ops::DerefMut;
-
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
@@ -53,6 +51,7 @@ use {
         fmt::Debug,
         marker::PhantomData,
         mem,
+        ops::DerefMut,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed},
             Arc, Mutex, MutexGuard, OnceLock, Weak,


### PR DESCRIPTION

#### Problem

When using the latest versions of the rust nightly toolchain (e.g. `nightly-2025-03-13`), builds were failing after a change to the function signature of the `extract_if` method.

#### Summary of Changes

Replaced direct calls to `extract_if` with a new `MakeExtractIf::extract_if` method for both `scheduler_inners` and `timeout_listeners`. By directly using the `MakeExtractIf` trait builds work on both stable and nightly despite the change in function signature.


Fixes #5322
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
