### PR TITLE
runtime: bank: make program cache prep a method

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8648,7 +8648,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-account",
- "solana-bpf-loader-program",
  "solana-clock",
  "solana-feature-set",
  "solana-fee-structure",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1427,18 +1427,8 @@ impl Bank {
             new.distribute_partitioned_epoch_rewards();
         });
 
-        let (_epoch, slot_index) = new.epoch_schedule.get_epoch_and_slot_index(new.slot);
-        let slots_in_epoch = new.epoch_schedule.get_slots_in_epoch(new.epoch);
-
-        let (_, cache_preparation_time_us) = measure_us!(new
-            .transaction_processor
-            .prepare_program_cache_for_upcoming_feature_set(
-                &new,
-                &new.compute_active_feature_set(true).0,
-                &new.compute_budget.unwrap_or_default().to_budget(),
-                slot_index,
-                slots_in_epoch,
-            ));
+        let (_, cache_preparation_time_us) =
+            measure_us!(new.prepare_program_cache_for_upcoming_feature_set());
 
         // Update sysvars before processing transactions
         let (_, update_sysvars_time_us) = measure_us!({
@@ -1531,6 +1521,20 @@ impl Bank {
             .write()
             .unwrap()
             .set_fork_graph(fork_graph);
+    }
+
+    fn prepare_program_cache_for_upcoming_feature_set(&self) {
+        let (_epoch, slot_index) = self.epoch_schedule.get_epoch_and_slot_index(self.slot);
+        let slots_in_epoch = self.epoch_schedule.get_slots_in_epoch(self.epoch);
+
+        self.transaction_processor
+            .prepare_program_cache_for_upcoming_feature_set(
+                self,
+                &self.compute_active_feature_set(true).0,
+                &self.compute_budget.unwrap_or_default().to_budget(),
+                slot_index,
+                slots_in_epoch,
+            );
     }
 
     pub fn prune_program_cache(&self, new_root_slot: Slot, new_root_epoch: Epoch) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -153,6 +153,7 @@ use {
     solana_svm::{
         account_loader::{collect_rent_from_account, LoadedTransaction},
         account_overrides::AccountOverrides,
+        program_loader::load_program_with_pubkey,
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{
@@ -182,7 +183,7 @@ use {
         sync::{
             atomic::{
                 AtomicBool, AtomicI64, AtomicU64, AtomicUsize,
-                Ordering::{AcqRel, Acquire, Relaxed},
+                Ordering::{self, AcqRel, Acquire, Relaxed},
             },
             Arc, LockResult, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
         },
@@ -201,7 +202,6 @@ use {
     solana_nonce_account::{get_system_account_kind, SystemAccountKind},
     solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
     solana_sdk::nonce,
-    solana_svm::program_loader::load_program_with_pubkey,
 };
 
 /// params to `verify_accounts_hash`
@@ -1526,15 +1526,89 @@ impl Bank {
     fn prepare_program_cache_for_upcoming_feature_set(&self) {
         let (_epoch, slot_index) = self.epoch_schedule.get_epoch_and_slot_index(self.slot);
         let slots_in_epoch = self.epoch_schedule.get_slots_in_epoch(self.epoch);
+        let compute_budget = self.compute_budget.unwrap_or_default().to_budget();
+        let (upcoming_feature_set, _newly_activated) = self.compute_active_feature_set(true);
 
-        self.transaction_processor
-            .prepare_program_cache_for_upcoming_feature_set(
-                self,
-                &self.compute_active_feature_set(true).0,
-                &self.compute_budget.unwrap_or_default().to_budget(),
-                slot_index,
-                slots_in_epoch,
+        // Recompile loaded programs one at a time before the next epoch hits
+        let slots_in_recompilation_phase =
+            (solana_program_runtime::loaded_programs::MAX_LOADED_ENTRY_COUNT as u64)
+                .min(slots_in_epoch)
+                .checked_div(2)
+                .unwrap();
+
+        let mut program_cache = self.transaction_processor.program_cache.write().unwrap();
+
+        if program_cache.upcoming_environments.is_some() {
+            if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
+                let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
+                drop(program_cache);
+                let environments_for_epoch = self
+                    .transaction_processor
+                    .program_cache
+                    .read()
+                    .unwrap()
+                    .get_environments_for_epoch(effective_epoch);
+                if let Some(recompiled) = load_program_with_pubkey(
+                    self,
+                    &environments_for_epoch,
+                    &key,
+                    self.slot,
+                    &mut ExecuteTimings::default(),
+                    false,
+                ) {
+                    recompiled.tx_usage_counter.fetch_add(
+                        program_to_recompile
+                            .tx_usage_counter
+                            .load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
+                    recompiled.ix_usage_counter.fetch_add(
+                        program_to_recompile
+                            .ix_usage_counter
+                            .load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
+                    let mut program_cache =
+                        self.transaction_processor.program_cache.write().unwrap();
+                    program_cache.assign_program(key, recompiled);
+                }
+            }
+        } else if self.epoch != program_cache.latest_root_epoch
+            || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
+        {
+            // Anticipate the upcoming program runtime environment for the next epoch,
+            // so we can try to recompile loaded programs before the feature transition hits.
+            drop(program_cache);
+            let mut program_cache = self.transaction_processor.program_cache.write().unwrap();
+            let program_runtime_environment_v1 = create_program_runtime_environment_v1(
+                &upcoming_feature_set,
+                &compute_budget,
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap();
+            let program_runtime_environment_v2 = create_program_runtime_environment_v2(
+                &compute_budget,
+                false, /* debugging_features */
             );
+            let mut upcoming_environments = program_cache.environments.clone();
+            let changed_program_runtime_v1 =
+                *upcoming_environments.program_runtime_v1 != program_runtime_environment_v1;
+            let changed_program_runtime_v2 =
+                *upcoming_environments.program_runtime_v2 != program_runtime_environment_v2;
+            if changed_program_runtime_v1 {
+                upcoming_environments.program_runtime_v1 = Arc::new(program_runtime_environment_v1);
+            }
+            if changed_program_runtime_v2 {
+                upcoming_environments.program_runtime_v2 = Arc::new(program_runtime_environment_v2);
+            }
+            program_cache.upcoming_environments = Some(upcoming_environments);
+            program_cache.programs_to_recompile = program_cache
+                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
+            program_cache
+                .programs_to_recompile
+                .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
+        }
     }
 
     pub fn prune_program_cache(&self, new_root_slot: Slot, new_root_epoch: Epoch) {

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -19,7 +19,6 @@ qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
 solana-account = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
 solana-clock = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true }
@@ -68,6 +67,7 @@ openssl = { workspace = true }
 prost = { workspace = true }
 rand0-7 = { workspace = true }
 shuttle = { workspace = true }
+solana-bpf-loader-program = { workspace = true }
 solana-clock = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-compute-budget-interface = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7967,7 +7967,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-account",
- "solana-bpf-loader-program",
  "solana-clock",
  "solana-feature-set",
  "solana-fee-structure",

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     crate::transaction_processing_callback::TransactionProcessingCallback,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},
@@ -118,8 +116,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
 /// If the account doesn't exist it returns `None`. If the account does exist, it must be a program
 /// account (belong to one of the program loaders). Returns `Some(InvalidAccountData)` if the program
 /// account is `Closed`, contains invalid data or any of the programdata accounts are invalid.
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-pub(crate) fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
+pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     environments: &ProgramRuntimeEnvironments,
     pubkey: &Pubkey,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -21,9 +21,6 @@ use {
     log::debug,
     percentage::Percentage,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
-    solana_bpf_loader_program::syscalls::{
-        create_program_runtime_environment_v1, create_program_runtime_environment_v2,
-    },
     solana_clock::{Epoch, Slot},
     solana_feature_set::{remove_accounts_executable_flag_checks, FeatureSet},
     solana_hash::Hash,
@@ -36,7 +33,7 @@ use {
         versions::Versions as NonceVersions,
     },
     solana_program_runtime::{
-        execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
+        execution_budget::SVMTransactionExecutionCost,
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             ForkGraph, ProgramCache, ProgramCacheEntry, ProgramCacheForTxBatch,
@@ -778,92 +775,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         loaded_programs_for_txs.unwrap()
     }
 
-    pub fn prepare_program_cache_for_upcoming_feature_set<CB: TransactionProcessingCallback>(
-        &self,
-        callbacks: &CB,
-        upcoming_feature_set: &FeatureSet,
-        compute_budget: &SVMTransactionExecutionBudget,
-        slot_index: u64,
-        slots_in_epoch: u64,
-    ) {
-        // Recompile loaded programs one at a time before the next epoch hits
-        let slots_in_recompilation_phase =
-            (solana_program_runtime::loaded_programs::MAX_LOADED_ENTRY_COUNT as u64)
-                .min(slots_in_epoch)
-                .checked_div(2)
-                .unwrap();
-        let mut program_cache = self.program_cache.write().unwrap();
-        if program_cache.upcoming_environments.is_some() {
-            if let Some((key, program_to_recompile)) = program_cache.programs_to_recompile.pop() {
-                let effective_epoch = program_cache.latest_root_epoch.saturating_add(1);
-                drop(program_cache);
-                let environments_for_epoch = self
-                    .program_cache
-                    .read()
-                    .unwrap()
-                    .get_environments_for_epoch(effective_epoch);
-                if let Some(recompiled) = load_program_with_pubkey(
-                    callbacks,
-                    &environments_for_epoch,
-                    &key,
-                    self.slot,
-                    &mut ExecuteTimings::default(),
-                    false,
-                ) {
-                    recompiled.tx_usage_counter.fetch_add(
-                        program_to_recompile
-                            .tx_usage_counter
-                            .load(Ordering::Relaxed),
-                        Ordering::Relaxed,
-                    );
-                    recompiled.ix_usage_counter.fetch_add(
-                        program_to_recompile
-                            .ix_usage_counter
-                            .load(Ordering::Relaxed),
-                        Ordering::Relaxed,
-                    );
-                    let mut program_cache = self.program_cache.write().unwrap();
-                    program_cache.assign_program(key, recompiled);
-                }
-            }
-        } else if self.epoch != program_cache.latest_root_epoch
-            || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
-        {
-            // Anticipate the upcoming program runtime environment for the next epoch,
-            // so we can try to recompile loaded programs before the feature transition hits.
-            drop(program_cache);
-            let mut program_cache = self.program_cache.write().unwrap();
-            let program_runtime_environment_v1 = create_program_runtime_environment_v1(
-                upcoming_feature_set,
-                compute_budget,
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap();
-            let program_runtime_environment_v2 = create_program_runtime_environment_v2(
-                compute_budget,
-                false, /* debugging_features */
-            );
-            let mut upcoming_environments = program_cache.environments.clone();
-            let changed_program_runtime_v1 =
-                *upcoming_environments.program_runtime_v1 != program_runtime_environment_v1;
-            let changed_program_runtime_v2 =
-                *upcoming_environments.program_runtime_v2 != program_runtime_environment_v2;
-            if changed_program_runtime_v1 {
-                upcoming_environments.program_runtime_v1 = Arc::new(program_runtime_environment_v1);
-            }
-            if changed_program_runtime_v2 {
-                upcoming_environments.program_runtime_v2 = Arc::new(program_runtime_environment_v2);
-            }
-            program_cache.upcoming_environments = Some(upcoming_environments);
-            program_cache.programs_to_recompile = program_cache
-                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
-            program_cache
-                .programs_to_recompile
-                .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));
-        }
-    }
-
     /// Execute a transaction using the provided loaded accounts and update
     /// the executors cache if the transaction was successful.
     #[allow(clippy::too_many_arguments)]
@@ -1174,7 +1085,9 @@ mod tests {
         solana_message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
         solana_nonce as nonce,
         solana_program_runtime::{
-            execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
+            execution_budget::{
+                SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionBudget,
+            },
             loaded_programs::{BlockRelation, ProgramCacheEntryType},
         },
         solana_rent::Rent,


### PR DESCRIPTION
#### Problem
The SVM API offers a very nuanced method for updating the program cache on a `TransactionBatchProcessor` instance, given an upcoming feature set. It's designed to manage the "recompilation phase", in which program cache entries are recompiled ahead of time to prepare for the anticipated new feature set at the turn of the epoch.

Since this is a very Agave-specific optimization, it belongs in Agave (runtime), not SVM.

#### Summary of Changes
Hoist it out!

Note: This also extracts the last SVM syscall registration callsite into Agave's runtime. In a follow-up PR, I can refactor the BPF Loader program crate so we can split the SVM stack into a new repository.