### PR TITLE
[feature-set] Rekey secp256r1 precompile feature

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -977,7 +977,7 @@ pub mod disable_account_loader_special_case {
 }
 
 pub mod enable_secp256r1_precompile {
-    solana_pubkey::declare_id!("sryYyFwxzJop1Bh9XpyiVWjZP4nfHExiqNp3Dh71W9i");
+    solana_pubkey::declare_id!("srremy31J5Y25FrAApwVb9kZcfXbusYMMsvTK9aWv5q");
 }
 
 pub mod accounts_lt_hash {


### PR DESCRIPTION
#### Problem
The secp256r1 feature gate is rekeyed in https://github.com/anza-xyz/solana-sdk/pull/38 and https://github.com/anza-xyz/agave/pull/5417, but it has not been rekeyed in the v2.2 branch even though secp256r1 is targeting v2.2 activation.

See https://github.com/anza-xyz/feature-gate-tracker/issues/65#issuecomment-2751815622.

#### Summary of Changes
Rekey the feature in the v2.2 branch.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
