### PR TITLE
Moves AccountsIndexIterator to submodule

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,10 +1,8 @@
 mod account_map_entry;
 pub(crate) mod in_mem_accounts_index;
+mod iter;
 mod roots_tracker;
 mod secondary;
-pub use secondary::{
-    AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude, IndexKey,
-};
 use {
     crate::{
         accounts_index_storage::{AccountsIndexStorage, Startup},
@@ -18,6 +16,7 @@ use {
     },
     account_map_entry::{AccountMapEntry, PreAllocatedAccountMapEntry},
     in_mem_accounts_index::{InMemAccountsIndex, InsertNewEntryResults, StartupStats},
+    iter::{AccountsIndexIterator, AccountsIndexIteratorReturnsItems},
     log::*,
     rand::{thread_rng, Rng},
     rayon::{
@@ -33,10 +32,7 @@ use {
         collections::{btree_map::BTreeMap, HashSet},
         fmt::Debug,
         num::NonZeroUsize,
-        ops::{
-            Bound::{self, Unbounded},
-            Range, RangeBounds,
-        },
+        ops::{Bound, Range, RangeBounds},
         path::PathBuf,
         sync::{
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -45,8 +41,13 @@ use {
     },
     thiserror::Error,
 };
+pub use {
+    iter::ITER_BATCH_SIZE,
+    secondary::{
+        AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude, IndexKey,
+    },
+};
 
-pub const ITER_BATCH_SIZE: usize = 1000;
 pub const BINS_DEFAULT: usize = 8192;
 pub const BINS_FOR_TESTING: usize = 2; // we want > 1, but each bin is a few disk files with a disk based index, so fewer is better
 pub const BINS_FOR_BENCHMARKS: usize = 8192;
@@ -234,88 +235,6 @@ pub struct AccountsIndexRootsStats {
     pub unrooted_cleaned_count: usize,
     pub clean_unref_from_storage_us: u64,
     pub clean_dead_slot_us: u64,
-}
-
-pub struct AccountsIndexIterator<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
-    account_maps: &'a [Arc<InMemAccountsIndex<T, U>>],
-    start_bound: Bound<&'a Pubkey>,
-    end_bound: Bound<&'a Pubkey>,
-    start_bin: usize,
-    end_bin_inclusive: usize,
-    bin_range: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
-    returns_items: AccountsIndexIteratorReturnsItems,
-}
-
-impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexIterator<'a, T, U> {
-    pub fn new<R>(
-        index: &'a AccountsIndex<T, U>,
-        range: Option<&'a R>,
-        returns_items: AccountsIndexIteratorReturnsItems,
-    ) -> Self
-    where
-        R: RangeBounds<Pubkey>,
-    {
-        match range {
-            Some(range) => {
-                let (start_bin, end_bin_inclusive) = index.bin_start_end_inclusive(range);
-                Self {
-                    account_maps: &index.account_maps,
-                    start_bound: range.start_bound(),
-                    end_bound: range.end_bound(),
-                    start_bin,
-                    end_bin_inclusive,
-                    bin_range: Vec::new(),
-                    returns_items,
-                }
-            }
-            None => Self {
-                account_maps: &index.account_maps,
-                start_bound: Unbounded,
-                end_bound: Unbounded,
-                start_bin: 0,
-                end_bin_inclusive: index.account_maps.len().saturating_sub(1),
-                bin_range: Vec::new(),
-                returns_items,
-            },
-        }
-    }
-}
-
-/// Implement the Iterator trait for AccountsIndexIterator
-impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
-    for AccountsIndexIterator<'_, T, U>
-{
-    type Item = Vec<(Pubkey, Arc<AccountMapEntry<T>>)>;
-    fn next(&mut self) -> Option<Self::Item> {
-        while self.bin_range.len() < ITER_BATCH_SIZE {
-            if self.start_bin > self.end_bin_inclusive {
-                break;
-            }
-
-            let bin = self.start_bin;
-            let map = &self.account_maps[bin];
-            let mut range = map.items(&(self.start_bound, self.end_bound));
-            if self.returns_items == AccountsIndexIteratorReturnsItems::Sorted {
-                range.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-            }
-            self.bin_range.append(&mut range);
-            self.start_bin += 1;
-        }
-
-        (!self.bin_range.is_empty()).then(|| std::mem::take(&mut self.bin_range))
-    }
-}
-
-/// Specify how the accounts index iterator should return items
-///
-/// Users should prefer `Unsorted`, unless required otherwise,
-/// as sorting incurs additional runtime cost.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AccountsIndexIteratorReturnsItems {
-    /// Returns items *not* sorted
-    Unsorted,
-    /// Returns items *sorted*
-    Sorted,
 }
 
 pub trait ZeroLamport {
@@ -1846,7 +1765,7 @@ pub mod tests {
         solana_inline_spl::token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET,
         solana_pubkey::PUBKEY_BYTES,
         std::ops::{
-            Bound::{Excluded, Included},
+            Bound::{Excluded, Included, Unbounded},
             RangeInclusive,
         },
     };
@@ -2793,28 +2712,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accounts_iter_finished() {
-        let (index, _) = setup_accounts_index_keys(0);
-        let mut iter = index.iter(
-            None::<&Range<Pubkey>>,
-            AccountsIndexIteratorReturnsItems::Sorted,
-        );
-        assert!(iter.next().is_none());
-        let mut gc = vec![];
-        index.upsert(
-            0,
-            0,
-            &solana_pubkey::new_rand(),
-            &AccountSharedData::default(),
-            &AccountSecondaryIndexes::default(),
-            true,
-            &mut gc,
-            UPSERT_POPULATE_RECLAIMS,
-        );
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
     fn test_is_alive_root() {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         assert!(!index.is_alive_root(0));
@@ -3633,52 +3530,6 @@ pub mod tests {
     impl ZeroLamport for u64 {
         fn is_zero_lamport(&self) -> bool {
             false
-        }
-    }
-
-    #[test]
-    fn test_account_index_iter_batched() {
-        let index = AccountsIndex::<bool, bool>::default_for_tests();
-        // Setup an account index for test.
-        // Two bins. First bin has 2000 accounts, second bin has 0 accounts.
-        let num_pubkeys = 2 * ITER_BATCH_SIZE;
-        let pubkeys = std::iter::repeat_with(Pubkey::new_unique)
-            .take(num_pubkeys)
-            .collect::<Vec<_>>();
-
-        for key in pubkeys {
-            let slot = 0;
-            let value = true;
-            let mut gc = Vec::new();
-            index.upsert(
-                slot,
-                slot,
-                &key,
-                &AccountSharedData::default(),
-                &AccountSecondaryIndexes::default(),
-                value,
-                &mut gc,
-                UPSERT_POPULATE_RECLAIMS,
-            );
-        }
-
-        for returns_items in [
-            AccountsIndexIteratorReturnsItems::Sorted,
-            AccountsIndexIteratorReturnsItems::Unsorted,
-        ] {
-            // Create a sorted iterator for the whole pubkey range.
-            let mut iter = index.iter(None::<&Range<Pubkey>>, returns_items);
-            // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
-            let x = iter.next().unwrap();
-            assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
-            assert_eq!(
-                x.is_sorted_by(|a, b| a.0 < b.0),
-                returns_items == AccountsIndexIteratorReturnsItems::Sorted
-            );
-            assert_eq!(iter.bin_range.len(), 0); // should be empty.
-
-            // Then iter.next() should return None.
-            assert!(iter.next().is_none());
         }
     }
 

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -1,0 +1,176 @@
+use {
+    super::{
+        account_map_entry::AccountMapEntry, in_mem_accounts_index::InMemAccountsIndex,
+        AccountsIndex, DiskIndexValue, IndexValue,
+    },
+    solana_pubkey::Pubkey,
+    std::{
+        ops::{Bound, RangeBounds},
+        sync::Arc,
+    },
+};
+
+pub const ITER_BATCH_SIZE: usize = 1000;
+
+pub struct AccountsIndexIterator<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
+    account_maps: &'a [Arc<InMemAccountsIndex<T, U>>],
+    start_bound: Bound<&'a Pubkey>,
+    end_bound: Bound<&'a Pubkey>,
+    start_bin: usize,
+    end_bin_inclusive: usize,
+    bin_range: Vec<(Pubkey, Arc<AccountMapEntry<T>>)>,
+    returns_items: AccountsIndexIteratorReturnsItems,
+}
+
+impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexIterator<'a, T, U> {
+    pub fn new<R>(
+        index: &'a AccountsIndex<T, U>,
+        range: Option<&'a R>,
+        returns_items: AccountsIndexIteratorReturnsItems,
+    ) -> Self
+    where
+        R: RangeBounds<Pubkey>,
+    {
+        match range {
+            Some(range) => {
+                let (start_bin, end_bin_inclusive) = index.bin_start_end_inclusive(range);
+                Self {
+                    account_maps: &index.account_maps,
+                    start_bound: range.start_bound(),
+                    end_bound: range.end_bound(),
+                    start_bin,
+                    end_bin_inclusive,
+                    bin_range: Vec::new(),
+                    returns_items,
+                }
+            }
+            None => Self {
+                account_maps: &index.account_maps,
+                start_bound: Bound::Unbounded,
+                end_bound: Bound::Unbounded,
+                start_bin: 0,
+                end_bin_inclusive: index.account_maps.len().saturating_sub(1),
+                bin_range: Vec::new(),
+                returns_items,
+            },
+        }
+    }
+}
+
+/// Implement the Iterator trait for AccountsIndexIterator
+impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
+    for AccountsIndexIterator<'_, T, U>
+{
+    type Item = Vec<(Pubkey, Arc<AccountMapEntry<T>>)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.bin_range.len() < ITER_BATCH_SIZE {
+            if self.start_bin > self.end_bin_inclusive {
+                break;
+            }
+
+            let bin = self.start_bin;
+            let map = &self.account_maps[bin];
+            let mut range = map.items(&(self.start_bound, self.end_bound));
+            if self.returns_items == AccountsIndexIteratorReturnsItems::Sorted {
+                range.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            }
+            self.bin_range.append(&mut range);
+            self.start_bin += 1;
+        }
+
+        (!self.bin_range.is_empty()).then(|| std::mem::take(&mut self.bin_range))
+    }
+}
+
+/// Specify how the accounts index iterator should return items
+///
+/// Users should prefer `Unsorted`, unless required otherwise,
+/// as sorting incurs additional runtime cost.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum AccountsIndexIteratorReturnsItems {
+    /// Returns items *not* sorted
+    Unsorted,
+    /// Returns items *sorted*
+    Sorted,
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{
+            super::{secondary::AccountSecondaryIndexes, UpsertReclaim},
+            *,
+        },
+        solana_account::AccountSharedData,
+        std::ops::Range,
+    };
+
+    #[test]
+    fn test_account_index_iter_batched() {
+        let index = AccountsIndex::<bool, bool>::default_for_tests();
+        // Setup an account index for test.
+        // Two bins. First bin has 2000 accounts, second bin has 0 accounts.
+        let num_pubkeys = 2 * ITER_BATCH_SIZE;
+        let pubkeys = std::iter::repeat_with(Pubkey::new_unique)
+            .take(num_pubkeys)
+            .collect::<Vec<_>>();
+
+        for key in pubkeys {
+            let slot = 0;
+            let value = true;
+            let mut gc = Vec::new();
+            index.upsert(
+                slot,
+                slot,
+                &key,
+                &AccountSharedData::default(),
+                &AccountSecondaryIndexes::default(),
+                value,
+                &mut gc,
+                UpsertReclaim::PopulateReclaims,
+            );
+        }
+
+        for returns_items in [
+            AccountsIndexIteratorReturnsItems::Sorted,
+            AccountsIndexIteratorReturnsItems::Unsorted,
+        ] {
+            // Create a sorted iterator for the whole pubkey range.
+            let mut iter = index.iter(None::<&Range<Pubkey>>, returns_items);
+            // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
+            let x = iter.next().unwrap();
+            assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
+            assert_eq!(
+                x.is_sorted_by(|a, b| a.0 < b.0),
+                returns_items == AccountsIndexIteratorReturnsItems::Sorted
+            );
+            assert_eq!(iter.bin_range.len(), 0); // should be empty.
+
+            // Then iter.next() should return None.
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_accounts_iter_finished() {
+        let index = AccountsIndex::<bool, bool>::default_for_tests();
+        index.add_root(0);
+        let mut iter = index.iter(
+            None::<&Range<Pubkey>>,
+            AccountsIndexIteratorReturnsItems::Sorted,
+        );
+        assert!(iter.next().is_none());
+        let mut gc = vec![];
+        index.upsert(
+            0,
+            0,
+            &solana_pubkey::new_rand(),
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            true,
+            &mut gc,
+            UpsertReclaim::PopulateReclaims,
+        );
+        assert!(iter.next().is_none());
+    }
+}


### PR DESCRIPTION
#### Problem

The `accounts_index.rs` file is large, and contains many inner/utility types. These non `AccountsIndex` types make it harder for me to quickly traverse the file and understand the code.


#### Summary of Changes

Move inner/utility types out, into their own submodule as a separate file.

For this PR, move out `AccountsIndexIterator`.

