### PR TITLE
remove dependency on solana-feature-set-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,6 @@ version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
- "solana-feature-set-interface",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash",
@@ -7981,16 +7980,6 @@ dependencies = [
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-feature-set-interface"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02007757246e40f10aa936dae4fa27efbf8dbd6a59575a12ccc802c1aea6e708"
-dependencies = [
- "ahash 0.8.11",
- "solana-pubkey",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -417,7 +417,6 @@ solana-derivation-path = "=2.2.1"
 solana-download-utils = { path = "download-utils", version = "=2.3.0" }
 solana-ed25519-program = "=2.2.2"
 solana-entry = { path = "entry", version = "=2.3.0" }
-solana-feature-set-interface = "=4.0.0"
 solana-program-entrypoint = "=2.2.1"
 solana-epoch-info = "=2.2.1"
 solana-epoch-rewards = "=2.2.1"

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -12,7 +12,6 @@ readme = false
 [dependencies]
 ahash = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-feature-set-interface = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -3,7 +3,6 @@
 use {
     ahash::{AHashMap, AHashSet},
     solana_epoch_schedule::EpochSchedule,
-    solana_feature_set_interface::FeatureSet as SdkFeatureSet,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_sha256_hasher::Hasher,
@@ -13,60 +12,59 @@ use {
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
-    feature_set: SdkFeatureSet,
+    active: AHashMap<Pubkey, u64>,
+    inactive: AHashSet<Pubkey>,
 }
 
 impl Default for FeatureSet {
     fn default() -> Self {
-        // All features disabled
         Self {
-            feature_set: SdkFeatureSet {
-                active: AHashMap::new(),
-                inactive: AHashSet::from_iter((*FEATURE_NAMES).keys().cloned()),
-            },
+            // All features disabled
+            active: AHashMap::new(),
+            inactive: AHashSet::from_iter((*FEATURE_NAMES).keys().cloned()),
         }
     }
 }
 
 impl FeatureSet {
     pub fn new(active: AHashMap<Pubkey, u64>, inactive: AHashSet<Pubkey>) -> Self {
-        Self {
-            feature_set: SdkFeatureSet { active, inactive },
-        }
+        Self { active, inactive }
     }
 
     pub fn active(&self) -> &AHashMap<Pubkey, u64> {
-        &self.feature_set.active
+        &self.active
     }
 
     pub fn active_mut(&mut self) -> &mut AHashMap<Pubkey, u64> {
-        &mut self.feature_set.active
+        &mut self.active
     }
 
     pub fn inactive(&self) -> &AHashSet<Pubkey> {
-        &self.feature_set.inactive
+        &self.inactive
     }
 
     pub fn inactive_mut(&mut self) -> &mut AHashSet<Pubkey> {
-        &mut self.feature_set.inactive
+        &mut self.inactive
     }
 
     pub fn is_active(&self, feature_id: &Pubkey) -> bool {
-        self.feature_set.is_active(feature_id)
+        self.active.contains_key(feature_id)
     }
 
     pub fn activated_slot(&self, feature_id: &Pubkey) -> Option<u64> {
-        self.feature_set.activated_slot(feature_id)
+        self.active.get(feature_id).copied()
     }
 
     /// Activate a feature
     pub fn activate(&mut self, feature_id: &Pubkey, slot: u64) {
-        self.feature_set.activate(feature_id, slot)
+        self.inactive.remove(feature_id);
+        self.active.insert(*feature_id, slot);
     }
 
     /// Deactivate a feature
     pub fn deactivate(&mut self, feature_id: &Pubkey) {
-        self.feature_set.deactivate(feature_id)
+        self.active.remove(feature_id);
+        self.inactive.insert(*feature_id);
     }
 
     /// List of enabled features that trigger full inflation
@@ -91,10 +89,8 @@ impl FeatureSet {
     /// All features enabled, useful for testing
     pub fn all_enabled() -> Self {
         Self {
-            feature_set: SdkFeatureSet {
-                active: AHashMap::from_iter((*FEATURE_NAMES).keys().cloned().map(|key| (key, 0))),
-                inactive: AHashSet::new(),
-            },
+            active: AHashMap::from_iter((*FEATURE_NAMES).keys().cloned().map(|key| (key, 0))),
+            inactive: AHashSet::new(),
         }
     }
 
@@ -1305,7 +1301,6 @@ mod test {
         let mut feature_set = FeatureSet::default();
         assert!(feature_set.full_inflation_features_enabled().is_empty());
         feature_set
-            .feature_set
             .active
             .insert(full_inflation::devnet_and_testnet::id(), 42);
         assert_eq!(
@@ -1323,12 +1318,10 @@ mod test {
         let mut feature_set = FeatureSet::default();
         assert!(feature_set.full_inflation_features_enabled().is_empty());
         feature_set
-            .feature_set
             .active
             .insert(full_inflation::mainnet::certusone::vote::id(), 42);
         assert!(feature_set.full_inflation_features_enabled().is_empty());
         feature_set
-            .feature_set
             .active
             .insert(full_inflation::mainnet::certusone::enable::id(), 42);
         assert_eq!(
@@ -1343,12 +1336,10 @@ mod test {
         let mut feature_set = FeatureSet::default();
         assert!(feature_set.full_inflation_features_enabled().is_empty());
         feature_set
-            .feature_set
             .active
             .insert(full_inflation::mainnet::certusone::enable::id(), 42);
         assert!(feature_set.full_inflation_features_enabled().is_empty());
         feature_set
-            .feature_set
             .active
             .insert(full_inflation::mainnet::certusone::vote::id(), 42);
         assert_eq!(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -77,7 +77,6 @@ version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
- "solana-feature-set-interface",
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
@@ -6272,16 +6271,6 @@ dependencies = [
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-feature-set-interface"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02007757246e40f10aa936dae4fa27efbf8dbd6a59575a12ccc802c1aea6e708"
-dependencies = [
- "ahash 0.8.11",
- "solana-pubkey",
 ]
 
 [[package]]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -77,7 +77,6 @@ version = "2.3.0"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
- "solana-feature-set-interface",
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
@@ -6118,16 +6117,6 @@ dependencies = [
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-feature-set-interface"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02007757246e40f10aa936dae4fa27efbf8dbd6a59575a12ccc802c1aea6e708"
-dependencies = [
- "ahash 0.8.11",
- "solana-pubkey",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

we thought it would be nice to have a common feature set interface between sdk and monorepo. we were wrong

#### Summary of Changes

removes all use of `solana-feature-set-interface`