### PR TITLE
Moves shrink in with flush, clean, and squash

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -622,22 +622,16 @@ impl AccountsBackgroundService {
                                     break;
                                 }
                             }
-                        } else {
-                            if bank.block_height() - last_cleaned_block_height
-                                > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0..10))
-                            {
-                                // Note that the flush will do an internal clean of the
-                                // cache up to bank.slot(), so should be safe as long
-                                // as any later snapshots that are taken are of
-                                // slots >= bank.slot()
-                                bank.force_flush_accounts_cache();
-                                bank.clean_accounts();
-                                last_cleaned_block_height = bank.block_height();
-                                // See justification below for why we skip 'shrink' here.
-                                if bank.is_startup_verification_complete() {
-                                    bank.shrink_ancient_slots();
-                                }
-                            }
+                        } else if bank.block_height() - last_cleaned_block_height
+                            > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0..10))
+                        {
+                            // Note that the flush will do an internal clean of the
+                            // cache up to bank.slot(), so should be safe as long
+                            // as any later snapshots that are taken are of
+                            // slots >= bank.slot()
+                            bank.force_flush_accounts_cache();
+                            bank.clean_accounts();
+                            last_cleaned_block_height = bank.block_height();
                             // Do not 'shrink' until *after* the startup verification is complete.
                             // This is because startup verification needs to get the snapshot
                             // storages *as they existed at startup* (to calculate the accounts
@@ -646,6 +640,7 @@ impl AccountsBackgroundService {
                             // shrinking is not in progress, or (2) could get snapshot storages
                             // that were newer than what was in the snapshot itself.
                             if bank.is_startup_verification_complete() {
+                                bank.shrink_ancient_slots();
                                 bank.shrink_candidate_slots();
                             }
                         }


### PR DESCRIPTION
#### Problem

In AccountsBackgroundService, when a snapshot request is not handled then flush/clean/shrink may run, depending on the `last_cleaned_block_height`. Interestingly, `shrink_candidate_slots()` was *always* called. This seems to be the case even going back to https://github.com/solana-labs/solana/pull/13140, the PR that introduced this originally. I don't believe that we should be running `shrink` more often than the other background tasks.

#### Summary of Changes

Move `shrink` into the same `if` block that checks when the last time they were run.

