### PR TITLE
Fix for calling 'fetch-spl.sh' from any directory

### DIFF
--- a/fetch-spl.sh
+++ b/fetch-spl.sh
@@ -6,7 +6,9 @@
 
 set -e
 
-source fetch-programs.sh
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+source "$here"/fetch-programs.sh
 
 PREFIX="spl"
 


### PR DESCRIPTION
#### Problem
Invoking this script with absolute path without being in the repo root directory first fails to find a second invoked script. I hit this error in the invalidator buildkite pipeline.

#### Summary of Changes
Determine absolute path of the script and append to other invoked scripts.
