### PR TITLE
Stops flushing append vecs in reopen_as_readonly()

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -244,7 +244,7 @@ impl LatestAccountsIndexRootsStats {
             ),
             (
                 "append_vecs_dirty",
-                APPEND_VEC_STATS.mmap_files_dirty.load(Ordering::Relaxed),
+                APPEND_VEC_STATS.files_dirty.load(Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -34,7 +34,7 @@ use {
         path::{Path, PathBuf},
         ptr, slice,
         sync::{
-            atomic::{self, AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Mutex,
         },
     },
@@ -477,7 +477,7 @@ impl AppendVec {
 
                 // add a memory barrier to ensure the the last mmap writes
                 // happen before the first file-io reads
-                atomic::fence(Ordering::AcqRel);
+                std::sync::atomic::fence(Ordering::AcqRel);
 
                 // The file should have already been sanitized. Don't need to check when we open the file again.
                 let mut new = AppendVec::new_from_file_unchecked(

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -314,7 +314,7 @@ impl Drop for AppendVec {
     fn drop(&mut self) {
         APPEND_VEC_STATS.files_open.fetch_sub(1, Ordering::Relaxed);
 
-        if self.is_dirty.load(Ordering::Acquire) {
+        if *self.is_dirty.get_mut() {
             APPEND_VEC_STATS.files_dirty.fetch_sub(1, Ordering::Relaxed);
         }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -2194,7 +2194,7 @@ pub mod tests {
         *av2.remove_file_on_drop.get_mut() = false;
 
         // ensure `is_dirty` is moved
-        assert_eq!(*av1.is_dirty.get_mut(), false);
+        assert!(!*av1.is_dirty.get_mut());
         assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
 
         // ensure we can flush the new append vec

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -482,9 +482,9 @@ impl AppendVec {
                     StorageAccess::File,
                 )
                 .ok()?;
-                if self.is_dirty.load(Ordering::Acquire) {
+                if self.is_dirty.swap(false, Ordering::AcqRel) {
+                    // *move* the dirty-ness to the new append vec
                     *new.is_dirty.get_mut() = true;
-                    APPEND_VEC_STATS.files_dirty.fetch_add(1, Ordering::Relaxed);
                 }
                 Some(new)
             }
@@ -2166,31 +2166,31 @@ pub mod tests {
     }
 
     // Test to make sure that `is_dirty` is tracked properly
-    // * `reopen_as_readonly()` copies `is_dirty`
+    // * `reopen_as_readonly()` moves `is_dirty`
     // * `flush()` clears `is_dirty`
     #[test_case(false)]
     #[test_case(true)]
     fn test_is_dirty(begins_dirty: bool) {
         let file = get_append_vec_path("test_is_dirty");
 
-        let mut av = AppendVec::new(&file.path, true, 1024 * 1024);
+        let mut av1 = AppendVec::new(&file.path, true, 1024 * 1024);
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
-        *av.remove_file_on_drop.get_mut() = false;
+        *av1.remove_file_on_drop.get_mut() = false;
 
         // ensure the append vec begins not dirty
-        assert!(!*av.is_dirty.get_mut());
+        assert!(!*av1.is_dirty.get_mut());
 
         if begins_dirty {
-            av.append_account_test(&create_test_account(10)).unwrap();
+            av1.append_account_test(&create_test_account(10)).unwrap();
         }
-        assert_eq!(*av.is_dirty.get_mut(), begins_dirty);
+        assert_eq!(*av1.is_dirty.get_mut(), begins_dirty);
 
-        let mut av2 = av.reopen_as_readonly().unwrap();
+        let mut av2 = av1.reopen_as_readonly().unwrap();
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
         *av2.remove_file_on_drop.get_mut() = false;
 
-        // ensure `is_dirty` did not change
-        assert_eq!(*av.is_dirty.get_mut(), begins_dirty);
+        // ensure `is_dirty` is moved
+        assert_eq!(*av1.is_dirty.get_mut(), false);
         assert_eq!(*av2.is_dirty.get_mut(), begins_dirty);
 
         // ensure we can flush the new append vec
@@ -2199,8 +2199,8 @@ pub mod tests {
         assert!(!*av2.is_dirty.get_mut());
 
         // ensure we can flush the old append vec too
-        assert!(av.flush().is_ok());
+        assert!(av1.flush().is_ok());
         // and now should not be dirty
-        assert!(!*av.is_dirty.get_mut());
+        assert!(!*av1.is_dirty.get_mut());
     }
 }


### PR DESCRIPTION
#### Problem

mmap `flush` is very slow, and should be avoided whenever possible. (This also includes `msync/fsync`.)

We currently flush the append vec mmap during `reopen_as_readonly()`, which is called when flushing the accounts db write cache. This ends up with lots of OS contention.

We also flush account storage files when taking a bank snapshot, to make it fastboot-able and safe across power failures. We will evaluate if we need this safety guarantee separately, but note that this is the only time we need to actually flush the file. So if a node operator has disabled snapshots, they shouldn't need to pay for flushing the append vec mmap ever.


#### Summary of Changes

Stop flushing append vec mmaps in `reopen_as_readonly()`.

Note, I intend to backport this to v2.2.