### PR TITLE
refactor: make SnapshotController optional to disable account hash requests

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -269,7 +269,6 @@ mod tests {
         solana_runtime::{
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
-            snapshot_controller::SnapshotController,
         },
         solana_sdk::{account::Account, pubkey::Pubkey, signature::Signer},
         solana_stake_program::stake_state,
@@ -580,11 +579,7 @@ mod tests {
             .root_slot
             .unwrap();
         for x in 0..root {
-            bank_forks
-                .write()
-                .unwrap()
-                .set_root(x, &SnapshotController::default(), None)
-                .unwrap();
+            bank_forks.write().unwrap().set_root(x, None, None).unwrap();
         }
 
         // Add an additional bank/vote that will root slot 2
@@ -627,11 +622,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(
-                root,
-                &SnapshotController::default(),
-                Some(highest_super_majority_root),
-            )
+            .set_root(root, None, Some(highest_super_majority_root))
             .unwrap();
         let highest_super_majority_root_bank =
             bank_forks.read().unwrap().get(highest_super_majority_root);
@@ -715,11 +706,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(
-                root,
-                &SnapshotController::default(),
-                Some(highest_super_majority_root),
-            )
+            .set_root(root, None, Some(highest_super_majority_root))
             .unwrap();
         let highest_super_majority_root_bank =
             bank_forks.read().unwrap().get(highest_super_majority_root);

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -924,7 +924,7 @@ mod test {
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
         solana_net_utils::bind_to_unspecified,
-        solana_runtime::{bank_forks::BankForks, snapshot_controller::SnapshotController},
+        solana_runtime::bank_forks::BankForks,
         solana_sdk::{
             hash::Hash,
             signature::{Keypair, Signer},
@@ -1900,9 +1900,7 @@ mod test {
         {
             let mut w_bank_forks = bank_forks.write().unwrap();
             w_bank_forks.insert(new_root_bank);
-            w_bank_forks
-                .set_root(new_root_slot, &SnapshotController::default(), None)
-                .unwrap();
+            w_bank_forks.set_root(new_root_slot, None, None).unwrap();
         }
         popular_pruned_slot_pool.insert(dead_duplicate_confirmed_slot);
         assert!(!dead_slot_pool.is_empty());

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -145,7 +145,7 @@ impl Tvu {
         max_slots: &Arc<MaxSlots>,
         block_metadata_notifier: Option<BlockMetadataNotifierArc>,
         wait_to_vote_slot: Option<Slot>,
-        snapshot_controller: Arc<SnapshotController>,
+        snapshot_controller: Option<Arc<SnapshotController>>,
         log_messages_bytes_limit: Option<usize>,
         connection_cache: Option<&Arc<ConnectionCache>>,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
@@ -573,7 +573,7 @@ pub mod tests {
             &Arc::new(MaxSlots::default()),
             None,
             None,
-            Arc::new(SnapshotController::default()),
+            None, // snapshot_controller
             None,
             Some(&Arc::new(ConnectionCache::new("connection_cache_test"))),
             &ignored_prioritization_fee_cache,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1526,7 +1526,7 @@ impl Validator {
             &max_slots,
             block_metadata_notifier,
             config.wait_to_vote_slot,
-            snapshot_controller.clone(),
+            Some(snapshot_controller.clone()),
             config.runtime_config.log_messages_bytes_limit,
             connection_cache_for_warmup,
             &prioritization_fee_cache,
@@ -1558,7 +1558,7 @@ impl Validator {
                 wait_for_supermajority_threshold_percent:
                     WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT,
                 snapshot_config: config.snapshot_config.clone(),
-                snapshot_controller: snapshot_controller.clone(),
+                snapshot_controller: Some(snapshot_controller.clone()),
                 abs_status: accounts_background_service.status().clone(),
                 genesis_config_hash: genesis_config.hash(),
                 exit: exit.clone(),
@@ -2202,7 +2202,7 @@ impl<'a> ProcessBlockStore<'a> {
                 self.transaction_status_sender,
                 self.block_meta_sender.as_ref(),
                 self.entry_notification_sender,
-                self.snapshot_controller,
+                Some(self.snapshot_controller),
             )
             .map_err(|err| {
                 exit.store(true, Ordering::Relaxed);
@@ -2297,7 +2297,7 @@ fn maybe_warp_slot(
             solana_accounts_db::accounts_db::CalcAccountsHashDataSource::Storages,
         ));
         bank_forks
-            .set_root(warp_slot, snapshot_controller, Some(warp_slot))
+            .set_root(warp_slot, Some(snapshot_controller), Some(warp_slot))
             .map_err(|err| err.to_string())?;
         leader_schedule_cache.set_root(&bank_forks.root_bank());
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -95,7 +95,7 @@ use {
     },
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
+            AbsRequestHandlers, AccountsBackgroundService, DroppedSlotsReceiver,
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         bank::Bank,
@@ -912,10 +912,8 @@ impl Validator {
         );
 
         let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
-        let accounts_background_request_sender =
-            AbsRequestSender::new(snapshot_request_sender.clone());
         let snapshot_controller = Arc::new(SnapshotController::new(
-            accounts_background_request_sender,
+            snapshot_request_sender.clone(),
             config.snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         ));

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -24,7 +24,6 @@ use {
         genesis_utils::{
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
-        snapshot_controller::SnapshotController,
     },
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer},
     solana_vote::vote_transaction,
@@ -233,7 +232,7 @@ impl VoteSimulator {
             new_root,
             &self.bank_forks,
             &mut self.progress,
-            &SnapshotController::default(),
+            None, // snapshot_controller
             None,
             &mut self.heaviest_subtree_fork_choice,
             &mut DuplicateSlotsTracker::default(),

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -297,7 +297,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                 .unwrap()
                 .set_root(
                     bank.slot(),
-                    &test_environment.background_services.snapshot_controller,
+                    Some(&test_environment.background_services.snapshot_controller),
                     None,
                 )
                 .unwrap();
@@ -409,7 +409,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
             .unwrap()
             .set_root(
                 bank.slot(),
-                &test_environment.background_services.snapshot_controller,
+                Some(&test_environment.background_services.snapshot_controller),
                 None,
             )
             .unwrap();
@@ -533,7 +533,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
                 .unwrap()
                 .set_root(
                     bank.slot(),
-                    &test_environment.background_services.snapshot_controller,
+                    Some(&test_environment.background_services.snapshot_controller),
                     None,
                 )
                 .unwrap();
@@ -592,7 +592,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment.background_services.snapshot_controller,
+            Some(&test_environment.background_services.snapshot_controller),
             None,
         )
         .unwrap();
@@ -620,7 +620,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment.background_services.snapshot_controller,
+            Some(&test_environment.background_services.snapshot_controller),
             None,
         )
         .unwrap();
@@ -662,7 +662,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .set_root(
             bank.slot(),
-            &test_environment.background_services.snapshot_controller,
+            Some(&test_environment.background_services.snapshot_controller),
             None,
         )
         .unwrap();

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -15,7 +15,7 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
+            AbsRequestHandlers, AccountsBackgroundService, DroppedSlotsReceiver,
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         bank::{epoch_accounts_hash_utils, Bank},
@@ -196,10 +196,8 @@ impl BackgroundServices {
         );
 
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-        let accounts_background_request_sender =
-            AbsRequestSender::new(snapshot_request_sender.clone());
         let snapshot_controller = SnapshotController::new(
-            accounts_background_request_sender,
+            snapshot_request_sender.clone(),
             snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         );

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -229,7 +229,7 @@ fn run_bank_forks_snapshot_n<F>(
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(bank.slot(), &snapshot_controller, None)
+                .set_root(bank.slot(), Some(&snapshot_controller), None)
                 .unwrap();
             snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
         }
@@ -336,7 +336,7 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(current_bank.slot(), &snapshot_controller, None)
+                .set_root(current_bank.slot(), Some(&snapshot_controller), None)
                 .unwrap();
 
             // Since the accounts background services are not running, EpochAccountsHash
@@ -514,7 +514,7 @@ fn test_bank_forks_incremental_snapshot(
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(bank.slot(), &snapshot_controller, None)
+                .set_root(bank.slot(), Some(&snapshot_controller), None)
                 .unwrap();
             snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
         }
@@ -795,7 +795,7 @@ fn test_snapshots_with_background_services(
             bank_forks
                 .write()
                 .unwrap()
-                .set_root(slot, &snapshot_controller, None)
+                .set_root(slot, Some(&snapshot_controller), None)
                 .unwrap();
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -16,8 +16,8 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
-            PrunedBanksRequestHandler, SendDroppedBankCallback, SnapshotRequestHandler,
+            AbsRequestHandlers, AccountsBackgroundService, PrunedBanksRequestHandler,
+            SendDroppedBankCallback, SnapshotRequestHandler,
         },
         bank::{Bank, BankTestConfig},
         bank_forks::BankForks,
@@ -198,9 +198,8 @@ fn run_bank_forks_snapshot_n<F>(
 
     let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
-    let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
-        abs_request_sender,
+        snapshot_request_sender.clone(),
         snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
@@ -319,9 +318,8 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         let bank_forks_r = bank_forks.read().unwrap();
         let mut current_bank = bank_forks_r[0].clone();
         drop(bank_forks_r);
-        let abs_request_sender = AbsRequestSender::new(snapshot_sender);
         let snapshot_controller = SnapshotController::new(
-            abs_request_sender,
+            snapshot_sender,
             snapshot_test_config.snapshot_config.clone(),
             bank_forks.read().unwrap().root(),
         );
@@ -471,9 +469,8 @@ fn test_bank_forks_incremental_snapshot(
 
     let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
-    let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
-        abs_request_sender,
+        snapshot_request_sender.clone(),
         snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );
@@ -719,9 +716,8 @@ fn test_snapshots_with_background_services(
         bank.set_callback(Some(Box::new(callback.clone())));
     }
 
-    let abs_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
-        abs_request_sender,
+        snapshot_request_sender.clone(),
         snapshot_test_config.snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -29,7 +29,7 @@ use {
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
-        prioritization_fee_cache::PrioritizationFeeCache, snapshot_controller::SnapshotController,
+        prioritization_fee_cache::PrioritizationFeeCache,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_sdk::{
@@ -165,7 +165,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
             root,
             &bank_forks,
             &mut progress,
-            &SnapshotController::default(),
+            None, // snapshot_controller
             None,
             &mut heaviest_subtree_fork_choice,
             &mut duplicate_slots_tracker,

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -236,7 +236,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             shred::Shredder,
         },
-        solana_runtime::{bank::Bank, snapshot_controller::SnapshotController},
+        solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_time_utils::timestamp,
     };
@@ -298,9 +298,7 @@ mod tests {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
-            bank_forks
-                .set_root(9, &SnapshotController::default(), None)
-                .unwrap();
+            bank_forks.set_root(9, None, None).unwrap();
         }
         blockstore.set_roots([0, 9].iter()).unwrap();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
@@ -391,9 +389,7 @@ mod tests {
             let mut bank_forks = bank_forks_arc.write().unwrap();
             let bank0 = bank_forks.get(0).unwrap();
             bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
-            bank_forks
-                .set_root(9, &SnapshotController::default(), None)
-                .unwrap();
+            bank_forks.set_root(9, None, None).unwrap();
         }
         blockstore.set_roots([0, 9].iter()).unwrap();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -81,10 +81,7 @@ mod tests {
     use {
         super::*,
         solana_clock::Slot,
-        solana_runtime::{
-            genesis_utils::{create_genesis_config, GenesisConfigInfo},
-            snapshot_controller::SnapshotController,
-        },
+        solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
 
     #[test]
@@ -161,7 +158,6 @@ mod tests {
             let bank = Bank::new_from_parent(bank, &Pubkey::new_unique(), slot);
             bank_forks.write().unwrap().insert(bank);
         }
-        let snapshot_controller = SnapshotController::default();
         // root is still 0, epoch 0.
         let root_bank = bank_forks.read().unwrap().get(0).unwrap();
         verify_epoch_specs(
@@ -174,7 +170,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(17, &snapshot_controller, None)
+            .set_root(17, None, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(17).unwrap();
         verify_epoch_specs(
@@ -187,7 +183,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(19, &snapshot_controller, None)
+            .set_root(19, None, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(19).unwrap();
         verify_epoch_specs(
@@ -200,7 +196,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(37, &snapshot_controller, None)
+            .set_root(37, None, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(37).unwrap();
         verify_epoch_specs(
@@ -213,7 +209,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(59, &snapshot_controller, None)
+            .set_root(59, None, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(59).unwrap();
         verify_epoch_specs(
@@ -226,7 +222,7 @@ mod tests {
         bank_forks
             .write()
             .unwrap()
-            .set_root(97, &snapshot_controller, None)
+            .set_root(97, None, None)
             .unwrap();
         let root_bank = bank_forks.read().unwrap().get(97).unwrap();
         verify_epoch_specs(

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -29,8 +29,8 @@ use {
     },
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandlers, AbsRequestSender, AccountsBackgroundService,
-            PrunedBanksRequestHandler, SnapshotRequestHandler,
+            AbsRequestHandlers, AccountsBackgroundService, PrunedBanksRequestHandler,
+            SnapshotRequestHandler,
         },
         bank_forks::BankForks,
         prioritization_fee_cache::PrioritizationFeeCache,
@@ -407,9 +407,8 @@ pub fn load_and_process_ledger(
         SnapshotConfig::new_load_only(),
     );
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-    let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender.clone());
     let snapshot_controller = SnapshotController::new(
-        accounts_background_request_sender,
+        snapshot_request_sender.clone(),
         snapshot_config.clone(),
         bank_forks.read().unwrap().root(),
     );

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -442,7 +442,7 @@ pub fn load_and_process_ledger(
         transaction_status_sender.as_ref(),
         block_meta_sender.as_ref(),
         None, // entry_notification_sender
-        &snapshot_controller,
+        Some(&snapshot_controller),
     )
     .map(|_| LoadAndProcessLedgerOutput {
         bank_forks,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -18,7 +18,6 @@ use {
         },
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
-        snapshot_controller::SnapshotController,
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
         snapshot_utils,
     },
@@ -110,7 +109,7 @@ pub fn load(
         transaction_status_sender,
         block_meta_sender,
         entry_notification_sender,
-        &SnapshotController::default(),
+        None, // snapshot_controller
     )
     .map_err(BankForksUtilsError::ProcessBlockstoreFromRoot)?;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -26,7 +26,7 @@ use {
     solana_metrics::datapoint_error,
     solana_rayon_threadlimit::get_max_thread_count,
     solana_runtime::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
+        accounts_background_service::SnapshotRequestKind,
         bank::{Bank, PreCommitResult, TransactionBalancesSet},
         bank_forks::{BankForks, SetRootError},
         bank_utils,
@@ -867,9 +867,8 @@ pub fn test_process_blockstore(
     // EpochAccountsHash requests so future rooted banks do not hang in Bank::freeze() waiting for
     // an in-flight EAH calculation to complete.
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-    let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
     let snapshot_controller = SnapshotController::new(
-        abs_request_sender,
+        snapshot_request_sender,
         snapshot_config,
         bank_forks.read().unwrap().root(),
     );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -907,7 +907,7 @@ pub fn test_process_blockstore(
         None,
         None,
         None,
-        &snapshot_controller,
+        Some(&snapshot_controller),
     )
     .unwrap();
 
@@ -974,7 +974,7 @@ pub fn process_blockstore_from_root(
     transaction_status_sender: Option<&TransactionStatusSender>,
     block_meta_sender: Option<&BlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
-    snapshot_controller: &SnapshotController,
+    snapshot_controller: Option<&SnapshotController>,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let (start_slot, start_slot_hash) = {
         // Starting slot must be a root, and thus has no parents
@@ -1854,7 +1854,7 @@ fn load_frozen_forks(
     block_meta_sender: Option<&BlockMetaSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
     timing: &mut ExecuteTimings,
-    snapshot_controller: &SnapshotController,
+    snapshot_controller: Option<&SnapshotController>,
 ) -> result::Result<(u64, usize), BlockstoreProcessorError> {
     let blockstore_max_root = blockstore.max_root();
     let mut root = bank_forks.read().unwrap().root();
@@ -4169,11 +4169,7 @@ pub mod tests {
             &mut ExecuteTimings::default(),
         )
         .unwrap();
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(1, &SnapshotController::default(), None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(1, None, None).unwrap();
 
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank1);
 
@@ -4186,7 +4182,7 @@ pub mod tests {
             None,
             None,
             None,
-            &SnapshotController::default(),
+            None, // snapshot_controller
         )
         .unwrap();
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1180,7 +1180,11 @@ impl ProgramTestContext {
         );
 
         bank_forks
-            .set_root(pre_warp_slot, &snapshot_controller, Some(pre_warp_slot))
+            .set_root(
+                pre_warp_slot,
+                Some(&snapshot_controller),
+                Some(pre_warp_slot),
+            )
             .unwrap();
 
         // The call to `set_root()` above will send an EAH request.  Need to intercept and handle
@@ -1246,7 +1250,7 @@ impl ProgramTestContext {
         bank_forks
             .set_root(
                 pre_warp_slot,
-                &SnapshotController::default(),
+                None, // snapshot_controller
                 Some(pre_warp_slot),
             )
             .unwrap();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -20,7 +20,7 @@ use {
         serialization::serialize_parameters, stable_log,
     },
     solana_runtime::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
+        accounts_background_service::SnapshotRequestKind,
         bank::Bank,
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
@@ -1173,9 +1173,8 @@ impl ProgramTestContext {
         };
 
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-        let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
-            abs_request_sender,
+            snapshot_request_sender,
             SnapshotConfig::new_disabled(),
             bank_forks.root(),
         );

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -403,9 +403,7 @@ mod tests {
         crossbeam_channel::unbounded,
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
         solana_pubkey::Pubkey,
-        solana_runtime::{
-            commitment::BlockCommitmentCache, snapshot_controller::SnapshotController,
-        },
+        solana_runtime::commitment::BlockCommitmentCache,
         std::sync::atomic::AtomicU64,
     };
 
@@ -604,11 +602,7 @@ mod tests {
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         let bank7 = Bank::new_from_parent(bank5, &Pubkey::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
-        bank_forks
-            .write()
-            .unwrap()
-            .set_root(7, &SnapshotController::default(), None)
-            .unwrap();
+        bank_forks.write().unwrap().set_root(7, None, None).unwrap();
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(6),
             &bank_forks,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4532,7 +4532,6 @@ pub mod tests {
             bank::BankTestConfig,
             commitment::{BlockCommitment, CommitmentSlots},
             non_circulating_supply::non_circulating_accounts,
-            snapshot_controller::SnapshotController,
         },
         solana_sdk::{
             account::{Account, WritableAccount},
@@ -4885,7 +4884,7 @@ pub mod tests {
                 self.bank_forks
                     .write()
                     .unwrap()
-                    .set_root(*root, &SnapshotController::default(), Some(0))
+                    .set_root(*root, None, Some(0))
                     .unwrap();
                 let block_time = self
                     .bank_forks

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -444,34 +444,6 @@ impl SnapshotRequestHandler {
     }
 }
 
-#[derive(Default, Clone)]
-pub struct AbsRequestSender {
-    snapshot_request_sender: Option<SnapshotRequestSender>,
-}
-
-impl AbsRequestSender {
-    pub fn new(snapshot_request_sender: SnapshotRequestSender) -> Self {
-        Self {
-            snapshot_request_sender: Some(snapshot_request_sender),
-        }
-    }
-
-    pub fn is_snapshot_creation_enabled(&self) -> bool {
-        self.snapshot_request_sender.is_some()
-    }
-
-    pub fn send_snapshot_request(
-        &self,
-        snapshot_request: SnapshotRequest,
-    ) -> Result<(), SendError<SnapshotRequest>> {
-        if let Some(ref snapshot_request_sender) = self.snapshot_request_sender {
-            snapshot_request_sender.send(snapshot_request)
-        } else {
-            Ok(())
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct PrunedBanksRequestHandler {
     pub pruned_banks_receiver: DroppedSlotsReceiver,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -334,7 +334,7 @@ impl BankForks {
     fn do_set_root_return_metrics(
         &mut self,
         root: Slot,
-        snapshot_controller: &SnapshotController,
+        snapshot_controller: Option<&SnapshotController>,
         highest_super_majority_root: Option<Slot>,
     ) -> Result<(Vec<BankWithScheduler>, SetRootMetrics), SetRootError> {
         let old_epoch = self.root_bank().epoch();
@@ -370,7 +370,12 @@ impl BankForks {
         banks.extend(parents.iter());
         let total_parent_banks = banks.len();
         let (is_root_bank_squashed, mut squash_timing, total_snapshot_ms) =
-            snapshot_controller.handle_new_roots(root, &banks)?;
+            if let Some(snapshot_controller) = snapshot_controller {
+                snapshot_controller.handle_new_roots(root, &banks)?
+            } else {
+                (false, SquashTiming::default(), 0)
+            };
+
         if !is_root_bank_squashed {
             squash_timing += root_bank.squash();
         }
@@ -414,7 +419,7 @@ impl BankForks {
     pub fn set_root(
         &mut self,
         root: Slot,
-        snapshot_controller: &SnapshotController,
+        snapshot_controller: Option<&SnapshotController>,
         highest_super_majority_root: Option<Slot>,
     ) -> Result<Vec<BankWithScheduler>, SetRootError> {
         let program_cache_prune_start = Instant::now();
@@ -796,7 +801,9 @@ mod tests {
         let bank0 = Bank::new_for_tests(&genesis_config);
         let bank_forks0 = BankForks::new_rw_arc(bank0);
         let mut bank_forks0 = bank_forks0.write().unwrap();
-        bank_forks0.set_root(0, &snapshot_controller, None).unwrap();
+        bank_forks0
+            .set_root(0, Some(&snapshot_controller), None)
+            .unwrap();
 
         let bank1 = Bank::new_for_tests(&genesis_config);
         let bank_forks1 = BankForks::new_rw_arc(bank1);
@@ -832,7 +839,7 @@ mod tests {
             // Set root in bank_forks0 to truncate the ancestor history
             bank_forks0.insert(child1);
             bank_forks0
-                .set_root(slot, &snapshot_controller, None)
+                .set_root(slot, Some(&snapshot_controller), None)
                 .unwrap();
 
             // Don't set root in bank_forks1 to keep the ancestor history
@@ -902,8 +909,8 @@ mod tests {
             .write()
             .unwrap()
             .set_root(
-                2,
-                &SnapshotController::default(),
+                2,    // root
+                None, // snapshot_controller
                 None, // highest confirmed root
             )
             .unwrap();
@@ -970,7 +977,7 @@ mod tests {
             .unwrap()
             .set_root(
                 2,
-                &SnapshotController::default(),
+                None,    // snapshot_controller
                 Some(1), // highest confirmed root
             )
             .unwrap();
@@ -1062,7 +1069,7 @@ mod tests {
         bank_forks
             .set_root(
                 2,
-                &SnapshotController::default(),
+                None,    // snapshot_controller
                 Some(1), // highest confirmed root
             )
             .unwrap();

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -642,7 +642,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
+            accounts_background_service::SnapshotRequestKind,
             bank::test_utils::update_vote_account_timestamp,
             genesis_utils::{
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
@@ -761,9 +761,8 @@ mod tests {
         // all EpochAccountsHash requests so future rooted banks do not hang in Bank::freeze()
         // waiting for an in-flight EAH calculation to complete.
         let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();
-        let abs_request_sender = AbsRequestSender::new(snapshot_request_sender);
         let snapshot_controller = SnapshotController::new(
-            abs_request_sender,
+            snapshot_request_sender,
             SnapshotConfig::new_disabled(),
             0, /* root_slot */
         );

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -52,7 +52,6 @@ mod tests {
         crate::{
             bank_forks::BankForks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
-            snapshot_controller::SnapshotController,
         },
         solana_pubkey::Pubkey,
     };
@@ -77,11 +76,7 @@ mod tests {
             assert_eq!(bank.slot(), cached_root_bank.slot());
         }
         {
-            bank_forks
-                .write()
-                .unwrap()
-                .set_root(1, &SnapshotController::default(), None)
-                .unwrap();
+            bank_forks.write().unwrap().set_root(1, None, None).unwrap();
             let bank = bank_forks.read().unwrap().root_bank();
 
             // cached slot and bank are not updated until we call `root_bank()`

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -20,9 +20,8 @@ use {
     },
 };
 
-#[derive(Default)]
 pub struct SnapshotController {
-    abs_request_sender: Option<SnapshotRequestSender>,
+    abs_request_sender: SnapshotRequestSender,
     snapshot_config: SnapshotConfig,
     latest_abs_request_slot: AtomicU64,
 }
@@ -34,7 +33,7 @@ impl SnapshotController {
         root_slot: Slot,
     ) -> Self {
         Self {
-            abs_request_sender: Some(abs_request_sender),
+            abs_request_sender,
             snapshot_config,
             latest_abs_request_slot: AtomicU64::new(root_slot),
         }
@@ -56,10 +55,6 @@ impl SnapshotController {
         let (mut is_root_bank_squashed, mut squash_timing) =
             self.send_eah_request_if_needed(root, banks)?;
         let mut total_snapshot_ms = 0;
-
-        let Some(abs_request_sender) = &self.abs_request_sender else {
-            return Ok((is_root_bank_squashed, squash_timing, total_snapshot_ms));
-        };
 
         // After checking for EAH requests, also check for regular snapshot requests.
         //
@@ -84,7 +79,7 @@ impl SnapshotController {
                     // `set_root()` is called before the snapshots package can be generated
                     let status_cache_slot_deltas =
                         bank.status_cache.read().unwrap().root_slot_deltas();
-                    if let Err(e) = abs_request_sender.send(SnapshotRequest {
+                    if let Err(e) = self.abs_request_sender.send(SnapshotRequest {
                         snapshot_root_bank: Arc::clone(bank),
                         status_cache_slot_deltas,
                         request_kind: SnapshotRequestKind::Snapshot,
@@ -131,9 +126,6 @@ impl SnapshotController {
     ) -> Result<(bool, SquashTiming), SetRootError> {
         let mut is_root_bank_squashed = false;
         let mut squash_timing = SquashTiming::default();
-        let Some(abs_request_sender) = &self.abs_request_sender else {
-            return Ok((is_root_bank_squashed, squash_timing));
-        };
 
         // Go through all the banks and see if we should send an EAH request.
         // Only one EAH bank is allowed to send an EAH request.
@@ -167,7 +159,7 @@ impl SnapshotController {
                 .epoch_accounts_hash_manager
                 .set_in_flight(eah_bank.slot());
 
-            if let Err(err) = abs_request_sender.send(SnapshotRequest {
+            if let Err(err) = self.abs_request_sender.send(SnapshotRequest {
                 snapshot_root_bank: Arc::clone(eah_bank),
                 status_cache_slot_deltas: Vec::default(),
                 request_kind: SnapshotRequestKind::EpochAccountsHash,

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        accounts_background_service::{AbsRequestSender, SnapshotRequest, SnapshotRequestKind},
+        accounts_background_service::{
+            SnapshotRequest, SnapshotRequestKind, SnapshotRequestSender,
+        },
         bank::{epoch_accounts_hash_utils, Bank, SquashTiming},
         bank_forks::SetRootError,
         snapshot_config::SnapshotConfig,
@@ -20,19 +22,19 @@ use {
 
 #[derive(Default)]
 pub struct SnapshotController {
-    abs_request_sender: AbsRequestSender,
+    abs_request_sender: Option<SnapshotRequestSender>,
     snapshot_config: SnapshotConfig,
     latest_abs_request_slot: AtomicU64,
 }
 
 impl SnapshotController {
     pub fn new(
-        abs_request_sender: AbsRequestSender,
+        abs_request_sender: SnapshotRequestSender,
         snapshot_config: SnapshotConfig,
         root_slot: Slot,
     ) -> Self {
         Self {
-            abs_request_sender,
+            abs_request_sender: Some(abs_request_sender),
             snapshot_config,
             latest_abs_request_slot: AtomicU64::new(root_slot),
         }
@@ -55,6 +57,10 @@ impl SnapshotController {
             self.send_eah_request_if_needed(root, banks)?;
         let mut total_snapshot_ms = 0;
 
+        let Some(abs_request_sender) = &self.abs_request_sender else {
+            return Ok((is_root_bank_squashed, squash_timing, total_snapshot_ms));
+        };
+
         // After checking for EAH requests, also check for regular snapshot requests.
         //
         // This is needed when a snapshot request occurs in a slot after an EAH request, and is
@@ -62,43 +68,38 @@ impl SnapshotController {
         // unlikely for a validator with default snapshot intervals (and accounts hash verifier
         // intervals), it *is* possible, and there are tests to exercise this possibility.
         if let Some(abs_request_interval) = self.abs_request_interval() {
-            if self.abs_request_sender.is_snapshot_creation_enabled() {
-                if let Some(bank) = banks.iter().find(|bank| {
-                    bank.slot() > self.latest_abs_request_slot()
-                        && bank.block_height() % abs_request_interval == 0
-                }) {
-                    let bank_slot = bank.slot();
-                    self.set_latest_abs_request_slot(bank_slot);
-                    squash_timing += bank.squash();
+            if let Some(bank) = banks.iter().find(|bank| {
+                bank.slot() > self.latest_abs_request_slot()
+                    && bank.block_height() % abs_request_interval == 0
+            }) {
+                let bank_slot = bank.slot();
+                self.set_latest_abs_request_slot(bank_slot);
+                squash_timing += bank.squash();
 
-                    is_root_bank_squashed = bank_slot == root;
+                is_root_bank_squashed = bank_slot == root;
 
-                    let mut snapshot_time = Measure::start("squash::snapshot_time");
-                    if bank.is_startup_verification_complete() {
-                        // Save off the status cache because these may get pruned if another
-                        // `set_root()` is called before the snapshots package can be generated
-                        let status_cache_slot_deltas =
-                            bank.status_cache.read().unwrap().root_slot_deltas();
-                        if let Err(e) =
-                            self.abs_request_sender
-                                .send_snapshot_request(SnapshotRequest {
-                                    snapshot_root_bank: Arc::clone(bank),
-                                    status_cache_slot_deltas,
-                                    request_kind: SnapshotRequestKind::Snapshot,
-                                    enqueued: Instant::now(),
-                                })
-                        {
-                            warn!(
-                                "Error sending snapshot request for bank: {}, err: {:?}",
-                                bank_slot, e
-                            );
-                        }
-                    } else {
-                        info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
+                let mut snapshot_time = Measure::start("squash::snapshot_time");
+                if bank.is_startup_verification_complete() {
+                    // Save off the status cache because these may get pruned if another
+                    // `set_root()` is called before the snapshots package can be generated
+                    let status_cache_slot_deltas =
+                        bank.status_cache.read().unwrap().root_slot_deltas();
+                    if let Err(e) = abs_request_sender.send(SnapshotRequest {
+                        snapshot_root_bank: Arc::clone(bank),
+                        status_cache_slot_deltas,
+                        request_kind: SnapshotRequestKind::Snapshot,
+                        enqueued: Instant::now(),
+                    }) {
+                        warn!(
+                            "Error sending snapshot request for bank: {}, err: {:?}",
+                            bank_slot, e
+                        );
                     }
-                    snapshot_time.stop();
-                    total_snapshot_ms += snapshot_time.as_ms();
+                } else {
+                    info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
                 }
+                snapshot_time.stop();
+                total_snapshot_ms += snapshot_time.as_ms();
             }
         }
 
@@ -130,6 +131,9 @@ impl SnapshotController {
     ) -> Result<(bool, SquashTiming), SetRootError> {
         let mut is_root_bank_squashed = false;
         let mut squash_timing = SquashTiming::default();
+        let Some(abs_request_sender) = &self.abs_request_sender else {
+            return Ok((is_root_bank_squashed, squash_timing));
+        };
 
         // Go through all the banks and see if we should send an EAH request.
         // Only one EAH bank is allowed to send an EAH request.
@@ -162,17 +166,18 @@ impl SnapshotController {
                 .accounts_db
                 .epoch_accounts_hash_manager
                 .set_in_flight(eah_bank.slot());
-            if let Err(e) = self
-                .abs_request_sender
-                .send_snapshot_request(SnapshotRequest {
-                    snapshot_root_bank: Arc::clone(eah_bank),
-                    status_cache_slot_deltas: Vec::default(),
-                    request_kind: SnapshotRequestKind::EpochAccountsHash,
-                    enqueued: Instant::now(),
-                })
-            {
-                return Err(SetRootError::SendEpochAccountHashError(eah_bank.slot(), e));
-            };
+
+            if let Err(err) = abs_request_sender.send(SnapshotRequest {
+                snapshot_root_bank: Arc::clone(eah_bank),
+                status_cache_slot_deltas: Vec::default(),
+                request_kind: SnapshotRequestKind::EpochAccountsHash,
+                enqueued: Instant::now(),
+            }) {
+                return Err(SetRootError::SendEpochAccountHashError(
+                    eah_bank.slot(),
+                    err,
+                ));
+            }
         }
 
         Ok((is_root_bank_squashed, squash_timing))

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -253,7 +253,6 @@ mod tests {
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
-            snapshot_controller::SnapshotController,
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -287,11 +286,7 @@ mod tests {
         let bank0 = bank_forks.read().unwrap().root_bank();
         let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        assert!(bank_forks
-            .write()
-            .unwrap()
-            .set_root(1, &SnapshotController::default(), None)
-            .is_ok());
+        assert!(bank_forks.write().unwrap().set_root(1, None, None).is_ok());
         let root_bank = bank_forks.read().unwrap().root_bank();
         let root_slot = root_bank.slot();
         let last_voted_fork_slots = vec![


### PR DESCRIPTION
#### Problem
`SnapshotController` has a `AbsRequestSender` which internally option wraps a sender to conditionally disable accounts hash requests. This is not very explicit and it would be cleaner to just not setup a snapshot controller if accounts hashing is disabled (ie for tests).
#### Summary of Changes
- Remove `AbsRequestSender` in favor of directly holding a snapshot request sender inside `SnapshotController`
- Make `SnapshotController` optional where necessary when account hashing should be disabled.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
