### PR TITLE
simd96 - fix ForwardingStage priority

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -271,7 +271,7 @@ impl AddAssign for SquashTiming {
 }
 
 #[derive(Debug, Default, PartialEq)]
-pub(crate) struct CollectorFeeDetails {
+pub struct CollectorFeeDetails {
     transaction_fee: u64,
     priority_fee: u64,
 }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -77,7 +77,7 @@ impl Bank {
         reward
     }
 
-    fn calculate_reward_and_burn_fee_details(
+    pub fn calculate_reward_and_burn_fee_details(
         &self,
         fee_details: &CollectorFeeDetails,
     ) -> (u64, u64) {


### PR DESCRIPTION
#### Problem
- `ForwardingStage` was written pre-SIMD96 and did not correctly calculate the reward from fees after the activation

#### Summary of Changes
- Make `CollectoFeeDetails` and `Bank::calculate_reward_and_burn_fee_details` public
- Correctly caculate the reward for prioritization calculation

Fixes #5218
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
