### PR TITLE
tpu-client-next: introduce `ForwardingClient` trait in `ForwardingStage`

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -130,13 +130,12 @@ impl ForwardingClient for VoteClient {
     }
 
     fn send_transactions_in_batch(&self, wire_transactions: Vec<Vec<u8>>) {
-        assert!(
-            self.current_address.is_some(),
-            "current_address should be updated before send_batch call."
-        );
+        let Some(current_address) = self.current_address else {
+            panic!("current_address should be updated before send_batch call");
+        };
         let batch_with_addresses = wire_transactions
             .iter()
-            .map(|bytes| (bytes, self.current_address.unwrap()));
+            .map(|bytes| (bytes, current_address));
         let _res = batch_send(&self.udp_socket, batch_with_addresses);
     }
 }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -374,7 +374,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
 
             if packet.meta().is_simple_vote_tx() {
                 vote_batch.push(packet_data_vec);
-                if vote_batch.len() == vote_batch.capacity() {
+                if vote_batch.len() == FORWARD_BATCH_SIZE {
                     self.metrics.votes_forwarded += vote_batch.len();
 
                     let mut batch = Vec::with_capacity(FORWARD_BATCH_SIZE);
@@ -383,7 +383,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                 }
             } else {
                 non_vote_batch.push(packet_data_vec);
-                if non_vote_batch.len() == non_vote_batch.capacity() {
+                if non_vote_batch.len() == FORWARD_BATCH_SIZE {
                     self.metrics.non_votes_forwarded += non_vote_batch.len();
 
                     let mut batch = Vec::with_capacity(FORWARD_BATCH_SIZE);

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -48,7 +48,10 @@ const FORWARD_BATCH_SIZE: usize = 128;
 /// This lookahead is needed because the immediate next leader might not have
 /// shared their forwarding ports. In such cases, we skip them and attempt to
 /// forward to the next available leader (up to this limit).
-const NUM_LOOKAHEAD_LEADERS: u64 = 2;
+///
+/// The value is chosen to ensure that the likelihood of the same leader occupying
+/// all lookahead slots is negligible.
+const NUM_LOOKAHEAD_LEADERS: u64 = 3;
 
 /// [`ForwardAddressGetter`] provides helper methods for retrieving forwarding
 /// addresses for both vote and non-vote transactions.

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -6,9 +6,8 @@ use {
         contact_info::{ContactInfoQuery, Protocol},
     },
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{
-        clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS},
-        pubkey::Pubkey,
+    solana_sdk::clock::{
+        FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS,
     },
     std::{net::SocketAddr, sync::RwLock},
 };
@@ -39,35 +38,12 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .collect()
 }
 
-pub(crate) fn next_leader_tpu_vote(
-    cluster_info: &impl LikeClusterInfo,
-    poh_recorder: &RwLock<PohRecorder>,
-) -> Option<(Pubkey, SocketAddr)> {
-    next_leader(cluster_info, poh_recorder, |node| {
-        node.tpu_vote(Protocol::UDP)
-    })
-}
-
-pub(crate) fn next_leader(
-    cluster_info: &impl LikeClusterInfo,
-    poh_recorder: &RwLock<PohRecorder>,
-    port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
-) -> Option<(Pubkey, SocketAddr)> {
-    let leader_pubkey = poh_recorder
-        .read()
-        .unwrap()
-        .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET)?;
-    cluster_info
-        .lookup_contact_info(&leader_pubkey, port_selector)?
-        .map(|addr| (leader_pubkey, addr))
-}
-
 pub(crate) fn next_leaders(
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &RwLock<PohRecorder>,
     max_count: u64,
     port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
-) -> Vec<Option<SocketAddr>> {
+) -> Vec<SocketAddr> {
     let recorder = poh_recorder.read().unwrap();
     let leader_pubkeys: Vec<_> = (0..max_count)
         .filter_map(|i| {
@@ -80,6 +56,8 @@ pub(crate) fn next_leaders(
 
     leader_pubkeys
         .iter()
-        .map(|leader_pubkey| cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?)
+        .filter_map(|leader_pubkey| {
+            cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?
+        })
         .collect()
 }

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -6,7 +6,10 @@ use {
         contact_info::{ContactInfoQuery, Protocol},
     },
     solana_poh::poh_recorder::PohRecorder,
-    solana_sdk::{clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, pubkey::Pubkey},
+    solana_sdk::{
+        clock::{FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, NUM_CONSECUTIVE_LEADER_SLOTS},
+        pubkey::Pubkey,
+    },
     std::{net::SocketAddr, sync::RwLock},
 };
 
@@ -57,4 +60,26 @@ pub(crate) fn next_leader(
     cluster_info
         .lookup_contact_info(&leader_pubkey, port_selector)?
         .map(|addr| (leader_pubkey, addr))
+}
+
+pub(crate) fn next_leaders(
+    cluster_info: &impl LikeClusterInfo,
+    poh_recorder: &RwLock<PohRecorder>,
+    max_count: u64,
+    port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
+) -> Vec<Option<SocketAddr>> {
+    let recorder = poh_recorder.read().unwrap();
+    let leader_pubkeys: Vec<_> = (0..max_count)
+        .filter_map(|i| {
+            recorder.leader_after_n_slots(
+                FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET + i * NUM_CONSECUTIVE_LEADER_SLOTS,
+            )
+        })
+        .collect();
+    drop(recorder);
+
+    leader_pubkeys
+        .iter()
+        .map(|leader_pubkey| cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?)
+        .collect()
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -17,7 +17,7 @@ use {
             VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
-        forwarding_stage::ForwardingStage,
+        forwarding_stage::{spawn_forwarding_stage, ForwardAddressGetter},
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -280,11 +280,11 @@ impl Tpu {
             prioritization_fee_cache,
         );
 
-        let forwarding_stage = ForwardingStage::spawn(
+        let forwarding_stage = spawn_forwarding_stage(
             forward_stage_receiver,
             connection_cache.clone(),
             RootBankCache::new(bank_forks.clone()),
-            (cluster_info.clone(), poh_recorder.clone()),
+            ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),
             DataBudget::default(),
         );
 


### PR DESCRIPTION
#### Problem

With current implementation of `ForwardingStage<F: ForwardingAddressGetter>` it is hard to add another client in addition to `ConnectionCache`. It is cumbersome to implement tests with `ForwardingAddressGetter`.

 
#### Summary of Changes

This PR introduces a new trait `ForwardingClient`, provides implementations of this crate for `ConnectionCacheClient` (wraps `ConnectionCache`) along with for `VoteClient`. This way we can get rid of `ForwardingAddressGetter` trait used everywhere, simplify tests by using `MockClient` and reducing the public interface of  forwarding stage.

Beside of that, this PR also introduces change in the way we fetch next leaders to forward transactions:
* Old behavior: if we don't have contact info for leader, skip sending (so the packet queue is growing)
* New behavior: we try to get contact info for leaders of the next 12 slots and if none has this info, skip sending.

This is the first part of https://github.com/anza-xyz/agave/pull/5278
