### PR TITLE
Refactor: Separate TransactionRecorder from PohRecorder

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -432,12 +432,13 @@ fn main() {
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-    let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(
-        bank.clone(),
-        blockstore.clone(),
-        None,
-        Some(leader_schedule_cache),
-    );
+    let (exit, poh_recorder, transaction_recorder, poh_service, signal_receiver) =
+        create_test_recorder(
+            bank.clone(),
+            blockstore.clone(),
+            None,
+            Some(leader_schedule_cache),
+        );
     let (banking_tracer, tracer_thread) =
         BankingTracer::new(matches.is_present("trace_banking").then_some((
             &blockstore.banking_trace_path(),
@@ -465,6 +466,7 @@ fn main() {
         transaction_struct,
         &cluster_info,
         &poh_recorder,
+        transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,
         gossip_vote_receiver,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -233,7 +233,7 @@ fn bench_banking(
     let blockstore = Arc::new(
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
     );
-    let (exit, poh_recorder, poh_service, signal_receiver) =
+    let (exit, poh_recorder, transaction_recorder, poh_service, signal_receiver) =
         create_test_recorder(bank.clone(), blockstore, None, None);
     let cluster_info = {
         let keypair = Arc::new(Keypair::new());
@@ -247,6 +247,7 @@ fn bench_banking(
         transaction_struct,
         &cluster_info,
         &poh_recorder,
+        transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,
         gossip_vote_receiver,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -913,7 +913,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -924,7 +924,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         poh_recorder
@@ -1018,7 +1019,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1029,7 +1030,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1165,7 +1167,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1176,7 +1178,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::new(false)),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         fn poh_tick_before_returning_record_response(
@@ -1306,7 +1309,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1317,7 +1320,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1382,7 +1386,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1393,7 +1397,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1540,7 +1545,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1551,7 +1556,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         poh_recorder
@@ -1745,7 +1751,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1759,7 +1765,8 @@ mod tests {
 
         // Poh Recorder has no working bank, so should throw MaxHeightReached error on
         // record
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
 
         let poh_simulator = simulate_poh(record_receiver, &Arc::new(RwLock::new(poh_recorder)));
 
@@ -1843,7 +1850,7 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1854,7 +1861,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
@@ -1987,7 +1995,7 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -1998,7 +2006,8 @@ mod tests {
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
-        let recorder = poh_recorder.new_recorder();
+        let (record_sender, record_receiver) = unbounded();
+        let recorder = TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let poh_simulator = simulate_poh(record_receiver, &poh_recorder);

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -175,7 +175,7 @@ mod tests {
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let ledger_path = temp_dir();
         let blockstore = Arc::new(Blockstore::open(ledger_path.as_path()).unwrap());
-        let (exit, poh_recorder, poh_service, _entry_receiver) =
+        let (exit, poh_recorder, _transaction_recorder, poh_service, _entry_receiver) =
             create_test_recorder(bank.clone(), blockstore, None, None);
         // Drop the poh service immediately to avoid potential ticking
         exit.store(true, Ordering::Relaxed);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -354,7 +354,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
         solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
-        solana_poh::poh_recorder::{PohRecorder, Record, WorkingBankEntry},
+        solana_poh::poh_recorder::PohRecorder,
         solana_runtime::bank::Bank,
         solana_runtime_transaction::transaction_meta::StaticMeta,
         solana_sdk::{
@@ -377,8 +377,6 @@ mod tests {
         bank: Arc<Bank>,
         mint_keypair: Keypair,
         _ledger_path: TempDir,
-        _entry_receiver: Receiver<WorkingBankEntry>,
-        _record_receiver: Receiver<Record>,
         poh_recorder: Arc<RwLock<PohRecorder>>,
         banking_packet_sender: Sender<Arc<Vec<PacketBatch>>>,
 
@@ -422,7 +420,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.clone(),
@@ -447,8 +445,6 @@ mod tests {
             bank,
             mint_keypair,
             _ledger_path: ledger_path,
-            _entry_receiver: entry_receiver,
-            _record_receiver: record_receiver,
             poh_recorder,
             banking_packet_sender,
             consume_work_receivers,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -34,7 +34,7 @@ use {
     },
     crate::banking_trace::Channels,
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    solana_poh::poh_recorder::PohRecorder,
+    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder},
     solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache},
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::sync::{Arc, RwLock},
@@ -48,11 +48,11 @@ pub(crate) fn ensure_banking_stage_setup(
     channels: &Channels,
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &Arc<RwLock<PohRecorder>>,
+    transaction_recorder: TransactionRecorder,
 ) {
     let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
     let unified_receiver = channels.unified_receiver().clone();
     let mut decision_maker = DecisionMaker::new(cluster_info.id(), poh_recorder.clone());
-    let transaction_recorder = poh_recorder.read().unwrap().new_recorder();
 
     let banking_packet_handler = Box::new(
         move |helper: &BankingStageHelper, batches: BankingPacketBatch| {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,7 @@ use {
         entry_notifier_service::EntryNotifierSender,
     },
     solana_perf::data_budget::DataBudget,
-    solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
+    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder, WorkingBankEntry},
     solana_rpc::{
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,
@@ -91,6 +91,7 @@ impl Tpu {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
+        transaction_recorder: TransactionRecorder,
         entry_receiver: Receiver<WorkingBankEntry>,
         retransmit_slots_receiver: Receiver<Slot>,
         sockets: TpuSockets,
@@ -265,6 +266,7 @@ impl Tpu {
             transaction_struct,
             cluster_info,
             poh_recorder,
+            transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -496,7 +496,7 @@ pub mod tests {
             .expect("Expected to successfully open ledger");
         let blockstore = Arc::new(blockstore);
         let bank = bank_forks.read().unwrap().working_bank();
-        let (exit, poh_recorder, poh_service, _entry_receiver) =
+        let (exit, poh_recorder, _transaction_recorder, poh_service, _entry_receiver) =
             create_test_recorder(bank.clone(), blockstore.clone(), None, None);
         let vote_keypair = Keypair::new();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -76,7 +76,7 @@ use {
         datapoint_info, metrics::metrics_config_sanity_check, poh_timing_point::PohTimingSender,
     },
     solana_poh::{
-        poh_recorder::PohRecorder,
+        poh_recorder::{PohRecorder, TransactionRecorder},
         poh_service::{self, PohService},
     },
     solana_rayon_threadlimit::{get_max_thread_count, get_thread_count},
@@ -950,7 +950,7 @@ impl Validator {
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let startup_verification_complete;
-        let (poh_recorder, entry_receiver, record_receiver) = {
+        let (poh_recorder, entry_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
             startup_verification_complete = Arc::clone(bank.get_startup_verification_complete());
             PohRecorder::new_with_clear_signal(
@@ -968,6 +968,9 @@ impl Validator {
                 exit.clone(),
             )
         };
+        let (record_sender, record_receiver) = unbounded();
+        let transaction_recorder =
+            TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let (banking_tracer, tracer_thread) =
@@ -1556,6 +1559,7 @@ impl Validator {
         let (tpu, mut key_notifies) = Tpu::new(
             &cluster_info,
             &poh_recorder,
+            transaction_recorder,
             entry_receiver,
             retransmit_slots_receiver,
             TpuSockets {

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -223,12 +223,13 @@ fn test_scheduler_producing_blocks() {
     let genesis_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     genesis_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&genesis_bank));
-    let (exit, poh_recorder, poh_service, signal_receiver) = create_test_recorder(
-        genesis_bank.clone(),
-        blockstore.clone(),
-        None,
-        Some(leader_schedule_cache),
-    );
+    let (exit, poh_recorder, transaction_recorder, poh_service, signal_receiver) =
+        create_test_recorder(
+            genesis_bank.clone(),
+            blockstore.clone(),
+            None,
+            Some(leader_schedule_cache),
+        );
     let pool = DefaultSchedulerPool::new(None, None, None, None, ignored_prioritization_fee_cache);
     let channels = {
         let banking_tracer = BankingTracer::new_disabled();
@@ -243,7 +244,14 @@ fn test_scheduler_producing_blocks() {
             SocketAddrSpace::Unspecified,
         ))
     };
-    ensure_banking_stage_setup(&pool, &bank_forks, &channels, &cluster_info, &poh_recorder);
+    ensure_banking_stage_setup(
+        &pool,
+        &bank_forks,
+        &channels,
+        &cluster_info,
+        &poh_recorder,
+        transaction_recorder,
+    );
     bank_forks.write().unwrap().install_scheduler_pool(pool);
 
     // Wait until genesis_bank reaches its tick height...

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -86,7 +86,7 @@ fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let prev_hash = bank.last_blockhash();
 
-    let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
+    let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
         0,
         prev_hash,
         bank.clone(),
@@ -136,7 +136,7 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
     let bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let prev_hash = bank.last_blockhash();
 
-    let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
+    let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
         0,
         prev_hash,
         bank.clone(),

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -376,6 +376,7 @@ impl PohService {
 mod tests {
     use {
         super::*,
+        crossbeam_channel::unbounded,
         rand::{thread_rng, Rng},
         solana_clock::DEFAULT_HASHES_PER_TICK,
         solana_ledger::{
@@ -416,7 +417,7 @@ mod tests {
         let ticks_per_slot = bank.ticks_per_slot();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let blockstore = Arc::new(blockstore);
-        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+        let (poh_recorder, entry_receiver) = PohRecorder::new(
             bank.tick_height(),
             prev_hash,
             bank.clone(),
@@ -482,6 +483,7 @@ mod tests {
         let hashes_per_batch = std::env::var("HASHES_PER_BATCH")
             .map(|x| x.parse().unwrap())
             .unwrap_or(DEFAULT_HASHES_PER_BATCH);
+        let (_record_sender, record_receiver) = unbounded();
         let poh_service = PohService::new(
             poh_recorder.clone(),
             &poh_config,

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -171,7 +171,7 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
             bank.last_blockhash(),
             bank.clone(),
@@ -233,7 +233,7 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
             bank.last_blockhash(),
             bank.clone(),

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -3162,7 +3162,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (_banking_packet_sender, banking_packet_receiver) = crossbeam_channel::unbounded();
-        let (exit, poh_recorder, poh_service, _signal_receiver) = {
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) = {
             // Create a dummy bank to prevent it from being frozen; otherwise, the following panic
             // will happen:
             //    thread 'solPohTickProd' panicked at runtime/src/bank.rs:LL:CC:
@@ -3181,7 +3181,7 @@ mod tests {
             pool.register_banking_stage(
                 banking_packet_receiver,
                 Box::new(|_, _| unreachable!()),
-                poh_recorder.read().unwrap().new_recorder(),
+                transaction_recorder,
             );
         }
 
@@ -3650,7 +3650,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, signal_receiver) =
+        let (exit, poh_recorder, transaction_recorder, poh_service, signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3665,7 +3665,7 @@ mod tests {
             banking_packet_receiver: never(),
             banking_packet_handler: Box::new(|_, _| {}),
             banking_stage_helper: None,
-            transaction_recorder: Some(poh_recorder.read().unwrap().new_recorder()),
+            transaction_recorder: Some(transaction_recorder),
         };
 
         let task =
@@ -3748,7 +3748,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3759,7 +3759,7 @@ mod tests {
             banking_packet_receiver,
             // we don't use the banking packet channel in this test. so, pass panicking handler.
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         assert_eq!(bank.transaction_count(), 0);
@@ -3804,7 +3804,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3833,7 +3833,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             fixed_banking_packet_handler,
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Confirm the banking packet channel is cleared, even before taking scheduler
@@ -3875,7 +3875,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3899,7 +3899,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             fixed_banking_packet_handler,
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Quickly take and return the scheduler so that this test can test the behavior while
@@ -3960,7 +3960,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -3971,7 +3971,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         let context = SchedulingContext::for_production(bank.clone());
@@ -4011,7 +4011,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -4023,7 +4023,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         let context = SchedulingContext::for_production(bank);
@@ -4066,7 +4066,7 @@ mod tests {
         let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let (exit, poh_recorder, poh_service, _signal_receiver) =
+        let (exit, _poh_recorder, transaction_recorder, poh_service, _signal_receiver) =
             create_test_recorder_with_index_tracking(
                 bank.clone(),
                 blockstore.clone(),
@@ -4076,7 +4076,7 @@ mod tests {
         pool.register_banking_stage(
             banking_packet_receiver,
             Box::new(|_, _| unreachable!()),
-            poh_recorder.read().unwrap().new_recorder(),
+            transaction_recorder,
         );
 
         // Make sure the assertion in BlockProductionSchedulerInner::can_put() doesn't cause false


### PR DESCRIPTION
- PohRecorder has too many responsibilities:
    - holding a channel to copy for transaction recording
    - actual recording into the poh stream
    - controlling poh slot/bank state
    - providing access to working bank
- Design makes it difficult to reason about structural changes to how we record transactions

#### Summary of Changes
- First refactor steps aiming to separate responsibilities out of `PohRecorder`.
- This PR separates `TransactionRecorder` from `PohRecorder`
