### PR TITLE
ci: use pr head instead of merge commit in some gh pipelines

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: mozilla-actions/sccache-action@v0.0.5
         with:

--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # This can be removed once cargo-ndk >= 3.5.4 is used.
       - name: Setup environment for Android NDK
@@ -62,6 +64,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust
         run: |

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -46,6 +46,8 @@ jobs:
         version: ["master"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - shell: bash
         run: |

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -57,6 +57,8 @@ jobs:
           # - token
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - shell: bash
         run: |
@@ -86,6 +88,8 @@ jobs:
           - token-2022
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - shell: bash
         run: |
@@ -125,6 +129,8 @@ jobs:
           # - token
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - shell: bash
         run: |

--- a/.github/workflows/svm-exampls.yml
+++ b/.github/workflows/svm-exampls.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - shell: bash
         run: |


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1351499670161063989

the default behavior of `actions/checkout@v4` is to merge PR changes into the master branch before starting tests. we only test for as-is in Buildkite side. I think we should keep them the same, even though we get some benefits from it. we can run merge commits when we introduce the merge group

#### Summary of Changes

add the code below to some places

```diff
        with:
          ref: ${{ github.event.pull_request.head.sha || github.sha }}
```
