### PR TITLE
Optimize epoch rewards payout assertions in PER calculation  

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -175,7 +175,6 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
     std::{
         collections::{HashMap, HashSet},
-        convert::TryFrom,
         fmt,
         ops::{AddAssign, RangeFull, RangeInclusive},
         path::PathBuf,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2362,26 +2362,6 @@ impl Bank {
         }
     }
 
-    fn assert_validator_rewards_paid(&self, validator_rewards_paid: u64) {
-        assert_eq!(
-            validator_rewards_paid,
-            u64::try_from(
-                self.rewards
-                    .read()
-                    .unwrap()
-                    .par_iter()
-                    .map(|(_address, reward_info)| {
-                        match reward_info.reward_type {
-                            RewardType::Voting | RewardType::Staking => reward_info.lamports,
-                            _ => 0,
-                        }
-                    })
-                    .sum::<i64>()
-            )
-            .unwrap()
-        );
-    }
-
     fn filter_stake_delegations<'a>(
         &self,
         stakes: &'a Stakes<StakeAccount<Delegation>>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2409,6 +2409,7 @@ impl Bank {
         let mut result = VoteRewardsAccounts {
             rewards: Vec::with_capacity(len),
             accounts_to_store: Vec::with_capacity(len),
+            total_vote_rewards_lamports: 0,
         };
         vote_account_rewards.into_iter().for_each(
             |(
@@ -2437,6 +2438,7 @@ impl Bank {
                 result
                     .accounts_to_store
                     .push(vote_needs_store.then_some(vote_account));
+                result.total_vote_rewards_lamports += vote_rewards;
             },
         );
         result

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -24,6 +24,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) vote_accounts_cache_miss_count: AtomicU64,
     pub(crate) hash_partition_rewards_us: u64,
+    pub(crate) assert_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -103,6 +104,7 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.hash_partition_rewards_us,
             i64
         ),
