### PR TITLE
Reduce number of program_instructions_iter calls in RuntimeTransaction::try_new

### DIFF
--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -51,13 +51,14 @@ pub struct ComputeBudgetInstructionDetails {
 }
 
 impl ComputeBudgetInstructionDetails {
-    pub fn try_from<'a>(
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
-    ) -> Result<Self> {
+    pub fn try_from<'a, I>(instructions: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
+    {
         let mut filter = ComputeBudgetProgramIdFilter::new();
         let mut compute_budget_instruction_details = ComputeBudgetInstructionDetails::default();
 
-        for (i, (program_id, instruction)) in instructions.clone().enumerate() {
+        for (i, (program_id, instruction)) in instructions.clone().into_iter().enumerate() {
             if filter.is_compute_budget_program(instruction.program_id_index as usize, program_id) {
                 compute_budget_instruction_details.process_instruction(i as u8, &instruction)?;
             } else {

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -11,9 +11,10 @@ pub struct PrecompileSignatureDetails {
 }
 
 /// Get transaction signature details.
-pub fn get_precompile_signature_details<'a>(
-    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
-) -> PrecompileSignatureDetails {
+pub fn get_precompile_signature_details<'a, I>(instructions: I) -> PrecompileSignatureDetails
+where
+    I: IntoIterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+{
     let mut filter = SignatureDetailsFilter::new();
 
     // Wrapping arithmetic is safe below because the maximum number of signatures

--- a/runtime-transaction/src/signature_details.rs
+++ b/runtime-transaction/src/signature_details.rs
@@ -140,7 +140,7 @@ mod tests {
             make_instruction(&program_ids, 1, &[]),
         ];
 
-        let signature_details = get_precompile_signature_details(instructions.into_iter());
+        let signature_details = get_precompile_signature_details(instructions);
         assert_eq!(signature_details.num_secp256k1_instruction_signatures, 0);
         assert_eq!(signature_details.num_ed25519_instruction_signatures, 0);
     }
@@ -164,7 +164,7 @@ mod tests {
             make_instruction(&program_ids, 3, &[3]),
         ];
 
-        let signature_details = get_precompile_signature_details(instructions.into_iter());
+        let signature_details = get_precompile_signature_details(instructions);
         assert_eq!(signature_details.num_secp256k1_instruction_signatures, 6);
         assert_eq!(signature_details.num_ed25519_instruction_signatures, 5);
         assert_eq!(signature_details.num_secp256r1_instruction_signatures, 7);
@@ -182,7 +182,7 @@ mod tests {
             make_instruction(&program_ids, 1, &[]),
         ];
 
-        let signature_details = get_precompile_signature_details(instructions.into_iter());
+        let signature_details = get_precompile_signature_details(instructions);
         assert_eq!(signature_details.num_secp256k1_instruction_signatures, 0);
         assert_eq!(signature_details.num_ed25519_instruction_signatures, 0);
         assert_eq!(signature_details.num_secp256r1_instruction_signatures, 0);


### PR DESCRIPTION
#### Problem

There are many places where we do unaligned access, which lead to slow`movups` instructions. These in particular could come from call to `program_instructions_iter()`.
Since it is hard to avoid unaligned access unaligned access when using packet data, what we can try instead is to minimize number of such access. 

In particular, `program_instructions_iter` is called 3 times from `RuntimeTransaction::try_from` which lead to marking these movups so red. So we can call it once and pass later cached values where necessary, this gives in benchmark 38% boost:

```shell
receive_and_buffer/transaction_view_max_instructions
                        time:   [306.64 ms 306.80 ms 307.06 ms]
                        thrpt:  [53.358 Kelem/s 53.403 Kelem/s 53.432 Kelem/s]
                 change:
                        time:   [-28.010% -27.969% -27.918%] (p = 0.00 < 0.05)
                        thrpt:  [+38.730% +38.829% +38.908%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
```

