### PR TITLE
svm-rent-collector: drop solana-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10411,8 +10411,15 @@ dependencies = [
 name = "solana-svm-rent-collector"
 version = "2.3.0"
 dependencies = [
- "solana-sdk",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-rent-collector",
+ "solana-sdk-ids",
  "solana-transaction-context 2.3.0",
+ "solana-transaction-error",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8681,8 +8681,14 @@ dependencies = [
 name = "solana-svm-rent-collector"
 version = "2.3.0"
 dependencies = [
- "solana-sdk",
+ "solana-account",
+ "solana-clock",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-rent-collector",
+ "solana-sdk-ids",
  "solana-transaction-context 2.3.0",
+ "solana-transaction-error",
 ]
 
 [[package]]

--- a/svm-rent-collector/Cargo.toml
+++ b/svm-rent-collector/Cargo.toml
@@ -10,5 +10,14 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-solana-sdk = { workspace = true }
+solana-account = { workspace = true }
+solana-clock = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent = { workspace = true }
+solana-rent-collector = { workspace = true }
+solana-sdk-ids = { workspace = true }
 solana-transaction-context = { workspace = true }
+solana-transaction-error = { workspace = true }
+
+[dev-dependencies]
+solana-epoch-schedule = { workspace = true }

--- a/svm-rent-collector/src/svm_rent_collector.rs
+++ b/svm-rent-collector/src/svm_rent_collector.rs
@@ -2,15 +2,13 @@
 
 use {
     crate::rent_state::RentState,
-    solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
-        clock::Epoch,
-        pubkey::Pubkey,
-        rent::{Rent, RentDue},
-        rent_collector::CollectedInfo,
-        transaction::{Result, TransactionError},
-    },
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_clock::Epoch,
+    solana_pubkey::Pubkey,
+    solana_rent::{Rent, RentDue},
+    solana_rent_collector::CollectedInfo,
     solana_transaction_context::{IndexOfAccount, TransactionContext},
+    solana_transaction_error::{TransactionError, TransactionResult},
 };
 
 mod rent_collector;
@@ -33,7 +31,7 @@ pub trait SVMRentCollector {
         post_rent_state: Option<&RentState>,
         transaction_context: &TransactionContext,
         index: IndexOfAccount,
-    ) -> Result<()> {
+    ) -> TransactionResult<()> {
         if let Some((pre_rent_state, post_rent_state)) = pre_rent_state.zip(post_rent_state) {
             let expect_msg =
                 "account must exist at TransactionContext index if rent-states are Some";
@@ -65,8 +63,8 @@ pub trait SVMRentCollector {
         address: &Pubkey,
         _account_state: &AccountSharedData,
         account_index: IndexOfAccount,
-    ) -> Result<()> {
-        if !solana_sdk::incinerator::check_id(address)
+    ) -> TransactionResult<()> {
+        if !solana_sdk_ids::incinerator::check_id(address)
             && !self.transition_allowed(pre_rent_state, post_rent_state)
         {
             let account_index = account_index as u8;

--- a/svm-rent-collector/src/svm_rent_collector/rent_collector.rs
+++ b/svm-rent-collector/src/svm_rent_collector/rent_collector.rs
@@ -3,13 +3,11 @@
 
 use {
     crate::svm_rent_collector::SVMRentCollector,
-    solana_sdk::{
-        account::AccountSharedData,
-        clock::Epoch,
-        pubkey::Pubkey,
-        rent::{Rent, RentDue},
-        rent_collector::{CollectedInfo, RentCollector},
-    },
+    solana_account::AccountSharedData,
+    solana_clock::Epoch,
+    solana_pubkey::Pubkey,
+    solana_rent::{Rent, RentDue},
+    solana_rent_collector::{CollectedInfo, RentCollector},
 };
 
 impl SVMRentCollector for RentCollector {
@@ -31,11 +29,12 @@ mod tests {
     use {
         super::*,
         crate::rent_state::RentState,
-        solana_sdk::{
-            account::ReadableAccount, clock::Epoch, epoch_schedule::EpochSchedule, pubkey::Pubkey,
-            transaction::TransactionError,
-        },
+        solana_account::ReadableAccount,
+        solana_clock::Epoch,
+        solana_epoch_schedule::EpochSchedule,
+        solana_pubkey::Pubkey,
         solana_transaction_context::{IndexOfAccount, TransactionContext},
+        solana_transaction_error::TransactionError,
     };
 
     #[test]
@@ -207,7 +206,7 @@ mod tests {
         let result = rent_collector.check_rent_state_with_account(
             &pre_rent_state,
             &post_rent_state,
-            &solana_sdk::incinerator::id(),
+            &solana_sdk_ids::incinerator::id(),
             &AccountSharedData::default(),
             account_index,
         );

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8019,8 +8019,14 @@ dependencies = [
 name = "solana-svm-rent-collector"
 version = "2.3.0"
 dependencies = [
- "solana-sdk",
+ "solana-account",
+ "solana-clock",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-rent-collector",
+ "solana-sdk-ids",
  "solana-transaction-context 2.3.0",
+ "solana-transaction-error",
 ]
 
 [[package]]


### PR DESCRIPTION
Just like #5531, drop `solana-sdk` from `solana-svm-rent-collector`.