### PR TITLE
banking stage: accumulate transaction balances

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -2,23 +2,24 @@ use {
     super::leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
     itertools::Itertools,
     solana_ledger::{
-        blockstore_processor::TransactionStatusSender, token_balances::collect_token_balances,
+        blockstore_processor::TransactionStatusSender,
+        token_balances::collect_token_balances,
+        transaction_balances::{calculate_transaction_balances, BalanceInfo},
     },
     solana_measure::measure_us,
     solana_runtime::{
-        bank::{Bank, ProcessedTransactionCounts, TransactionBalancesSet},
+        bank::{Bank, ProcessedTransactionCounts},
         bank_utils,
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{pubkey::Pubkey, saturating_add_assign},
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::{
-            ProcessedTransaction, TransactionProcessingResult,
-            TransactionProcessingResultExtensions,
+            TransactionProcessingResult, TransactionProcessingResultExtensions,
         },
     },
     solana_transaction_status::{
@@ -41,88 +42,6 @@ pub(super) struct PreBalanceInfo {
     pub native: Vec<Vec<u64>>,
     pub token: Vec<Vec<TransactionTokenBalance>>,
     pub mint_decimals: HashMap<Pubkey, u8>,
-}
-
-// HANA idk struct maybe
-type BalanceInfo = (TransactionBalancesSet, TransactionTokenBalancesSet);
-
-#[allow(unused_variables)] // HANA
-#[allow(unused_mut)] // HANA
-fn calculate_balances(
-    batch: &TransactionBatch<impl TransactionWithMeta>,
-    processing_results: &[TransactionProcessingResult],
-    bank: &Arc<Bank>,
-) -> BalanceInfo {
-    // running pre-balances and current mint decimals as we step through results
-    let mut native: HashMap<Pubkey, u64> = HashMap::default();
-    let mut token: HashMap<Pubkey, TransactionTokenBalance> = HashMap::default();
-    let mut mint_decimals: HashMap<Pubkey, Option<u8>> = HashMap::default();
-
-    // accumulated pre/post lamport balances for each transaction
-    let mut native_pre_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
-    let mut native_post_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
-
-    // accumulated pre/post token balances for each transaction
-    let mut token_pre_balances: Vec<Vec<TransactionTokenBalance>> =
-        Vec::with_capacity(processing_results.len());
-    let mut token_post_balances: Vec<Vec<TransactionTokenBalance>> =
-        Vec::with_capacity(processing_results.len());
-
-    // accumulate lamport balances
-    for (result, transaction) in processing_results
-        .iter()
-        .zip(batch.sanitized_transactions())
-    {
-        let mut tx_native_pre: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
-        let mut tx_native_post: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
-
-        // first get lamport balances for this transaction
-        for (index, key) in transaction.account_keys().iter().enumerate() {
-            let is_fee_payer = key == transaction.fee_payer();
-
-            let native_pre_balance = *native.entry(*key).or_insert_with(|| bank.get_balance(key));
-            tx_native_pre.push(native_pre_balance);
-
-            let native_post_balance = match result {
-                Ok(ProcessedTransaction::Executed(ref executed)) if executed.was_successful() => {
-                    executed.loaded_transaction.accounts[index].1.lamports()
-                }
-                Ok(ProcessedTransaction::Executed(ref executed)) if is_fee_payer => executed
-                    .loaded_transaction
-                    .rollback_accounts
-                    .fee_payer_balance(),
-                Ok(ProcessedTransaction::FeesOnly(ref fees_only)) if is_fee_payer => {
-                    fees_only.rollback_accounts.fee_payer_balance()
-                }
-                _ => native_pre_balance,
-            };
-            native.insert(*key, native_post_balance);
-            tx_native_post.push(native_post_balance);
-        }
-
-        native_pre_balances.push(tx_native_pre);
-        native_post_balances.push(tx_native_post);
-
-        // TODO tokens are significantly more complicated
-        // * for pre it isnt so bad. step through accounts, getting balance details from hashmap
-        //   and decimals from hashmap, falling back to bank (and inserting) in both cases if we miss
-        // * next we need to refresh decimals for any mints we find on successful executed transactions
-        //   this uses the AccountSharedData from the LoadedTransaction. remember to check lamports
-        //   mints may be opened, closed, and remade. need a null placeholder
-        // * finally we need post balances. for executed-failed, processed-failed, and discarded, its the pre
-        //   for executed-succeeded, if lamports is 0 balance is 0. otherwise parse the account
-        //   this is structurally the same as the pre case except we use our own account instead of bank result
-        //   insert it into the hashmap, this concludes our token experiment
-        // note the balance asserts are that there are the same number of *transactions*
-        // it is normal and expected that the number of token balances per transaction may be unbalanced
-        // to preserve existing behavior... we do *not* return a balance if the account is opened (pre) or closed (post)
-        // the existing design is that it fails ownership checks and gets skipped. not that it returns a 0 balance
-    }
-
-    (
-        TransactionBalancesSet::new(native_pre_balances, native_post_balances),
-        TransactionTokenBalancesSet::new(token_pre_balances, token_post_balances),
-    )
 }
 
 #[derive(Clone)]
@@ -165,7 +84,7 @@ impl Committer {
             .filter_map(|(processing_result, tx)| processing_result.was_processed().then_some(tx))
             .collect_vec();
 
-        let balance_info = calculate_balances(batch, &processing_results, bank);
+        let balance_info = calculate_transaction_balances(batch, &processing_results, bank);
 
         let (commit_results, commit_time_us) = measure_us!(bank.commit_transactions(
             batch.sanitized_transactions(),

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -13,11 +13,12 @@ use {
         vote_sender_types::ReplayVoteSender,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    solana_sdk::{pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, saturating_add_assign},
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::{
-            TransactionProcessingResult, TransactionProcessingResultExtensions,
+            ProcessedTransaction, TransactionProcessingResult,
+            TransactionProcessingResultExtensions,
         },
     },
     solana_transaction_status::{
@@ -40,6 +41,124 @@ pub(super) struct PreBalanceInfo {
     pub native: Vec<Vec<u64>>,
     pub token: Vec<Vec<TransactionTokenBalance>>,
     pub mint_decimals: HashMap<Pubkey, u8>,
+}
+
+// HANA ok i am doing something similar to the prebal attempt
+// using code from the intrabatch attempt because it is generally of higher quality
+// the idea is this time i want a mutable object that collects initial prebals
+// * init from batch: create four empty internal vecs and two hashmaps using bank
+// * accumulate bals: fill the vecs using the post-commit state
+// * finalize: drop the struct and return the needed balance structs with ownerhip of the vecs
+// for tokens i need to think what happens if the account doesnt exist, is dropped and recreated, etc
+// basically if it doesnt exist or doesnt parse i need to drop it from the balance store
+// programid need to be part of the value rather than the key
+// i dont think i need an intermediate struct. im never comparing values or anythig
+// we also have to be careful with mints... we might need another hashmap for decimals
+// otherwise dropping and recreating mints can fuck us up
+// its all relatively straightforward tho just loop through each tx twice
+// we need all mint decimals to be correct before we calculate ui token bals
+// it does this sort of already, it always gets the mint from bank
+// the logic isnt usable, it sort of has a bug but probably no real impact
+// if you closed a mint and reopened it with different decimals the post-bal would be wrong
+// but this cant really affect anyone since it would need to have or be brought to 0 supply
+//
+// HANA ok my entire perspective on this is changed
+// we can do all balance fuckery BEFORE commit
+// that means we dont actually need to gather prebals systematically
+// because bank will always contain the pre-state for an account first seen mid-batch
+// that means our true desired flow is... one function that takes results (possibly also batch?) and bank
+// honestly just loop on accts threetimes and optimize down to two if it makes sense after
+// * first loop: get and push prelamps from hashmap, fall back to bank if not found
+//   get postlamps from acct, push and insert
+// * second loop: go through keys. get any that exist in token hashmap, fall back to bank and try parse
+//   if we have a token account, use mint key on acct, decs in hashmap, fall back to bank (and insert?)
+//   convert to ui and push to pretoken
+// * third loop: go through keys. try to parse the result accounts themselves as token accounts
+//   if we succeed look for the mint *in the results*, parse for decimals, insert. fall back to hashmap for decs
+//   fall back to bank *and insert* if mint not in result accts. use the decs we have *not* for ui convert
+//   push to posttokens
+// we can combine the first and second loops but get it right b4 i fuck with it
+// this all means we DO NOT NEED a stateful object. we just need an ugly fucking function
+
+type BalanceInfo = (TransactionBalancesSet, TransactionTokenBalancesSet);
+
+#[allow(unused_variables)] // HANA
+#[allow(unused_mut)] // HANA
+fn calculate_balances(
+    batch: &TransactionBatch<impl TransactionWithMeta>,
+    processing_results: &Vec<TransactionProcessingResult>,
+    bank: &Arc<Bank>,
+) -> BalanceInfo {
+    // running pre-balances and current mint decimals as we step through results
+    let mut native: HashMap<Pubkey, u64> = HashMap::default();
+    let mut token: HashMap<Pubkey, TransactionTokenBalance> = HashMap::default();
+    let mut mint_decimals: HashMap<Pubkey, Option<u8>> = HashMap::default();
+
+    // accumulated pre/post lamport balances for each transaction
+    let mut native_pre_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
+    let mut native_post_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
+
+    // accumulated pre/post token balances for each transaction
+    let mut token_pre_balances: Vec<Vec<TransactionTokenBalance>> =
+        Vec::with_capacity(processing_results.len());
+    let mut token_post_balances: Vec<Vec<TransactionTokenBalance>> =
+        Vec::with_capacity(processing_results.len());
+
+    // accumulate lamport balances
+    for (result, transaction) in processing_results
+        .iter()
+        .zip(batch.sanitized_transactions())
+    {
+        let mut tx_native_pre: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
+        let mut tx_native_post: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
+
+        // first get lamport balances for this transaction
+        for (index, key) in transaction.account_keys().iter().enumerate() {
+            let is_fee_payer = key == transaction.fee_payer();
+
+            let native_pre_balance = *native.entry(*key).or_insert_with(|| bank.get_balance(key));
+            tx_native_pre.push(native_pre_balance);
+
+            let native_post_balance = match result {
+                Ok(ProcessedTransaction::Executed(ref executed)) if executed.was_successful() => {
+                    executed.loaded_transaction.accounts[index].1.lamports()
+                }
+                Ok(ProcessedTransaction::Executed(ref executed)) if is_fee_payer => executed
+                    .loaded_transaction
+                    .rollback_accounts
+                    .fee_payer_balance(),
+                Ok(ProcessedTransaction::FeesOnly(ref fees_only)) if is_fee_payer => {
+                    fees_only.rollback_accounts.fee_payer_balance()
+                }
+                _ => native_pre_balance,
+            };
+            native.insert(*key, native_post_balance);
+            tx_native_post.push(native_post_balance);
+        }
+
+        native_pre_balances.push(tx_native_pre);
+        native_post_balances.push(tx_native_post);
+
+        // TODO tokens are significantly more complicated
+        // * for pre it isnt so bad. step through accounts, getting balance details from hashmap
+        //   and decimals from hashmap, falling back to bank (and inserting) in both cases if we miss
+        // * next we need to refresh decimals for any mints we find on successful executed transactions
+        //   this uses the AccountSharedData from the LoadedTransaction. remember to check lamports
+        //   mints may be opened, closed, and remade. need a null placeholder
+        // * finally we need post balances. for executed-failed, processed-failed, and discarded, its the pre
+        //   for executed-succeeded, if lamports is 0 balance is 0. otherwise parse the account
+        //   this is structurally the same as the pre case except we use our own account instead of bank result
+        //   insert it into the hashmap, this concludes our token experiment
+        // note the balance asserts are that there are the same number of *transactions*
+        // it is normal and expected that the number of token balances per transaction may be unbalanced
+        // to preserve existing behavior... we do *not* return a balance if the account is opened (pre) or closed (post)
+        // the existing design is that it fails ownership checks and gets skipped. not that it returns a 0 balance
+    }
+
+    (
+        TransactionBalancesSet::new(native_pre_balances, native_post_balances),
+        TransactionTokenBalancesSet::new(token_pre_balances, token_post_balances),
+    )
 }
 
 #[derive(Clone)]
@@ -72,7 +191,7 @@ impl Committer {
         processing_results: Vec<TransactionProcessingResult>,
         starting_transaction_index: Option<usize>,
         bank: &Arc<Bank>,
-        pre_balance_info: &mut PreBalanceInfo,
+        pre_balance_info: &mut PreBalanceInfo, // HANA remove
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
         processed_counts: &ProcessedTransactionCounts,
     ) -> (u64, Vec<CommitTransactionDetails>) {
@@ -81,6 +200,8 @@ impl Committer {
             .zip(batch.sanitized_transactions())
             .filter_map(|(processing_result, tx)| processing_result.was_processed().then_some(tx))
             .collect_vec();
+
+        let balance_info = calculate_balances(batch, &processing_results, bank);
 
         let (commit_results, commit_time_us) = measure_us!(bank.commit_transactions(
             batch.sanitized_transactions(),
@@ -116,7 +237,8 @@ impl Committer {
                 commit_results,
                 bank,
                 batch,
-                pre_balance_info,
+                pre_balance_info, // HANA remove
+                balance_info,
                 starting_transaction_index,
             );
             self.prioritization_fee_cache
@@ -131,7 +253,8 @@ impl Committer {
         commit_results: Vec<TransactionCommitResult>,
         bank: &Arc<Bank>,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        pre_balance_info: &mut PreBalanceInfo,
+        pre_balance_info: &mut PreBalanceInfo, // HANA remove
+        balance_info: BalanceInfo,
         starting_transaction_index: Option<usize>,
     ) {
         if let Some(transaction_status_sender) = &self.transaction_status_sender {
@@ -142,7 +265,6 @@ impl Committer {
                 .iter()
                 .map(|tx| tx.as_sanitized_transaction().into_owned())
                 .collect_vec();
-            let post_balances = bank.collect_balances(batch);
             let post_token_balances =
                 collect_token_balances(bank, batch, &mut pre_balance_info.mint_decimals);
             let mut transaction_index = starting_transaction_index.unwrap_or_default();
@@ -162,10 +284,7 @@ impl Committer {
                 bank.slot(),
                 txs,
                 commit_results,
-                TransactionBalancesSet::new(
-                    std::mem::take(&mut pre_balance_info.native),
-                    post_balances,
-                ),
+                balance_info.0,
                 TransactionTokenBalancesSet::new(
                     std::mem::take(&mut pre_balance_info.token),
                     post_token_balances,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1,7 +1,6 @@
 use {
     super::{
         committer::{CommitTransactionDetails, Committer},
-        immutable_deserialized_packet::ImmutableDeserializedPacket,
         leader_slot_metrics::{
             CommittedTransactionsCounts, LeaderSlotMetricsTracker, ProcessTransactionsSummary,
         },

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1,6 +1,7 @@
 use {
     super::{
-        committer::{CommitTransactionDetails, Committer, PreBalanceInfo},
+        committer::{CommitTransactionDetails, Committer},
+        immutable_deserialized_packet::ImmutableDeserializedPacket,
         leader_slot_metrics::{
             CommittedTransactionsCounts, LeaderSlotMetricsTracker, ProcessTransactionsSummary,
         },
@@ -13,7 +14,6 @@ use {
     itertools::Itertools,
     solana_feature_set as feature_set,
     solana_fee::FeeFeatures,
-    solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::{
         poh_recorder::{BankStart, PohRecorderError},
@@ -566,17 +566,8 @@ impl Consumer {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
 
-        let mut pre_balance_info = PreBalanceInfo::default();
-        let (_, collect_balances_us) = measure_us!({
-            // If the extra meta-data services are enabled for RPC, collect the
-            // pre-balances for native and token programs.
-            if transaction_status_sender_enabled {
-                pre_balance_info.native = bank.collect_balances(batch);
-                pre_balance_info.token =
-                    collect_token_balances(bank, batch, &mut pre_balance_info.mint_decimals)
-            }
-        });
-        execute_and_commit_timings.collect_balances_us = collect_balances_us;
+        // HANA REMOVE
+        //execute_and_commit_timings.collect_balances_us = collect_balances_us;
 
         let min_max = batch
             .sanitized_transactions()
@@ -715,7 +706,6 @@ impl Consumer {
                     processing_results,
                     starting_transaction_index,
                     bank,
-                    &mut pre_balance_info,
                     &mut execute_and_commit_timings,
                     &processed_counts,
                 )

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -219,6 +219,7 @@ pub fn execute_batch<'a>(
         }
     };
 
+    // TODO HANA we need to put the balance stuff in the pre-commit callback... do this next
     let (commit_results, balances) = batch
         .bank()
         .load_execute_and_commit_transactions_with_pre_commit_callback(

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -32,6 +32,7 @@ pub mod slot_stats;
 mod staking_utils;
 pub mod token_balances;
 mod transaction_address_lookup_table_scanner;
+pub mod transaction_balances;
 pub mod use_snapshot_archives_at_startup;
 
 #[macro_use]

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -95,7 +95,7 @@ pub(crate) struct TokenBalanceData {
 }
 
 impl TokenBalanceData {
-    pub(crate) fn to_transaction_balance(self, account_index: u8) -> TransactionTokenBalance {
+    pub(crate) fn into_transaction_balance(self, account_index: u8) -> TransactionTokenBalance {
         TransactionTokenBalance {
             account_index,
             mint: self.mint,

--- a/ledger/src/token_balances.rs
+++ b/ledger/src/token_balances.rs
@@ -174,6 +174,7 @@ pub(crate) fn process_and_store_token_balance(
     token_balance_data
 }
 
+/* HANA disable for fix
 #[cfg(test)]
 mod test {
     use {
@@ -535,3 +536,4 @@ mod test {
         );
     }
 }
+*/

--- a/ledger/src/transaction_balances.rs
+++ b/ledger/src/transaction_balances.rs
@@ -1,0 +1,134 @@
+#![allow(unused)] // HANA
+
+use {
+    crate::{
+        blockstore_processor::TransactionStatusSender, token_balances::collect_token_balances,
+    },
+    itertools::Itertools,
+    solana_measure::measure_us,
+    solana_runtime::{
+        bank::{Bank, ProcessedTransactionCounts, TransactionBalancesSet},
+        bank_utils,
+        prioritization_fee_cache::PrioritizationFeeCache,
+        transaction_batch::TransactionBatch,
+        vote_sender_types::ReplayVoteSender,
+    },
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, saturating_add_assign},
+    solana_svm::{
+        transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
+        transaction_processing_result::{
+            ProcessedTransaction, TransactionProcessingResult,
+            TransactionProcessingResultExtensions,
+        },
+    },
+    solana_transaction_status::{
+        token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
+    },
+    std::{collections::HashMap, sync::Arc},
+};
+
+// TODO lamports done, tokens are significantly more complicated
+// * for pre it isnt so bad. step through accounts, getting balance details from hashmap
+//   and decimals from hashmap, falling back to bank (and inserting) in both cases if we miss
+// * next we need to refresh decimals for any mints we find on successful executed transactions
+//   this uses the AccountSharedData from the LoadedTransaction. remember to check lamports
+//   mints may be opened, closed, and remade. need a null placeholder
+// * finally we need post balances. for executed-failed, processed-failed, and discarded, its the pre
+//   for executed-succeeded, if lamports is 0 balance is 0. otherwise parse the account
+//   this is structurally the same as the pre case except we use our own account instead of bank result
+//   insert it into the hashmap, this concludes our token experiment
+// note the balance asserts are that there are the same number of *transactions*
+// it is normal and expected that the number of token balances per transaction may be unbalanced
+// to preserve existing behavior... we do *not* return a balance if the account is opened (pre) or closed (post)
+// the existing design is that it fails ownership checks and gets skipped. not that it returns a 0 balance
+//
+// ok two notes:
+// * remember to gate this on tx status sender
+// * theres also code in bstore proc and the bank functions it calls to collect balances
+//   if we put this function in ledger/ instead it should cover all usecases
+//
+// starry suggested we might be able to avoid balances for failed txns
+// im going to code the token part assuming that is kosher
+// in other words, the flow is much simpler:
+// * if txn failed in any way, skip. otherwise...
+// * step through and collect prebals from hashmap falling back to bank and inserting
+//   get decimals from hashmap falling back to bank
+// * step through and update decimals
+// * step through getting postbals from raw account data
+// and remember to check lamports plus parse fails are no balance not 0 balance
+//
+// altho that raises an interesting question about how these are used, ask rpc person:
+// * is it fine to exclude failed transactions
+// * how does it cope with missing balances from new (pre) and closed (post) accounts
+//   because the existing code does not capture 0 bals for these
+
+// HANA idk struct maybe
+pub type BalanceInfo = (TransactionBalancesSet, TransactionTokenBalancesSet);
+
+pub fn calculate_transaction_balances(
+    batch: &TransactionBatch<impl TransactionWithMeta>,
+    processing_results: &[TransactionProcessingResult],
+    bank: &Arc<Bank>,
+) -> BalanceInfo {
+    // running pre-balances and current mint decimals as we step through results
+    let mut native: HashMap<Pubkey, u64> = HashMap::default();
+    let mut token: HashMap<Pubkey, TransactionTokenBalance> = HashMap::default();
+    let mut mint_decimals: HashMap<Pubkey, Option<u8>> = HashMap::default();
+
+    // accumulated pre/post lamport balances for each transaction
+    let mut native_pre_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
+    let mut native_post_balances: Vec<Vec<u64>> = Vec::with_capacity(processing_results.len());
+
+    // accumulated pre/post token balances for each transaction
+    let mut token_pre_balances: Vec<Vec<TransactionTokenBalance>> =
+        Vec::with_capacity(processing_results.len());
+    let mut token_post_balances: Vec<Vec<TransactionTokenBalance>> =
+        Vec::with_capacity(processing_results.len());
+
+    // accumulate lamport balances
+    for (result, transaction) in processing_results
+        .iter()
+        .zip(batch.sanitized_transactions())
+    {
+        let mut tx_native_pre: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
+        let mut tx_native_post: Vec<u64> = Vec::with_capacity(transaction.account_keys().len());
+
+        // first get lamport balances for this transaction
+        for (index, key) in transaction.account_keys().iter().enumerate() {
+            let is_fee_payer = key == transaction.fee_payer();
+
+            let native_pre_balance = *native.entry(*key).or_insert_with(|| bank.get_balance(key));
+            tx_native_pre.push(native_pre_balance);
+
+            let native_post_balance = match result {
+                Ok(ProcessedTransaction::Executed(ref executed)) if executed.was_successful() => {
+                    executed.loaded_transaction.accounts[index].1.lamports()
+                }
+                Ok(ProcessedTransaction::Executed(ref executed)) if is_fee_payer => executed
+                    .loaded_transaction
+                    .rollback_accounts
+                    .fee_payer_balance(),
+                Ok(ProcessedTransaction::FeesOnly(ref fees_only)) if is_fee_payer => {
+                    fees_only.rollback_accounts.fee_payer_balance()
+                }
+                _ => native_pre_balance,
+            };
+            native.insert(*key, native_post_balance);
+            tx_native_post.push(native_post_balance);
+        }
+
+        native_pre_balances.push(tx_native_pre);
+        native_post_balances.push(tx_native_post);
+
+        // next get token balances if the transaction was successful
+        if !result.was_processed_with_successful_result() {
+            continue;
+        }
+    }
+
+    (
+        TransactionBalancesSet::new(native_pre_balances, native_post_balances),
+        TransactionTokenBalancesSet::new(token_pre_balances, token_post_balances),
+    )
+}

--- a/ledger/src/transaction_balances.rs
+++ b/ledger/src/transaction_balances.rs
@@ -2,8 +2,9 @@
 
 use {
     crate::{
-        blockstore_processor::TransactionStatusSender, token_balances::collect_token_balances,
+        blockstore_processor::TransactionStatusSender, token_balances::{TokenBalanceData, collect_token_balances, collect_token_balance_from_account},
     },
+solana_account_decoder::parse_token::is_known_spl_token_id,
     itertools::Itertools,
     solana_measure::measure_us,
     solana_runtime::{
@@ -15,6 +16,10 @@ use {
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_sdk::{account::ReadableAccount, pubkey::Pubkey, saturating_add_assign},
+    spl_token_2022::{
+        extension::StateWithExtensions,
+        state::{Account as TokenAccount, Mint},
+    },
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::{
@@ -73,7 +78,7 @@ pub fn calculate_transaction_balances(
 ) -> BalanceInfo {
     // running pre-balances and current mint decimals as we step through results
     let mut native: HashMap<Pubkey, u64> = HashMap::default();
-    let mut token: HashMap<Pubkey, TransactionTokenBalance> = HashMap::default();
+    let mut token: HashMap<Pubkey, Option<TokenBalanceData>> = HashMap::default();
     let mut mint_decimals: HashMap<Pubkey, Option<u8>> = HashMap::default();
 
     // accumulated pre/post lamport balances for each transaction
@@ -98,9 +103,11 @@ pub fn calculate_transaction_balances(
         for (index, key) in transaction.account_keys().iter().enumerate() {
             let is_fee_payer = key == transaction.fee_payer();
 
+            // get pre-balance from past executions or bank
             let native_pre_balance = *native.entry(*key).or_insert_with(|| bank.get_balance(key));
             tx_native_pre.push(native_pre_balance);
 
+            // get post-balance from execution result
             let native_post_balance = match result {
                 Ok(ProcessedTransaction::Executed(ref executed)) if executed.was_successful() => {
                     executed.loaded_transaction.accounts[index].1.lamports()
@@ -121,9 +128,74 @@ pub fn calculate_transaction_balances(
         native_pre_balances.push(tx_native_pre);
         native_post_balances.push(tx_native_post);
 
-        // next get token balances if the transaction was successful
-        if !result.was_processed_with_successful_result() {
-            continue;
+        let mut tx_token_pre: Vec<TransactionTokenBalance> = vec![];
+        let mut tx_token_post: Vec<TransactionTokenBalance> = vec![];
+        let has_token_program = transaction.account_keys().iter().any(is_known_spl_token_id);
+
+        // next get token balances if the transaction was successful and included the token program
+        if result.was_processed_with_successful_result() && has_token_program {
+            let result_accounts =  match result {
+                Ok(ProcessedTransaction::Executed(ref executed)) if executed.was_successful() => {
+                    &executed.loaded_transaction.accounts
+                }
+                // unreachable
+                _ => continue,
+            };
+
+            // get pre- and post-balances together. we rely on the presence of the mint in the transaction
+            // we ignore pre-balances under a variety of scenarios where mints or accounts change in pathological ways
+            // this allows us to produce trustworthy post-balances even in extreme scenarios
+            for (index, (key, account)) in result_accounts.into_iter().enumerate() {
+                // if the transaction succeeded this cannot be a token account
+                if transaction.is_invoked(index) || is_known_spl_token_id(key) {
+                    continue;
+                }
+
+                // we ignore anything that isnt an open, valid token account *after* the transaction
+                if !is_known_spl_token_id(account.owner()) || account.lamports() == 0 {
+                    continue;
+                }
+
+                // parse the post-transaction account state
+                let Ok(token_account) = StateWithExtensions::<TokenAccount>::unpack(account.data()) else {
+                    continue;
+                };
+
+                // parse the mint. if it is not present, the............
+                // nevermind. this doesnt work. rack up another failure
+                // transfers dont require the mint. the *only* way is to track *all* mints in the batch
+                // which means all my efforts toward doing this outside of svm... are complicated
+            }
+
+/*
+            // first get pre-balances from prior transactions or bank, using prior or bank decimals
+            for (index, key) in transaction.account_keys().iter().enumerate() {
+                // this cannot be a token account if the transaction succeeded
+                if transaction.is_invoked(index) || is_known_spl_token_id(key) {
+                    continue;
+                }
+
+                if let Some(balance) = collect_token_balance_from_account(&mut token, bank, key, &mut mint_decimals) {
+                    tx_token_pre.push(balance.to_transaction_balance(index as u8));
+                }
+            }
+
+            // next update all mint decimals
+            for (index, (key, account)) in result_accounts.into_iter().enumerate() {
+                // this cannot be a mint if the transaction succeeded
+                if transaction.is_invoked(index) || is_known_spl_token_id(key) {
+                    continue;
+                }
+
+                // HANA this is maddening. we have to screen anything that *could have been* a mint
+                // otherwise in a case where we see an account where a previous transaction edited the mint
+                // we would fall back to the bank state. this is the one thing 
+
+                || !is_known_spl_token_id(account.owner()) {
+
+                //let result_account = result
+            }
+*/
         }
     }
 

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -105,7 +105,9 @@ impl RollbackAccounts {
         match self {
             RollbackAccounts::FeePayerOnly { fee_payer_account } => fee_payer_account.lamports(),
             RollbackAccounts::SameNonceAndFeePayer { nonce } => nonce.account().lamports(),
-            RollbackAccounts::SeparateNonceAndFeePayer { fee_payer_account, .. } => fee_payer_account.lamports(), 
+            RollbackAccounts::SeparateNonceAndFeePayer {
+                fee_payer_account, ..
+            } => fee_payer_account.lamports(),
         }
     }
 }

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -99,6 +99,15 @@ impl RollbackAccounts {
                 .saturating_add(nonce.account().data().len()),
         }
     }
+
+    // HANA desc
+    pub fn fee_payer_balance(&self) -> u64 {
+        match self {
+            RollbackAccounts::FeePayerOnly { fee_payer_account } => fee_payer_account.lamports(),
+            RollbackAccounts::SameNonceAndFeePayer { nonce } => nonce.account().lamports(),
+            RollbackAccounts::SeparateNonceAndFeePayer { fee_payer_account, .. } => fee_payer_account.lamports(), 
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
trying to do the first attempt (pick apart results in banking stage) in a more quarantined fashion. the second attempt (get balances in svm via account loader and pass up in results, with callback for parsing token accounts) was rejected and the theorized alternate approach (do all work in callbacks in svm) does not make much sense because its the same as this except with more indirection

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
