### PR TITLE
fix clippy warning

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1205,7 +1205,7 @@ impl Blockstore {
     ///   - [`cf::MerkleRootMeta`]: the associated MerkleRootMeta of the coding and data
     ///     shreds inside `shreds` will be updated and committed to
     ///     `cf::MerkleRootMeta`.
-    ///   - [`cf::Index`]: stores (slot id, index to the index_working_set_entry)
+    ///   - [`cf::Index`][]: stores (slot id, index to the index_working_set_entry)
     ///     pair to the `cf::Index` column family for each index_working_set_entry which insert did occur in this function call.
     ///
     /// Arguments:


### PR DESCRIPTION
#### Problem
Warning popped up after https://github.com/anza-xyz/agave/commit/2c0861ee9931db1dda5b42c0d7b9508452c006aa

```
warning: link reference defined in list item                                                                                                                                                                          
    --> ledger/src/blockstore.rs:1208:13                                                                                                                                                                              
     |                                                                                                                                                                                                                
1208 |     ///   - [`cf::Index`]: stores (slot id, index to the index_working_set_entry)                                                                                                                              
     |             ^^^^^^^^^^^^^                                                                                                                                                                                      
     |                                                                                                                                                                                                                
     = help: link definitions are not shown in rendered documentation                                                                                                                                                 
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_nested_refdefs                                                                                               
     = note: `#[warn(clippy::doc_nested_refdefs)]` on by default                                                                                                                                                      
help: for an intra-doc link, add `[]` between the label and the colon                                                                                                                                                 
     |                                                                                                                                                                                                                
1208 |     ///   - [`cf::Index`][]: stores (slot id, index to the index_working_set_entry)                                                                                                                            
     |                          ++                                                                                                                                                                                    
                                                                                                                                                                                                                      
warning: `solana-ledger` (lib) generated 1 warning                                                                                                                                                                    
```

#### Summary of Changes
Fix warning

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
