### PR TITLE
remove base58 transaction encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9471,6 +9471,7 @@ dependencies = [
 name = "solana-rpc-test"
 version = "2.3.0"
 dependencies = [
+ "base64 0.22.1",
  "bincode",
  "bs58",
  "crossbeam-channel",

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -452,7 +452,6 @@ pub fn parse_balance(
 pub fn parse_decode_transaction(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let blob = value_t_or_exit!(matches, "transaction", String);
     let binary_encoding = match matches.value_of("encoding").unwrap() {
-        "base58" => TransactionBinaryEncoding::Base58,
         "base64" => TransactionBinaryEncoding::Base64,
         _ => unreachable!(),
     };

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -350,12 +350,12 @@ impl RpcSender for MockSender {
                 parent_slot: 429,
                 transactions: vec![EncodedTransactionWithStatusMeta {
                     transaction: EncodedTransaction::Binary(
-                        "ju9xZWuDBX4pRxX2oZkTjxU5jB4SSTgEGhX8bQ8PURNzyzqKMPPpNvWihx8zUe\
-                                 FfrbVNoAaEsNKZvGzAnTDy5bhNT9kt6KFCTBixpvrLCzg4M5UdFUQYrn1gdgjX\
-                                 pLHxcaShD81xBNaFDgnA2nkkdHnKtZt4hVSfKAmw3VRZbjrZ7L2fKZBx21CwsG\
-                                 hD6onjM2M3qZW5C8J6d1pj41MxKmZgPBSha3MyKkNLkAGFASK"
+                        "ASQffZKTaGW1YaJ5haQqVH7ZtK/zVZiYy/W5NaYO1aSqKiMvIGell7XKo5wimQwVSMMTEr4\
+                        lm5O9+DkF5QrvyAkBAAAC70MCfWZjFFXbkIVru6heL6R1kkGN+IIjav1M/yCDigdy9cB+bX6\
+                        mz0z3jZRqMKamWbSZZq0y+INBh+LY4YWCOwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+                        AAAAAAf8ABAAAAAA="
                             .to_string(),
-                        TransactionBinaryEncoding::Base58,
+                        TransactionBinaryEncoding::Base64,
                     ),
                     meta: None,
                     version: Some(TransactionVersion::LEGACY),

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2297,7 +2297,7 @@ impl RpcClient {
     /// # futures::executor::block_on(async {
     /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// #     let slot = rpc_client.get_slot().await?;
-    /// let encoding = UiTransactionEncoding::Base58;
+    /// let encoding = UiTransactionEncoding::Base64;
     /// let block = rpc_client.get_block_with_encoding(
     ///     slot,
     ///     encoding,
@@ -2339,7 +2339,7 @@ impl RpcClient {
     /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// #     let slot = rpc_client.get_slot().await?;
     /// let config = RpcBlockConfig {
-    ///     encoding: Some(UiTransactionEncoding::Base58),
+    ///     encoding: Some(UiTransactionEncoding::Base64),
     ///     transaction_details: Some(TransactionDetails::None),
     ///     rewards: Some(true),
     ///     commitment: None,
@@ -4646,7 +4646,6 @@ where
     let serialized = serialize(input)
         .map_err(|e| ClientErrorKind::Custom(format!("Serialization failed: {e}")))?;
     let encoded = match encoding {
-        UiTransactionEncoding::Base58 => bs58::encode(serialized).into_string(),
         UiTransactionEncoding::Base64 => BASE64_STANDARD.encode(serialized),
         _ => {
             return Err(ClientErrorKind::Custom(format!(

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1955,7 +1955,7 @@ impl RpcClient {
     /// # use solana_transaction_status_client_types::UiTransactionEncoding;
     /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// # let slot = rpc_client.get_slot()?;
-    /// let encoding = UiTransactionEncoding::Base58;
+    /// let encoding = UiTransactionEncoding::Base64;
     /// let block = rpc_client.get_block_with_encoding(
     ///     slot,
     ///     encoding,
@@ -1993,7 +1993,7 @@ impl RpcClient {
     /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// # let slot = rpc_client.get_slot()?;
     /// let config = RpcBlockConfig {
-    ///     encoding: Some(UiTransactionEncoding::Base58),
+    ///     encoding: Some(UiTransactionEncoding::Base64),
     ///     transaction_details: Some(TransactionDetails::None),
     ///     rewards: Some(true),
     ///     commitment: None,

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+base64 = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -1,4 +1,5 @@
 use {
+    base64::{prelude::BASE64_STANDARD, Engine},
     bincode::serialize,
     crossbeam_channel::unbounded,
     futures_util::StreamExt,
@@ -90,7 +91,7 @@ fn test_rpc_send_tx() {
         Rent::default().minimum_balance(0),
         blockhash,
     );
-    let serialized_encoded_tx = bs58::encode(serialize(&tx).unwrap()).into_string();
+    let serialized_encoded_tx = BASE64_STANDARD.encode(serialize(&tx).unwrap());
 
     let req = json_req!("sendTransaction", json!([serialized_encoded_tx]));
     let json: Value = post_rpc(req, &rpc_url);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8804,10 +8804,10 @@ pub mod tests {
         assert_eq!(
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
-            Error::invalid_params(format!(
-                "decoded solana_transaction::Transaction too large: 1234 bytes (max: 1232 bytes)",
+            Error::invalid_params(
+                "decoded solana_transaction::Transaction too large: 1234 bytes (max: 1232 bytes)"
             )
-        ));
+        );
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
         assert_eq!(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5866,11 +5866,11 @@ pub mod tests {
             rent_exempt_amount,
             recent_blockhash,
         );
-        let tx_serialized_encoded = bs58::encode(serialize(&tx).unwrap()).into_string();
+        let tx_serialized_encoded = BASE64_STANDARD.encode(serialize(&tx).unwrap());
         tx.signatures[0] = Signature::default();
-        let tx_badsig_serialized_encoded = bs58::encode(serialize(&tx).unwrap()).into_string();
+        let tx_badsig_serialized_encoded = BASE64_STANDARD.encode(serialize(&tx).unwrap());
         tx.message.recent_blockhash = Hash::default();
-        let tx_invalid_recent_blockhash = bs58::encode(serialize(&tx).unwrap()).into_string();
+        let tx_invalid_recent_blockhash = BASE64_STANDARD.encode(serialize(&tx).unwrap());
 
         // Simulation bank must be frozen
         bank.freeze();
@@ -6204,7 +6204,7 @@ pub mod tests {
         let recent_blockhash = bank.confirmed_last_blockhash();
         let tx =
             system_transaction::transfer(&fee_payer, &token_account_pubkey, 1, recent_blockhash);
-        let tx_serialized_encoded = bs58::encode(serialize(&tx).unwrap()).into_string();
+        let tx_serialized_encoded = BASE64_STANDARD.encode(serialize(&tx).unwrap());
 
         // Simulation bank must be frozen
         bank.freeze();
@@ -6510,7 +6510,7 @@ pub mod tests {
 
         let bob_pubkey = Pubkey::new_unique();
         let tx = system_transaction::transfer(&mint_keypair, &bob_pubkey, 1234, recent_blockhash);
-        let tx_serialized_encoded = bs58::encode(serialize(&tx).unwrap()).into_string();
+        let tx_serialized_encoded = BASE64_STANDARD.encode(serialize(&tx).unwrap());
 
         assert!(!bank.is_frozen());
 
@@ -6727,7 +6727,7 @@ pub mod tests {
         // sendTransaction will fail because the blockhash is invalid
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}"]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta.clone());
         assert_eq!(
@@ -6743,7 +6743,7 @@ pub mod tests {
         bad_transaction.sign(&[&mint_keypair], recent_blockhash);
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}"]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta.clone());
         assert_eq!(
@@ -6763,7 +6763,7 @@ pub mod tests {
         health.stub_set_health_status(Some(RpcHealthStatus::Behind { num_slots: 42 }));
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}"]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta.clone());
         assert_eq!(
@@ -6779,7 +6779,7 @@ pub mod tests {
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}"]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta.clone());
         assert_eq!(
@@ -6793,7 +6793,7 @@ pub mod tests {
         // transaction
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}", {{"skipPreflight": true}}]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta.clone());
         assert_eq!(
@@ -6807,7 +6807,7 @@ pub mod tests {
         bad_transaction.signatures.clear();
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["{}"]}}"#,
-            bs58::encode(serialize(&bad_transaction).unwrap()).into_string()
+            BASE64_STANDARD.encode(serialize(&bad_transaction).unwrap())
         );
         let res = io.handle_request_sync(&req, meta);
         assert_eq!(
@@ -8801,7 +8801,6 @@ pub mod tests {
         let tx_ser = vec![0xffu8; too_big];
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
-        let tx64_len = tx64.len();
         assert_eq!(
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8804,15 +8804,6 @@ pub mod tests {
         assert_eq!(
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
-            Error::invalid_params(
-                "decoded solana_transaction::Transaction too large: 1234 bytes (max: 1232 bytes)"
-            )
-        );
-
-        let tx64 = BASE64_STANDARD.encode(&tx_ser);
-        assert_eq!(
-            decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
-                .unwrap_err(),
             Error::invalid_params(format!(
                 "decoded solana_transaction::Transaction too large: {too_big} bytes (max: {PACKET_DATA_SIZE} bytes)"
             ))

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8806,7 +8806,7 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
+                "decoded solana_transaction::Transaction too large: 1234 bytes (max: 1232 bytes)",
             )
         ));
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3853,7 +3853,7 @@ pub mod rpc_full {
             let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base64);
             let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
                 Error::invalid_params(format!(
-                    "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+                    "unsupported encoding: {tx_encoding}. Supported encodings: base64"
                 ))
             })?;
             let (wire_transaction, unsanitized_tx) =
@@ -3976,7 +3976,7 @@ pub mod rpc_full {
             let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base64);
             let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
                 Error::invalid_params(format!(
-                    "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+                    "unsupported encoding: {tx_encoding}. Supported encodings: base64"
                 ))
             })?;
             let (_, mut unsanitized_tx) =
@@ -8831,19 +8831,19 @@ pub mod tests {
 
     #[test]
     fn test_sanitize_unsanitary() {
-        let unsanitary_tx58 = "ASQffZKTaGW1YaJ5haQqVH7ZtK/zVZiYy/W5NaYO1aSqKiMvIGell7X\
+        let unsanitary_tx64 = "ASQffZKTaGW1YaJ5haQqVH7ZtK/zVZiYy/W5NaYO1aSqKiMvIGell7X\
         Ko5wimQwVSMMTEr4lm5O9+DkF5QrvyAkBAAAC70MCfWZjFFXbkIVru6heL6R1kkGN+IIjav1\
         M/yCDigdy9cB+bX6mz0z3jZRqMKamWbSZZq0y+INBh+LY4YWCOwE\
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf8ABAAAAAA="
             .to_string();
 
         let unsanitary_versioned_tx = decode_and_deserialize::<VersionedTransaction>(
-            unsanitary_tx58,
+            unsanitary_tx64,
             TransactionBinaryEncoding::Base64,
         )
         .unwrap()
         .1;
-        let expect58 = Error::invalid_params(
+        let expect64 = Error::invalid_params(
             "invalid transaction: Transaction failed to sanitize accounts offsets correctly"
                 .to_string(),
         );
@@ -8854,7 +8854,7 @@ pub mod tests {
                 &ReservedAccountKeys::empty_key_set()
             )
             .unwrap_err(),
-            expect58
+            expect64
         );
     }
 

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -667,7 +667,7 @@ pub mod rpc {
                 min_context_slot: _,
                 inner_instructions: enable_cpi_recording,
             } = config.unwrap_or_default();
-            let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base58);
+            let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base64);
             let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
                 Error::invalid_params(format!(
                     "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
@@ -822,20 +822,6 @@ where
     T: serde::de::DeserializeOwned,
 {
     let wire_output = match encoding {
-        TransactionBinaryEncoding::Base58 => {
-            if encoded.len() > MAX_BASE58_SIZE {
-                return Err(Error::invalid_params(format!(
-                    "base58 encoded {} too large: {} bytes (max: encoded/raw {}/{})",
-                    type_name::<T>(),
-                    encoded.len(),
-                    MAX_BASE58_SIZE,
-                    PACKET_DATA_SIZE,
-                )));
-            }
-            bs58::decode(encoded)
-                .into_vec()
-                .map_err(|e| Error::invalid_params(format!("invalid base58 encoding: {e:?}")))?
-        }
         TransactionBinaryEncoding::Base64 => {
             if encoded.len() > MAX_BASE64_SIZE {
                 return Err(Error::invalid_params(format!(

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -88,7 +88,6 @@ pub const MAX_REQUEST_BODY_SIZE: usize = 50 * (1 << 10); // 50kB
 
 const EXECUTION_SLOT: u64 = 5; // The execution slot must be greater than the deployment slot
 const EXECUTION_EPOCH: u64 = 2; // The execution epoch must be greater than the deployment epoch
-const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
 
 fn new_response<T>(slot: Slot, value: T) -> RpcResponse<T> {

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -627,13 +627,6 @@ impl EncodableWithMeta for VersionedTransaction {
         meta: &TransactionStatusMeta,
     ) -> Self::Encoded {
         match encoding {
-            UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-            ),
-            UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-                TransactionBinaryEncoding::Base58,
-            ),
             UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
                 BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
                 TransactionBinaryEncoding::Base64,
@@ -667,13 +660,6 @@ impl Encodable for VersionedTransaction {
     type Encoded = EncodedTransaction;
     fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
         match encoding {
-            UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-            ),
-            UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-                TransactionBinaryEncoding::Base58,
-            ),
             UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
                 BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
                 TransactionBinaryEncoding::Base64,
@@ -699,13 +685,6 @@ impl Encodable for Transaction {
     type Encoded = EncodedTransaction;
     fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
         match encoding {
-            UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-            ),
-            UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
-                TransactionBinaryEncoding::Base58,
-            ),
             UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
                 BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
                 TransactionBinaryEncoding::Base64,


### PR DESCRIPTION
#### Problem
Encoding transactions as base58 is inefficient and not IBRL.

#### Summary of Changes
Remove the Base58 variants of enums related to transaction encoding. This is a breaking change
