### PR TITLE
remove bank.get_lamport_per_signature function, repalce with is_zero_fees_for_test

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -765,7 +765,7 @@ impl Consumer {
         );
         let fee = solana_fee::calculate_fee(
             transaction,
-            bank.get_lamports_per_signature() == 0,
+            bank.is_zero_fees_for_test(),
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2847,6 +2847,12 @@ impl Bank {
         (last_hash, last_lamports_per_signature)
     }
 
+    pub fn is_zero_fees_for_test(&self) -> bool {
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
+        last_lamports_per_signature == 0
+    }
+
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         blockhash_queue.is_hash_valid_for_age(hash, MAX_PROCESSING_AGE)
@@ -2854,10 +2860,6 @@ impl Bank {
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
         self.rent_collector.rent.minimum_balance(data_len).max(1)
-    }
-
-    pub fn get_lamports_per_signature(&self) -> u64 {
-        self.fee_rate_governor.lamports_per_signature
     }
 
     pub fn get_lamports_per_signature_for_blockhash(&self, hash: &Hash) -> Option<u64> {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -63,11 +63,9 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
-        let (_last_hash, last_lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
-            last_lamports_per_signature == 0,
+            self.is_zero_fees_for_test(),
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),


### PR DESCRIPTION
#### Problem

Remove another bank.fee_rate_governor use. Should use last lamports_per_signature from blockhash to check "for test" flag.

#### Summary of Changes
- remove bank.get_lamport_per_signature function, repalce with is_zero_fees_for_test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
