### PR TITLE
Adds metric for in-memory size estimate when disk index is disabled

### DIFF
--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -564,6 +564,12 @@ impl BucketMapHolderStats {
                     "accounts_index"
                 },
                 (
+                    "estimate_mem_bytes",
+                    self.count_in_mem.load(Ordering::Relaxed)
+                        * InMemAccountsIndex::<T, U>::approx_size_of_one_entry(),
+                    i64
+                ),
+                (
                     "count_in_mem",
                     self.count_in_mem.load(Ordering::Relaxed),
                     i64


### PR DESCRIPTION
#### Problem

We have stats for the size of the in-memory accounts index, but we only submit the metrics if the disk index is enabled. They are not submitted otherwise. It would be nice to also see this estimate when the disk index is disabled.


#### Summary of Changes

Submit in-memory estimate metric for the accounts index when the disk index is disabled.