### PR TITLE
fix: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/4834 was stale and merged an old version of `syn` into the `Cargo.lock` file

#### Summary of Changes
Update `Cargo.lock`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
