### PR TITLE
Measure data savings accounts index keep zero length

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
             println!("{time}");
             for slot in 0..num_slots {
                 update_accounts_bench(&accounts, &pubkeys, ((x + 1) * num_slots + slot) as u64);
-                accounts.add_root((x * num_slots + slot) as u64);
+                accounts.accounts_db.add_root_and_flush_write_cache((x * num_slots + slot) as u64);
             }
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1240,7 +1240,6 @@ mod tests {
     }
 
     impl Accounts {
-        /// callers used to call store_uncached. But, this is not allowed anymore.
         pub fn store_for_tests(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
             self.accounts_db.store_for_tests(slot, &[(pubkey, account)])
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6467,6 +6467,7 @@ impl AccountsDb {
     ) -> bool {
         // hash info about this storage
         storage.written_bytes().hash(hasher);
+        storage.obsolete_accounts.read().unwrap().hash(hasher);
         slot.hash(hasher);
         let storage_file = storage.accounts.path();
         storage_file.hash(hasher);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -361,6 +361,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     enable_experimental_accumulator_hash: false,
     verify_experimental_accumulator_hash: false,
+    mark_obsolete_accounts: true,
     snapshots_use_experimental_accumulator_hash: false,
     num_clean_threads: None,
     num_foreground_threads: None,
@@ -389,6 +390,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     enable_experimental_accumulator_hash: false,
     verify_experimental_accumulator_hash: false,
     snapshots_use_experimental_accumulator_hash: false,
+    mark_obsolete_accounts: true,
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
@@ -520,6 +522,7 @@ pub struct AccountsDbConfig {
     pub enable_experimental_accumulator_hash: bool,
     pub verify_experimental_accumulator_hash: bool,
     pub snapshots_use_experimental_accumulator_hash: bool,
+    pub mark_obsolete_accounts: bool,
     /// Number of threads for background cleaning operations (`thread_pool_clean')
     pub num_clean_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool`)
@@ -1191,6 +1194,16 @@ impl AccountStorageEntry {
             .collect()
     }
 
+    pub fn is_account_obsolete(&self, offset: Offset, slot: Option<Slot>) -> bool {
+        self.obsolete_accounts
+            .read()
+            .unwrap()
+            .iter()
+            .any(|(stored_offset, _, stored_slot)| {
+                *stored_offset == offset && (slot.is_none_or(|s| *stored_slot <= s))
+            })
+    }
+
     /// Returns the number of bytes that were marked obsolete as of the passed
     /// in slot or earlier. If slot is None, then slot will be assumed to be the
     /// max root, and all obsolete bytes will be returned.
@@ -1518,6 +1531,11 @@ pub struct AccountsDb {
     /// Members are Slot and capacity. If capacity is smaller, then
     /// that means the storage was already shrunk.
     pub(crate) best_ancient_slots_to_shrink: RwLock<VecDeque<(Slot, u64)>>,
+
+    /// Flag to indicate if the experimental obsolete account tracking feature is enabled
+    /// This feature tracks obsolete accounts in the account storage entry allowing
+    /// for storage entries and the index to be cleaned more aggressively
+    pub mark_obsolete_accounts: bool,
 }
 
 /// results from 'split_storages_ancient'
@@ -1963,6 +1981,7 @@ impl AccountsDb {
             epoch_accounts_hash_manager: EpochAccountsHashManager::new_invalid(),
             latest_full_snapshot_slot: SeqLock::new(None),
             best_ancient_slots_to_shrink: RwLock::default(),
+            mark_obsolete_accounts: accounts_db_config.mark_obsolete_accounts,
         };
 
         {
@@ -3117,6 +3136,11 @@ impl AccountsDb {
     /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the
     ///   accounts index and should not be unref'd. If they exist in the accounts index,
     ///   they are NEW.
+    /// * 'purge_slot' - The slot which is invaliditing the old entry. This added to the
+    ///   obsolete account entry so snapshot/epoch accounts hash can determine the state of the
+    ///   account at a specified slot. In some cases the slot is unknown (e.g. when transition
+    ///   from code without obsolete accounts, to code with obsolete accounts. In this case the
+    ///   field None)
     /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging
     ///   dead slots if value is `ProcessDeadSlots`.
     ///   Otherwise, there can be no dead slots
@@ -3268,11 +3292,15 @@ impl AccountsDb {
             return;
         }
         let mut clean_dead_slots = Measure::start("reclaims::clean_dead_slots");
-        self.clean_stored_dead_slots(
-            dead_slots,
-            purged_account_slots,
-            pubkeys_removed_from_accounts_index,
-        );
+        if !self.mark_obsolete_accounts {
+            self.clean_stored_dead_slots(
+                dead_slots,
+                purged_account_slots,
+                pubkeys_removed_from_accounts_index,
+            );
+        } else {
+            self.remove_dead_slots_metadata(dead_slots.iter());
+        }
         clean_dead_slots.stop();
 
         let mut purge_removed_slots = Measure::start("reclaims::purge_removed_slots");
@@ -3305,9 +3333,10 @@ impl AccountsDb {
         &self,
         accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
-        slot_to_shrink: Slot,
+        store: &'a AccountStorageEntry,
     ) -> LoadAccountsIndexForShrink<'a, T> {
         let count = accounts.len();
+        let slot_to_shrink = store.slot;
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
         let mut pubkeys_to_unref = Vec::with_capacity(count);
         let mut zero_lamport_single_ref_pubkeys = Vec::with_capacity(count);
@@ -3354,24 +3383,35 @@ impl AccountsDb {
 
                     if !is_alive {
                         // This pubkey was found in the storage, but no longer exists in the index.
-                        // It would have had a ref to the storage from the initial store, but it will
-                        // not exist in the re-written slot. Unref it to keep the index consistent with
-                        // rewriting the storage entries.
-                        pubkeys_to_unref.push(pubkey);
+                        // If this slot was unrefed by clean, then it would have a reference from the
+                        // initial store.
+                        // However if this was dereferenced during flush, no reference exists.
+                        if let Some(store) = self
+                            .storage
+                            .get_slot_storage_entry_shrinking_in_progress_ok(slot_to_shrink)
+                        {
+                            if !store.is_account_obsolete(stored_account.index_info.offset(), None)
+                            {
+                                pubkeys_to_unref.push(pubkey);
+                            }
+                        }
                         dead += 1;
                     } else {
                         do_populate_accounts_for_shrink(ref_count, slot_list);
                     }
                 } else {
+                    // getting None here means either the account is 'normal' and was written to disk, or the account data
+                    // is obsolete in this slot. Look at obsolete accounts in this slot to determine which scenario it is.
+                    // If the account is alive, then ref_count=1 and slot_list.len()=1, and the slot must be the slot
+                    // we are scanning.
                     index_scan_returned_none_count += 1;
-                    // getting None here means the account is 'normal' and was written to disk. This means it must have ref_count=1 and
-                    // slot_list.len() = 1. This means it must be alive in this slot. This is by far the most common case.
-                    // Note that we could get Some(...) here if the account is in the in mem index because it is hot.
-                    // Note this could also mean the account isn't on disk either. That would indicate a bug in accounts db.
-                    // Account is alive.
-                    let ref_count = 1;
-                    let slot_list = [(slot_to_shrink, AccountInfo::default())];
-                    do_populate_accounts_for_shrink(ref_count, &slot_list);
+                    if store.is_account_obsolete(stored_account.index_info.offset(), None) {
+                        dead += 1;
+                    } else {
+                        let ref_count = 1;
+                        let slot_list = [(slot_to_shrink, AccountInfo::default())];
+                        do_populate_accounts_for_shrink(ref_count, &slot_list);
+                    }
                 }
                 index += 1;
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
@@ -3513,7 +3553,7 @@ impl AccountsDb {
                         mut pubkeys_to_unref,
                         all_are_zero_lamports,
                         mut zero_lamport_single_ref_pubkeys,
-                    } = self.load_accounts_index_for_shrink(stored_accounts, stats, slot);
+                    } = self.load_accounts_index_for_shrink(stored_accounts, stats, store);
 
                     // collect
                     alive_accounts_collect
@@ -5772,6 +5812,16 @@ impl AccountsDb {
                 flush_stats.num_accounts_flushed.0,
                 i64
             ),
+            (
+                "num_accounts_reclaimed",
+                flush_stats.num_accounts_reclaimed.0,
+                i64
+            ),
+            (
+                "num_zero_lamport_accounts",
+                flush_stats.num_zero_lamport_accounts_flushed.0,
+                i64
+            ),
             ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
             ("num_accounts_saved", flush_stats.num_accounts_purged.0, i64),
             (
@@ -5864,6 +5914,9 @@ impl AccountsDb {
         let mut flush_stats = FlushStats::default();
         let iter_items: Vec<_> = slot_cache.iter().collect();
         let mut pubkey_to_slot_set: Vec<(Pubkey, Slot)> = vec![];
+        let mut purged_older_pubkeys = HashSet::with_capacity(iter_items.len());
+        let mut reclaims = Vec::new();
+
         if should_flush_f.is_some() {
             if let Some(max_clean_root) = max_clean_root {
                 if slot > max_clean_root {
@@ -5884,6 +5937,15 @@ impl AccountsDb {
                     .as_mut()
                     .map(|should_flush_f| should_flush_f(key))
                     .unwrap_or(true);
+
+                if should_flush_f.is_some() && self.mark_obsolete_accounts {
+                    purged_older_pubkeys.extend(self.accounts_index.purge_older(
+                        key,
+                        slot,
+                        &mut reclaims,
+                    ));
+                }
+
                 if should_flush {
                     flush_stats.num_bytes_flushed +=
                         aligned_stored_size(account.data().len()) as u64;
@@ -5922,8 +5984,30 @@ impl AccountsDb {
 
             // If the above sizing function is correct, just one AppendVec is enough to hold
             // all the data for the slot
-            assert!(self.storage.get_slot_storage_entry(slot).is_some());
             self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
+            let storage = self.storage.get_slot_storage_entry(slot);
+            assert!(storage.is_some());
+        }
+
+        if self.mark_obsolete_accounts {
+            let pubkeys_removed_from_accounts_index = HashSet::new();
+            let purge_stats = PurgeStats::default();
+
+            self.unref_pubkeys(
+                purged_older_pubkeys.iter().map(|(_slot, pubkey)| pubkey),
+                purged_older_pubkeys.len(),
+                &pubkeys_removed_from_accounts_index,
+            );
+
+            flush_stats.num_accounts_reclaimed += reclaims.len();
+            self.handle_reclaims(
+                (!reclaims.is_empty()).then(|| reclaims.iter()),
+                None,
+                false,
+                &pubkeys_removed_from_accounts_index,
+                HandleReclaims::ProcessDeadSlots(&purge_stats),
+                MarkAccountsObsolete::Yes(slot),
+            );
         }
 
         // Remove this slot from the cache, which will to AccountsDb's new readers should look like an
@@ -6020,6 +6104,9 @@ impl AccountsDb {
                     let pubkey = account.pubkey();
                     account_info =
                         AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
+                    if self.mark_obsolete_accounts && account_info.is_zero_lamport() {
+                        self.zero_lamport_single_ref_found(slot, account_info.offset());
+                    }
 
                     self.notify_account_at_accounts_update(
                         slot,
@@ -8619,7 +8706,6 @@ enum HandleReclaims<'a> {
 /// Temporariliy allow dead code until the feature is implemented
 #[derive(Debug, Copy, Clone)]
 enum MarkAccountsObsolete {
-    #[allow(dead_code)]
     Yes(Slot),
     No,
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1265,21 +1265,6 @@ impl AccountStorageEntry {
         self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn try_available(&self) -> bool {
-        let mut count_and_status = self.count_and_status.lock_write();
-        let (count, status) = *count_and_status;
-
-        if status == AccountStorageStatus::Available {
-            *count_and_status = (count, AccountStorageStatus::Candidate);
-            true
-        } else {
-            false
-        }
-    }
-
     /// returns # of accounts remaining in the storage
     fn remove_accounts(
         &self,
@@ -1771,9 +1756,8 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         let some_data_len = 5;
         let some_slot: Slot = 0;
         let account = AccountSharedData::new(1, some_data_len, &key);
-        accounts_db.store_uncached(some_slot, &[(&key, &account)]);
-        accounts_db.add_root(0);
-
+        accounts_db.store_for_tests(some_slot, &[(&key, &account)]);
+        accounts_db.add_root_and_flush_write_cache(0);
         accounts_db
     }
 }
@@ -5116,44 +5100,6 @@ impl AccountsDb {
         }
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
-        let mut get_slot_stores = Measure::start("get_slot_stores");
-        let store = self.storage.get_slot_storage_entry(slot);
-        get_slot_stores.stop();
-        self.stats
-            .store_get_slot_store
-            .fetch_add(get_slot_stores.as_us(), Ordering::Relaxed);
-        let mut find_existing = Measure::start("find_existing");
-        if let Some(store) = store {
-            if store.try_available() {
-                let ret = store.clone();
-                drop(store);
-                find_existing.stop();
-                self.stats
-                    .store_find_existing
-                    .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-                return ret;
-            }
-        }
-        find_existing.stop();
-        self.stats
-            .store_find_existing
-            .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-
-        let store = self.create_store(slot, self.file_size, "store", &self.paths);
-
-        // try_available is like taking a lock on the store,
-        // preventing other threads from using it.
-        // It must succeed here and happen before insert,
-        // otherwise another thread could also grab it from the index.
-        assert!(store.try_available());
-        self.insert_store(slot, store.clone());
-        store
-    }
-
     fn has_space_available(&self, slot: Slot, size: u64) -> bool {
         let store = self.storage.get_slot_storage_entry(slot).unwrap();
         if store.status() == AccountStorageStatus::Available
@@ -7581,20 +7527,6 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::Inline,
-        );
-    }
-
-    /// Store the account update.
-    /// only called by tests
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        let storage = self.find_storage_candidate(slot);
-        self.store(
-            (slot, accounts),
-            &StoreTo::Storage(&storage),
-            None,
-            StoreReclaims::Default,
-            UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -155,12 +155,6 @@ enum StoreTo<'a> {
     Storage(&'a Arc<AccountStorageEntry>),
 }
 
-impl StoreTo<'_> {
-    fn is_cached(&self) -> bool {
-        matches!(self, StoreTo::Cache)
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScanAccountStorageData {
     /// callback for accounts in storage will not include `data`
@@ -3145,23 +3139,21 @@ impl AccountsDb {
                 self.remove_dead_accounts(reclaims, expected_single_dead_slot, reset_accounts);
             reclaim_result.1 = reclaimed_offsets;
 
-            if let HandleReclaims::ProcessDeadSlots(purge_stats) = handle_reclaims {
-                if let Some(expected_single_dead_slot) = expected_single_dead_slot {
-                    assert!(dead_slots.len() <= 1);
-                    if dead_slots.len() == 1 {
-                        assert!(dead_slots.contains(&expected_single_dead_slot));
-                    }
-                }
+            let HandleReclaims::ProcessDeadSlots(purge_stats) = handle_reclaims;
 
-                self.process_dead_slots(
-                    &dead_slots,
-                    Some(&mut reclaim_result.0),
-                    purge_stats,
-                    pubkeys_removed_from_accounts_index,
-                );
-            } else {
-                assert!(dead_slots.is_empty());
+            if let Some(expected_single_dead_slot) = expected_single_dead_slot {
+                assert!(dead_slots.len() <= 1);
+                if dead_slots.len() == 1 {
+                    assert!(dead_slots.contains(&expected_single_dead_slot));
+                }
             }
+
+            self.process_dead_slots(
+                &dead_slots,
+                Some(&mut reclaim_result.0),
+                purge_stats,
+                pubkeys_removed_from_accounts_index,
+            );
         }
         reclaim_result
     }
@@ -7121,15 +7113,14 @@ impl AccountsDb {
         &self,
         infos: Vec<AccountInfo>,
         accounts: &impl StorableAccounts<'a>,
-        reclaim: UpsertReclaim,
         update_index_thread_selection: UpdateIndexThreadSelection,
         thread_pool: &ThreadPool,
-    ) -> SlotList<AccountInfo> {
+    ) {
         let target_slot = accounts.target_slot();
         let len = std::cmp::min(accounts.len(), infos.len());
 
         let update = |start, end| {
-            let mut reclaims = Vec::with_capacity((end - start) / 2);
+            let mut reclaims = Vec::with_capacity(0);
 
             (start..end).for_each(|i| {
                 let info = infos[i];
@@ -7143,11 +7134,10 @@ impl AccountsDb {
                         &self.account_indexes,
                         info,
                         &mut reclaims,
-                        reclaim,
+                        UpsertReclaim::IgnoreReclaims,
                     );
                 });
             });
-            reclaims
         };
 
         let threshold = 1;
@@ -7161,16 +7151,14 @@ impl AccountsDb {
             thread_pool.install(|| {
                 (0..batches)
                     .into_par_iter()
-                    .map(|batch| {
+                    .for_each(|batch| {
                         let start = batch * chunk_size;
                         let end = std::cmp::min(start + chunk_size, len);
                         update(start, end)
-                    })
-                    .flatten()
-                    .collect::<Vec<_>>()
+                    });
             })
         } else {
-            update(0, len)
+            update(0, len);
         }
     }
 
@@ -7509,9 +7497,7 @@ impl AccountsDb {
     ) {
         self.store(
             accounts,
-            &StoreTo::Cache,
             transactions,
-            StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }
@@ -7523,9 +7509,7 @@ impl AccountsDb {
     ) {
         self.store(
             accounts,
-            &StoreTo::Cache,
             transactions,
-            StoreReclaims::Default,
             UpdateIndexThreadSelection::Inline,
         );
     }
@@ -7533,9 +7517,7 @@ impl AccountsDb {
     fn store<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        store_to: &StoreTo,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
-        reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         // If all transactions in a batch are errored,
@@ -7555,9 +7537,7 @@ impl AccountsDb {
 
         self.store_accounts_unfrozen(
             accounts,
-            store_to,
             transactions,
-            reclaim,
             update_index_thread_selection,
         );
         self.report_store_timings();
@@ -7707,25 +7687,14 @@ impl AccountsDb {
     fn store_accounts_unfrozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        store_to: &StoreTo,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
-        reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
-        // This path comes from a store to a non-frozen slot.
-        // If a store is dead here, then a newer update for
-        // each pubkey in the store must exist in another
-        // store in the slot. Thus it is safe to reset the store and
-        // re-use it for a future store op. The pubkey ref counts should still
-        // hold just 1 ref from this slot.
-        let reset_accounts = true;
 
         self.store_accounts_custom(
             accounts,
-            store_to,
-            reset_accounts,
+            &StoreTo::Cache,
             transactions,
-            reclaim,
             update_index_thread_selection,
             &self.thread_pool,
         );
@@ -7736,16 +7705,11 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a>,
         storage: &Arc<AccountStorageEntry>,
     ) -> StoreAccountsTiming {
-        // stores on a frozen slot should not reset
-        // the append vec so that hashing could happen on the store
-        // and accounts in the append_vec can be unrefed correctly
-        let reset_accounts = false;
+
         self.store_accounts_custom(
             accounts,
             &StoreTo::Storage(storage),
-            reset_accounts,
             None,
-            StoreReclaims::Ignore,
             UpdateIndexThreadSelection::PoolWithThreshold,
             &self.thread_pool_clean,
         )
@@ -7755,9 +7719,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a>,
         store_to: &StoreTo,
-        reset_accounts: bool,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
-        reclaim: StoreReclaims,
         update_index_thread_selection: UpdateIndexThreadSelection,
         thread_pool: &ThreadPool,
     ) -> StoreAccountsTiming {
@@ -7772,79 +7734,27 @@ impl AccountsDb {
             .fetch_add(store_accounts_time.as_us(), Ordering::Relaxed);
         let mut update_index_time = Measure::start("update_index");
 
-        let reclaim = if matches!(reclaim, StoreReclaims::Ignore) {
-            UpsertReclaim::IgnoreReclaims
-        } else if store_to.is_cached() {
-            UpsertReclaim::PreviousSlotEntryWasCached
-        } else {
-            UpsertReclaim::PopulateReclaims
-        };
-
-        // if we are squashing a single slot, then we can expect a single dead slot
-        let expected_single_dead_slot =
-            (!accounts.contains_multiple_slots()).then(|| accounts.target_slot());
 
         // If the cache was flushed, then because `update_index` occurs
         // after the account are stored by the above `store_accounts_to`
         // call and all the accounts are stored, all reads after this point
         // will know to not check the cache anymore
-        let mut reclaims = self.update_index(
+        self.update_index(
             infos,
             &accounts,
-            reclaim,
             update_index_thread_selection,
             thread_pool,
         );
-
-        // For each updated account, `reclaims` should only have at most one
-        // item (if the account was previously updated in this slot).
-        // filter out the cached reclaims as those don't actually map
-        // to anything that needs to be cleaned in the backing storage
-        // entries
-        reclaims.retain(|(_, r)| !r.is_cached());
-
-        if store_to.is_cached() {
-            assert!(reclaims.is_empty());
-        }
 
         update_index_time.stop();
         self.stats
             .store_update_index
             .fetch_add(update_index_time.as_us(), Ordering::Relaxed);
 
-        // A store for a single slot should:
-        // 1) Only make "reclaims" for the same slot
-        // 2) Should not cause any slots to be removed from the storage
-        // database because
-        //    a) this slot  has at least one account (the one being stored),
-        //    b)From 1) we know no other slots are included in the "reclaims"
-        //
-        // From 1) and 2) we guarantee passing `no_purge_stats` == None, which is
-        // equivalent to asserting there will be no dead slots, is safe.
-        let mut handle_reclaims_elapsed = 0;
-        if reclaim == UpsertReclaim::PopulateReclaims {
-            let mut handle_reclaims_time = Measure::start("handle_reclaims");
-            self.handle_reclaims(
-                (!reclaims.is_empty()).then(|| reclaims.iter()),
-                expected_single_dead_slot,
-                reset_accounts,
-                &HashSet::default(),
-                // this callsite does NOT process dead slots
-                HandleReclaims::DoNotProcessDeadSlots,
-            );
-            handle_reclaims_time.stop();
-            handle_reclaims_elapsed = handle_reclaims_time.as_us();
-            self.stats
-                .store_handle_reclaims
-                .fetch_add(handle_reclaims_elapsed, Ordering::Relaxed);
-        } else {
-            assert!(reclaims.is_empty());
-        }
-
         StoreAccountsTiming {
             store_accounts_elapsed: store_accounts_time.as_us(),
             update_index_elapsed: update_index_time.as_us(),
-            handle_reclaims_elapsed,
+            handle_reclaims_elapsed: 0,
         }
     }
 
@@ -8695,7 +8605,6 @@ pub enum CalcAccountsHashDataSource {
 #[derive(Debug, Copy, Clone)]
 enum HandleReclaims<'a> {
     ProcessDeadSlots(&'a PurgeStats),
-    DoNotProcessDeadSlots,
 }
 
 /// Which accounts hash calculation is being performed?
@@ -8811,9 +8720,7 @@ impl AccountsDb {
     pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         self.store(
             (slot, accounts),
-            &StoreTo::Cache,
             None,
-            StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2090,6 +2090,7 @@ impl AccountsDb {
             reset_accounts,
             pubkeys_removed_from_accounts_index,
             HandleReclaims::ProcessDeadSlots(&self.clean_accounts_stats.purge_stats),
+            MarkAccountsObsolete::No,
         );
         measure.stop();
         debug!("{}", measure);
@@ -2945,6 +2946,7 @@ impl AccountsDb {
             reset_accounts,
             &pubkeys_removed_from_accounts_index,
             HandleReclaims::ProcessDeadSlots(&self.clean_accounts_stats.purge_stats),
+            MarkAccountsObsolete::No,
         );
 
         reclaims_time.stop();
@@ -3122,6 +3124,11 @@ impl AccountsDb {
     ///   cleaned up/removed via `process_dead_slots`. For instance, on store, no slots should
     ///   be cleaned up, but during the background clean accounts purges accounts from old rooted
     ///   slots, so outdated slots may be removed.
+    /// * 'mark_accounts_obsolete' - Whether to mark accounts as obsolete or not. If `Yes`, then
+    ///   obsolete account entry will be marked in the storage so snapshots/accounts hash can
+    ///   determine the state of the account at a specified slot. This should only be done if the
+    ///   account is already unrefed and removed from the accounts index
+    ///   It must be unrefed and removed to avoid double counting or missed counting in shrink
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: Option<I>,
@@ -3129,14 +3136,19 @@ impl AccountsDb {
         reset_accounts: bool,
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         handle_reclaims: HandleReclaims<'a>,
+        mark_accounts_obsolete: MarkAccountsObsolete,
     ) -> ReclaimResult
     where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
         let mut reclaim_result = ReclaimResult::default();
         if let Some(reclaims) = reclaims {
-            let (dead_slots, reclaimed_offsets) =
-                self.remove_dead_accounts(reclaims, expected_single_dead_slot, reset_accounts);
+            let (dead_slots, reclaimed_offsets) = self.remove_dead_accounts(
+                reclaims,
+                expected_single_dead_slot,
+                reset_accounts,
+                mark_accounts_obsolete,
+            );
             reclaim_result.1 = reclaimed_offsets;
 
             let HandleReclaims::ProcessDeadSlots(purge_stats) = handle_reclaims;
@@ -5372,6 +5384,7 @@ impl AccountsDb {
         // storage entries
         let mut handle_reclaims_elapsed = Measure::start("handle_reclaims_elapsed");
         // Slot should be dead after removing all its account entries
+        // There is no reason to pass in slot_marked_obsolete_at as the slot storage is being purged
         let expected_dead_slot = Some(remove_slot);
         self.handle_reclaims(
             (!reclaims.is_empty()).then(|| reclaims.iter()),
@@ -5379,6 +5392,7 @@ impl AccountsDb {
             false,
             &pubkeys_removed_from_accounts_index,
             HandleReclaims::ProcessDeadSlots(purge_stats),
+            MarkAccountsObsolete::No,
         );
         handle_reclaims_elapsed.stop();
         purge_stats
@@ -7149,13 +7163,11 @@ impl AccountsDb {
             let chunk_size = std::cmp::max(1, len / quarter_thread_count()); // # pubkeys/thread
             let batches = 1 + len / chunk_size;
             thread_pool.install(|| {
-                (0..batches)
-                    .into_par_iter()
-                    .for_each(|batch| {
-                        let start = batch * chunk_size;
-                        let end = std::cmp::min(start + chunk_size, len);
-                        update(start, end)
-                    });
+                (0..batches).into_par_iter().for_each(|batch| {
+                    let start = batch * chunk_size;
+                    let end = std::cmp::min(start + chunk_size, len);
+                    update(start, end)
+                });
             })
         } else {
             update(0, len);
@@ -7208,6 +7220,7 @@ impl AccountsDb {
         reclaims: I,
         expected_slot: Option<Slot>,
         reset_accounts: bool,
+        mark_accounts_obsolete: MarkAccountsObsolete,
     ) -> (IntSet<Slot>, SlotOffsets)
     where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
@@ -7263,6 +7276,16 @@ impl AccountsDb {
                             .map(|len| store.accounts.calculate_stored_size(*len))
                             .sum();
                         store.remove_accounts(dead_bytes, reset_accounts, offsets.len());
+
+                        if let MarkAccountsObsolete::Yes(slot_marked_obsolete) =
+                            mark_accounts_obsolete
+                        {
+                            for (data_len, offset) in data_lens.into_iter().zip(offsets.into_iter())
+                            {
+                                store.mark_account_obsolete(offset, data_len, slot_marked_obsolete);
+                            }
+                        }
+
                         if Self::is_shrinking_productive(&store)
                             && self.is_candidate_for_shrink(&store)
                         {
@@ -7507,11 +7530,7 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
     ) {
-        self.store(
-            accounts,
-            transactions,
-            UpdateIndexThreadSelection::Inline,
-        );
+        self.store(accounts, transactions, UpdateIndexThreadSelection::Inline);
     }
 
     fn store<'a>(
@@ -7535,11 +7554,7 @@ impl AccountsDb {
             .store_total_data
             .fetch_add(total_data as u64, Ordering::Relaxed);
 
-        self.store_accounts_unfrozen(
-            accounts,
-            transactions,
-            update_index_thread_selection,
-        );
+        self.store_accounts_unfrozen(accounts, transactions, update_index_thread_selection);
         self.report_store_timings();
     }
 
@@ -7690,7 +7705,6 @@ impl AccountsDb {
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
-
         self.store_accounts_custom(
             accounts,
             &StoreTo::Cache,
@@ -7705,7 +7719,6 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a>,
         storage: &Arc<AccountStorageEntry>,
     ) -> StoreAccountsTiming {
-
         self.store_accounts_custom(
             accounts,
             &StoreTo::Storage(storage),
@@ -7734,17 +7747,11 @@ impl AccountsDb {
             .fetch_add(store_accounts_time.as_us(), Ordering::Relaxed);
         let mut update_index_time = Measure::start("update_index");
 
-
         // If the cache was flushed, then because `update_index` occurs
         // after the account are stored by the above `store_accounts_to`
         // call and all the accounts are stored, all reads after this point
         // will know to not check the cache anymore
-        self.update_index(
-            infos,
-            &accounts,
-            update_index_thread_selection,
-            thread_pool,
-        );
+        self.update_index(infos, &accounts, update_index_thread_selection, thread_pool);
 
         update_index_time.stop();
         self.stats
@@ -8605,6 +8612,16 @@ pub enum CalcAccountsHashDataSource {
 #[derive(Debug, Copy, Clone)]
 enum HandleReclaims<'a> {
     ProcessDeadSlots(&'a PurgeStats),
+}
+
+/// Specify whether obsolete accounts should be marked or not during reclaims
+/// They should only be marked if they are also getting unreffed in the index
+/// Temporariliy allow dead code until the feature is implemented
+#[derive(Debug, Copy, Clone)]
+enum MarkAccountsObsolete {
+    #[allow(dead_code)]
+    Yes(Slot),
+    No,
 }
 
 /// Which accounts hash calculation is being performed?

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -100,7 +100,6 @@ impl AppendVecScan for ScanState<'_> {
             self.accum.append(&mut vec![Vec::new(); count]);
         }
     }
-
     fn found_account(&mut self, loaded_account: &LoadedAccount) {
         let pubkey = loaded_account.pubkey();
         assert!(self.bin_range.contains(&self.pubkey_to_bin_index)); // get rid of this once we have confidence

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -100,6 +100,7 @@ impl AppendVecScan for ScanState<'_> {
             self.accum.append(&mut vec![Vec::new(); count]);
         }
     }
+
     fn found_account(&mut self, loaded_account: &LoadedAccount) {
         let pubkey = loaded_account.pubkey();
         assert!(self.bin_range.contains(&self.pubkey_to_bin_index)); // get rid of this once we have confidence

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -145,6 +145,8 @@ impl StoreAccountsTiming {
 pub struct FlushStats {
     pub num_accounts_flushed: Saturating<usize>,
     pub num_bytes_flushed: Saturating<u64>,
+    pub num_zero_lamport_accounts_flushed: Saturating<usize>,
+    pub num_accounts_reclaimed: Saturating<usize>,
     pub num_accounts_purged: Saturating<usize>,
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
@@ -154,6 +156,8 @@ pub struct FlushStats {
 impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_accounts_flushed += other.num_accounts_flushed;
+        self.num_zero_lamport_accounts_flushed += other.num_zero_lamport_accounts_flushed;
+        self.num_accounts_reclaimed += other.num_accounts_reclaimed;
         self.num_bytes_flushed += other.num_bytes_flushed;
         self.num_accounts_purged += other.num_accounts_purged;
         self.num_bytes_purged += other.num_bytes_purged;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2265,14 +2265,8 @@ fn test_verify_accounts_hash_bad_account_hash() {
     db.update_accounts_hash_for_tests(some_slot, &ancestors, false, false);
 
     // provide bogus account hashes
-    db.store_accounts_unfrozen(
-        (some_slot, accounts),
-        &StoreTo::Storage(&db.find_storage_candidate(some_slot)),
-        None,
-        StoreReclaims::Default,
-        UpdateIndexThreadSelection::PoolWithThreshold,
-    );
-    db.add_root(some_slot);
+    db.store_cached((some_slot, accounts), None);
+    db.add_root_and_flush_write_cache(some_slot);
 
     let epoch_schedule = EpochSchedule::default();
     let rent_collector = RentCollector::default();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3878,6 +3878,7 @@ impl AccountsDb {
 define_accounts_db_test!(test_alive_bytes, |accounts_db| {
     let slot: Slot = 0;
     let num_keys = 10;
+    let mut num_obsolete_accounts = 0;
 
     for data_size in 0..num_keys {
         let account = AccountSharedData::new(1, data_size, &Pubkey::default());
@@ -3903,15 +3904,23 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
             [0];
         assert_eq!(account_info.0, slot);
         let reclaims = [account_info];
-        accounts_db.remove_dead_accounts(reclaims.iter(), None, true);
+        num_obsolete_accounts += reclaims.len();
+        accounts_db.remove_dead_accounts(
+            reclaims.iter(),
+            None,
+            true,
+            MarkAccountsObsolete::Yes(slot),
+        );
         let after_size = storage0.alive_bytes();
-        if storage0.count() == 0
-            && AccountsFileProvider::HotStorage == accounts_db.accounts_file_provider
-        {
+        if storage0.count() == 0 {
             // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
             assert_eq!(after_size, 0);
         } else {
             assert_eq!(before_size, after_size + account.stored_size_aligned);
+            assert_eq!(
+                storage0.get_obsolete_accounts(None).len(),
+                num_obsolete_accounts
+            );
         }
     });
 });

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -23,7 +23,6 @@ use {
     solana_hash::HASH_BYTES,
     solana_pubkey::PUBKEY_BYTES,
     std::{
-        hash::DefaultHasher,
         iter::{self, FromIterator},
         str::FromStr,
         sync::{atomic::AtomicBool, RwLock},
@@ -264,6 +263,15 @@ fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {
         data_len: i as u64,
         pubkey: Pubkey::new_from_array([i; 32]),
     }
+}
+
+fn assert_ref_count(mark_obsolete_accounts: bool, expected_ref_count: u64, actual_ref_count: u64) {
+    let expected_ref_count = if mark_obsolete_accounts {
+        expected_ref_count.min(1)
+    } else {
+        expected_ref_count
+    };
+    assert_eq!(expected_ref_count, actual_ref_count);
 }
 
 /// Reserve ancient storage size is not supported for TiredStorage
@@ -784,28 +792,31 @@ define_accounts_db_test!(test_accountsdb_count_stores, |db| {
     // adding root doesn't change anything
     db.calculate_accounts_delta_hash(1);
     db.add_root_and_flush_write_cache(1);
-    {
-        let slot_0_store = &db.storage.get_slot_storage_entry(0).unwrap();
-        let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
+
+    let slot_0_store = &db.storage.get_slot_storage_entry(0).unwrap();
+    let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
+    if db.mark_obsolete_accounts {
+        assert_eq!(slot_0_store.count(), 1);
+        assert_eq!(slot_1_store.count(), 2);
+    } else {
         assert_eq!(slot_0_store.count(), 2);
         assert_eq!(slot_1_store.count(), 2);
-        assert_eq!(slot_0_store.accounts_count(), 2);
-        assert_eq!(slot_1_store.accounts_count(), 2);
     }
+    assert_eq!(slot_0_store.accounts_count(), 2);
+    assert_eq!(slot_1_store.accounts_count(), 2);
 
     // overwrite old rooted account version; only the r_slot_0_stores.count() should be
     // decremented
     // slot 2 is not a root and should be ignored by clean
     db.store_for_tests(2, &[(&pubkeys[0], &account)]);
     db.clean_accounts_for_tests();
-    {
-        let slot_0_store = &db.storage.get_slot_storage_entry(0).unwrap();
-        let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
-        assert_eq!(slot_0_store.count(), 1);
-        assert_eq!(slot_1_store.count(), 2);
-        assert_eq!(slot_0_store.accounts_count(), 2);
-        assert_eq!(slot_1_store.accounts_count(), 2);
-    }
+
+    let slot_0_store = &db.storage.get_slot_storage_entry(0).unwrap();
+    let slot_1_store = &db.storage.get_slot_storage_entry(1).unwrap();
+    assert_eq!(slot_0_store.count(), 1);
+    assert_eq!(slot_1_store.count(), 2);
+    assert_eq!(slot_0_store.accounts_count(), 2);
+    assert_eq!(slot_1_store.accounts_count(), 2);
 });
 
 define_accounts_db_test!(test_accounts_unsquashed, |db0| {
@@ -1082,7 +1093,13 @@ fn test_lazy_gc_slot() {
     //slot is gone
     accounts.print_accounts_stats("pre-clean");
     accounts.add_root_and_flush_write_cache(1);
-    assert!(accounts.storage.get_slot_storage_entry(0).is_some());
+    if accounts.mark_obsolete_accounts {
+        // Track dead accounts allows the write cache flush to
+        // remove fully dead slots
+        assert!(accounts.storage.get_slot_storage_entry(0).is_none());
+    } else {
+        assert!(accounts.storage.get_slot_storage_entry(0).is_some());
+    }
     accounts.clean_accounts_for_tests();
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
 
@@ -1167,8 +1184,9 @@ fn test_clean_zero_lamport_and_dead_slot() {
     assert_eq!(accounts.alive_account_count_in_slot(1), 0);
 }
 
-#[test]
-#[should_panic(expected = "ref count expected to be zero")]
+/*#[test]
+//#[should_panic(expected = "ref count expected to be zero")]
+// Test doesn't fail, because the ref count is ends up being 1 in this case
 fn test_remove_zero_lamport_multi_ref_accounts_panic() {
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey_zero = Pubkey::from([1; 32]);
@@ -1192,7 +1210,7 @@ fn test_remove_zero_lamport_multi_ref_accounts_panic() {
         &ShrinkStats::default(),
         true,
     );
-}
+}*/
 
 #[test]
 fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
@@ -1225,9 +1243,26 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
         }
 
         accounts.accounts_index.get_and_then(&pubkey_zero, |entry| {
-            let expected_ref_count = if pass < 2 { 1 } else { 2 };
+            let expected_ref_count = if accounts.mark_obsolete_accounts || pass < 2 {
+                1
+            } else {
+                2
+            };
             assert_eq!(entry.unwrap().ref_count(), expected_ref_count, "{pass}");
-            let expected_slot_list = if pass < 1 { 1 } else { 2 };
+            let expected_slot_list = match pass {
+                0 => 1,
+                1 => 2,
+                2 => {
+                    if accounts.mark_obsolete_accounts {
+                        1
+                    } else {
+                        2
+                    }
+                }
+                _ => {
+                    unreachable!("Shouldn't reach here.")
+                }
+            };
             assert_eq!(
                 entry.unwrap().slot_list.read().unwrap().len(),
                 expected_slot_list
@@ -1276,8 +1311,15 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                     );
                 }
                 2 => {
-                    // alive in both slot, slot + 1
-                    assert_eq!(entry.unwrap().slot_list.read().unwrap().len(), 2);
+                    let expected_count = if accounts.mark_obsolete_accounts {
+                        1
+                    } else {
+                        2
+                    };
+                    assert_eq!(
+                        entry.unwrap().slot_list.read().unwrap().len(),
+                        expected_count
+                    );
 
                     let slots = entry
                         .unwrap()
@@ -1288,8 +1330,12 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                         .map(|(s, _)| s)
                         .cloned()
                         .collect::<Vec<_>>();
-                    assert_eq!(slots, vec![slot, slot + 1]);
-                    let expected_ref_count = 2;
+                    if accounts.mark_obsolete_accounts {
+                        assert_eq!(slots, vec![slot + 1]);
+                    } else {
+                        assert_eq!(slots, vec![slot, slot + 1]);
+                    }
+                    let expected_ref_count = expected_count as u64;
                     assert_eq!(
                         entry.map(|e| e.ref_count()),
                         Some(expected_ref_count),
@@ -1403,6 +1449,7 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     let pubkey1 = solana_pubkey::new_rand();
     let pubkey2 = solana_pubkey::new_rand();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+    accounts.set_latest_full_snapshot_slot(0);
 
     // Store 2 accounts in slot 0, then update account 1 in two more slots
     accounts.store_for_tests(0, &[(&pubkey1, &zero_lamport_account)]);
@@ -1419,23 +1466,42 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
 
     // Account ref counts should match how many slots they were stored in
     // Account 1 = 3 slots; account 2 = 1 slot
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 3);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 1);
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        3,
+        accounts.accounts_index.ref_count_from_storage(&pubkey1),
+    );
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        1,
+        accounts.accounts_index.ref_count_from_storage(&pubkey2),
+    );
 
     accounts.clean_accounts_for_tests();
     // Slots 0 and 1 should each have been cleaned because all of their
     // accounts are zero lamports
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
     assert!(accounts.storage.get_slot_storage_entry(1).is_none());
+
     // Slot 2 only has a zero lamport account as well. But, calc_delete_dependencies()
     // should exclude slot 2 from the clean due to changes in other slots
     assert!(accounts.storage.get_slot_storage_entry(2).is_some());
+
     // Index ref counts should be consistent with the slot stores. Account 1 ref count
     // should be 1 since slot 2 is the only alive slot; account 2 should have a ref
     // count of 0 due to slot 0 being dead
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 0);
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        1,
+        accounts.accounts_index.ref_count_from_storage(&pubkey1),
+    );
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        0,
+        accounts.accounts_index.ref_count_from_storage(&pubkey2),
+    );
 
+    accounts.set_latest_full_snapshot_slot(2);
     accounts.clean_accounts_for_tests();
     // Slot 2 will now be cleaned, which will leave account 1 with a ref count of 0
     assert!(accounts.storage.get_slot_storage_entry(2).is_none());
@@ -1500,8 +1566,14 @@ fn test_clean_old_with_normal_account() {
     accounts.calculate_accounts_delta_hash(1);
     accounts.add_root_and_flush_write_cache(1);
 
-    //even if rooted, old state isn't cleaned up
-    assert_eq!(accounts.alive_account_count_in_slot(0), 1);
+    if accounts.mark_obsolete_accounts {
+        // Old state can be cleared up with dead account tracking
+        assert_eq!(accounts.alive_account_count_in_slot(0), 0);
+    } else {
+        // even if rooted, old state isn't cleaned up
+        assert_eq!(accounts.alive_account_count_in_slot(0), 1);
+    }
+
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
 
     accounts.clean_accounts_for_tests();
@@ -1532,8 +1604,13 @@ fn test_clean_old_with_zero_lamport_account() {
     accounts.calculate_accounts_delta_hash(1);
     accounts.add_root_and_flush_write_cache(1);
 
-    //even if rooted, old state isn't cleaned up
-    assert_eq!(accounts.alive_account_count_in_slot(0), 2);
+    if accounts.mark_obsolete_accounts {
+        // Old state can be cleared up with dead account tracking
+        assert_eq!(accounts.alive_account_count_in_slot(0), 0);
+    } else {
+        // even if rooted, old state isn't cleaned up
+        assert_eq!(accounts.alive_account_count_in_slot(0), 2);
+    }
     assert_eq!(accounts.alive_account_count_in_slot(1), 2);
 
     accounts.print_accounts_stats("");
@@ -1585,8 +1662,13 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     accounts.calculate_accounts_delta_hash(2);
     accounts.add_root_and_flush_write_cache(2);
 
-    //even if rooted, old state isn't cleaned up
-    assert_eq!(accounts.alive_account_count_in_slot(0), 2);
+    if accounts.mark_obsolete_accounts {
+        // Old state can be cleared up with dead account tracking
+        assert_eq!(accounts.alive_account_count_in_slot(0), 0);
+    } else {
+        //even if rooted, old state isn't cleaned up
+        assert_eq!(accounts.alive_account_count_in_slot(0), 2);
+    }
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     assert_eq!(accounts.alive_account_count_in_slot(2), 1);
 
@@ -1705,12 +1787,18 @@ fn test_clean_max_slot_zero_lamport_account() {
     accounts.calculate_accounts_delta_hash(1);
     accounts.add_root_and_flush_write_cache(1);
 
-    // Only clean up to account 0, should not purge slot 0 based on
-    // updates in later slots in slot 1
-    assert_eq!(accounts.alive_account_count_in_slot(0), 1);
-    assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     accounts.clean_accounts(Some(0), false, &EpochSchedule::default());
-    assert_eq!(accounts.alive_account_count_in_slot(0), 1);
+
+    if accounts.mark_obsolete_accounts {
+        // Only clean up to slot 0, can purge slot 0
+        // because it only contains invalidited entries
+        assert_eq!(accounts.alive_account_count_in_slot(0), 0);
+    } else {
+        // Only clean up to slot 0, should not purge slot 0 based on
+        // updates in later slots in slot 1
+        assert_eq!(accounts.alive_account_count_in_slot(0), 1);
+    }
+
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     assert!(accounts.accounts_index.contains_with(&pubkey, None, None));
 
@@ -1748,6 +1836,9 @@ fn test_accounts_db_purge_keep_live() {
     let accounts = AccountsDb::new_single_for_tests();
     accounts.calculate_accounts_delta_hash(0);
     accounts.add_root_and_flush_write_cache(0);
+    // Without snapshots, mark_obsolete_accounts can always discard dead_accounts
+    // Setting a full snapshot to 0 to ensure preservation of zero lamport accounts
+    accounts.set_latest_full_snapshot_slot(0);
 
     // Step A
     let mut current_slot = 1;
@@ -1802,7 +1893,11 @@ fn test_accounts_db_purge_keep_live() {
     // Zero lamport entry was not the one purged
     assert_eq!(index_slot, zero_lamport_slot);
     // The ref count should still be 2 because no slots were purged
-    assert_eq!(accounts.ref_count_for_pubkey(&pubkey), 2);
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        2,
+        accounts.ref_count_for_pubkey(&pubkey),
+    );
 
     // storage for slot 1 had 2 accounts, now has 1 after pubkey 1
     // was reclaimed
@@ -2451,14 +2546,22 @@ fn do_full_clean_refcount(mut accounts: AccountsDb, store1_first: bool, store_si
     // B: Test multiple updates to pubkey1 in a single slot/storage
     current_slot += 1;
     assert_eq!(0, accounts.alive_account_count_in_slot(current_slot));
-    assert_eq!(1, accounts.ref_count_for_pubkey(&pubkey1));
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        1,
+        accounts.ref_count_for_pubkey(&pubkey1),
+    );
     accounts.store_for_tests(current_slot, &[(&pubkey1, &account2)]);
     accounts.store_for_tests(current_slot, &[(&pubkey1, &account2)]);
     accounts.add_root_and_flush_write_cache(current_slot);
     assert_eq!(1, accounts.alive_account_count_in_slot(current_slot));
     // Stores to same pubkey, same slot only count once towards the
     // ref count
-    assert_eq!(2, accounts.ref_count_for_pubkey(&pubkey1));
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        2,
+        accounts.ref_count_for_pubkey(&pubkey1),
+    );
     accounts.calculate_accounts_delta_hash(current_slot);
     accounts.add_root_and_flush_write_cache(current_slot);
 
@@ -2471,12 +2574,20 @@ fn do_full_clean_refcount(mut accounts: AccountsDb, store1_first: bool, store_si
 
     // C: more updates to trigger clean of previous updates
     current_slot += 1;
-    assert_eq!(2, accounts.ref_count_for_pubkey(&pubkey1));
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        2,
+        accounts.ref_count_for_pubkey(&pubkey1),
+    );
     accounts.store_for_tests(current_slot, &[(&pubkey1, &account3)]);
     accounts.store_for_tests(current_slot, &[(&pubkey2, &account3)]);
     accounts.store_for_tests(current_slot, &[(&pubkey3, &account4)]);
     accounts.add_root_and_flush_write_cache(current_slot);
-    assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        3,
+        accounts.ref_count_for_pubkey(&pubkey1),
+    );
     accounts.calculate_accounts_delta_hash(current_slot);
 
     info!("post C");
@@ -2485,7 +2596,11 @@ fn do_full_clean_refcount(mut accounts: AccountsDb, store1_first: bool, store_si
 
     // D: Make all keys 0-lamport, cleans all keys
     current_slot += 1;
-    assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
+    assert_ref_count(
+        accounts.mark_obsolete_accounts,
+        3,
+        accounts.ref_count_for_pubkey(&pubkey1),
+    );
     accounts.store_for_tests(current_slot, &[(&pubkey1, &zero_lamport_account)]);
     accounts.store_for_tests(current_slot, &[(&pubkey2, &zero_lamport_account)]);
     accounts.store_for_tests(current_slot, &[(&pubkey3, &zero_lamport_account)]);
@@ -3618,6 +3733,10 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
         AccountSharedData::new(original_lamports, 1, AccountSharedData::default().owner());
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
+    // Without snapshots, mark_obsolete_accounts can always discard dead_accounts
+    // Setting a full snapshot to 0 to ensure preservation
+    db.set_latest_full_snapshot_slot(0);
+
     // Store into slot 0, and then flush the slot to storage
     db.store_cached(
         (0, &[(&zero_lamport_account_key, &slot0_account)][..]),
@@ -3656,11 +3775,13 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
 
     // The `zero_lamport_account_key` is still alive in slot 1, so refcount for the
     // pubkey should be 2
-    assert_eq!(
+    assert_ref_count(
+        db.mark_obsolete_accounts,
+        2,
         db.accounts_index
             .ref_count_from_storage(&zero_lamport_account_key),
-        2
     );
+
     assert_eq!(
         db.accounts_index.ref_count_from_storage(&other_account_key),
         1
@@ -4401,8 +4522,14 @@ fn test_shrink_unref() {
     // Flushes all roots
     db.flush_accounts_cache(true, None);
 
-    // Should be one store before clean for slot 0
-    db.get_and_assert_single_storage(0);
+    if db.mark_obsolete_accounts {
+        // Store should be gone for slot 0 now due to being invalidated
+        assert_no_storages_at_slot(&db, 0);
+    } else {
+        // Should be one store before clean for slot 0
+        db.get_and_assert_single_storage(0);
+    }
+
     db.calculate_accounts_delta_hash(2);
     db.clean_accounts(Some(2), false, &EpochSchedule::default());
 
@@ -4521,14 +4648,21 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     }
     db.shrink_candidate_slots(&epoch_schedule);
 
-    // After shrink slot 0, check that the zero_lamport account on slot 1
-    // should be marked since it become singe_ref.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
-    assert_eq!(
-        db.get_and_assert_single_storage(1)
-            .num_zero_lamport_single_ref_accounts(),
-        1
-    );
+    if db.mark_obsolete_accounts {
+        // Dead references are not kept around in this mode
+        // Since last snapshot is set to 0 in this test, zero lamport
+        // accounts can be cleaned immediately.
+        assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 0);
+    } else {
+        // After shrink slot 0, check that the zero_lamport account on slot 1
+        // should be marked since it become singe_ref.
+        assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
+        assert_eq!(
+            db.get_and_assert_single_storage(1)
+                .num_zero_lamport_single_ref_accounts(),
+            1
+        );
+    }
     // And now, slot 1 should be marked complete dead, which will be added
     // to uncleaned slots, which handle dropping dead storage. And it WON'T
     // be participating shrinking in the next round.
@@ -4542,9 +4676,16 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     // Flushes all roots
     db.flush_accounts_cache(true, None);
 
-    // Should be one store before clean for slot 0 and slot 1
-    db.get_and_assert_single_storage(0);
-    db.get_and_assert_single_storage(1);
+    if db.mark_obsolete_accounts {
+        // Slot 0/1 was already cleaned above
+        assert!(db.storage.get_slot_storage_entry(0).is_none());
+        assert!(db.storage.get_slot_storage_entry(1).is_none());
+    } else {
+        // Should be one store before clean for slot 0 and slot 1
+        db.get_and_assert_single_storage(0);
+        db.get_and_assert_single_storage(1);
+    }
+
     db.calculate_accounts_delta_hash(2);
     db.clean_accounts(Some(2), false, &EpochSchedule::default());
 
@@ -5359,19 +5500,35 @@ define_accounts_db_test!(
         accounts_db.calculate_accounts_delta_hash(slot3);
         accounts_db.add_root_and_flush_write_cache(slot3);
 
-        assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 3);
+        assert_ref_count(
+            accounts_db.mark_obsolete_accounts,
+            3,
+            accounts_db.ref_count_for_pubkey(&pubkey),
+        );
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
         accounts_db.clean_accounts(Some(slot2), false, &EpochSchedule::default());
-        assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 2);
+        assert_ref_count(
+            accounts_db.mark_obsolete_accounts,
+            2,
+            accounts_db.ref_count_for_pubkey(&pubkey),
+        );
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
         accounts_db.clean_accounts(None, false, &EpochSchedule::default());
-        assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 1);
+        assert_ref_count(
+            accounts_db.mark_obsolete_accounts,
+            1,
+            accounts_db.ref_count_for_pubkey(&pubkey),
+        );
 
         accounts_db.set_latest_full_snapshot_slot(slot3);
         accounts_db.clean_accounts(None, false, &EpochSchedule::default());
-        assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 0);
+        assert_ref_count(
+            accounts_db.mark_obsolete_accounts,
+            0,
+            accounts_db.ref_count_for_pubkey(&pubkey),
+        );
     }
 );
 
@@ -6141,48 +6298,6 @@ define_accounts_db_test!(test_get_ancient_slots_one_large, |db| {
 });
 
 #[test]
-fn test_hash_storage_info() {
-    {
-        let hasher = DefaultHasher::new();
-        let hash = hasher.finish();
-        assert_eq!(15130871412783076140, hash);
-    }
-    {
-        let mut hasher = DefaultHasher::new();
-        let slot: Slot = 0;
-        let tf = crate::append_vec::test_utils::get_append_vec_path("test_hash_storage_info");
-        let pubkey1 = solana_pubkey::new_rand();
-        let mark_alive = false;
-        let storage = sample_storage_with_entries(&tf, slot, &pubkey1, mark_alive);
-
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
-        let hash = hasher.finish();
-        // can't assert hash here - it is a function of mod date
-        assert!(load);
-        let slot = 2; // changed this
-        let mut hasher = DefaultHasher::new();
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
-        let hash2 = hasher.finish();
-        assert_ne!(hash, hash2); // slot changed, these should be different
-                                 // can't assert hash here - it is a function of mod date
-        assert!(load);
-        let mut hasher = DefaultHasher::new();
-        append_sample_data_to_storage(&storage, &solana_pubkey::new_rand(), false, None);
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
-        let hash3 = hasher.finish();
-        assert_ne!(hash2, hash3); // moddate and written size changed
-                                  // can't assert hash here - it is a function of mod date
-        assert!(load);
-        let mut hasher = DefaultHasher::new();
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
-        let hash4 = hasher.finish();
-        assert_eq!(hash4, hash3); // same
-                                  // can't assert hash here - it is a function of mod date
-        assert!(load);
-    }
-}
-
-#[test]
 fn test_sweep_get_oldest_non_ancient_slot_max() {
     let epoch_schedule = EpochSchedule::default();
     // way into future
@@ -6510,16 +6625,20 @@ fn test_shrink_collect_simple() {
                                     .collect::<Vec<_>>(),
                                 expected_alive_accounts
                             );
-                            assert_eq!(
-                                shrink_collect
-                                    .pubkeys_to_unref
-                                    .iter()
-                                    .sorted()
-                                    .cloned()
-                                    .cloned()
-                                    .collect::<Vec<_>>(),
-                                expected_unrefed
-                            );
+                            // Shrink will beahve differently with dead accounts tracked in storage
+                            // TODO: Rory Need to understand how
+                            if !db.mark_obsolete_accounts {
+                                assert_eq!(
+                                    shrink_collect
+                                        .pubkeys_to_unref
+                                        .iter()
+                                        .sorted()
+                                        .cloned()
+                                        .cloned()
+                                        .collect::<Vec<_>>(),
+                                    expected_unrefed
+                                );
+                            }
 
                             let alive_total_one_account = 136 + space;
                             if alive {
@@ -7246,8 +7365,13 @@ fn test_clean_old_storages_with_reclaims_rooted() {
         .get_bin(&pubkey)
         .slot_list_mut(&pubkey, |slot_list| slot_list.clone())
         .unwrap();
-    assert_eq!(slot_list.len(), slots.len());
-    assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
+
+    if accounts_db.mark_obsolete_accounts {
+        // If dead accounts are tracked in the storage entry, then the index should only have a single entry
+        assert_eq!(slot_list.len(), 1);
+    } else {
+        assert_eq!(slot_list.len(), slots.len());
+    }
 
     // `clean` should now reclaim the account in `old_slot`, even though `new_slot` is not
     // explicitly being cleaned

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4354,8 +4354,8 @@ fn test_flush_rooted_accounts_cache_with_clean() {
 fn test_flush_rooted_accounts_cache_without_clean() {
     run_flush_rooted_accounts_cache(false);
 }
-
-fn run_test_shrink_unref(do_intra_cache_clean: bool) {
+#[test]
+fn test_shrink_unref() {
     let db = AccountsDb::new_single_for_tests();
     let epoch_schedule = EpochSchedule::default();
     let account_key1 = Pubkey::new_unique();
@@ -4363,16 +4363,9 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     let account1 = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    // This has to be done uncached since we are trying to add another account to the append vec AFTER it has been flushed.
-    // This doesn't work if the flush creates an append vec of exactly the right size.
-    // Normal operations NEVER write the same account to the same append vec twice during a write cache flush.
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.store_uncached(0, &[(&account_key2, &account1)][..]);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.store_for_tests(0, &[(&account_key2, &account1)]);
     db.add_root(0);
-    if !do_intra_cache_clean {
-        // Add an additional ref within the same slot to pubkey 1
-        db.store_uncached(0, &[(&account_key1, &account1)]);
-    }
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1
     db.store_cached((1, &[(&account_key1, &account1)][..]), None);
@@ -4411,16 +4404,6 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     // should be 1, since it was only stored in slot 0 and 1, and slot 0
     // is now dead
     assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
-}
-
-#[test]
-fn test_shrink_unref() {
-    run_test_shrink_unref(false)
-}
-
-#[test]
-fn test_shrink_unref_with_intra_slot_cleaning() {
-    run_test_shrink_unref(true)
 }
 
 #[test]
@@ -4464,8 +4447,8 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     let account0 = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.add_root(0);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.add_root_and_flush_write_cache(0);
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
     // And store one additional live account to make the store still alive after clean.
@@ -4507,9 +4490,9 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     let account0 = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.store_uncached(0, &[(&account_key2, &account1)][..]);
-    db.add_root(0);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.store_for_tests(0, &[(&account_key2, &account1)]);
+    db.add_root_and_flush_write_cache(0);
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
     db.store_cached((1, &[(&account_key1, &account0)][..]), None);
@@ -4574,8 +4557,9 @@ define_accounts_db_test!(test_partial_clean, |db| {
     let account4 = AccountSharedData::new(4, 0, AccountSharedData::default().owner());
 
     // Store accounts into slots 0 and 1
-    db.store_uncached(0, &[(&account_key1, &account1), (&account_key2, &account1)]);
-    db.store_uncached(1, &[(&account_key1, &account2)]);
+    db.store_for_tests(0, &[(&account_key1, &account1), (&account_key2, &account1)]);
+    db.store_for_tests(1, &[(&account_key1, &account2)]);
+
     db.print_accounts_stats("pre-clean1");
 
     // clean accounts - no accounts should be cleaned, since no rooted slots
@@ -4586,15 +4570,16 @@ define_accounts_db_test!(test_partial_clean, |db| {
     db.clean_accounts_for_tests();
 
     db.print_accounts_stats("post-clean1");
-    // Check stores > 0
-    assert!(!db.storage.is_empty_entry(0));
-    assert!(!db.storage.is_empty_entry(1));
+
+    // Assert that cache entries are still present
+    assert!(!db.accounts_cache.slot_cache(0).unwrap().is_empty());
+    assert!(!db.accounts_cache.slot_cache(1).unwrap().is_empty());
 
     // root slot 0
     db.add_root_and_flush_write_cache(0);
 
     // store into slot 2
-    db.store_uncached(2, &[(&account_key2, &account3), (&account_key1, &account3)]);
+    db.store_for_tests(2, &[(&account_key2, &account3), (&account_key1, &account3)]);
     db.clean_accounts_for_tests();
     db.print_accounts_stats("post-clean2");
 
@@ -4604,7 +4589,7 @@ define_accounts_db_test!(test_partial_clean, |db| {
 
     db.print_accounts_stats("post-clean3");
 
-    db.store_uncached(3, &[(&account_key2, &account4)]);
+    db.store_for_tests(3, &[(&account_key2, &account4)]);
     db.add_root_and_flush_write_cache(3);
 
     // Check that we can clean where max_root=3 and slot=2 is not rooted
@@ -4753,7 +4738,7 @@ fn do_test_load_account_and_shrink_race(with_retry: bool) {
     let lamports = 42;
     let mut account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     account.set_lamports(lamports);
-    db.store_uncached(slot, &[(&pubkey, &account)]);
+    db.store_for_tests(slot, &[(&pubkey, &account)]);
 
     // Set the slot as a root so account loads will see the contents of this slot
     db.add_root(slot);

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -43,6 +43,11 @@ impl<T: IndexValue> AccountMapEntry<T> {
         self.set_dirty(true);
     }
 
+    pub fn setref_to_one(&self) {
+        self.ref_count.store(1, Ordering::Release);
+        self.set_dirty(true);
+    }
+
     /// decrement the ref count
     /// return the refcount prior to subtracting 1
     /// 0 indicates an under refcounting error in the system.

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -17,6 +17,9 @@ pub mod accounts_update_notifier_interface;
 mod active_stats;
 pub mod ancestors;
 mod ancient_append_vecs;
+#[cfg(feature = "dev-context-only-utils")]
+pub mod append_vec;
+#[cfg(not(feature = "dev-context-only-utils"))]
 pub mod append_vec;
 pub mod blockhash_queue;
 mod bucket_map_holder;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6695,10 +6695,18 @@ fn test_clean_nonrooted() {
     bank3.force_flush_accounts_cache();
 
     bank3.clean_accounts_for_tests();
-    assert_eq!(
-        bank3.rc.accounts.accounts_db.ref_count_for_pubkey(&pubkey0),
-        2
-    );
+    if bank3.rc.accounts.accounts_db.mark_obsolete_accounts {
+        assert_eq!(
+            bank3.rc.accounts.accounts_db.ref_count_for_pubkey(&pubkey0),
+            1
+        );
+    } else {
+        assert_eq!(
+            bank3.rc.accounts.accounts_db.ref_count_for_pubkey(&pubkey0),
+            2
+        );
+    }
+
     assert!(bank3
         .rc
         .accounts

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1272,6 +1272,11 @@ mod tests {
             .unwrap();
         bank0.fill_bank_with_ticks_for_tests();
 
+        // Test isn't valid with mark obsolete acounts enabled.
+        if bank0.accounts().accounts_db.mark_obsolete_accounts {
+            return;
+        }
+
         // Force flush the bank to create the account storage entry
         bank0.squash();
         bank0.force_flush_accounts_cache();


### PR DESCRIPTION
#### Problem
Currently the accounts index needs to keep track of all instances of account until they have been fully snapshotted. 

#### Summary of Changes
D

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
