### PR TITLE
SIMD-0242: Static Nonce Account Only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10438,6 +10438,7 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction",
  "static_assertions",
+ "test-case",
 ]
 
 [[package]]

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -209,6 +209,10 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
         core::iter::empty()
     }
 
+    fn static_account_keys(&self) -> &[Pubkey] {
+        &self.0
+    }
+
     fn account_keys(&self) -> solana_message::AccountKeys {
         solana_message::AccountKeys::new(&self.0, None)
     }

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1028,6 +1028,10 @@ pub mod enable_vote_address_leader_schedule {
     solana_pubkey::declare_id!("5JsG4NWH8Jbrqdd8uL6BNwnyZK3dQSoieRXG5vmofj9y");
 }
 
+pub mod require_static_nonce_account {
+    solana_pubkey::declare_id!("7VVhpg5oAjAmnmz1zCcSHb2Z9ecZB2FQqpnEwReka9Zm");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1260,6 +1264,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (create_slashing_program::id(), "creates an enshrined slashing program SIMD-0204"),
         (disable_partitioned_rent_collection::id(), "Disable partitioned rent collection SIMD-0175 #4562"),
         (enable_vote_address_leader_schedule::id(), "Enable vote address leader schedule SIMD-0180 #4573"),
+        (require_static_nonce_account::id(), "SIMD-0242: Static Nonce Account Only"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -103,6 +103,10 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
         self.transaction.program_instructions_iter()
     }
 
+    fn static_account_keys(&self) -> &[Pubkey] {
+        self.transaction.static_account_keys()
+    }
+
     fn account_keys(&self) -> AccountKeys {
         self.transaction.account_keys()
     }

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -237,7 +237,10 @@ impl Bank {
         &self,
         message: &impl SVMMessage,
     ) -> Option<(Pubkey, AccountSharedData, NonceData)> {
-        let nonce_address = message.get_durable_nonce()?;
+        let require_static_nonce_account = self
+            .feature_set
+            .is_active(&agave_feature_set::require_static_nonce_account::id());
+        let nonce_address = message.get_durable_nonce(require_static_nonce_account)?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
         let nonce_data =
             nonce_account::verify_nonce_account(&nonce_account, message.recent_blockhash())?;
@@ -300,8 +303,20 @@ mod tests {
             setup_nonce_with_bank,
         },
         solana_sdk::{
-            hash::Hash, message::Message, signature::Keypair, signer::Signer, system_instruction,
+            hash::Hash,
+            instruction::CompiledInstruction,
+            message::{
+                v0::{self, LoadedAddresses, MessageAddressTableLookup},
+                Message, MessageHeader, SanitizedMessage, SanitizedVersionedMessage,
+                SimpleAddressLoader, VersionedMessage,
+            },
+            signature::Keypair,
+            signer::Signer,
+            system_instruction::{self, SystemInstruction},
+            system_program,
         },
+        std::collections::HashSet,
+        test_case::test_case,
     };
 
     #[test]
@@ -491,8 +506,79 @@ mod tests {
             .check_load_and_advance_message_nonce_account(
                 &message,
                 &bank.next_durable_nonce(),
-                lamports_per_signature
+                lamports_per_signature,
             )
             .is_none());
+    }
+
+    #[test_case(true; "test_check_and_load_message_nonce_account_nonce_is_alt_disallowed")]
+    #[test_case(false; "test_check_and_load_message_nonce_account_nonce_is_alt_allowed")]
+    fn test_check_and_load_message_nonce_account_nonce_is_alt(require_static_nonce_account: bool) {
+        let feature_set = if require_static_nonce_account {
+            FeatureSet::all_enabled()
+        } else {
+            FeatureSet::default()
+        };
+        let nonce_authority = Pubkey::new_unique();
+        let (bank, _mint_keypair, _custodian_keypair, nonce_keypair, _) = setup_nonce_with_bank(
+            10_000_000,
+            |_| {},
+            5_000_000,
+            250_000,
+            Some(nonce_authority),
+            feature_set,
+        )
+        .unwrap();
+
+        let nonce_pubkey = nonce_keypair.pubkey();
+        let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
+        let loaded_addresses = LoadedAddresses {
+            writable: vec![nonce_pubkey],
+            readonly: vec![],
+        };
+
+        let message = SanitizedMessage::try_new(
+            SanitizedVersionedMessage::try_new(VersionedMessage::V0(v0::Message {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                account_keys: vec![nonce_authority, system_program::id()],
+                recent_blockhash: nonce_hash,
+                instructions: vec![CompiledInstruction::new(
+                    1, // index of system program
+                    &SystemInstruction::AdvanceNonceAccount,
+                    vec![
+                        2, // index of alt nonce account
+                        0, // index of nonce_authority
+                    ],
+                )],
+                address_table_lookups: vec![MessageAddressTableLookup {
+                    account_key: Pubkey::new_unique(),
+                    writable_indexes: (0..loaded_addresses.writable.len())
+                        .map(|x| x as u8)
+                        .collect(),
+                    readonly_indexes: (0..loaded_addresses.readonly.len())
+                        .map(|x| (loaded_addresses.writable.len() + x) as u8)
+                        .collect(),
+                }],
+            }))
+            .unwrap(),
+            SimpleAddressLoader::Enabled(loaded_addresses),
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        let (_, lamports_per_signature) = bank.last_blockhash_and_lamports_per_signature();
+        assert_eq!(
+            bank.check_load_and_advance_message_nonce_account(
+                &message,
+                &bank.next_durable_nonce(),
+                lamports_per_signature
+            )
+            .is_none(),
+            require_static_nonce_account,
+        );
     }
 }

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -22,3 +22,4 @@ solana-message = { workspace = true, features = ["bincode"] }
 solana-nonce = { workspace = true }
 solana-system-interface = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -37,6 +37,10 @@ impl SVMMessage for SanitizedMessage {
             .map(|(pubkey, ix)| (pubkey, SVMInstruction::from(ix)))
     }
 
