### PR TITLE
Serializes rent_epoch as u64::MAX in VM

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1024,7 +1024,7 @@ pub mod raise_block_limits_to_60m {
     solana_pubkey::declare_id!("6oMCUgfY6BzZ6jwB681J6ju5Bh6CjVXbd7NeWYqiXBSu");
 }
 
-pub mod rent_epoch_is_a_constant_in_vm {
+pub mod mask_out_rent_epoch_in_vm_serialization {
     solana_pubkey::declare_id!("RENtePQcDLrAbxAsP3k8dwVcnNYQ466hi2uKvALjnXx");
 }
 
@@ -1260,7 +1260,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (disable_partitioned_rent_collection::id(), "Disable partitioned rent collection SIMD-0175 #4562"),
         (enable_vote_address_leader_schedule::id(), "Enable vote address leader schedule SIMD-0180 #4573"),
         (raise_block_limits_to_60m::id(), "Raise block limit to 60M SIMD-0256"),
-        (rent_epoch_is_a_constant_in_vm::id(), "SIMD-0267: Sets rent_epoch to a constant in the VM"),
+        (mask_out_rent_epoch_in_vm_serialization::id(), "SIMD-0267: Sets rent_epoch to a constant in the VM"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1024,6 +1024,10 @@ pub mod raise_block_limits_to_60m {
     solana_pubkey::declare_id!("6oMCUgfY6BzZ6jwB681J6ju5Bh6CjVXbd7NeWYqiXBSu");
 }
 
+pub mod rent_epoch_is_a_constant_in_vm {
+    solana_pubkey::declare_id!("RENtePQcDLrAbxAsP3k8dwVcnNYQ466hi2uKvALjnXx");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1256,6 +1260,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (disable_partitioned_rent_collection::id(), "Disable partitioned rent collection SIMD-0175 #4562"),
         (enable_vote_address_leader_schedule::id(), "Enable vote address leader schedule SIMD-0180 #4573"),
         (raise_block_limits_to_60m::id(), "Raise block limit to 60M SIMD-0256"),
+        (rent_epoch_is_a_constant_in_vm::id(), "SIMD-0267: Sets rent_epoch to a constant in the VM"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -540,7 +540,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     invoke_context.push().unwrap();
     let rent_epoch_is_a_constant = invoke_context
         .get_feature_set()
-        .is_active(&agave_feature_set::rent_epoch_is_a_constant_in_vm::id());
+        .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
     let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,
         invoke_context

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -538,6 +538,9 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             &instruction_data,
         );
     invoke_context.push().unwrap();
+    let rent_epoch_is_a_constant = invoke_context
+        .get_feature_set()
+        .is_active(&agave_feature_set::rent_epoch_is_a_constant_in_vm::id());
     let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,
         invoke_context
@@ -545,6 +548,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         true, // copy_account_data
+        rent_epoch_is_a_constant,
     )
     .unwrap();
 

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -538,7 +538,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             &instruction_data,
         );
     invoke_context.push().unwrap();
-    let rent_epoch_is_a_constant = invoke_context
+    let mask_out_rent_epoch_in_vm_serialization = invoke_context
         .get_feature_set()
         .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
     let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
@@ -548,7 +548,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         true, // copy_account_data
-        rent_epoch_is_a_constant,
+        mask_out_rent_epoch_in_vm_serialization,
     )
     .unwrap();
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -189,6 +189,7 @@ pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     copy_account_data: bool,
+    rent_epoch_is_a_constant: bool,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -237,6 +238,7 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             copy_account_data,
+            rent_epoch_is_a_constant,
         )
     } else {
         serialize_parameters_aligned(
@@ -244,6 +246,7 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             copy_account_data,
+            rent_epoch_is_a_constant,
         )
     }
 }
