### PR TITLE
clean: move precompiles feature

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -8,7 +8,7 @@ use {
         TransactionSimulationDetails, TransactionStatus,
     },
     solana_client::connection_cache::ConnectionCache,
-    solana_feature_set::{move_precompile_verification_to_svm, FeatureSet},
+    solana_feature_set::FeatureSet,
     solana_runtime::{
         bank::{Bank, TransactionSimulationResult},
         bank_forks::BankForks,
@@ -159,21 +159,6 @@ impl BanksServer {
         }
         status
     }
-}
-
-fn verify_transaction(
-    transaction: &SanitizedTransaction,
-    feature_set: &Arc<FeatureSet>,
-) -> transaction::Result<()> {
-    transaction.verify()?;
-
-    let move_precompile_verification_to_svm =
-        feature_set.is_active(&move_precompile_verification_to_svm::id());
-    if !move_precompile_verification_to_svm {
-        verify_precompiles(transaction, feature_set)?;
-    }
-
-    Ok(())
 }
 
 fn simulate_transaction(
@@ -328,7 +313,7 @@ impl Banks for BanksServer {
             Err(err) => return Some(Err(err)),
         };
 
-        if let Err(err) = verify_transaction(&sanitized_transaction, &bank.feature_set) {
+        if let Err(err) = sanitized_transaction.verify() {
             return Some(Err(err));
         }
 

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -8,12 +8,10 @@ use {
         TransactionSimulationDetails, TransactionStatus,
     },
     solana_client::connection_cache::ConnectionCache,
-    solana_feature_set::FeatureSet,
     solana_runtime::{
         bank::{Bank, TransactionSimulationResult},
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
-        verify_precompiles::verify_precompiles,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -11,7 +11,6 @@ use {
         BankingStageStats,
     },
     itertools::Itertools,
-    solana_feature_set as feature_set,
     solana_fee::FeeFeatures,
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
@@ -24,7 +23,6 @@ use {
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},
         transaction_batch::TransactionBatch,
-        verify_precompiles::verify_precompiles,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_sdk::{

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -13,7 +13,7 @@ use {
         clock::MAX_PROCESSING_AGE,
         compute_budget::ComputeBudgetInstruction,
         genesis_config::{create_genesis_config, GenesisConfig},
-        instruction::{Instruction, InstructionError},
+        instruction::{AccountMeta, Instruction, InstructionError},
         message::Message,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
@@ -512,12 +512,9 @@ fn test_builtin_ix_set_cu_price_only() {
     }
 }
 
-#[allow(clippy::explicit_counter_loop)]
 #[test]
 fn test_builtin_ix_precompiled() {
     let mut test_setup = TestSetup::new();
-    let data = [0_u8, 1_u8];
-    let mut index = 0;
 
     // single precompiled instruction
     for (is_simd_170_enabled, expected) in [
@@ -550,12 +547,12 @@ fn test_builtin_ix_precompiled() {
             test_setup.execute_test_transaction(
                 &[Instruction::new_with_bincode(
                     solana_sdk::secp256k1_program::id(),
-                    &data[index],
-                    vec![]
+                    &[0u8],
+                    // Add a dummy account to generate a unique transaction
+                    vec![AccountMeta::new_readonly(Pubkey::new_unique(), false)]
                 )],
                 is_simd_170_enabled
             )
         );
-        index += 1;
     }
 }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -490,10 +490,7 @@ fn start_verify_transactions_gpu<Tx: TransactionWithMeta + Send + Sync + 'static
 ) -> Result<EntrySigVerificationState<Tx>> {
     let verify_func = {
         move |versioned_tx: VersionedTransaction| -> Result<Tx> {
-            verify(
-                versioned_tx,
-                TransactionVerificationMode::HashAndVerifyPrecompiles,
-            )
+            verify(versioned_tx, TransactionVerificationMode::HashOnly)
         }
     };
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -12,8 +12,7 @@ use {
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_set::{
-        lift_cpi_caller_restriction, move_precompile_verification_to_svm,
-        remove_accounts_executable_flag_checks, FeatureSet,
+        lift_cpi_caller_restriction, remove_accounts_executable_flag_checks, FeatureSet,
     },
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta},
@@ -499,17 +498,11 @@ impl<'a> InvokeContext<'a> {
         self.push()?;
 
         let feature_set = self.get_feature_set();
-        let move_precompile_verification_to_svm =
-            feature_set.is_active(&move_precompile_verification_to_svm::id());
-        if move_precompile_verification_to_svm {
-            let instruction_datas: Vec<_> = message_instruction_datas_iter.collect();
-            precompile
-                .verify(instruction_data, &instruction_datas, feature_set)
-                .map_err(InstructionError::from)
-                .and(self.pop())
-        } else {
-            self.pop()
-        }
+        let instruction_datas: Vec<_> = message_instruction_datas_iter.collect();
+        precompile
+            .verify(instruction_data, &instruction_datas, feature_set)
+            .map_err(InstructionError::from)
+            .and(self.pop())
     }
 
     /// Calls the instruction's program entrypoint method

--- a/programs/ed25519-tests/tests/process_transaction.rs
+++ b/programs/ed25519-tests/tests/process_transaction.rs
@@ -3,7 +3,6 @@ use {
     solana_program_test::*,
     solana_sdk::{
         ed25519_instruction::new_ed25519_instruction,
-        feature_set,
         instruction::InstructionError,
         precompiles::PrecompileError,
         signature::Signer,

--- a/programs/ed25519-tests/tests/process_transaction.rs
+++ b/programs/ed25519-tests/tests/process_transaction.rs
@@ -48,37 +48,6 @@ async fn test_success() {
 }
 
 #[tokio::test]
-async fn test_failure_without_move_precompiles_feature() {
-    let mut program_test = ProgramTest::default();
-    program_test.deactivate_feature(feature_set::move_precompile_verification_to_svm::id());
-    let mut context = program_test.start_with_context().await;
-
-    let client = &mut context.banks_client;
-    let payer = &context.payer;
-    let recent_blockhash = context.last_blockhash;
-
-    let privkey = generate_keypair();
-    let message_arr = b"hello";
-    let mut instruction = new_ed25519_instruction(&privkey, message_arr);
-
-    instruction.data[0] += 1;
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&payer.pubkey()),
-        &[payer],
-        recent_blockhash,
-    );
-
-    assert_matches!(
-        client.process_transaction(transaction).await,
-        Err(BanksClientError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::Custom(3))
-        ))
-    );
-}
-
-#[tokio::test]
 async fn test_failure() {
     let mut context = ProgramTest::default().start_with_context().await;
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2414,21 +2414,10 @@ pub(crate) fn optimize_filters(filters: &mut [RpcFilterType]) {
     })
 }
 
-fn verify_transaction(
-    transaction: &SanitizedTransaction,
-    feature_set: &Arc<feature_set::FeatureSet>,
-) -> Result<()> {
+fn verify_transaction(transaction: &SanitizedTransaction) -> Result<()> {
     #[allow(clippy::question_mark)]
     if transaction.verify().is_err() {
         return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
-    }
-
-    let move_precompile_verification_to_svm =
-        feature_set.is_active(&feature_set::move_precompile_verification_to_svm::id());
-    if !move_precompile_verification_to_svm {
-        if let Err(e) = verify_precompiles(transaction, feature_set) {
-            return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
-        }
     }
 
     Ok(())
@@ -3884,7 +3873,7 @@ pub mod rpc_full {
             }
 
             if !skip_preflight {
-                verify_transaction(&transaction, &preflight_bank.feature_set)?;
+                verify_transaction(&transaction)?;
 
                 if !meta.config.skip_preflight_health_check {
                     match meta.health.check() {
@@ -4001,7 +3990,7 @@ pub mod rpc_full {
             let transaction =
                 sanitize_transaction(unsanitized_tx, bank, bank.get_reserved_account_keys())?;
             if sig_verify {
-                verify_transaction(&transaction, &bank.feature_set)?;
+                verify_transaction(&transaction)?;
             }
 
             let TransactionSimulationResult {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -31,7 +31,6 @@ use {
     solana_client::connection_cache::Protocol,
     solana_entry::entry::Entry,
     solana_faucet::faucet::request_airdrop_transaction,
-    solana_feature_set as feature_set,
     solana_gossip::cluster_info::ClusterInfo,
     solana_inline_spl::{
         token::{SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
@@ -65,7 +64,6 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_config::SnapshotConfig,
         snapshot_utils,
-        verify_precompiles::verify_precompiles,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -56,7 +56,6 @@ use {
         stakes::{Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
-        verify_precompiles::verify_precompiles,
     },
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     ahash::AHashSet,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5685,16 +5685,6 @@ impl Bank {
             )
         }?;
 
-        let move_precompile_verification_to_svm = self
-            .feature_set
-            .is_active(&feature_set::move_precompile_verification_to_svm::id());
-        if !move_precompile_verification_to_svm && {
-            verification_mode == TransactionVerificationMode::HashAndVerifyPrecompiles
-                || verification_mode == TransactionVerificationMode::FullVerification
-        } {
-            verify_precompiles(&sanitized_tx, &self.feature_set)?;
-        }
-
         Ok(sanitized_tx)
     }
 


### PR DESCRIPTION
#### Problem
The move precompiles feature has been activated on all clusters and can be cleaned up

#### Summary of Changes
Clean up move precompiles feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
