### PR TITLE
fix: tpu client when no sockets found

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -703,6 +703,12 @@ impl LocalCluster {
         attempts: usize,
         pending_confirmations: usize,
     ) -> std::result::Result<Signature, TransportError> {
+        // @gregcusack: send_wire_transaction() and try_send_transaction() both fail in
+        // a specific case when used in LocalCluster. They both invoke the nonblocking
+        // TPUClient and both fail when calling `transfer_with_client()` multiple times.
+        // I do not full understand WHY the nonblocking TPUClient fails in this specific
+        // case. But the method defined below does work although it has only been tested
+        // in LocalCluster integration tests
         for attempt in 0..attempts {
             let now = Instant::now();
             let mut num_confirmed = 0;

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -136,7 +136,7 @@ where
         if let Some(err) = last_error {
             Err(err)
         } else if !some_success {
-            std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted").into()
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted").into())
         } else {
             Ok(())
         }


### PR DESCRIPTION
#### Problem
Sometimes the tpu client is created using an rpc client connected to a node that hasn't discovered the cluster yet and therefore has no known leader tpu sockets until it refreshes cluster info every 5min.

#### Summary of Changes
- Retry fetching cluster info if no node contact info was returned
- Fail hard when trying to send transactions to no leaders

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
