### PR TITLE
default to BlockProductionMethod::CentralSchedulerGreedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Release channels have their own copy of this changelog:
 #### Changes
 * Account notifications for Geyser are no longer deduplicated when restorting from a snapshot.
 * Add `--no-snapshots` to disable generating snapshots.
+* `--block-production-method central-scheduler-greedy` is now the default.
 
 #### Deprecations
 * Using `--snapshot-interval-slots 0` to disable generating snapshots is now deprecated.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -190,8 +190,8 @@ impl BlockVerificationMethod {
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockProductionMethod {
-    #[default]
     CentralScheduler,
+    #[default]
     CentralSchedulerGreedy,
 }
 


### PR DESCRIPTION
#### Problem
- Greedy Scheduler should be the default but is not

#### Summary of Changes
- Make it the default

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
