### PR TITLE
Refactor: separate transaction_recorder.rs

### DIFF
--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -16,8 +16,8 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     },
     solana_poh::{
-        poh_recorder::{create_test_recorder, TransactionRecorder},
-        poh_service::PohService,
+        poh_recorder::create_test_recorder, poh_service::PohService,
+        transaction_recorder::TransactionRecorder,
     },
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -26,8 +26,9 @@ use {
     },
     solana_net_utils::bind_to_localhost,
     solana_poh::{
-        poh_recorder::{PohRecorder, TransactionRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
+        poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
         poh_service::{PohService, DEFAULT_HASHES_PER_BATCH, DEFAULT_PINNED_CPU_CORE},
+        transaction_recorder::TransactionRecorder,
     },
     solana_runtime::{
         bank::{Bank, HashOverrides},

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -33,7 +33,7 @@ use {
     solana_ledger::blockstore_processor::TransactionStatusSender,
     solana_measure::measure_us,
     solana_perf::packet::PACKETS_PER_BATCH,
-    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder},
+    solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
         vote_sender_types::ReplayVoteSender,
@@ -763,10 +763,9 @@ mod tests {
         },
         solana_perf::packet::to_packet_batches,
         solana_poh::{
-            poh_recorder::{
-                create_test_recorder, PohRecorderError, Record, RecordTransactionsSummary,
-            },
+            poh_recorder::{create_test_recorder, PohRecorderError, Record},
             poh_service::PohService,
+            transaction_recorder::RecordTransactionsSummary,
         },
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -745,7 +745,10 @@ mod tests {
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
-        solana_poh::poh_recorder::{PohRecorder, TransactionRecorder, WorkingBankEntry},
+        solana_poh::{
+            poh_recorder::{PohRecorder, WorkingBankEntry},
+            transaction_recorder::TransactionRecorder,
+        },
         solana_runtime::{
             bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
             vote_sender_types::ReplayVoteReceiver,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -16,9 +16,11 @@ use {
     solana_fee::FeeFeatures,
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
-    solana_poh::poh_recorder::{
-        BankStart, PohRecorderError, RecordTransactionsSummary, RecordTransactionsTimings,
-        TransactionRecorder,
+    solana_poh::{
+        poh_recorder::{BankStart, PohRecorderError},
+        transaction_recorder::{
+            RecordTransactionsSummary, RecordTransactionsTimings, TransactionRecorder,
+        },
     },
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -1,5 +1,5 @@
 use {
-    solana_poh::poh_recorder::RecordTransactionsTimings, solana_sdk::clock::Slot,
+    solana_poh::transaction_recorder::RecordTransactionsTimings, solana_sdk::clock::Slot,
     solana_timings::ExecuteTimings, std::time::Instant,
 };
 

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -34,7 +34,7 @@ use {
     },
     crate::banking_trace::Channels,
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder},
+    solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache},
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::sync::{Arc, RwLock},

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -33,7 +33,10 @@ use {
         entry_notifier_service::EntryNotifierSender,
     },
     solana_perf::data_budget::DataBudget,
-    solana_poh::poh_recorder::{PohRecorder, TransactionRecorder, WorkingBankEntry},
+    solana_poh::{
+        poh_recorder::{PohRecorder, WorkingBankEntry},
+        transaction_recorder::TransactionRecorder,
+    },
     solana_rpc::{
         optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -76,8 +76,9 @@ use {
         datapoint_info, metrics::metrics_config_sanity_check, poh_timing_point::PohTimingSender,
     },
     solana_poh::{
-        poh_recorder::{PohRecorder, TransactionRecorder},
+        poh_recorder::PohRecorder,
         poh_service::{self, PohService},
+        transaction_recorder::TransactionRecorder,
     },
     solana_rayon_threadlimit::{get_max_thread_count, get_thread_count},
     solana_rpc::{

--- a/poh/src/lib.rs
+++ b/poh/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod leader_bank_notifier;
 pub mod poh_recorder;
 pub mod poh_service;
+pub mod transaction_recorder;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -11,16 +11,14 @@
 //! * recorded entry must be >= WorkingBank::min_tick_height && entry must be < WorkingBank::max_tick_height
 //!
 use {
-    crate::{leader_bank_notifier::LeaderBankNotifier, poh_service::PohService},
-    crossbeam_channel::{
-        bounded, unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError,
+    crate::{
+        leader_bank_notifier::LeaderBankNotifier, poh_service::PohService,
+        transaction_recorder::TransactionRecorder,
     },
+    crossbeam_channel::{unbounded, Receiver, SendError, Sender, TrySendError},
     log::*,
     solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-    solana_entry::{
-        entry::{hash_transactions, Entry},
-        poh::Poh,
-    },
+    solana_entry::{entry::Entry, poh::Poh},
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_measure::measure_us,
@@ -31,12 +29,8 @@ use {
     solana_transaction::versioned::VersionedTransaction,
     std::{
         cmp,
-        num::Saturating,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc, Mutex, RwLock,
-        },
-        time::{Duration, Instant},
+        sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+        time::Instant,
     },
     thiserror::Error,
 };
@@ -56,7 +50,7 @@ pub enum PohRecorderError {
     SendError(#[from] SendError<WorkingBankEntry>),
 }
 
-type Result<T> = std::result::Result<T, PohRecorderError>;
+pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;
 
 pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));
 
@@ -97,133 +91,6 @@ impl Record {
             transactions,
             slot,
             sender,
-        }
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct RecordTransactionsTimings {
-    pub processing_results_to_transactions_us: Saturating<u64>,
-    pub hash_us: Saturating<u64>,
-    pub poh_record_us: Saturating<u64>,
-}
-
-impl RecordTransactionsTimings {
-    pub fn accumulate(&mut self, other: &RecordTransactionsTimings) {
-        self.processing_results_to_transactions_us += other.processing_results_to_transactions_us;
-        self.hash_us += other.hash_us;
-        self.poh_record_us += other.poh_record_us;
-    }
-}
-
-pub struct RecordTransactionsSummary {
-    // Metrics describing how time was spent recording transactions
-    pub record_transactions_timings: RecordTransactionsTimings,
-    // Result of trying to record the transactions into the PoH stream
-    pub result: Result<()>,
-    // Index in the slot of the first transaction recorded
-    pub starting_transaction_index: Option<usize>,
-}
-
-#[derive(Clone, Debug)]
-pub struct TransactionRecorder {
-    // shared by all users of PohRecorder
-    pub record_sender: Sender<Record>,
-    pub is_exited: Arc<AtomicBool>,
-}
-
-impl TransactionRecorder {
-    pub fn new(record_sender: Sender<Record>, is_exited: Arc<AtomicBool>) -> Self {
-        Self {
-            record_sender,
-            is_exited,
-        }
-    }
-
-    /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.
-    /// Panics on unexpected (non-`MaxHeightReached`) errors.
-    pub fn record_transactions(
-        &self,
-        bank_slot: Slot,
-        transactions: Vec<VersionedTransaction>,
-    ) -> RecordTransactionsSummary {
-        let mut record_transactions_timings = RecordTransactionsTimings::default();
-        let mut starting_transaction_index = None;
-
-        if !transactions.is_empty() {
-            let (hash, hash_us) = measure_us!(hash_transactions(&transactions));
-            record_transactions_timings.hash_us = Saturating(hash_us);
-
-            let (res, poh_record_us) = measure_us!(self.record(bank_slot, hash, transactions));
-            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
-
-            match res {
-                Ok(starting_index) => {
-                    starting_transaction_index = starting_index;
-                }
-                Err(PohRecorderError::MaxHeightReached) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::MaxHeightReached),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(PohRecorderError::SendError(e)) => {
-                    return RecordTransactionsSummary {
-                        record_transactions_timings,
-                        result: Err(PohRecorderError::SendError(e)),
-                        starting_transaction_index: None,
-                    };
-                }
-                Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
-            }
-        }
-
-        RecordTransactionsSummary {
-            record_transactions_timings,
-            result: Ok(()),
-            starting_transaction_index,
-        }
-    }
-
-    // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
-    pub fn record(
-        &self,
-        bank_slot: Slot,
-        mixin: Hash,
-        transactions: Vec<VersionedTransaction>,
-    ) -> Result<Option<usize>> {
-        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
-        let (result_sender, result_receiver) = bounded(1);
-        let res =
-            self.record_sender
-                .send(Record::new(mixin, transactions, bank_slot, result_sender));
-        if res.is_err() {
-            // If the channel is dropped, then the validator is shutting down so return that we are hitting
-            //  the max tick height to stop transaction processing and flush any transactions in the pipeline.
-            return Err(PohRecorderError::MaxHeightReached);
-        }
-        // Besides validator exit, this timeout should primarily be seen to affect test execution environments where the various pieces can be shutdown abruptly
-        let mut is_exited = false;
-        loop {
-            let res = result_receiver.recv_timeout(Duration::from_millis(1000));
-            match res {
-                Err(RecvTimeoutError::Timeout) => {
-                    if is_exited {
-                        return Err(PohRecorderError::MaxHeightReached);
-                    } else {
-                        // A result may have come in between when we timed out checking this
-                        // bool, so check the channel again, even if is_exited == true
-                        is_exited = self.is_exited.load(Ordering::SeqCst);
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    return Err(PohRecorderError::MaxHeightReached);
-                }
-                Ok(result) => {
-                    return result;
-                }
-            }
         }
     }
 }

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -1,0 +1,144 @@
+use {
+    crate::poh_recorder::{PohRecorderError, Record, Result},
+    crossbeam_channel::{bounded, RecvTimeoutError, Sender},
+    solana_clock::Slot,
+    solana_entry::entry::hash_transactions,
+    solana_hash::Hash,
+    solana_measure::measure_us,
+    solana_transaction::versioned::VersionedTransaction,
+    std::{
+        num::Saturating,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+};
+
+#[derive(Default, Debug)]
+pub struct RecordTransactionsTimings {
+    pub processing_results_to_transactions_us: Saturating<u64>,
+    pub hash_us: Saturating<u64>,
+    pub poh_record_us: Saturating<u64>,
+}
+
+impl RecordTransactionsTimings {
+    pub fn accumulate(&mut self, other: &RecordTransactionsTimings) {
+        self.processing_results_to_transactions_us += other.processing_results_to_transactions_us;
+        self.hash_us += other.hash_us;
+        self.poh_record_us += other.poh_record_us;
+    }
+}
+
+pub struct RecordTransactionsSummary {
+    // Metrics describing how time was spent recording transactions
+    pub record_transactions_timings: RecordTransactionsTimings,
+    // Result of trying to record the transactions into the PoH stream
+    pub result: Result<()>,
+    // Index in the slot of the first transaction recorded
+    pub starting_transaction_index: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TransactionRecorder {
+    // shared by all users of PohRecorder
+    pub record_sender: Sender<Record>,
+    pub is_exited: Arc<AtomicBool>,
+}
+
+impl TransactionRecorder {
+    pub fn new(record_sender: Sender<Record>, is_exited: Arc<AtomicBool>) -> Self {
+        Self {
+            record_sender,
+            is_exited,
+        }
+    }
+
+    /// Hashes `transactions` and sends to PoH service for recording. Waits for response up to 1s.
+    /// Panics on unexpected (non-`MaxHeightReached`) errors.
+    pub fn record_transactions(
+        &self,
+        bank_slot: Slot,
+        transactions: Vec<VersionedTransaction>,
+    ) -> RecordTransactionsSummary {
+        let mut record_transactions_timings = RecordTransactionsTimings::default();
+        let mut starting_transaction_index = None;
+
+        if !transactions.is_empty() {
+            let (hash, hash_us) = measure_us!(hash_transactions(&transactions));
+            record_transactions_timings.hash_us = Saturating(hash_us);
+
+            let (res, poh_record_us) = measure_us!(self.record(bank_slot, hash, transactions));
+            record_transactions_timings.poh_record_us = Saturating(poh_record_us);
+
+            match res {
+                Ok(starting_index) => {
+                    starting_transaction_index = starting_index;
+                }
+                Err(PohRecorderError::MaxHeightReached) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecorderError::MaxHeightReached),
+                        starting_transaction_index: None,
+                    };
+                }
+                Err(PohRecorderError::SendError(e)) => {
+                    return RecordTransactionsSummary {
+                        record_transactions_timings,
+                        result: Err(PohRecorderError::SendError(e)),
+                        starting_transaction_index: None,
+                    };
+                }
+                Err(e) => panic!("Poh recorder returned unexpected error: {e:?}"),
+            }
+        }
+
+        RecordTransactionsSummary {
+            record_transactions_timings,
+            result: Ok(()),
+            starting_transaction_index,
+        }
+    }
+
+    // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank
+    pub fn record(
+        &self,
+        bank_slot: Slot,
+        mixin: Hash,
+        transactions: Vec<VersionedTransaction>,
+    ) -> Result<Option<usize>> {
+        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
+        let (result_sender, result_receiver) = bounded(1);
+        let res =
+            self.record_sender
+                .send(Record::new(mixin, transactions, bank_slot, result_sender));
+        if res.is_err() {
+            // If the channel is dropped, then the validator is shutting down so return that we are hitting
+            //  the max tick height to stop transaction processing and flush any transactions in the pipeline.
+            return Err(PohRecorderError::MaxHeightReached);
+        }
+        // Besides validator exit, this timeout should primarily be seen to affect test execution environments where the various pieces can be shutdown abruptly
+        let mut is_exited = false;
+        loop {
+            let res = result_receiver.recv_timeout(Duration::from_millis(1000));
+            match res {
+                Err(RecvTimeoutError::Timeout) => {
+                    if is_exited {
+                        return Err(PohRecorderError::MaxHeightReached);
+                    } else {
+                        // A result may have come in between when we timed out checking this
+                        // bool, so check the channel again, even if is_exited == true
+                        is_exited = self.is_exited.load(Ordering::SeqCst);
+                    }
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(PohRecorderError::MaxHeightReached);
+                }
+                Ok(result) => {
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -26,7 +26,7 @@ use {
     solana_ledger::blockstore_processor::{
         execute_batch, TransactionBatchWithIndexes, TransactionStatusSender,
     },
-    solana_poh::poh_recorder::{RecordTransactionsSummary, TransactionRecorder},
+    solana_poh::transaction_recorder::{RecordTransactionsSummary, TransactionRecorder},
     solana_pubkey::Pubkey,
     solana_runtime::{
         installed_scheduler_pool::{


### PR DESCRIPTION
#### Problem
- PohRecorder refactoring
- TransactionRecorder was logically separated from `PohRecorder`, but the type still lives in the same file

#### Summary of Changes
- Separate `transaction_recorder` module to hold `TransactionRecorder` type/impl

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
