### PR TITLE
Removes rent_epoch from lt_hash_account()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6027,7 +6027,7 @@ impl AccountsDb {
             return ZERO_LAMPORT_ACCOUNT_LT_HASH;
         }
 
-        let hasher = Self::hash_account_helper(account, pubkey);
+        let hasher = Self::hash_account_helper(account, pubkey, RentEpochInAccountHash::Excluded);
         let lt_hash = LtHash::with(&hasher);
         AccountLtHash(lt_hash)
     }
@@ -6038,13 +6038,17 @@ impl AccountsDb {
             return ZERO_LAMPORT_ACCOUNT_HASH;
         }
 
-        let hasher = Self::hash_account_helper(account, pubkey);
+        let hasher = Self::hash_account_helper(account, pubkey, RentEpochInAccountHash::Included);
         let hash = Hash::new_from_array(hasher.finalize().into());
         AccountHash(hash)
     }
 
     /// Hashes `account` and returns the underlying Hasher
-    fn hash_account_helper(account: &impl ReadableAccount, pubkey: &Pubkey) -> blake3::Hasher {
+    fn hash_account_helper(
+        account: &impl ReadableAccount,
+        pubkey: &Pubkey,
+        rent_epoch_in_account_hash: RentEpochInAccountHash,
+    ) -> blake3::Hasher {
         let mut hasher = blake3::Hasher::new();
 
         // allocate a buffer on the stack that's big enough
@@ -6056,7 +6060,12 @@ impl AccountsDb {
 
         // collect lamports, rent_epoch into buffer to hash
         buffer.extend_from_slice(&account.lamports().to_le_bytes());
-        buffer.extend_from_slice(&account.rent_epoch().to_le_bytes());
+
+        if rent_epoch_in_account_hash == RentEpochInAccountHash::Included {
+            // conditionally hash in the rent epoch
+            // once the rent epoch is permanently excluded, also remove the 8 bytes in the META_SIZE above
+            buffer.extend_from_slice(&account.rent_epoch().to_le_bytes());
+        }
 
         let data = account.data();
         if data.len() > DATA_SIZE {
@@ -9198,6 +9207,15 @@ impl AccountsDb {
             );
         }
     }
+}
+
+/// Should the rent_epoch field be used to compute the hash of an account?
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum RentEpochInAccountHash {
+    /// Do include the rent_epoch when computing the hash of an account
+    Included,
+    /// Do *not* include the rent_epoch when computing the hash of an account
+    Excluded,
 }
 
 /// Specify the source of the accounts data when calculating the accounts hash

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -981,7 +981,7 @@ pub mod enable_secp256r1_precompile {
 }
 
 pub mod accounts_lt_hash {
-    solana_pubkey::declare_id!("LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn");
+    solana_pubkey::declare_id!("LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq");
 }
 
 pub mod snapshots_lt_hash {


### PR DESCRIPTION
#### Problem

SIMD-215 describes the LtHash of a single account as follows:
https://github.com/solana-foundation/solana-improvement-documents/blob/c5134c5f7a451e570938217c470bb6ad6e2f6110/proposals/0215-accounts-lattice-hash.md?plain=1#L104-L110

This explicitly does *not* include the rent epoch field.

However, our current implementation *does* (incorrectly) include the rent epoch field.

We want to remove this field from the account hash anyway (now that rent fees collection has been disabled), so we can implement the SIMD as written to fix that. 


#### Summary of Changes

Remove the rent epoch field when computing the lt hash of a single account.

We'll need to backport this change to v2.2, and also rekey the feature gate.