### PR TITLE
Put back profile.release to preserve the build config modified in #5313

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ debug = true
 split-debuginfo = "packed"
 lto = false                # Preserve the 'thin local LTO' for this build.
 
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
+
 [profile.release-with-lto]
 inherits = "release"
 split-debuginfo = "unpacked"


### PR DESCRIPTION
Seems like we use profile.release for benchmarking and publishing tarball. Replacing the profile.release with profile.release-with-lto in #5313 regressed benchmarks. It'll likely regress other validators as jito seems to use the default script [for upgrading](https://jito-foundation.gitbook.io/mev/jito-solana/building-the-software#upgrading)

#### Summary of Changes
Put back the previous config.