### PR TITLE
bpf-loader: syscalls: move morph env helper into loader root

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -310,28 +310,6 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub(crate) fn morph_into_deployment_environment_v1(
-    from: Arc<BuiltinProgram<InvokeContext>>,
-) -> Result<BuiltinProgram<InvokeContext>, Error> {
-    let mut config = from.get_config().clone();
-    config.reject_broken_elfs = true;
-    // Once the tests are being build using a toolchain which supports the newer SBPF versions,
-    // the deployment of older versions will be disabled:
-    // config.enabled_sbpf_versions =
-    //     *config.enabled_sbpf_versions.end()..=*config.enabled_sbpf_versions.end();
-
-    let mut result = BuiltinProgram::new_loader(config);
-
-    for (_key, (name, value)) in from.get_function_registry().iter() {
-        // Deployment of programs with sol_alloc_free is disabled. So do not register the syscall.
-        if name != *b"sol_alloc_free_" {
-            result.register_function(unsafe { std::str::from_utf8_unchecked(name) }, value)?;
-        }
-    }
-
-    Ok(result)
-}
-
 pub fn create_program_runtime_environment_v1<'a>(
     feature_set: &FeatureSet,
     compute_budget: &SVMTransactionExecutionBudget,


### PR DESCRIPTION
#### Problem
The `morph_into_deployment_environment_v1` function is only used by the BPF loader, and its intention is specific to the loader's ELF verification step. As part of a broader refactor of the BPF Loader crate - with the goal of splitting syscalls into their own library - this helper can be included in the loader's root module.

#### Summary of Changes
Move the `morph_into_deployment_environment_v1` into the loader's root module.