### PR TITLE
agave-validator: Better error propagation for commands

### DIFF
--- a/validator/src/commands/contact_info/mod.rs
+++ b/validator/src/commands/contact_info/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{admin_rpc_service, commands::FromClapArgMatches},
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{App, Arg, ArgMatches, SubCommand},
     solana_cli_output::OutputFormat,
     std::path::Path,
@@ -13,7 +16,7 @@ pub struct ContactInfoArgs {
 }
 
 impl FromClapArgMatches for ContactInfoArgs {
-    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(ContactInfoArgs {
             output: OutputFormat::from_matches(matches, "output", false),
         })
@@ -33,13 +36,12 @@ pub fn command<'a>() -> App<'a, 'a> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let contact_info_args = ContactInfoArgs::from_clap_arg_match(matches)?;
 
     let admin_client = admin_rpc_service::connect(ledger_path);
     let contact_info = admin_rpc_service::runtime()
-        .block_on(async move { admin_client.await?.contact_info().await })
-        .map_err(|err| format!("contact info request failed: {err}"))?;
+        .block_on(async move { admin_client.await?.contact_info().await })?;
 
     println!(
         "{}",

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -12,8 +12,26 @@ pub mod set_public_address;
 pub mod staked_nodes_overrides;
 pub mod wait_for_restart_window;
 
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("admin rpc error: {0}")]
+    AdminRpc(#[from] jsonrpc_core_client::RpcError),
+
+    #[error(transparent)]
+    Clap(#[from] clap::Error),
+
+    #[error(transparent)]
+    Dynamic(#[from] Box<dyn std::error::Error>),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+pub type Result<T> = std::result::Result<T, Error>;
+
 pub trait FromClapArgMatches {
-    fn from_clap_arg_match(matches: &clap::ArgMatches) -> Result<Self, String>
+    fn from_clap_arg_match(matches: &clap::ArgMatches) -> Result<Self>
     where
         Self: Sized;
 }

--- a/validator/src/commands/monitor/mod.rs
+++ b/validator/src/commands/monitor/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::dashboard::Dashboard,
+    crate::{commands::Result, dashboard::Dashboard},
     clap::{App, ArgMatches, SubCommand},
     std::{path::Path, time::Duration},
 };
@@ -8,11 +8,11 @@ pub fn command<'a>() -> App<'a, 'a> {
     SubCommand::with_name("monitor").about("Monitor the validator")
 }
 
-pub fn execute(_matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+pub fn execute(_matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     monitor_validator(ledger_path)
 }
 
-pub fn monitor_validator(ledger_path: &Path) -> Result<(), String> {
+pub fn monitor_validator(ledger_path: &Path) -> Result<()> {
     let dashboard = Dashboard::new(ledger_path, None, None);
     dashboard.run(Duration::from_secs(2));
 

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -44,6 +44,7 @@ pub fn command<'a>() -> App<'a, 'a> {
             Arg::with_name("slot")
                 .long("slot")
                 .value_name("SLOT")
+                .required(true)
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .help("Slot to repair"),
@@ -52,6 +53,7 @@ pub fn command<'a>() -> App<'a, 'a> {
             Arg::with_name("shred")
                 .long("shred")
                 .value_name("SHRED")
+                .required(true)
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .help("Shred to repair"),
@@ -78,22 +80,25 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::commands::tests::verify_args_struct_by_command, std::str::FromStr};
+    use {
+        super::*,
+        crate::commands::tests::{
+            verify_args_struct_by_command, verify_args_struct_by_command_is_error,
+        },
+        std::str::FromStr,
+    };
 
     #[test]
-    fn verify_args_struct_by_command_repair_shred_from_peer_missing_slot() {
-        let app = command();
-        let matches = app.get_matches_from(vec![COMMAND]);
-        let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
-        assert_eq!(args, Err("slot is not a valid number".to_string()));
-    }
-
-    #[test]
-    fn verify_args_struct_by_command_repair_shred_from_peer_missing_shred() {
-        let app = command();
-        let matches = app.get_matches_from(vec![COMMAND, "--slot", "1"]);
-        let args = RepairShredFromPeerArgs::from_clap_arg_match(&matches);
-        assert_eq!(args, Err("shred is not a valid number".to_string()));
+    fn verify_args_struct_by_command_repair_shred_from_peer_missing_slot_and_shred() {
+        verify_args_struct_by_command_is_error::<RepairShredFromPeerArgs>(command(), vec![COMMAND]);
+        verify_args_struct_by_command_is_error::<RepairShredFromPeerArgs>(
+            command(),
+            vec![COMMAND, "--slot", "1"],
+        );
+        verify_args_struct_by_command_is_error::<RepairShredFromPeerArgs>(
+            command(),
+            vec![COMMAND, "--shred", "2"],
+        );
     }
 
     #[test]

--- a/validator/src/commands/repair_shred_from_peer/mod.rs
+++ b/validator/src/commands/repair_shred_from_peer/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{admin_rpc_service, commands::FromClapArgMatches},
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_pubkey},
     solana_sdk::pubkey::Pubkey,
@@ -16,11 +19,11 @@ pub struct RepairShredFromPeerArgs {
 }
 
 impl FromClapArgMatches for RepairShredFromPeerArgs {
-    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(RepairShredFromPeerArgs {
             pubkey: value_t!(matches, "pubkey", Pubkey).ok(),
-            slot: value_t!(matches, "slot", u64).map_err(|_| "slot is not a valid number")?,
-            shred: value_t!(matches, "shred", u64).map_err(|_| "shred is not a valid number")?,
+            slot: value_t!(matches, "slot", u64)?,
+            shred: value_t!(matches, "shred", u64)?,
         })
     }
 }
@@ -55,7 +58,7 @@ pub fn command<'a>() -> App<'a, 'a> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let RepairShredFromPeerArgs {
         pubkey,
         slot,
@@ -63,14 +66,14 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
     } = RepairShredFromPeerArgs::from_clap_arg_match(matches)?;
 
     let admin_client = admin_rpc_service::connect(ledger_path);
-    admin_rpc_service::runtime()
-        .block_on(async move {
-            admin_client
-                .await?
-                .repair_shred_from_peer(pubkey, slot, shred)
-                .await
-        })
-        .map_err(|err| format!("repair shred from peer request failed: {err}"))
+    admin_rpc_service::runtime().block_on(async move {
+        admin_client
+            .await?
+            .repair_shred_from_peer(pubkey, slot, shred)
+            .await
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -94,7 +94,7 @@ pub fn execute(
     socket_addr_space: SocketAddrSpace,
     ledger_path: &Path,
     operation: Operation,
-) -> Result<(), String> {
+) -> Result<(), Box<dyn std::error::Error>> {
     let cli::thread_args::NumThreadConfig {
         accounts_db_clean_threads,
         accounts_db_foreground_threads,

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{admin_rpc_service, commands::FromClapArgMatches},
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{value_t, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::is_keypair,
     solana_sdk::signature::{read_keypair, Signer},
@@ -16,7 +19,7 @@ pub struct SetIdentityArgs {
 }
 
 impl FromClapArgMatches for SetIdentityArgs {
-    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(SetIdentityArgs {
             identity: value_t!(matches, "identity", String).ok(),
             require_tower: matches.is_present("require_tower"),
@@ -46,15 +49,14 @@ pub fn command<'a>() -> App<'a, 'a> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let SetIdentityArgs {
         identity,
         require_tower,
     } = SetIdentityArgs::from_clap_arg_match(matches)?;
 
     if let Some(identity_keypair) = identity {
-        let identity_keypair = fs::canonicalize(&identity_keypair)
-            .map_err(|err| format!("unable to access path {identity_keypair}: {err:?}"))?;
+        let identity_keypair = fs::canonicalize(&identity_keypair)?;
 
         println!(
             "New validator identity path: {}",
@@ -62,31 +64,28 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
         );
 
         let admin_client = admin_rpc_service::connect(ledger_path);
-        admin_rpc_service::runtime()
-            .block_on(async move {
-                admin_client
-                    .await?
-                    .set_identity(identity_keypair.display().to_string(), require_tower)
-                    .await
-            })
-            .map_err(|err| format!("set identity request failed: {err}"))
+        admin_rpc_service::runtime().block_on(async move {
+            admin_client
+                .await?
+                .set_identity(identity_keypair.display().to_string(), require_tower)
+                .await
+        })?;
     } else {
         let mut stdin = std::io::stdin();
-        let identity_keypair = read_keypair(&mut stdin)
-            .map_err(|err| format!("unable to read json keypair from stdin: {err:?}"))?;
+        let identity_keypair = read_keypair(&mut stdin)?;
 
         println!("New validator identity: {}", identity_keypair.pubkey());
 
         let admin_client = admin_rpc_service::connect(ledger_path);
-        admin_rpc_service::runtime()
-            .block_on(async move {
-                admin_client
-                    .await?
-                    .set_identity_from_bytes(Vec::from(identity_keypair.to_bytes()), require_tower)
-                    .await
-            })
-            .map_err(|err| format!("set identity request failed: {err}"))
+        admin_rpc_service::runtime().block_on(async move {
+            admin_client
+                .await?
+                .set_identity_from_bytes(Vec::from(identity_keypair.to_bytes()), require_tower)
+                .await
+        })?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/validator/src/commands/staked_nodes_overrides/mod.rs
+++ b/validator/src/commands/staked_nodes_overrides/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{admin_rpc_service, commands::FromClapArgMatches},
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{App, Arg, ArgMatches, SubCommand},
     std::path::Path,
 };
@@ -12,7 +15,7 @@ pub struct StakedNodesOverridesArgs {
 }
 
 impl FromClapArgMatches for StakedNodesOverridesArgs {
-    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self, String> {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(StakedNodesOverridesArgs {
             path: matches
                 .value_of("path")
@@ -39,18 +42,18 @@ pub fn command<'a>() -> App<'a, 'a> {
         )
 }
 
-pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<(), String> {
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let staked_nodes_overrides_args = StakedNodesOverridesArgs::from_clap_arg_match(matches)?;
 
     let admin_client = admin_rpc_service::connect(ledger_path);
-    admin_rpc_service::runtime()
-        .block_on(async move {
-            admin_client
-                .await?
-                .set_staked_nodes_overrides(staked_nodes_overrides_args.path)
-                .await
-        })
-        .map_err(|err| format!("set staked nodes override request failed: {err}"))
+    admin_rpc_service::runtime().block_on(async move {
+        admin_client
+            .await?
+            .set_staked_nodes_overrides(staked_nodes_overrides_args.path)
+            .await
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -33,7 +33,8 @@ pub fn main() {
             &ledger_path,
             commands::run::execute::Operation::Initialize,
         )
-        .inspect_err(|err| error!("Failed to initialize validator: {err}")),
+        .inspect_err(|err| error!("Failed to initialize validator: {err}"))
+        .map_err(commands::Error::Dynamic),
         ("", _) | ("run", _) => commands::run::execute(
             &matches,
             solana_version,
@@ -41,7 +42,8 @@ pub fn main() {
             &ledger_path,
             commands::run::execute::Operation::Run,
         )
-        .inspect_err(|err| error!("Failed to start validator: {err}")),
+        .inspect_err(|err| error!("Failed to start validator: {err}"))
+        .map_err(commands::Error::Dynamic),
         ("authorized-voter", Some(authorized_voter_subcommand_matches)) => {
             commands::authorized_voter::execute(authorized_voter_subcommand_matches, &ledger_path)
         }


### PR DESCRIPTION
#### Problem
The command parsing and execute functions currently return a Result<T, String>. This introduces a lot of .map_err()'s into the codebase when the underlying error might already be well-formed (such as CLAP).


#### Summary of Changes
Instead, introduce a new error type that can automatically convert from the underlying error types with the ? operator