### PR TITLE
Moves IsZeroLamport trait to submodule

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -4,9 +4,8 @@
 //! Note that AccountInfo is saved to disk buckets during runtime, but disk buckets are recreated at startup.
 use {
     crate::{
-        accounts_db::AccountsFileId,
-        accounts_file::ALIGN_BOUNDARY_OFFSET,
-        accounts_index::{IsCached, ZeroLamport},
+        accounts_db::AccountsFileId, accounts_file::ALIGN_BOUNDARY_OFFSET,
+        accounts_index::IsCached, is_zero_lamport::IsZeroLamport,
     },
     modular_bitfield::prelude::*,
 };
@@ -97,7 +96,7 @@ pub struct AccountOffsetAndFlags {
     packed_offset_and_flags: PackedOffsetAndFlags,
 }
 
-impl ZeroLamport for AccountInfo {
+impl IsZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
         self.account_offset_and_flags
             .packed_offset_and_flags

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -51,8 +51,7 @@ use {
             in_mem_accounts_index::StartupStats, AccountSecondaryIndexes, AccountsIndex,
             AccountsIndexConfig, AccountsIndexRootsStats, AccountsIndexScanResult, DiskIndexValue,
             IndexKey, IndexValue, IsCached, RefCount, ScanConfig, ScanFilter, ScanResult, SlotList,
-            UpsertReclaim, ZeroLamport, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
-            ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+            UpsertReclaim, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
         },
         accounts_index_storage::Startup,
         accounts_partition::RentPayingAccountsByPartition,
@@ -66,6 +65,7 @@ use {
         cache_hash_data::{CacheHashData, DeletionPolicy as CacheHashDeletionPolicy},
         contains::Contains,
         epoch_accounts_hash::EpochAccountsHashManager,
+        is_zero_lamport::IsZeroLamport,
         partitioned_rewards::{
             PartitionedEpochRewardsConfig, DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
         },
@@ -571,7 +571,7 @@ pub struct AccountFromStorage {
     pub pubkey: Pubkey,
 }
 
-impl ZeroLamport for AccountFromStorage {
+impl IsZeroLamport for AccountFromStorage {
     fn is_zero_lamport(&self) -> bool {
         self.index_info.is_zero_lamport()
     }
@@ -870,13 +870,13 @@ impl GenerateIndexTimings {
 impl IndexValue for AccountInfo {}
 impl DiskIndexValue for AccountInfo {}
 
-impl ZeroLamport for AccountSharedData {
+impl IsZeroLamport for AccountSharedData {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }
 }
 
-impl ZeroLamport for Account {
+impl IsZeroLamport for Account {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }
@@ -1878,7 +1878,7 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
     }
 }
 
-impl ZeroLamport for StoredAccountMeta<'_> {
+impl IsZeroLamport for StoredAccountMeta<'_> {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -10,6 +10,7 @@ use {
         ancestors::Ancestors,
         bucket_map_holder::Age,
         contains::Contains,
+        is_zero_lamport::IsZeroLamport,
         pubkey_bins::PubkeyBinCalculator24,
         rolling_bit_field::RollingBitField,
         secondary_index::*,
@@ -178,7 +179,7 @@ pub trait IsCached {
     fn is_cached(&self) -> bool;
 }
 
-pub trait IndexValue: 'static + IsCached + ZeroLamport + DiskIndexValue {}
+pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue {}
 
 pub trait DiskIndexValue:
     'static + Clone + Debug + PartialEq + Copy + Default + Sync + Send
@@ -234,10 +235,6 @@ pub struct AccountsIndexRootsStats {
     pub unrooted_cleaned_count: usize,
     pub clean_unref_from_storage_us: u64,
     pub clean_dead_slot_us: u64,
-}
-
-pub trait ZeroLamport {
-    fn is_zero_lamport(&self) -> bool;
 }
 
 #[derive(Copy, Clone)]
@@ -2001,7 +1998,7 @@ pub mod tests {
         }
     }
 
-    impl ZeroLamport for AccountInfoTest {
+    impl IsZeroLamport for AccountInfoTest {
         fn is_zero_lamport(&self) -> bool {
             true
         }
@@ -3521,13 +3518,13 @@ pub mod tests {
             false
         }
     }
-    impl ZeroLamport for bool {
+    impl IsZeroLamport for bool {
         fn is_zero_lamport(&self) -> bool {
             false
         }
     }
 
-    impl ZeroLamport for u64 {
+    impl IsZeroLamport for u64 {
         fn is_zero_lamport(&self) -> bool {
             false
         }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -1,6 +1,9 @@
 use {
-    super::{DiskIndexValue, IndexValue, RefCount, SlotList, ZeroLamport},
-    crate::bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+    super::{DiskIndexValue, IndexValue, RefCount, SlotList},
+    crate::{
+        bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+        is_zero_lamport::IsZeroLamport,
+    },
     log::*,
     solana_clock::Slot,
     std::sync::{
@@ -124,7 +127,7 @@ pub enum PreAllocatedAccountMapEntry<T: IndexValue> {
     Raw((Slot, T)),
 }
 
-impl<T: IndexValue> ZeroLamport for PreAllocatedAccountMapEntry<T> {
+impl<T: IndexValue> IsZeroLamport for PreAllocatedAccountMapEntry<T> {
     fn is_zero_lamport(&self) -> bool {
         match self {
             PreAllocatedAccountMapEntry::Entry(entry) => {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -4,10 +4,11 @@ use {
             account_map_entry::{
                 AccountMapEntry, AccountMapEntryMeta, PreAllocatedAccountMapEntry,
             },
-            DiskIndexValue, IndexValue, RefCount, SlotList, UpsertReclaim, ZeroLamport,
+            DiskIndexValue, IndexValue, RefCount, SlotList, UpsertReclaim,
         },
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         bucket_map_holder_stats::BucketMapHolderStats,
+        is_zero_lamport::IsZeroLamport,
         pubkey_bins::PubkeyBinCalculator24,
         waitable_condvar::WaitableCondvar,
     },

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -12,9 +12,9 @@ use {
             StoredAccountsInfo, ALIGN_BOUNDARY_OFFSET,
         },
         accounts_hash::AccountHash,
-        accounts_index::ZeroLamport,
         buffered_reader::{BufferedReader, BufferedReaderStatus, Stack},
         file_io::read_into_buffer,
+        is_zero_lamport::IsZeroLamport,
         storable_accounts::StorableAccounts,
         u64_align,
     },
@@ -211,14 +211,14 @@ pub(crate) struct IndexInfoInner {
     pub data_len: u64,
 }
 
-impl ZeroLamport for IndexInfoInner {
+impl IsZeroLamport for IndexInfoInner {
     #[inline(always)]
     fn is_zero_lamport(&self) -> bool {
         self.lamports == 0
     }
 }
 
-impl ZeroLamport for IndexInfo {
+impl IsZeroLamport for IndexInfo {
     #[inline(always)]
     fn is_zero_lamport(&self) -> bool {
         self.index_info.is_zero_lamport()

--- a/accounts-db/src/is_zero_lamport.rs
+++ b/accounts-db/src/is_zero_lamport.rs
@@ -1,0 +1,5 @@
+/// A trait to see if an account's balance is zero lamports or not.
+pub trait IsZeroLamport {
+    /// Is this a zero-lamport account?
+    fn is_zero_lamport(&self) -> bool;
+}

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -30,6 +30,7 @@ pub mod contains;
 pub mod epoch_accounts_hash;
 mod file_io;
 pub mod hardened_unpack;
+mod is_zero_lamport;
 pub mod partitioned_rewards;
 pub mod pubkey_bins;
 #[cfg(feature = "dev-context-only-utils")]

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        accounts_index::ZeroLamport,
+        is_zero_lamport::IsZeroLamport,
         storable_accounts::{AccountForStorage, StorableAccounts},
     },
     solana_account::{AccountSharedData, ReadableAccount},
@@ -25,7 +25,7 @@ impl StakeReward {
     }
 }
 
-impl ZeroLamport for StakeReward {
+impl IsZeroLamport for StakeReward {
     fn is_zero_lamport(&self) -> bool {
         self.stake_account.lamports() == 0
     }

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         account_storage::meta::StoredAccountMeta,
         accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
-        accounts_index::ZeroLamport,
+        is_zero_lamport::IsZeroLamport,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},
@@ -30,7 +30,7 @@ impl<'a> From<&'a StoredAccountMeta<'a>> for AccountForStorage<'a> {
     }
 }
 
-impl ZeroLamport for AccountForStorage<'_> {
+impl IsZeroLamport for AccountForStorage<'_> {
     fn is_zero_lamport(&self) -> bool {
         self.lamports() == 0
     }


### PR DESCRIPTION
#### Problem

The ZeroLamport trait is in `accounts_index.rs`, but used all over the accounts-db crate. Let's put it someone common to the whole crate.

Also, the trait name and its one function do not currently match, but they can (and they should). So fix that too 😸 


#### Summary of Changes

* Rename the trait to IsZeroLamport
* Move the trait to its own submodule