### PR TITLE
Drop the Feature Gate builtin

### DIFF
--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -154,17 +154,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     }),
 ];
 
-pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltinPrototype {
-    core_bpf_migration_config: Some(CoreBpfMigrationConfig {
-        source_buffer_address: buffer_accounts::feature_gate_program::id(),
-        upgrade_authority_address: None,
-        feature_id: solana_feature_set::migrate_feature_gate_program_to_core_bpf::id(),
-        migration_target: CoreBpfMigrationTargetType::Stateless,
-        datapoint_name: "migrate_stateless_to_core_bpf_feature_gate_program",
-    }),
-    name: "feature_gate_program",
-    program_id: solana_sdk_ids::feature::id(),
-}];
+pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[];
 
 /// Live source buffer accounts for builtin migrations.
 mod buffer_accounts {
@@ -173,9 +163,6 @@ mod buffer_accounts {
     }
     pub mod config_program {
         solana_pubkey::declare_id!("BuafH9fBv62u6XjzrzS4ZjAE8963ejqF5rt1f8Uga4Q3");
-    }
-    pub mod feature_gate_program {
-        solana_pubkey::declare_id!("3D3ydPWvmEszrSjrickCtnyRSJm1rzbbSsZog8Ub6vLh");
     }
     pub mod stake_program {
         solana_pubkey::declare_id!("8t3vv6v99tQA6Gp7fVdsBH66hQMaswH5qsJVqJqo8xvG");
@@ -413,7 +400,5 @@ mod tests {
             &super::BUILTINS[11].core_bpf_migration_config,
             &Some(super::test_only::zk_elgamal_proof_program::CONFIG)
         );
-        // Feature Gate has a live migration config, so it has no test-only
-        // configs to test here.
     }
 }

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -74,7 +74,7 @@ mod tests_core_bpf_migration {
         solana_builtins::{
             core_bpf_migration::CoreBpfMigrationConfig,
             prototype::{BuiltinPrototype, StatelessBuiltinPrototype},
-            BUILTINS, STATELESS_BUILTINS,
+            BUILTINS,
         },
         solana_feature_set::FeatureSet,
         solana_program_runtime::loaded_programs::ProgramCacheEntry,
@@ -127,6 +127,8 @@ mod tests_core_bpf_migration {
 
     enum TestPrototype<'a> {
         Builtin(&'a BuiltinPrototype),
+        #[allow(unused)]
+        // We aren't migrating any stateless builtins right now. Uncomment if needed.
         Stateless(&'a StatelessBuiltinPrototype),
     }
     impl<'a> TestPrototype<'a> {
@@ -157,7 +159,6 @@ mod tests_core_bpf_migration {
     #[test_case(TestPrototype::Builtin(&BUILTINS[4]); "bpf_loader_deprecated")]
     #[test_case(TestPrototype::Builtin(&BUILTINS[5]); "bpf_loader")]
     #[test_case(TestPrototype::Builtin(&BUILTINS[8]); "address_lookup_table")]
-    #[test_case(TestPrototype::Stateless(&STATELESS_BUILTINS[0]); "feature_gate")]
     fn test_core_bpf_migration(prototype: TestPrototype) {
         let (mut genesis_config, mint_keypair) =
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);


### PR DESCRIPTION
#### Problem
The Feature Gate program has been migrated to an on-chain BPF program. It's time to remove it from the monorepo.

This one is a big of a misnomer, since it was never a builtin, but a "stateless" builtin. So this PR basically just cleans up the migration config.

#### Summary of Changes
Cut the migration config for the Feature Gate stateless builtin from the validator.