### PR TITLE
Add assert_us timing in PER and also assert only vote rewards are paid at PER calc block

### DIFF
--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -24,6 +24,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) vote_accounts_cache_miss_count: AtomicU64,
     pub(crate) hash_partition_rewards_us: u64,
+    pub(crate) assert_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -103,6 +104,7 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.hash_partition_rewards_us,
             i64
         ),
+        ("assert_us", metrics.assert_us, i64),
     );
 }
 

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -24,7 +24,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) vote_accounts_cache_miss_count: AtomicU64,
     pub(crate) hash_partition_rewards_us: u64,
-    pub(crate) assert_us: u64,
+    pub(crate) assert_reward_payment_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -104,7 +104,11 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.hash_partition_rewards_us,
             i64
         ),
-        ("assert_us", metrics.assert_us, i64),
+        (
+            "assert_reward_payment_us",
+            metrics.assert_reward_payment_us,
+            i64
+        ),
     );
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -120,7 +120,7 @@ impl Bank {
             total_stake_rewards_lamports,
         } = stake_rewards_by_partition;
 
-        let (_, assert_us) = measure_us!({
+        let (_, assert_reward_payment_us) = measure_us!({
             // the remaining code mirrors `update_rewards_with_thread_pool()`
             let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
 
@@ -136,7 +136,7 @@ impl Bank {
                 validator_rewards_paid, point_value.rewards, total_stake_rewards_lamports
             );
         });
-        metrics.assert_us += assert_us;
+        metrics.assert_reward_payment_us += assert_reward_payment_us;
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();


### PR DESCRIPTION
#### Problem

In PER calcuation, there is an step to assert the total paid rewards against
calculated rewards. This assert requires to iterate all stake delgations, which
could be expensive. 

In this PR, we added a stat to measure this time. 

Mainnet measurements indicate that `assert_us` is the most time-consuming
operation within reward calculations. It is implemented as a very **inefficient sequential** loop,
which accounts for 370-450ms - a block worth of timing. It takes roughly 20%
of total reward calculation time.

I propose that we remove the calculation assert and move it to distribution. This should improve calculation speed without losing essential checks.


#### Summary of Changes

- add `assert_us` for PER calculation.
- modify vote reward store fn to return total vote rewards
- assert that only and all vote rewards are paid at PER calculation block.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
