### PR TITLE
Run downstream tests for SBPFv1

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -134,11 +134,26 @@ jobs:
         with:
           version: "v0.9.1"
 
-      - shell: bash
+      - name: Install dependencies
+        shell: bash
         run: |
           source .github/scripts/downstream-project-spl-install-deps.sh
           source .github/scripts/downstream-project-spl-common.sh "${{ matrix.programs }}"
           if [ -n "$SKIP_SPL_DOWNSTREAM_PROJECT_TEST" ]; then
             exit 0
           fi
-          $CARGO_TEST_SBF --manifest-path program/Cargo.toml
+
+      - name: Test SBPFv0
+        shell: bash
+        run: |
+          source ci/downstream-projects/common.sh
+          cd "${{ matrix.programs }}"
+          $CARGO_TEST_SBF --arch v0 --manifest-path program/Cargo.toml
+
+      - name: Test SBPFv1
+        shell: bash
+        run: |
+          source ci/downstream-projects/common.sh
+          cd "${{ matrix.programs }}"
+          cargo clean
+          $CARGO_TEST_SBF --arch v1 --manifest-path program/Cargo.toml

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -155,5 +155,5 @@ jobs:
         run: |
           source ci/downstream-projects/common.sh
           cd "${{ matrix.programs }}"
-          cargo clean
+          rm -rf target/deploy target/sbpf*
           $CARGO_TEST_SBF --arch v1 --manifest-path program/Cargo.toml


### PR DESCRIPTION
#### Problem

We've released new version of SBPF that will be activated soon. Although we run tests for them using the programs in `programs/sbf`, downstream programs are not tests using the new versions yet.

#### Summary of Changes

1. Refactor the CI job with a separate task for SBPFv0.
2. Include a task to test SBPFv1.

Other SBPF versions will be included in follow up PRs.
