### PR TITLE
add readme field to all Cargo.toml files

### DIFF
--- a/account-decoder-client-types/Cargo.toml
+++ b/account-decoder-client-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 Inflector = { workspace = true }

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/accounts-db/store-histogram/Cargo.toml
+++ b/accounts-db/store-histogram/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }

--- a/banking-stage-ingress-types/Cargo.toml
+++ b/banking-stage-ingress-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 crossbeam-channel = { workspace = true }

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 borsh = { workspace = true }

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 serde = { workspace = true }

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 chrono = { workspace = true }

--- a/bench-vote/Cargo.toml
+++ b/bench-vote/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bv = { workspace = true, features = ["serde"] }

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/builtins/Cargo.toml
+++ b/builtins/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [features]
 dev-context-only-utils = []

--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 chrono = { workspace = true, features = ["default"] }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 chrono = { workspace = true, features = ["default"] }

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 dirs-next = { workspace = true }

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 Inflector = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 futures-util = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 qualifier_attr = { workspace = true, optional = true }

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/fee/Cargo.toml
+++ b/fee/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-feature-set = { workspace = true }

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true, features = ["std"] }

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 arrayvec = { workspace = true }

--- a/inline-spl/Cargo.toml
+++ b/inline-spl/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 atty = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bs58 = { workspace = true }

--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bs58 = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 crossbeam-channel = { workspace = true }

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 byte-unit = { workspace = true }

--- a/log-collector/Cargo.toml
+++ b/log-collector/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/memory-management/Cargo.toml
+++ b/memory-management/Cargo.toml
@@ -7,3 +7,4 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 fast-math = { workspace = true }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 crossbeam-channel = { workspace = true }

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 rust-version = "1.83.0"
 
 [dependencies]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bzip2 = { workspace = true }

--- a/platform-tools-sdk/cargo-test-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-test-sbf/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 cargo_metadata = { workspace = true }

--- a/platform-tools-sdk/gen-headers/Cargo.toml
+++ b/platform-tools-sdk/gen-headers/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true, features = ["std"] }

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 core_affinity = { workspace = true }

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 thiserror = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/programs/address-lookup-table-tests/Cargo.toml
+++ b/programs/address-lookup-table-tests/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/bpf_loader/gen-syscall-list/Cargo.toml
+++ b/programs/bpf_loader/gen-syscall-list/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [build-dependencies]
 regex = { workspace = true }

--- a/programs/compute-budget-bench/Cargo.toml
+++ b/programs/compute-budget-bench/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 criterion = { workspace = true }

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program-runtime = { workspace = true }

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/programs/sbf/rust/128bit/Cargo.toml
+++ b/programs/sbf/rust/128bit/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/128bit_dep/Cargo.toml
+++ b/programs/sbf/rust/128bit_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/account_mem/Cargo.toml
+++ b/programs/sbf/rust/account_mem/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/account_mem_deprecated/Cargo.toml
+++ b/programs/sbf/rust/account_mem_deprecated/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/alloc/Cargo.toml
+++ b/programs/sbf/rust/alloc/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/alt_bn128/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 array-bytes = { workspace = true }

--- a/programs/sbf/rust/alt_bn128_compression/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128_compression/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 array-bytes = { workspace = true }

--- a/programs/sbf/rust/big_mod_exp/Cargo.toml
+++ b/programs/sbf/rust/big_mod_exp/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 array-bytes = { workspace = true }

--- a/programs/sbf/rust/call_args/Cargo.toml
+++ b/programs/sbf/rust/call_args/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 borsh = { workspace = true }

--- a/programs/sbf/rust/call_depth/Cargo.toml
+++ b/programs/sbf/rust/call_depth/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/caller_access/Cargo.toml
+++ b/programs/sbf/rust/caller_access/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/curve25519/Cargo.toml
+++ b/programs/sbf/rust/curve25519/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-curve25519 = { workspace = true }

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/dep_crate/Cargo.toml
+++ b/programs/sbf/rust/dep_crate/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 byteorder = { workspace = true }

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/divide_by_zero/Cargo.toml
+++ b/programs/sbf/rust/divide_by_zero/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/dup_accounts/Cargo.toml
+++ b/programs/sbf/rust/dup_accounts/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/error_handling/Cargo.toml
+++ b/programs/sbf/rust/error_handling/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 num-derive = { workspace = true }