+        ("assert_us", metrics.assert_us, i64),
     );
 }
 

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -24,7 +24,6 @@ pub(crate) struct RewardsMetrics {
     pub(crate) store_vote_accounts_us: AtomicU64,
     pub(crate) vote_accounts_cache_miss_count: AtomicU64,
     pub(crate) hash_partition_rewards_us: u64,
-    pub(crate) assert_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -104,7 +103,6 @@ pub(crate) fn report_new_epoch_metrics(
             metrics.hash_partition_rewards_us,
             i64
         ),
-        ("assert_us", metrics.assert_us, i64),
     );
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -97,7 +97,7 @@ impl Bank {
         let PartitionedRewardsCalculation {
             vote_account_rewards,
             stake_rewards_by_partition,
-            old_vote_balance_and_staked,
+            //old_vote_balance_and_staked,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,
@@ -117,26 +117,26 @@ impl Bank {
 
         let StakeRewardCalculationPartitioned {
             stake_rewards_by_partition,
-            total_stake_rewards_lamports,
+            total_stake_rewards_lamports: _total_stake_rewards_lamports,
         } = stake_rewards_by_partition;
 
-        let (_, assert_us) = measure_us!({
-            // the remaining code mirrors `update_rewards_with_thread_pool()`
-            let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
+        // let (_, assert_us) = measure_us!({
+        //     // the remaining code mirrors `update_rewards_with_thread_pool()`
+        //     let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
 
-            // This is for vote rewards only.
-            let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
-            assert_eq!(total_vote_rewards, validator_rewards_paid);
-            self.assert_validator_rewards_paid(validator_rewards_paid);
+        //     // This is for vote rewards only.
+        //     let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
+        //     assert_eq!(total_vote_rewards, validator_rewards_paid);
+        //     self.assert_validator_rewards_paid(validator_rewards_paid);
 
-            // verify that we didn't pay any more than we expected to
-            assert!(point_value.rewards >= validator_rewards_paid + total_stake_rewards_lamports);
-            info!(
-                "distributed vote rewards: {} out of {}, remaining {}",
-                validator_rewards_paid, point_value.rewards, total_stake_rewards_lamports
-            );
-        });
-        metrics.assert_us += assert_us;
+        //     // verify that we didn't pay any more than we expected to
+        //     assert!(point_value.rewards >= validator_rewards_paid + total_stake_rewards_lamports);
+        //     info!(
+        //         "distributed vote rewards: {} out of {}, remaining {}",
+        //         validator_rewards_paid, point_value.rewards, total_stake_rewards_lamports
+        //     );
+        // });
+        // metrics.assert_us += assert_us;
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();
@@ -223,7 +223,7 @@ impl Bank {
             foundation_rate,
         } = self.calculate_previous_epoch_inflation_rewards(capitalization, prev_epoch);
 
-        let old_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
+        //let old_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
 
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
@@ -257,7 +257,7 @@ impl Bank {
                 stake_rewards_by_partition,
                 total_stake_rewards_lamports: stake_rewards.total_stake_rewards_lamports,
             },
-            old_vote_balance_and_staked,
+            //old_vote_balance_and_staked,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -180,8 +180,10 @@ impl Bank {
                 .iter()
                 .filter_map(|account| account.as_ref())
                 .enumerate()
-                .map(|(i, account)| {
+                .inspect(|(i, _account)| {
                     total_rewards += vote_account_rewards.rewards[i].1.lamports;
+                })
+                .map(|(i, account)| {
                     (&vote_account_rewards.rewards[i].0, account)
                 })
                 .collect::<Vec<_>>();

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -19,7 +19,7 @@ use {
         stakes::Stakes,
     },
     dashmap::DashMap,
-    log::debug,
+    log::{debug, info},
     rayon::{
         iter::{IntoParallelRefIterator, ParallelIterator},
         ThreadPool,
@@ -116,8 +116,15 @@ impl Bank {
 
         let StakeRewardCalculationPartitioned {
             stake_rewards_by_partition,
-            total_stake_rewards_lamports: _total_stake_rewards_lamports,
+            total_stake_rewards_lamports,
         } = stake_rewards_by_partition;
+
+        // verify that we didn't pay any more than we expected to
+        assert!(point_value.rewards >= total_vote_rewards + total_stake_rewards_lamports);
+        info!(
+            "distributed vote rewards: {} out of {}, remaining {}",
+            total_vote_rewards, point_value.rewards, total_stake_rewards_lamports
+        );
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -19,7 +19,7 @@ use {
         stakes::Stakes,
     },
     dashmap::DashMap,
-    log::{debug, info},
+    log::debug,
     rayon::{
         iter::{IntoParallelRefIterator, ParallelIterator},
         ThreadPool,
@@ -97,7 +97,6 @@ impl Bank {
         let PartitionedRewardsCalculation {
             vote_account_rewards,
             stake_rewards_by_partition,
-            //old_vote_balance_and_staked,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,
@@ -119,24 +118,6 @@ impl Bank {
             stake_rewards_by_partition,
             total_stake_rewards_lamports: _total_stake_rewards_lamports,
         } = stake_rewards_by_partition;
-
-        // let (_, assert_us) = measure_us!({
-        //     // the remaining code mirrors `update_rewards_with_thread_pool()`
-        //     let new_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
-
-        //     // This is for vote rewards only.
-        //     let validator_rewards_paid = new_vote_balance_and_staked - old_vote_balance_and_staked;
-        //     assert_eq!(total_vote_rewards, validator_rewards_paid);
-        //     self.assert_validator_rewards_paid(validator_rewards_paid);
-
-        //     // verify that we didn't pay any more than we expected to
-        //     assert!(point_value.rewards >= validator_rewards_paid + total_stake_rewards_lamports);
-        //     info!(
-        //         "distributed vote rewards: {} out of {}, remaining {}",
-        //         validator_rewards_paid, point_value.rewards, total_stake_rewards_lamports
-        //     );
-        // });
-        // metrics.assert_us += assert_us;
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();
@@ -223,8 +204,6 @@ impl Bank {
             foundation_rate,
         } = self.calculate_previous_epoch_inflation_rewards(capitalization, prev_epoch);
 
-        //let old_vote_balance_and_staked = self.stakes_cache.stakes().vote_balance_and_staked();
-
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
             stake_reward_calculation: mut stake_rewards,
@@ -257,7 +236,6 @@ impl Bank {
                 stake_rewards_by_partition,
                 total_stake_rewards_lamports: stake_rewards.total_stake_rewards_lamports,
             },
-            //old_vote_balance_and_staked,
             validator_rate,
             foundation_rate,
             prev_epoch_duration_in_years,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -114,7 +114,7 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 pub(super) struct PartitionedRewardsCalculation {
     pub(super) vote_account_rewards: VoteRewardsAccounts,
     pub(super) stake_rewards_by_partition: StakeRewardCalculationPartitioned,
-    pub(super) old_vote_balance_and_staked: u64,
+    //pub(super) old_vote_balance_and_staked: u64,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
     pub(super) prev_epoch_duration_in_years: f64,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -114,7 +114,6 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 pub(super) struct PartitionedRewardsCalculation {
     pub(super) vote_account_rewards: VoteRewardsAccounts,
     pub(super) stake_rewards_by_partition: StakeRewardCalculationPartitioned,
-    //pub(super) old_vote_balance_and_staked: u64,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
     pub(super) prev_epoch_duration_in_years: f64,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -70,6 +70,8 @@ pub(super) struct VoteRewardsAccounts {
     /// Some if account is to be stored.
     /// None if to be skipped.
     pub(super) accounts_to_store: Vec<Option<AccountSharedData>>,
+    /// total lamports across all `vote_rewards`
+    pub(super) total_vote_rewards_lamports: u64,
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -346,15 +346,6 @@ impl Stakes<StakeAccount> {
             .sum()
     }
 
-    /// Sum the lamports of the vote accounts and the delegated stake
-    pub(crate) fn vote_balance_and_staked(&self) -> u64 {
-        let get_stake = |stake_account: &StakeAccount| stake_account.delegation().stake;
-        let get_lamports = |(_, vote_account): (_, &VoteAccount)| vote_account.lamports();
-
-        self.stake_delegations.values().map(get_stake).sum::<u64>()
-            + self.vote_accounts.iter().map(get_lamports).sum::<u64>()
-    }
-
     fn remove_vote_account(&mut self, vote_pubkey: &Pubkey) -> Option<VoteAccount> {
         self.vote_accounts.remove(vote_pubkey).map(|(_, a)| a)
     }
@@ -975,58 +966,6 @@ pub(crate) mod tests {
             let vote_accounts = stakes.vote_accounts();
             assert!(vote_accounts.get(&vote_pubkey).is_some());
             assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey), 0);
-        }
-    }
-
-    #[test]
-    fn test_vote_balance_and_staked_empty() {
-        let stakes = Stakes::<StakeAccount>::default();
-        assert_eq!(stakes.vote_balance_and_staked(), 0);
-    }
-
-    #[test]
-    fn test_vote_balance_and_staked_normal() {
-        let stakes_cache = StakesCache::default();
-        #[allow(non_local_definitions)]
-        impl Stakes<StakeAccount> {
-            fn vote_balance_and_warmed_staked(&self) -> u64 {
-                let vote_balance: u64 = self
-                    .vote_accounts
-                    .iter()
-                    .map(|(_pubkey, account)| account.lamports())
-                    .sum();
-                let warmed_stake: u64 = self
-                    .vote_accounts
-                    .delegated_stakes()
-                    .map(|(_pubkey, stake)| stake)
-                    .sum();
-                vote_balance + warmed_stake
-            }
-        }
-
-        let genesis_epoch = 0;
-        let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-            create_warming_staked_node_accounts(10, genesis_epoch);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
-
-        {
-            let stakes = stakes_cache.stakes();
-            assert_eq!(stakes.vote_balance_and_staked(), 11);
-            assert_eq!(stakes.vote_balance_and_warmed_staked(), 1);
-        }
-
-        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
-        for (epoch, expected_warmed_stake) in ((genesis_epoch + 1)..=3).zip(&[2, 3, 4]) {
-            stakes_cache.activate_epoch(epoch, &thread_pool, None);
-            // vote_balance_and_staked() always remain to return same lamports
-            // while vote_balance_and_warmed_staked() gradually increases
-            let stakes = stakes_cache.stakes();
-            assert_eq!(stakes.vote_balance_and_staked(), 11);
-            assert_eq!(
-                stakes.vote_balance_and_warmed_staked(),
-                *expected_warmed_stake
-            );
         }
     }
 }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -632,39 +632,6 @@ pub(crate) mod tests {
         )
     }
 
-    fn create_warming_staked_node_accounts(
-        stake: u64,
-        epoch: Epoch,
-    ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
-        let vote_pubkey = solana_pubkey::new_rand();
-        let vote_account =
-            vote_state::create_account(&vote_pubkey, &solana_pubkey::new_rand(), 0, 1);
-        (
-            (vote_pubkey, vote_account),
-            create_warming_stake_account(stake, epoch, &vote_pubkey),
-        )
-    }
-
-    // add stake to a vote_pubkey                               (   stake    )
-    fn create_warming_stake_account(
-        stake: u64,
-        epoch: Epoch,
-        vote_pubkey: &Pubkey,
-    ) -> (Pubkey, AccountSharedData) {
-        let stake_pubkey = solana_pubkey::new_rand();
-        (
-            stake_pubkey,
-            stake_state::create_account_with_activation_epoch(
-                &stake_pubkey,
-                vote_pubkey,
-                &vote_state::create_account(vote_pubkey, &solana_pubkey::new_rand(), 0, 1),
-                &Rent::free(),
-                stake,
-                epoch,
-            ),
-        )
-    }
-
     #[test]
     fn test_stakes_basic() {
         for i in 0..4 {


### PR DESCRIPTION
#### Problem

The current reward payout assertion in PER calculation is a significant performance bottleneck during PER at epoch processing. This change optimizes the assertion to reduce processing time of PER at epoch boundaries.


#### Summary of Changes

optimize epoch rewards payout assertions in PER.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
