### PR TITLE
Replace tuple with simple struct

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -618,8 +618,9 @@ fn calculate_priority(
         .saturating_mul(bank.fee_structure().lamports_per_signature);
     let fee_details = FeeDetails::new(signature_fee, prioritization_fee);
 
-    let (reward, _burn) =
-        bank.calculate_reward_and_burn_fee_details(&CollectorFeeDetails::from(fee_details));
+    let reward = bank
+        .calculate_reward_and_burn_fee_details(&CollectorFeeDetails::from(fee_details))
+        .get_deposit();
 
     let cost = CostModel::estimate_cost(
         transaction,

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -29,9 +29,15 @@ enum DepositFeeError {
 }
 
 #[derive(Default)]
-struct FeeDistribution {
+pub struct FeeDistribution {
     deposit: u64,
     burn: u64,
+}
+
+impl FeeDistribution {
+    pub fn get_deposit(&self) -> u64 {
+        self.deposit
+    }
 }
 
 impl Bank {


### PR DESCRIPTION
#### Problem

`struct` with explicit field names could make code more readable than `tuple`

#### Summary of Changes
- replace tuple with struct for burned_transaction_fee

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
