### PR TITLE
Include flag to optimize SBF programs for size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Release channels have their own copy of this changelog:
 * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
 * SBFPv1 and SBPFv2 are also available for Anza's C compiler toolchain.
 * SBPFv3 will be only available for the Rust toolchain. The C toolchain will no longer be supported for SBPFv3 onwards.
+* `cargo-build-sbf` now supports the `--optimize-size` argument, which can decrease program size in about 20%.
 
 #### Breaking
 * Although the solana rust toolchain still supports the `sbf-solana-solana` target, the new `cargo-build-sbf` version target defaults to `sbpf-solana-solana`. The generated programs will be available on `target/deploy` and `target/sbpf-solana-solana/release`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Release channels have their own copy of this changelog:
 * `cargo-build-sbf` and `cargo-test-sbf` now accept `v0`, `v1`, `v2` and `v3` for the `--arch` argument. These parameters specify the SBPF version to build for.
 * SBFPv1 and SBPFv2 are also available for Anza's C compiler toolchain.
 * SBPFv3 will be only available for the Rust toolchain. The C toolchain will no longer be supported for SBPFv3 onwards.
-* `cargo-build-sbf` now supports the `--optimize-size` argument, which can decrease program size in about 20%.
+* `cargo-build-sbf` now supports the `--optimize-size` argument, which reduces program size, potentially at the cost of increased CU usage.
 
 #### Breaking
 * Although the solana rust toolchain still supports the `sbf-solana-solana` target, the new `cargo-build-sbf` version target defaults to `sbpf-solana-solana`. The generated programs will be available on `target/deploy` and `target/sbpf-solana-solana/release`.

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -1178,7 +1178,7 @@ fn main() {
                 .help("Build for the given target architecture"),
         )
         .arg(
-            Arg::new("optimize-size")
+            Arg::new("optimize_size")
                 .long("optimize-size")
                 .takes_value(false)
                 .help("Optimize program for size. This option may reduce program size, potentially increasing CU consumption.")

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -1252,7 +1252,7 @@ fn main() {
         workspace: matches.is_present("workspace"),
         jobs: matches.value_of_t("jobs").ok(),
         arch: matches.value_of("arch").unwrap(),
-        optimize_size: matches.is_present("optimize-size"),
+        optimize_size: matches.is_present("optimize_size"),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -1181,7 +1181,7 @@ fn main() {
             Arg::new("optimize-size")
                 .long("optimize-size")
                 .takes_value(false)
-                .help("Optimize program for size. This option can decrease a program size in about 20%, but increases CU consumption")
+                .help("Optimize program for size. This option may reduce program size, potentially increasing CU consumption.")
         )
         .get_matches_from(args);
 

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -44,6 +44,7 @@ struct Config<'a> {
     workspace: bool,
     jobs: Option<String>,
     arch: &'a str,
+    optimize_size: bool,
 }
 
 impl Default for Config<'_> {
@@ -74,6 +75,7 @@ impl Default for Config<'_> {
             workspace: false,
             jobs: None,
             arch: "v0",
+            optimize_size: false,
         }
     }
 }
@@ -782,6 +784,9 @@ fn build_solana_package(
     if config.remap_cwd && !config.debug {
         target_rustflags = Cow::Owned(format!("{} -Zremap-cwd-prefix=", &target_rustflags));
     }
+    if config.optimize_size {
+        target_rustflags = Cow::Owned(format!("{} -C opt-level=s", &target_rustflags));
+    }
     if config.debug {
         // Replace with -Zsplit-debuginfo=packed when stabilized.
         target_rustflags = Cow::Owned(format!("{} -g", &target_rustflags));
@@ -1172,6 +1177,12 @@ fn main() {
                 .default_value("v0")
                 .help("Build for the given target architecture"),
         )
+        .arg(
+            Arg::new("optimize-size")
+                .long("optimize-size")
+                .takes_value(false)
+                .help("Optimize program for size. This option can decrease a program size in about 20%, but increases CU consumption")
+        )
         .get_matches_from(args);
 
     let sbf_sdk: PathBuf = matches.value_of_t_or_exit("sbf_sdk");
@@ -1241,6 +1252,7 @@ fn main() {
         workspace: matches.is_present("workspace"),
         jobs: matches.value_of_t("jobs").ok(),
         arch: matches.value_of("arch").unwrap(),
+        optimize_size: matches.is_present("optimize-size"),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {


### PR DESCRIPTION
#### Problem

SBF programs can become very large depending on the Rust construct. A low-hanging fruit is to allow developers to optimize their programs for size, using the `Os` compiler flag.

#### Summary of Changes

I added an argument in `cargo-build-sbf` select the `-C opt-level=s` for programs. Enabling it by default doesn't work, since some downstream programs exceed the CU limit.

The caveat of using this flag is the increase in CU usage. See the complete break down comparison here: https://github.com/anza-xyz/agave/pull/5546