@@ -284,6 +287,7 @@ fn serialize_parameters_unaligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     copy_account_data: bool,
+    rent_epoch_is_a_constant: bool,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -338,7 +342,12 @@ fn serialize_parameters_unaligned(
                 let vm_owner_addr = s.write_all(account.get_owner().as_ref());
                 #[allow(deprecated)]
                 s.write::<u8>(account.is_executable() as u8);
-                s.write::<u64>((account.get_rent_epoch()).to_le());
+                let rent_epoch = if rent_epoch_is_a_constant {
+                    u64::MAX
+                } else {
+                    account.get_rent_epoch()
+                };
+                s.write::<u64>(rent_epoch.to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
                     original_data_len: account.get_data().len(),
                     vm_key_addr,
@@ -417,6 +426,7 @@ fn serialize_parameters_aligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     copy_account_data: bool,
+    rent_epoch_is_a_constant: bool,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -474,7 +484,12 @@ fn serialize_parameters_aligned(
                 let vm_lamports_addr = s.write::<u64>(borrowed_account.get_lamports().to_le());
                 s.write::<u64>((borrowed_account.get_data().len() as u64).to_le());
                 let vm_data_addr = s.write_account(&mut borrowed_account)?;
-                s.write::<u64>((borrowed_account.get_rent_epoch()).to_le());
+                let rent_epoch = if rent_epoch_is_a_constant {
+                    u64::MAX
+                } else {
+                    borrowed_account.get_rent_epoch()
+                };
+                s.write::<u64>(rent_epoch.to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
                     original_data_len: borrowed_account.get_data().len(),
                     vm_key_addr,
@@ -750,6 +765,7 @@ mod tests {
                     invoke_context.transaction_context,
                     instruction_context,
                     copy_account_data,
+                    false,
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -893,6 +909,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
+                false,
             )
             .unwrap();
 
@@ -984,6 +1001,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
+                false,
             )
             .unwrap();
             let mut serialized_regions = concat_regions(&regions);
@@ -1035,6 +1053,177 @@ mod tests {
                     .try_borrow(index_in_transaction as IndexOfAccount)
                     .unwrap();
                 assert_eq!(&*account, original_account);
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize_parameters_rent_epoch_is_a_constant() {
+        for rent_epoch_is_a_constant in [false, true] {
+            let transaction_accounts = vec![
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 0,
+                        data: vec![],
+                        owner: bpf_loader::id(),
+                        executable: true,
+                        rent_epoch: 0,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 1,
+                        data: vec![1u8, 2, 3, 4, 5],
+                        owner: bpf_loader::id(),
+                        executable: false,
+                        rent_epoch: 100,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 2,
+                        data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
+                        owner: bpf_loader::id(),
+                        executable: true,
+                        rent_epoch: 200,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 3,
+                        data: vec![],
+                        owner: bpf_loader::id(),
+                        executable: false,
+                        rent_epoch: 300,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 4,
+                        data: vec![1u8, 2, 3, 4, 5],
+                        owner: bpf_loader::id(),
+                        executable: false,
+                        rent_epoch: 100,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 5,
+                        data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
+                        owner: bpf_loader::id(),
+                        executable: true,
+                        rent_epoch: 200,
+                    }),
+                ),
+                (
+                    solana_pubkey::new_rand(),
+                    AccountSharedData::from(Account {
+                        lamports: 6,
+                        data: vec![],
+                        owner: bpf_loader::id(),
+                        executable: false,
+                        rent_epoch: 3100,
+                    }),
+                ),
+            ];
+            let instruction_accounts =
+                deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
+            let instruction_data = vec![];
+            let program_indices = [0];
+            let mut original_accounts = transaction_accounts.clone();
+            with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+            invoke_context
+                .transaction_context
+                .get_next_instruction_context()
+                .unwrap()
+                .configure(&program_indices, &instruction_accounts, &instruction_data);
+            invoke_context.push().unwrap();
+            let instruction_context = invoke_context
+                .transaction_context
+                .get_current_instruction_context()
+                .unwrap();
+
+            // check serialize_parameters_aligned
+            let (_serialized, regions, _accounts_metadata) = serialize_parameters(
+                invoke_context.transaction_context,
+                instruction_context,
+                true,
+                rent_epoch_is_a_constant,
+            )
+            .unwrap();
+
+            let mut serialized_regions = concat_regions(&regions);
+            let (_de_program_id, de_accounts, _de_instruction_data) = unsafe {
+                deserialize(serialized_regions.as_slice_mut().first_mut().unwrap() as *mut u8)
+            };
+
+            for account_info in de_accounts {
+                let index_in_transaction = invoke_context
+                    .transaction_context
+                    .find_index_of_account(account_info.key)
+                    .unwrap();
+                let account = invoke_context
+                    .transaction_context
+                    .accounts()
+                    .try_borrow(index_in_transaction)
+                    .unwrap();
+                let expected_rent_epoch = if rent_epoch_is_a_constant {
+                    u64::MAX
+                } else {
+                    account.rent_epoch()
+                };
+                assert_eq!(expected_rent_epoch, account_info.rent_epoch);
+            }
+
+            // check serialize_parameters_unaligned
+            original_accounts
+                .first_mut()
+                .unwrap()
+                .1
+                .set_owner(bpf_loader_deprecated::id());
+            invoke_context
+                .transaction_context
+                .accounts()
+                .try_borrow_mut(0)
+                .unwrap()
+                .set_owner(bpf_loader_deprecated::id());
+
+            let (_serialized, regions, _account_lengths) = serialize_parameters(
+                invoke_context.transaction_context,
+                instruction_context,
+                true,
+                rent_epoch_is_a_constant,
+            )
+            .unwrap();
+            let mut serialized_regions = concat_regions(&regions);
+
+            let (_de_program_id, de_accounts, _de_instruction_data) = unsafe {
+                deserialize_unaligned(
+                    serialized_regions.as_slice_mut().first_mut().unwrap() as *mut u8
+                )
+            };
+            for account_info in de_accounts {
+                let index_in_transaction = invoke_context
+                    .transaction_context
+                    .find_index_of_account(account_info.key)
+                    .unwrap();
+                let account = invoke_context
+                    .transaction_context
+                    .accounts()
+                    .try_borrow(index_in_transaction)
+                    .unwrap();
+                let expected_rent_epoch = if rent_epoch_is_a_constant {
+                    u64::MAX
+                } else {
+                    account.rent_epoch()
+                };
+                assert_eq!(expected_rent_epoch, account_info.rent_epoch);
             }
         }
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -765,7 +765,7 @@ mod tests {
                     invoke_context.transaction_context,
                     instruction_context,
                     copy_account_data,
-                    false,
+                    false, // mask_out_rent_epoch_in_vm_serialization
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -909,7 +909,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                false,
+                false, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
 
@@ -1001,7 +1001,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                false,
+                false, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
             let mut serialized_regions = concat_regions(&regions);

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -765,7 +765,7 @@ mod tests {
                     invoke_context.transaction_context,
                     instruction_context,
                     copy_account_data,
-                    false, // mask_out_rent_epoch_in_vm_serialization
+                    true, // mask_out_rent_epoch_in_vm_serialization
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -805,7 +805,7 @@ mod tests {
                     assert_eq!(account.data(), &account_info.data.borrow()[..]);
                     assert_eq!(account.owner(), account_info.owner);
                     assert_eq!(account.executable(), account_info.executable);
-                    assert_eq!(account.rent_epoch(), account_info.rent_epoch);
+                    assert_eq!(u64::MAX, account_info.rent_epoch);
                 }
             }
         }
@@ -909,7 +909,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                false, // mask_out_rent_epoch_in_vm_serialization
+                true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
 
@@ -949,7 +949,7 @@ mod tests {
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
                 assert_eq!(account.executable(), account_info.executable);
-                assert_eq!(account.rent_epoch(), account_info.rent_epoch);
+                assert_eq!(u64::MAX, account_info.rent_epoch);
 
                 assert_eq!(
                     (*account_info.lamports.borrow() as *const u64).align_offset(BPF_ALIGN_OF_U128),
@@ -1001,7 +1001,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                false, // mask_out_rent_epoch_in_vm_serialization
+                true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
             let mut serialized_regions = concat_regions(&regions);
@@ -1033,7 +1033,7 @@ mod tests {
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
                 assert_eq!(account.executable(), account_info.executable);
-                assert_eq!(account.rent_epoch(), account_info.rent_epoch);
+                assert_eq!(u64::MAX, account_info.rent_epoch);
             }
 
             deserialize_parameters(

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -131,7 +131,7 @@ pub fn invoke_builtin_function(
     // Serialize entrypoint parameters with SBF ABI
     let rent_epoch_is_a_constant = invoke_context
         .get_feature_set()
-        .is_active(&agave_feature_set::rent_epoch_is_a_constant_in_vm::id());
+        .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -129,10 +129,14 @@ pub fn invoke_builtin_function(
     let deduplicated_indices: HashSet<IndexOfAccount> = instruction_account_indices.collect();
 
     // Serialize entrypoint parameters with SBF ABI
+    let rent_epoch_is_a_constant = invoke_context
+        .get_feature_set()
+        .is_active(&agave_feature_set::rent_epoch_is_a_constant_in_vm::id());
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
+        rent_epoch_is_a_constant,
     )?;
 
     // Deserialize data back into instruction params

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -129,14 +129,14 @@ pub fn invoke_builtin_function(
     let deduplicated_indices: HashSet<IndexOfAccount> = instruction_account_indices.collect();
 
     // Serialize entrypoint parameters with SBF ABI
-    let rent_epoch_is_a_constant = invoke_context
+    let mask_out_rent_epoch_in_vm_serialization = invoke_context
         .get_feature_set()
         .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
-        rent_epoch_is_a_constant,
+        mask_out_rent_epoch_in_vm_serialization,
     )?;
 
     // Deserialize data back into instruction params

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -121,8 +121,13 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
 
     c.bench_function("serialize_unaligned", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                false,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }
@@ -134,8 +139,13 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
         .unwrap();
     c.bench_function("serialize_unaligned_copy_account_data", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, true, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                true,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }
@@ -148,8 +158,13 @@ fn bench_serialize_aligned(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                false,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }
@@ -162,8 +177,13 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned_copy_account_data", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, true, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                true,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }
@@ -176,8 +196,13 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
 
     c.bench_function("serialize_unaligned_max_accounts", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                false,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }
@@ -190,8 +215,13 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned_max_accounts", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
-                .unwrap();
+            let _ = serialize_parameters(
+                &transaction_context,
+                instruction_context,
+                false,
+                true, // mask_out_rent_epoch_in_vm_serialization
+            )
+            .unwrap();
         });
     });
 }

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -121,7 +121,8 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
 
     c.bench_function("serialize_unaligned", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
+                .unwrap();
         });
     });
 }
