### PR TITLE
Migrate to using `solana_transaction_context` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9478,6 +9478,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-context 2.3.0",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -75,7 +75,7 @@ pub use {
         error::EbpfError,
         vm::{get_runtime_environment_key, EbpfVm},
     },
-    solana_sdk::transaction_context::IndexOfAccount,
+    solana_transaction_context::IndexOfAccount,
 };
 
 pub mod programs;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7438,6 +7438,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-context 2.3.0",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -55,6 +55,7 @@ solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }
 solana-svm = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction-context = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -83,11 +83,11 @@ use {
             self, AddressLoader, MessageHash, SanitizedTransaction, TransactionError,
             VersionedTransaction, MAX_TX_ACCOUNT_LOCKS,
         },
-        transaction_context::TransactionAccount,
     },
     solana_send_transaction_service::send_transaction_service::TransactionInfo,
     solana_stake_program,
     solana_storage_bigtable::Error as StorageError,
+    solana_transaction_context::TransactionAccount,
     solana_transaction_status::{
         map_inner_instructions, BlockEncodingOptions, ConfirmedBlock,
         ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta,

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,9 +1,6 @@
 use {
     core::borrow::Borrow,
-    solana_sdk::{
-        account::AccountSharedData, pubkey::Pubkey, transaction::SanitizedTransaction,
-        transaction_context::TransactionAccount,
-    },
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey, transaction::SanitizedTransaction},
     solana_svm::{
         rollback_accounts::RollbackAccounts,
         transaction_processing_result::{
@@ -12,6 +9,7 @@ use {
         },
     },
     solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction_context::TransactionAccount,
 };
 
 // Used to approximate how many accounts will be calculated for storage so that

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -101,7 +101,6 @@ use {
             Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode,
         },
-        transaction_context::TransactionAccount,
     },
     solana_stake_program::stake_state::{self, StakeStateV2},
     solana_svm::{
@@ -112,6 +111,7 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_timings::ExecuteTimings,
+    solana_transaction_context::TransactionAccount,
     solana_vote_program::{
         vote_instruction,
         vote_state::{

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -17,9 +17,9 @@ use {
         rent::{Rent, RentDue},
         rent_collector::{CollectedInfo, RentCollector},
         transaction::{Result, TransactionError},
-        transaction_context::IndexOfAccount,
     },
     solana_svm_rent_collector::{rent_state::RentState, svm_rent_collector::SVMRentCollector},
+    solana_transaction_context::IndexOfAccount,
 };
 
 /// Wrapper around `RentCollector` to allow for overriding of some

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7260,6 +7260,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-context 2.3.0",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",


### PR DESCRIPTION
#### Problem
The `solana_sdk::transaction_context` module was deprecated in https://github.com/anza-xyz/solana-sdk/pull/95 so we should stop using it before updating to newer versions of `solana-sdk`

#### Summary of Changes
Switch over to `solana-transaction-context` where appropriate

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
