### PR TITLE
make and confirm tx bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,6 +6450,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-version",
+ "spl-memo",
  "spl-token",
 ]
 

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -30,6 +30,7 @@ solana-streamer = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
+spl-memo = { workspace = true, features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-accounts-db = { workspace = true }


### PR DESCRIPTION
#### Problem
There is no existing benchmarking for `send_and_confirm_transaction`

#### Summary of Changes
Add a benchmark that exercises `send_and_confirm_transaction`. This is more of an exercise in learning how to write a benchmark, as `send_and_confirm_transaction` is negligibly improved by my PR (https://github.com/anza-xyz/agave/pull/5459) and in a way that isn't well-measured by this bench.