--- a/programs/sbf/rust/external_spend/Cargo.toml
+++ b/programs/sbf/rust/external_spend/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/sbf/rust/get_minimum_delegation/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/instruction_introspection/Cargo.toml
+++ b/programs/sbf/rust/instruction_introspection/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoke_and_error/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_error/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_ok/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoke_and_return/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_return/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/invoke_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/rust/invoked/Cargo.toml
+++ b/programs/sbf/rust/invoked/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/invoked_dep/Cargo.toml
+++ b/programs/sbf/rust/invoked_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/iter/Cargo.toml
+++ b/programs/sbf/rust/iter/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/log_data/Cargo.toml
+++ b/programs/sbf/rust/log_data/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/many_args/Cargo.toml
+++ b/programs/sbf/rust/many_args/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/many_args_dep/Cargo.toml
+++ b/programs/sbf/rust/many_args_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/mem_dep/Cargo.toml
+++ b/programs/sbf/rust/mem_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/noop/Cargo.toml
+++ b/programs/sbf/rust/noop/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/param_passing/Cargo.toml
+++ b/programs/sbf/rust/param_passing/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/param_passing_dep/Cargo.toml
+++ b/programs/sbf/rust/param_passing_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 array-bytes = { workspace = true }

--- a/programs/sbf/rust/rand/Cargo.toml
+++ b/programs/sbf/rust/rand/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 getrandom = { workspace = true, features = ["custom"] }

--- a/programs/sbf/rust/realloc/Cargo.toml
+++ b/programs/sbf/rust/realloc/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/realloc_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/realloc_invoke/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/rust/remaining_compute_units/Cargo.toml
+++ b/programs/sbf/rust/remaining_compute_units/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/ro_account_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_account_modify/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/sbf/rust/secp256k1_recover/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 libsecp256k1 = { workspace = true }

--- a/programs/sbf/rust/sha/Cargo.toml
+++ b/programs/sbf/rust/sha/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 blake3 = { workspace = true }

--- a/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/sibling_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_instructions/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/spoof1/Cargo.toml
+++ b/programs/sbf/rust/spoof1/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/spoof1_system/Cargo.toml
+++ b/programs/sbf/rust/spoof1_system/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
+++ b/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode =  { workspace = true }

--- a/programs/sbf/rust/upgradeable/Cargo.toml
+++ b/programs/sbf/rust/upgradeable/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/sbf/rust/upgraded/Cargo.toml
+++ b/programs/sbf/rust/upgraded/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-program = { workspace = true }

--- a/programs/stake-tests/Cargo.toml
+++ b/programs/stake-tests/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/programs/zk-token-proof-tests/Cargo.toml
+++ b/programs/zk-token-proof-tests/Cargo.toml
@@ -6,6 +6,7 @@ authors = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dev-dependencies]
 bytemuck = { workspace = true }

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/pubsub-client/Cargo.toml
+++ b/pubsub-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 crossbeam-channel = { workspace = true }

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-lock = { workspace = true }

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -9,5 +9,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 console = { workspace = true }

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { version = "2.33.0", optional = true }

--- a/rpc-client-types/Cargo.toml
+++ b/rpc-client-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-transaction-view = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 backoff = { workspace = true, features = ["tokio"] }

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 tonic-build = { workspace = true }

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-channel = { workspace = true }

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 prost = { workspace = true }

--- a/svm-rent-collector/Cargo.toml
+++ b/svm-rent-collector/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-sdk = { workspace = true }

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-hash = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 ahash = { workspace = true }

--- a/thin-client/Cargo.toml
+++ b/thin-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/thread-manager/Cargo.toml
+++ b/thread-manager/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/timings/Cargo.toml
+++ b/timings/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 eager = { workspace = true }

--- a/tls-utils/Cargo.toml
+++ b/tls-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 rustls = { workspace = true, features = ["ring"] }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 chrono = { workspace = true, features = ["default", "serde"] }

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 log = { workspace = true }

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 serde = { workspace = true, optional = true }

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 Inflector = { workspace = true }

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 solana-hash = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true }

--- a/type-overrides/Cargo.toml
+++ b/type-overrides/Cargo.toml
@@ -7,6 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 futures = { workspace = true, optional = true }

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 assert_matches = { workspace = true }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 serde_json = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 semver = { workspace = true }

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bincode = { workspace = true, optional = true }

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 clap = { workspace = true }

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 publish = true
 
 [dependencies]

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -14,6 +14,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 bs58 = { workspace = true }

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+readme = false
 
 [dependencies]
 base64 = { workspace = true }


### PR DESCRIPTION
#### Problem
The crate check task now requires `readme` to be set in the `Cargo.toml` if it's modified in a PR

#### Summary of Changes
Set readme in all Cargo.toml files

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
