### PR TITLE
Bump solana-vote-interface to v2.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11173,9 +11173,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9f6a1651310a94cd5a1a6b7f33ade01d9e5ea38a2220becb5fd737b756514"
+checksum = "6b630547b7f12ee742e1c5069951fedba0fe5cbd4786f6342a779384e2b11f71"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,7 +559,7 @@ solana-udp-client = { path = "udp-client", version = "=2.3.0" }
 solana-validator-exit = "=2.2.1"
 solana-version = { path = "version", version = "=2.3.0" }
 solana-vote = { path = "vote", version = "=2.3.0" }
-solana-vote-interface = "=2.2.2"
+solana-vote-interface = "=2.2.3"
 solana-vote-program = { path = "programs/vote", version = "=2.3.0", default-features = false }
 solana-wen-restart = { path = "wen-restart", version = "=2.3.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.3.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9255,9 +9255,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9f6a1651310a94cd5a1a6b7f33ade01d9e5ea38a2220becb5fd737b756514"
+checksum = "6b630547b7f12ee742e1c5069951fedba0fe5cbd4786f6342a779384e2b11f71"
 dependencies = [
  "bincode",
  "num-derive",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8593,9 +8593,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9f6a1651310a94cd5a1a6b7f33ade01d9e5ea38a2220becb5fd737b756514"
+checksum = "6b630547b7f12ee742e1c5069951fedba0fe5cbd4786f6342a779384e2b11f71"
 dependencies = [
  "bincode",
  "num-derive",


### PR DESCRIPTION
#### Problem
Firedancer's fuzzing framework has to special case handling of `VoteState::lockout` because it is allowed to overflow. This can't happen on a normal cluster.

#### Summary of Changes
Bring in a fix for `solana-vote-interface` which prevents `VoteState::lockout` from overflowing: https://github.com/anza-xyz/solana-sdk/pull/92


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
