### PR TITLE
precompiles: Add benches from the sdk

### DIFF
--- a/ci/bench/part2.sh
+++ b/ci/bench/part2.sh
@@ -28,3 +28,6 @@ _ cargo +"$rust_nightly" run --release --manifest-path accounts-bench/Cargo.toml
 
 # Run zk-elgamal-proof benches.
 _ cargo +"$rust_nightly" bench --manifest-path programs/zk-elgamal-proof/Cargo.toml ${V:+--verbose} | tee -a "$BENCH_FILE"
+
+# Run precompile benches.
+_ cargo +"$rust_nightly" bench --manifest-path precompiles/Cargo.toml ${V:+--verbose} | tee -a "$BENCH_FILE"

--- a/precompiles/benches/ed25519_instructions.rs
+++ b/precompiles/benches/ed25519_instructions.rs
@@ -1,0 +1,71 @@
+#![feature(test)]
+
+extern crate test;
+use {
+    agave_feature_set::FeatureSet,
+    agave_precompiles::ed25519::verify,
+    rand0_7::{thread_rng, Rng},
+    solana_ed25519_program::new_ed25519_instruction,
+    solana_instruction::Instruction,
+    test::Bencher,
+};
+
+// 5K instructions should be enough for benching loop
+const IX_COUNT: u16 = 5120;
+
+// prepare a bunch of unique txs
+fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
+    (0..IX_COUNT)
+        .map(|_| {
+            let mut rng = thread_rng();
+            let privkey = ed25519_dalek::Keypair::generate(&mut rng);
+            let message: Vec<u8> = (0..message_length).map(|_| rng.gen_range(0, 255)).collect();
+            new_ed25519_instruction(&privkey, &message)
+        })
+        .collect()
+}
+
+#[bench]
+fn bench_ed25519_len_032(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_ed25519_len_128(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(128);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_ed25519_len_32k(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32 * 1024);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_ed25519_len_max(b: &mut Bencher) {
+    let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(u16::MAX - required_extra_space);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}

--- a/precompiles/benches/secp256k1_instructions.rs
+++ b/precompiles/benches/secp256k1_instructions.rs
@@ -1,0 +1,71 @@
+#![feature(test)]
+
+extern crate test;
+use {
+    agave_feature_set::FeatureSet,
+    agave_precompiles::secp256k1::verify,
+    rand0_7::{thread_rng, Rng},
+    solana_instruction::Instruction,
+    solana_secp256k1_program::new_secp256k1_instruction,
+    test::Bencher,
+};
+
+// 5K transactions should be enough for benching loop
+const TX_COUNT: u16 = 5120;
+
+// prepare a bunch of unique ixs
+fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
+    (0..TX_COUNT)
+        .map(|_| {
+            let mut rng = thread_rng();
+            let secp_privkey = libsecp256k1::SecretKey::random(&mut thread_rng());
+            let message: Vec<u8> = (0..message_length).map(|_| rng.gen_range(0, 255)).collect();
+            new_secp256k1_instruction(&secp_privkey, &message)
+        })
+        .collect()
+}
+
+#[bench]
+fn bench_secp256k1_len_032(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256k1_len_256(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(256);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256k1_len_32k(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32 * 1024);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256k1_len_max(b: &mut Bencher) {
+    let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(u16::MAX - required_extra_space);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}

--- a/precompiles/benches/secp256r1_instructions.rs
+++ b/precompiles/benches/secp256r1_instructions.rs
@@ -1,0 +1,76 @@
+#![feature(test)]
+
+extern crate test;
+use {
+    agave_feature_set::FeatureSet,
+    agave_precompiles::secp256r1::verify,
+    openssl::{
+        ec::{EcGroup, EcKey},
+        nid::Nid,
+    },
+    rand0_7::{thread_rng, Rng},
+    solana_instruction::Instruction,
+    solana_secp256r1_program::new_secp256r1_instruction,
+    test::Bencher,
+};
+
+// 5k transactions should be enough for benching loop
+const TX_COUNT: u16 = 5120;
+
+// prepare a bunch of unique ixs
+fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
+    (0..TX_COUNT)
+        .map(|_| {
+            let mut rng = thread_rng();
+            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+            let secp_privkey = EcKey::generate(&group).unwrap();
+            let message: Vec<u8> = (0..message_length).map(|_| rng.gen_range(0, 255)).collect();
+            new_secp256r1_instruction(&message, secp_privkey).unwrap()
+        })
+        .collect()
+}
+
+#[bench]
+fn bench_secp256r1_len_032(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_256(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(256);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_32k(b: &mut Bencher) {
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(32 * 1024);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}
+
+#[bench]
+fn bench_secp256r1_len_max(b: &mut Bencher) {
+    let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
+    let feature_set = FeatureSet::all_enabled();
+    let ixs = create_test_instructions(u16::MAX - required_extra_space);
+    let mut ix_iter = ixs.iter().cycle();
+    b.iter(|| {
+        let instruction = ix_iter.next().unwrap();
+        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    });
+}


### PR DESCRIPTION
#### Problem

The precompiles are being deprecated from the sdk repo, but the benches haven't been moved over.

#### Summary of changes

Port over all of the benches from the sdk.

Note that because the `verify_precompiles` function will be removed from `Transaction`, these benches were updated to use instructions instead of transactions, and calling each precompile's individual `verify` function with the created instruction data directly.

These benches give almost exactly the same results as the previous ones.