### PR TITLE
Remove unnecessary lamports_per_signature from SVM interface

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3388,7 +3388,6 @@ impl Bank {
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
             feature_set: Arc::clone(&self.feature_set),
-            fee_lamports_per_signature: self.fee_structure.lamports_per_signature,
             rent_collector: Some(&rent_collector_with_metrics),
         };
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -165,7 +165,7 @@ impl Bank {
         } else {
             compute_budget_and_limits
         };
-        CheckedTransactionDetails::new(nonce, lamports_per_signature, compute_budget_and_limits)
+        CheckedTransactionDetails::new(nonce, compute_budget_and_limits)
     }
 
     fn check_transaction_age(

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -426,7 +426,6 @@ impl JsonRpcRequestProcessor {
         /* for now just return defaults */
         Ok(CheckedTransactionDetails::new(
             None,
-            u64::default(),
             Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
         ))
     }
@@ -547,7 +546,6 @@ impl JsonRpcRequestProcessor {
             blockhash_lamports_per_signature: lamports_per_signature,
             epoch_total_stake: 0,
             feature_set: Arc::clone(&bank.feature_set),
-            fee_lamports_per_signature: lamports_per_signature,
             rent_collector: None,
         };
 

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -150,7 +150,6 @@ impl PayTubeChannel {
             blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
             epoch_total_stake: 0,
             feature_set: Arc::new(feature_set),
-            fee_lamports_per_signature: fee_structure.lamports_per_signature,
             rent_collector: Some(&rent_collector),
         };
 
@@ -172,10 +171,7 @@ impl PayTubeChannel {
         let results = processor.load_and_execute_sanitized_transactions(
             &account_loader,
             &svm_transactions,
-            get_transaction_check_results(
-                svm_transactions.len(),
-                fee_structure.lamports_per_signature,
-            ),
+            get_transaction_check_results(svm_transactions.len()),
             &processing_environment,
             &processing_config,
         );

--- a/svm/examples/paytube/src/processor.rs
+++ b/svm/examples/paytube/src/processor.rs
@@ -94,13 +94,11 @@ pub(crate) fn create_transaction_batch_processor<CB: TransactionProcessingCallba
 /// PayTube, since we don't need to perform such pre-checks.
 pub(crate) fn get_transaction_check_results(
     len: usize,
-    lamports_per_signature: u64,
 ) -> Vec<transaction::Result<CheckedTransactionDetails>> {
     let compute_budget_limit = ComputeBudgetLimits::default();
     vec![
         transaction::Result::Ok(CheckedTransactionDetails::new(
             None,
-            lamports_per_signature,
             Ok(compute_budget_limit.get_compute_budget_and_limits(
                 compute_budget_limit.loaded_accounts_bytes,
                 FeeDetails::default()

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -60,13 +60,9 @@ pub(crate) enum TransactionLoadResult {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[cfg_attr(
-    feature = "svm-internal",
-    field_qualifiers(nonce(pub), lamports_per_signature(pub),)
-)]
+#[cfg_attr(feature = "svm-internal", field_qualifiers(nonce(pub)))]
 pub struct CheckedTransactionDetails {
     pub(crate) nonce: Option<NonceInfo>,
-    pub(crate) lamports_per_signature: u64,
     pub(crate) compute_budget_and_limits: Result<SVMTransactionExecutionAndFeeBudgetLimits>,
 }
 
@@ -75,7 +71,6 @@ impl Default for CheckedTransactionDetails {
     fn default() -> Self {
         Self {
             nonce: None,
-            lamports_per_signature: 0,
             compute_budget_and_limits: Ok(SVMTransactionExecutionAndFeeBudgetLimits {
                 budget: SVMTransactionExecutionBudget::default(),
                 loaded_accounts_data_size_limit: NonZeroU32::new(32)
@@ -89,12 +84,10 @@ impl Default for CheckedTransactionDetails {
 impl CheckedTransactionDetails {
     pub fn new(
         nonce: Option<NonceInfo>,
-        lamports_per_signature: u64,
         compute_budget_and_limits: Result<SVMTransactionExecutionAndFeeBudgetLimits>,
     ) -> Self {
         Self {
             nonce,
-            lamports_per_signature,
             compute_budget_and_limits,
         }
     }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -246,7 +246,6 @@ fn svm_concurrent() {
                 .map(|tx| {
                     Ok(CheckedTransactionDetails::new(
                         None,
-                        20,
                         Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
                             MockBankCallback::calculate_fee_details(tx, 0),
                         )),

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -248,12 +248,7 @@ fn svm_concurrent() {
                         None,
                         20,
                         Ok(SVMTransactionExecutionAndFeeBudgetLimits::with_fee(
-                            MockBankCallback::calculate_fee_details(
-                                tx,
-                                TransactionProcessingEnvironment::default()
-                                    .fee_lamports_per_signature,
-                                0,
-                            ),
+                            MockBankCallback::calculate_fee_details(tx, 0),
                         )),
                     )) as TransactionCheckResult
                 })

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -117,7 +117,6 @@ impl SvmTestEnvironment<'_> {
             blockhash: LAST_BLOCKHASH,
             feature_set: feature_set.into(),
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
-            fee_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
             ..TransactionProcessingEnvironment::default()
         };
 
@@ -451,16 +450,12 @@ impl SvmTestEntry {
                         v.get_compute_budget_and_limits(
                             v.loaded_accounts_bytes,
                             FeeDetails::new(
-                                signature_count.saturating_mul(tx_details.lamports_per_signature),
+                                signature_count.saturating_mul(LAMPORTS_PER_SIGNATURE),
                                 v.get_prioritization_fee(),
                             ),
                         )
                     });
-                    CheckedTransactionDetails::new(
-                        tx_details.nonce,
-                        tx_details.lamports_per_signature,
-                        compute_budget,
-                    )
+                    CheckedTransactionDetails::new(tx_details.nonce, compute_budget)
                 });
 
                 (message, check_result)
@@ -491,7 +486,6 @@ impl TransactionBatchItem {
         Self {
             check_result: Ok(CheckedTransactionDetails::new(
                 Some(nonce_info),
-                LAMPORTS_PER_SIGNATURE,
                 Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
             )),
             ..Self::default()
@@ -505,7 +499,6 @@ impl Default for TransactionBatchItem {
             transaction: Transaction::default(),
             check_result: Ok(CheckedTransactionDetails::new(
                 None,
-                LAMPORTS_PER_SIGNATURE,
                 Ok(SVMTransactionExecutionAndFeeBudgetLimits::default()),
             )),
             asserts: TransactionBatchItemAsserts::default(),

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+
 #[allow(deprecated)]
 use solana_sdk::sysvar::recent_blockhashes::{Entry as BlockhashesEntry, RecentBlockhashes};
 use {
@@ -7,7 +8,7 @@ use {
         SyscallLog, SyscallMemcpy, SyscallMemset, SyscallSetReturnData,
     },
     solana_feature_set::FeatureSet,
-    solana_fee_structure::FeeDetails,
+    solana_fee_structure::{FeeDetails, FeeStructure},
     solana_program_runtime::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
         invoke_context::InvokeContext,
@@ -113,11 +114,7 @@ impl TransactionProcessingCallback for MockBankCallback {
 }
 
 impl MockBankCallback {
-    pub fn calculate_fee_details(
-        message: &impl SVMMessage,
-        lamports_per_signature: u64,
-        prioritization_fee: u64,
-    ) -> FeeDetails {
+    pub fn calculate_fee_details(message: &impl SVMMessage, prioritization_fee: u64) -> FeeDetails {
         let signature_count = message
             .num_transaction_signatures()
             .saturating_add(message.num_ed25519_signatures())
@@ -125,7 +122,7 @@ impl MockBankCallback {
             .saturating_add(message.num_secp256r1_signatures());
 
         FeeDetails::new(
-            signature_count.saturating_mul(lamports_per_signature),
+            signature_count.saturating_mul(FeeStructure::default().lamports_per_signature),
             prioritization_fee,
         )
     }


### PR DESCRIPTION
#### Problem
`fee_lamports_per_signature` and `lamports_per_signature` in SVM interfaces are unused, since fee calculation has been moved out of SVM. These should also be removed from the interface.

#### Summary of Changes
Remove these config items from the interface.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
