### PR TITLE
refactor: remove useless accounts hash interval config

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -268,7 +268,6 @@ pub struct ValidatorConfig {
     pub repair_validators: Option<HashSet<Pubkey>>, // None = repair from all
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
-    pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     /// Run PoH, transaction signature and other transaction verifications during blockstore
     /// processing.
@@ -344,7 +343,6 @@ impl Default for ValidatorConfig {
             repair_validators: None,
             repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
             gossip_validators: None,
-            accounts_hash_interval_slots: u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             run_verification: true,
             require_tower: false,
@@ -881,10 +879,7 @@ impl Validator {
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
         let cluster_info = Arc::new(cluster_info);
 
-        assert!(is_snapshot_config_valid(
-            &config.snapshot_config,
-            config.accounts_hash_interval_slots,
-        ));
+        assert!(is_snapshot_config_valid(&config.snapshot_config));
 
         let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
         let snapshot_packager_service = if config.snapshot_config.should_generate_snapshots() {
@@ -2758,10 +2753,7 @@ fn cleanup_accounts_paths(config: &ValidatorConfig) {
     }
 }
 
-pub fn is_snapshot_config_valid(
-    snapshot_config: &SnapshotConfig,
-    accounts_hash_interval_slots: Slot,
-) -> bool {
+pub fn is_snapshot_config_valid(snapshot_config: &SnapshotConfig) -> bool {
     // if the snapshot config is configured to *not* take snapshots, then it is valid
     if !snapshot_config.should_generate_snapshots() {
         return true;
@@ -2771,18 +2763,14 @@ pub fn is_snapshot_config_valid(
     let incremental_snapshot_interval_slots =
         snapshot_config.incremental_snapshot_archive_interval_slots;
 
-    let is_incremental_config_valid =
-        if incremental_snapshot_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
-            true
-        } else {
-            incremental_snapshot_interval_slots >= accounts_hash_interval_slots
-                && incremental_snapshot_interval_slots % accounts_hash_interval_slots == 0
-                && full_snapshot_interval_slots > incremental_snapshot_interval_slots
-        };
-
-    full_snapshot_interval_slots >= accounts_hash_interval_slots
-        && full_snapshot_interval_slots % accounts_hash_interval_slots == 0
-        && is_incremental_config_valid
+    if incremental_snapshot_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
+        true
+    } else if incremental_snapshot_interval_slots == 0 {
+        false
+    } else {
+        full_snapshot_interval_slots % incremental_snapshot_interval_slots == 0
+            && full_snapshot_interval_slots > incremental_snapshot_interval_slots
+    }
 }
 
 #[cfg(test)]
@@ -3167,89 +3155,46 @@ mod tests {
             }
         }
 
-        assert!(is_snapshot_config_valid(
-            &new_snapshot_config(300, 200),
-            100
-        ));
+        assert!(is_snapshot_config_valid(&new_snapshot_config(300, 100)));
 
-        let default_accounts_hash_interval =
-            snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS;
-        assert!(is_snapshot_config_valid(
-            &new_snapshot_config(
-                snapshot_bank_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS
-            ),
-            default_accounts_hash_interval,
-        ));
-        assert!(is_snapshot_config_valid(
-            &new_snapshot_config(
-                snapshot_bank_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
-            ),
-            default_accounts_hash_interval
-        ));
-        assert!(is_snapshot_config_valid(
-            &new_snapshot_config(
-                snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
-            ),
-            default_accounts_hash_interval
-        ));
-        assert!(is_snapshot_config_valid(
-            &new_snapshot_config(
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
-            ),
-            Slot::MAX
-        ));
+        assert!(is_snapshot_config_valid(&new_snapshot_config(
+            snapshot_bank_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS
+        )));
+        assert!(is_snapshot_config_valid(&new_snapshot_config(
+            snapshot_bank_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
+        )));
+        assert!(is_snapshot_config_valid(&new_snapshot_config(
+            snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
+        )));
+        assert!(is_snapshot_config_valid(&new_snapshot_config(
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+            DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
+        )));
 
-        assert!(!is_snapshot_config_valid(&new_snapshot_config(0, 100), 100));
-        assert!(!is_snapshot_config_valid(&new_snapshot_config(100, 0), 100));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(42, 100),
-            100
-        ));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(100, 42),
-            100
-        ));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(100, 100),
-            100
-        ));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(100, 200),
-            100
-        ));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(444, 200),
-            100
-        ));
-        assert!(!is_snapshot_config_valid(
-            &new_snapshot_config(400, 222),
-            100
-        ));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(0, 100)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(100, 0)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(0, 0)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(42, 100)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(100, 42)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(100, 100)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(100, 200)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(444, 200)));
+        assert!(!is_snapshot_config_valid(&new_snapshot_config(400, 222)));
 
