### PR TITLE
clean: load failure fees feature

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3192,17 +3192,11 @@ fn test_interleaving_locks() {
         .is_ok());
 }
 
-#[test_case(false; "disable fees-only transactions")]
-#[test_case(true; "enable fees-only transactions")]
-fn test_load_and_execute_commit_transactions_fees_only(enable_fees_only_txs: bool) {
+#[test]
+fn test_load_and_execute_commit_transactions_fees_only() {
     let GenesisConfigInfo {
         mut genesis_config, ..
     } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
-    if !enable_fees_only_txs {
-        genesis_config
-            .accounts
-            .remove(&solana_sdk::feature_set::enable_transaction_loading_failure_fees::id());
-    }
     genesis_config.rent = Rent::default();
     genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -3264,29 +3258,22 @@ fn test_load_and_execute_commit_transactions_fees_only(enable_fees_only_txs: boo
         )
         .0;
 
-    if enable_fees_only_txs {
-        assert_eq!(
-            commit_results,
-            vec![Ok(CommittedTransaction {
-                status: Err(TransactionError::ProgramAccountNotFound),
-                log_messages: None,
-                inner_instructions: None,
-                return_data: None,
-                executed_units: 0,
-                fee_details: FeeDetails::new(5000, 0),
-                rent_debits: RentDebits::default(),
-                loaded_account_stats: TransactionLoadedAccountsStats {
-                    loaded_accounts_count: 2,
-                    loaded_accounts_data_size: nonce_size as u32,
-                },
-            })]
-        );
-    } else {
-        assert_eq!(
-            commit_results,
-            vec![Err(TransactionError::ProgramAccountNotFound)]
-        );
-    }
+    assert_eq!(
+        commit_results,
+        vec![Ok(CommittedTransaction {
+            status: Err(TransactionError::ProgramAccountNotFound),
+            log_messages: None,
+            inner_instructions: None,
+            return_data: None,
+            executed_units: 0,
+            fee_details: FeeDetails::new(5000, 0),
+            rent_debits: RentDebits::default(),
+            loaded_account_stats: TransactionLoadedAccountsStats {
+                loaded_accounts_count: 2,
+                loaded_accounts_data_size: nonce_size as u32,
+            },
+        })]
+    );
 }
 
 #[test]

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2017,7 +2017,7 @@ fn simd83_fee_payer_deallocate() -> Vec<SvmTestEntry> {
 
     // 0/1: a rent-paying fee-payer goes to zero lamports on an executed transaction, the batch sees it as deallocated
     // 2/3: the same, except if fee-only transactions are enabled, it goes to zero lamports from a a fee-only transaction
-    for do_fee_only_transaction in vec![false, true] {
+    for do_fee_only_transaction in [false, true] {
         let dealloc_fee_payer_keypair = Keypair::new();
         let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -44,7 +44,7 @@ use {
     solana_transaction_context::TransactionReturnData,
     solana_type_overrides::sync::{Arc, RwLock},
     std::collections::HashMap,
-    test_case::{test_case, test_matrix},
+    test_case::test_case,
 };
 
 // This module contains the implementation of TransactionProcessingCallback
@@ -808,14 +808,9 @@ fn program_medley() -> Vec<SvmTestEntry> {
     vec![test_entry]
 }
 
-fn simple_transfer(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+fn simple_transfer() -> Vec<SvmTestEntry> {
     let mut test_entry = SvmTestEntry::default();
     let transfer_amount = LAMPORTS_PER_SOL;
-    if enable_fee_only_transactions {
-        test_entry
-            .enabled_features
-            .push(feature_set::enable_transaction_loading_failure_fees::id());
-    }
 
     // 0: a transfer that succeeds
     {
@@ -911,12 +906,7 @@ fn simple_transfer(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
             system_instruction::transfer(&source, &Pubkey::new_unique(), transfer_amount);
         instruction.program_id = Pubkey::new_unique();
 
-        let expected_status = if enable_fee_only_transactions {
-            test_entry.decrease_expected_lamports(&source, LAMPORTS_PER_SIGNATURE);
-            ExecutionStatus::ProcessedFailed
-        } else {
-            ExecutionStatus::Discarded
-        };
+        test_entry.decrease_expected_lamports(&source, LAMPORTS_PER_SIGNATURE);
 
         test_entry.push_transaction_with_status(
             Transaction::new_signed_with_payer(
@@ -925,20 +915,15 @@ fn simple_transfer(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
                 &[&source_keypair],
                 Hash::default(),
             ),
-            expected_status,
+            ExecutionStatus::ProcessedFailed,
         );
     }
 
     vec![test_entry]
 }
 
-fn simple_nonce(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
+fn simple_nonce(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
     let mut test_entry = SvmTestEntry::default();
-    if enable_fee_only_transactions {
-        test_entry
-            .enabled_features
-            .push(feature_set::enable_transaction_loading_failure_fees::id());
-    }
 
     let program_name = "hello-solana";
     let real_program_id = program_address(program_name);
@@ -1083,55 +1068,35 @@ fn simple_nonce(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> V
         let (transaction, fee_payer, mut nonce_info) =
             mk_nonce_transaction(&mut test_entry, Pubkey::new_unique(), false, false);
 
-        if enable_fee_only_transactions {
-            test_entry.push_nonce_transaction_with_status(
-                transaction,
-                nonce_info.clone(),
-                ExecutionStatus::ProcessedFailed,
-            );
+        test_entry.push_nonce_transaction_with_status(
+            transaction,
+            nonce_info.clone(),
+            ExecutionStatus::ProcessedFailed,
+        );
 
-            test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
 
-            nonce_info
-                .try_advance_nonce(
-                    DurableNonce::from_blockhash(&LAST_BLOCKHASH),
-                    LAMPORTS_PER_SIGNATURE,
-                )
-                .unwrap();
+        nonce_info
+            .try_advance_nonce(
+                DurableNonce::from_blockhash(&LAST_BLOCKHASH),
+                LAMPORTS_PER_SIGNATURE,
+            )
+            .unwrap();
 
-            test_entry
-                .final_accounts
-                .get_mut(nonce_info.address())
-                .unwrap()
-                .data_as_mut_slice()
-                .copy_from_slice(nonce_info.account().data());
+        test_entry
+            .final_accounts
+            .get_mut(nonce_info.address())
+            .unwrap()
+            .data_as_mut_slice()
+            .copy_from_slice(nonce_info.account().data());
 
-            // if the nonce account pays fees, it keeps its new rent epoch, otherwise it resets
-            if !fee_paying_nonce {
-                test_entry
-                    .final_accounts
-                    .get_mut(nonce_info.address())
-                    .unwrap()
-                    .set_rent_epoch(0);
-            }
-        } else {
-            test_entry
-                .final_accounts
-                .get_mut(&fee_payer)
-                .unwrap()
-                .set_rent_epoch(0);
-
+        // if the nonce account pays fees, it keeps its new rent epoch, otherwise it resets
+        if !fee_paying_nonce {
             test_entry
                 .final_accounts
                 .get_mut(nonce_info.address())
                 .unwrap()
                 .set_rent_epoch(0);
-
-            test_entry.push_nonce_transaction_with_status(
-                transaction,
-                nonce_info,
-                ExecutionStatus::Discarded,
-            );
         }
     }
 
@@ -1157,7 +1122,7 @@ fn simple_nonce(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> V
     }
 
     // 5: rent-paying nonce fee-payers are also not charged for fee-only transactions
-    if enable_fee_only_transactions && fee_paying_nonce {
+    if fee_paying_nonce {
         let (transaction, _, nonce_info) =
             mk_nonce_transaction(&mut test_entry, Pubkey::new_unique(), false, true);
 
@@ -1177,7 +1142,7 @@ fn simple_nonce(enable_fee_only_transactions: bool, fee_paying_nonce: bool) -> V
     vec![test_entry]
 }
 
-fn simd83_intrabatch_account_reuse(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+fn simd83_intrabatch_account_reuse() -> Vec<SvmTestEntry> {
     let mut test_entries = vec![];
     let transfer_amount = LAMPORTS_PER_SOL;
     let wallet_rent = Rent::default().minimum_balance(0);
@@ -1373,66 +1338,52 @@ fn simd83_intrabatch_account_reuse(enable_fee_only_transactions: bool) -> Vec<Sv
     // * processable non-executable transaction
     // * successful transfer
     // this confirms we update the AccountsMap from RollbackAccounts intrabatch
-    if enable_fee_only_transactions {
-        let mut test_entry = SvmTestEntry::default();
+    let mut test_entry = SvmTestEntry::default();
 
-        let source_keypair = Keypair::new();
-        let source = source_keypair.pubkey();
-        let destination = Pubkey::new_unique();
+    let source_keypair = Keypair::new();
+    let source = source_keypair.pubkey();
+    let destination = Pubkey::new_unique();
 
-        let mut source_data = AccountSharedData::default();
-        let mut destination_data = AccountSharedData::default();
+    let mut source_data = AccountSharedData::default();
+    let mut destination_data = AccountSharedData::default();
 
-        source_data.set_lamports(LAMPORTS_PER_SOL * 10);
-        test_entry.add_initial_account(source, &source_data);
+    source_data.set_lamports(LAMPORTS_PER_SOL * 10);
+    test_entry.add_initial_account(source, &source_data);
 
-        let mut load_program_fail_instruction =
-            system_instruction::transfer(&source, &Pubkey::new_unique(), transfer_amount);
-        load_program_fail_instruction.program_id = Pubkey::new_unique();
+    let mut load_program_fail_instruction =
+        system_instruction::transfer(&source, &Pubkey::new_unique(), transfer_amount);
+    load_program_fail_instruction.program_id = Pubkey::new_unique();
 
-        test_entry.push_transaction_with_status(
-            Transaction::new_signed_with_payer(
-                &[load_program_fail_instruction],
-                Some(&source),
-                &[&source_keypair],
-                Hash::default(),
-            ),
-            ExecutionStatus::ProcessedFailed,
-        );
-
-        test_entry.push_transaction(system_transaction::transfer(
-            &source_keypair,
-            &destination,
-            transfer_amount,
+    test_entry.push_transaction_with_status(
+        Transaction::new_signed_with_payer(
+            &[load_program_fail_instruction],
+            Some(&source),
+            &[&source_keypair],
             Hash::default(),
-        ));
+        ),
+        ExecutionStatus::ProcessedFailed,
+    );
 
-        destination_data
-            .checked_add_lamports(transfer_amount)
-            .unwrap();
-        test_entry.create_expected_account(destination, &destination_data);
+    test_entry.push_transaction(system_transaction::transfer(
+        &source_keypair,
+        &destination,
+        transfer_amount,
+        Hash::default(),
+    ));
 
-        test_entry
-            .decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE * 2);
+    destination_data
+        .checked_add_lamports(transfer_amount)
+        .unwrap();
+    test_entry.create_expected_account(destination, &destination_data);
 
-        test_entries.push(test_entry);
-    }
+    test_entry.decrease_expected_lamports(&source, transfer_amount + LAMPORTS_PER_SIGNATURE * 2);
 
-    for test_entry in &mut test_entries {
-        if enable_fee_only_transactions {
-            test_entry
-                .enabled_features
-                .push(feature_set::enable_transaction_loading_failure_fees::id());
-        }
-    }
+    test_entries.push(test_entry);
 
     test_entries
 }
 
-fn simd83_nonce_reuse(
-    enable_fee_only_transactions: bool,
-    fee_paying_nonce: bool,
-) -> Vec<SvmTestEntry> {
+fn simd83_nonce_reuse(fee_paying_nonce: bool) -> Vec<SvmTestEntry> {
     let mut test_entries = vec![];
 
     let program_name = "hello-solana";
@@ -1585,39 +1536,37 @@ fn simd83_nonce_reuse(
     // batch 3:
     // * a processable non-executable nonce transaction, if fee-only transactions are enabled
     // * a nonce transaction that reuses the same nonce; this transaction must be dropped
-    if enable_fee_only_transactions {
-        let mut test_entry = common_test_entry.clone();
+    let mut test_entry = common_test_entry.clone();
 
-        let first_transaction = Transaction::new_signed_with_payer(
-            &[advance_instruction.clone(), fee_only_noop_instruction],
-            Some(&fee_payer),
-            &[&fee_payer_keypair],
-            *initial_durable.as_hash(),
-        );
+    let first_transaction = Transaction::new_signed_with_payer(
+        &[advance_instruction.clone(), fee_only_noop_instruction],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        *initial_durable.as_hash(),
+    );
 
-        test_entry.push_nonce_transaction_with_status(
-            first_transaction,
-            initial_nonce_info.clone(),
-            ExecutionStatus::ProcessedFailed,
-        );
+    test_entry.push_nonce_transaction_with_status(
+        first_transaction,
+        initial_nonce_info.clone(),
+        ExecutionStatus::ProcessedFailed,
+    );
 
-        test_entry.push_nonce_transaction_with_status(
-            second_transaction.clone(),
-            advanced_nonce_info.clone(),
-            ExecutionStatus::Discarded,
-        );
+    test_entry.push_nonce_transaction_with_status(
+        second_transaction.clone(),
+        advanced_nonce_info.clone(),
+        ExecutionStatus::Discarded,
+    );
 
-        // if the nonce account pays fees, it keeps its new rent epoch, otherwise it resets
-        if !fee_paying_nonce {
-            test_entry
-                .final_accounts
-                .get_mut(&nonce_pubkey)
-                .unwrap()
-                .set_rent_epoch(0);
-        }
-
-        test_entries.push(test_entry);
+    // if the nonce account pays fees, it keeps its new rent epoch, otherwise it resets
+    if !fee_paying_nonce {
+        test_entry
+            .final_accounts
+            .get_mut(&nonce_pubkey)
+            .unwrap()
+            .set_rent_epoch(0);
     }
+
+    test_entries.push(test_entry);
 
     // batch 4:
     // * a successful blockhash transaction that also advances the nonce
@@ -1647,12 +1596,6 @@ fn simd83_nonce_reuse(
 
     for test_entry in &mut test_entries {
         test_entry.add_initial_program(program_name);
-
-        if enable_fee_only_transactions {
-            test_entry
-                .enabled_features
-                .push(feature_set::enable_transaction_loading_failure_fees::id());
-        }
     }
 
     // batch 5:
@@ -1932,12 +1875,6 @@ fn simd83_nonce_reuse(
 
     for test_entry in &mut test_entries {
         test_entry.add_initial_program(program_name);
-
-        if enable_fee_only_transactions {
-            test_entry
-                .enabled_features
-                .push(feature_set::enable_transaction_loading_failure_fees::id());
-        }
     }
 
     test_entries
@@ -2071,13 +2008,8 @@ fn simd83_account_deallocate() -> Vec<SvmTestEntry> {
     test_entries
 }
 
-fn simd83_fee_payer_deallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+fn simd83_fee_payer_deallocate() -> Vec<SvmTestEntry> {
     let mut test_entry = SvmTestEntry::default();
-    if enable_fee_only_transactions {
-        test_entry
-            .enabled_features
-            .push(feature_set::enable_transaction_loading_failure_fees::id());
-    }
 
     let program_name = "hello-solana";
     let real_program_id = program_address(program_name);
@@ -2085,11 +2017,7 @@ fn simd83_fee_payer_deallocate(enable_fee_only_transactions: bool) -> Vec<SvmTes
 
     // 0/1: a rent-paying fee-payer goes to zero lamports on an executed transaction, the batch sees it as deallocated
     // 2/3: the same, except if fee-only transactions are enabled, it goes to zero lamports from a a fee-only transaction
-    for do_fee_only_transaction in if enable_fee_only_transactions {
-        vec![false, true]
-    } else {
-        vec![false]
-    } {
+    for do_fee_only_transaction in vec![false, true] {
         let dealloc_fee_payer_keypair = Keypair::new();
         let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
 
@@ -2154,78 +2082,75 @@ fn simd83_fee_payer_deallocate(enable_fee_only_transactions: bool) -> Vec<SvmTes
 
     // 4: a rent-paying non-nonce fee-payer goes to zero on a fee-only nonce transaction, the batch sees it as deallocated
     // we test in `simple_nonce()` that nonce fee-payers cannot as a rule be brought below rent-exemption
-    if enable_fee_only_transactions {
-        let dealloc_fee_payer_keypair = Keypair::new();
-        let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
+    let dealloc_fee_payer_keypair = Keypair::new();
+    let dealloc_fee_payer = dealloc_fee_payer_keypair.pubkey();
 
-        let mut dealloc_fee_payer_data = AccountSharedData::default();
-        dealloc_fee_payer_data.set_lamports(LAMPORTS_PER_SIGNATURE);
-        dealloc_fee_payer_data.set_rent_epoch(u64::MAX - 1);
-        test_entry.add_initial_account(dealloc_fee_payer, &dealloc_fee_payer_data);
+    let mut dealloc_fee_payer_data = AccountSharedData::default();
+    dealloc_fee_payer_data.set_lamports(LAMPORTS_PER_SIGNATURE);
+    dealloc_fee_payer_data.set_rent_epoch(u64::MAX - 1);
+    test_entry.add_initial_account(dealloc_fee_payer, &dealloc_fee_payer_data);
 
-        let stable_fee_payer_keypair = Keypair::new();
-        let stable_fee_payer = stable_fee_payer_keypair.pubkey();
+    let stable_fee_payer_keypair = Keypair::new();
+    let stable_fee_payer = stable_fee_payer_keypair.pubkey();
 
-        let mut stable_fee_payer_data = AccountSharedData::default();
-        stable_fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
-        test_entry.add_initial_account(stable_fee_payer, &stable_fee_payer_data);
+    let mut stable_fee_payer_data = AccountSharedData::default();
+    stable_fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+    test_entry.add_initial_account(stable_fee_payer, &stable_fee_payer_data);
 
-        let nonce_pubkey = Pubkey::new_unique();
-        let initial_durable = DurableNonce::from_blockhash(&Hash::new_unique());
-        let initial_nonce_data =
-            nonce::state::Data::new(dealloc_fee_payer, initial_durable, LAMPORTS_PER_SIGNATURE);
-        let initial_nonce_account = AccountSharedData::new_data(
-            LAMPORTS_PER_SOL,
-            &nonce::state::Versions::new(nonce::State::Initialized(initial_nonce_data.clone())),
-            &system_program::id(),
-        )
+    let nonce_pubkey = Pubkey::new_unique();
+    let initial_durable = DurableNonce::from_blockhash(&Hash::new_unique());
+    let initial_nonce_data =
+        nonce::state::Data::new(dealloc_fee_payer, initial_durable, LAMPORTS_PER_SIGNATURE);
+    let initial_nonce_account = AccountSharedData::new_data(
+        LAMPORTS_PER_SOL,
+        &nonce::state::Versions::new(nonce::State::Initialized(initial_nonce_data.clone())),
+        &system_program::id(),
+    )
+    .unwrap();
+    let initial_nonce_info = NonceInfo::new(nonce_pubkey, initial_nonce_account.clone());
+
+    let advanced_durable = DurableNonce::from_blockhash(&LAST_BLOCKHASH);
+    let mut advanced_nonce_info = initial_nonce_info.clone();
+    advanced_nonce_info
+        .try_advance_nonce(advanced_durable, LAMPORTS_PER_SIGNATURE)
         .unwrap();
-        let initial_nonce_info = NonceInfo::new(nonce_pubkey, initial_nonce_account.clone());
 
-        let advanced_durable = DurableNonce::from_blockhash(&LAST_BLOCKHASH);
-        let mut advanced_nonce_info = initial_nonce_info.clone();
-        advanced_nonce_info
-            .try_advance_nonce(advanced_durable, LAMPORTS_PER_SIGNATURE)
-            .unwrap();
+    let advance_instruction =
+        system_instruction::advance_nonce_account(&nonce_pubkey, &dealloc_fee_payer);
+    let fee_only_noop_instruction = Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
 
-        let advance_instruction =
-            system_instruction::advance_nonce_account(&nonce_pubkey, &dealloc_fee_payer);
-        let fee_only_noop_instruction =
-            Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
+    // fee-only nonce transaction which drains a fee-payer
+    let transaction = Transaction::new_signed_with_payer(
+        &[advance_instruction, fee_only_noop_instruction],
+        Some(&dealloc_fee_payer),
+        &[&dealloc_fee_payer_keypair],
+        Hash::default(),
+    );
+    test_entry.push_transaction_with_status(transaction, ExecutionStatus::ProcessedFailed);
 
-        // fee-only nonce transaction which drains a fee-payer
-        let transaction = Transaction::new_signed_with_payer(
-            &[advance_instruction, fee_only_noop_instruction],
-            Some(&dealloc_fee_payer),
-            &[&dealloc_fee_payer_keypair],
-            Hash::default(),
-        );
-        test_entry.push_transaction_with_status(transaction, ExecutionStatus::ProcessedFailed);
+    test_entry.decrease_expected_lamports(&dealloc_fee_payer, LAMPORTS_PER_SIGNATURE);
 
-        test_entry.decrease_expected_lamports(&dealloc_fee_payer, LAMPORTS_PER_SIGNATURE);
+    // as noted in `account_deallocate()` we must touch the account to see if anything actually happened
+    let instruction = Instruction::new_with_bytes(
+        real_program_id,
+        &[],
+        vec![AccountMeta::new_readonly(dealloc_fee_payer, false)],
+    );
+    test_entry.push_transaction(Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&stable_fee_payer),
+        &[&stable_fee_payer_keypair],
+        Hash::default(),
+    ));
 
-        // as noted in `account_deallocate()` we must touch the account to see if anything actually happened
-        let instruction = Instruction::new_with_bytes(
-            real_program_id,
-            &[],
-            vec![AccountMeta::new_readonly(dealloc_fee_payer, false)],
-        );
-        test_entry.push_transaction(Transaction::new_signed_with_payer(
-            &[instruction],
-            Some(&stable_fee_payer),
-            &[&stable_fee_payer_keypair],
-            Hash::default(),
-        ));
+    test_entry.decrease_expected_lamports(&stable_fee_payer, LAMPORTS_PER_SIGNATURE);
 
-        test_entry.decrease_expected_lamports(&stable_fee_payer, LAMPORTS_PER_SIGNATURE);
-
-        test_entry.drop_expected_account(dealloc_fee_payer);
-    }
+    test_entry.drop_expected_account(dealloc_fee_payer);
 
     vec![test_entry]
 }
 
-fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestEntry> {
+fn simd83_account_reallocate() -> Vec<SvmTestEntry> {
     let mut test_entries = vec![];
 
     let program_name = "write-to-account";
@@ -2233,11 +2158,6 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
 
     let mut common_test_entry = SvmTestEntry::default();
     common_test_entry.add_initial_program(program_name);
-    if enable_fee_only_transactions {
-        common_test_entry
-            .enabled_features
-            .push(feature_set::enable_transaction_loading_failure_fees::id());
-    }
 
     let fee_payer_keypair = Keypair::new();
     let fee_payer = fee_payer_keypair.pubkey();
@@ -2299,18 +2219,15 @@ fn simd83_account_reallocate(enable_fee_only_transactions: bool) -> Vec<SvmTestE
         let mut test_entry = common_test_entry.clone();
 
         let new_target_size = target_start_size + MAX_PERMITTED_DATA_INCREASE;
-        let expected_print_status = if enable_fee_only_transactions {
-            ExecutionStatus::ProcessedFailed
-        } else {
-            test_entry.increase_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
-            ExecutionStatus::Discarded
-        };
 
         let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
             .create_transaction(program_id, &fee_payer_keypair, target, None);
         test_entry.push_transaction(realloc_transaction);
 
-        test_entry.push_transaction_with_status(print_transaction.clone(), expected_print_status);
+        test_entry.push_transaction_with_status(
+            print_transaction.clone(),
+            ExecutionStatus::ProcessedFailed,
+        );
 
         test_entry.update_expected_account_data(target, &mk_target(new_target_size));
 
@@ -2370,23 +2287,15 @@ fn program_cache_update_tombstone() -> Vec<SvmTestEntry> {
 }
 
 #[test_case(program_medley())]
-#[test_case(simple_transfer(false))]
-#[test_case(simple_transfer(true))]
-#[test_case(simple_nonce(false, false))]
-#[test_case(simple_nonce(true, false))]
-#[test_case(simple_nonce(false, true))]
-#[test_case(simple_nonce(true, true))]
-#[test_case(simd83_intrabatch_account_reuse(false))]
-#[test_case(simd83_intrabatch_account_reuse(true))]
-#[test_case(simd83_nonce_reuse(false, false))]
-#[test_case(simd83_nonce_reuse(true, false))]
-#[test_case(simd83_nonce_reuse(false, true))]
-#[test_case(simd83_nonce_reuse(true, true))]
+#[test_case(simple_transfer())]
+#[test_case(simple_nonce(false))]
+#[test_case(simple_nonce(true))]
+#[test_case(simd83_intrabatch_account_reuse())]
+#[test_case(simd83_nonce_reuse(false))]
+#[test_case(simd83_nonce_reuse(true))]
 #[test_case(simd83_account_deallocate())]
-#[test_case(simd83_fee_payer_deallocate(false))]
-#[test_case(simd83_fee_payer_deallocate(true))]
-#[test_case(simd83_account_reallocate(false))]
-#[test_case(simd83_account_reallocate(true))]
+#[test_case(simd83_fee_payer_deallocate())]
+#[test_case(simd83_account_reallocate())]
 #[test_case(program_cache_update_tombstone())]
 fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     for test_entry in test_entries {
@@ -2395,18 +2304,11 @@ fn svm_integration(test_entries: Vec<SvmTestEntry>) {
     }
 }
 
-#[test_matrix([false, true], [false, true])]
-fn program_cache_create_account(
-    enable_fee_only_transactions: bool,
-    remove_accounts_executable_flag_checks: bool,
-) {
+#[test_case(true; "remove accounts executable flag check")]
+#[test_case(false; "don't remove accounts executable flag check")]
+fn program_cache_create_account(remove_accounts_executable_flag_checks: bool) {
     for loader_id in PROGRAM_OWNERS {
         let mut test_entry = SvmTestEntry::with_loader_v4();
-        if enable_fee_only_transactions {
-            test_entry
-                .enabled_features
-                .push(feature_set::enable_transaction_loading_failure_fees::id());
-        }
         if remove_accounts_executable_flag_checks {
             test_entry
                 .enabled_features
@@ -2444,13 +2346,10 @@ fn program_cache_create_account(
             Hash::default(),
         );
 
-        let expected_status = match (
-            enable_fee_only_transactions,
-            remove_accounts_executable_flag_checks,
-        ) {
-            (_, true) => ExecutionStatus::ExecutedFailed,
-            (true, false) => ExecutionStatus::ProcessedFailed,
-            (false, false) => ExecutionStatus::Discarded,
+        let expected_status = if remove_accounts_executable_flag_checks {
+            ExecutionStatus::ExecutedFailed
+        } else {
+            ExecutionStatus::ProcessedFailed
         };
 
         test_entry.push_transaction_with_status(invoke_transaction.clone(), expected_status);


### PR DESCRIPTION
#### Problem
`enable_transaction_loading_failure_fees` is activated on all clusters and can be cleaned up

#### Summary of Changes
Remove feature logic for `enable_transaction_loading_failure_fees`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
