### PR TITLE
perf: compare pubkey first in precompile check_id

### DIFF
--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -37,9 +37,10 @@ impl Precompile {
     where
         F: Fn(&Pubkey) -> bool,
     {
-        self.feature
-            .is_none_or(|ref feature_id| is_enabled(feature_id))
-            && self.program_id == *program_id
+        self.program_id == *program_id
+            && self
+                .feature
+                .is_none_or(|ref feature_id| is_enabled(feature_id))
     }
     /// Verify this precompiled program
     pub fn verify(


### PR DESCRIPTION
#### Problem
Even now that `FeatureSet` uses `AHashSet`, it's still lower to look up whether a feature set is active or not than doing a pubkey equality check. The precompile `check_id` method always does a feature check when run for the `secp256r1` precompile. 

#### Summary of Changes
- Check pubkey equality before the feature check

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
