### PR TITLE
Optimized Internal Index Search for Storable Accounts

### DIFF
--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -277,7 +277,7 @@ impl<'a> StorableAccountsBySlot<'a> {
                 ord => ord,
             });
         match upper_bound {
-            Ok(offset_index) => (offset_index, 0),
+            Ok(offset_index) => unreachable!("we shouldn't reach here: {}", offset_index),
             Err(offset_index) => {
                 let prior_offset = if offset_index > 0 {
                     self.starting_offsets_for_slots_accounts_slice[offset_index - 1]
@@ -376,7 +376,7 @@ pub mod tests {
         /// return (slots_and_accounts index, index within those accounts)
         /// This is the baseline unoptimized implementation. It is not used in the validator. It
         /// is used for testing an optimized version - `find_internal_index`, in the actual implementation.
-        pub fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
+        fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
             // search offsets for the accounts slice that contains 'index'.
             // This could be a binary search.
             for (offset_index, next_offset) in self
@@ -872,14 +872,17 @@ pub mod tests {
         let mut slot_accounts = Vec::new();
         let mut all_accounts = Vec::new();
         let mut total = 0;
-        for _slot in 0..10_u64 {
+        let num_slots = 10_u64;
+        // generate accounts for 10 slots
+        // each slot has a random number of accounts, between 1 and 10
+        for _slot in 0..num_slots {
             // generate random accounts per slot
             let n = rand::thread_rng().gen_range(1..10);
             total += n;
             let accounts = (0..n).map(|_| &account_from_storage).collect::<Vec<_>>();
             all_accounts.push(accounts);
         }
-        for slot in 0..10_u64 {
+        for slot in 0..num_slots {
             slot_accounts.push((slot, &all_accounts[slot as usize][..]));
         }
         let storable_accounts = StorableAccountsBySlot::new(0, &slot_accounts[..], &db);

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -366,7 +366,7 @@ pub mod tests {
         std::sync::Arc,
     };
 
-    impl<'a> StorableAccountsBySlot<'a> {
+    impl StorableAccountsBySlot<'_> {
         /// given an overall index for all accounts in self:
         /// return (slots_and_accounts index, index within those accounts)
         /// This is the baseline unoptimized implementation. It is not used in the validator. It

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -265,6 +265,11 @@ impl<'a> StorableAccountsBySlot<'a> {
     /// on the starting_offsets based on the assumption that the
     /// starting_offsets are always sorted.
     fn find_internal_index(&self, index: usize) -> (usize, usize) {
+        // special case for when there is only one slot - just return the first index without searching.
+        // This happens when we are just shrinking a single slot storage, which happens very often.
+        if self.starting_offsets.len() == 1 {
+            return (0, index);
+        }
         let upper_bound =
             self.starting_offsets
                 .binary_search_by(|element| match element.cmp(&index) {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -1,6 +1,4 @@
 //! trait for abstracting underlying storage of pubkey and account pairs to be written
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     crate::{
         account_storage::stored_account_info::StoredAccountInfo,
@@ -259,12 +257,12 @@ impl<'a> StorableAccountsBySlot<'a> {
         }
     }
 
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    #[cfg(feature = "dev-context-only-utils")]
     /// given an overall index for all accounts in self:
     /// return (slots_and_accounts index, index within those accounts)
     /// This is the baseline unoptimized implementation. It is not used in the validator. It
     /// is used for testing an optimized version below - `find_internal_index.`
-    fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
+    pub fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
         // search offsets for the accounts slice that contains 'index'.
         // This could be a binary search.
         for (offset_index, next_offset) in self.starting_offsets.iter().enumerate() {
@@ -379,6 +377,7 @@ pub mod tests {
             accounts_hash::AccountHash,
             append_vec::{AccountMeta, StoredAccountMeta, StoredMeta},
         },
+        rand::Rng,
         solana_account::{accounts_equal, AccountSharedData, WritableAccount},
         solana_hash::Hash,
         std::sync::Arc,
@@ -860,7 +859,6 @@ pub mod tests {
         let mut total = 0;
         for _slot in 0..10_u64 {
             // generate random accounts per slot
-            use rand::Rng;
             let n = rand::thread_rng().gen_range(1..10);
             total += n;
             let accounts = (0..n).map(|_| &account_from_storage).collect::<Vec<_>>();

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -257,7 +257,7 @@ impl<'a> StorableAccountsBySlot<'a> {
     }
     /// given an overall index for all accounts in self:
     /// return (slots_and_accounts index, index within those accounts)
-    fn find_internal_index(&self, index: usize) -> (usize, usize) {
+    fn find_internal_index_loop(&self, index: usize) -> (usize, usize) {
         // search offsets for the accounts slice that contains 'index'.
         // This could be a binary search.
         for (offset_index, next_offset) in self.starting_offsets.iter().enumerate() {
@@ -272,6 +272,22 @@ impl<'a> StorableAccountsBySlot<'a> {
             }
         }
         panic!("failed");
+    }
+
+    /// given an overall index for all accounts in self:
+    /// return (slots_and_accounts index, index within those accounts)
+    fn find_internal_index(&self, index: usize) -> (usize, usize) {
+        match self.starting_offsets.binary_search(&index) {
+            Ok(offset_index) => (offset_index, 0),
+            Err(offset_index) => {
+                let prior_offset = if offset_index > 0 {
+                    self.starting_offsets[offset_index - 1]
+                } else {
+                    0
+                };
+                (offset_index, index - prior_offset)
+            }
+        }
     }
 }
 

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -8,8 +8,10 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    std::cmp::Ordering,
-    std::sync::{Arc, RwLock},
+    std::{
+        cmp::Ordering,
+        sync::{Arc, RwLock},
+    },
 };
 
 /// hold a ref to an account to store. The account could be represented in memory a few different ways


### PR DESCRIPTION
#### Problem

StorableAccountsBySlot::Account() fn, which looks up the account by index from a collection of accounts stored across different slots, is widely used in shrink/squash. However, this function use a sequential loop over starting_offsets to find the internal index. Because the start_offset is calculated from cumulative len of accounts in each slot, start_offsets must be never decresing hence it is sorted. Based on this, we can do binary search in stead of sequential looping to find the internal index. 


#### Summary of Changes

Implement a binary search to find internal index for StorableAccountsBySlot.

#### Testing

Running [this branch plus timing stats instrumentation](https://github.com/HaoranYi/solana/tree/bin_search_stat) on mainnet shows that for large number of storage to squash, such as 12K, binary search is 10X faster. 
Note that the number of storages being squashed/shrunk varies a lot. The most common number is 1. But it could be in the range from 1 to 16K. 

Considering squashing16K storages, find_internal_index by looping will need 8K*16K = 128M lookups, while by bin-search only needs 14*16K=224K lookups, much less lookups.

```
bin_search_ns =197,312,537i 
loop_search_ns=1867,956,100i 
arr_size=11745i
```


```
[2025-06-09T18:09:48.014520008Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=170i loop_search_ns=40i arr_size=1683i
[2025-06-09T18:09:53.974187484Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=197312537i loop_search_ns=1867956100i arr_size=11745i
[2025-06-09T19:34:56.809002431Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=690i loop_search_ns=40i arr_size=3922i
[2025-06-09T19:35:02.085991760Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=176359544i loop_search_ns=1739709682i arr_size=11739i
[2025-06-09T20:00:05.628058797Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=150i loop_search_ns=40i arr_size=409i
[2025-06-09T20:00:10.914010012Z INFO  solana_metrics::metrics] datapoint: find_internal_index bin_search_ns=174845058i loop_search_ns=1694038608i arr_size=11744i
```

chronograph from mainnet with the above stats

red: loop_search
blue: binary_search

![image](https://github.com/user-attachments/assets/2fb4c6e6-c1e8-424f-bb98-d9c9d5eef3e9)




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
