### PR TITLE
Lower default local-cluster test timeouts

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -30,8 +30,44 @@ filter = "package(solana-cargo-build-sbf)"
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster)'
+filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_progress$/)'
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_no_progress$/)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_run_test_load_program_accounts_partition_root$/)'
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_fork_choice_refresh_old_votes$/)'
+slow-timeout = { period = "60s", terminate-after = 5 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_cluster_partition_1_1_1$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_wait_for_max_stake$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_snapshots_restart_validity$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_slot_hash_expiry$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_boot_from_local_state$/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'package(solana-local-cluster)'
+slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
 filter = 'package(solana-cargo-build-sbf)'


### PR DESCRIPTION
#### Problem
Some local cluster tests should only take a minute or so but can get stuck and should be retried rather than let run for 10min

#### Summary of Changes
- Decrease local cluster default timeout from 10min to 2min
- Add specific overrides as necessary for longer running tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
