### PR TITLE
Improves estimate of accounts index's in-mem usage metric

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1063,9 +1063,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// assumes 1 entry in the slot list. Ignores overhead of the HashMap and such
     pub const fn approx_size_of_one_entry() -> usize {
-        std::mem::size_of::<T>()
-            + std::mem::size_of::<Pubkey>()
-            + std::mem::size_of::<AccountMapEntry<T>>()
+        size_of::<(Slot, T)>() + size_of::<Pubkey>() + size_of::<AccountMapEntry<T>>()
     }
 
     fn should_evict_based_on_age(


### PR DESCRIPTION
#### Problem

The accounts index metric for the in-mem usage is off. It doesn't include the `Slot` for the slot list, and doesn't consider the "held in mem" items that are >= 2 slot list entries.


#### Summary of Changes

* Include the Slot in the size considerations of the SlotList
* Assume that the "held in mem" items have (at least) two slot list entries.