### PR TITLE
refactor: move account hash purging

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7038,6 +7038,7 @@ impl AccountsDb {
                  {accounts_hash:?}"
             );
         }
+        self.purge_old_accounts_hashes(slot);
         accounts_hash
     }
 
@@ -7141,10 +7142,7 @@ impl AccountsDb {
     }
 
     /// Purge accounts hashes that are older than `latest_full_snapshot_slot`
-    ///
-    /// Should only be called by AccountsHashVerifier, since it consumes the accounts hashes and
-    /// knows which ones are still needed.
-    pub fn purge_old_accounts_hashes(&self, latest_full_snapshot_slot: Slot) {
+    fn purge_old_accounts_hashes(&self, latest_full_snapshot_slot: Slot) {
         self.accounts_hashes
             .lock()
             .unwrap()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7023,7 +7023,7 @@ impl AccountsDb {
     }
 
     /// Calculate the full accounts hash for `storages` and save the results at `slot`
-    pub fn update_accounts_hash(
+    pub fn update_accounts_hash_and_purge_old_hashes(
         &self,
         config: &CalcAccountsHashConfig<'_>,
         storages: &SortedStorages<'_>,

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -221,8 +221,6 @@ impl AccountsHashVerifier {
 
         Self::save_epoch_accounts_hash(&accounts_package, &merkle_or_lattice_accounts_hash);
 
-        Self::purge_old_accounts_hashes(&accounts_package, snapshot_config);
-
         Self::submit_for_packaging(
             accounts_package,
             pending_snapshot_packages,
@@ -451,37 +449,6 @@ impl AccountsHashVerifier {
                 .accounts_db
                 .epoch_accounts_hash_manager
                 .set_valid((*accounts_hash).into(), accounts_package.slot);
-        }
-    }
-
-    fn purge_old_accounts_hashes(
-        accounts_package: &AccountsPackage,
-        snapshot_config: &SnapshotConfig,
-    ) {
-        let should_purge = match (
-            snapshot_config.should_generate_snapshots(),
-            accounts_package.package_kind,
-        ) {
-            (false, _) => {
-                // If we are *not* generating snapshots, then it is safe to purge every time.
-                true
-            }
-            (true, AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)) => {
-                // If we *are* generating snapshots, then only purge old accounts hashes after
-                // handling full snapshot packages.  This is because handling incremental snapshot
-                // packages requires the accounts hash from the latest full snapshot, and if we
-                // purged after every package, we'd remove the accounts hash needed by the next
-                // incremental snapshot.
-                true
-            }
-            (true, _) => false,
-        };
-
-        if should_purge {
-            accounts_package
-                .accounts
-                .accounts_db
-                .purge_old_accounts_hashes(accounts_package.slot);
         }
     }
 


### PR DESCRIPTION
#### Problem
AHV has overly complex behavior for deciding when to purge account hashes. We shouldn't need to rely on snapshot config to purge old hashes.

#### Summary of Changes
Purge account hashes whenever updating accounts db with a new account hash insertion

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
