### PR TITLE
Speed up manual ticking tests

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -986,10 +986,11 @@ mod tests {
     fn test_bank_process_and_record_transactions() {
         solana_logger::setup();
         let GenesisConfigInfo {
-            genesis_config,
+            mut genesis_config,
             mint_keypair,
             ..
         } = create_slow_genesis_config(10_000);
+        genesis_config.ticks_per_slot = 64;
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let pubkey = solana_pubkey::new_rand();
 
@@ -1118,10 +1119,11 @@ mod tests {
     fn test_bank_nonce_update_blockhash_queried_before_transaction_record() {
         solana_logger::setup();
         let GenesisConfigInfo {
-            genesis_config,
+            mut genesis_config,
             mint_keypair,
             ..
         } = create_slow_genesis_config(10_000);
+        genesis_config.ticks_per_slot = 64;
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let pubkey = Pubkey::new_unique();
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -843,7 +843,10 @@ mod tests {
         solana_ledger::{
             blockstore::{entries_to_test_shreds, Blockstore},
             blockstore_processor::TransactionStatusSender,
-            genesis_utils::GenesisConfigInfo,
+            genesis_utils::{
+                bootstrap_validator_stake_lamports, create_genesis_config_with_leader,
+                GenesisConfigInfo,
+            },
             get_tmp_ledger_path_auto_delete,
             leader_schedule_cache::LeaderScheduleCache,
         },
@@ -986,11 +989,14 @@ mod tests {
     fn test_bank_process_and_record_transactions() {
         solana_logger::setup();
         let GenesisConfigInfo {
-            mut genesis_config,
+            genesis_config,
             mint_keypair,
             ..
-        } = create_slow_genesis_config(10_000);
-        genesis_config.ticks_per_slot = 64;
+        } = create_genesis_config_with_leader(
+            10_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        );
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let pubkey = solana_pubkey::new_rand();
 
@@ -1119,11 +1125,14 @@ mod tests {
     fn test_bank_nonce_update_blockhash_queried_before_transaction_record() {
         solana_logger::setup();
         let GenesisConfigInfo {
-            mut genesis_config,
+            genesis_config,
             mint_keypair,
             ..
-        } = create_slow_genesis_config(10_000);
-        genesis_config.ticks_per_slot = 64;
+        } = create_genesis_config_with_leader(
+            10_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        );
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         let pubkey = Pubkey::new_unique();
 


### PR DESCRIPTION
#### Problem
- #5160 increased ticks from 64 to 64 * 1024.
- Few of these tests tick manually - making them slow after merge of #5160

master:
```
$ time cargo test --package solana-core --lib -- banking_stage::consumer::tests::test_bank_process_and_record_transactions --exact
...
test banking_stage::consumer::tests::test_bank_process_and_record_transactions has been running for over 60 seconds
^C

real    3m26.047s
user    0m0.330s
sys     0m0.167s
```

#### Summary of Changes
- For tests that manually tick, mutate number of ticks in genesis config back to 64.

with patch:
```
$ time cargo test --package solana-core --lib -- banking_stage::consumer::tests::test_bank_process_and_record_transactions --exact
...
real    0m1.082s
user    0m0.807s
sys     0m0.186s
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
