### PR TITLE
patch stake info from epochspecs into the ClusterSlots update logic

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -119,7 +119,11 @@ impl ClusterSlotsService {
                 }
             }
             let root_bank = bank_forks.read().unwrap().root_bank();
-            cluster_slots.update(&root_bank, &cluster_info);
+            cluster_slots.update(
+                &root_bank,
+                epoch_specs.current_epoch_staked_nodes(),
+                &cluster_info,
+            );
             process_cluster_slots_updates_elapsed.stop();
 
             cluster_slots_service_timing.update(

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -249,9 +249,10 @@ mod tests {
         let cs = ClusterSlots::default();
         let mut epoch_slot = EpochSlots::default();
         epoch_slot.fill(&[1], 0);
+        let from = epoch_slot.from;
         cs.update_internal(
             0,
-            &HashMap::new(),
+            &HashMap::from([(from, 42)]),
             vec![epoch_slot],
             DEFAULT_SLOTS_PER_EPOCH,
         );
@@ -263,7 +264,7 @@ mod tests {
                 .read()
                 .unwrap()
                 .get(&Pubkey::default()),
-            Some(&0)
+            Some(&42)
         );
     }
 

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -64,12 +64,10 @@ impl ClusterSlots {
         let epoch_slots_list: Vec<_> = {
             epoch_slots_list
                 .into_iter()
-                .map(|epoch_slots| {
-                    let stake = validator_stakes
+                .filter_map(|epoch_slots| {
+                    validator_stakes
                         .get(&epoch_slots.from)
-                        .cloned()
-                        .unwrap_or(0);
-                    (epoch_slots, stake)
+                        .map(|&stake| (epoch_slots, stake))
                 })
                 .collect()
         };

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -15,7 +15,7 @@ use {
 // of receiving bogus epoch slots values.
 // This also constraints the size of the datastructure
 // if we are really far behind.
-const CLUSTER_SLOTS_TRIM_SIZE: usize = 5000;
+const CLUSTER_SLOTS_TRIM_SIZE: usize = 1500;
 
 pub(crate) type SlotPubkeys = HashMap</*node:*/ Pubkey, /*stake:*/ u64>;
 


### PR DESCRIPTION
#### Problem
ClusterSlots is too slow and can sometimes slow down repair. Details in 
https://github.com/anza-xyz/agave/issues/5440

A deeper rework available in https://github.com/anza-xyz/agave/pull/5476
#### Summary of Changes

- patch stake info from epochspecs into the ClusterSlots update logic to save some cycles locking stuff
- Limit the datastructure to store only up to 1500 slots (vs 512000)
- prevent unstaked nodes from populating ClusterSlots to save space in the datastructure


Fixes https://github.com/anza-xyz/agave/issues/5440