### PR TITLE
local-cluster: speed up waiting for next snapshot

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1253,12 +1253,10 @@ fn test_snapshot_restart_tower() {
         .unwrap();
     let validator_info = cluster.exit_node(&validator_id);
 
-    // Get slot after which this was generated
     let full_snapshot_archives_dir = &leader_snapshot_test_config
         .validator_config
         .snapshot_config
         .full_snapshot_archives_dir;
-
     let full_snapshot_archive_info = cluster.wait_for_next_full_snapshot(
         full_snapshot_archives_dir,
         Some(Duration::from_secs(5 * 60)),


### PR DESCRIPTION
#### Problem
Local cluster tests often wait for a new snapshot to produced to know that a node is healthy but they wait far longer than necessary because they wait for a new snapshot to be produced at a slot greater than the most recently processed slot.

#### Summary of Changes
Change `wait_for_next_snapshot` to check the latest snapshot on disk and then wait for a newer one to be produced.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
