### PR TITLE
ci: ignore flaky test_kill_heaviest_partition test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3771,6 +3771,7 @@ fn test_fork_choice_refresh_old_votes() {
 
 #[test]
 #[serial]
+#[ignore]
 fn test_kill_heaviest_partition() {
     // This test:
     // 1) Spins up four partitions, the heaviest being the first with more stake


### PR DESCRIPTION
#### Problem
`test_kill_heaviest_partition` became flaky recently

#### Summary of Changes
Temporarily ignore while investigating

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
