### PR TITLE
ci: Extend timeout for test_snapshots_have_expected_epoch_accounts_hash

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -70,6 +70,10 @@ filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_mainnetbe
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
+filter = 'package(solana-core) & test(/^test_snapshots_have_expected_epoch_accounts_hash/)'
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
 filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 


### PR DESCRIPTION
#### Problem

The `solana-core::epoch_accounts_hash test_snapshots_have_expected_epoch_accounts_hash` test takes about 65 seconds to run locally for me, and in CI this exceeds the 60 seconds timeout and causes spurious failures.

Here's an example:
https://buildkite.com/anza/agave/builds/20723#0195a5ca-f201-404a-ba37-f7b280bfa662


#### Summary of Changes

Extend the timeout to 120 seconds.