### PR TITLE
fix: no extra discovered nodes in local cluster tests

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -74,7 +74,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
         socket_addr_space,
     )
     .unwrap();
-    assert!(cluster_nodes.len() >= nodes);
+    assert_eq!(cluster_nodes.len(), nodes);
     let ignore_nodes = Arc::new(ignore_nodes);
     cluster_nodes.par_iter().for_each(|ingress_node| {
         if ignore_nodes.contains(ingress_node.pubkey()) {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1286,7 +1286,7 @@ fn test_snapshot_restart_tower() {
     cluster_tests::spend_and_verify_all_nodes(
         restarted_node_info,
         &cluster.funding_keypair,
-        1,
+        2,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
         &cluster.connection_cache,


### PR DESCRIPTION
#### Problem
Some local cluster tests aren't configured to discover all running nodes, which produces inconsistency in test runs. This goes undetected because the node count check is not strict.

#### Summary of Changes
- Discover both nodes in `test_snapshot_restart_tower`
- Add strict equality check for discovered nodes in `spend_and_verify_all_nodes`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
