### PR TITLE
Run 'fetch-core-bpf.sh' from any directory

### DIFF
--- a/fetch-core-bpf.sh
+++ b/fetch-core-bpf.sh
@@ -6,7 +6,9 @@
 
 set -e
 
-source fetch-programs.sh
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+source "$here"/fetch-programs.sh
 
 PREFIX="core-bpf"
 


### PR DESCRIPTION
Problem
Invoking this script with absolute path without being in the repo root directory first fails to find a second invoked script. 

Summary of Changes
Determine absolute path of the script and append to other invoked scripts.
