### PR TITLE
perf: cache instruction offsets and lens

### DIFF
--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -238,7 +238,7 @@ impl TransactionFrame {
             offset: usize::from(self.instructions.offset),
             num_instructions: self.instructions.num_instructions,
             index: 0,
-            cached_offsets_and_lens: &self.instructions.cached_offsets_and_lens,
+            frames: &self.instructions.frames,
         }
     }
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -229,12 +229,16 @@ impl TransactionFrame {
     /// - This function must be called with the same `bytes` slice that was
     ///   used to create the `TransactionFrame` instance.
     #[inline]
-    pub(crate) unsafe fn instructions_iter<'a>(&self, bytes: &'a [u8]) -> InstructionsIterator<'a> {
+    pub(crate) unsafe fn instructions_iter<'a>(
+        &'a self,
+        bytes: &'a [u8],
+    ) -> InstructionsIterator<'a> {
         InstructionsIterator {
             bytes,
             offset: usize::from(self.instructions.offset),
             num_instructions: self.instructions.num_instructions,
             index: 0,
+            cached_offsets_and_lens: &self.instructions.cached_offsets_and_lens,
         }
     }
 


### PR DESCRIPTION
#### Problem
- re parsing u16s is expensive

#### Summary of Changes
- cache parsed u16 lengths, and the offsets so we do not need to reparse u16s each iteration

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