+    fn static_account_keys(&self) -> &[Pubkey] {
+        SanitizedMessage::static_account_keys(self)
+    }
+
     fn account_keys(&self) -> AccountKeys {
         SanitizedMessage::account_keys(self)
     }

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -34,6 +34,10 @@ impl SVMMessage for SanitizedTransaction {
         SVMMessage::program_instructions_iter(SanitizedTransaction::message(self))
     }
 
+    fn static_account_keys(&self) -> &[Pubkey] {
+        SVMMessage::static_account_keys(SanitizedTransaction::message(self))
+    }
+
     fn account_keys(&self) -> AccountKeys {
         SVMMessage::account_keys(SanitizedTransaction::message(self))
     }

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![allow(clippy::arithmetic_side_effects)]
 use {
     crate::svm_message::SVMMessage,
     solana_hash::Hash,
@@ -30,8 +29,10 @@ fn test_get_durable_nonce(require_static_nonce_account: bool) {
         let header = MessageHeader {
             num_required_signatures: num_signers,
             num_readonly_signed_accounts: 0,
-            num_readonly_unsigned_accounts: u8::try_from(account_keys.len()).unwrap()
-                - num_writable,
+            num_readonly_unsigned_accounts: u8::try_from(account_keys.len())
+                .unwrap()
+                .checked_sub(num_writable)
+                .unwrap(),
         };
         let (versioned_message, loader) = match loaded_addresses {
             None => (
@@ -55,7 +56,7 @@ fn test_get_durable_nonce(require_static_nonce_account: bool) {
                             .map(|x| x as u8)
                             .collect(),
                         readonly_indexes: (0..loaded_addresses.readonly.len())
-                            .map(|x| (loaded_addresses.writable.len() + x) as u8)
+                            .map(|x| loaded_addresses.writable.len().saturating_add(x) as u8)
                             .collect(),
                     }],
                 }),

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -183,6 +183,10 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
         self.view.program_instructions_iter()
     }
 
+    fn static_account_keys(&self) -> &[Pubkey] {
+        self.view.static_account_keys()
+    }
+
     fn account_keys(&self) -> AccountKeys {
         AccountKeys::new(
             self.view.static_account_keys(),


### PR DESCRIPTION
#### Problem
Durable nonce transactions were unintentionally allowed to load their nonce accounts from address lookup tables rather than restricted to being a static account.

#### Summary of Changes
Implement [SIMD-0242](https://github.com/solana-foundation/solana-improvement-documents/pull/242) by adding a feature gate to start requiring nonces to be static

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
