### PR TITLE
Bump `solana-bn254` version to 2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,9 +6740,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc69625158faaab02347370b91c0d8e0fe347bf9287239f0fbe8f5864d91da"
+checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,7 +372,7 @@ solana-big-mod-exp = "=2.2.1"
 solana-bincode = "=2.2.1"
 solana-blake3-hasher = "=2.2.1"
 solana-bloom = { path = "bloom", version = "=2.3.0" }
-solana-bn254 = "=2.2.1"
+solana-bn254 = "=2.2.2"
 solana-borsh = "=2.2.1"
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.3.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5414,9 +5414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc69625158faaab02347370b91c0d8e0fe347bf9287239f0fbe8f5864d91da"
+checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -35,7 +35,7 @@ serde_derive = "1.0.112"                                                        
 serde_json = "1.0.56"
 solana-account-decoder = { path = "../../account-decoder", version = "=2.3.0" }
 solana-accounts-db = { path = "../../accounts-db", version = "=2.3.0" }
-solana-bn254 = "=2.2.1"
+solana-bn254 = "=2.2.2"
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.3.0" }
 solana-cli-output = { path = "../../cli-output", version = "=2.3.0" }
 solana-compute-budget = { path = "../../compute-budget", version = "=2.3.0" }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5272,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc69625158faaab02347370b91c0d8e0fe347bf9287239f0fbe8f5864d91da"
+checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
  "ark-bn254",
  "ark-ec",


### PR DESCRIPTION
#### Problem
There is a panic behavior in `solana-bn254` due to a wrong remainder check (https://github.com/anza-xyz/solana-sdk/blob/master/bn254/src/lib.rs#L321-L327). This was fixed in https://github.com/anza-xyz/solana-sdk/pull/80 and is included in `solana-bn254` v2.2.2.

#### Summary of Changes
Bump `solana-bn254` to v2.2.2. This should be backported to v2.2 as a security fix.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
