### PR TITLE
Refactor: Separate TransactionRecorder from PohRecorder

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -435,12 +435,13 @@ fn main() {
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-    let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(
-        bank.clone(),
-        blockstore.clone(),
-        None,
-        Some(leader_schedule_cache),
-    );
+    let (exit, transaction_recorder, poh_recorder, poh_service, signal_receiver) =
+        create_test_recorder(
+            bank.clone(),
+            blockstore.clone(),
+            None,
+            Some(leader_schedule_cache),
+        );
     let (banking_tracer, tracer_thread) =
         BankingTracer::new(matches.is_present("trace_banking").then_some((
             &blockstore.banking_trace_path(),
@@ -467,6 +468,7 @@ fn main() {
         block_production_method,
         transaction_struct,
         &cluster_info,
+        transaction_recorder,
         &poh_recorder,
         non_vote_receiver,
         tpu_vote_receiver,

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -21,7 +21,10 @@ use {
     },
     solana_measure::measure::Measure,
     solana_perf::packet::{to_packet_batches, PacketBatch},
-    solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry},
+    solana_poh::{
+        poh_recorder::{create_test_recorder, PohRecorder},
+        working_bank_entry::WorkingBankEntry,
+    },
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
     },

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -234,7 +234,7 @@ fn bench_banking(
     let blockstore = Arc::new(
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
-    let (exit, poh_recorder, poh_service, signal_receiver) =
+    let (exit, transaction_recorder, poh_recorder, poh_service, signal_receiver) =
         create_test_recorder(bank.clone(), blockstore, None, None);
     let cluster_info = {
         let keypair = Arc::new(Keypair::new());
@@ -247,6 +247,7 @@ fn bench_banking(
         block_production_method,
         transaction_struct,
         &cluster_info,
+        transaction_recorder,
         &poh_recorder,
         non_vote_receiver,
         tpu_vote_receiver,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -7,6 +7,7 @@ use {
         banking_trace::Channels,
         validator::{BlockProductionMethod, TransactionStructure},
     },
+    solana_poh::working_bank_entry::WorkingBankEntry,
     solana_vote::vote_transaction::new_tower_sync_transaction,
     solana_vote_program::vote_state::TowerSync,
 };
@@ -28,7 +29,7 @@ use {
         get_tmp_ledger_path_auto_delete,
     },
     solana_perf::packet::to_packet_batches,
-    solana_poh::poh_recorder::{create_test_recorder, WorkingBankEntry},
+    solana_poh::poh_recorder::create_test_recorder,
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
     },

--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -18,6 +18,7 @@ use {
     solana_poh::{
         poh_recorder::{create_test_recorder, PohRecorder},
         poh_service::PohService,
+        transaction_recorder::TransactionRecorder,
     },
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -81,10 +82,9 @@ fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<Saniti
         .collect()
 }
 
-fn create_consumer(poh_recorder: &RwLock<PohRecorder>) -> Consumer {
+fn create_consumer(transaction_recorder: TransactionRecorder) -> Consumer {
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let committer = Committer::new(None, replay_vote_sender, Arc::default());
-    let transaction_recorder = poh_recorder.read().unwrap().new_recorder();
     Consumer::new(committer, transaction_recorder, QosService::new(0), None)
 }
 
@@ -93,7 +93,8 @@ struct BenchFrame {
     _bank_forks: Arc<RwLock<BankForks>>,
     ledger_path: TempDir,
     exit: Arc<AtomicBool>,
-    poh_recorder: Arc<RwLock<PohRecorder>>,
+    transaction_recorder: TransactionRecorder,
+    _poh_recorder: Arc<RwLock<PohRecorder>>,
     poh_service: PohService,
     signal_receiver: Receiver<(Arc<Bank>, (Entry, u64))>,
 }
@@ -123,7 +124,7 @@ fn setup() -> BenchFrame {
     let blockstore = Arc::new(
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
-    let (exit, poh_recorder, poh_service, signal_receiver) =
+    let (exit, transaction_recorder, poh_recorder, poh_service, signal_receiver) =
         create_test_recorder(bank.clone(), blockstore, None, None);
 
     BenchFrame {
@@ -131,7 +132,8 @@ fn setup() -> BenchFrame {
         _bank_forks: bank_forks,
         ledger_path,
         exit,
-        poh_recorder,
+        transaction_recorder,
+        _poh_recorder: poh_recorder,
         poh_service,
         signal_receiver,
     }
@@ -152,11 +154,12 @@ fn bench_process_and_record_transactions(bencher: &mut Bencher, batch_size: usiz
         _bank_forks,
         ledger_path: _ledger_path,
         exit,
-        poh_recorder,
+        transaction_recorder,
+        _poh_recorder,
         poh_service,
         signal_receiver: _signal_receiver,
     } = setup();
-    let consumer = create_consumer(&poh_recorder);
+    let consumer = create_consumer(transaction_recorder);
     let transactions = create_transactions(&bank, 2_usize.pow(20));
     let mut transaction_iter = transactions.chunks(batch_size);
 

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -726,20 +726,21 @@ impl BankingSimulator {
 
         info!("Poh is starting!");
 
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new_with_clear_signal(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            None,
-            bank.ticks_per_slot(),
-            false,
-            blockstore.clone(),
-            blockstore.get_new_shred_signal(0),
-            &leader_schedule_cache,
-            &genesis_config.poh_config,
-            None,
-            exit.clone(),
-        );
+        let (poh_recorder, transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new_with_clear_signal(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                None,
+                bank.ticks_per_slot(),
+                false,
+                blockstore.clone(),
+                blockstore.get_new_shred_signal(0),
+                &leader_schedule_cache,
+                &genesis_config.poh_config,
+                None,
+                exit.clone(),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let poh_service = PohService::new(
             poh_recorder.clone(),
@@ -823,6 +824,7 @@ impl BankingSimulator {
             block_production_method.clone(),
             transaction_struct.clone(),
             &cluster_info_for_banking,
+            transaction_recorder,
             &poh_recorder,
             non_vote_receiver,
             tpu_vote_receiver,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -757,7 +757,7 @@ mod tests {
         solana_perf::packet::to_packet_batches,
         solana_poh::{
             poh_recorder::{
-                create_test_recorder, PohRecorderError, Record, RecordTransactionsSummary,
+                create_test_recorder, PohRecordError, Record, RecordTransactionsSummary,
             },
             poh_service::PohService,
         },
@@ -1198,7 +1198,7 @@ mod tests {
         // record_transactions should throw MaxHeightReached
         let next_slot = bank.slot() + 1;
         let RecordTransactionsSummary { result, .. } = recorder.record_transactions(next_slot, txs);
-        assert_matches!(result, Err(PohRecorderError::MaxHeightReached));
+        assert_matches!(result, Err(PohRecordError::MaxHeightReached));
         // Should receive nothing from PohRecorder b/c record failed
         assert!(entry_receiver.try_recv().is_err());
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -756,9 +756,8 @@ mod tests {
         },
         solana_perf::packet::to_packet_batches,
         solana_poh::{
-            poh_recorder::{
-                create_test_recorder, PohRecordError, Record, RecordTransactionsSummary,
-            },
+            poh_record_error::PohRecordError,
+            poh_recorder::{create_test_recorder, Record, RecordTransactionsSummary},
             poh_service::PohService,
         },
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -757,8 +757,9 @@ mod tests {
         solana_perf::packet::to_packet_batches,
         solana_poh::{
             poh_record_error::PohRecordError,
-            poh_recorder::{create_test_recorder, Record, RecordTransactionsSummary},
+            poh_recorder::{create_test_recorder, RecordTransactionsSummary},
             poh_service::PohService,
+            record::Record,
         },
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -33,7 +33,7 @@ use {
     solana_ledger::blockstore_processor::TransactionStatusSender,
     solana_measure::measure_us,
     solana_perf::packet::PACKETS_PER_BATCH,
-    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder},
+    solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
         vote_sender_types::ReplayVoteSender,
@@ -756,10 +756,9 @@ mod tests {
         },
         solana_perf::packet::to_packet_batches,
         solana_poh::{
-            poh_record_error::PohRecordError,
-            poh_recorder::{create_test_recorder, RecordTransactionsSummary},
-            poh_service::PohService,
-            record::Record,
+            poh_record_error::PohRecordError, poh_recorder::create_test_recorder,
+            poh_service::PohService, record::Record,
+            transaction_recorder::RecordTransactionsSummary,
         },
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -814,18 +814,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
@@ -835,7 +835,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let (consume_sender, consume_receiver) = unbounded();
         let (consumed_sender, consumed_receiver) = unbounded();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -745,7 +745,7 @@ mod tests {
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
-        solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
+        solana_poh::{poh_recorder::PohRecorder, working_bank_entry::WorkingBankEntry},
         solana_runtime::{
             bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
             vote_sender_types::ReplayVoteReceiver,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -17,7 +17,7 @@ use {
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::poh_recorder::{
-        BankStart, PohRecorderError, RecordTransactionsSummary, RecordTransactionsTimings,
+        BankStart, PohRecordError, RecordTransactionsSummary, RecordTransactionsTimings,
         TransactionRecorder,
     },
     solana_runtime::{
@@ -67,7 +67,7 @@ pub struct ExecuteAndCommitTransactionsOutput {
     pub(crate) retryable_transaction_indexes: Vec<usize>,
     // A result that indicates whether transactions were successfully
     // committed into the Poh stream.
-    pub commit_transactions_result: Result<Vec<CommitTransactionDetails>, PohRecorderError>,
+    pub commit_transactions_result: Result<Vec<CommitTransactionDetails>, PohRecordError>,
     pub(crate) execute_and_commit_timings: LeaderExecuteAndCommitTimings,
     pub(crate) error_counters: TransactionErrorMetrics,
     pub(crate) min_prioritization_fees: u64,
@@ -352,7 +352,7 @@ impl Consumer {
                 new_commit_transactions_result,
                 should_bank_still_be_processing_txs,
             ) {
-                (Err(PohRecorderError::MaxHeightReached), _) | (_, false) => {
+                (Err(PohRecordError::MaxHeightReached), _) | (_, false) => {
                     info!(
                         "process transactions: max height reached slot: {} height: {}",
                         bank.slot(),
@@ -1115,7 +1115,7 @@ mod tests {
         assert_eq!(retryable_transaction_indexes, vec![0]);
         assert_matches!(
             commit_transactions_result,
-            Err(PohRecorderError::MaxHeightReached)
+            Err(PohRecordError::MaxHeightReached)
         );
 
         poh_recorder

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -18,8 +18,9 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_poh::{
         poh_record_error::PohRecordError,
-        poh_recorder::{
-            BankStart, RecordTransactionsSummary, RecordTransactionsTimings, TransactionRecorder,
+        poh_recorder::BankStart,
+        transaction_recorder::{
+            RecordTransactionsSummary, RecordTransactionsTimings, TransactionRecorder,
         },
     },
     solana_runtime::{

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -16,9 +16,11 @@ use {
     solana_fee::FeeFeatures,
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
-    solana_poh::poh_recorder::{
-        BankStart, PohRecordError, RecordTransactionsSummary, RecordTransactionsTimings,
-        TransactionRecorder,
+    solana_poh::{
+        poh_record_error::PohRecordError,
+        poh_recorder::{
+            BankStart, RecordTransactionsSummary, RecordTransactionsTimings, TransactionRecorder,
+        },
     },
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -916,18 +916,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         poh_recorder
@@ -943,7 +943,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
         let process_transactions_summary =
             consumer.process_transactions(&bank, &Instant::now(), &transactions);
 
@@ -1021,18 +1021,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1047,7 +1047,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let process_transactions_batch_output =
             consumer.process_and_record_transactions(&bank, &transactions, 0);
@@ -1168,18 +1168,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::new(false)),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::new(false)),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         fn poh_tick_before_returning_record_response(
@@ -1234,7 +1234,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let process_transactions_batch_output =
             consumer.process_and_record_transactions(&bank, &transactions, 0);
@@ -1309,18 +1309,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1335,7 +1335,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let process_transactions_batch_output =
             consumer.process_and_record_transactions(&bank, &transactions, 0);
@@ -1385,18 +1385,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1411,7 +1411,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let get_block_cost = || bank.read_cost_tracker().unwrap().block_cost();
         let get_tx_count = || bank.read_cost_tracker().unwrap().transaction_count();
@@ -1543,18 +1543,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         poh_recorder
@@ -1570,7 +1570,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let process_transactions_batch_output =
             consumer.process_and_record_transactions(&bank, &transactions, 0);
@@ -1748,22 +1748,21 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
 
         // Poh Recorder has no working bank, so should throw MaxHeightReached error on
         // record
-        let recorder = poh_recorder.new_recorder();
-
         let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
@@ -1772,7 +1771,12 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder.clone(), QosService::new(1), None);
+        let consumer = Consumer::new(
+            committer,
+            transaction_recorder.clone(),
+            QosService::new(1),
+            None,
+        );
 
         let process_transactions_summary =
             consumer.process_transactions(&bank, &Instant::now(), &transactions);
@@ -1799,7 +1803,9 @@ mod tests {
         let expected: Vec<usize> = (0..transactions.len()).collect();
         assert_eq!(retryable_transaction_indexes, expected);
 
-        recorder.is_exited.store(true, Ordering::Relaxed);
+        transaction_recorder
+            .is_exited
+            .store(true, Ordering::Relaxed);
         let _ = poh_simulator.join();
     }
 
@@ -1846,18 +1852,18 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            blockstore.clone(),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                blockstore.clone(),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1898,7 +1904,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let _ = consumer.process_and_record_transactions(&bank, &transactions, 0);
 
@@ -1990,18 +1996,18 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            blockstore.clone(),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
-        let recorder = poh_recorder.new_recorder();
+        let (poh_recorder, transaction_recorder, _entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                blockstore.clone(),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -2042,7 +2048,7 @@ mod tests {
             replay_vote_sender,
             Arc::new(PrioritizationFeeCache::new(0u64)),
         );
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, transaction_recorder, QosService::new(1), None);
 
         let _ = consumer.process_and_record_transactions(&bank, &[sanitized_tx.clone()], 0);
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -864,7 +864,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             leader_schedule_cache::LeaderScheduleCache,
         },
-        solana_poh::poh_recorder::{PohRecorder, Record},
+        solana_poh::{poh_recorder::PohRecorder, record::Record},
         solana_rpc::transaction_status_service::TransactionStatusService,
         solana_runtime::prioritization_fee_cache::PrioritizationFeeCache,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -175,7 +175,7 @@ mod tests {
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let ledger_path = temp_dir();
         let blockstore = Arc::new(Blockstore::open(ledger_path.as_path()).unwrap());
-        let (exit, poh_recorder, poh_service, _entry_receiver) =
+        let (exit, _transaction_recorder, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(bank.clone(), blockstore, None, None);
         // Drop the poh service immediately to avoid potential ticking
         exit.store(true, Ordering::Relaxed);

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -1,5 +1,5 @@
 use {
-    solana_poh::poh_recorder::RecordTransactionsTimings, solana_sdk::clock::Slot,
+    solana_poh::transaction_recorder::RecordTransactionsTimings, solana_sdk::clock::Slot,
     solana_timings::ExecuteTimings, std::time::Instant,
 };
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -424,17 +424,18 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((4, 4)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
+        let (poh_recorder, _transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let decision_maker = DecisionMaker::new(Pubkey::new_unique(), poh_recorder.clone());
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -354,7 +354,10 @@ mod tests {
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
         solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
-        solana_poh::poh_recorder::{PohRecorder, Record, WorkingBankEntry},
+        solana_poh::{
+            poh_recorder::{PohRecorder, Record},
+            working_bank_entry::WorkingBankEntry,
+        },
         solana_runtime::bank::Bank,
         solana_runtime_transaction::transaction_meta::StaticMeta,
         solana_sdk::{

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -355,8 +355,7 @@ mod tests {
         },
         solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
         solana_poh::{
-            poh_recorder::{PohRecorder, Record},
-            working_bank_entry::WorkingBankEntry,
+            poh_recorder::PohRecorder, record::Record, working_bank_entry::WorkingBankEntry,
         },
         solana_runtime::bank::Bank,
         solana_runtime_transaction::transaction_meta::StaticMeta,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -34,7 +34,7 @@ use {
     },
     crate::banking_trace::Channels,
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    solana_poh::poh_recorder::PohRecorder,
+    solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache},
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::sync::{Arc, RwLock},
@@ -47,12 +47,12 @@ pub(crate) fn ensure_banking_stage_setup(
     bank_forks: &Arc<RwLock<BankForks>>,
     channels: &Channels,
     cluster_info: &impl LikeClusterInfo,
+    transaction_recorder: TransactionRecorder,
     poh_recorder: &Arc<RwLock<PohRecorder>>,
 ) {
     let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
     let unified_receiver = channels.unified_receiver().clone();
     let mut decision_maker = DecisionMaker::new(cluster_info.id(), poh_recorder.clone());
-    let transaction_recorder = poh_recorder.read().unwrap().new_recorder();
 
     let banking_packet_handler = Box::new(
         move |helper: &BankingStageHelper, batches: BankingPacketBatch| {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,7 @@ use {
         entry_notifier_service::EntryNotifierSender,
     },
     solana_perf::data_budget::DataBudget,
-    solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
+    solana_poh::{poh_recorder::PohRecorder, working_bank_entry::WorkingBankEntry},
     solana_rpc::{
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,10 @@ use {
         entry_notifier_service::EntryNotifierSender,
     },
     solana_perf::data_budget::DataBudget,
-    solana_poh::{poh_recorder::PohRecorder, working_bank_entry::WorkingBankEntry},
+    solana_poh::{
+        poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder,
+        working_bank_entry::WorkingBankEntry,
+    },
     solana_rpc::{
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,
@@ -90,6 +93,7 @@ impl Tpu {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
+        transaction_recorder: TransactionRecorder,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntry>,
         retransmit_slots_receiver: Receiver<Slot>,
@@ -264,6 +268,7 @@ impl Tpu {
             block_production_method,
             transaction_struct,
             cluster_info,
+            transaction_recorder,
             poh_recorder,
             non_vote_receiver,
             tpu_vote_receiver,

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -2,7 +2,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_entry::entry::EntrySummary,
     solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::working_bank_entry::WorkingBankEntry,
     std::{
         sync::{
             atomic::{AtomicBool, Ordering},

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -496,7 +496,7 @@ pub mod tests {
             .expect("Expected to successfully open ledger");
         let blockstore = Arc::new(blockstore);
         let bank = bank_forks.read().unwrap().working_bank();
-        let (exit, poh_recorder, poh_service, _entry_receiver) =
+        let (exit, _transaction_recorder, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(bank.clone(), blockstore.clone(), None, None);
         let vote_keypair = Keypair::new();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -950,7 +950,7 @@ impl Validator {
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let startup_verification_complete;
-        let (poh_recorder, entry_receiver, record_receiver) = {
+        let (poh_recorder, transaction_recorder, entry_receiver, record_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
             startup_verification_complete = Arc::clone(bank.get_startup_verification_complete());
             PohRecorder::new_with_clear_signal(
@@ -1555,6 +1555,7 @@ impl Validator {
 
         let (tpu, mut key_notifies) = Tpu::new(
             &cluster_info,
+            transaction_recorder,
             &poh_recorder,
             entry_receiver,
             retransmit_slots_receiver,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -223,12 +223,13 @@ fn test_scheduler_producing_blocks() {
     let genesis_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     genesis_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&genesis_bank));
-    let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(
-        genesis_bank.clone(),
-        blockstore.clone(),
-        None,
-        Some(leader_schedule_cache),
-    );
+    let (exit, transaction_recorder, poh_recorder, poh_service, signal_receiver) =
+        create_test_recorder(
+            genesis_bank.clone(),
+            blockstore.clone(),
+            None,
+            Some(leader_schedule_cache),
+        );
     let pool = DefaultSchedulerPool::new(None, None, None, None, ignored_prioritization_fee_cache);
     let channels = {
         let banking_tracer = BankingTracer::new_disabled();
@@ -243,7 +244,14 @@ fn test_scheduler_producing_blocks() {
             SocketAddrSpace::Unspecified,
         ))
     };
-    ensure_banking_stage_setup(&pool, &bank_forks, &channels, &cluster_info, &poh_recorder);
+    ensure_banking_stage_setup(
+        &pool,
+        &bank_forks,
+        &channels,
+        &cluster_info,
+        transaction_recorder,
+        &poh_recorder,
+    );
     bank_forks.write().unwrap().install_scheduler_pool(pool);
 
     // Wait until genesis_bank reaches its tick height...

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -86,17 +86,18 @@ fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let prev_hash = bank.last_blockhash();
 
-    let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
-        0,
-        prev_hash,
-        bank.clone(),
-        Some((4, 4)),
-        bank.ticks_per_slot(),
-        Arc::new(blockstore),
-        &std::sync::Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-        &PohConfig::default(),
-        Arc::new(AtomicBool::default()),
-    );
+    let (mut poh_recorder, _transaction_recorder, _entry_receiver, _record_receiver) =
+        PohRecorder::new(
+            0,
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &std::sync::Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
     let h1 = hash(b"hello Agave, hello Anza!");
 
     poh_recorder.set_bank_with_transaction_index_for_test(bank.clone());
@@ -136,17 +137,18 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let prev_hash = bank.last_blockhash();
 
-    let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
-        0,
-        prev_hash,
-        bank.clone(),
-        Some((4, 4)),
-        bank.ticks_per_slot(),
-        Arc::new(blockstore),
-        &std::sync::Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-        &PohConfig::default(),
-        Arc::new(AtomicBool::default()),
-    );
+    let (mut poh_recorder, _transaction_recorder, _entry_receiver, _record_receiver) =
+        PohRecorder::new(
+            0,
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &std::sync::Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
     bencher.iter(|| {
         poh_recorder.set_bank_with_transaction_index_for_test(bank.clone());
         poh_recorder.tick();

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -4,6 +4,7 @@ pub mod poh_record_error;
 pub mod poh_recorder;
 pub mod poh_service;
 pub mod record;
+pub mod transaction_recorder;
 pub mod working_bank_entry;
 
 #[macro_use]

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -3,6 +3,7 @@ pub mod leader_bank_notifier;
 pub mod poh_record_error;
 pub mod poh_recorder;
 pub mod poh_service;
+pub mod record;
 pub mod working_bank_entry;
 
 #[macro_use]

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod leader_bank_notifier;
+pub mod poh_record_error;
 pub mod poh_recorder;
 pub mod poh_service;
+pub mod working_bank_entry;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/poh/src/poh_record_error.rs
+++ b/poh/src/poh_record_error.rs
@@ -1,0 +1,15 @@
+use {crate::working_bank_entry::WorkingBankEntry, crossbeam_channel::SendError, thiserror::Error};
+
+pub(crate) type Result<T> = std::result::Result<T, PohRecordError>;
+
+#[derive(Error, Debug, Clone)]
+pub enum PohRecordError {
+    #[error("max height reached")]
+    MaxHeightReached,
+
+    #[error("min height not reached")]
+    MinHeightNotReached,
+
+    #[error("send WorkingBankEntry error")]
+    SendError(#[from] SendError<WorkingBankEntry>),
+}

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -11,7 +11,12 @@
 //! * recorded entry must be >= WorkingBank::min_tick_height && entry must be < WorkingBank::max_tick_height
 //!
 use {
-    crate::{leader_bank_notifier::LeaderBankNotifier, poh_service::PohService},
+    crate::{
+        leader_bank_notifier::LeaderBankNotifier,
+        poh_record_error::{PohRecordError, Result},
+        poh_service::PohService,
+        working_bank_entry::WorkingBankEntry,
+    },
     crossbeam_channel::{
         bounded, unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError,
     },
@@ -38,27 +43,10 @@ use {
         },
         time::{Duration, Instant},
     },
-    thiserror::Error,
 };
 
 pub const GRACE_TICKS_FACTOR: u64 = 2;
 pub const MAX_GRACE_SLOTS: u64 = 2;
-
-#[derive(Error, Debug, Clone)]
-pub enum PohRecordError {
-    #[error("max height reached")]
-    MaxHeightReached,
-
-    #[error("min height not reached")]
-    MinHeightNotReached,
-
-    #[error("send WorkingBankEntry error")]
-    SendError(#[from] SendError<WorkingBankEntry>),
-}
-
-type Result<T> = std::result::Result<T, PohRecordError>;
-
-pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));
 
 #[derive(Debug, Clone)]
 pub struct BankStart {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -16,17 +16,13 @@ use {
         poh_record_error::{PohRecordError, Result},
         poh_service::PohService,
         record::Record,
+        transaction_recorder::TransactionRecorder,
         working_bank_entry::WorkingBankEntry,
     },
-    crossbeam_channel::{
-        bounded, unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError,
-    },
+    crossbeam_channel::{unbounded, Receiver, SendError, Sender, TrySendError},
     log::*,
     solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-    solana_entry::{
-        entry::{hash_transactions, Entry},
-        poh::Poh,
-    },
+    solana_entry::{entry::Entry, poh::Poh},
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_measure::measure_us,
@@ -37,12 +33,8 @@ use {
     solana_transaction::versioned::VersionedTransaction,
     std::{
         cmp,
-        num::Saturating,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc, Mutex, RwLock,
-        },
-        time::{Duration, Instant},
+        sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+        time::Instant,
     },
 };
 
@@ -61,133 +53,6 @@ impl BankStart {
             &self.bank_creation_time,
             self.working_bank.ns_per_slot,
         )
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct RecordTransactionsTimings {
-    pub processing_results_to_transactions_us: Saturating<u64>,
-    pub hash_us: Saturating<u64>,
-    pub poh_record_us: Saturating<u64>,
-}
-
-impl RecordTransactionsTimings {
-    pub fn accumulate(&mut self, other: &RecordTransactionsTimings) {
-        self.processing_results_to_transactions_us += other.processing_results_to_transactions_us;
-        self.hash_us += other.hash_us;
-        self.poh_record_us += other.poh_record_us;
-    }
-}
-
-pub struct RecordTransactionsSummary {
-    // Metrics describing how time was spent recording transactions
-    pub record_transactions_timings: RecordTransactionsTimings,
-    // Result of trying to record the transactions into the PoH stream
-    pub result: Result<()>,
-    // Index in the slot of the first transaction recorded
-    pub starting_transaction_index: Option<usize>,
-}
-
-#[derive(Clone, Debug)]
-pub struct TransactionRecorder {
-    // shared by all users of PohRecorder
-    pub record_sender: Sender<Record>,
-    pub is_exited: Arc<AtomicBool>,
-}
-
-impl TransactionRecorder {
-    pub fn new(record_sender: Sender<Record>, is_exited: Arc<AtomicBool>) -> Self {
-        Self {
-            record_sender,
-            is_exited,
-        }
-    }
-
-    /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.
-    /// Panics on unexpected (non-`MaxHeightReached`) errors.
-    pub fn record_transactions(
-        &self,
-        bank_slot: Slot,
-        transactions: Vec<VersionedTransaction>,
-    ) -> RecordTransactionsSummary {
-        let mut record_transactions_timings = RecordTransactionsTimings::default();
-        let mut starting_transaction_index = None;
-
-        if !transactions.is_empty() {
-            let (hash, hash_us) = measure_us!(hash_transactions(&transactions));
-            record_transactions_timings.hash_us = Saturating(hash_us);
-
-            let (res, poh_record_us) = measure_us!(self.record(bank_slot, hash, transactions));
-            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
-
-            match res {
-                Ok(starting_index) => {
-                    starting_transaction_index = starting_index;
-                }
-                Err(PohRecordError::MaxHeightReached) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecordError::MaxHeightReached),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(PohRecordError::SendError(e)) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecordError::SendError(e)),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
-            }
-        }
-
-        RecordTransactionsSummary {
-            record_transactions_timings,
-            result: Ok(()),
-            starting_transaction_index,
-        }
-    }
-
-    // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
-    pub fn record(
-        &self,
-        bank_slot: Slot,
-        mixin: Hash,
-        transactions: Vec<VersionedTransaction>,
-    ) -> Result<Option<usize>> {
-        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
-        let (result_sender, result_receiver) = bounded(1);
-        let res =
-            self.record_sender
-                .send(Record::new(mixin, transactions, bank_slot, result_sender));
-        if res.is_err() {
-            // If the channel is dropped, then the validator is shutting down so return that we are hitting
-            //  the max tick height to stop transaction processing and flush any transactions in the pipeline.
-            return Err(PohRecordError::MaxHeightReached);
-        }
-        // Besides validator exit, this timeout should primarily be seen to affect test execution environments where the various pieces can be shutdown abruptly
-        let mut is_exited = false;
-        loop {
-            let res = result_receiver.recv_timeout(Duration::from_millis(1000));
-            match res {
-                Err(RecvTimeoutError::Timeout) => {
-                    if is_exited {
-                        return Err(PohRecordError::MaxHeightReached);
-                    } else {
-                        // A result may have come in between when we timed out checking this
-                        // bool, so check the channel again, even if is_exited == true
-                        is_exited = self.is_exited.load(Ordering::SeqCst);
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    return Err(PohRecordError::MaxHeightReached);
-                }
-                Ok(result) => {
-                    return result;
-                }
-            }
-        }
     }
 }
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -15,6 +15,7 @@ use {
         leader_bank_notifier::LeaderBankNotifier,
         poh_record_error::{PohRecordError, Result},
         poh_service::PohService,
+        record::Record,
         working_bank_entry::WorkingBankEntry,
     },
     crossbeam_channel::{
@@ -60,32 +61,6 @@ impl BankStart {
             &self.bank_creation_time,
             self.working_bank.ns_per_slot,
         )
-    }
-}
-
-// Sends the Result of the record operation, including the index in the slot of the first
-// transaction, if being tracked by WorkingBank
-type RecordResultSender = Sender<Result<Option<usize>>>;
-
-pub struct Record {
-    pub mixin: Hash,
-    pub transactions: Vec<VersionedTransaction>,
-    pub slot: Slot,
-    pub sender: RecordResultSender,
-}
-impl Record {
-    pub fn new(
-        mixin: Hash,
-        transactions: Vec<VersionedTransaction>,
-        slot: Slot,
-        sender: RecordResultSender,
-    ) -> Self {
-        Self {
-            mixin,
-            transactions,
-            slot,
-            sender,
-        }
     }
 }
 

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -416,17 +416,18 @@ mod tests {
         let ticks_per_slot = bank.ticks_per_slot();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
-            bank.tick_height(),
-            prev_hash,
-            bank.clone(),
-            Some((4, 4)),
-            ticks_per_slot,
-            blockstore,
-            &leader_schedule_cache,
-            &poh_config,
-            exit.clone(),
-        );
+        let (poh_recorder, _transaction_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new(
+                bank.tick_height(),
+                prev_hash,
+                bank.clone(),
+                Some((4, 4)),
+                ticks_per_slot,
+                blockstore,
+                &leader_schedule_cache,
+                &poh_config,
+                exit.clone(),
+            );
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let ticks_per_slot = bank.ticks_per_slot();
         let bank_slot = bank.slot();

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -1,7 +1,7 @@
 //! The `poh_service` module implements a service that records the passing of
 //! "ticks", a measure of time in the PoH stream
 use {
-    crate::poh_recorder::{PohRecorder, Record},
+    crate::{poh_recorder::PohRecorder, record::Record},
     crossbeam_channel::Receiver,
     log::*,
     solana_entry::poh::Poh,

--- a/poh/src/record.rs
+++ b/poh/src/record.rs
@@ -1,0 +1,30 @@
+use {
+    crate::poh_record_error::Result, crossbeam_channel::Sender, solana_clock::Slot,
+    solana_hash::Hash, solana_transaction::versioned::VersionedTransaction,
+};
+
+// Sends the Result of the record operation, including the index in the slot of the first
+// transaction, if being tracked by WorkingBank
+type RecordResultSender = Sender<Result<Option<usize>>>;
+
+pub struct Record {
+    pub mixin: Hash,
+    pub transactions: Vec<VersionedTransaction>,
+    pub slot: Slot,
+    pub sender: RecordResultSender,
+}
+impl Record {
+    pub fn new(
+        mixin: Hash,
+        transactions: Vec<VersionedTransaction>,
+        slot: Slot,
+        sender: RecordResultSender,
+    ) -> Self {
+        Self {
+            mixin,
+            transactions,
+            slot,
+            sender,
+        }
+    }
+}

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -1,0 +1,147 @@
+use {
+    crate::{
+        poh_record_error::{PohRecordError, Result},
+        record::Record,
+    },
+    crossbeam_channel::{bounded, RecvTimeoutError, Sender},
+    solana_clock::Slot,
+    solana_entry::entry::hash_transactions,
+    solana_hash::Hash,
+    solana_measure::measure_us,
+    solana_transaction::versioned::VersionedTransaction,
+    std::{
+        num::Saturating,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+};
+
+#[derive(Default, Debug)]
+pub struct RecordTransactionsTimings {
+    pub processing_results_to_transactions_us: Saturating<u64>,
+    pub hash_us: Saturating<u64>,
+    pub poh_record_us: Saturating<u64>,
+}
+
+impl RecordTransactionsTimings {
+    pub fn accumulate(&mut self, other: &RecordTransactionsTimings) {
+        self.processing_results_to_transactions_us += other.processing_results_to_transactions_us;
+        self.hash_us += other.hash_us;
+        self.poh_record_us += other.poh_record_us;
+    }
+}
+
+pub struct RecordTransactionsSummary {
+    // Metrics describing how time was spent recording transactions
+    pub record_transactions_timings: RecordTransactionsTimings,
+    // Result of trying to record the transactions into the PoH stream
+    pub result: Result<()>,
+    // Index in the slot of the first transaction recorded
+    pub starting_transaction_index: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TransactionRecorder {
+    // shared by all users of PohRecorder
+    pub record_sender: Sender<Record>,
+    pub is_exited: Arc<AtomicBool>,
+}
+
+impl TransactionRecorder {
+    pub fn new(record_sender: Sender<Record>, is_exited: Arc<AtomicBool>) -> Self {
+        Self {
+            record_sender,
+            is_exited,
+        }
+    }
+
+    /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.
+    /// Panics on unexpected (non-`MaxHeightReached`) errors.
+    pub fn record_transactions(
+        &self,
+        bank_slot: Slot,
+        transactions: Vec<VersionedTransaction>,
+    ) -> RecordTransactionsSummary {
+        let mut record_transactions_timings = RecordTransactionsTimings::default();
+        let mut starting_transaction_index = None;
+
+        if !transactions.is_empty() {
+            let (hash, hash_us) = measure_us!(hash_transactions(&transactions));
+            record_transactions_timings.hash_us = Saturating(hash_us);
+
+            let (res, poh_record_us) = measure_us!(self.record(bank_slot, hash, transactions));
+            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
+
+            match res {
+                Ok(starting_index) => {
+                    starting_transaction_index = starting_index;
+                }
+                Err(PohRecordError::MaxHeightReached) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecordError::MaxHeightReached),
+                        starting_transaction_index: None,
+                    };
+                }
+                Err(PohRecordError::SendError(e)) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecordError::SendError(e)),
+                        starting_transaction_index: None,
+                    };
+                }
+                Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
+            }
+        }
+
+        RecordTransactionsSummary {
+            record_transactions_timings,
+            result: Ok(()),
+            starting_transaction_index,
+        }
+    }
+
+    // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
+    pub fn record(
+        &self,
+        bank_slot: Slot,
+        mixin: Hash,
+        transactions: Vec<VersionedTransaction>,
+    ) -> Result<Option<usize>> {
+        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
+        let (result_sender, result_receiver) = bounded(1);
+        let res =
+            self.record_sender
+                .send(Record::new(mixin, transactions, bank_slot, result_sender));
+        if res.is_err() {
+            // If the channel is dropped, then the validator is shutting down so return that we are hitting
+            //  the max tick height to stop transaction processing and flush any transactions in the pipeline.
+            return Err(PohRecordError::MaxHeightReached);
+        }
+        // Besides validator exit, this timeout should primarily be seen to affect test execution environments where the various pieces can be shutdown abruptly
+        let mut is_exited = false;
+        loop {
+            let res = result_receiver.recv_timeout(Duration::from_millis(1000));
+            match res {
+                Err(RecvTimeoutError::Timeout) => {
+                    if is_exited {
+                        return Err(PohRecordError::MaxHeightReached);
+                    } else {
+                        // A result may have come in between when we timed out checking this
+                        // bool, so check the channel again, even if is_exited == true
+                        is_exited = self.is_exited.load(Ordering::SeqCst);
+                    }
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(PohRecordError::MaxHeightReached);
+                }
+                Ok(result) => {
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/poh/src/working_bank_entry.rs
+++ b/poh/src/working_bank_entry.rs
@@ -1,0 +1,3 @@
+use {solana_entry::entry::Entry, solana_runtime::bank::Bank, std::sync::Arc};
+
+pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -171,17 +171,18 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
-            0,
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((2, 2)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
+        let (poh_recorder, _transaction_recorder, _entry_receiver, _record_receiver) =
+            PohRecorder::new(
+                0,
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((2, 2)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
 
         let validator0_contact_info = ContactInfo::new_localhost(
             &validator_vote_keypairs0.node_keypair.pubkey(),
@@ -233,17 +234,18 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
-            0,
-            bank.last_blockhash(),
-            bank.clone(),
-            Some((2, 2)),
-            bank.ticks_per_slot(),
-            Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
-            &PohConfig::default(),
-            Arc::new(AtomicBool::default()),
-        );
+        let (poh_recorder, _transaction_recorder, _entry_receiver, _record_receiver) =
+            PohRecorder::new(
+                0,
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((2, 2)),
+                bank.ticks_per_slot(),
+                Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &PohConfig::default(),
+                Arc::new(AtomicBool::default()),
+            );
 
         let node_keypair = Arc::new(Keypair::new());
         let cluster_info = Arc::new(ClusterInfo::new(

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -22,7 +22,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::{inc_new_counter_error, inc_new_counter_info},
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::working_bank_entry::WorkingBankEntry,
     solana_runtime::{bank::MAX_LEADER_SCHEDULE_STAKES, bank_forks::BankForks},
     solana_sdk::{
         clock::Slot,

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -7,7 +7,7 @@ use {
         blockstore::Blockstore,
         shred::{self, ShredData},
     },
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::working_bank_entry::WorkingBankEntry,
     solana_runtime::bank::Bank,
     solana_sdk::{clock::Slot, hash::Hash},
     std::{

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -26,7 +26,7 @@ use {
     solana_ledger::blockstore_processor::{
         execute_batch, TransactionBatchWithIndexes, TransactionStatusSender,
     },
-    solana_poh::poh_recorder::{RecordTransactionsSummary, TransactionRecorder},
+    solana_poh::transaction_recorder::{RecordTransactionsSummary, TransactionRecorder},
     solana_pubkey::Pubkey,
     solana_runtime::{
         installed_scheduler_pool::{

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -3162,7 +3162,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
-        let (exit, poh_recorder, poh_service, _signal_receiver) = {
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) = {
             // Create a dummy bank to prevent it from being frozen; otherwise, the following panic
             // will happen:
             //    thread 'solPohTickProd' panicked at runtime/src/bank.rs:LL:CC:
@@ -3181,7 +3181,7 @@ mod tests {
             pool.register_banking_stage(
                 banking_packet_receiver,
                 Box::new(|_, _| unreachable!()),
-                poh_recorder.read().unwrap().new_recorder(),
+                transaction_recorder,
             );
         }
 
@@ -3650,7 +3650,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, signal_receiver) =
+        let (exit, transaction_recorder, poh_recorder, poh_service, signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3665,7 +3665,7 @@ mod tests {
             banking_packet_receiver: never(),
             banking_packet_handler: Box::new(|_, _| {}),
             banking_stage_helper: None,
-            transaction_recorder: Some(poh_recorder.read().unwrap().new_recorder()),
+            transaction_recorder: Some(transaction_recorder),
         };
 
         let task =
@@ -3748,7 +3748,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3759,7 +3759,7 @@ mod tests {
             banking_packet_receiver,
             // we don't use the banking packet channel in this test. so, pass panicking handler.
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         assert_eq!(bank.transaction_count(), 0);
@@ -3804,7 +3804,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3833,7 +3833,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             fixed_banking_packet_handler,
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Confirm the banking packet channel is cleared, even before taking scheduler
@@ -3875,7 +3875,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3899,7 +3899,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             fixed_banking_packet_handler,
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Quickly take and return the scheduler so that this test can test the behavior while
@@ -3960,7 +3960,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3971,7 +3971,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         let context = SchedulingContext::for_production(bank.clone());
@@ -4011,7 +4011,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -4023,7 +4023,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         let context = SchedulingContext::for_production(bank);
@@ -4066,7 +4066,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, transaction_recorder, _poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -4076,7 +4076,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Make sure the assertion in BlockProductionSchedulerInner::can_put() doesn't cause false


### PR DESCRIPTION
#### Problem
- PohRecorder has too many responsibilities:
    - holding a channel to copy for transaction recording
    - actual recording into the poh stream
    - controlling poh slot/bank state
    - providing access to working bank
- Design makes it difficult to reason about structural changes to how we record transactions

#### Summary of Changes
- First refactor steps aiming to separate responsibilities out of `PohRecorder`.
- This PR separates `TransactionRecorder` from `PohRecorder`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
