### PR TITLE
Remove snapshots enabled check in AHV

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -226,7 +226,6 @@ impl AccountsHashVerifier {
         Self::submit_for_packaging(
             accounts_package,
             pending_snapshot_packages,
-            snapshot_config,
             merkle_or_lattice_accounts_hash,
             bank_incremental_snapshot_persistence,
         );
@@ -489,16 +488,13 @@ impl AccountsHashVerifier {
     fn submit_for_packaging(
         accounts_package: AccountsPackage,
         pending_snapshot_packages: &Mutex<PendingSnapshotPackages>,
-        snapshot_config: &SnapshotConfig,
         merkle_or_lattice_accounts_hash: MerkleOrLatticeAccountsHash,
         bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     ) {
-        if !snapshot_config.should_generate_snapshots()
-            || !matches!(
-                accounts_package.package_kind,
-                AccountsPackageKind::Snapshot(_)
-            )
-        {
+        if !matches!(
+            accounts_package.package_kind,
+            AccountsPackageKind::Snapshot(_)
+        ) {
             return;
         }
 


### PR DESCRIPTION
#### Problem
AHV unnecessarily double checks whether snapshot generation is enabled before submitting a snapshot for packaging.

#### Summary of Changes
Remove the snapshot generation enabled check and trust upstream services to not send any snapshot requests if snapshot generation is disabled

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
