### PR TITLE
ledger-tool: Make genesis accounts support json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "num_cpus",
+ "pretty-hex",
  "rayon",
  "regex",
  "serde",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -22,6 +22,7 @@ histogram = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }
+pretty-hex = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -7,7 +7,7 @@ use {
         ledger_path::*,
         ledger_utils::*,
         output::{
-            output_account, AccountsOutputConfig, AccountsOutputMode, AccountsOutputStreamer,
+            AccountsOutputConfig, AccountsOutputMode, AccountsOutputStreamer, CliAccounts,
             SlotBankHash,
         },
         program::*,
@@ -20,7 +20,7 @@ use {
     dashmap::DashMap,
     log::*,
     serde_derive::Serialize,
-    solana_account_decoder::UiAccountEncoding,
+    solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
         accounts_db::CalcAccountsHashDataSource,
         accounts_index::{ScanConfig, ScanOrder},
@@ -33,7 +33,7 @@ use {
             is_within_range,
         },
     },
-    solana_cli_output::OutputFormat,
+    solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
     solana_core::{
         banking_simulation::{BankingSimulator, BankingTraceEvents},
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
@@ -1671,20 +1671,46 @@ fn main() {
 
             match matches.subcommand() {
                 ("genesis", Some(arg_matches)) => {
+                    let output_format =
+                        OutputFormat::from_matches(arg_matches, "output_format", false);
+                    let output_accounts = arg_matches.is_present("accounts");
+
                     let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
-                    let print_accounts = arg_matches.is_present("accounts");
-                    if print_accounts {
-                        let print_account_data = !arg_matches.is_present("no_account_data");
-                        let print_encoding_format = parse_encoding_format(arg_matches);
-                        for (pubkey, account) in genesis_config.accounts {
-                            output_account(
-                                &pubkey,
-                                &AccountSharedData::from(account),
-                                None,
-                                print_account_data,
-                                print_encoding_format,
-                            );
-                        }
+
+                    if output_accounts {
+                        let data_encoding = parse_encoding_format(arg_matches);
+                        let output_account_data = !arg_matches.is_present("no_account_data");
+                        let data_slice_config = if output_account_data {
+                            // None yields the entire account in the slice
+                            None
+                        } else {
+                            // usize::MAX is a sentinel that will yield an
+                            // empty data slice. Because of this, length is
+                            // ignored so any value will do
+                            let offset = usize::MAX;
+                            let length = 0;
+                            Some(UiDataSliceConfig { offset, length })
+                        };
+                        let cli_account_config = CliAccountNewConfig {
+                            data_encoding,
+                            data_slice_config,
+                            ..CliAccountNewConfig::default()
+                        };
+
+                        let accounts: Vec<_> = genesis_config
+                            .accounts
+                            .into_iter()
+                            .map(|(pubkey, account)| {
+                                CliAccount::new_with_config(
+                                    &pubkey,
+                                    &AccountSharedData::from(account),
+                                    &cli_account_config,
+                                )
+                            })
+                            .collect();
+                        let accounts = CliAccounts { accounts };
+
+                        println!("{}", output_format.formatted_string(&accounts));
                     } else {
                         println!("{genesis_config}");
                     }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -939,6 +939,29 @@ impl serde::Serialize for AccountsScanner {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct CliAccounts {
+    pub accounts: Vec<CliAccount>,
+}
+
+impl fmt::Display for CliAccounts {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for account in &self.accounts {
+            write!(f, "{account}")?;
+            let account_data = account.keyed_account.account.data.decode();
+            if let Some(data) = account_data {
+                if !data.is_empty() {
+                    use pretty_hex::*;
+                    writeln!(f, "{:?}", data.hex_dump())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+impl QuietDisplay for CliAccounts {}
+impl VerboseDisplay for CliAccounts {}
+
 pub fn output_account(
     pubkey: &Pubkey,
     account: &AccountSharedData,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -5,6 +5,7 @@ use {
     },
     chrono::{Local, TimeZone},
     itertools::Either,
+    pretty_hex::PrettyHex,
     serde::ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     serde_derive::{Deserialize, Serialize},
     solana_account_decoder::{encode_ui_account, UiAccountData, UiAccountEncoding},
@@ -951,7 +952,6 @@ impl fmt::Display for CliAccounts {
             let account_data = account.keyed_account.account.data.decode();
             if let Some(data) = account_data {
                 if !data.is_empty() {
-                    use pretty_hex::*;
                     writeln!(f, "{:?}", data.hex_dump())?;
                 }
             }


### PR DESCRIPTION
#### Summary of Changes
- `agave-ledger-tool genesis --accounts --output json` now prints json
- `agave-ledger-tool genesis --accounts` (display) will now match the output from the CLI (ie `solana account`) by making use of `CliAccount`

#### Output
Old output:
```
$ cargo run -- genesis --accounts
...
JCo7ptMT38iZdjXXdxD8Ye79dGBBkMi2nttnv965k3pE:
  balance: 104166.66626894 SOL
  owner: 'Stake11111111111111111111111111111111111111'
  executable: false
  rent_epoch: 0
  data_len: 200
  data: 'AQAAAIDVIgAAAAAAHo5ufv6LXJUFQplRqRqFRQY4YFx4p81H20CZkWDY9q37k5kcYLD2AC8789vlnsUxaVMBz0/FeathVFoOL2wFSwAAAAAAAAAAigoAAAAAAAAFR0dn5PH8Rp6b7RVvpNOHD2ek8+95bZYJHcoJ866WowAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
  encoding: "base64"
```
New output with comparison to `solana account`
```
$ cargo run -- genesis --accounts
...
Public Key: JCo7ptMT38iZdjXXdxD8Ye79dGBBkMi2nttnv965k3pE
Balance: 104166.66626894 SOL
Owner: Stake11111111111111111111111111111111111111
Executable: false
Rent Epoch: 0
Length: 200 (0xc8) bytes
0000:   01 00 00 00  80 d5 22 00  00 00 00 00  1e 8e 6e 7e   ......".......n~
...

$ solana account BLADE1qNA1uNjRgER6DtUFf7FU3c1TWLLdpPeEcKatZ2

Public Key: BLADE1qNA1uNjRgER6DtUFf7FU3c1TWLLdpPeEcKatZ2
Balance: 154.16887391 SOL
Owner: Vote111111111111111111111111111111111111111
Executable: false
Rent Epoch: 18446744073709551615
Length: 3762 (0xeb2) bytes
0000:   02 00 00 00  05 90 72 89  e7 0a 13 44  2f 09 2e c9   ......r....D/...
...
```
and json output (`--output json` previously did nothing for this command):
```
    ....
    },
    {
      "pubkey": "JCo7ptMT38iZdjXXdxD8Ye79dGBBkMi2nttnv965k3pE",
      "account": {
        "lamports": 104166666268940,
        "data": [
          "AQAAAIDVIgAAAAAAHo5ufv6LXJUFQplRqRqFRQY4YFx4p81H20CZkWDY9q37k5kcYLD2AC8789vlnsUxaVMBz0/FeathVFoOL2wFSwAAAAAAAAAAigoAAAAAAAAFR0dn5PH8Rp6b7RVvpNOHD2ek8+95bZYJHcoJ866WowAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
          "base64"
        ],
        "owner": "Stake11111111111111111111111111111111111111",
        "executable": false,
        "rentEpoch": 0,
        "space": 200
      }
    }
  ]
}
```