### PR TITLE
refactor: wen-restart combine snapshot config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11244,6 +11244,7 @@ version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "crossbeam-channel",
  "log",
  "prost",
  "prost-build",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1554,7 +1554,6 @@ impl Validator {
                 wen_restart_repair_slots: wen_restart_repair_slots.clone(),
                 wait_for_supermajority_threshold_percent:
                     WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT,
-                snapshot_config: config.snapshot_config.clone(),
                 snapshot_controller: Some(snapshot_controller.clone()),
                 abs_status: accounts_background_service.status().clone(),
                 genesis_config_hash: genesis_config.hash(),

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -32,6 +32,7 @@ solana-vote-program = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+crossbeam-channel = { workspace = true }
 rand = { workspace = true }
 serial_test = { workspace = true }
 solana-accounts-db = { workspace = true }


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/agave/pull/5397, wen-restart no longer needs to separately manage a snapshot config since it can get that from the snapshot controller.

#### Summary of Changes
Remove extra reference to snapshot config and use the config from the snapshot controller

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