@@ -133,7 +134,8 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
         .unwrap();
     c.bench_function("serialize_unaligned_copy_account_data", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, true, false)
+                .unwrap();
         });
     });
 }
@@ -146,7 +148,8 @@ fn bench_serialize_aligned(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
+                .unwrap();
         });
     });
 }
@@ -159,7 +162,8 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned_copy_account_data", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, true, false)
+                .unwrap();
         });
     });
 }
@@ -172,7 +176,8 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
 
     c.bench_function("serialize_unaligned_max_accounts", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
+                .unwrap();
         });
     });
 }
@@ -185,7 +190,8 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
 
     c.bench_function("serialize_aligned_max_accounts", |b| {
         b.iter(|| {
-            let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
+            let _ = serialize_parameters(&transaction_context, instruction_context, false, false)
+                .unwrap();
         });
     });
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1574,7 +1574,7 @@ fn execute<'a, 'b: 'a>(
     let direct_mapping = invoke_context
         .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
-    let rent_epoch_is_a_constant = invoke_context
+    let mask_out_rent_epoch_in_vm_serialization = invoke_context
         .get_feature_set()
         .is_active(&mask_out_rent_epoch_in_vm_serialization::id());
 
@@ -1583,7 +1583,7 @@ fn execute<'a, 'b: 'a>(
         invoke_context.transaction_context,
         instruction_context,
         !direct_mapping,
