### PR TITLE
Removes accounts_hash_interval from BankForks

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2099,7 +2099,6 @@ fn load_blockstore(
     {
         let mut bank_forks = bank_forks.write().unwrap();
         bank_forks.set_snapshot_config(Some(config.snapshot_config.clone()));
-        bank_forks.set_accounts_hash_interval_slots(config.accounts_hash_interval_slots);
     }
 
     Ok((

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -68,9 +68,6 @@ impl TestEnvironment {
     /// A small, round number to make the tests run quickly, and easy to debug
     const SLOTS_PER_EPOCH: u64 = 400;
 
-    /// A small, round number to ensure accounts packages are sent to the background services
-    const ACCOUNTS_HASH_INTERVAL: u64 = 40;
-
     #[must_use]
     fn new() -> TestEnvironment {
         Self::_new(SnapshotConfig::new_load_only())
@@ -125,10 +122,6 @@ impl TestEnvironment {
             .write()
             .unwrap()
             .set_snapshot_config(Some(snapshot_config.clone()));
-        bank_forks
-            .write()
-            .unwrap()
-            .set_accounts_hash_interval_slots(Self::ACCOUNTS_HASH_INTERVAL);
 
         let exit = Arc::new(AtomicBool::new(false));
         let node_id = Arc::new(Keypair::new());

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -74,7 +74,6 @@ impl SnapshotTestConfig {
     fn new(
         snapshot_version: SnapshotVersion,
         cluster_type: ClusterType,
-        _accounts_hash_interval_slots: Slot,
         full_snapshot_archive_interval_slots: Slot,
         incremental_snapshot_archive_interval_slots: Slot,
     ) -> SnapshotTestConfig {
@@ -192,7 +191,6 @@ fn run_bank_forks_snapshot_n<F>(
         snapshot_version,
         cluster_type,
         set_root_interval,
-        set_root_interval,
         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
     );
 
@@ -309,7 +307,6 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         let snapshot_test_config = SnapshotTestConfig::new(
             snapshot_version,
             cluster_type,
-            (*add_root_interval * num_set_roots * 2) as Slot,
             (*add_root_interval * num_set_roots * 2) as Slot,
             DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         );
@@ -441,7 +438,6 @@ fn test_bank_forks_incremental_snapshot(
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
         cluster_type,
-        SET_ROOT_INTERVAL,
         FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
     );
@@ -678,7 +674,6 @@ fn test_snapshots_with_background_services(
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
         cluster_type,
-        BANK_SNAPSHOT_INTERVAL_SLOTS,
         FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
     );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -74,7 +74,7 @@ impl SnapshotTestConfig {
     fn new(
         snapshot_version: SnapshotVersion,
         cluster_type: ClusterType,
-        accounts_hash_interval_slots: Slot,
+        _accounts_hash_interval_slots: Slot,
         full_snapshot_archive_interval_slots: Slot,
         incremental_snapshot_archive_interval_slots: Slot,
     ) -> SnapshotTestConfig {
@@ -102,7 +102,6 @@ impl SnapshotTestConfig {
         bank0.set_startup_verification_complete();
         let bank_forks_arc = BankForks::new_rw_arc(bank0);
         let mut bank_forks = bank_forks_arc.write().unwrap();
-        bank_forks.accounts_hash_interval_slots = accounts_hash_interval_slots;
 
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -748,10 +748,6 @@ impl BankForks {
         self.snapshot_config = snapshot_config;
     }
 
-    pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: u64) {
-        // brooks TODO: remove me
-    }
-
     /// Determine if this bank should request an epoch accounts hash
     #[must_use]
     fn should_request_epoch_accounts_hash(&self, bank: &Bank) -> bool {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -20,6 +20,7 @@ use {
     },
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
+        cmp,
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
         sync::{
@@ -79,7 +80,6 @@ pub struct BankForks {
 
     pub snapshot_config: Option<SnapshotConfig>,
 
-    pub accounts_hash_interval_slots: Slot,
     /// Highest slot request that has been sent to AccountsBackgroundService
     latest_abs_request_slot: Slot,
     in_vote_only_mode: Arc<AtomicBool>,
@@ -132,7 +132,6 @@ impl BankForks {
             banks,
             descendants,
             snapshot_config: None,
-            accounts_hash_interval_slots: u64::MAX,
             latest_abs_request_slot: root_slot,
             in_vote_only_mode: Arc::new(AtomicBool::new(false)),
             highest_slot_at_startup: 0,
@@ -400,6 +399,21 @@ impl BankForks {
         Ok((is_root_bank_squashed, squash_timing))
     }
 
+    /// Returns the interval, in slots, for sending an ABS request
+    fn abs_request_interval(&self) -> Slot {
+        let Some(snapshot_config) = self.snapshot_config.as_ref() else {
+            // If there's no snapshot config, then we shouldn't take snapshots.
+            // Return the max value to prevent sending an ABS request.
+            return Slot::MAX;
+        };
+
+        // N.B. This assumes if a snapshot kind is disabled that its interval will be Slot::MAX
+        cmp::min(
+            snapshot_config.full_snapshot_archive_interval_slots,
+            snapshot_config.incremental_snapshot_archive_interval_slots,
+        )
+    }
+
     fn do_set_root_return_metrics(
         &mut self,
         root: Slot,
@@ -446,12 +460,13 @@ impl BankForks {
         // After checking for EAH requests, also check for regular snapshot requests.
         //
         // This is needed when a snapshot request occurs in a slot after an EAH request, and is
-        // part of the same set of `banks` in a single `set_root()` invocation.  While (very)
-        // unlikely for a validator with default snapshot intervals (and accounts hash verifier
-        // intervals), it *is* possible, and there are tests to exercise this possibility.
+        // part of the same set of `banks` in a single `set_root()` invocation.
+        // While (very) unlikely for a validator with default snapshot intervals,
+        // it *is* possible, and there are tests to exercise this possibility.
+        let abs_request_interval = self.abs_request_interval();
         if let Some(bank) = banks.iter().find(|bank| {
             bank.slot() > self.latest_abs_request_slot
-                && bank.block_height() % self.accounts_hash_interval_slots == 0
+                && bank.block_height() % abs_request_interval == 0
         }) {
             let bank_slot = bank.slot();
             self.latest_abs_request_slot = bank_slot;
@@ -734,7 +749,7 @@ impl BankForks {
     }
 
     pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: u64) {
-        self.accounts_hash_interval_slots = accounts_interval_slots;
+        // brooks TODO: remove me
     }
 
     /// Determine if this bank should request an epoch accounts hash


### PR DESCRIPTION
#### Problem

Big goal is that we'd like to have a way to update the snapshot config on the fly. This will allow operators to change snapshot intervals, and/or enable/disable snapshot generation entirely. Future work will include sending ad hoc requests to generate a one-off snapshot too.

In order to get there, we need the snapshot config to be (1) shared, and (2) updatable. Currently, code that needs snapshot information has a local copy of the SnapshotConfig, which is fine since it cannot change once the node starts.

Once the snapshot config is shareable, then it needs to be updatable. Assume we'll have a way to do that eventually. Now, we need to look at the code that sends snapshot requests and ensure it is robust to updates.

BankForks::set_root() is the function that determines if a snapshot should be taken at a slot or not. Currently it uses the "accounts hash interval" to do this determination. However, the accounts hash interval has been effectively disabled. Additionally, if the snapshot config is changed, the accounts hash interval is *not*, yet it would need to, in order to facilitate the big goal. 

In the code today, we already set the accounts hash interval to be the snapshot archive interval. So we should formalize that behavior and remove the accounts hash interval from determining if a snapshot should be taken or not, and then use the snapshot archive intervals in the snapshot config directly. This will enable updating the snapshot config in subsequent PRs.


#### Summary of Changes

Remove the accounts hash interval from BankForks, and instead use the SnapshotConfig's snapshot interval fields to determine when to take a snapshot or not.

Note that there is still other uses/mentions of the accounts hash interval. This PR purposely leaves out those other locations to keep this PR to its logical minimum. Subsequent PRs will clean those up.