### PR TITLE
local-cluster: speed up tx polling

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -252,7 +252,6 @@ fn test_local_cluster_signature_subscribe() {
         &[&cluster.funding_keypair],
         &mut transaction,
         5,
-        0,
     )
     .unwrap();
 
@@ -2846,7 +2845,6 @@ fn test_oc_bad_signatures() {
                     &[&cluster_funding_keypair, &bad_authorized_signer_keypair],
                     &mut vote_tx,
                     5,
-                    0,
                 )
                 .unwrap();
 


### PR DESCRIPTION
#### Problem
The default polling behavior in the local cluster's client uses the "finalized" commitment level to get transaction confirmation status and then checks number of "confirmations" rather just checking the faster "processed" level.

#### Summary of Changes
- Use processed commitment to poll for transactions in local-cluster
- Stop poller if the transaction's recent blockhash is no longer valid.
- Remove arbitrary timeout from retry logic

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
