### PR TITLE
refactor: use SnapshotController in snapshot services

### DIFF
--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -43,6 +43,14 @@ impl SnapshotController {
         }
     }
 
+    pub fn snapshot_config(&self) -> &SnapshotConfig {
+        &self.snapshot_config
+    }
+
+    pub fn request_sender(&self) -> &SnapshotRequestSender {
+        &self.abs_request_sender
+    }
+
     fn latest_abs_request_slot(&self) -> Slot {
         self.latest_abs_request_slot.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
#### Problem
Need a source of truth for what the latest snapshot config is when we eventually add support for dynamically updating snapshot configuration while a validator is running

#### Summary of Changes
Use `SnapshotController` as the source of truth for the snapshot config and snapshot request sender in background services and wen-restart

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
