### PR TITLE
refactor: add SnapshotController

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -267,9 +267,9 @@ mod tests {
         super::*,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_runtime::{
-            accounts_background_service::AbsRequestSender,
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
+            snapshot_controller::SnapshotController,
         },
         solana_sdk::{account::Account, pubkey::Pubkey, signature::Signer},
         solana_stake_program::stake_state,
@@ -583,7 +583,7 @@ mod tests {
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(x, &AbsRequestSender::default(), None)
+                .set_root(x, &SnapshotController::default(), None)
                 .unwrap();
         }
 
@@ -629,7 +629,7 @@ mod tests {
             .unwrap()
             .set_root(
                 root,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 Some(highest_super_majority_root),
             )
             .unwrap();
@@ -717,7 +717,7 @@ mod tests {
             .unwrap()
             .set_root(
                 root,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 Some(highest_super_majority_root),
             )
             .unwrap();

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -924,7 +924,7 @@ mod test {
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
         solana_net_utils::bind_to_unspecified,
-        solana_runtime::{accounts_background_service::AbsRequestSender, bank_forks::BankForks},
+        solana_runtime::{bank_forks::BankForks, snapshot_controller::SnapshotController},
         solana_sdk::{
             hash::Hash,
             signature::{Keypair, Signer},
@@ -1901,7 +1901,7 @@ mod test {
             let mut w_bank_forks = bank_forks.write().unwrap();
             w_bank_forks.insert(new_root_bank);
             w_bank_forks
-                .set_root(new_root_slot, &AbsRequestSender::default(), None)
+                .set_root(new_root_slot, &SnapshotController::default(), None)
                 .unwrap();
         }
         popular_pruned_slot_pool.insert(dead_duplicate_confirmed_slot);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4357,7 +4357,6 @@ pub(crate) mod tests {
             slot_status_notifier::SlotStatusNotifierInterface,
         },
         solana_runtime::{
-            accounts_background_service::AbsRequestSender,
             commitment::{BlockCommitment, VOTE_THRESHOLD_SIZE},
             genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs},
         },
@@ -4694,7 +4693,7 @@ pub(crate) mod tests {
             root,
             &bank_forks,
             &mut progress,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             None,
             &mut heaviest_subtree_fork_choice,
             &mut duplicate_slots_tracker,
@@ -4773,7 +4772,7 @@ pub(crate) mod tests {
             root,
             &bank_forks,
             &mut progress,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             Some(confirmed_root),
             &mut heaviest_subtree_fork_choice,
             &mut DuplicateSlotsTracker::default(),
@@ -5844,7 +5843,7 @@ pub(crate) mod tests {
         let bank9 = bank_forks.get(9).unwrap();
         bank_forks.insert(Bank::new_from_parent(bank9, &Pubkey::default(), 10));
         bank_forks
-            .set_root(9, &AbsRequestSender::default(), None)
+            .set_root(9, &SnapshotController::default(), None)
             .unwrap();
         let total_epoch_stake = bank0.total_epoch_stake();
 
@@ -5940,7 +5939,7 @@ pub(crate) mod tests {
             .unwrap()
             .is_leader_slot = true;
         bank_forks
-            .set_root(0, &AbsRequestSender::default(), None)
+            .set_root(0, &SnapshotController::default(), None)
             .unwrap();
         let total_epoch_stake = bank_forks.root_bank().total_epoch_stake();
 
@@ -6025,7 +6024,7 @@ pub(crate) mod tests {
             .unwrap()
             .is_leader_slot = true;
         bank_forks
-            .set_root(0, &AbsRequestSender::default(), None)
+            .set_root(0, &SnapshotController::default(), None)
             .unwrap();
 
         let total_epoch_stake = num_validators as u64 * stake_per_validator;
@@ -6652,7 +6651,7 @@ pub(crate) mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(3, &AbsRequestSender::default(), None)
+            .set_root(3, &SnapshotController::default(), None)
             .unwrap();
         let mut descendants = bank_forks.read().unwrap().descendants();
         let mut ancestors = bank_forks.read().unwrap().ancestors();
@@ -9233,11 +9232,7 @@ pub(crate) mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(
-                1,
-                &solana_runtime::accounts_background_service::AbsRequestSender::default(),
-                None,
-            )
+            .set_root(1, &SnapshotController::default(), None)
             .unwrap();
 
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank1);
@@ -9251,7 +9246,7 @@ pub(crate) mod tests {
             None,
             None,
             None,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
         )
         .unwrap();
 
@@ -9426,7 +9421,7 @@ pub(crate) mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(1, &AbsRequestSender::default(), None)
+            .set_root(1, &SnapshotController::default(), None)
             .unwrap();
 
         // Mark 0 as duplicate confirmed, should fail as it is 0 < root
@@ -9541,7 +9536,7 @@ pub(crate) mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(1, &AbsRequestSender::default(), None)
+            .set_root(1, &SnapshotController::default(), None)
             .unwrap();
 
         // Mark 0 as duplicate confirmed, should fail as it is 0 < root

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -573,7 +573,7 @@ pub mod tests {
             &Arc::new(MaxSlots::default()),
             None,
             None,
-            AbsRequestSender::default(),
+            Arc::new(SnapshotController::default()),
             None,
             Some(&Arc::new(ConnectionCache::new("connection_cache_test"))),
             &ignored_prioritization_fee_cache,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -40,8 +40,8 @@ use {
         rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier,
     },
     solana_runtime::{
-        accounts_background_service::AbsRequestSender, bank_forks::BankForks,
-        commitment::BlockCommitmentCache, prioritization_fee_cache::PrioritizationFeeCache,
+        bank_forks::BankForks, commitment::BlockCommitmentCache,
+        prioritization_fee_cache::PrioritizationFeeCache, snapshot_controller::SnapshotController,
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Keypair},
@@ -145,7 +145,7 @@ impl Tvu {
         max_slots: &Arc<MaxSlots>,
         block_metadata_notifier: Option<BlockMetadataNotifierArc>,
         wait_to_vote_slot: Option<Slot>,
-        accounts_background_request_sender: AbsRequestSender,
+        snapshot_controller: Arc<SnapshotController>,
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Option<&Arc<ConnectionCache>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
@@ -282,7 +282,6 @@ impl Tvu {
         let replay_senders = ReplaySenders {
             rpc_subscriptions: rpc_subscriptions.clone(),
             slot_status_notifier,
-            accounts_background_request_sender,
             transaction_status_sender,
             block_meta_sender,
             entry_notification_sender,
@@ -328,6 +327,7 @@ impl Tvu {
             log_messages_bytes_limit,
             prioritization_fee_cache: prioritization_fee_cache.clone(),
             banking_tracer,
+            snapshot_controller,
         };
 
         let voting_service = VotingService::new(

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -19,12 +19,12 @@ use {
     },
     crossbeam_channel::unbounded,
     solana_runtime::{
-        accounts_background_service::AbsRequestSender,
         bank::Bank,
         bank_forks::BankForks,
         genesis_utils::{
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
+        snapshot_controller::SnapshotController,
     },
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer},
     solana_vote::vote_transaction,
@@ -233,7 +233,7 @@ impl VoteSimulator {
             new_root,
             &self.bank_forks,
             &mut self.progress,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             None,
             &mut self.heaviest_subtree_fork_choice,
             &mut DuplicateSlotsTracker::default(),

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -25,6 +25,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
+        snapshot_controller::SnapshotController,
         snapshot_utils,
     },
     solana_sdk::{
@@ -118,10 +119,6 @@ impl TestEnvironment {
 
         let bank_forks =
             BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config_info.genesis_config));
-        bank_forks
-            .write()
-            .unwrap()
-            .set_snapshot_config(Some(snapshot_config.clone()));
 
         let exit = Arc::new(AtomicBool::new(false));
         let node_id = Arc::new(Keypair::new());
@@ -163,7 +160,7 @@ impl TestEnvironment {
 struct BackgroundServices {
     exit: Arc<AtomicBool>,
     accounts_background_service: ManuallyDrop<AccountsBackgroundService>,
-    accounts_background_request_sender: AbsRequestSender,
+    snapshot_controller: SnapshotController,
     accounts_hash_verifier: ManuallyDrop<AccountsHashVerifier>,
     snapshot_packager_service: ManuallyDrop<SnapshotPackagerService>,
 }
@@ -201,6 +198,11 @@ impl BackgroundServices {
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
         let accounts_background_request_sender =
             AbsRequestSender::new(snapshot_request_sender.clone());
+        let snapshot_controller = SnapshotController::new(
+            accounts_background_request_sender,
+            Some(snapshot_config.clone()),
+            bank_forks.read().unwrap().root(),
+        );
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_config: snapshot_config.clone(),
             snapshot_request_sender,
@@ -224,7 +226,7 @@ impl BackgroundServices {
         Self {
             exit,
             accounts_background_service: ManuallyDrop::new(accounts_background_service),
-            accounts_background_request_sender,
+            snapshot_controller,
             accounts_hash_verifier: ManuallyDrop::new(accounts_hash_verifier),
             snapshot_packager_service: ManuallyDrop::new(snapshot_packager_service),
         }
@@ -297,9 +299,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                 .unwrap()
                 .set_root(
                     bank.slot(),
-                    &test_environment
-                        .background_services
-                        .accounts_background_request_sender,
+                    &test_environment.background_services.snapshot_controller,
                     None,
                 )
                 .unwrap();
@@ -411,9 +411,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
             .unwrap()
             .set_root(
                 bank.slot(),
-                &test_environment
-                    .background_services
-                    .accounts_background_request_sender,
+                &test_environment.background_services.snapshot_controller,
                 None,
             )
             .unwrap();
@@ -537,9 +535,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
                 .unwrap()
                 .set_root(
                     bank.slot(),
-                    &test_environment
-                        .background_services
-                        .accounts_background_request_sender,
+                    &test_environment.background_services.snapshot_controller,
                     None,
                 )
                 .unwrap();
@@ -598,9 +594,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment
-                .background_services
-                .accounts_background_request_sender,
+            &test_environment.background_services.snapshot_controller,
             None,
         )
         .unwrap();
@@ -628,9 +622,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment
-                .background_services
-                .accounts_background_request_sender,
+            &test_environment.background_services.snapshot_controller,
             None,
         )
         .unwrap();
@@ -672,9 +664,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment
-                .background_services
-                .accounts_background_request_sender,
+            &test_environment.background_services.snapshot_controller,
             None,
         )
         .unwrap();

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -27,9 +27,9 @@ use {
     solana_perf::packet::to_packet_batches,
     solana_poh::poh_recorder::create_test_recorder,
     solana_runtime::{
-        accounts_background_service::AbsRequestSender, bank::Bank, bank_forks::BankForks,
-        genesis_utils::GenesisConfigInfo, installed_scheduler_pool::SchedulingContext,
-        prioritization_fee_cache::PrioritizationFeeCache,
+        bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
+        installed_scheduler_pool::SchedulingContext,
+        prioritization_fee_cache::PrioritizationFeeCache, snapshot_controller::SnapshotController,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
@@ -165,7 +165,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
             root,
             &bank_forks,
             &mut progress,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             None,
             &mut heaviest_subtree_fork_choice,
             &mut duplicate_slots_tracker,

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -236,7 +236,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             shred::Shredder,
         },
-        solana_runtime::{accounts_background_service::AbsRequestSender, bank::Bank},
+        solana_runtime::{bank::Bank, snapshot_controller::SnapshotController},
         solana_signer::Signer,
         solana_time_utils::timestamp,
     };
@@ -299,7 +299,7 @@ mod tests {
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
             bank_forks
-                .set_root(9, &AbsRequestSender::default(), None)
+                .set_root(9, &SnapshotController::default(), None)
                 .unwrap();
         }
         blockstore.set_roots([0, 9].iter()).unwrap();
@@ -392,7 +392,7 @@ mod tests {
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
             bank_forks
-                .set_root(9, &AbsRequestSender::default(), None)
+                .set_root(9, &SnapshotController::default(), None)
                 .unwrap();
         }
         blockstore.set_roots([0, 9].iter()).unwrap();

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -82,8 +82,8 @@ mod tests {
         super::*,
         solana_clock::Slot,
         solana_runtime::{
-            accounts_background_service::AbsRequestSender,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            snapshot_controller::SnapshotController,
         },
     };
 
@@ -161,7 +161,7 @@ mod tests {
             let bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), slot);
             bank_forks.write().unwrap().insert(bank);
         }
-        let abs_request_sender = AbsRequestSender::default();
+        let snapshot_controller = SnapshotController::default();
         // root is still 0, epoch 0.
         let root_bank = bank_forks.read().unwrap().get(0).unwrap();
         verify_epoch_specs(
@@ -174,7 +174,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(17, &abs_request_sender, None)
+            .set_root(17, &snapshot_controller, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(17).unwrap();
         verify_epoch_specs(
@@ -187,7 +187,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(19, &abs_request_sender, None)
+            .set_root(19, &snapshot_controller, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(19).unwrap();
         verify_epoch_specs(
@@ -200,7 +200,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(37, &abs_request_sender, None)
+            .set_root(37, &snapshot_controller, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(37).unwrap();
         verify_epoch_specs(
@@ -213,7 +213,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(59, &abs_request_sender, None)
+            .set_root(59, &snapshot_controller, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(59).unwrap();
         verify_epoch_specs(
@@ -226,7 +226,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(97, &abs_request_sender, None)
+            .set_root(97, &snapshot_controller, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(97).unwrap();
         verify_epoch_specs(

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -12,13 +12,13 @@ use {
     log::*,
     solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifier,
     solana_runtime::{
-        accounts_background_service::AbsRequestSender,
         bank_forks::BankForks,
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
         },
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
+        snapshot_controller::SnapshotController,
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
         snapshot_utils,
     },
@@ -110,7 +110,7 @@ pub fn load(
         transaction_status_sender,
         block_meta_sender,
         entry_notification_sender,
-        &AbsRequestSender::default(),
+        &SnapshotController::default(),
     )
     .map_err(BankForksUtilsError::ProcessBlockstoreFromRoot)?;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -34,6 +34,7 @@ use {
         installed_scheduler_pool::BankWithScheduler,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
+        snapshot_controller::SnapshotController,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
         vote_sender_types::ReplayVoteSender,
     },
@@ -847,11 +848,30 @@ pub fn test_process_blockstore(
     opts: &ProcessOptions,
     exit: Arc<AtomicBool>,
 ) -> (Arc<RwLock<BankForks>>, LeaderScheduleCache) {
+    let snapshot_config = None;
+    let (bank_forks, leader_schedule_cache, ..) = crate::bank_forks_utils::load_bank_forks(
+        genesis_config,
+        blockstore,
+        Vec::new(),
+        snapshot_config.as_ref(),
+        opts,
+        None,
+        None,
+        None,
+        exit.clone(),
+    )
+    .unwrap();
+
     // Spin up a thread to be a fake Accounts Background Service.  Need to intercept and handle all
     // EpochAccountsHash requests so future rooted banks do not hang in Bank::freeze() waiting for
     // an in-flight EAH calculation to complete.
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
+    let snapshot_controller = SnapshotController::new(
+        abs_request_sender,
+        snapshot_config,
+        bank_forks.read().unwrap().root(),
+    );
     let bg_exit = Arc::new(AtomicBool::new(false));
     let bg_thread = {
         let exit = Arc::clone(&bg_exit);
@@ -879,19 +899,6 @@ pub fn test_process_blockstore(
         })
     };
 
-    let (bank_forks, leader_schedule_cache, ..) = crate::bank_forks_utils::load_bank_forks(
-        genesis_config,
-        blockstore,
-        Vec::new(),
-        None,
-        opts,
-        None,
-        None,
-        None,
-        exit,
-    )
-    .unwrap();
-
     process_blockstore_from_root(
         blockstore,
         &bank_forks,
@@ -900,7 +907,7 @@ pub fn test_process_blockstore(
         None,
         None,
         None,
-        &abs_request_sender,
+        &snapshot_controller,
     )
     .unwrap();
 
@@ -967,7 +974,7 @@ pub fn process_blockstore_from_root(
     transaction_status_sender: Option<&TransactionStatusSender>,
     block_meta_sender: Option<&BlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
-    accounts_background_request_sender: &AbsRequestSender,
+    snapshot_controller: &SnapshotController,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let (start_slot, start_slot_hash) = {
         // Starting slot must be a root, and thus has no parents
@@ -1034,7 +1041,7 @@ pub fn process_blockstore_from_root(
             block_meta_sender,
             entry_notification_sender,
             &mut timing,
-            accounts_background_request_sender,
+            snapshot_controller,
         )?
     } else {
         // If there's no meta in the blockstore for the input `start_slot`,
@@ -1847,7 +1854,7 @@ fn load_frozen_forks(
     block_meta_sender: Option<&BlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
     timing: &mut ExecuteTimings,
-    accounts_background_request_sender: &AbsRequestSender,
+    snapshot_controller: &SnapshotController,
 ) -> result::Result<(u64, usize), BlockstoreProcessorError> {
     let blockstore_max_root = blockstore.max_root();
     let mut root = bank_forks.read().unwrap().root();
@@ -2009,11 +2016,10 @@ fn load_frozen_forks(
 
                 leader_schedule_cache.set_root(new_root_bank);
                 new_root_bank.prune_program_cache(root, new_root_bank.epoch());
-                let _ = bank_forks.write().unwrap().set_root(
-                    root,
-                    accounts_background_request_sender,
-                    None,
-                )?;
+                let _ = bank_forks
+                    .write()
+                    .unwrap()
+                    .set_root(root, snapshot_controller, None)?;
                 m.stop();
                 set_root_us += m.as_us();
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4172,11 +4172,7 @@ pub mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(
-                1,
-                &solana_runtime::accounts_background_service::AbsRequestSender::default(),
-                None,
-            )
+            .set_root(1, &SnapshotController::default(), None)
             .unwrap();
 
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank1);
@@ -4190,7 +4186,7 @@ pub mod tests {
             None,
             None,
             None,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
         )
         .unwrap();
 

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -404,7 +404,7 @@ mod tests {
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_pubkey::Pubkey,
         solana_runtime::{
-            accounts_background_service::AbsRequestSender, commitment::BlockCommitmentCache,
+            commitment::BlockCommitmentCache, snapshot_controller::SnapshotController,
         },
         std::sync::atomic::AtomicU64,
     };
@@ -607,7 +607,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(7, &AbsRequestSender::default(), None)
+            .set_root(7, &SnapshotController::default(), None)
             .unwrap();
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(6),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4529,10 +4529,10 @@ pub mod tests {
             filter::MemcmpEncodedBytes,
         },
         solana_runtime::{
-            accounts_background_service::AbsRequestSender,
             bank::BankTestConfig,
             commitment::{BlockCommitment, CommitmentSlots},
             non_circulating_supply::non_circulating_accounts,
+            snapshot_controller::SnapshotController,
         },
         solana_sdk::{
             account::{Account, WritableAccount},
@@ -4885,7 +4885,7 @@ pub mod tests {
                 self.bank_forks
                     .write()
                     .unwrap()
-                    .set_root(*root, &AbsRequestSender::default(), Some(0))
+                    .set_root(*root, &SnapshotController::default(), Some(0))
                     .unwrap();
                 let block_time = self
                     .bank_forks

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -2,13 +2,13 @@
 
 use {
     crate::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestKind},
-        bank::{bank_hash_details, epoch_accounts_hash_utils, Bank, SquashTiming},
+        accounts_background_service::SnapshotRequest,
+        bank::{bank_hash_details, Bank, SquashTiming},
         bank_hash_cache::DumpedSlotSubscription,
         installed_scheduler_pool::{
             BankWithScheduler, InstalledSchedulerPoolArc, SchedulingContext,
         },
-        snapshot_config::SnapshotConfig,
+        snapshot_controller::SnapshotController,
     },
     crossbeam_channel::SendError,
     log::*,
@@ -20,7 +20,6 @@ use {
     },
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
-        cmp,
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
         sync::{
@@ -77,15 +76,9 @@ pub struct BankForks {
     banks: HashMap<Slot, BankWithScheduler>,
     descendants: HashMap<Slot, HashSet<Slot>>,
     root: Arc<AtomicSlot>,
-
-    pub snapshot_config: Option<SnapshotConfig>,
-
-    /// Highest slot request that has been sent to AccountsBackgroundService
-    latest_abs_request_slot: Slot,
     in_vote_only_mode: Arc<AtomicBool>,
     highest_slot_at_startup: Slot,
     scheduler_pool: Option<InstalledSchedulerPoolArc>,
-
     dumped_slot_subscribers: Vec<DumpedSlotSubscription>,
 }
 
@@ -131,8 +124,6 @@ impl BankForks {
             root: Arc::new(AtomicSlot::new(root_slot)),
             banks,
             descendants,
-            snapshot_config: None,
-            latest_abs_request_slot: root_slot,
             in_vote_only_mode: Arc::new(AtomicBool::new(false)),
             highest_slot_at_startup: 0,
             scheduler_pool: None,
@@ -340,83 +331,10 @@ impl BankForks {
             .unzip()
     }
 
-    /// Sends an EpochAccountsHash request if one of the `banks` crosses the EAH boundary.
-    /// Returns if the bank at slot `root` was squashed, and its timings.
-    ///
-    /// Panics if more than one bank in `banks` should send an EAH request.
-    pub fn send_eah_request_if_needed(
-        &mut self,
-        root: Slot,
-        banks: &[&Arc<Bank>],
-        accounts_background_request_sender: &AbsRequestSender,
-    ) -> Result<(bool, SquashTiming), SetRootError> {
-        let mut is_root_bank_squashed = false;
-        let mut squash_timing = SquashTiming::default();
-
-        // Go through all the banks and see if we should send an EAH request.
-        // Only one EAH bank is allowed to send an EAH request.
-        // NOTE: Instead of filter-collect-assert, `.find()` could be used instead.
-        // Once sufficient testing guarantees only one bank will ever request an EAH,
-        // change to `.find()`.
-        let eah_banks: Vec<_> = banks
-            .iter()
-            .filter(|bank| self.should_request_epoch_accounts_hash(bank))
-            .collect();
-        assert!(
-            eah_banks.len() <= 1,
-            "At most one bank should request an epoch accounts hash calculation! num banks: {}, bank slots: {:?}",
-            eah_banks.len(),
-            eah_banks.iter().map(|bank| bank.slot()).collect::<Vec<_>>(),
-        );
-        if let Some(&&eah_bank) = eah_banks.first() {
-            debug!(
-                "sending epoch accounts hash request, slot: {}",
-                eah_bank.slot(),
-            );
-
-            self.latest_abs_request_slot = eah_bank.slot();
-            squash_timing += eah_bank.squash();
-            is_root_bank_squashed = eah_bank.slot() == root;
-
-            eah_bank
-                .rc
-                .accounts
-                .accounts_db
-                .epoch_accounts_hash_manager
-                .set_in_flight(eah_bank.slot());
-            if let Err(e) =
-                accounts_background_request_sender.send_snapshot_request(SnapshotRequest {
-                    snapshot_root_bank: Arc::clone(eah_bank),
-                    status_cache_slot_deltas: Vec::default(),
-                    request_kind: SnapshotRequestKind::EpochAccountsHash,
-                    enqueued: Instant::now(),
-                })
-            {
-                return Err(SetRootError::SendEpochAccountHashError(eah_bank.slot(), e));
-            };
-        }
-
-        Ok((is_root_bank_squashed, squash_timing))
-    }
-
-    /// Returns the interval, in slots, for sending an ABS request
-    ///
-    /// Returns None if ABS requests should not be sent
-    fn abs_request_interval(&self) -> Option<Slot> {
-        self.snapshot_config.as_ref().and_then(|snapshot_config| {
-            snapshot_config.should_generate_snapshots().then(||
-                // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
-                cmp::min(
-                    snapshot_config.full_snapshot_archive_interval_slots,
-                    snapshot_config.incremental_snapshot_archive_interval_slots,
-                ))
-        })
-    }
-
     fn do_set_root_return_metrics(
         &mut self,
         root: Slot,
-        accounts_background_request_sender: &AbsRequestSender,
+        snapshot_controller: &SnapshotController,
         highest_super_majority_root: Option<Slot>,
     ) -> Result<(Vec<BankWithScheduler>, SetRootMetrics), SetRootError> {
         let old_epoch = self.root_bank().epoch();
@@ -451,57 +369,8 @@ impl BankForks {
         let parents = root_bank.parents();
         banks.extend(parents.iter());
         let total_parent_banks = banks.len();
-        let mut total_snapshot_ms = 0;
-
-        let (mut is_root_bank_squashed, mut squash_timing) =
-            self.send_eah_request_if_needed(root, &banks, accounts_background_request_sender)?;
-
-        // After checking for EAH requests, also check for regular snapshot requests.
-        //
-        // This is needed when a snapshot request occurs in a slot after an EAH request, and is
-        // part of the same set of `banks` in a single `set_root()` invocation.
-        // While (very) unlikely for a validator with default snapshot intervals,
-        // it *is* possible, and there are tests to exercise this possibility.
-        if let Some(abs_request_interval) = self.abs_request_interval() {
-            if accounts_background_request_sender.is_snapshot_creation_enabled() {
-                if let Some(bank) = banks.iter().find(|bank| {
-                    bank.slot() > self.latest_abs_request_slot
-                        && bank.block_height() % abs_request_interval == 0
-                }) {
-                    let bank_slot = bank.slot();
-                    self.latest_abs_request_slot = bank_slot;
-                    squash_timing += bank.squash();
-
-                    is_root_bank_squashed = bank_slot == root;
-
-                    let mut snapshot_time = Measure::start("squash::snapshot_time");
-                    if bank.is_startup_verification_complete() {
-                        // Save off the status cache because these may get pruned if another
-                        // `set_root()` is called before the snapshots package can be generated
-                        let status_cache_slot_deltas =
-                            bank.status_cache.read().unwrap().root_slot_deltas();
-                        if let Err(e) = accounts_background_request_sender.send_snapshot_request(
-                            SnapshotRequest {
-                                snapshot_root_bank: Arc::clone(bank),
-                                status_cache_slot_deltas,
-                                request_kind: SnapshotRequestKind::Snapshot,
-                                enqueued: Instant::now(),
-                            },
-                        ) {
-                            warn!(
-                                "Error sending snapshot request for bank: {}, err: {:?}",
-                                bank_slot, e
-                            );
-                        }
-                    } else {
-                        info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
-                    }
-                    snapshot_time.stop();
-                    total_snapshot_ms += snapshot_time.as_ms() as i64;
-                }
-            }
-        }
-
+        let (is_root_bank_squashed, mut squash_timing, total_snapshot_ms) =
+            snapshot_controller.handle_new_roots(root, &banks)?;
         if !is_root_bank_squashed {
             squash_timing += root_bank.squash();
         }
@@ -522,7 +391,7 @@ impl BankForks {
             SetRootMetrics {
                 timings: SetRootTimings {
                     total_squash_time: squash_timing,
-                    total_snapshot_ms,
+                    total_snapshot_ms: total_snapshot_ms as i64,
                     prune_non_rooted_ms: prune_time.as_ms() as i64,
                     drop_parent_banks_ms: drop_parent_banks_time.as_ms() as i64,
                     prune_slots_ms: prune_slots_ms as i64,
@@ -545,14 +414,14 @@ impl BankForks {
     pub fn set_root(
         &mut self,
         root: Slot,
-        accounts_background_request_sender: &AbsRequestSender,
+        snapshot_controller: &SnapshotController,
         highest_super_majority_root: Option<Slot>,
     ) -> Result<Vec<BankWithScheduler>, SetRootError> {
         let program_cache_prune_start = Instant::now();
         let set_root_start = Instant::now();
         let (removed_banks, set_root_metrics) = self.do_set_root_return_metrics(
             root,
-            accounts_background_request_sender,
+            snapshot_controller,
             highest_super_majority_root,
         )?;
         datapoint_info!(
@@ -740,23 +609,6 @@ impl BankForks {
             prune_slots_time.as_ms(),
             prune_remove_time.as_ms(),
         )
-    }
-
-    pub fn set_snapshot_config(&mut self, snapshot_config: Option<SnapshotConfig>) {
-        self.snapshot_config = snapshot_config;
-    }
-
-    /// Determine if this bank should request an epoch accounts hash
-    #[must_use]
-    fn should_request_epoch_accounts_hash(&self, bank: &Bank) -> bool {
-        if !epoch_accounts_hash_utils::is_enabled_this_epoch(bank) {
-            return false;
-        }
-
-        let start_slot = epoch_accounts_hash_utils::calculation_start(bank);
-        bank.slot() > self.latest_abs_request_slot
-            && bank.parent_slot() < start_slot
-            && bank.slot() >= start_slot
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,6 +27,7 @@ pub mod serde_snapshot;
 pub mod snapshot_archive_info;
 pub mod snapshot_bank_utils;
 pub mod snapshot_config;
+pub mod snapshot_controller;
 pub mod snapshot_hash;
 pub mod snapshot_minimizer;
 pub mod snapshot_package;

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -50,9 +50,9 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_background_service::AbsRequestSender,
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            snapshot_controller::SnapshotController,
         },
         solana_pubkey::Pubkey,
     };
@@ -80,7 +80,7 @@ mod tests {
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(1, &AbsRequestSender::default(), None)
+                .set_root(1, &SnapshotController::default(), None)
                 .unwrap();
             let bank = bank_forks.read().unwrap().root_bank();
 

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -38,20 +38,6 @@ impl SnapshotController {
         }
     }
 
-    /// Returns the interval, in slots, for sending an ABS request
-    ///
-    /// Returns None if ABS requests should not be sent
-    fn abs_request_interval(&self) -> Option<Slot> {
-        self.snapshot_config.as_ref().and_then(|snapshot_config| {
-            snapshot_config.should_generate_snapshots().then(||
-                // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
-                cmp::min(
-                    snapshot_config.full_snapshot_archive_interval_slots,
-                    snapshot_config.incremental_snapshot_archive_interval_slots,
-                ))
-        })
-    }
-
     fn latest_abs_request_slot(&self) -> Slot {
         self.latest_abs_request_slot.load(Ordering::Relaxed)
     }
@@ -117,6 +103,20 @@ impl SnapshotController {
         }
 
         Ok((is_root_bank_squashed, squash_timing, total_snapshot_ms))
+    }
+
+    /// Returns the interval, in slots, for sending an ABS request
+    ///
+    /// Returns None if ABS requests should not be sent
+    fn abs_request_interval(&self) -> Option<Slot> {
+        self.snapshot_config.as_ref().and_then(|snapshot_config| {
+            snapshot_config.should_generate_snapshots().then(||
+                // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
+                cmp::min(
+                    snapshot_config.full_snapshot_archive_interval_slots,
+                    snapshot_config.incremental_snapshot_archive_interval_slots,
+                ))
+        })
     }
 
     /// Sends an EpochAccountsHash request if one of the `banks` crosses the EAH boundary.

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -1,0 +1,193 @@
+use {
+    crate::{
+        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestKind},
+        bank::{epoch_accounts_hash_utils, Bank, SquashTiming},
+        bank_forks::SetRootError,
+        snapshot_config::SnapshotConfig,
+    },
+    log::*,
+    solana_measure::measure::Measure,
+    solana_sdk::clock::Slot,
+    std::{
+        cmp,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+        time::Instant,
+    },
+};
+
+#[derive(Default)]
+pub struct SnapshotController {
+    abs_request_sender: AbsRequestSender,
+    snapshot_config: Option<SnapshotConfig>,
+    latest_abs_request_slot: AtomicU64,
+}
+
+impl SnapshotController {
+    pub fn new(
+        abs_request_sender: AbsRequestSender,
+        snapshot_config: Option<SnapshotConfig>,
+        root_slot: Slot,
+    ) -> Self {
+        Self {
+            abs_request_sender,
+            snapshot_config,
+            latest_abs_request_slot: AtomicU64::new(root_slot),
+        }
+    }
+
+    /// Returns the interval, in slots, for sending an ABS request
+    ///
+    /// Returns None if ABS requests should not be sent
+    fn abs_request_interval(&self) -> Option<Slot> {
+        self.snapshot_config.as_ref().and_then(|snapshot_config| {
+            snapshot_config.should_generate_snapshots().then(||
+                // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
+                cmp::min(
+                    snapshot_config.full_snapshot_archive_interval_slots,
+                    snapshot_config.incremental_snapshot_archive_interval_slots,
+                ))
+        })
+    }
+
+    fn latest_abs_request_slot(&self) -> Slot {
+        self.latest_abs_request_slot.load(Ordering::Relaxed)
+    }
+
+    fn set_latest_abs_request_slot(&self, slot: Slot) {
+        self.latest_abs_request_slot.store(slot, Ordering::Relaxed);
+    }
+
+    pub fn handle_new_roots(
+        &self,
+        root: Slot,
+        banks: &[&Arc<Bank>],
+    ) -> Result<(bool, SquashTiming, u64), SetRootError> {
+        let (mut is_root_bank_squashed, mut squash_timing) =
+            self.send_eah_request_if_needed(root, banks)?;
+        let mut total_snapshot_ms = 0;
+
+        // After checking for EAH requests, also check for regular snapshot requests.
+        //
+        // This is needed when a snapshot request occurs in a slot after an EAH request, and is
+        // part of the same set of `banks` in a single `set_root()` invocation.  While (very)
+        // unlikely for a validator with default snapshot intervals (and accounts hash verifier
+        // intervals), it *is* possible, and there are tests to exercise this possibility.
+        if let Some(abs_request_interval) = self.abs_request_interval() {
+            if self.abs_request_sender.is_snapshot_creation_enabled() {
+                if let Some(bank) = banks.iter().find(|bank| {
+                    bank.slot() > self.latest_abs_request_slot()
+                        && bank.block_height() % abs_request_interval == 0
+                }) {
+                    let bank_slot = bank.slot();
+                    self.set_latest_abs_request_slot(bank_slot);
+                    squash_timing += bank.squash();
+
+                    is_root_bank_squashed = bank_slot == root;
+
+                    let mut snapshot_time = Measure::start("squash::snapshot_time");
+                    if bank.is_startup_verification_complete() {
+                        // Save off the status cache because these may get pruned if another
+                        // `set_root()` is called before the snapshots package can be generated
+                        let status_cache_slot_deltas =
+                            bank.status_cache.read().unwrap().root_slot_deltas();
+                        if let Err(e) =
+                            self.abs_request_sender
+                                .send_snapshot_request(SnapshotRequest {
+                                    snapshot_root_bank: Arc::clone(bank),
+                                    status_cache_slot_deltas,
+                                    request_kind: SnapshotRequestKind::Snapshot,
+                                    enqueued: Instant::now(),
+                                })
+                        {
+                            warn!(
+                                "Error sending snapshot request for bank: {}, err: {:?}",
+                                bank_slot, e
+                            );
+                        }
+                    } else {
+                        info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
+                    }
+                    snapshot_time.stop();
+                    total_snapshot_ms += snapshot_time.as_ms();
+                }
+            }
+        }
+
+        Ok((is_root_bank_squashed, squash_timing, total_snapshot_ms))
+    }
+
+    /// Sends an EpochAccountsHash request if one of the `banks` crosses the EAH boundary.
+    /// Returns if the bank at slot `root` was squashed, and its timings.
+    ///
+    /// Panics if more than one bank in `banks` should send an EAH request.
+    pub fn send_eah_request_if_needed(
+        &self,
+        root: Slot,
+        banks: &[&Arc<Bank>],
+    ) -> Result<(bool, SquashTiming), SetRootError> {
+        let mut is_root_bank_squashed = false;
+        let mut squash_timing = SquashTiming::default();
+
+        // Go through all the banks and see if we should send an EAH request.
+        // Only one EAH bank is allowed to send an EAH request.
+        // NOTE: Instead of filter-collect-assert, `.find()` could be used instead.
+        // Once sufficient testing guarantees only one bank will ever request an EAH,
+        // change to `.find()`.
+        let eah_banks: Vec<_> = banks
+            .iter()
+            .filter(|bank| self.should_request_epoch_accounts_hash(bank))
+            .collect();
+        assert!(
+            eah_banks.len() <= 1,
+            "At most one bank should request an epoch accounts hash calculation! num banks: {}, bank slots: {:?}",
+            eah_banks.len(),
+            eah_banks.iter().map(|bank| bank.slot()).collect::<Vec<_>>(),
+        );
+        if let Some(&&eah_bank) = eah_banks.first() {
+            debug!(
+                "sending epoch accounts hash request, slot: {}",
+                eah_bank.slot(),
+            );
+
+            self.set_latest_abs_request_slot(eah_bank.slot());
+            squash_timing += eah_bank.squash();
+            is_root_bank_squashed = eah_bank.slot() == root;
+
+            eah_bank
+                .rc
+                .accounts
+                .accounts_db
+                .epoch_accounts_hash_manager
+                .set_in_flight(eah_bank.slot());
+            if let Err(e) = self
+                .abs_request_sender
+                .send_snapshot_request(SnapshotRequest {
+                    snapshot_root_bank: Arc::clone(eah_bank),
+                    status_cache_slot_deltas: Vec::default(),
+                    request_kind: SnapshotRequestKind::EpochAccountsHash,
+                    enqueued: Instant::now(),
+                })
+            {
+                return Err(SetRootError::SendEpochAccountHashError(eah_bank.slot(), e));
+            };
+        }
+
+        Ok((is_root_bank_squashed, squash_timing))
+    }
+
+    /// Determine if this bank should request an epoch accounts hash
+    #[must_use]
+    fn should_request_epoch_accounts_hash(&self, bank: &Bank) -> bool {
+        if !epoch_accounts_hash_utils::is_enabled_this_epoch(bank) {
+            return false;
+        }
+
+        let start_slot = epoch_accounts_hash_utils::calculation_start(bank);
+        bank.slot() > self.latest_abs_request_slot()
+            && bank.parent_slot() < start_slot
+            && bank.slot() >= start_slot
+    }
+}

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -248,12 +248,12 @@ mod tests {
         solana_hash::Hash,
         solana_program::clock::Slot,
         solana_runtime::{
-            accounts_background_service::AbsRequestSender,
             bank::Bank,
             epoch_stakes::EpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
+            snapshot_controller::SnapshotController,
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -290,7 +290,7 @@ mod tests {
         assert!(bank_forks
             .write()
             .unwrap()
-            .set_root(1, &AbsRequestSender::default(), None)
+            .set_root(1, &SnapshotController::default(), None)
             .is_ok());
         let root_bank = bank_forks.read().unwrap().root_bank();
         let root_slot = root_bank.slot();

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1708,7 +1708,7 @@ mod tests {
             wen_restart_repair_slots: Some(Arc::new(RwLock::new(Vec::new()))),
             wait_for_supermajority_threshold_percent: 80,
             snapshot_config: SnapshotConfig::default(),
-            accounts_background_request_sender: AbsRequestSender::default(),
+            snapshot_controller: Arc::new(SnapshotController::default()),
             abs_status: AbsStatus::new_for_tests(),
             genesis_config_hash: test_state.genesis_config_hash,
             exit: exit.clone(),
@@ -1752,11 +1752,6 @@ mod tests {
                 .to_path_buf(),
             ..Default::default()
         };
-        test_state
-            .bank_forks
-            .write()
-            .unwrap()
-            .set_snapshot_config(Some(snapshot_config.clone()));
         let old_root_bank = test_state.bank_forks.read().unwrap().root_bank();
         // Trigger full snapshot generation on the old root bank.
         assert!(bank_to_full_snapshot_archive(
@@ -1780,7 +1775,7 @@ mod tests {
             wen_restart_repair_slots: wen_restart_repair_slots.clone(),
             wait_for_supermajority_threshold_percent: 80,
             snapshot_config,
-            accounts_background_request_sender: AbsRequestSender::default(),
+            snapshot_controller: Arc::new(SnapshotController::default()),
             abs_status: AbsStatus::new_for_tests(),
             genesis_config_hash: test_state.genesis_config_hash,
             exit: exit.clone(),
@@ -2062,7 +2057,7 @@ mod tests {
             let mut bank_forks = test_state.bank_forks.write().unwrap();
             let _ = bank_forks.set_root(
                 last_vote_slot + 1,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 Some(last_vote_slot + 1),
             );
         }
@@ -2135,7 +2130,7 @@ mod tests {
                 wen_restart_repair_slots: Some(Arc::new(RwLock::new(Vec::new()))),
                 wait_for_supermajority_threshold_percent: 80,
                 snapshot_config: SnapshotConfig::default(),
-                accounts_background_request_sender: AbsRequestSender::default(),
+                snapshot_controller: Arc::new(SnapshotController::default()),
                 abs_status: AbsStatus::new_for_tests(),
                 genesis_config_hash: test_state.genesis_config_hash,
                 exit: Arc::new(AtomicBool::new(false)),
@@ -3253,17 +3248,12 @@ mod tests {
             &exit,
         )
         .unwrap();
-        test_state
-            .bank_forks
-            .write()
-            .unwrap()
-            .set_snapshot_config(Some(snapshot_config.clone()));
         // We don't have any full snapshot, so if we call generate_snapshot() on the old
         // root bank now, it should generate a full snapshot.
         let generated_record = generate_snapshot(
             test_state.bank_forks.clone(),
             &snapshot_config,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             &AbsStatus::new_for_tests(),
             test_state.genesis_config_hash,
             old_root_slot,
@@ -3279,7 +3269,7 @@ mod tests {
         let generated_record = generate_snapshot(
             test_state.bank_forks.clone(),
             &snapshot_config,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             &AbsStatus::new_for_tests(),
             test_state.genesis_config_hash,
             new_root_slot,
@@ -3329,7 +3319,7 @@ mod tests {
             generate_snapshot(
                 test_state.bank_forks.clone(),
                 &snapshot_config,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 &AbsStatus::new_for_tests(),
                 test_state.genesis_config_hash,
                 old_root_slot,
@@ -3351,7 +3341,7 @@ mod tests {
             generate_snapshot(
                 test_state.bank_forks.clone(),
                 &snapshot_config,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 &AbsStatus::new_for_tests(),
                 test_state.genesis_config_hash,
                 older_slot,
@@ -3374,7 +3364,7 @@ mod tests {
             generate_snapshot(
                 test_state.bank_forks.clone(),
                 &snapshot_config,
-                &AbsRequestSender::default(),
+                &SnapshotController::default(),
                 &AbsStatus::new_for_tests(),
                 test_state.genesis_config_hash,
                 empty_slot,
@@ -3397,7 +3387,7 @@ mod tests {
         let generated_record = generate_snapshot(
             test_state.bank_forks.clone(),
             &snapshot_config,
-            &AbsRequestSender::default(),
+            &SnapshotController::default(),
             &AbsStatus::new_for_tests(),
             test_state.genesis_config_hash,
             test_state.last_voted_fork_slots[0],
@@ -3428,7 +3418,7 @@ mod tests {
             wen_restart_repair_slots: Some(Arc::new(RwLock::new(Vec::new()))),
             wait_for_supermajority_threshold_percent: 80,
             snapshot_config: SnapshotConfig::default(),
-            accounts_background_request_sender: AbsRequestSender::default(),
+            snapshot_controller: Arc::new(SnapshotController::default()),
             abs_status: AbsStatus::new_for_tests(),
             genesis_config_hash: test_state.genesis_config_hash,
             exit: Arc::new(AtomicBool::new(false)),
@@ -3675,7 +3665,7 @@ mod tests {
             wen_restart_repair_slots: Some(Arc::new(RwLock::new(Vec::new()))),
             wait_for_supermajority_threshold_percent: 80,
             snapshot_config: SnapshotConfig::default(),
-            accounts_background_request_sender: AbsRequestSender::default(),
+            snapshot_controller: Arc::new(SnapshotController::default()),
             abs_status: AbsStatus::new_for_tests(),
             genesis_config_hash: test_state.genesis_config_hash,
             exit: exit.clone(),


### PR DESCRIPTION
#### Problem
> Big goal is that we'd like to have a way to update the snapshot config on the fly. This will allow operators to change snapshot intervals, and/or enable/disable snapshot generation entirely. Future work will include sending ad hoc requests to generate a one-off snapshot too.

> In order to get there, we need the snapshot config to be (1) shared, and (2) updatable. Currently, code that needs snapshot information has a local copy of the SnapshotConfig, which is fine since it cannot change once the node starts.

> Once the snapshot config is shareable, then it needs to be updatable. Assume we'll have a way to do that eventually. Now, we need to look at the code that sends snapshot requests and ensure it is robust to updates.

Copied from https://github.com/anza-xyz/agave/pull/5394

`BankForks` shouldn't need to be responsible to handle all the logic around updating snapshot configuration. We should have a new entity that is responsible for that logic.

#### Summary of Changes
Created a new `SnapshotController` struct that is responsible for conditionally requesting snapshots and tracking the last request sent. This change is intentionally incremental to get us closer to having a single place to control when and how snapshot config can be updated in the future.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
