### PR TITLE
chore: do not re-zip vectors in repair

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1127,10 +1127,7 @@ impl ServeRepair {
         if repair_peers.is_empty() {
             return Err(ClusterInfoError::NoPeers.into());
         }
-        let (weights, index): (Vec<_>, Vec<_>) = cluster_slots
-            .compute_weights_exclude_nonfrozen(slot, &repair_peers)
-            .into_iter()
-            .unzip();
+        let (weights, index) = cluster_slots.compute_weights_exclude_nonfrozen(slot, &repair_peers);
         let peers = WeightedShuffle::new("repair_request_ancestor_hashes", weights)
             .shuffle(&mut rand::thread_rng())
             .map(|i| index[i])
@@ -1154,10 +1151,7 @@ impl ServeRepair {
         if repair_peers.is_empty() {
             return None;
         }
-        let (weights, index): (Vec<_>, Vec<_>) = cluster_slots
-            .compute_weights_exclude_nonfrozen(slot, &repair_peers)
-            .into_iter()
-            .unzip();
+        let (weights, index) = cluster_slots.compute_weights_exclude_nonfrozen(slot, &repair_peers);
         let k = WeightedIndex::new(weights)
             .ok()?
             .sample(&mut rand::thread_rng());


### PR DESCRIPTION
#### Problem

Repair creates a vector which it immediately unzips into two vectors. 

#### Summary of Changes

- just make 2 vectors to begin with.
- preallocate memory