### PR TITLE
Bump timeout for test_kill_heaviest_partition

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3771,7 +3771,6 @@ fn test_fork_choice_refresh_old_votes() {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_kill_heaviest_partition() {
     // This test:
     // 1) Spins up four partitions, the heaviest being the first with more stake

--- a/nextest.toml
+++ b/nextest.toml
@@ -62,6 +62,10 @@ filter = 'package(solana-local-cluster) & test(/^test_slot_hash_expiry$/)'
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.ci.overrides]]
+filter = 'package(solana-local-cluster) & test(/^test_kill_heaviest_partition$/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
 filter = 'package(solana-local-cluster) & test(/^test_boot_from_local_state$/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 


### PR DESCRIPTION
#### Problem
test_kill_heaviest_partition rarely finishes within 2min now. Running locally shows it take just under 3min

#### Summary of Changes
- Bump timeout to 4min
- Un-ignore test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
