### PR TITLE
Removes SlotCache type alias

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5825,7 +5825,7 @@ impl AccountsDb {
             .fetch_add(num_stored_slots_removed as u64, Ordering::Relaxed);
     }
 
-    fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: SlotCache) {
+    fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: Arc<SlotCache>) {
         let mut purged_slot_pubkeys: HashSet<(Slot, Pubkey)> = HashSet::new();
         let pubkey_to_slot_set: Vec<(Pubkey, Slot)> = slot_cache
             .iter()
@@ -6340,7 +6340,7 @@ impl AccountsDb {
     fn do_flush_slot_cache(
         &self,
         slot: Slot,
-        slot_cache: &SlotCache,
+        slot_cache: &Arc<SlotCache>,
         mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
         max_clean_root: Option<Slot>,
     ) -> FlushStats {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5738,7 +5738,7 @@ impl AccountsDb {
                 // the slot and from the Accounts Index
                 num_cached_slots_removed += 1;
                 total_removed_cached_bytes += slot_cache.total_bytes();
-                self.purge_slot_cache(*remove_slot, slot_cache);
+                self.purge_slot_cache(*remove_slot, &slot_cache);
                 remove_cache_elapsed.stop();
                 remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
                 // Nobody else should have removed the slot cache entry yet
@@ -5825,7 +5825,7 @@ impl AccountsDb {
             .fetch_add(num_stored_slots_removed as u64, Ordering::Relaxed);
     }
 
-    fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: Arc<SlotCache>) {
+    fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: &SlotCache) {
         let mut purged_slot_pubkeys: HashSet<(Slot, Pubkey)> = HashSet::new();
         let pubkey_to_slot_set: Vec<(Pubkey, Slot)> = slot_cache
             .iter()
@@ -6340,7 +6340,7 @@ impl AccountsDb {
     fn do_flush_slot_cache(
         &self,
         slot: Slot,
-        slot_cache: &Arc<SlotCache>,
+        slot_cache: &SlotCache,
         mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
         max_clean_root: Option<Slot>,
     ) -> FlushStats {


### PR DESCRIPTION
#### Problem

The `SlotCache` alias is not a useful type alias, IMO. It only wraps an `Arc` around `SlotCacheInner`, so it doesn't reduce typing by all that much. But more so, I feel that `Arc`s should *not* be aliased away to begin with. Since `Arc` impacts thread safety and performance, I *do* want to see when there is an `Arc` somewhere.


#### Summary of Changes

Remove the alias and use the type directly.

Also, replace the anti-pattern of `&Arc<T>` with `&T` directly. This is something that was hidden by the type alias before.
