### PR TITLE
Adding counter to track accounts that were not cleaned due to ongoing…

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6277,6 +6277,11 @@ impl AccountsDb {
                 flush_stats.num_accounts_flushed.0,
                 i64
             ),
+            (
+                "slots_not_cleaned_due_to_scans",
+                flush_stats.slots_not_cleaned_due_to_scans.0,
+                i64
+            ),
             ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
             ("num_accounts_saved", flush_stats.num_accounts_purged.0, i64),
             (
@@ -6372,6 +6377,7 @@ impl AccountsDb {
         if should_flush_f.is_some() {
             if let Some(max_clean_root) = max_clean_root {
                 if slot > max_clean_root {
+                    flush_stats.slots_not_cleaned_due_to_scans += 1;
                     // Only if the root is greater than the `max_clean_root` do we
                     // have to prevent cleaning, otherwise, just default to `should_flush_f`
                     // for any slots <= `max_clean_root`

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -149,6 +149,7 @@ pub struct FlushStats {
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
     pub store_accounts_total_us: Saturating<u64>,
+    pub slots_not_cleaned_due_to_scans: Saturating<usize>,
 }
 
 impl FlushStats {
@@ -160,6 +161,7 @@ impl FlushStats {
         self.store_accounts_timing
             .accumulate(&other.store_accounts_timing);
         self.store_accounts_total_us += other.store_accounts_total_us;
+        self.slots_not_cleaned_due_to_scans += other.slots_not_cleaned_due_to_scans;
     }
 }
 


### PR DESCRIPTION
#### Problem
Write cache flush cleaning greatly reduces the size of storage files but is blocked if a scan is ongoing. The rate at which this occurs is unknown

#### Summary of Changes
Added counter to track the rate of write cache cleaning being blocked due to scans. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
