### PR TITLE
Obviate need to read account from AppendVec for AccountInfo

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -346,7 +346,7 @@ fn bench_sort_and_remove_dups(b: &mut Bencher) {
         // offset has to be 8 byte aligned
         let offset = (i as usize) * std::mem::size_of::<u64>();
         AccountFromStorage {
-            index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i as u64),
+            index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i == 0),
             data_len: i as u64,
             pubkey: Pubkey::new_from_array([i; 32]),
         }
@@ -368,7 +368,7 @@ fn bench_sort_and_remove_dups_no_dups(b: &mut Bencher) {
         // offset has to be 8 byte aligned
         let offset = (i as usize) * std::mem::size_of::<u64>();
         AccountFromStorage {
-            index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i as u64),
+            index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i == 0),
             data_len: i as u64,
             pubkey: Pubkey::new_unique(),
         }

--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -124,7 +124,7 @@ impl IsCached for StorageLocation {
 const CACHE_VIRTUAL_STORAGE_ID: AccountsFileId = AccountsFileId::MAX;
 
 impl AccountInfo {
-    pub fn new(storage_location: StorageLocation, lamports: u64) -> Self {
+    pub fn new(storage_location: StorageLocation, is_zero_lamport: bool) -> Self {
         let mut packed_offset_and_flags = PackedOffsetAndFlags::default();
         let store_id = match storage_location {
             StorageLocation::AppendVec(store_id, offset) => {
@@ -146,7 +146,7 @@ impl AccountInfo {
                 CACHE_VIRTUAL_STORAGE_ID
             }
         };
-        packed_offset_and_flags.set_is_zero_lamport(lamports == 0);
+        packed_offset_and_flags.set_is_zero_lamport(is_zero_lamport);
         let account_offset_and_flags = AccountOffsetAndFlags {
             packed_offset_and_flags,
         };
@@ -202,7 +202,7 @@ mod test {
             ALIGN_BOUNDARY_OFFSET,
             4 * ALIGN_BOUNDARY_OFFSET,
         ] {
-            let info = AccountInfo::new(StorageLocation::AppendVec(0, offset), 0);
+            let info = AccountInfo::new(StorageLocation::AppendVec(0, offset), true);
             assert!(info.offset() == offset);
         }
     }
@@ -211,13 +211,13 @@ mod test {
     #[should_panic(expected = "illegal offset")]
     fn test_illegal_offset() {
         let offset = (MAXIMUM_APPEND_VEC_FILE_SIZE - (ALIGN_BOUNDARY_OFFSET as u64)) as Offset;
-        AccountInfo::new(StorageLocation::AppendVec(0, offset), 0);
+        AccountInfo::new(StorageLocation::AppendVec(0, offset), true);
     }
 
     #[test]
     #[should_panic(expected = "illegal offset")]
     fn test_alignment() {
         let offset = 1; // not aligned
-        AccountInfo::new(StorageLocation::AppendVec(0, offset), 0);
+        AccountInfo::new(StorageLocation::AppendVec(0, offset), true);
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6108,25 +6108,20 @@ impl AccountsDb {
                 storage.set_status(AccountStorageStatus::Full);
 
                 // See if an account overflows the append vecs in the slot.
-                accounts_and_meta_to_store.account_default_if_zero_lamport(
-                    infos.len(),
-                    |account| {
-                        let data_len = account.data().len();
-                        let data_len = (data_len + STORE_META_OVERHEAD) as u64;
-                        if !self.has_space_available(slot, data_len) {
-                            info!(
-                                "write_accounts_to_storage, no space: {}, {}, {}, {}, {}",
-                                storage.accounts.capacity(),
-                                storage.accounts.remaining_bytes(),
-                                data_len,
-                                infos.len(),
-                                accounts_and_meta_to_store.len()
-                            );
-                            let special_store_size = std::cmp::max(data_len * 2, self.file_size);
-                            self.create_and_insert_store(slot, special_store_size, "large create");
-                        }
-                    },
-                );
+                let data_len = accounts_and_meta_to_store.data_len(infos.len());
+                let data_len = (data_len + STORE_META_OVERHEAD) as u64;
+                if !self.has_space_available(slot, data_len) {
+                    info!(
+                        "write_accounts_to_storage, no space: {}, {}, {}, {}, {}",
+                        storage.accounts.capacity(),
+                        storage.accounts.remaining_bytes(),
+                        data_len,
+                        infos.len(),
+                        accounts_and_meta_to_store.len()
+                    );
+                    let special_store_size = std::cmp::max(data_len * 2, self.file_size);
+                    self.create_and_insert_store(slot, special_store_size, "large create");
+                }
                 continue;
             };
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -595,7 +595,7 @@ impl AccountFromStorage {
         AccountFromStorage {
             index_info: AccountInfo::new(
                 StorageLocation::AppendVec(storage_id, account.offset()),
-                account.lamports(),
+                account.is_zero_lamport(),
             ),
             pubkey: *account.pubkey(),
             data_len: account.data_len() as u64,
@@ -3587,7 +3587,7 @@ impl AccountsDb {
             stored_accounts.push(AccountFromStorage {
                 index_info: AccountInfo::new(
                     StorageLocation::AppendVec(file_id, info.index_info.offset),
-                    info.index_info.lamports,
+                    info.is_zero_lamport(),
                 ),
                 pubkey: info.index_info.pubkey,
                 data_len: info.index_info.data_len,
@@ -6134,8 +6134,7 @@ impl AccountsDb {
             for (i, offset) in stored_accounts_info.offsets.iter().enumerate() {
                 infos.push(AccountInfo::new(
                     StorageLocation::AppendVec(store_id, *offset),
-                    accounts_and_meta_to_store
-                        .account_default_if_zero_lamport(i, |account| account.lamports()),
+                    accounts_and_meta_to_store.is_zero_lamport(i),
                 ));
             }
             storage.add_accounts(
@@ -6529,7 +6528,8 @@ impl AccountsDb {
                 accounts_and_meta_to_store.account_default_if_zero_lamport(index, |account| {
                     let account_shared_data = account.to_account_shared_data();
                     let pubkey = account.pubkey();
-                    account_info = AccountInfo::new(StorageLocation::Cached, account.lamports());
+                    account_info =
+                        AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
 
                     self.notify_account_at_accounts_update(
                         slot,
@@ -8532,7 +8532,7 @@ impl AccountsDb {
                     info.pubkey,
                     AccountInfo::new(
                         StorageLocation::AppendVec(store_id, info.offset), // will never be cached
-                        info.lamports,
+                        info.is_zero_lamport(),
                     ),
                 )
             });
@@ -8742,7 +8742,7 @@ impl AccountsDb {
                                                 store_id,
                                                 account_info.offset(),
                                             ), // will never be cached
-                                            account_info.lamports(),
+                                            account_info.is_zero_lamport(),
                                         );
                                         assert_eq!(&ai, account_info2);
                                     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -51,6 +51,9 @@ impl<'a, T: ReadableAccount + Sync> StorableAccounts<'a> for (Slot, &'a [(&'a Pu
 where
     AccountForStorage<'a>: From<&'a T>,
 {
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.1[index].1.lamports() == 0
+    }
     fn account<Ret>(
         &self,
         index: usize,
@@ -235,7 +238,7 @@ fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {
     // offset has to be 8 byte aligned
     let offset = (i as usize) * std::mem::size_of::<u64>();
     AccountFromStorage {
-        index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i as u64),
+        index_info: AccountInfo::new(StorageLocation::AppendVec(i as u32, offset), i == 0),
         data_len: i as u64,
         pubkey: Pubkey::new_from_array([i; 32]),
     }
@@ -300,7 +303,7 @@ fn test_sort_and_remove_dups() {
         .collect::<Vec<_>>();
     test1.iter_mut().take(3).for_each(|entry| {
         entry.data_len = 2342342; // this one should be ignored, so modify the data_len so it will fail the compare below if it is used
-        entry.index_info = AccountInfo::new(StorageLocation::Cached, 23434);
+        entry.index_info = AccountInfo::new(StorageLocation::Cached, false);
     });
 
     let expected = [0, 1u8]
@@ -788,7 +791,7 @@ pub(crate) fn append_single_account_with_default_hash(
     if let Some(index) = add_to_index {
         let account_info = AccountInfo::new(
             StorageLocation::AppendVec(storage.id(), stored_accounts_info.offsets[0]),
-            account.lamports(),
+            account.lamports() == 0,
         );
         index.upsert(
             slot,
@@ -3162,10 +3165,10 @@ fn test_delete_dependencies() {
     let key0 = Pubkey::new_from_array([0u8; 32]);
     let key1 = Pubkey::new_from_array([1u8; 32]);
     let key2 = Pubkey::new_from_array([2u8; 32]);
-    let info0 = AccountInfo::new(StorageLocation::AppendVec(0, 0), 0);
-    let info1 = AccountInfo::new(StorageLocation::AppendVec(1, 0), 0);
-    let info2 = AccountInfo::new(StorageLocation::AppendVec(2, 0), 0);
-    let info3 = AccountInfo::new(StorageLocation::AppendVec(3, 0), 0);
+    let info0 = AccountInfo::new(StorageLocation::AppendVec(0, 0), true);
+    let info1 = AccountInfo::new(StorageLocation::AppendVec(1, 0), true);
+    let info2 = AccountInfo::new(StorageLocation::AppendVec(2, 0), true);
+    let info3 = AccountInfo::new(StorageLocation::AppendVec(3, 0), true);
     let mut reclaims = vec![];
     accounts_index.upsert(
         0,
@@ -5713,7 +5716,7 @@ fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
     }
 
     let do_test = |test_params: TestParameters| {
-        let account_info = AccountInfo::new(StorageLocation::AppendVec(42, 128), 0);
+        let account_info = AccountInfo::new(StorageLocation::AppendVec(42, 128), true);
         let pubkey = solana_pubkey::new_rand();
         let mut key_set = HashSet::default();
         key_set.insert(pubkey);
@@ -7551,7 +7554,7 @@ fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
             storage.accounts.scan_accounts(|account| {
                 let info = AccountInfo::new(
                     StorageLocation::AppendVec(storage.id(), account.offset()),
-                    account.lamports(),
+                    account.is_zero_lamport(),
                 );
                 db.accounts_index.upsert(
                     slot,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -54,6 +54,9 @@ where
     fn is_zero_lamport(&self, index: usize) -> bool {
         self.1[index].1.lamports() == 0
     }
+    fn data_len(&self, index: usize) -> usize {
+        self.1[index].1.data().len()
+    }
     fn account<Ret>(
         &self,
         index: usize,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3750,8 +3750,10 @@ pub mod tests {
                         }
                         1 => {
                             // non-empty slot list (but ignored) because slot_list = 1
-                            let slot_list =
-                                vec![(slot, AccountInfo::new(StorageLocation::Cached, lamports))];
+                            let slot_list = vec![(
+                                slot,
+                                AccountInfo::new(StorageLocation::Cached, lamports == 0),
+                            )];
                             alive_accounts.add(2, &account, &slot_list);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
@@ -3763,10 +3765,13 @@ pub mod tests {
                         2 => {
                             // multiple slot list, ref_count=2, this is NOT newest alive, so many_refs_old_alive
                             let slot_list = vec![
-                                (slot, AccountInfo::new(StorageLocation::Cached, lamports)),
+                                (
+                                    slot,
+                                    AccountInfo::new(StorageLocation::Cached, lamports == 0),
+                                ),
                                 (
                                     slot + 1,
-                                    AccountInfo::new(StorageLocation::Cached, lamports),
+                                    AccountInfo::new(StorageLocation::Cached, lamports == 0),
                                 ),
                             ];
                             alive_accounts.add(2, &account, &slot_list);
@@ -3780,10 +3785,13 @@ pub mod tests {
                         3 => {
                             // multiple slot list, ref_count=2, this is newest
                             let slot_list = vec![
-                                (slot, AccountInfo::new(StorageLocation::Cached, lamports)),
+                                (
+                                    slot,
+                                    AccountInfo::new(StorageLocation::Cached, lamports == 0),
+                                ),
                                 (
                                     slot - 1,
-                                    AccountInfo::new(StorageLocation::Cached, lamports),
+                                    AccountInfo::new(StorageLocation::Cached, lamports == 0),
                                 ),
                             ];
                             alive_accounts.add(2, &account, &slot_list);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -208,6 +208,20 @@ pub(crate) struct IndexInfoInner {
     pub data_len: u64,
 }
 
+impl ZeroLamport for IndexInfoInner {
+    #[inline(always)]
+    fn is_zero_lamport(&self) -> bool {
+        self.lamports == 0
+    }
+}
+
+impl ZeroLamport for IndexInfo {
+    #[inline(always)]
+    fn is_zero_lamport(&self) -> bool {
+        self.index_info.is_zero_lamport()
+    }
+}
+
 /// offsets to help navigate the persisted format of `AppendVec`
 #[derive(Debug)]
 struct AccountOffsets {

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -44,6 +44,9 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn is_zero_lamport(&self, index: usize) -> bool {
         self.1[index].is_zero_lamport()
     }
+    fn data_len(&self, index: usize) -> usize {
+        self.1[index].stake_account.data().len()
+    }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
         self.target_slot()

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -1,8 +1,11 @@
 //! Code for stake and vote rewards
 
 use {
-    crate::storable_accounts::{AccountForStorage, StorableAccounts},
-    solana_account::AccountSharedData,
+    crate::{
+        accounts_index::ZeroLamport,
+        storable_accounts::{AccountForStorage, StorableAccounts},
+    },
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
     solana_pubkey::Pubkey,
     solana_reward_info::RewardInfo,
@@ -22,6 +25,12 @@ impl StakeReward {
     }
 }
 
+impl ZeroLamport for StakeReward {
+    fn is_zero_lamport(&self) -> bool {
+        self.stake_account.lamports() == 0
+    }
+}
+
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn account<Ret>(
@@ -31,6 +40,9 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     ) -> Ret {
         let entry = &self.1[index];
         callback((&self.1[index].stake_pubkey, &entry.stake_account).into())
+    }
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.1[index].is_zero_lamport()
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -111,6 +111,8 @@ pub trait StorableAccounts<'a>: Sync {
     ) -> Ret;
     /// whether account at 'index' has zero lamports
     fn is_zero_lamport(&self, index: usize) -> bool;
+    /// data length of account at 'index'
+    fn data_len(&self, index: usize) -> usize;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret>(
         &self,
@@ -157,6 +159,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
     fn is_zero_lamport(&self, index: usize) -> bool {
         self.1[index].1.is_zero_lamport()
     }
+    fn data_len(&self, index: usize) -> usize {
+        self.1[index].1.data().len()
+    }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
         self.target_slot()
@@ -179,6 +184,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, AccountSharedData
     }
     fn is_zero_lamport(&self, index: usize) -> bool {
         self.1[index].1.is_zero_lamport()
+    }
+    fn data_len(&self, index: usize) -> usize {
+        self.1[index].1.data().len()
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
@@ -304,6 +312,10 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
         let indexes = self.find_internal_index(index);
         self.slots_and_accounts[indexes.0].1[indexes.1].is_zero_lamport()
     }
+    fn data_len(&self, index: usize) -> usize {
+        let indexes = self.find_internal_index(index);
+        self.slots_and_accounts[indexes.0].1[indexes.1].data_len()
+    }
     fn slot(&self, index: usize) -> Slot {
         let indexes = self.find_internal_index(index);
         self.slots_and_accounts[indexes.0].0
@@ -350,6 +362,9 @@ pub mod tests {
         fn is_zero_lamport(&self, index: usize) -> bool {
             self.1[index].is_zero_lamport()
         }
+        fn data_len(&self, index: usize) -> usize {
+            self.1[index].data_len()
+        }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.0
@@ -377,6 +392,9 @@ pub mod tests {
         fn is_zero_lamport(&self, index: usize) -> bool {
             self.1[index].1.lamports() == 0
         }
+        fn data_len(&self, index: usize) -> usize {
+            self.1[index].1.data().len()
+        }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.target_slot()
@@ -402,6 +420,9 @@ pub mod tests {
         }
         fn is_zero_lamport(&self, index: usize) -> bool {
             self.1[index].is_zero_lamport()
+        }
+        fn data_len(&self, index: usize) -> usize {
+            self.1[index].data_len()
         }
         fn slot(&self, _index: usize) -> Slot {
             // same other slot for all accounts

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -109,6 +109,8 @@ pub trait StorableAccounts<'a>: Sync {
         index: usize,
         callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret;
+    /// whether account at 'index' has zero lamports
+    fn is_zero_lamport(&self, index: usize) -> bool;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret>(
         &self,
@@ -152,6 +154,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
     ) -> Ret {
         callback((self.1[index].0, self.1[index].1).into())
     }
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.1[index].1.is_zero_lamport()
+    }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
         self.target_slot()
@@ -171,6 +176,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, AccountSharedData
         mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
     ) -> Ret {
         callback((&self.1[index].0, &self.1[index].1).into())
+    }
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.1[index].1.is_zero_lamport()
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
@@ -292,6 +300,10 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
         writer.storage = Some(storage);
         ret
     }
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        let indexes = self.find_internal_index(index);
+        self.slots_and_accounts[indexes.0].1[indexes.1].is_zero_lamport()
+    }
     fn slot(&self, index: usize) -> Slot {
         let indexes = self.find_internal_index(index);
         self.slots_and_accounts[indexes.0].0
@@ -335,6 +347,9 @@ pub mod tests {
         ) -> Ret {
             callback(self.1[index].into())
         }
+        fn is_zero_lamport(&self, index: usize) -> bool {
+            self.1[index].is_zero_lamport()
+        }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.0
@@ -359,6 +374,9 @@ pub mod tests {
         ) -> Ret {
             callback((&self.1[index].0, &self.1[index].1).into())
         }
+        fn is_zero_lamport(&self, index: usize) -> bool {
+            self.1[index].1.lamports() == 0
+        }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.target_slot()
@@ -381,6 +399,9 @@ pub mod tests {
             mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
         ) -> Ret {
             callback(self.1[index].into())
+        }
+        fn is_zero_lamport(&self, index: usize) -> bool {
+            self.1[index].is_zero_lamport()
         }
         fn slot(&self, _index: usize) -> Slot {
             // same other slot for all accounts
@@ -545,7 +566,7 @@ pub mod tests {
                             .for_each(|(account, offset)| {
                                 account.index_info = AccountInfo::new(
                                     StorageLocation::AppendVec(0, *offset),
-                                    if account.is_zero_lamport() { 0 } else { 1 },
+                                    account.is_zero_lamport(),
                                 )
                             });
                     }
@@ -684,7 +705,7 @@ pub mod tests {
                                             |(account, offset)| {
                                                 account.index_info = AccountInfo::new(
                                                     StorageLocation::AppendVec(0, *offset),
-                                                    if account.is_zero_lamport() { 0 } else { 1 },
+                                                    account.is_zero_lamport(),
                                                 )
                                             },
                                         );


### PR DESCRIPTION
#### Problem
`write_accounts_to_storage` in `AccountsDb` creates a new `AccountInfo` struct for each appended account. 

https://github.com/anza-xyz/agave/blob/14f2953eafc0849159824dbd8b5a1b8ab761b831/accounts-db/src/accounts_db.rs#L6134-L6140

The `AccountInfo::new` constructor takes a `lamports` parameter, which `StorableAccounts` cannot provide. As such, it makes a call to `account_default_if_zero_lamport` to retrieve the account and its lamport value. Behind the scenes, this actually entails a read from the `AppendVec`.

But ultimately the lamport value is only used to set the `is_zero_lamport` flag.
https://github.com/anza-xyz/agave/blob/14f2953eafc0849159824dbd8b5a1b8ab761b831/accounts-db/src/account_info.rs#L127-L149

Additionally, this same `account_default_if_zero_lamport` call is made to retrieve the data length of the account.

https://github.com/anza-xyz/agave/blob/14f2953eafc0849159824dbd8b5a1b8ab761b831/accounts-db/src/accounts_db.rs#L6111-L6129

In this case however, `StorableAccounts` can actually provide the data length without an `AppendVec` lookup.

#### Summary of Changes

##### `AccountInfo::new`
The `AccountInfo::new` constructor only actually needs to know whether the account is a zero lamport account (rather than the actual lamport value of the account), and _importantly_, `AccountFromStorage` _does_ have enough information to determine whether the account is a zero lamport account.

As such, we can obviate the need to do an `AppendVec` lookup by changing the signature of `AccountInfo::new` to:
```rs
pub fn new(storage_location: StorageLocation, is_zero_lamport: bool) -> Self 
```

This PR makes this API change to `AccountInfo::new` and updates all the call sites to pass whether the account `is_zero_lamport` rather than the lamport value itself. It also plumbs `StorableAccounts` to support reading `is_zero_lamport` for contained accounts. Importantly, this allows us to remove the call to `account_default_if_zero_lamport` in `write_accounts_to_storage` that is triggering file reads.

##### Acquiring account data length

Similarly to the above, `StorableAccounts` can trivially provide the data length of an account without doing a file lookup. An additional method is provided to provide that data for contained accounts.