### PR TITLE
Move the block cost check outside of Bank callback

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -18,7 +18,7 @@ use {
         accounts_db::AccountsDbConfig, accounts_update_notifier_interface::AccountsUpdateNotifier,
         epoch_accounts_hash::EpochAccountsHash,
     },
-    solana_cost_model::cost_model::CostModel,
+    solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::entry::{
         self, create_ticks, Entry, EntrySlice, EntryType, EntryVerificationStatus, VerifyRecyclers,
     },
@@ -55,7 +55,7 @@ use {
     },
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
-        transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
+        transaction_processing_result::ProcessedTransaction,
         transaction_processor::ExecutionRecordingConfig,
     },
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
@@ -183,11 +183,10 @@ pub fn execute_batch<'a>(
         vec![]
     };
 
-    let pre_commit_callback = |timings: &mut _, processing_results: &_| -> PreCommitResult {
+    let pre_commit_callback = |_timings: &mut _, processing_results: &_| -> PreCommitResult {
         match extra_pre_commit_callback {
             None => {
                 get_first_error(batch, processing_results)?;
-                check_block_cost_limits_if_enabled(batch, bank, timings, processing_results)?;
                 Ok(None)
             }
             Some(extra_pre_commit_callback) => {
@@ -231,6 +230,8 @@ pub fn execute_batch<'a>(
             pre_commit_callback,
         )?;
 
+    get_and_check_transaction_costs(batch, bank, timings, &commit_results)?;
+
     bank_utils::find_and_send_votes(
         batch.sanitized_transactions(),
         &commit_results,
@@ -273,64 +274,67 @@ pub fn execute_batch<'a>(
     Ok(())
 }
 
-// collect transactions actual execution costs, subject to block limits;
-// block will be marked as dead if exceeds cost limits, details will be
-// reported to metric `replay-stage-mark_dead_slot`
-fn check_block_cost_limits(
+// Add transaction execution costs to the cost tracker; this function will
+// error and the block will be marked dead if the cost limit is exceeded
+fn check_block_cost_limits<Tx: TransactionWithMeta>(
     bank: &Bank,
-    processing_results: &[TransactionProcessingResult],
-    sanitized_transactions: &[impl TransactionWithMeta],
+    tx_costs: &[TransactionCost<'_, Tx>],
 ) -> Result<()> {
-    assert_eq!(sanitized_transactions.len(), processing_results.len());
-
-    let tx_costs_with_actual_execution_units: Vec<_> = processing_results
-        .iter()
-        .zip(sanitized_transactions)
-        .filter_map(|(processing_result, tx)| {
-            if let Ok(processed_tx) = processing_result {
-                Some(CostModel::calculate_cost_for_executed_transaction(
-                    tx,
-                    processed_tx.executed_units(),
-                    processed_tx.loaded_accounts_data_size(),
-                    &bank.feature_set,
-                ))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        for tx_cost in &tx_costs_with_actual_execution_units {
-            cost_tracker
-                .try_add(tx_cost)
-                .map_err(TransactionError::from)?;
-        }
+    let mut cost_tracker = bank.write_cost_tracker().unwrap();
+    for tx_cost in tx_costs {
+        cost_tracker
+            .try_add(tx_cost)
+            .map_err(TransactionError::from)?;
     }
     Ok(())
 }
 
-fn check_block_cost_limits_if_enabled(
-    batch: &TransactionBatch<impl TransactionWithMeta>,
+fn get_and_check_transaction_costs<'a, Tx: TransactionWithMeta>(
+    batch: &'a TransactionBatch<Tx>,
     bank: &Bank,
     timings: &mut ExecuteTimings,
-    processing_results: &[TransactionProcessingResult],
-) -> Result<()> {
-    let (check_block_cost_limits_result, check_block_cost_limits_us) = measure_us!(if bank
-        .feature_set
-        .is_active(&agave_feature_set::apply_cost_tracker_during_replay::id())
-    {
-        check_block_cost_limits(bank, processing_results, batch.sanitized_transactions())
-    } else {
-        Ok(())
+    commit_results: &[TransactionCommitResult],
+) -> Result<Vec<TransactionCost<'a, Tx>>> {
+    let sanitized_transactions = batch.sanitized_transactions();
+    assert_eq!(sanitized_transactions.len(), commit_results.len());
+
+    let ((tx_costs, check_block_cost_limits_result), check_block_cost_elapsed_us) = measure_us!({
+        let tx_costs: Vec<_> = commit_results
+            .iter()
+            .zip(sanitized_transactions)
+            .filter_map(|(commit_result, tx)| {
+                if let Ok(committed_tx) = commit_result {
+                    Some(CostModel::calculate_cost_for_executed_transaction(
+                        tx,
+                        committed_tx.executed_units,
+                        committed_tx.loaded_account_stats.loaded_accounts_data_size,
+                        &bank.feature_set,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let should_check_block_cost_limits = bank
+            .feature_set
+            .is_active(&agave_feature_set::apply_cost_tracker_during_replay::id());
+
+        let check_block_cost_limits_result = if should_check_block_cost_limits {
+            check_block_cost_limits(bank, &tx_costs)
+        } else {
+            Ok(())
+        };
+
+        (tx_costs, check_block_cost_limits_result)
     });
 
     timings.saturating_add_in_place(
         ExecuteTimingType::CheckBlockLimitsUs,
-        check_block_cost_limits_us,
+        check_block_cost_elapsed_us,
     );
-    check_block_cost_limits_result
+
+    check_block_cost_limits_result.map(|_| tx_costs)
 }
 
 #[derive(Default)]
@@ -2339,12 +2343,7 @@ pub mod tests {
             system_transaction,
             transaction::{Transaction, TransactionError},
         },
-        solana_svm::{
-            account_loader::LoadedTransaction,
-            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
-            transaction_processing_result::ProcessedTransaction,
-            transaction_processor::ExecutionRecordingConfig,
-        },
+        solana_svm::transaction_processor::ExecutionRecordingConfig,
         solana_vote::{vote_account::VoteAccount, vote_transaction},
         solana_vote_program::{
             self,
@@ -5309,38 +5308,20 @@ pub mod tests {
                 actual_loaded_accounts_data_size,
                 &bank.feature_set,
             );
+
         // set block-limit to be able to just have one transaction
         let block_limit = tx_cost.sum();
-
         bank.write_cost_tracker()
             .unwrap()
             .set_limits(u64::MAX, block_limit, u64::MAX);
-        let txs = vec![tx.clone(), tx];
-        let processing_results = vec![
-            Ok(ProcessedTransaction::Executed(Box::new(
-                ExecutedTransaction {
-                    execution_details: TransactionExecutionDetails {
-                        status: Ok(()),
-                        log_messages: None,
-                        inner_instructions: None,
-                        return_data: None,
-                        executed_units: actual_execution_cu,
-                        accounts_data_len_delta: 0,
-                    },
-                    loaded_transaction: LoadedTransaction {
-                        loaded_accounts_data_size: actual_loaded_accounts_data_size,
-                        ..LoadedTransaction::default()
-                    },
-                    programs_modified_by_tx: HashMap::new(),
-                },
-            ))),
-            Err(TransactionError::AccountNotFound),
-        ];
 
-        assert!(check_block_cost_limits(&bank, &processing_results, &txs).is_ok());
+        let tx_costs = vec![tx_cost];
+        // The transaction will fit when added the first time
+        assert!(check_block_cost_limits(&bank, &tx_costs).is_ok());
+        // But not when added a second time
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
-            check_block_cost_limits(&bank, &processing_results, &txs)
+            check_block_cost_limits(&bank, &tx_costs)
         );
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -55,7 +55,7 @@ use {
     },
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
-        transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
+        transaction_processing_result::ProcessedTransaction,
         transaction_processor::ExecutionRecordingConfig,
     },
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
@@ -172,9 +172,15 @@ pub fn execute_batch<'a>(
         batch,
         transaction_indexes,
     } = batch;
-    let record_token_balances = transaction_status_sender.is_some();
-    let mut transaction_indexes = Cow::from(transaction_indexes);
 
+    // extra_pre_commit_callback allows for reuse of this function between the
+    // unified scheduler block production path and block verification path(s)
+    //   Some(_) => unified scheduler block production path
+    //   None    => block verification path(s)
+    let block_verification = extra_pre_commit_callback.is_none();
+    let record_token_balances = transaction_status_sender.is_some();
+
+    let mut transaction_indexes = Cow::from(transaction_indexes);
     let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
 
     let pre_token_balances = if record_token_balances {
@@ -183,11 +189,10 @@ pub fn execute_batch<'a>(
         vec![]
     };
 
-    let pre_commit_callback = |timings: &mut _, processing_results: &_| -> PreCommitResult {
+    let pre_commit_callback = |_timings: &mut _, processing_results: &_| -> PreCommitResult {
         match extra_pre_commit_callback {
             None => {
                 get_first_error(batch, processing_results)?;
-                check_block_cost_limits_if_enabled(batch, bank, timings, processing_results)?;
                 Ok(None)
             }
             Some(extra_pre_commit_callback) => {
@@ -230,6 +235,10 @@ pub fn execute_batch<'a>(
             log_messages_bytes_limit,
             pre_commit_callback,
         )?;
+
+    if block_verification {
+        check_block_cost_limits_if_enabled(batch, bank, timings, &commit_results)?;
+    }
 
     bank_utils::find_and_send_votes(
         batch.sanitized_transactions(),
@@ -278,20 +287,20 @@ pub fn execute_batch<'a>(
 // reported to metric `replay-stage-mark_dead_slot`
 fn check_block_cost_limits(
     bank: &Bank,
-    processing_results: &[TransactionProcessingResult],
+    commit_results: &[TransactionCommitResult],
     sanitized_transactions: &[impl TransactionWithMeta],
 ) -> Result<()> {
-    assert_eq!(sanitized_transactions.len(), processing_results.len());
+    assert_eq!(sanitized_transactions.len(), commit_results.len());
 
-    let tx_costs_with_actual_execution_units: Vec<_> = processing_results
+    let tx_costs_with_actual_execution_units: Vec<_> = commit_results
         .iter()
         .zip(sanitized_transactions)
-        .filter_map(|(processing_result, tx)| {
-            if let Ok(processed_tx) = processing_result {
+        .filter_map(|(commit_result, tx)| {
+            if let Ok(committed_tx) = commit_result {
                 Some(CostModel::calculate_cost_for_executed_transaction(
                     tx,
-                    processed_tx.executed_units(),
-                    processed_tx.loaded_accounts_data_size(),
+                    committed_tx.executed_units,
+                    committed_tx.loaded_account_stats.loaded_accounts_data_size,
                     &bank.feature_set,
                 ))
             } else {
@@ -315,13 +324,13 @@ fn check_block_cost_limits_if_enabled(
     batch: &TransactionBatch<impl TransactionWithMeta>,
     bank: &Bank,
     timings: &mut ExecuteTimings,
-    processing_results: &[TransactionProcessingResult],
+    commit_results: &[TransactionCommitResult],
 ) -> Result<()> {
     let (check_block_cost_limits_result, check_block_cost_limits_us) = measure_us!(if bank
         .feature_set
         .is_active(&agave_feature_set::apply_cost_tracker_during_replay::id())
     {
-        check_block_cost_limits(bank, processing_results, batch.sanitized_transactions())
+        check_block_cost_limits(bank, commit_results, batch.sanitized_transactions())
     } else {
         Ok(())
     });
@@ -2329,10 +2338,12 @@ pub mod tests {
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
             epoch_schedule::EpochSchedule,
+            fee::FeeDetails,
             hash::Hash,
             instruction::{Instruction, InstructionError},
             native_token::LAMPORTS_PER_SOL,
             pubkey::Pubkey,
+            rent_debits::RentDebits,
             signature::{Keypair, Signer},
             signer::SeedDerivable,
             system_instruction::SystemError,
@@ -2340,9 +2351,8 @@ pub mod tests {
             transaction::{Transaction, TransactionError},
         },
         solana_svm::{
-            account_loader::LoadedTransaction,
-            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
-            transaction_processing_result::ProcessedTransaction,
+            transaction_commit_result::CommittedTransaction,
+            transaction_execution_result::TransactionLoadedAccountsStats,
             transaction_processor::ExecutionRecordingConfig,
         },
         solana_vote::{vote_account::VoteAccount, vote_transaction},
@@ -5316,31 +5326,27 @@ pub mod tests {
             .unwrap()
             .set_limits(u64::MAX, block_limit, u64::MAX);
         let txs = vec![tx.clone(), tx];
-        let processing_results = vec![
-            Ok(ProcessedTransaction::Executed(Box::new(
-                ExecutedTransaction {
-                    execution_details: TransactionExecutionDetails {
-                        status: Ok(()),
-                        log_messages: None,
-                        inner_instructions: None,
-                        return_data: None,
-                        executed_units: actual_execution_cu,
-                        accounts_data_len_delta: 0,
-                    },
-                    loaded_transaction: LoadedTransaction {
-                        loaded_accounts_data_size: actual_loaded_accounts_data_size,
-                        ..LoadedTransaction::default()
-                    },
-                    programs_modified_by_tx: HashMap::new(),
+        let commit_results = vec![
+            Ok(CommittedTransaction {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: actual_execution_cu,
+                fee_details: FeeDetails::default(),
+                rent_debits: RentDebits::default(),
+                loaded_account_stats: TransactionLoadedAccountsStats {
+                    loaded_accounts_data_size: actual_loaded_accounts_data_size,
+                    loaded_accounts_count: 2,
                 },
-            ))),
+            }),
             Err(TransactionError::AccountNotFound),
         ];
 
-        assert!(check_block_cost_limits(&bank, &processing_results, &txs).is_ok());
+        assert!(check_block_cost_limits(&bank, &commit_results, &txs).is_ok());
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
-            check_block_cost_limits(&bank, &processing_results, &txs)
+            check_block_cost_limits(&bank, &commit_results, &txs)
         );
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -162,8 +162,6 @@ pub fn execute_batch<'a>(
     timings: &'a mut ExecuteTimings,
     log_messages_bytes_limit: Option<usize>,
     prioritization_fee_cache: &'a PrioritizationFeeCache,
-    // None is meaningfully used to detect this is called from the block producing unified
-    // scheduler. If so, suppress too verbose logging for the code path.
     extra_pre_commit_callback: Option<
         impl FnOnce(&Result<ProcessedTransaction>) -> Result<Option<usize>>,
     >,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -278,10 +278,10 @@ pub fn execute_batch<'a>(
 // error and the block will be marked dead if the cost limit is exceeded
 fn check_block_cost_limits<Tx: TransactionWithMeta>(
     bank: &Bank,
-    tx_costs: &[Option<TransactionCost<'_, Tx>>],
+    tx_costs: &[TransactionCost<'_, Tx>],
 ) -> Result<()> {
     let mut cost_tracker = bank.write_cost_tracker().unwrap();
-    for tx_cost in tx_costs.iter().flatten() {
+    for tx_cost in tx_costs {
         cost_tracker
             .try_add(tx_cost)
             .map_err(TransactionError::from)?;
@@ -294,7 +294,7 @@ fn get_and_check_transaction_costs<'a, Tx: TransactionWithMeta>(
     bank: &Bank,
     timings: &mut ExecuteTimings,
     commit_results: &[TransactionCommitResult],
-) -> Result<Vec<Option<TransactionCost<'a, Tx>>>> {
+) -> Result<Vec<TransactionCost<'a, Tx>>> {
     let sanitized_transactions = batch.sanitized_transactions();
     assert_eq!(sanitized_transactions.len(), commit_results.len());
 
@@ -302,7 +302,7 @@ fn get_and_check_transaction_costs<'a, Tx: TransactionWithMeta>(
         let tx_costs: Vec<_> = commit_results
             .iter()
             .zip(sanitized_transactions)
-            .map(|(commit_result, tx)| {
+            .filter_map(|(commit_result, tx)| {
                 if let Ok(committed_tx) = commit_result {
                     Some(CostModel::calculate_cost_for_executed_transaction(
                         tx,
@@ -5315,18 +5315,13 @@ pub mod tests {
             .unwrap()
             .set_limits(u64::MAX, block_limit, u64::MAX);
 
-        let tx_costs = vec![None, Some(tx_cost), None];
+        let tx_costs = vec![tx_cost];
         // The transaction will fit when added the first time
         assert!(check_block_cost_limits(&bank, &tx_costs).is_ok());
-        // But adding a second time will exceed block limit
+        // But not when added a second time
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
             check_block_cost_limits(&bank, &tx_costs)
         );
-        // Adding more None's will noop (even though the block is already full)
-        let (none_costs, _): (Vec<_>, Vec<_>) =
-            tx_costs.into_iter().partition(|tx_cost| tx_cost.is_none());
-        assert_eq!(none_costs.len(), 2);
-        assert!(check_block_cost_limits(&bank, &none_costs).is_ok());
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -18,7 +18,7 @@ use {
         accounts_db::AccountsDbConfig, accounts_update_notifier_interface::AccountsUpdateNotifier,
         epoch_accounts_hash::EpochAccountsHash,
     },
-    solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
+    solana_cost_model::cost_model::CostModel,
     solana_entry::entry::{
         self, create_ticks, Entry, EntrySlice, EntryType, EntryVerificationStatus, VerifyRecyclers,
     },
@@ -55,7 +55,7 @@ use {
     },
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
-        transaction_processing_result::ProcessedTransaction,
+        transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
         transaction_processor::ExecutionRecordingConfig,
     },
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
@@ -183,10 +183,11 @@ pub fn execute_batch<'a>(
         vec![]
     };
 
-    let pre_commit_callback = |_timings: &mut _, processing_results: &_| -> PreCommitResult {
+    let pre_commit_callback = |timings: &mut _, processing_results: &_| -> PreCommitResult {
         match extra_pre_commit_callback {
             None => {
                 get_first_error(batch, processing_results)?;
+                check_block_cost_limits_if_enabled(batch, bank, timings, processing_results)?;
                 Ok(None)
             }
             Some(extra_pre_commit_callback) => {
@@ -230,8 +231,6 @@ pub fn execute_batch<'a>(
             pre_commit_callback,
         )?;
 
-    get_and_check_transaction_costs(batch, bank, timings, &commit_results)?;
-
     bank_utils::find_and_send_votes(
         batch.sanitized_transactions(),
         &commit_results,
@@ -274,67 +273,64 @@ pub fn execute_batch<'a>(
     Ok(())
 }
 
-// Add transaction execution costs to the cost tracker; this function will
-// error and the block will be marked dead if the cost limit is exceeded
-fn check_block_cost_limits<Tx: TransactionWithMeta>(
+// collect transactions actual execution costs, subject to block limits;
+// block will be marked as dead if exceeds cost limits, details will be
+// reported to metric `replay-stage-mark_dead_slot`
+fn check_block_cost_limits(
     bank: &Bank,
-    tx_costs: &[TransactionCost<'_, Tx>],
+    processing_results: &[TransactionProcessingResult],
+    sanitized_transactions: &[impl TransactionWithMeta],
 ) -> Result<()> {
-    let mut cost_tracker = bank.write_cost_tracker().unwrap();
-    for tx_cost in tx_costs {
-        cost_tracker
-            .try_add(tx_cost)
-            .map_err(TransactionError::from)?;
+    assert_eq!(sanitized_transactions.len(), processing_results.len());
+
+    let tx_costs_with_actual_execution_units: Vec<_> = processing_results
+        .iter()
+        .zip(sanitized_transactions)
+        .filter_map(|(processing_result, tx)| {
+            if let Ok(processed_tx) = processing_result {
+                Some(CostModel::calculate_cost_for_executed_transaction(
+                    tx,
+                    processed_tx.executed_units(),
+                    processed_tx.loaded_accounts_data_size(),
+                    &bank.feature_set,
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    {
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        for tx_cost in &tx_costs_with_actual_execution_units {
+            cost_tracker
+                .try_add(tx_cost)
+                .map_err(TransactionError::from)?;
+        }
     }
     Ok(())
 }
 
-fn get_and_check_transaction_costs<'a, Tx: TransactionWithMeta>(
-    batch: &'a TransactionBatch<Tx>,
+fn check_block_cost_limits_if_enabled(
+    batch: &TransactionBatch<impl TransactionWithMeta>,
     bank: &Bank,
     timings: &mut ExecuteTimings,
-    commit_results: &[TransactionCommitResult],
-) -> Result<Vec<TransactionCost<'a, Tx>>> {
-    let sanitized_transactions = batch.sanitized_transactions();
-    assert_eq!(sanitized_transactions.len(), commit_results.len());
-
-    let ((tx_costs, check_block_cost_limits_result), check_block_cost_elapsed_us) = measure_us!({
-        let tx_costs: Vec<_> = commit_results
-            .iter()
-            .zip(sanitized_transactions)
-            .filter_map(|(commit_result, tx)| {
-                if let Ok(committed_tx) = commit_result {
-                    Some(CostModel::calculate_cost_for_executed_transaction(
-                        tx,
-                        committed_tx.executed_units,
-                        committed_tx.loaded_account_stats.loaded_accounts_data_size,
-                        &bank.feature_set,
-                    ))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let should_check_block_cost_limits = bank
-            .feature_set
-            .is_active(&agave_feature_set::apply_cost_tracker_during_replay::id());
-
-        let check_block_cost_limits_result = if should_check_block_cost_limits {
-            check_block_cost_limits(bank, &tx_costs)
-        } else {
-            Ok(())
-        };
-
-        (tx_costs, check_block_cost_limits_result)
+    processing_results: &[TransactionProcessingResult],
+) -> Result<()> {
+    let (check_block_cost_limits_result, check_block_cost_limits_us) = measure_us!(if bank
+        .feature_set
+        .is_active(&agave_feature_set::apply_cost_tracker_during_replay::id())
+    {
+        check_block_cost_limits(bank, processing_results, batch.sanitized_transactions())
+    } else {
+        Ok(())
     });
 
     timings.saturating_add_in_place(
         ExecuteTimingType::CheckBlockLimitsUs,
-        check_block_cost_elapsed_us,
+        check_block_cost_limits_us,
     );
-
-    check_block_cost_limits_result.map(|_| tx_costs)
+    check_block_cost_limits_result
 }
 
 #[derive(Default)]
@@ -2343,7 +2339,12 @@ pub mod tests {
             system_transaction,
             transaction::{Transaction, TransactionError},
         },
-        solana_svm::transaction_processor::ExecutionRecordingConfig,
+        solana_svm::{
+            account_loader::LoadedTransaction,
+            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+            transaction_processing_result::ProcessedTransaction,
+            transaction_processor::ExecutionRecordingConfig,
+        },
         solana_vote::{vote_account::VoteAccount, vote_transaction},
         solana_vote_program::{
             self,
@@ -5308,20 +5309,38 @@ pub mod tests {
                 actual_loaded_accounts_data_size,
                 &bank.feature_set,
             );
-
         // set block-limit to be able to just have one transaction
         let block_limit = tx_cost.sum();
+
         bank.write_cost_tracker()
             .unwrap()
             .set_limits(u64::MAX, block_limit, u64::MAX);
+        let txs = vec![tx.clone(), tx];
+        let processing_results = vec![
+            Ok(ProcessedTransaction::Executed(Box::new(
+                ExecutedTransaction {
+                    execution_details: TransactionExecutionDetails {
+                        status: Ok(()),
+                        log_messages: None,
+                        inner_instructions: None,
+                        return_data: None,
+                        executed_units: actual_execution_cu,
+                        accounts_data_len_delta: 0,
+                    },
+                    loaded_transaction: LoadedTransaction {
+                        loaded_accounts_data_size: actual_loaded_accounts_data_size,
+                        ..LoadedTransaction::default()
+                    },
+                    programs_modified_by_tx: HashMap::new(),
+                },
+            ))),
+            Err(TransactionError::AccountNotFound),
+        ];
 
-        let tx_costs = vec![tx_cost];
-        // The transaction will fit when added the first time
-        assert!(check_block_cost_limits(&bank, &tx_costs).is_ok());
-        // But not when added a second time
+        assert!(check_block_cost_limits(&bank, &processing_results, &txs).is_ok());
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
-            check_block_cost_limits(&bank, &tx_costs)
+            check_block_cost_limits(&bank, &processing_results, &txs)
         );
     }
 }


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/4150 previously shifted the block cost check into a function pointer that is passed to `Bank:: load_execute_and_commit_transactions_with_pre_commit_callback()`. The PR notes the following but doesn't elaborate much more:
> Also, this pr slightly changes the error code path on transaction errors and apply_cost_tracker_during_replay.

https://github.com/anza-xyz/agave/pull/5245 looks to enable the storage of total transaction cost in RPC data. In order to do so, we need access to the transaction costs in `execute_batch()` so we can include them in the `TransactionStatusSender` message.

#### Summary of Changes
Shift the block cost check outside of the callback & refactor so that the downstream PR (#5245) will be able to easily access the tx costs in replay without further refactoring