### PR TITLE
Moves waiting for the EpochAccountsHash from AccountsBackgroundService to AccountsHashVerifier

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6883,15 +6883,19 @@ impl Bank {
         total_accounts_stats
     }
 
+    /// Must a snapshot of this bank include the EAH?
+    pub fn must_include_epoch_accounts_hash_in_snapshot(&self) -> bool {
+        epoch_accounts_hash_utils::is_enabled_this_epoch(self)
+            && epoch_accounts_hash_utils::is_in_calculation_window(self)
+    }
+
     /// Get the EAH that will be used by snapshots
     ///
     /// Since snapshots are taken on roots, if the bank is in the EAH calculation window then an
     /// EAH *must* be included.  This means if an EAH calculation is currently in-flight we will
     /// wait for it to complete.
     pub fn get_epoch_accounts_hash_to_serialize(&self) -> Option<EpochAccountsHash> {
-        let should_get_epoch_accounts_hash = epoch_accounts_hash_utils::is_enabled_this_epoch(self)
-            && epoch_accounts_hash_utils::is_in_calculation_window(self);
-        if !should_get_epoch_accounts_hash {
+        if !self.must_include_epoch_accounts_hash_in_snapshot() {
             return None;
         }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -96,7 +96,8 @@ impl AccountsPackage {
                 bank_fields_to_serialize,
                 bank_hash_stats,
                 accounts_delta_hash,
-                epoch_accounts_hash: bank.get_epoch_accounts_hash_to_serialize(),
+                must_include_epoch_accounts_hash: bank
+                    .must_include_epoch_accounts_hash_in_snapshot(),
                 write_version,
             }
         };
@@ -182,7 +183,7 @@ impl AccountsPackage {
                 bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
                 bank_hash_stats: BankHashStats::default(),
                 accounts_delta_hash: AccountsDeltaHash(Hash::default()),
-                epoch_accounts_hash: Option::default(),
+                must_include_epoch_accounts_hash: false,
                 write_version: StoredMetaWriteVersion::default(),
             }),
             enqueued: Instant::now(),
@@ -207,7 +208,7 @@ pub struct SupplementalSnapshotInfo {
     pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
     pub accounts_delta_hash: AccountsDeltaHash,
-    pub epoch_accounts_hash: Option<EpochAccountsHash>,
+    pub must_include_epoch_accounts_hash: bool,
     pub write_version: StoredMetaWriteVersion,
 }
 
@@ -280,13 +281,27 @@ impl SnapshotPackage {
             }
         };
 
+        let epoch_accounts_hash = snapshot_info.must_include_epoch_accounts_hash.then(|| {
+            // If we were told we must include the EAH in the snapshot, go retrieve it now.
+            // SAFETY: Snapshot handling happens sequentially, and EAH requests must be handled
+            // prior to snapshot requests for higher slots.  Therefore, a snapshot for a slot
+            // in the EAH calculation window is guaranteed to have been handled by AHV after the
+            // EAH request.  This guarantees the EAH calc has completed prior to here.
+            accounts_package
+                .accounts
+                .accounts_db
+                .epoch_accounts_hash_manager
+                .try_get_epoch_accounts_hash()
+                .unwrap()
+        });
+
         Self {
             snapshot_kind: kind,
             slot: accounts_package.slot,
             block_height: accounts_package.block_height,
             hash: SnapshotHash::new(
                 &merkle_or_lattice_accounts_hash,
-                snapshot_info.epoch_accounts_hash.as_ref(),
+                epoch_accounts_hash.as_ref(),
                 snapshot_info
                     .bank_fields_to_serialize
                     .accounts_lt_hash
@@ -299,7 +314,7 @@ impl SnapshotPackage {
             accounts_delta_hash: snapshot_info.accounts_delta_hash,
             bank_hash_stats: snapshot_info.bank_hash_stats,
             accounts_hash,
-            epoch_accounts_hash: snapshot_info.epoch_accounts_hash,
+            epoch_accounts_hash,
             bank_incremental_snapshot_persistence,
             write_version: snapshot_info.write_version,
             enqueued: Instant::now(),


### PR DESCRIPTION
#### Problem

When taking a snapshot in the *epoch accounts hash calculation window*[^1], the snapshot must include the EAH (the result of the calculation). Consider the following scenario:

* Assume there are 400 slots per epoch. The EAH calculation window starts at slot 100 and ends at slot 300.
* And EAH calculation request gets sent for slot 100
* While the EAH calculation is in-flight, a snapshot request comes in for slot 110
* AccountsBackgroundService begins handling the snapshot request and sees the slot is within the EAH calculation window. It then blocks until the EAH calculation completes.
* While ABS is blocked waiting for the EAH to complete, that also means the other ABS background tasks (`flush`, `clean`, `shrink`, etc) are blocked. 
* On mnb, the EAH calc can take 20+ minutes. This is 20+ minutes where the accounts write cache is not being flushed. This can cause the node's RAM usage to spike. We've seen spikes on the canaries of ~90 GB!

We never want to block flush/clean/shrink.

[^1]: https://github.com/anza-xyz/agave/blob/v2.2.0/docs/src/implemented-proposals/epoch_accounts_hash.md


#### Summary of Changes

Move where we get the EAH from ABS to AHV. This ensures we don't block ABS.


#### Results

Here's the results! Each graph will have four nodes:
1. brux1: this PR, disk index disabled
2. brux2: a different EAH fix, disk index enabled
3. 617: master, stock (disk index enabled)
4. ERE: master, disk index disabled

<details><summary>RAM</summary>
<p>

This one shows the top-line: RAM usage no longer spikes. See that RAM usage on brux1 (and brux2) both remain constant.
![ram bytes](https://github.com/user-attachments/assets/fcd304c2-fcfb-447e-be77-19fad333fe74)

</p>
</details>

<details><summary>Accounts Write Cache</summary>
<p>

RAM no longer spikes because we can keep flushing the accounts write cache. See that brux1 (and brux2) keep the normal number of slots in the write cache, whereas the other two nodes exhibit the ramp.
![write cache slots](https://github.com/user-attachments/assets/5044b11e-f9a5-42ee-92ba-6f0997adfdb3)
![write cache bytes](https://github.com/user-attachments/assets/4e5e8128-37e6-4a67-96bb-53d24490c56f)

</p>
</details> 

<details><summary>Flush, Clean, Shrink</summary>
<p>

Here's the background accounts-db tasks: flush, clean, and shrink. Similarly, brux1 (and brux2) keeps running these constantly, and without gaps nor spikes. Contrast that to gaps and spikes on 617/ERE that exhibit both gaps and spikes on flush/clean/shrink. The gaps are while ABS is blocked waiting for the EAH calc to complete. The spikes are due to the extra work each must do once ABS is unblocked.
![flush time](https://github.com/user-attachments/assets/9e525c1d-ab9b-47e3-a0de-d18ed3b5b46e)
![clean time](https://github.com/user-attachments/assets/5ffa1dac-0065-400a-90b1-6d4e58159882)
![shrink time](https://github.com/user-attachments/assets/771bf8b6-8ed5-4fc5-a225-ea7afa1752ae)

</p>
</details> 

<details><summary>Replay Load and Store</summary>
<p>

Lastly here's the metrics for Replay's load and store times, which now also no longer ramp.
![replay load time](https://github.com/user-attachments/assets/8f6ff5c5-73f9-48e2-a2a3-1c48ae5432fd)
![replay store time](https://github.com/user-attachments/assets/26d1f7e7-8630-4d5f-b7a5-aabc98d009cd)

</p>
</details> 

Note, I intend to backport this to v2.2 and v2.1.