### PR TITLE
Join for more parallelism

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7425,6 +7425,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bs58",
+ "futures 0.3.31",
  "indicatif",
  "log",
  "reqwest 0.12.15",

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
+futures = { workspace = true }
 indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7246,6 +7246,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bs58",
+ "futures 0.3.31",
  "indicatif",
  "log",
  "reqwest 0.12.15",


### PR DESCRIPTION
#### Problem
There are a couple of places where we have serial `await`s that can be parallelized in the non-blocking RPC client. This improvement is negligible and only helps in the nonce tx case.

#### Summary of Changes
Use `join!` to parallelize awaits.

Addresses #5089 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
