### PR TITLE
Remove unused  field in TransactionProcessingConfig

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -635,7 +635,6 @@ impl Consumer {
                     recording_config: ExecutionRecordingConfig::new_single_setting(
                         transaction_status_sender_enabled
                     ),
-                    transaction_account_lock_limit: Some(bank.get_transaction_account_lock_limit()),
                 }
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3241,7 +3241,6 @@ impl Bank {
                     enable_log_recording: true,
                     enable_return_data_recording: true,
                 },
-                transaction_account_lock_limit: Some(self.get_transaction_account_lock_limit()),
             },
         );
 
@@ -4582,7 +4581,6 @@ impl Bank {
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
-                transaction_account_lock_limit: Some(self.get_transaction_account_lock_limit()),
             },
         );
 

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -194,8 +194,6 @@ the transaction processor.
 - `limit_to_load_programs`: Whether to limit the number of programs loaded for
   the transaction batch.
 - `recording_config`: Recording capabilities for transaction execution.
-- `transaction_account_lock_limit`: The max number of accounts that a
-  transaction may lock.
 
 ### `LoadAndExecuteSanitizedTransactionsOutput`
 

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -333,7 +333,6 @@ impl JsonRpcRequestProcessor {
                     enable_log_recording: true,
                     enable_return_data_recording: true,
                 },
-                transaction_account_lock_limit: Some(64),
             },
         );
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -115,8 +115,6 @@ pub struct TransactionProcessingConfig<'a> {
     pub limit_to_load_programs: bool,
     /// Recording capabilities for transaction execution.
     pub recording_config: ExecutionRecordingConfig,
-    /// The max number of accounts that a transaction may lock.
-    pub transaction_account_lock_limit: Option<usize>,
 }
 
 /// Runtime environment for transaction batch processing.


### PR DESCRIPTION
#### Problem
`transaction_account_lock_limit` is unused in `TransactionProcessingConfig`

#### Summary of Changes
Removed the field, and it's initializers.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
