### PR TITLE
Metrics reporting for tpu-client-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10548,6 +10548,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
+ "solana-metrics",
  "solana-pubkey",
  "solana-quic-definitions",
  "solana-rpc-client",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8823,6 +8823,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
+ "solana-metrics",
  "solana-quic-definitions",
  "solana-rpc-client",
  "solana-streamer",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4985,7 +4985,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_request_processor_new_tpu_client_next() {
-        rpc_request_processor_new::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_request_processor_new::<TpuClientNextClient>();
     }
 
     fn rpc_get_balance<Client: ClientWithCreator>() {
@@ -5022,7 +5022,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_balance_new_tpu_client_next() {
-        rpc_get_balance::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_get_balance::<TpuClientNextClient>();
     }
 
     fn rpc_get_balance_via_client<Client: ClientWithCreator>() {
@@ -5061,7 +5061,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_balance_via_client_tpu_client_next() {
-        rpc_get_balance_via_client::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_get_balance_via_client::<TpuClientNextClient>();
     }
 
     #[test]
@@ -5196,7 +5196,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_tx_count_tpu_client_next() {
-        rpc_get_tx_count::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_get_tx_count::<TpuClientNextClient>();
     }
 
     #[test]
@@ -6657,7 +6657,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_send_bad_tx_tpu_client_next() {
-        rpc_send_bad_tx::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_send_bad_tx::<TpuClientNextClient>();
     }
 
     fn rpc_send_transaction_preflight<Client: ClientWithCreator>() {
@@ -6841,7 +6841,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_send_transaction_preflight_with_tpu_client_next() {
-        rpc_send_transaction_preflight::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_send_transaction_preflight::<TpuClientNextClient>();
     }
 
     #[test]
@@ -7054,7 +7054,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_processor_get_block_commitment_with_tpu_client_next() {
-        rpc_processor_get_block_commitment::<TpuClientNextClient<NullTpuInfo>>();
+        rpc_processor_get_block_commitment::<TpuClientNextClient>();
     }
 
     #[test]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -21,7 +21,7 @@ solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
-solana-tpu-client-next = { workspace = true }
+solana-tpu-client-next = { workspace = true, features = ["metrics"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -614,7 +614,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn service_exit_with_tpu_client_next() {
-        service_exit::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+        service_exit::<TpuClientNextClient>(Some(Handle::current()));
     }
 
     fn validator_exit<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
@@ -665,7 +665,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn validator_exit_with_tpu_client_next() {
-        validator_exit::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+        validator_exit::<TpuClientNextClient>(Some(Handle::current()));
     }
 
     fn process_transactions<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
@@ -924,7 +924,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn process_transactions_with_tpu_client_next() {
-        process_transactions::<TpuClientNextClient<NullTpuInfo>>(Some(Handle::current()));
+        process_transactions::<TpuClientNextClient>(Some(Handle::current()));
     }
 
     fn retry_durable_nonce_transactions<C: ClientWithCreator>(maybe_runtime: Option<Handle>) {
@@ -1234,8 +1234,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn retry_durable_nonce_transactions_with_tpu_client_next() {
-        retry_durable_nonce_transactions::<TpuClientNextClient<NullTpuInfo>>(Some(
-            Handle::current(),
-        ));
+        retry_durable_nonce_transactions::<TpuClientNextClient>(Some(Handle::current()));
     }
 }

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -43,7 +43,7 @@ impl CreateClient for ConnectionCacheClient<NullTpuInfo> {
     }
 }
 
-impl CreateClient for TpuClientNextClient<NullTpuInfo> {
+impl CreateClient for TpuClientNextClient {
     fn create_client(
         maybe_runtime: Option<Handle>,
         my_tpu_address: SocketAddr,
@@ -52,7 +52,7 @@ impl CreateClient for TpuClientNextClient<NullTpuInfo> {
     ) -> Self {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
-        Self::new(
+        Self::new::<NullTpuInfo>(
             runtime_handle,
             my_tpu_address,
             tpu_peers,
@@ -74,10 +74,7 @@ where
     fn stop(&self) {}
 }
 
-impl<T> Stoppable for TpuClientNextClient<T>
-where
-    T: TpuInfoWithSendStatic + Clone,
-{
+impl Stoppable for TpuClientNextClient {
     fn stop(&self) {
         self.cancel().unwrap();
     }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -8,9 +8,7 @@ use {
     solana_measure::measure::Measure,
     solana_sdk::quic::NotifyKeyUpdate,
     solana_tpu_client_next::{
-        connection_workers_scheduler::{
-            ConnectionWorkersSchedulerConfig, Fanout, TransactionStatsAndReceiver,
-        },
+        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::LeaderUpdater,
         transaction_batch::TransactionBatch,
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
@@ -230,27 +228,20 @@ where
 ///   scheduler. Most of the complexity of this structure arises from this
 ///   functionality.
 #[derive(Clone)]
-pub struct TpuClientNextClient<T>
-where
-    T: TpuInfoWithSendStatic + Clone,
-{
+pub struct TpuClientNextClient {
     runtime_handle: Handle,
     sender: mpsc::Sender<TransactionBatch>,
     // This handle is needed to implement `NotifyKeyUpdate` trait. It's only
     // method takes &self and thus we need to wrap with Mutex.
     join_and_cancel: Arc<Mutex<(Option<TpuClientJoinHandle>, CancellationToken)>>,
-    leader_updater: SendTransactionServiceLeaderUpdater<T>,
     leader_forward_count: u64,
 }
 
 type TpuClientJoinHandle =
-    TokioJoinHandle<Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>>;
+    TokioJoinHandle<Result<ConnectionWorkersScheduler, ConnectionWorkersSchedulerError>>;
 
-impl<T> TpuClientNextClient<T>
-where
-    T: TpuInfoWithSendStatic + Clone,
-{
-    pub fn new(
+impl TpuClientNextClient {
+    pub fn new<T>(
         runtime_handle: Handle,
         my_tpu_address: SocketAddr,
         tpu_peers: Option<Vec<SocketAddr>>,
@@ -275,18 +266,18 @@ where
                 tpu_peers,
             };
         let config = Self::create_config(identity, leader_forward_count as usize);
-        let handle = runtime_handle.spawn(ConnectionWorkersScheduler::run(
-            config,
-            Box::new(leader_updater.clone()),
-            receiver,
+        let scheduler = ConnectionWorkersScheduler::new(Box::new(leader_updater), receiver);
+        // leaking handle to this task, as it will run until the end of life of the process
+        runtime_handle.spawn(scheduler.stats.clone().report_to_influxdb(
+            "send-transaction-service-TPU-client",
+            Duration::from_secs(3),
             cancel.clone(),
         ));
-
+        let handle = runtime_handle.spawn(scheduler.run(config, cancel.clone()));
         Self {
             runtime_handle,
             join_and_cancel: Arc::new(Mutex::new((Some(handle), cancel))),
             sender,
-            leader_updater,
             leader_forward_count,
         }
     }
@@ -322,7 +313,6 @@ where
     async fn do_update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
         let runtime_handle = self.runtime_handle.clone();
         let config = Self::create_config(Some(identity), self.leader_forward_count as usize);
-        let leader_updater = self.leader_updater.clone();
         let handle = self.join_and_cancel.clone();
 
         let join_handle = {
@@ -340,14 +330,9 @@ where
             };
 
             match result {
-                Ok((_stats, receiver)) => {
+                Ok(scheduler) => {
                     let cancel = CancellationToken::new();
-                    let join_handle = runtime_handle.spawn(ConnectionWorkersScheduler::run(
-                        config,
-                        Box::new(leader_updater),
-                        receiver,
-                        cancel.clone(),
-                    ));
+                    let join_handle = runtime_handle.spawn(scheduler.run(config, cancel.clone()));
 
                     let Ok(mut lock) = handle.lock() else {
                         return Err("TpuClientNext task panicked.".into());
@@ -363,19 +348,13 @@ where
     }
 }
 
-impl<T> NotifyKeyUpdate for TpuClientNextClient<T>
-where
-    T: TpuInfoWithSendStatic + Clone,
-{
+impl NotifyKeyUpdate for TpuClientNextClient {
     fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
         self.runtime_handle.block_on(self.do_update_key(identity))
     }
 }
 
-impl<T> TransactionClient for TpuClientNextClient<T>
-where
-    T: TpuInfoWithSendStatic + Clone,
-{
+impl TransactionClient for TpuClientNextClient {
     fn send_transactions_in_batch(
         &self,
         wire_transactions: Vec<Vec<u8>>,
@@ -415,8 +394,11 @@ where
         };
         match self.runtime_handle.block_on(handle) {
             Ok(result) => match result {
-                Ok(stats) => {
-                    debug!("tpu-client-next statistics over all the connections: {stats:?}");
+                Ok(scheduler) => {
+                    debug!(
+                        "tpu-client-next statistics over all the connections: {:?}",
+                        scheduler.stats
+                    );
                 }
                 Err(error) => error!("tpu-client-next exits with error {error}."),
             },

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8163,6 +8163,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
+ "solana-metrics",
  "solana-quic-definitions",
  "solana-rpc-client",
  "solana-streamer",

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -18,6 +18,7 @@ solana-clock = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
+solana-metrics ={ workspace = true, optional = true }
 solana-quic-definitions = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-streamer = { workspace = true }
@@ -39,3 +40,6 @@ solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+metrics =["dep:solana-metrics"]

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -32,7 +32,7 @@ pub type TransactionReceiver = mpsc::Receiver<TransactionBatch>;
 pub struct ConnectionWorkersScheduler {
     leader_updater: Box<dyn LeaderUpdater>,
     transaction_receiver: TransactionReceiver,
-    pub stats: Arc<SendTransactionStats>,
+    stats: Arc<SendTransactionStats>,
 }
 
 /// Errors that arise from running [`ConnectionWorkersSchedulerError`].
@@ -143,6 +143,8 @@ pub trait WorkersBroadcaster {
 }
 
 impl ConnectionWorkersScheduler {
+    /// Creates the scheduler, which manages the distribution of transactions to
+    /// the network's upcoming leaders.
     pub fn new(
         leader_updater: Box<dyn LeaderUpdater>,
         transaction_receiver: mpsc::Receiver<TransactionBatch>,
@@ -155,8 +157,12 @@ impl ConnectionWorkersScheduler {
         }
     }
 
-    /// Starts the scheduler, which manages the distribution of transactions to
-    /// the network's upcoming leaders.
+    /// Retrieves a reference to the statistics of the scheduler
+    pub fn get_stats(&self) -> Arc<SendTransactionStats> {
+        self.stats.clone()
+    }
+
+    /// Starts the scheduler.
     ///
     /// This method is a shorthand for
     /// [`ConnectionWorkersScheduler::run_with_broadcaster`] using

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -2,7 +2,7 @@
 //! to the upcoming leaders.
 
 use {
-    super::{leader_updater::LeaderUpdater, SendTransactionStatsPerAddr},
+    super::leader_updater::LeaderUpdater,
     crate::{
         connection_worker::ConnectionWorker,
         quic_networking::{
@@ -21,6 +21,7 @@ use {
     tokio::sync::mpsc,
     tokio_util::sync::CancellationToken,
 };
+pub type TransactionReceiver = mpsc::Receiver<TransactionBatch>;
 
 /// The [`ConnectionWorkersScheduler`] sends transactions from the provided
 /// receiver channel to upcoming leaders. It obtains information about future
@@ -28,7 +29,11 @@ use {
 ///
 /// Internally, it enables the management and coordination of multiple network
 /// connections, schedules and oversees connection workers.
-pub struct ConnectionWorkersScheduler;
+pub struct ConnectionWorkersScheduler {
+    leader_updater: Box<dyn LeaderUpdater>,
+    transaction_receiver: TransactionReceiver,
+    pub stats: Arc<SendTransactionStats>,
+}
 
 /// Errors that arise from running [`ConnectionWorkersSchedulerError`].
 #[derive(Debug, Error, PartialEq)]
@@ -137,12 +142,19 @@ pub trait WorkersBroadcaster {
     ) -> Result<(), ConnectionWorkersSchedulerError>;
 }
 
-pub type TransactionStatsAndReceiver = (
-    SendTransactionStatsPerAddr,
-    mpsc::Receiver<TransactionBatch>,
-);
-
 impl ConnectionWorkersScheduler {
+    pub fn new(
+        leader_updater: Box<dyn LeaderUpdater>,
+        transaction_receiver: mpsc::Receiver<TransactionBatch>,
+    ) -> Self {
+        let stats = Arc::new(SendTransactionStats::default());
+        Self {
+            leader_updater,
+            transaction_receiver,
+            stats,
+        }
+    }
+
     /// Starts the scheduler, which manages the distribution of transactions to
     /// the network's upcoming leaders.
     ///
@@ -154,18 +166,12 @@ impl ConnectionWorkersScheduler {
     /// will be dropped. The same for transactions that failed to be delivered
     /// over the network.
     pub async fn run(
+        self,
         config: ConnectionWorkersSchedulerConfig,
-        leader_updater: Box<dyn LeaderUpdater>,
-        transaction_receiver: mpsc::Receiver<TransactionBatch>,
         cancel: CancellationToken,
-    ) -> Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError> {
-        Self::run_with_broadcaster::<NonblockingBroadcaster>(
-            config,
-            leader_updater,
-            transaction_receiver,
-            cancel,
-        )
-        .await
+    ) -> Result<Self, ConnectionWorkersSchedulerError> {
+        self.run_with_broadcaster::<NonblockingBroadcaster>(config, cancel)
+            .await
     }
 
     /// Starts the scheduler, which manages the distribution of transactions to
@@ -182,6 +188,7 @@ impl ConnectionWorkersScheduler {
     /// Importantly, if some transactions were not delivered due to network
     /// problems, they will not be retried when the problem is resolved.
     pub async fn run_with_broadcaster<Broadcaster: WorkersBroadcaster>(
+        mut self,
         ConnectionWorkersSchedulerConfig {
             bind,
             stake_identity,
@@ -191,20 +198,17 @@ impl ConnectionWorkersScheduler {
             max_reconnect_attempts,
             leaders_fanout,
         }: ConnectionWorkersSchedulerConfig,
-        mut leader_updater: Box<dyn LeaderUpdater>,
-        mut transaction_receiver: mpsc::Receiver<TransactionBatch>,
         cancel: CancellationToken,
-    ) -> Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError> {
+    ) -> Result<Self, ConnectionWorkersSchedulerError> {
         let endpoint = Self::setup_endpoint(bind, stake_identity)?;
         debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
         let mut workers = WorkersCache::new(num_connections, cancel.clone());
-        let mut send_stats_per_addr = SendTransactionStatsPerAddr::new();
 
         let mut last_error = None;
 
         loop {
             let transaction_batch: TransactionBatch = tokio::select! {
-                recv_res = transaction_receiver.recv() => match recv_res {
+                recv_res = self.transaction_receiver.recv() => match recv_res {
                     Some(txs) => txs,
                     None => {
                         debug!("End of `transaction_receiver`: shutting down.");
@@ -217,21 +221,20 @@ impl ConnectionWorkersScheduler {
                 }
             };
 
-            let connect_leaders = leader_updater.next_leaders(leaders_fanout.connect);
+            let connect_leaders = self.leader_updater.next_leaders(leaders_fanout.connect);
             let send_leaders = extract_send_leaders(&connect_leaders, leaders_fanout.send);
 
             // add future leaders to the cache to hide the latency of opening
             // the connection.
             for peer in connect_leaders {
                 if !workers.contains(&peer) {
-                    let stats = send_stats_per_addr.entry(peer.ip()).or_default();
                     let worker = Self::spawn_worker(
                         &endpoint,
                         &peer,
                         worker_channel_size,
                         skip_check_transaction_age,
                         max_reconnect_attempts,
-                        stats.clone(),
+                        self.stats.clone(),
                     );
                     maybe_shutdown_worker(workers.push(peer, worker));
                 }
@@ -248,11 +251,11 @@ impl ConnectionWorkersScheduler {
         workers.shutdown().await;
 
         endpoint.close(0u32.into(), b"Closing connection");
-        leader_updater.stop().await;
+        self.leader_updater.stop().await;
         if let Some(error) = last_error {
             return Err(error);
         }
-        Ok((send_stats_per_addr, transaction_receiver))
+        Ok(self)
     }
 
     /// Sets up the QUIC endpoint for the scheduler to handle connections.

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -4,9 +4,12 @@ pub mod send_transaction_stats;
 pub mod workers_cache;
 pub use crate::{
     connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
-    send_transaction_stats::{SendTransactionStats, SendTransactionStatsPerAddr},
+    send_transaction_stats::SendTransactionStats,
 };
 pub(crate) mod quic_networking;
 pub(crate) use crate::quic_networking::QuicError;
 pub mod leader_updater;
 pub mod transaction_batch;
+
+#[cfg(feature = "metrics")]
+pub mod metrics;

--- a/tpu-client-next/src/metrics.rs
+++ b/tpu-client-next/src/metrics.rs
@@ -1,0 +1,47 @@
+use {
+    crate::SendTransactionStats,
+    solana_metrics::datapoint_info,
+    std::{sync::Arc, time::Duration},
+    tokio::time::interval,
+    tokio_util::sync::CancellationToken,
+};
+
+impl SendTransactionStats {
+    ///Report the statistics to influxdb in a compact form
+    #[allow(clippy::arithmetic_side_effects)]
+    pub async fn report_to_influxdb(
+        self: Arc<Self>,
+        name: &'static str,
+        reporting_interval: Duration,
+        cancel: CancellationToken,
+    ) {
+        let mut interval = interval(reporting_interval);
+        let stats = self.clone();
+        while !cancel.is_cancelled() {
+            interval.tick().await;
+            let view = stats.read_and_reset();
+            let connect_error = view.connect_error_cids_exhausted
+                + view.connect_error_other
+                + view.connect_error_invalid_remote_address;
+            let connection_error = view.connection_error_reset
+                + view.connection_error_cids_exhausted
+                + view.connection_error_timed_out
+                + view.connection_error_application_closed
+                + view.connection_error_transport_error
+                + view.connection_error_version_mismatch
+                + view.connection_error_locally_closed;
+            let write_error = view.write_error_stopped
+                + view.write_error_closed_stream
+                + view.write_error_connection_lost
+                + view.write_error_zero_rtt_rejected;
+
+            datapoint_info!(
+                name,
+                ("connect_error", connect_error, i64),
+                ("connection_error", connection_error, i64),
+                ("successfully_sent", view.successfully_sent, i64),
+                ("write_error", write_error, i64),
+            );
+        }
+    }
+}

--- a/tpu-client-next/src/metrics.rs
+++ b/tpu-client-next/src/metrics.rs
@@ -1,3 +1,6 @@
+//! If `metrics` feature is activated, this module provides `report_to_influxdb`
+//! method for [`SendTransactionStats`] which periodically reports transaction
+//! sending statistics to InfluxDB.
 use {
     crate::SendTransactionStats,
     solana_metrics::datapoint_info,
@@ -7,7 +10,7 @@ use {
 };
 
 impl SendTransactionStats {
-    ///Report the statistics to influxdb in a compact form
+    /// Report the statistics to influxdb in a compact form.
     #[allow(clippy::arithmetic_side_effects)]
     pub async fn report_to_influxdb(
         self: Arc<Self>,
@@ -17,31 +20,34 @@ impl SendTransactionStats {
     ) {
         let mut interval = interval(reporting_interval);
         let stats = self.clone();
-        while !cancel.is_cancelled() {
-            interval.tick().await;
-            let view = stats.read_and_reset();
-            let connect_error = view.connect_error_cids_exhausted
-                + view.connect_error_other
-                + view.connect_error_invalid_remote_address;
-            let connection_error = view.connection_error_reset
-                + view.connection_error_cids_exhausted
-                + view.connection_error_timed_out
-                + view.connection_error_application_closed
-                + view.connection_error_transport_error
-                + view.connection_error_version_mismatch
-                + view.connection_error_locally_closed;
-            let write_error = view.write_error_stopped
-                + view.write_error_closed_stream
-                + view.write_error_connection_lost
-                + view.write_error_zero_rtt_rejected;
+        loop {
+            select! {
+                    _ = interval.tick() => {
+                    let view = stats.read_and_reset();
+                    let connect_error = view.connect_error_cids_exhausted
+                        + view.connect_error_other
+                        + view.connect_error_invalid_remote_address;
+                    let connection_error = view.connection_error_reset
+                        + view.connection_error_cids_exhausted
+                        + view.connection_error_timed_out
+                        + view.connection_error_application_closed
+                        + view.connection_error_transport_error
+                        + view.connection_error_version_mismatch
+                        + view.connection_error_locally_closed;
+                    let write_error = view.write_error_stopped
+                        + view.write_error_closed_stream
+                        + view.write_error_connection_lost
+                        + view.write_error_zero_rtt_rejected;
 
-            datapoint_info!(
-                name,
-                ("connect_error", connect_error, i64),
-                ("connection_error", connection_error, i64),
-                ("successfully_sent", view.successfully_sent, i64),
-                ("write_error", write_error, i64),
-            );
-        }
+                    datapoint_info!(
+                        name,
+                        ("connect_error", connect_error, i64),
+                        ("connection_error", connection_error, i64),
+                        ("successfully_sent", view.successfully_sent, i64),
+                        ("write_error", write_error, i64),
+                    );
+                }
+                _ = cancel.cancelled() => break,
+            }
     }
 }

--- a/tpu-client-next/src/metrics.rs
+++ b/tpu-client-next/src/metrics.rs
@@ -5,7 +5,7 @@ use {
     crate::SendTransactionStats,
     solana_metrics::datapoint_info,
     std::{sync::Arc, time::Duration},
-    tokio::time::interval,
+    tokio::{select, time::interval},
     tokio_util::sync::CancellationToken,
 };
 
@@ -49,5 +49,6 @@ impl SendTransactionStats {
                 }
                 _ = cancel.cancelled() => break,
             }
+        }
     }
 }

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -160,7 +160,7 @@ impl fmt::Display for SendTransactionStats {
     }
 }
 
-/// For external use it is useful to be have direct access to data and PartialEq but
+/// For external use it is useful to have direct access to data and `PartialEq` but
 /// we cannot have that on top of atomics. This macro creates a structure with the same
 /// fields but of type u64.
 macro_rules! define_non_atomic_struct_for {

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -1,5 +1,7 @@
-//! This module defines [`SendTransactionStats`] which is used to collect per IP
-//! statistics about relevant network errors.
+//! This module defines [`SendTransactionStats`] which is used to collect
+//! statistics about relevant network events. This will aggregate
+//! events from all transactions and all leaders. Stats can be reset at
+//! any time to start a new monitoring period.
 
 use {
     super::QuicError,
@@ -158,9 +160,9 @@ impl fmt::Display for SendTransactionStats {
     }
 }
 
-/// For tests it is useful to be have PartialEq but we cannot have it on top of
-/// atomics. This macro creates a structure with the same attributes but of type
-/// u64.
+/// For external use it is useful to be have direct access to data and PartialEq but
+/// we cannot have that on top of atomics. This macro creates a structure with the same
+/// fields but of type u64.
 macro_rules! define_non_atomic_struct_for {
     ($name:ident, $atomic_name:ident, {$($field:ident),* $(,)?}) => {
         #[derive(Debug, Default, PartialEq)]

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -97,7 +97,7 @@ async fn join_scheduler(
         .await
         .unwrap()
         .expect("Scheduler should stop successfully.");
-    scheduler.stats.read_and_reset()
+    scheduler.get_stats().read_and_reset()
 }
 
 // Specify the pessimistic time to finish generation and result checks.

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -15,9 +15,7 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
-        connection_workers_scheduler::{
-            ConnectionWorkersSchedulerConfig, Fanout, TransactionStatsAndReceiver,
-        },
+        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::create_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
         transaction_batch::TransactionBatch,
@@ -27,7 +25,6 @@ use {
         collections::HashMap,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
         num::Saturating,
-        str::FromStr,
         sync::{atomic::Ordering, Arc},
         time::Duration,
     },
@@ -67,7 +64,7 @@ async fn setup_connection_worker_scheduler(
     transaction_receiver: Receiver<TransactionBatch>,
     stake_identity: Option<Keypair>,
 ) -> (
-    JoinHandle<Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>>,
+    JoinHandle<Result<ConnectionWorkersScheduler, ConnectionWorkersSchedulerError>>,
     CancellationToken,
 ) {
     let json_rpc_url = "http://127.0.0.1:8899";
@@ -85,29 +82,22 @@ async fn setup_connection_worker_scheduler(
 
     let cancel = CancellationToken::new();
     let config = test_config(stake_identity);
-    let scheduler = tokio::spawn(ConnectionWorkersScheduler::run(
-        config,
-        leader_updater,
-        transaction_receiver,
-        cancel.clone(),
-    ));
+    let scheduler = ConnectionWorkersScheduler::new(leader_updater, transaction_receiver);
+    let scheduler = tokio::spawn(scheduler.run(config, cancel.clone()));
 
     (scheduler, cancel)
 }
 
 async fn join_scheduler(
     scheduler_handle: JoinHandle<
-        Result<TransactionStatsAndReceiver, ConnectionWorkersSchedulerError>,
+        Result<ConnectionWorkersScheduler, ConnectionWorkersSchedulerError>,
     >,
 ) -> SendTransactionStatsNonAtomic {
-    let (stats_per_ip, _) = scheduler_handle
+    let scheduler = scheduler_handle
         .await
         .unwrap()
         .expect("Scheduler should stop successfully.");
-    stats_per_ip
-        .get(&IpAddr::from_str("127.0.0.1").unwrap())
-        .expect("setup_connection_worker_scheduler() connected to a leader at 127.0.0.1")
-        .to_non_atomic()
+    scheduler.stats.read_and_reset()
 }
 
 // Specify the pessimistic time to finish generation and result checks.
@@ -246,14 +236,8 @@ async fn test_basic_transactions_sending() {
 
     // Stop sending
     tx_sender_shutdown.await;
-    let localhost_stats = join_scheduler(scheduler_handle).await;
-    assert_eq!(
-        localhost_stats,
-        SendTransactionStatsNonAtomic {
-            successfully_sent: expected_num_txs as u64,
-            ..Default::default()
-        }
-    );
+    let stats = join_scheduler(scheduler_handle).await;
+    assert_eq!(stats.successfully_sent, expected_num_txs as u64,);
 
     // Stop server
     exit.store(true, Ordering::Relaxed);
@@ -323,14 +307,13 @@ async fn test_connection_denied_until_allowed() {
 
     // Wait for the exchange to finish.
     tx_sender_shutdown.await;
-    let localhost_stats = join_scheduler(scheduler_handle).await;
+    let stats = join_scheduler(scheduler_handle).await;
     // in case of pruning, server closes the connection with code 1 and error
     // message b"dropped". This might lead to connection error
     // (ApplicationClosed::ApplicationClose) or to stream error
     // (ConnectionLost::ApplicationClosed::ApplicationClose).
     assert_eq!(
-        localhost_stats.write_error_connection_lost
-            + localhost_stats.connection_error_application_closed,
+        stats.write_error_connection_lost + stats.connection_error_application_closed,
         1
     );
 
@@ -382,14 +365,13 @@ async fn test_connection_pruned_and_reopened() {
 
     // Wait for the exchange to finish.
     tx_sender_shutdown.await;
-    let localhost_stats = join_scheduler(scheduler_handle).await;
+    let stats = join_scheduler(scheduler_handle).await;
     // in case of pruning, server closes the connection with code 1 and error
     // message b"dropped". This might lead to connection error
     // (ApplicationClosed::ApplicationClose) or to stream error
     // (ConnectionLost::ApplicationClosed::ApplicationClose).
     assert_eq!(
-        localhost_stats.connection_error_application_closed
-            + localhost_stats.write_error_connection_lost,
+        stats.connection_error_application_closed + stats.write_error_connection_lost,
         1,
     );
 
@@ -442,9 +424,9 @@ async fn test_staked_connection() {
 
     // Wait for the exchange to finish.
     tx_sender_shutdown.await;
-    let localhost_stats = join_scheduler(scheduler_handle).await;
+    let stats = join_scheduler(scheduler_handle).await;
     assert_eq!(
-        localhost_stats,
+        stats,
         SendTransactionStatsNonAtomic {
             successfully_sent: expected_num_txs as u64,
             ..Default::default()
@@ -489,9 +471,9 @@ async fn test_connection_throttling() {
 
     // Stop sending
     tx_sender_shutdown.await;
-    let localhost_stats = join_scheduler(scheduler_handle).await;
+    let stats = join_scheduler(scheduler_handle).await;
     assert_eq!(
-        localhost_stats,
+        stats,
         SendTransactionStatsNonAtomic {
             successfully_sent: expected_num_txs as u64,
             ..Default::default()
@@ -534,11 +516,7 @@ async fn test_no_host() {
 
     // While attempting to establish a connection with a nonexistent host, we fill the worker's
     // channel.
-    let (stats, _) = scheduler_handle
-        .await
-        .expect("Scheduler should stop successfully")
-        .expect("Scheduler execution was successful");
-    let stats = stats.get(&server_ip).unwrap().to_non_atomic();
+    let stats = join_scheduler(scheduler_handle).await;
     // `5` because `config.max_reconnect_attempts` is 4
     assert_eq!(stats.connect_error_invalid_remote_address, 5);
 }
@@ -590,13 +568,13 @@ async fn test_rate_limiting() {
 
     // And the scheduler.
     scheduler_cancel.cancel();
-    let localhost_stats = join_scheduler(scheduler_handle).await;
+    let stats = join_scheduler(scheduler_handle).await;
 
     // We do not expect to see any errors, as the connection is in the pending state still, when we
     // do the shutdown.  If we increase the time we wait in `count_received_packets_for`, we would
     // start seeing a `connection_error_timed_out` incremented to 1.  Potentially, we may want to
     // accept both 0 and 1 as valid values for it.
-    assert_eq!(localhost_stats, SendTransactionStatsNonAtomic::default());
+    assert_eq!(stats, SendTransactionStatsNonAtomic::default());
 
     // Stop the server.
     exit.store(true, Ordering::Relaxed);
@@ -654,26 +632,26 @@ async fn test_rate_limiting_establish_connection() {
 
     // And the scheduler.
     scheduler_cancel.cancel();
-    let mut localhost_stats = join_scheduler(scheduler_handle).await;
+    let mut stats = join_scheduler(scheduler_handle).await;
     assert!(
-        localhost_stats.connection_error_timed_out > 0,
+        stats.connection_error_timed_out > 0,
         "As the quinn timeout is below 1 minute, a few connections will fail to connect during \
          the 1 minute delay.\n\
          Actual connection_error_timed_out: {}",
-        localhost_stats.connection_error_timed_out
+        stats.connection_error_timed_out
     );
     assert!(
-        localhost_stats.successfully_sent > 0,
+        stats.successfully_sent > 0,
         "As we run the test for longer than 1 minute, we expect a connection to be established, \
          and a number of transactions to be delivered.\n\
          Actual successfully_sent: {}",
-        localhost_stats.successfully_sent
+        stats.successfully_sent
     );
 
     // All the rest of the error counters should be 0.
-    localhost_stats.connection_error_timed_out = 0;
-    localhost_stats.successfully_sent = 0;
-    assert_eq!(localhost_stats, SendTransactionStatsNonAtomic::default());
+    stats.connection_error_timed_out = 0;
+    stats.successfully_sent = 0;
+    assert_eq!(stats, SendTransactionStatsNonAtomic::default());
 
     // Stop the server.
     exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

- tpu-client-next has internal stats but they are not well-designed: memory consumption is unbounded, and no reporting into metrics is provisioned
- much of the internal state for ConnectionWorkersScheduler is managed externally in callers

#### Summary of Changes

- Internalize some of the state for ConnectionsWorkerScheduler (including the stats)
- remove (now unneeded) generics from  TpuClientNextClient 
- patch ConnectionsWorkerScheduler stats into influxdb via a small coroutine that can periodically report stats using the same tokio runtime
