### PR TITLE
Fix TVU deduplication not deduping different protocols running on the same port

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -234,10 +234,6 @@ impl ContactInfo {
     pub fn wallclock(&self) -> u64 {
         self.wallclock
     }
-    #[inline]
-    pub fn outset(&self) -> u64 {
-        self.outset
-    }
 
     #[inline]
     pub fn shred_version(&self) -> u16 {

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -234,6 +234,10 @@ impl ContactInfo {
     pub fn wallclock(&self) -> u64 {
         self.wallclock
     }
+    #[inline]
+    pub fn outset(&self) -> u64 {
+        self.outset
+    }
 
     #[inline]
     pub fn shred_version(&self) -> u16 {

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -787,7 +787,7 @@ mod tests {
         let mut nodes = vec![
             Node {
                 node: NodeId::ContactInfo(ContactInfo {
-                    pubkey: pk.clone(),
+                    pubkey: pk,
                     wallclock: 0,
                     tvu_udp: Some("1.1.1.1:1".parse().unwrap()),
                     tvu_quic: None,

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -245,8 +245,7 @@ impl ClusterNodes<RetransmitStage> {
                 fanout,
                 |k| self.nodes[k].pubkey() == &self.pubkey,
                 weighted_shuffle.shuffle(&mut rng),
-            )
-            .expect("Could not find own pubkey in cluster nodes");
+            );
             let protocol = get_broadcast_protocol(shred);
             let peers = peers
                 .filter_map(|k| self.nodes[k].contact_info()?.tvu(protocol))
@@ -423,8 +422,7 @@ fn dedup_tvu_addrs(nodes: &mut Vec<Node>, keep_identity: Pubkey) {
             // deterministic shuffle.
             return node_stake > 0u64;
         };
-        // Do not delete our own identity under any circumstances
-        // https://github.com/anza-xyz/agave/issues/5356
+        // Do not delete the provided keep_identity
         if node.pubkey == keep_identity {
             return true;
         }


### PR DESCRIPTION
#### Problem

- `fn dedup_tvu_addrs` in cluster_nodes.rs did not dedup cases where QUIC and UDP were running on the same port
- there were no tests

#### Summary of Changes

- Fix deduplication logic in `fn dedup_tvu_addrs` to only allow one protocol to run on a given port (no point running both QUIC and UDP on the same port)
- Add extra tests 


