### PR TITLE
stake program: fix deprecated config genesis account setup

### DIFF
--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -32,7 +32,7 @@ pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
 
     account.set_lamports(lamports.max(1));
 
-    genesis_config.add_account(solana_sdk_ids::config::id(), account);
+    genesis_config.add_account(solana_stake_interface::config::id(), account);
 
     lamports
 }


### PR DESCRIPTION
#### Problem
Back when the Solana SDK was being evicted from the Stake program during https://github.com/anza-xyz/agave/pull/4447, this ID field was updated incorrectly. It's supposed to be the ID of the stake config account, not the Config program.

That being said, I have no idea if this is even being used anymore, since all of the code is deprecated. However, it definitely shouldn't be the Config program ID, since it will also be owned by the Config program ID.

#### Summary of Changes
Update the function to use the proper ID, as it was before, deprecations and all.