### PR TITLE
perf: unsafe optimizations for verified instruction iteration

### DIFF
--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -185,7 +185,7 @@ pub unsafe fn read_slice_data<'a, T: Sized>(
     offset: &mut usize,
     num_elements: u16,
 ) -> Result<&'a [T]> {
-    let current_ptr = bytes.as_ptr().wrapping_add(*offset);
+    let current_ptr = bytes.as_ptr().add(*offset);
     advance_offset_for_array::<T>(bytes, offset, num_elements)?;
     Ok(unsafe { core::slice::from_raw_parts(current_ptr as *const T, usize::from(num_elements)) })
 }
@@ -210,7 +210,7 @@ pub unsafe fn unchecked_read_slice_data<'a, T: Sized>(
     offset: &mut usize,
     num_elements: u16,
 ) -> &'a [T] {
-    let current_ptr = bytes.as_ptr().wrapping_add(*offset);
+    let current_ptr = bytes.as_ptr().add(*offset);
     let array_len_bytes = usize::from(num_elements).wrapping_mul(core::mem::size_of::<T>());
     *offset = offset.wrapping_add(array_len_bytes);
     unsafe { core::slice::from_raw_parts(current_ptr as *const T, usize::from(num_elements)) }
@@ -230,7 +230,7 @@ pub unsafe fn unchecked_read_slice_data<'a, T: Sized>(
 /// 4. `T` must be validly initialized.
 #[inline(always)]
 pub unsafe fn read_type<'a, T: Sized>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a T> {
-    let current_ptr = bytes.as_ptr().wrapping_add(*offset);
+    let current_ptr = bytes.as_ptr().add(*offset);
     advance_offset_for_type::<T>(bytes, offset)?;
     Ok(unsafe { &*(current_ptr as *const T) })
 }

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -35,8 +35,7 @@ pub fn read_byte(bytes: &[u8], offset: &mut usize) -> Result<u8> {
 /// Read a byte and advance the offset without any bounds checks.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
-/// * `num_elements` - Number of `T` elements in the slice.
+/// * `offset` - Current offset into `bytes`.
 ///
 /// # Safety
 /// 1. `bytes` must be a valid slice of bytes.
@@ -129,7 +128,7 @@ pub fn optimized_read_compressed_u16(bytes: &[u8], offset: &mut usize) -> Result
 /// of type `T`. If the buffer is too short, return Err.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
+/// * `offset` - Current offset into `bytes`.
 /// * `num_elements` - Number of `T` elements in the array.
 ///
 /// Assumptions:
@@ -152,7 +151,7 @@ pub fn advance_offset_for_array<T: Sized>(
 /// If the buffer is too short, return Err.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
+/// * `offset` - Current offset into `bytes`.
 ///
 /// Assumptions:
 /// 1. The current offset is not greater than `bytes.len()`.
@@ -170,7 +169,7 @@ pub fn advance_offset_for_type<T: Sized>(bytes: &[u8], offset: &mut usize) -> Re
 /// If the buffer is too short, return Err.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
+/// * `offset` - Current offset into `bytes`.
 /// * `num_elements` - Number of `T` elements in the slice.
 ///
 /// # Safety
@@ -195,7 +194,7 @@ pub unsafe fn read_slice_data<'a, T: Sized>(
 /// and advancing the offset.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
+/// * `offset` - Current offset into `bytes`.
 /// * `num_elements` - Number of `T` elements in the slice.
 ///
 /// # Safety
@@ -222,7 +221,7 @@ pub unsafe fn unchecked_read_slice_data<'a, T: Sized>(
 /// If the buffer is too short, return Err.
 ///
 /// * `bytes` - Slice of bytes to read from.
-/// * `offset` - Curernt offset into `bytes`.
+/// * `offset` - Current offset into `bytes`.
 ///
 /// # Safety
 /// 1. `bytes` must be a valid slice of bytes.


### PR DESCRIPTION
#### Problem
- Instruction iteration can be slow.
- We only ever iterate over data we have already validated has a valid form, yet we rerun all the expensive checks on the data.

#### Summary of Changes
- After initial instruction iteration that does validation, we can skip verification checks and use unsafe optimizations

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