-        rent_epoch_is_a_constant,
+        mask_out_rent_epoch_in_vm_serialization,
     )?;
     serialize_time.stop();
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -8,7 +8,8 @@ use qualifier_attr::qualifiers;
 use {
     agave_feature_set::{
         bpf_account_data_direct_mapping, enable_bpf_loader_set_authority_checked_ix,
-        enable_loader_v4, remove_accounts_executable_flag_checks, rent_epoch_is_a_constant_in_vm,
+        enable_loader_v4, mask_out_rent_epoch_in_vm_serialization,
+        remove_accounts_executable_flag_checks,
     },
     solana_account::WritableAccount,
     solana_bincode::limited_deserialize,
@@ -1575,7 +1576,7 @@ fn execute<'a, 'b: 'a>(
         .is_active(&bpf_account_data_direct_mapping::id());
     let rent_epoch_is_a_constant = invoke_context
         .get_feature_set()
-        .is_active(&rent_epoch_is_a_constant_in_vm::id());
+        .is_active(&mask_out_rent_epoch_in_vm_serialization::id());
 
     let mut serialize_time = Measure::start("serialize");
     let (parameter_bytes, regions, accounts_metadata) = serialization::serialize_parameters(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -8,7 +8,7 @@ use qualifier_attr::qualifiers;
 use {
     agave_feature_set::{
         bpf_account_data_direct_mapping, enable_bpf_loader_set_authority_checked_ix,
-        enable_loader_v4, remove_accounts_executable_flag_checks,
+        enable_loader_v4, remove_accounts_executable_flag_checks, rent_epoch_is_a_constant_in_vm,
     },
     solana_account::WritableAccount,
     solana_bincode::limited_deserialize,
@@ -1573,12 +1573,16 @@ fn execute<'a, 'b: 'a>(
     let direct_mapping = invoke_context
         .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
+    let rent_epoch_is_a_constant = invoke_context
+        .get_feature_set()
+        .is_active(&rent_epoch_is_a_constant_in_vm::id());
 
     let mut serialize_time = Measure::start("serialize");
     let (parameter_bytes, regions, accounts_metadata) = serialization::serialize_parameters(
         invoke_context.transaction_context,
         instruction_context,
         !direct_mapping,
+        rent_epoch_is_a_constant,
     )?;
     serialize_time.stop();
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -255,7 +255,8 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        !direct_mapping, // copy_account_data,
+        !direct_mapping, // copy_account_data
+        false,
     )
     .unwrap();
 
@@ -290,6 +291,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data
+        false,
     )
     .unwrap();
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -256,7 +256,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data
-        false,
+        true,            // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 
@@ -291,7 +291,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data
-        false,
+        true,            // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 


### PR DESCRIPTION
#### Problem

Implements SIMD-267[^1].

[^1]: https://github.com/solana-foundation/solana-improvement-documents/pull/267


#### Summary of Changes

Serializes rent_epoch as u64::MAX in the VM.