### PR TITLE
Add description to agave-feature-set to unblock cargo publish

### DIFF
--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "agave-feature-set"
+description = "Agave feature set"
 version = "2.3.0"
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem
cargo publish fails if `description` isn't provided:


```
the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields
```

#### Summary of Changes
Add a description 
