### PR TITLE
Sleep STAKE_REFRESH_SLEEP_DURATION when having error refresh stakes instead of 30 m

### DIFF
--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -50,7 +50,7 @@ impl StakeUpdater {
                         &rpc_load_balancer,
                     ) {
                         warn!("Failed to refresh pubkey to stake map! Error: {:?}", err);
-                        sleep(STAKE_REFRESH_INTERVAL);
+                        sleep(STAKE_REFRESH_SLEEP_DURATION);
                     }
                 }
             })


### PR DESCRIPTION

#### Problem
sleep 30m can impact the vortexor exit condition. And we also want to retry sooner.

#### Summary of Changes
sleep STAKE_REFRESH_SLEEP_DURATION (5s)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