-        assert!(is_snapshot_config_valid(
-            &SnapshotConfig::new_load_only(),
-            100
-        ));
-        assert!(is_snapshot_config_valid(
-            &SnapshotConfig {
-                full_snapshot_archive_interval_slots: 41,
-                incremental_snapshot_archive_interval_slots: 37,
-                ..SnapshotConfig::new_load_only()
-            },
-            100
-        ));
-        assert!(is_snapshot_config_valid(
-            &SnapshotConfig {
-                full_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                incremental_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                ..SnapshotConfig::new_load_only()
-            },
-            100
-        ));
+        assert!(is_snapshot_config_valid(&SnapshotConfig::new_load_only()));
+        assert!(is_snapshot_config_valid(&SnapshotConfig {
+            full_snapshot_archive_interval_slots: 41,
+            incremental_snapshot_archive_interval_slots: 37,
+            ..SnapshotConfig::new_load_only()
+        }));
+        assert!(is_snapshot_config_valid(&SnapshotConfig {
+            full_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+            incremental_snapshot_archive_interval_slots: DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+            ..SnapshotConfig::new_load_only()
+        }));
     }
 
     fn target_tick_duration() -> Duration {

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -537,11 +537,9 @@ impl SnapshotValidatorConfig {
     pub fn new(
         full_snapshot_archive_interval_slots: Slot,
         incremental_snapshot_archive_interval_slots: Slot,
-        accounts_hash_interval_slots: Slot,
         num_account_paths: usize,
     ) -> SnapshotValidatorConfig {
         // Interval values must be nonzero
-        assert!(accounts_hash_interval_slots > 0);
         assert!(full_snapshot_archive_interval_slots > 0);
         assert!(incremental_snapshot_archive_interval_slots > 0);
         // Ensure that some snapshots will be created
@@ -564,10 +562,7 @@ impl SnapshotValidatorConfig {
             maximum_incremental_snapshot_archives_to_retain: NonZeroUsize::new(usize::MAX).unwrap(),
             ..SnapshotConfig::default()
         };
-        assert!(is_snapshot_config_valid(
-            &snapshot_config,
-            accounts_hash_interval_slots
-        ));
+        assert!(is_snapshot_config_valid(&snapshot_config));
 
         // Create the account paths
         let (account_storage_dirs, account_storage_paths) =
@@ -577,7 +572,6 @@ impl SnapshotValidatorConfig {
         let validator_config = ValidatorConfig {
             snapshot_config,
             account_paths: account_storage_paths,
-            accounts_hash_interval_slots,
             ..ValidatorConfig::default_for_test()
         };
 
@@ -598,7 +592,6 @@ pub fn setup_snapshot_validator_config(
     SnapshotValidatorConfig::new(
         snapshot_interval_slots,
         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-        snapshot_interval_slots,
         num_account_paths,
     )
 }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -30,7 +30,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         repair_validators: config.repair_validators.clone(),
         repair_whitelist: config.repair_whitelist.clone(),
         gossip_validators: config.gossip_validators.clone(),
-        accounts_hash_interval_slots: config.accounts_hash_interval_slots,
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         run_verification: config.run_verification,
         require_tower: config.require_tower,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -555,21 +555,18 @@ fn test_snapshot_download() {
 fn test_incremental_snapshot_download() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // First set up the cluster with 1 node
-    let accounts_hash_interval = 3;
-    let incremental_snapshot_interval = accounts_hash_interval * 3;
+    let incremental_snapshot_interval = 9;
     let full_snapshot_interval = incremental_snapshot_interval * 3;
     let num_account_paths = 3;
 
     let leader_snapshot_test_config = SnapshotValidatorConfig::new(
         full_snapshot_interval,
         incremental_snapshot_interval,
-        accounts_hash_interval,
         num_account_paths,
     );
     let validator_snapshot_test_config = SnapshotValidatorConfig::new(
         full_snapshot_interval,
         incremental_snapshot_interval,
-        accounts_hash_interval,
         num_account_paths,
     );
 
@@ -594,10 +591,10 @@ fn test_incremental_snapshot_download() {
         .snapshot_config
         .incremental_snapshot_archives_dir;
 
-    debug!("snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}\n\taccounts hash interval: {}",
-           full_snapshot_interval,
-           incremental_snapshot_interval,
-           accounts_hash_interval);
+    debug!(
+        "snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}",
+        full_snapshot_interval, incremental_snapshot_interval,
+    );
     debug!(
         "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
         leader_snapshot_test_config
@@ -729,21 +726,18 @@ fn test_incremental_snapshot_download() {
 fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_startup() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     // If these intervals change, also make sure to change the loop timers accordingly.
-    let accounts_hash_interval = 3;
-    let incremental_snapshot_interval = accounts_hash_interval * 3;
+    let incremental_snapshot_interval = 9;
     let full_snapshot_interval = incremental_snapshot_interval * 5;
 
     let num_account_paths = 3;
     let leader_snapshot_test_config = SnapshotValidatorConfig::new(
         full_snapshot_interval,
         incremental_snapshot_interval,
-        accounts_hash_interval,
         num_account_paths,
     );
     let mut validator_snapshot_test_config = SnapshotValidatorConfig::new(
         full_snapshot_interval,
         incremental_snapshot_interval,
-        accounts_hash_interval,
         num_account_paths,
     );
     // The test has asserts that require the validator always boots from snapshot archives
@@ -762,10 +756,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
-    info!("snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}\n\taccounts hash interval: {}",
-           full_snapshot_interval,
-           incremental_snapshot_interval,
-           accounts_hash_interval);
+    info!(
+        "snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}",
+        full_snapshot_interval, incremental_snapshot_interval,
+    );
     debug!(
         "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
         leader_snapshot_test_config
@@ -1183,7 +1177,6 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     let final_validator_snapshot_test_config = SnapshotValidatorConfig::new(
         full_snapshot_interval,
         incremental_snapshot_interval,
-        accounts_hash_interval,
         num_account_paths,
     );
 
@@ -4993,24 +4986,12 @@ fn test_boot_from_local_state() {
     const FULL_SNAPSHOT_INTERVAL: Slot = 100;
     const INCREMENTAL_SNAPSHOT_INTERVAL: Slot = 10;
 
-    let validator1_config = SnapshotValidatorConfig::new(
-        FULL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        2,
-    );
-    let validator2_config = SnapshotValidatorConfig::new(
-        FULL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        4,
-    );
-    let validator3_config = SnapshotValidatorConfig::new(
-        FULL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        3,
-    );
+    let validator1_config =
+        SnapshotValidatorConfig::new(FULL_SNAPSHOT_INTERVAL, INCREMENTAL_SNAPSHOT_INTERVAL, 2);
+    let validator2_config =
+        SnapshotValidatorConfig::new(FULL_SNAPSHOT_INTERVAL, INCREMENTAL_SNAPSHOT_INTERVAL, 4);
+    let validator3_config =
+        SnapshotValidatorConfig::new(FULL_SNAPSHOT_INTERVAL, INCREMENTAL_SNAPSHOT_INTERVAL, 3);
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],
@@ -5285,12 +5266,8 @@ fn test_boot_from_local_state_missing_archive() {
     const FULL_SNAPSHOT_INTERVAL: Slot = 20;
     const INCREMENTAL_SNAPSHOT_INTERVAL: Slot = 10;
 
-    let validator_config = SnapshotValidatorConfig::new(
-        FULL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        INCREMENTAL_SNAPSHOT_INTERVAL,
-        7,
-    );
+    let validator_config =
+        SnapshotValidatorConfig::new(FULL_SNAPSHOT_INTERVAL, INCREMENTAL_SNAPSHOT_INTERVAL, 7);
 
     let mut cluster_config = ClusterConfig {
         node_stakes: vec![100 * DEFAULT_NODE_STAKE],

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1011,7 +1011,6 @@ impl TestValidator {
             )),
             rpc_config: config.rpc_config.clone(),
             pubsub_config: config.pubsub_config.clone(),
-            accounts_hash_interval_slots: 100,
             account_paths: vec![
                 create_accounts_run_and_snapshot_dirs(ledger_path.join("accounts"))
                     .unwrap()

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -982,12 +982,6 @@ pub fn execute(
         packager_thread_niceness_adj: snapshot_packager_niceness_adj,
     };
 
-    // The accounts hash interval shall match the snapshot interval
-    validator_config.accounts_hash_interval_slots = std::cmp::min(
-        full_snapshot_archive_interval_slots,
-        incremental_snapshot_archive_interval_slots,
-    );
-
     info!(
         "Snapshot configuration: full snapshot interval: {}, incremental snapshot interval: {}",
         if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
@@ -1014,10 +1008,7 @@ pub fn execute(
         );
     }
 
-    if !is_snapshot_config_valid(
-        &validator_config.snapshot_config,
-        validator_config.accounts_hash_interval_slots,
-    ) {
+    if !is_snapshot_config_valid(&validator_config.snapshot_config) {
         Err(
             "invalid snapshot configuration provided: snapshot intervals are incompatible. \
              \n\t- full snapshot interval MUST be a multiple of incremental snapshot interval \


### PR DESCRIPTION
#### Problem
The `accounts_hash_interval_slots` validator config is always created from the full and inc snapshot intervals and so it's not adding any value

#### Summary of Changes
Remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
