### PR TITLE
perf: Implement `Deref` and `DerefMut` for `PinnedVec` and `PacketBatch`

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -850,7 +850,7 @@ mod tests {
         .collect();
         assert_eq!(
             shreds.len(),
-            packets.iter().map(PacketBatch::len).sum::<usize>()
+            packets.iter().map(|batch| batch.len()).sum::<usize>()
         );
         assert!(count_packets_in_batches(&packets) > SIGN_SHRED_GPU_MIN);
         packets

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -91,7 +91,7 @@ pub fn dedup_packets_and_count_discards<const K: usize>(
 ) -> u64 {
     batches
         .iter_mut()
-        .flat_map(PacketBatch::iter_mut)
+        .flat_map(|batch| batch.iter_mut())
         .map(|packet| {
             if !packet.meta().discard()
                 && packet

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -9,8 +9,8 @@ use {
         borrow::Borrow,
         io::Read,
         net::SocketAddr,
-        ops::{Index, IndexMut},
-        slice::{Iter, IterMut, SliceIndex},
+        ops::{Deref, DerefMut, Index, IndexMut},
+        slice::{Iter, SliceIndex},
     },
 };
 
@@ -117,58 +117,24 @@ impl PacketBatch {
         batch
     }
 
-    pub fn resize(&mut self, new_len: usize, value: Packet) {
-        self.packets.resize(new_len, value)
-    }
-
-    pub fn truncate(&mut self, len: usize) {
-        self.packets.truncate(len);
-    }
-
-    pub fn push(&mut self, packet: Packet) {
-        self.packets.push(packet);
-    }
-
     pub fn set_addr(&mut self, addr: &SocketAddr) {
         for p in self.iter_mut() {
             p.meta_mut().set_socket_addr(addr);
         }
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.packets.len()
+impl Deref for PacketBatch {
+    type Target = PinnedVec<Packet>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.packets
     }
+}
 
-    pub fn capacity(&self) -> usize {
-        self.packets.capacity()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.packets.is_empty()
-    }
-
-    pub fn as_ptr(&self) -> *const Packet {
-        self.packets.as_ptr()
-    }
-
-    pub fn iter(&self) -> Iter<'_, Packet> {
-        self.packets.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<'_, Packet> {
-        self.packets.iter_mut()
-    }
-
-    /// See Vector::set_len() for more details
-    ///
-    /// # Safety
-    ///
-    /// - `new_len` must be less than or equal to [`self.capacity`].
-    /// - The elements at `old_len..new_len` must be initialized. Packet data
-    ///   will likely be overwritten when populating the packet, but the meta
-    ///   should specifically be initialized to known values.
-    pub unsafe fn set_len(&mut self, new_len: usize) {
-        self.packets.set_len(new_len);
+impl DerefMut for PacketBatch {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.packets
     }
 }
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -967,7 +967,8 @@ async fn packet_batch_sender(
                 }
 
                 unsafe {
-                    packet_batch.set_len(packet_batch.len() + 1);
+                    let new_len = packet_batch.len() + 1;
+                    packet_batch.set_len(new_len);
                 }
 
                 let i = packet_batch.len() - 1;

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -144,7 +144,7 @@ fn run_shred_sigverify<const K: usize>(
     let now = Instant::now();
     stats.num_iters += 1;
     stats.num_batches += packets.len();
-    stats.num_packets += packets.iter().map(PacketBatch::len).sum::<usize>();
+    stats.num_packets += packets.iter().map(|batch| batch.len()).sum::<usize>();
     stats.num_discards_pre += count_discards(&packets);
     // Repair shreds include a randomly generated u32 nonce, so it does not
     // make sense to deduplicate the entire packet payload (i.e. they are not
@@ -246,7 +246,7 @@ fn run_shred_sigverify<const K: usize>(
     // Extract shred payload from packets, and separate out repaired shreds.
     let (shreds, repairs): (Vec<_>, Vec<_>) = packets
         .iter()
-        .flat_map(PacketBatch::iter)
+        .flat_map(|batch| batch.iter())
         .filter(|packet| !packet.meta().discard())
         .filter_map(|packet| {
             let shred = shred::layout::get_shred(packet)?.to_vec();
@@ -358,7 +358,7 @@ fn get_slot_leaders(
     let mut leaders = HashMap::<Slot, Option<Pubkey>>::new();
     batches
         .iter_mut()
-        .flat_map(PacketBatch::iter_mut)
+        .flat_map(|batch| batch.iter_mut())
         .filter(|packet| !packet.meta().discard())
         .filter(|packet| {
             let shred = shred::layout::get_shred(packet);
@@ -382,7 +382,7 @@ fn get_slot_leaders(
 fn count_discards(packets: &[PacketBatch]) -> usize {
     packets
         .iter()
-        .flat_map(PacketBatch::iter)
+        .flat_map(|batch| batch.iter())
         .filter(|packet| packet.meta().discard())
         .count()
 }


### PR DESCRIPTION
#### Problem

Before this change, `PinnedVec` and `PacketBatch` were manually implementing various `Vec` methods without changing their implementations, e.g. `len()`, `capacity()`, `iter()`.

#### Summary of Changes

Avoid these unnecessary implementations by implementing `Deref` and `DerefMut` and keeping the custom implementations only if necessary (constructors and methods with intentionally different implementation).