### PR TITLE
Remove requirement that full snapshot intervals are a multiple of incremental

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1010,8 +1010,6 @@ pub fn execute(
     if !is_snapshot_config_valid(&validator_config.snapshot_config) {
         Err(
             "invalid snapshot configuration provided: snapshot intervals are incompatible. \
-             \n\t- full snapshot interval MUST be a multiple of incremental snapshot interval \
-             (if enabled) \
              \n\t- full snapshot interval MUST be larger than incremental snapshot interval \
              (if enabled)"
                 .to_string(),


### PR DESCRIPTION
#### Problem
There's no need to restrict snapshot intervals such that full is a multiple of incremental

#### Summary of Changes
- Loosen snapshot validation check
- Update validator warning to reflect loosened constraint

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
