### PR TITLE
Remove support for `AccountsPackageKind::AccountsHashVerifier` requests

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -258,7 +258,6 @@ impl AccountsHashVerifier {
         }
 
         let accounts_hash_calculation_kind = match accounts_package.package_kind {
-            AccountsPackageKind::AccountsHashVerifier => CalcAccountsHashKind::Full,
             AccountsPackageKind::EpochAccountsHash => CalcAccountsHashKind::Full,
             AccountsPackageKind::Snapshot(snapshot_kind) => match snapshot_kind {
                 SnapshotKind::FullSnapshot => CalcAccountsHashKind::Full,
@@ -541,9 +540,6 @@ mod tests {
             slot,
         )
     }
-    fn new_ahv(slot: Slot) -> AccountsPackage {
-        new(AccountsPackageKind::AccountsHashVerifier, slot)
-    }
 
     /// Ensure that unhandled accounts packages are properly re-enqueued or dropped
     ///
@@ -556,27 +552,15 @@ mod tests {
 
         // Populate the channel so that re-enqueueing and dropping will be tested
         let mut accounts_packages = [
-            new_ahv(99),
             new_fss(100), // skipped, since there's another full snapshot with a higher slot
-            new_ahv(101),
             new_iss(110, 100),
-            new_ahv(111),
             new_eah(200), // <-- handle 1st
-            new_ahv(201),
             new_iss(210, 100),
-            new_ahv(211),
             new_fss(300),
-            new_ahv(301),
             new_iss(310, 300),
-            new_ahv(311),
             new_fss(400), // <-- handle 2nd
-            new_ahv(401),
             new_iss(410, 400),
-            new_ahv(411),
             new_iss(420, 400), // <-- handle 3rd
-            new_ahv(421),
-            new_ahv(422),
-            new_ahv(423), // <-- handle 4th
         ];
         // Shuffle the accounts packages to simulate receiving new accounts packages from ABS
         // simultaneously as AHV is processing them.
@@ -638,24 +622,6 @@ mod tests {
         assert_eq!(account_package.slot, 420);
         assert_eq!(num_re_enqueued_accounts_packages, 3);
 
-        // The Accounts Hash Verifier from slot 423 is handled 4th
-        // (the older accounts hash verifiers from slot 421 and 422 are skipped and dropped)
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::AccountsHashVerifier
-        );
-        assert_eq!(account_package.slot, 423);
-        assert_eq!(num_re_enqueued_accounts_packages, 0);
-
         // And now the accounts package channel is empty!
         assert!(AccountsHashVerifier::get_next_accounts_package(
             &accounts_package_sender,
@@ -674,18 +640,11 @@ mod tests {
 
         // Populate the channel so that re-enqueueing and dropping will be tested
         let mut accounts_packages = [
-            new_ahv(99),
             new_fss(100), // <-- handle 1st
-            new_ahv(101),
             new_iss(110, 100),
-            new_ahv(111),
             new_eah(200), // <-- handle 2nd
-            new_ahv(201),
             new_iss(210, 100),
-            new_ahv(211),
             new_iss(220, 100), // <-- handle 3rd
-            new_ahv(221),
-            new_ahv(222), // <-- handle 4th
         ];
         // Shuffle the accounts packages to simulate receiving new accounts packages from ABS
         // simultaneously as AHV is processing them.
@@ -745,24 +704,6 @@ mod tests {
         );
         assert_eq!(account_package.slot, 220);
         assert_eq!(num_re_enqueued_accounts_packages, 2);
-
-        // The Accounts Hash Verifier from slot 222 is handled 4th
-        // (the older accounts hash verifier from slot 221 is skipped and dropped)
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::AccountsHashVerifier
-        );
-        assert_eq!(account_package.slot, 222);
-        assert_eq!(num_re_enqueued_accounts_packages, 0);
 
         // And now the accounts package channel is empty!
         assert!(AccountsHashVerifier::get_next_accounts_package(

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -777,7 +777,6 @@ fn new_accounts_package_kind(
 /// - Epoch Accounts Hash
 /// - Full Snapshot
 /// - Incremental Snapshot
-/// - Accounts Hash Verifier
 ///
 /// If two requests of the same kind are being compared, their bank slots are the tiebreaker.
 #[must_use]

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -115,25 +115,6 @@ impl AccountsPackage {
         )
     }
 
-    /// Package up fields needed to verify an accounts hash
-    #[must_use]
-    pub fn new_for_accounts_hash_verifier(
-        package_kind: AccountsPackageKind,
-        bank: &Bank,
-        snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-        accounts_hash_for_testing: Option<AccountsHash>,
-    ) -> Self {
-        assert_eq!(package_kind, AccountsPackageKind::AccountsHashVerifier);
-        Self::_new(
-            package_kind,
-            bank,
-            snapshot_storages,
-            accounts_hash_for_testing,
-            AccountsHashAlgorithm::Merkle,
-            None,
-        )
-    }
-
     /// Package up fields needed to compute an EpochAccountsHash
     #[must_use]
     pub fn new_for_epoch_accounts_hash(
@@ -185,7 +166,7 @@ impl AccountsPackage {
         let accounts_db = AccountsDb::default_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
         Self {
-            package_kind: AccountsPackageKind::AccountsHashVerifier,
+            package_kind: AccountsPackageKind::EpochAccountsHash,
             slot: Slot::default(),
             block_height: Slot::default(),
             snapshot_storages: Vec::default(),
@@ -234,7 +215,6 @@ pub struct SupplementalSnapshotInfo {
 /// packages do share some processing: such as calculating the accounts hash.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AccountsPackageKind {
-    AccountsHashVerifier,
     Snapshot(SnapshotKind),
     EpochAccountsHash,
 }

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -22,7 +22,6 @@ pub fn cmp_accounts_packages_by_priority(a: &AccountsPackage, b: &AccountsPackag
 /// - Epoch Accounts Hash
 /// - Full Snapshot
 /// - Incremental Snapshot
-/// - Accounts Hash Verifier
 ///
 /// If two `Snapshot`s are compared, their snapshot kinds are the tiebreaker.
 #[must_use]

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -41,11 +41,6 @@ pub fn cmp_accounts_package_kinds_by_priority(
         (Kind::Snapshot(snapshot_kind_a), Kind::Snapshot(snapshot_kind_b)) => {
             cmp_snapshot_kinds_by_priority(snapshot_kind_a, snapshot_kind_b)
         }
-        (Kind::Snapshot(_), _) => Greater,
-        (_, Kind::Snapshot(_)) => Less,
-
-        // Accounts Hash Verifier packages
-        (Kind::AccountsHashVerifier, Kind::AccountsHashVerifier) => Equal,
     }
 }
 
@@ -183,11 +178,6 @@ mod tests {
                 Greater,
             ),
             (
-                new(AccountsPackageKind::EpochAccountsHash, 123),
-                new(AccountsPackageKind::AccountsHashVerifier, 123),
-                Greater,
-            ),
-            (
                 new(
                     AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     123,
@@ -237,14 +227,6 @@ mod tests {
                     AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                     123,
                 ),
-                Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                new(AccountsPackageKind::AccountsHashVerifier, 123),
                 Greater,
             ),
             (
@@ -321,29 +303,6 @@ mod tests {
                 ),
                 Greater,
             ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(AccountsPackageKind::AccountsHashVerifier, 123),
-                Greater,
-            ),
-            (
-                new(AccountsPackageKind::AccountsHashVerifier, 11),
-                new(AccountsPackageKind::AccountsHashVerifier, 22),
-                Less,
-            ),
-            (
-                new(AccountsPackageKind::AccountsHashVerifier, 22),
-                new(AccountsPackageKind::AccountsHashVerifier, 22),
-                Equal,
-            ),
-            (
-                new(AccountsPackageKind::AccountsHashVerifier, 33),
-                new(AccountsPackageKind::AccountsHashVerifier, 22),
-                Greater,
-            ),
         ] {
             let actual_result =
                 cmp_accounts_packages_by_priority(&accounts_package_a, &accounts_package_b);
@@ -370,11 +329,6 @@ mod tests {
                 Greater,
             ),
             (
-                AccountsPackageKind::EpochAccountsHash,
-                AccountsPackageKind::AccountsHashVerifier,
-                Greater,
-            ),
-            (
                 AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 AccountsPackageKind::EpochAccountsHash,
                 Less,
@@ -387,11 +341,6 @@ mod tests {
             (
                 AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                Greater,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageKind::AccountsHashVerifier,
                 Greater,
             ),
             (
@@ -418,16 +367,6 @@ mod tests {
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
                 Greater,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::AccountsHashVerifier,
-                Greater,
-            ),
-            (
-                AccountsPackageKind::AccountsHashVerifier,
-                AccountsPackageKind::AccountsHashVerifier,
-                Equal,
             ),
         ] {
             let actual_result = cmp_accounts_package_kinds_by_priority(


### PR DESCRIPTION
#### Problem
`AccountsPackageKind::AccountsHashVerifier` isn't useful anymore. The only time those requests are sent are when an incremental snapshot request is received and no full snapshot request has been created yet. In that case, it's better not to waste resources performing a full accounts hash for every inc snapshot request.

#### Summary of Changes
- Drop all snapshot requests which cannot be handled as a full or inc snapshot request
- Remove the AccountsHashVerifier variant

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
