### PR TITLE
refactor: Add snapshot usage "disabled" variant

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -916,7 +916,7 @@ impl Validator {
             AbsRequestSender::new(snapshot_request_sender.clone());
         let snapshot_controller = Arc::new(SnapshotController::new(
             accounts_background_request_sender,
-            Some(config.snapshot_config.clone()),
+            config.snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         ));
         let snapshot_request_handler = SnapshotRequestHandler {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2082,7 +2082,7 @@ fn load_blockstore(
             genesis_config,
             &blockstore,
             config.account_paths.clone(),
-            Some(&config.snapshot_config),
+            &config.snapshot_config,
             &process_options,
             transaction_history_services.block_meta_sender.as_ref(),
             entry_notifier_service

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -200,7 +200,7 @@ impl BackgroundServices {
             AbsRequestSender::new(snapshot_request_sender.clone());
         let snapshot_controller = SnapshotController::new(
             accounts_background_request_sender,
-            Some(snapshot_config.clone()),
+            snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         );
         let snapshot_request_handler = SnapshotRequestHandler {

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -201,7 +201,7 @@ fn run_bank_forks_snapshot_n<F>(
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
         abs_request_sender,
-        Some(snapshot_test_config.snapshot_config.clone()),
+        snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
     let snapshot_request_handler = SnapshotRequestHandler {
@@ -322,7 +322,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         let abs_request_sender = AbsRequestSender::new(snapshot_sender);
         let snapshot_controller = SnapshotController::new(
             abs_request_sender,
-            Some(snapshot_test_config.snapshot_config.clone()),
+            snapshot_test_config.snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         );
         for _ in 0..num_set_roots {
@@ -474,7 +474,7 @@ fn test_bank_forks_incremental_snapshot(
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
         abs_request_sender,
-        Some(snapshot_test_config.snapshot_config.clone()),
+        snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
     let snapshot_request_handler = SnapshotRequestHandler {
@@ -722,7 +722,7 @@ fn test_snapshots_with_background_services(
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
         abs_request_sender,
-        Some(snapshot_test_config.snapshot_config.clone()),
+        snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
     let snapshot_request_handler = SnapshotRequestHandler {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -410,7 +410,7 @@ pub fn load_and_process_ledger(
     let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
         accounts_background_request_sender,
-        Some(snapshot_config.clone()),
+        snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
     let snapshot_request_handler = SnapshotRequestHandler {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -34,7 +34,7 @@ use {
         },
         bank_forks::BankForks,
         prioritization_fee_cache::PrioritizationFeeCache,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_controller::SnapshotController,
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
@@ -144,9 +144,7 @@ pub fn load_and_process_ledger(
     };
 
     let mut starting_slot = 0; // default start check with genesis
-    let snapshot_config = if arg_matches.is_present("no_snapshot") {
-        None
-    } else {
+    let snapshot_config = {
         let full_snapshot_archives_dir = value_t!(arg_matches, "snapshots", String)
             .ok()
             .map(PathBuf::from)
@@ -167,13 +165,19 @@ pub fn load_and_process_ledger(
                 .unwrap_or_default();
             starting_slot = std::cmp::max(full_snapshot_slot, incremental_snapshot_slot);
         }
+        let usage = if arg_matches.is_present("no_snapshot") {
+            SnapshotUsage::Disabled
+        } else {
+            SnapshotUsage::LoadOnly
+        };
 
-        Some(SnapshotConfig {
+        SnapshotConfig {
+            usage,
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             bank_snapshots_dir: bank_snapshots_dir.clone(),
-            ..SnapshotConfig::new_load_only()
-        })
+            ..SnapshotConfig::default()
+        }
     };
 
     match process_options.halt_at_slot {
@@ -347,7 +351,7 @@ pub fn load_and_process_ledger(
             genesis_config,
             blockstore.as_ref(),
             account_paths,
-            snapshot_config.as_ref(),
+            &snapshot_config,
             &process_options,
             block_meta_sender.as_ref(),
             None, // Maybe support this later, though
@@ -406,11 +410,11 @@ pub fn load_and_process_ledger(
     let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
         accounts_background_request_sender,
-        snapshot_config,
+        Some(snapshot_config.clone()),
         bank_forks.read().unwrap().root(),
     );
     let snapshot_request_handler = SnapshotRequestHandler {
-        snapshot_config: SnapshotConfig::new_load_only(),
+        snapshot_config,
         snapshot_request_sender,
         snapshot_request_receiver,
         accounts_package_sender,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -83,7 +83,7 @@ pub fn load(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
-    snapshot_config: Option<&SnapshotConfig>,
+    snapshot_config: &SnapshotConfig,
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     block_meta_sender: Option<&BlockMetaSender>,
@@ -122,7 +122,7 @@ pub fn load_bank_forks(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
-    snapshot_config: Option<&SnapshotConfig>,
+    snapshot_config: &SnapshotConfig,
     process_options: &ProcessOptions,
     block_meta_sender: Option<&BlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
@@ -130,12 +130,12 @@ pub fn load_bank_forks(
     exit: Arc<AtomicBool>,
 ) -> LoadResult {
     fn get_snapshots_to_load(
-        snapshot_config: Option<&SnapshotConfig>,
+        snapshot_config: &SnapshotConfig,
     ) -> Option<(
         FullSnapshotArchiveInfo,
         Option<IncrementalSnapshotArchiveInfo>,
     )> {
-        let Some(snapshot_config) = snapshot_config else {
+        if !snapshot_config.should_load_snapshots() {
             info!("Snapshots disabled; will load from genesis");
             return None;
         };
@@ -168,8 +168,6 @@ pub fn load_bank_forks(
         if let Some((full_snapshot_archive_info, incremental_snapshot_archive_info)) =
             get_snapshots_to_load(snapshot_config)
         {
-            // SAFETY: Having snapshots to load ensures a snapshot config
-            let snapshot_config = snapshot_config.unwrap();
             info!(
                 "Initializing bank snapshots dir: {}",
                 snapshot_config.bank_snapshots_dir.display()

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -870,7 +870,7 @@ pub fn test_process_blockstore(
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
     let snapshot_controller = SnapshotController::new(
         abs_request_sender,
-        Some(snapshot_config),
+        snapshot_config,
         bank_forks.read().unwrap().root(),
     );
     let bg_exit = Arc::new(AtomicBool::new(false));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -34,6 +34,7 @@ use {
         installed_scheduler_pool::BankWithScheduler,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
+        snapshot_config::SnapshotConfig,
         snapshot_controller::SnapshotController,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
         vote_sender_types::ReplayVoteSender,
@@ -848,12 +849,12 @@ pub fn test_process_blockstore(
     opts: &ProcessOptions,
     exit: Arc<AtomicBool>,
 ) -> (Arc<RwLock<BankForks>>, LeaderScheduleCache) {
-    let snapshot_config = None;
+    let snapshot_config = SnapshotConfig::new_disabled();
     let (bank_forks, leader_schedule_cache, ..) = crate::bank_forks_utils::load_bank_forks(
         genesis_config,
         blockstore,
         Vec::new(),
-        snapshot_config.as_ref(),
+        &snapshot_config,
         opts,
         None,
         None,
@@ -869,7 +870,7 @@ pub fn test_process_blockstore(
     let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
     let snapshot_controller = SnapshotController::new(
         abs_request_sender,
-        snapshot_config,
+        Some(snapshot_config),
         bank_forks.read().unwrap().root(),
     );
     let bg_exit = Arc::new(AtomicBool::new(false));

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2330,7 +2330,7 @@ fn create_snapshot_to_hard_fork(
                 .unwrap()
                 .0,
         ],
-        Some(&snapshot_config),
+        &snapshot_config,
         process_options,
         None,
         None,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1176,7 +1176,7 @@ impl ProgramTestContext {
         let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
             abs_request_sender,
-            Some(SnapshotConfig::new_disabled()),
+            SnapshotConfig::new_disabled(),
             bank_forks.root(),
         );
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -26,6 +26,7 @@ use {
         commitment::BlockCommitmentCache,
         genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo},
         runtime_config::RuntimeConfig,
+        snapshot_config::SnapshotConfig,
         snapshot_controller::SnapshotController,
     },
     solana_sdk::{
@@ -1175,7 +1176,7 @@ impl ProgramTestContext {
         let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
             abs_request_sender,
-            None, /* snapshot_config */
+            Some(SnapshotConfig::new_disabled()),
             bank_forks.root(),
         );
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -647,6 +647,7 @@ mod tests {
             genesis_utils::{
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
+            snapshot_config::SnapshotConfig,
         },
         assert_matches::assert_matches,
         solana_accounts_db::epoch_accounts_hash::EpochAccountsHash,
@@ -763,8 +764,8 @@ mod tests {
         let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
             abs_request_sender,
-            None, /* snapshot_config */
-            0,    /* root_slot */
+            Some(SnapshotConfig::new_disabled()),
+            0, /* root_slot */
         );
         let bg_exit = Arc::new(AtomicBool::new(false));
         let bg_thread = {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -764,7 +764,7 @@ mod tests {
         let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
             abs_request_sender,
-            Some(SnapshotConfig::new_disabled()),
+            SnapshotConfig::new_disabled(),
             0, /* root_slot */
         );
         let bg_exit = Arc::new(AtomicBool::new(false));

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -75,7 +75,6 @@ impl Default for SnapshotConfig {
 
 impl SnapshotConfig {
     /// A new snapshot config used for only loading at startup
-    #[must_use]
     pub fn new_load_only() -> Self {
         Self {
             usage: SnapshotUsage::LoadOnly,
@@ -83,16 +82,32 @@ impl SnapshotConfig {
         }
     }
 
+    /// A new snapshot config used to disable snapshot generation and loading at
+    /// startup
+    pub fn new_disabled() -> Self {
+        Self {
+            usage: SnapshotUsage::Disabled,
+            ..Self::default()
+        }
+    }
+
     /// Should snapshots be generated?
-    #[must_use]
     pub fn should_generate_snapshots(&self) -> bool {
         self.usage == SnapshotUsage::LoadAndGenerate
+    }
+
+    /// Should snapshots be loaded?
+    pub fn should_load_snapshots(&self) -> bool {
+        self.usage == SnapshotUsage::LoadAndGenerate || self.usage == SnapshotUsage::LoadOnly
     }
 }
 
 /// Specify the ways that snapshots are allowed to be used
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SnapshotUsage {
+    /// Snapshots are never generated or loaded at startup,
+    /// instead start from genesis.
+    Disabled,
     /// Snapshots are only used at startup, to load the accounts and bank
     LoadOnly,
     /// Snapshots are used everywhere; both at startup (i.e. load) and steady-state (i.e.

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -21,14 +21,14 @@ use {
 #[derive(Default)]
 pub struct SnapshotController {
     abs_request_sender: AbsRequestSender,
-    snapshot_config: Option<SnapshotConfig>,
+    snapshot_config: SnapshotConfig,
     latest_abs_request_slot: AtomicU64,
 }
 
 impl SnapshotController {
     pub fn new(
         abs_request_sender: AbsRequestSender,
-        snapshot_config: Option<SnapshotConfig>,
+        snapshot_config: SnapshotConfig,
         root_slot: Slot,
     ) -> Self {
         Self {
@@ -109,13 +109,13 @@ impl SnapshotController {
     ///
     /// Returns None if ABS requests should not be sent
     fn abs_request_interval(&self) -> Option<Slot> {
-        self.snapshot_config.as_ref().and_then(|snapshot_config| {
-            snapshot_config.should_generate_snapshots().then(||
-                // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
-                cmp::min(
-                    snapshot_config.full_snapshot_archive_interval_slots,
-                    snapshot_config.incremental_snapshot_archive_interval_slots,
-                ))
+        self.snapshot_config.should_generate_snapshots().then(|| {
+            // N.B. This assumes if a snapshot is disabled that its interval will be Slot::MAX
+            cmp::min(
+                self.snapshot_config.full_snapshot_archive_interval_slots,
+                self.snapshot_config
+                    .incremental_snapshot_archive_interval_slots,
+            )
         })
     }
 


### PR DESCRIPTION
#### Problem
It's awkward to have an option wrapped snapshot config in some places.

#### Summary of Changes
Add `Disabled` variant to `SnapshotUsage` and update `SnapshotController` to no longer option wrap its owned `SnapshotConfig`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
