### PR TITLE
fix: remove extra discover in local cluster

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -424,13 +424,6 @@ impl LocalCluster {
         )
         .unwrap();
 
-        discover_cluster(
-            &cluster.entry_point_info.gossip().unwrap(),
-            config.node_stakes.len(),
-            socket_addr_space,
-        )
-        .unwrap();
-
         cluster
     }
 


### PR DESCRIPTION
#### Problem
Used to have an extra discover cluster call for archivers but it wasn't properly cleaned up in https://github.com/anza-xyz/agave/commit/eb1acaf92742d90573fecefd2cd0849009c7dff2

#### Summary of Changes
Remove unnecessary call

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
