### PR TITLE
Revert "Directly storing and propagating target_lamports_per_signature"

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -771,7 +771,7 @@ impl Consumer {
         );
         let fee = solana_fee::calculate_fee(
             transaction,
-            bank.is_zero_fees_for_test(),
+            bank.get_lamports_per_signature() == 0,
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2744,9 +2744,7 @@ impl Bank {
 
         self.blockhash_queue.write().unwrap().genesis_hash(
             &genesis_hash,
-            genesis_config
-                .fee_rate_governor
-                .target_lamports_per_signature,
+            genesis_config.fee_rate_governor.lamports_per_signature,
         );
 
         self.hashes_per_tick = genesis_config.hashes_per_tick();
@@ -2988,9 +2986,6 @@ impl Bank {
         // consistent tx check_age handling.
         BankWithScheduler::wait_for_paused_scheduler(self, scheduler);
 
-        let (_last_hash, last_lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
-
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.
@@ -3016,10 +3011,7 @@ impl Bank {
         #[cfg(feature = "dev-context-only-utils")]
         let blockhash = blockhash_override.as_ref().unwrap_or(blockhash);
 
-        // lamports_per_signature stored in blockhash_queue is not used for fee calculation
-        // but only for determining zero_fees_for_test mode (lamports_per_signature == 0).
-        // Storing last_lamports_per_signature serves the same purpose.
-        w_blockhash_queue.register_hash(blockhash, last_lamports_per_signature);
+        w_blockhash_queue.register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
         self.update_recent_blockhashes_locked(&w_blockhash_queue);
     }
 
@@ -3038,9 +3030,6 @@ impl Bank {
         blockhash: &Hash,
         lamports_per_signature: Option<u64>,
     ) {
-        let (_last_hash, last_lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
-
         // Only acquire the write lock for the blockhash queue on block boundaries because
         // readers can starve this write lock acquisition and ticks would be slowed down too
         // much if the write lock is acquired for each tick.
@@ -3048,7 +3037,8 @@ impl Bank {
         if let Some(lamports_per_signature) = lamports_per_signature {
             w_blockhash_queue.register_hash(blockhash, lamports_per_signature);
         } else {
-            w_blockhash_queue.register_hash(blockhash, last_lamports_per_signature);
+            w_blockhash_queue
+                .register_hash(blockhash, self.fee_rate_governor.lamports_per_signature);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2839,12 +2839,6 @@ impl Bank {
         (last_hash, last_lamports_per_signature)
     }
 
-    pub fn is_zero_fees_for_test(&self) -> bool {
-        let (_last_hash, last_lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
-        last_lamports_per_signature == 0
-    }
-
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         blockhash_queue.is_hash_valid_for_age(hash, MAX_PROCESSING_AGE)
@@ -2852,6 +2846,10 @@ impl Bank {
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
         self.rent_collector.rent.minimum_balance(data_len).max(1)
+    }
+
+    pub fn get_lamports_per_signature(&self) -> u64 {
+        self.fee_rate_governor.lamports_per_signature
     }
 
     pub fn get_lamports_per_signature_for_blockhash(&self, hash: &Hash) -> Option<u64> {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -63,9 +63,11 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
-            self.is_zero_fees_for_test(),
+            last_lamports_per_signature == 0,
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2917,10 +2917,10 @@ fn test_bank_tx_compute_unit_fee() {
     );
 }
 
-#[test_case(0; "zero fees for tests")]
-#[test_case(10000; "default target lamports per signature")]
-#[test_case(1; "random non-zero target lamports per signature")]
-fn test_bank_transaction_fee(target_lamports_per_signature: u64) {
+#[test]
+fn test_bank_blockhash_fee_structure() {
+    //solana_logger::setup();
+
     let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
@@ -2929,46 +2929,115 @@ fn test_bank_transaction_fee(target_lamports_per_signature: u64) {
     } = create_genesis_config_with_leader(1_000_000, &leader, 3);
     genesis_config
         .fee_rate_governor
-        .target_lamports_per_signature = target_lamports_per_signature;
+        .target_lamports_per_signature = 5000;
+    genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
-    let early_blockhash = bank.last_blockhash();
+    let cheap_blockhash = bank.last_blockhash();
+    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
+    assert_eq!(cheap_lamports_per_signature, 0);
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
-    let later_blockhash = bank.last_blockhash();
+    let expensive_blockhash = bank.last_blockhash();
+    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
+    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
-    // transaction fee for same transaction must be consistent bewteen block hashs; it is
-    // either `0` if set up for zero_fees_for_test, or a non-zeo fee.
-    let tx_fee = calculate_test_fee(
+    // Send a transfer using cheap_blockhash
+    let key = solana_pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let cheap_fee = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        target_lamports_per_signature,
+        cheap_lamports_per_signature,
         bank.fee_structure(),
     );
-
-    // Send a transfer using early_blockhash
-    let key = solana_pubkey::new_rand();
-    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, early_blockhash);
-    assert_eq!(bank.process_transaction(&tx), Ok(()));
-    assert_eq!(bank.get_balance(&key), 1);
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - tx_fee
+        initial_mint_balance - 1 - cheap_fee
     );
 
-    // Send a transfer using later_blockhash
+    // Send a transfer using expensive_blockhash
     let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, later_blockhash);
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
+    let expensive_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        expensive_lamports_per_signature,
+        bank.fee_structure(),
+    );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - tx_fee
+        initial_mint_balance - 1 - expensive_fee
+    );
+}
+
+#[test]
+fn test_bank_blockhash_compute_unit_fee_structure() {
+    //solana_logger::setup();
+
+    let leader = solana_pubkey::new_rand();
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(1_000_000_000, &leader, 3);
+    genesis_config
+        .fee_rate_governor
+        .target_lamports_per_signature = 1000;
+    genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    goto_end_of_slot(bank.clone());
+    let cheap_blockhash = bank.last_blockhash();
+    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
+    assert_eq!(cheap_lamports_per_signature, 0);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
+    goto_end_of_slot(bank.clone());
+    let expensive_blockhash = bank.last_blockhash();
+    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
+    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
+
+    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
+
+    // Send a transfer using cheap_blockhash
+    let key = solana_pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let cheap_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        cheap_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - cheap_fee
+    );
+
+    // Send a transfer using expensive_blockhash
+    let key = solana_pubkey::new_rand();
+    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_balance(&key), 1);
+    let expensive_fee = calculate_test_fee(
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
+        expensive_lamports_per_signature,
+        bank.fee_structure(),
+    );
+    assert_eq!(
+        bank.get_balance(&mint_keypair.pubkey()),
+        initial_mint_balance - 1 - expensive_fee
     );
 }
 
@@ -5702,12 +5771,7 @@ fn test_nonce_fee_calculator_updates() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    // stored lamports_per_signature isn't used to calculate transaction fee, but to determine if
-    // zero_fees_for_test, only assess if the flag is same.
-    assert_eq!(
-        stored_fee_calculator.lamports_per_signature == 0,
-        fee_calculator.lamports_per_signature == 0
-    );
+    assert_ne!(stored_fee_calculator, fee_calculator);
 }
 
 #[test]
@@ -5756,8 +5820,7 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
     );
     bank.process_transaction(&nonce_tx).unwrap();
 
-    // Grab the new hash and fee_calculator; hash shoudl be updated, and lamports_per_signature
-    // should remain same in respect to zero_fees_for_test
+    // Grab the new hash and fee_calculator; both should be updated
     let (nonce_hash, fee_calculator) = bank
         .get_account(&nonce_pubkey)
         .and_then(|acc| {
@@ -5772,10 +5835,7 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    assert_eq!(
-        stored_fee_calculator.lamports_per_signature == 0,
-        fee_calculator.lamports_per_signature == 0
-    );
+    assert_ne!(stored_fee_calculator, fee_calculator);
 }
 
 #[test]
@@ -6454,27 +6514,26 @@ fn test_bank_hash_consistency() {
         if bank.slot == 0 {
             assert_eq!(
                 bank.hash().to_string(),
-                "2ggpD1h3XTdGnYYQUdsZxMmXzpvcNBjahPHWyvL2QdsS",
+                "Hn2FoJuoFWXVFVnwcQ6peuT24mUPmhDtXHXVjKD7M4yP",
             );
         }
 
         if bank.slot == 32 {
             assert_eq!(
                 bank.hash().to_string(),
-                "GhNtDfGcKTN1h1aTE13y2Xg4c6ojLUubyiyUYeLkJVR8"
+                "Hdrk5wqzRZbofSgZMC3ztfNimrFu6DeYp751JWvtabo"
             );
         }
-
         if bank.slot == 64 {
             assert_eq!(
                 bank.hash().to_string(),
-                "J8mmPaZyBp4ckfdbLr8RWzYBaXj6n2WV9z6S7nYU2PhD"
+                "4EcAFkTxymwwPGeCgadhkrkg2hqfAPzuQZoN2NFqPzyg"
             );
         }
         if bank.slot == 128 {
             assert_eq!(
                 bank.hash().to_string(),
-                "E2ueZJ73FbM6eE7MwPzk2TxkJiHTVQnv5t4Q44KmUm3v"
+                "4BK3VANr5mhyRyrwbUHYb2kmM5m76PBGkhmKMrQ2aq7L"
             );
             break;
         }


### PR DESCRIPTION
#### Problem
9fddc352aa300a194e5364298d445f3555cd5132 caused a testnet canary to diverge (see #5454 for more details)

#### Summary of Changes
Revert https://github.com/anza-xyz/agave/pull/5219. https://github.com/anza-xyz/agave/pull/5368 was also reverted to bring back some functions necessary to get tests in a compilable state
