### PR TITLE
Warn about broken platform-tools installation

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -526,12 +526,12 @@ fn corrupted_toolchain(config: &Config) -> bool {
         .join("platform-tools")
         .join("rust");
 
-    if !toolchain_path.exists() {
-        return true;
-    }
-
     let binaries = toolchain_path.join("bin");
-    !binaries.exists() || !binaries.join("rustc").exists() || !binaries.join("cargo").exists()
+
+    !toolchain_path.try_exists().unwrap_or(false)
+        || !binaries.try_exists().unwrap_or(false)
+        || !binaries.join("rustc").try_exists().unwrap_or(false)
+        || !binaries.join("cargo").try_exists().unwrap_or(false)
 }
 
 // check whether custom solana toolchain is linked, and link it if it is not.


### PR DESCRIPTION
#### Problem

If the download of the platform tools is interrupted, the command fails silently. If we run `cargo-build-sbf` with a corrupted toolchain, the error is not very helpful:

```
$ cargo build-sbf
error: not a directory: '/home/sol/.local/share/solana/install/releases/2.2.1/solana-release/bin/platform-tools-sdk/sbf/dependencies/platform-tools/rust/bin'
```

Also, see https://github.com/anza-xyz/agave/issues/5340

#### Summary of Changes

The problem is easily fixed if we run `cargo-build-sbf --force-tools-install`, which will replace the broken installation with a new one. Now, before invoking the compiler itself, we'll check if the installation is correct and warn otherwise.
