### PR TITLE
Stops flushing the accounts hash cache mmaps

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -6,7 +6,7 @@ use {
     bytemuck_derive::{Pod, Zeroable},
     memmap2::MmapMut,
     solana_clock::Slot,
-    solana_measure::{measure::Measure, measure_us},
+    solana_measure::measure::Measure,
     std::{
         collections::HashSet,
         fs::{self, remove_file, File, OpenOptions},
@@ -395,17 +395,10 @@ impl CacheHashData {
         });
         assert_eq!(i, entries);
         m2.stop();
-        // We must flush the mmap after writing, since we're about to turn around and load it for
-        // reading *not* via the mmap.  If the mmap is never flushed to disk, it is possible the
-        // entries will *not* be visible when the reader comes along.
-        let (_, measure_flush_us) = measure_us!(cache_file.mmap.flush()?);
         m.stop();
         stats
             .write_to_mmap_us
             .fetch_add(m2.as_us(), Ordering::Relaxed);
-        stats
-            .flush_mmap_us
-            .fetch_add(measure_flush_us, Ordering::Relaxed);
         stats.save_us.fetch_add(m.as_us(), Ordering::Relaxed);
         stats.saved_to_cache.fetch_add(1, Ordering::Relaxed);
         Ok(())

--- a/accounts-db/src/cache_hash_data_stats.rs
+++ b/accounts-db/src/cache_hash_data_stats.rs
@@ -11,7 +11,6 @@ pub struct CacheHashDataStats {
     pub save_us: AtomicU64,
     pub saved_to_cache: AtomicUsize,
     pub write_to_mmap_us: AtomicU64,
-    pub flush_mmap_us: AtomicU64,
     pub create_save_us: AtomicU64,
     pub load_us: AtomicU64,
     pub read_us: AtomicU64,
@@ -60,11 +59,6 @@ impl CacheHashDataStats {
             (
                 "write_to_mmap_us",
                 self.write_to_mmap_us.load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "flush_mmap_us",
-                self.flush_mmap_us.load(Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

mmap `flush` is very slow, and should be avoided whenever possible. (This also includes `msync/fsync`.)

We currently flush the accounts hash cache mmaps after creating them. This is unnecessary, and contributes to OS contention.

I originally added flushing the mmaps to fix a bug with accounts hash mismatches, but this was incorrect. Ultimately #5032 correctly identified and fixed the underlying issue.

Here's the accounts hash calc process. The peaks are during full accounts hash calcs. This shows the time spent writing the files themselves, and the time spent flushing the mmaps. It takes 115 seconds to write the files, but 190 seconds to flush the mmaps❗ 
![Screenshot 2025-03-26 at 12 50 02 AM](https://github.com/user-attachments/assets/57641517-9b3f-4cee-a90b-ee32f2df1e55)


#### Summary of Changes

Stop flushing the mmaps.

Note, I intend to backport this to v2.2.