### PR TITLE
Improves validator cli help text for --snapshots

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -288,9 +288,14 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("snapshots")
             .value_name("DIR")
             .takes_value(true)
-            .help(
+            .help("Use DIR as the base location for snapshots.")
+            .long_help(
                 "Use DIR as the base location for snapshots. \
-                 A subdirectory named \"snapshots\" will be created. \
+                 Snapshot archives will use DIR unless --full-snapshot-archive-path or \
+                 --incremental-snapshot-archive-path is specified. \
+                 Additionally, a subdirectory named \"snapshots\" will be created in DIR. \
+                 This subdirectory holds internal files/data that are used when generating \
+                 snapshot archives. \
                  [default: --ledger value]",
              ),
     )


### PR DESCRIPTION
#### Problem

Node operators get confused where snapshot archives are supposed to go when they copy/download them from outside the validator bootstrap process. 

Here's an example:
https://discord.com/channels/428295358100013066/837340113067049050/1354824356785688706

I agree we don't necessarily want people doing this, but it does show that the `--snapshots` help text is insufficient in general on where to put the snapshot archives.

For example, and node operator has some snapshot archives they've downloaded. Where should they be put?

##### Scenario 1: defaults

This scenario is when none of `--snapshots`/`--full-snapshot-archive-path`/`--incremental-snapshot-archive-path` are specified.

The operator should put snapshot archives in `ledger/`.
Note, *not* `ledger/snapshots/`.

##### Scenario 2: with `--snapshots`

This scenario is when `--snapshots /abc` is used, but not `--full-snapshot-archive-path`/`--incremental-snapshot-archive-path`.

The operator should put snapshot archives in `/abc/`.
Note, *not* `/abc/snapshots/`.

##### Scenario 3: with `--snapshots` and `--full-snapshot-archive-path`

This scenario is when `--snapshots /abc` and `--full-snapshot-archive-path /xyz` are used (not `--incremental-snapshot-archive-path`, but it'd be the same idea).

The operator should put full snapshot archives in `/xyz/`.
Note, *not* `/xyz/snapshots/`, nor `/abc/`.


#### Summary of Changes

Improve the help text.