### PR TITLE
add crate description for agave-feature-set

### DIFF
--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "agave-feature-set"
 version = "2.3.0"
+description = "Solana runtime feature declarations"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }


### PR DESCRIPTION
#### Problem

apparently crates.io requires a crate description, but our ci does not

#### Summary of Changes

populate crate description field