### PR TITLE
move version pinning to binary crates for sdk deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,24 +368,24 @@ smallvec = "1.14.0"
 smpl_jwt = "0.7.1"
 socket2 = "0.5.9"
 soketto = "0.7"
-solana-account = "=2.2.1"
+solana-account = "2.2.1"
 solana-account-decoder = { path = "account-decoder", version = "=2.3.0" }
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.3.0" }
-solana-account-info = "=2.2.1"
+solana-account-info = "2.2.1"
 solana-accounts-db = { path = "accounts-db", version = "=2.3.0" }
-solana-address-lookup-table-interface = "=2.2.2"
+solana-address-lookup-table-interface = "2.2.2"
 solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.3.0" }
-solana-atomic-u64 = "=2.2.1"
+solana-atomic-u64 = "2.2.1"
 solana-banks-client = { path = "banks-client", version = "=2.3.0" }
 solana-banks-interface = { path = "banks-interface", version = "=2.3.0" }
 solana-banks-server = { path = "banks-server", version = "=2.3.0" }
 solana-bench-tps = { path = "bench-tps", version = "=2.3.0" }
-solana-big-mod-exp = "=2.2.1"
-solana-bincode = "=2.2.1"
-solana-blake3-hasher = "=2.2.1"
+solana-big-mod-exp = "2.2.1"
+solana-bincode = "2.2.1"
+solana-blake3-hasher = "2.2.1"
 solana-bloom = { path = "bloom", version = "=2.3.0" }
-solana-bn254 = "=2.2.2"
-solana-borsh = "=2.2.1"
+solana-bn254 = "2.2.2"
+solana-borsh = "2.2.1"
 solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.3.0" }
 solana-builtins = { path = "builtins", version = "=2.3.0" }
@@ -398,117 +398,117 @@ solana-cli = { path = "cli", version = "=2.3.0" }
 solana-cli-config = { path = "cli-config", version = "=2.3.0" }
 solana-cli-output = { path = "cli-output", version = "=2.3.0" }
 solana-client = { path = "client", version = "=2.3.0" }
-solana-client-traits = "=2.2.1"
-solana-clock = "=2.2.1"
-solana-cluster-type = "=2.2.1"
-solana-commitment-config = "=2.2.1"
+solana-client-traits = "2.2.1"
+solana-clock = "2.2.1"
+solana-cluster-type = "2.2.1"
+solana-commitment-config = "2.2.1"
 solana-compute-budget = { path = "compute-budget", version = "=2.3.0" }
 solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.0" }
-solana-compute-budget-interface = "=2.2.1"
+solana-compute-budget-interface = "2.2.1"
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.0" }
 solana-config-program = { path = "programs/config", version = "=2.3.0" }
 solana-connection-cache = { path = "connection-cache", version = "=2.3.0", default-features = false }
 solana-core = { path = "core", version = "=2.3.0" }
 solana-cost-model = { path = "cost-model", version = "=2.3.0" }
-solana-cpi = "=2.2.1"
+solana-cpi = "2.2.1"
 solana-curve25519 = { path = "curves/curve25519", version = "=2.3.0" }
-solana-decode-error = "=2.2.1"
-solana-define-syscall = "=2.2.1"
-solana-derivation-path = "=2.2.1"
+solana-decode-error = "2.2.1"
+solana-define-syscall = "2.2.1"
+solana-derivation-path = "2.2.1"
 solana-download-utils = { path = "download-utils", version = "=2.3.0" }
-solana-ed25519-program = "=2.2.2"
+solana-ed25519-program = "2.2.2"
 solana-entry = { path = "entry", version = "=2.3.0" }
-solana-program-entrypoint = "=2.2.1"
-solana-epoch-info = "=2.2.1"
-solana-epoch-rewards = "=2.2.1"
-solana-epoch-rewards-hasher = "=2.2.1"
-solana-epoch-schedule = "=2.2.1"
-solana-example-mocks = "=2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-epoch-info = "2.2.1"
+solana-epoch-rewards = "2.2.1"
+solana-epoch-rewards-hasher = "2.2.1"
+solana-epoch-schedule = "2.2.1"
+solana-example-mocks = "2.2.1"
 solana-faucet = { path = "faucet", version = "=2.3.0" }
 solana-feature-gate-client = "0.0.2"
-solana-feature-gate-interface = "=2.2.1"
-solana-fee-calculator = "=2.2.1"
+solana-feature-gate-interface = "2.2.1"
+solana-fee-calculator = "2.2.1"
 solana-fee = { path = "fee", version = "=2.3.0" }
-solana-fee-structure = "=2.2.1"
-solana-frozen-abi = "=2.2.1"
-solana-frozen-abi-macro = "=2.2.1"
+solana-fee-structure = "2.2.1"
+solana-frozen-abi = "2.2.1"
+solana-frozen-abi-macro = "2.2.1"
 solana-tps-client = { path = "tps-client", version = "=2.3.0" }
-solana-file-download = "=2.2.1"
+solana-file-download = "2.2.1"
 solana-genesis = { path = "genesis", version = "=2.3.0" }
-solana-genesis-config = "=2.2.1"
+solana-genesis-config = "2.2.1"
 solana-genesis-utils = { path = "genesis-utils", version = "=2.3.0" }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.0" }
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.3.0" }
 solana-gossip = { path = "gossip", version = "=2.3.0" }
-solana-hard-forks = "=2.2.1"
-solana-hash = "=2.2.1"
-solana-inflation = "=2.2.1"
+solana-hard-forks = "2.2.1"
+solana-hash = "2.2.1"
+solana-inflation = "2.2.1"
 solana-inline-spl = { path = "inline-spl", version = "=2.3.0" }
-solana-instruction = "=2.2.1"
-solana-instructions-sysvar = "=2.2.1"
-solana-keccak-hasher = "=2.2.1"
-solana-keypair = "=2.2.1"
-solana-last-restart-slot = "=2.2.1"
+solana-instruction = "2.2.1"
+solana-instructions-sysvar = "2.2.1"
+solana-keccak-hasher = "2.2.1"
+solana-keypair = "2.2.1"
+solana-last-restart-slot = "2.2.1"
 solana-lattice-hash = { path = "lattice-hash", version = "=2.3.0" }
 solana-ledger = { path = "ledger", version = "=2.3.0" }
-solana-loader-v2-interface = "=2.2.1"
-solana-loader-v3-interface = "=3.0.0"
-solana-loader-v4-interface = "=2.2.1"
+solana-loader-v2-interface = "2.2.1"
+solana-loader-v3-interface = "3.0.0"
+solana-loader-v4-interface = "2.2.1"
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.3.0" }
 solana-local-cluster = { path = "local-cluster", version = "=2.3.0" }
 solana-log-collector = { path = "log-collector", version = "=2.3.0" }
-solana-logger = "=2.3.1"
+solana-logger = "2.3.1"
 solana-measure = { path = "measure", version = "=2.3.0" }
 solana-merkle-tree = { path = "merkle-tree", version = "=2.3.0" }
-solana-message = "=2.2.1"
+solana-message = "2.2.1"
 solana-metrics = { path = "metrics", version = "=2.3.0" }
-solana-msg = "=2.2.1"
-solana-native-token = "=2.2.1"
+solana-msg = "2.2.1"
+solana-native-token = "2.2.1"
 solana-net-utils = { path = "net-utils", version = "=2.3.0" }
 solana-nohash-hasher = "0.2.1"
-solana-nonce = "=2.2.1"
-solana-nonce-account = "=2.2.1"
+solana-nonce = "2.2.1"
+solana-nonce-account = "2.2.1"
 solana-notifier = { path = "notifier", version = "=2.3.0" }
-solana-offchain-message = "=2.2.1"
-solana-package-metadata = "=2.2.1"
-solana-package-metadata-macro = "=2.2.1"
-solana-packet = "=2.2.1"
+solana-offchain-message = "2.2.1"
+solana-package-metadata = "2.2.1"
+solana-package-metadata-macro = "2.2.1"
+solana-packet = "2.2.1"
 solana-perf = { path = "perf", version = "=2.3.0" }
 solana-poh = { path = "poh", version = "=2.3.0" }
-solana-poh-config = "=2.2.1"
+solana-poh-config = "2.2.1"
 solana-poseidon = { path = "poseidon", version = "=2.3.0" }
-solana-precompile-error = "=2.2.1"
-solana-presigner = "=2.2.1"
-solana-program = { version = "=2.2.1", default-features = false }
-solana-program-error = "=2.2.1"
-solana-program-memory = "=2.2.1"
-solana-program-option = "=2.2.1"
-solana-program-pack = "=2.2.1"
+solana-precompile-error = "2.2.1"
+solana-presigner = "2.2.1"
+solana-program = { version = "2.2.1", default-features = false }
+solana-program-error = "2.2.1"
+solana-program-memory = "2.2.1"
+solana-program-option = "2.2.1"
+solana-program-pack = "2.2.1"
 solana-program-runtime = { path = "program-runtime", version = "=2.3.0" }
 solana-program-test = { path = "program-test", version = "=2.3.0" }
-solana-pubkey = { version = "=2.2.1", default-features = false }
+solana-pubkey = { version = "2.2.1", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=2.3.0" }
 solana-quic-client = { path = "quic-client", version = "=2.3.0" }
-solana-quic-definitions = "=2.2.1"
+solana-quic-definitions = "2.2.1"
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.3.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=2.3.0", default-features = false }
-solana-rent = "=2.2.1"
-solana-rent-collector = "=2.2.1"
-solana-rent-debits = "=2.2.1"
-solana-reward-info = "=2.2.1"
-solana-sanitize = "=2.2.1"
-solana-secp256r1-program = "=2.2.2"
-solana-seed-derivable = "=2.2.1"
-solana-seed-phrase = "=2.2.1"
-solana-serde = "=2.2.1"
-solana-serde-varint = "=2.2.1"
-solana-serialize-utils = "=2.2.1"
-solana-sha256-hasher = "=2.2.1"
-solana-signature = { version = "=2.2.1", default-features = false }
-solana-signer = "=2.2.1"
-solana-slot-hashes = "=2.2.1"
-solana-slot-history = "=2.2.1"
-solana-time-utils = "=2.2.1"
+solana-rent = "2.2.1"
+solana-rent-collector = "2.2.1"
+solana-rent-debits = "2.2.1"
+solana-reward-info = "2.2.1"
+solana-sanitize = "2.2.1"
+solana-secp256r1-program = "2.2.2"
+solana-seed-derivable = "2.2.1"
+solana-seed-phrase = "2.2.1"
+solana-serde = "2.2.1"
+solana-serde-varint = "2.2.1"
+solana-serialize-utils = "2.2.1"
+solana-sha256-hasher = "2.2.1"
+solana-signature = { version = "2.2.1", default-features = false }
+solana-signer = "2.2.1"
+solana-slot-hashes = "2.2.1"
+solana-slot-history = "2.2.1"
+solana-time-utils = "2.2.1"
 solana-timings = { path = "timings", version = "=2.3.0" }
 solana-tls-utils = { path = "tls-utils", version = "=2.3.0" }
 solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.0" }
@@ -520,16 +520,16 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.0" }
 solana-runtime = { path = "runtime", version = "=2.3.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" }
-solana-sbpf = "=0.10.0"
-solana-sdk = "=2.2.2"
-solana-sdk-ids = "=2.2.1"
-solana-sdk-macro = "=2.2.1"
-solana-secp256k1-program = "=2.2.1"
-solana-secp256k1-recover = "=2.2.1"
+solana-sbpf = "0.10.0"
+solana-sdk = "2.2.2"
+solana-sdk-ids = "2.2.1"
+solana-sdk-macro = "2.2.1"
+solana-secp256k1-program = "2.2.1"
+solana-secp256k1-recover = "2.2.1"
 solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.0" }
-solana-short-vec = "=2.2.1"
-solana-shred-version = "=2.2.1"
-solana-stable-layout = "=2.2.1"
+solana-short-vec = "2.2.1"
+solana-shred-version = "2.2.1"
+solana-stable-layout = "2.2.1"
 solana-stake-interface = { version = "1.2.1" }
 solana-stake-program = { path = "programs/stake", version = "=2.3.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=2.3.0" }
@@ -542,13 +542,13 @@ solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.3.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.3.0" }
 solana-system-interface = "1.0"
 solana-system-program = { path = "programs/system", version = "=2.3.0" }
-solana-system-transaction = "=2.2.1"
-solana-sysvar = "=2.2.1"
-solana-sysvar-id = "=2.2.1"
+solana-system-transaction = "2.2.1"
+solana-sysvar = "2.2.1"
+solana-sysvar-id = "2.2.1"
 solana-test-validator = { path = "test-validator", version = "=2.3.0" }
 solana-thin-client = { path = "thin-client", version = "=2.3.0" }
-solana-transaction = "=2.2.2"
-solana-transaction-error = "=2.2.1"
+solana-transaction = "2.2.2"
+solana-transaction-error = "2.2.1"
 solana-tpu-client = { path = "tpu-client", version = "=2.3.0", default-features = false }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=2.3.0" }
 solana-transaction-context = { path = "transaction-context", version = "=2.3.0", features = [ "bincode", "debug-signature" ] }
@@ -558,10 +558,10 @@ solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", ver
 solana-turbine = { path = "turbine", version = "=2.3.0" }
 solana-type-overrides = { path = "type-overrides", version = "=2.3.0" }
 solana-udp-client = { path = "udp-client", version = "=2.3.0" }
-solana-validator-exit = "=2.2.1"
+solana-validator-exit = "2.2.1"
 solana-version = { path = "version", version = "=2.3.0" }
 solana-vote = { path = "vote", version = "=2.3.0" }
-solana-vote-interface = "=2.2.3"
+solana-vote-interface = "2.2.3"
 solana-vote-program = { path = "programs/vote", version = "=2.3.0", default-features = false }
 solana-wen-restart = { path = "wen-restart", version = "=2.3.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,7 +520,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.0" }
 solana-runtime = { path = "runtime", version = "=2.3.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" }
-solana-sbpf = "0.10.0"
+solana-sbpf = "=0.10.0"
 solana-sdk = "2.2.2"
 solana-sdk-ids = "2.2.1"
 solana-sdk-macro = "2.2.1"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -27,7 +27,7 @@ solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-faucet = { workspace = true }
 solana-genesis = { workspace = true }
 solana-gossip = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
@@ -37,7 +37,7 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-sdk = { workspace = true }
+solana-sdk = "=2.2.2"
 solana-streamer = { workspace = true }
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,59 +29,59 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-solana-account = { workspace = true }
+solana-account = "=2.2.1"
 solana-account-decoder = { workspace = true }
-solana-borsh = { workspace = true }
+solana-borsh = "=2.2.1"
 solana-bpf-loader-program = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-client = { workspace = true }
-solana-clock = { workspace = true }
-solana-cluster-type = { workspace = true }
-solana-commitment-config = { workspace = true }
+solana-clock = "=2.2.1"
+solana-cluster-type = "=2.2.1"
+solana-commitment-config = "=2.2.1"
 solana-compute-budget = { workspace = true }
-solana-compute-budget-interface = { workspace = true, features = ["borsh"] }
+solana-compute-budget-interface = { version = "=2.2.1", features = ["borsh"] }
 solana-config-program = { workspace = true }
 solana-connection-cache = { workspace = true }
-solana-decode-error = { workspace = true }
-solana-epoch-schedule = { workspace = true }
-solana-feature-gate-client = { workspace = true }
-solana-feature-gate-interface = { workspace = true }
-solana-hash = { workspace = true }
-solana-instruction = { workspace = true }
-solana-keypair = { workspace = true }
-solana-loader-v3-interface = { workspace = true }
-solana-loader-v4-interface = { workspace = true }
+solana-decode-error = "=2.2.1"
+solana-epoch-schedule = "=2.2.1"
+solana-feature-gate-client = "=0.0.2"
+solana-feature-gate-interface = "=2.2.1"
+solana-hash = "=2.2.1"
+solana-instruction = "=2.2.1"
+solana-keypair = "=2.2.1"
+solana-loader-v3-interface = "=3.0.0"
+solana-loader-v4-interface = "=2.2.1"
 solana-loader-v4-program = { workspace = true }
-solana-logger = { workspace = true }
-solana-message = { workspace = true }
-solana-native-token = { workspace = true }
-solana-nonce = { workspace = true }
-solana-offchain-message = { workspace = true, features = ["verify"] }
-solana-packet = { workspace = true }
-solana-program = { workspace = true }
+solana-logger = "=2.3.1"
+solana-message = "=2.2.1"
+solana-native-token = "=2.2.1"
+solana-nonce = "=2.2.1"
+solana-offchain-message = { version = "=2.2.1", features = ["verify"] }
+solana-packet = "=2.2.1"
+solana-program = { version = "=2.2.1", default-features = false }
 solana-program-runtime = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { version = "=2.2.1", default-features = false }
 solana-pubsub-client = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
-solana-rent = { workspace = true }
+solana-rent = "=2.2.1"
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true, features = ["clap"] }
 solana-sbpf = { workspace = true }
-solana-sdk-ids = { workspace = true }
-solana-signature = { workspace = true }
-solana-signer = { workspace = true }
-solana-slot-history = { workspace = true }
+solana-sdk-ids = "=2.2.1"
+solana-signature = { version = "=2.2.1", default-features = false }
+solana-signer = "=2.2.1"
+solana-slot-history = "=2.2.1"
 solana-streamer = { workspace = true }
-solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-sysvar = { workspace = true }
+solana-system-interface = "=1.0"
+solana-sysvar = "=2.2.1"
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }
-solana-transaction = { workspace = true }
-solana-transaction-error = { workspace = true }
+solana-transaction = "=2.2.2"
+solana-transaction-error = "=2.2.1"
 solana-transaction-status = { workspace = true }
 solana-udp-client = { workspace = true }
 solana-version = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -76,7 +76,7 @@ solana-signature = { version = "=2.2.1", default-features = false }
 solana-signer = "=2.2.1"
 solana-slot-history = "=2.2.1"
 solana-streamer = { workspace = true }
-solana-system-interface = "=1.0"
+solana-system-interface = { version = "=1.0", features = ["bincode"] }
 solana-sysvar = "=2.2.1"
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -19,12 +19,12 @@ indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-solana-keypair = "2.2.1"
+solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-time-utils = "2.2.1"
-solana-transaction-error = "2.2.1"
+solana-time-utils = { workspace = true }
+solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -19,12 +19,12 @@ indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-solana-keypair = { workspace = true }
+solana-keypair = "2.2.1"
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-time-utils = { workspace = true }
-solana-transaction-error = { workspace = true }
+solana-time-utils = "2.2.1"
+solana-transaction-error = "2.2.1"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -23,14 +23,14 @@ solana-connection-cache = { workspace = true }
 solana-core = { workspace = true }
 solana-faucet = { workspace = true }
 solana-gossip = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-measure = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
 solana-quic-client = { workspace = true }
 solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }
-solana-sdk = { workspace = true }
+solana-sdk = "=2.2.2"
 solana-streamer = { workspace = true }
 solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -29,7 +29,7 @@ solana-packet = "=2.2.1"
 solana-pubkey = { version = "=2.2.1", features = ["rand"] }
 solana-signer = "=2.2.1"
 solana-system-interface = "=1.0"
-solana-system-transaction = "2.2.1"
+solana-system-transaction = "=2.2.1"
 solana-transaction = "=2.2.2"
 solana-version = { workspace = true }
 spl-memo = { workspace = true, features = ["no-entrypoint"] }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -18,19 +18,19 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
-solana-hash = { workspace = true }
-solana-instruction = { workspace = true }
-solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
-solana-message = { workspace = true }
+solana-hash = "=2.2.1"
+solana-instruction = "=2.2.1"
+solana-keypair = "=2.2.1"
+solana-logger = "=2.3.1"
+solana-message = "=2.2.1"
 solana-metrics = { workspace = true }
-solana-native-token = { workspace = true }
-solana-packet = { workspace = true }
-solana-pubkey = { workspace = true, features = ["rand"] }
-solana-signer = { workspace = true }
-solana-system-interface = { workspace = true }
-solana-system-transaction = { workspace = true }
-solana-transaction = { workspace = true }
+solana-native-token = "=2.2.1"
+solana-packet = "=2.2.1"
+solana-pubkey = { version = "=2.2.1", features = ["rand"] }
+solana-signer = "=2.2.1"
+solana-system-interface = "=1.0"
+solana-system-transaction = "2.2.1"
+solana-transaction = "=2.2.2"
 solana-version = { workspace = true }
 spl-memo = { workspace = true, features = ["no-entrypoint"] }
 thiserror = { workspace = true }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -18,34 +18,34 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-solana-account = { workspace = true }
+solana-account = "=2.2.1"
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
-solana-clock = { workspace = true }
-solana-commitment-config = { workspace = true }
+solana-clock = "=2.2.1"
+solana-commitment-config = "=2.2.1"
 solana-entry = { workspace = true }
-solana-epoch-schedule = { workspace = true }
-solana-feature-gate-interface = { workspace = true }
-solana-fee-calculator = { workspace = true }
-solana-genesis-config = { workspace = true }
-solana-inflation = { workspace = true }
-solana-keypair = { workspace = true }
+solana-epoch-schedule = "=2.2.1"
+solana-feature-gate-interface = "=2.2.1"
+solana-fee-calculator = "=2.2.1"
+solana-genesis-config = "=2.2.1"
+solana-inflation = "=2.2.1"
+solana-keypair = "=2.2.1"
 solana-ledger = { workspace = true }
-solana-loader-v3-interface = { workspace = true }
-solana-logger = { workspace = true }
-solana-native-token = { workspace = true }
-solana-poh-config = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-rent = { workspace = true }
+solana-loader-v3-interface = "=3.0.0"
+solana-logger = "=2.3.1"
+solana-native-token = "=2.2.1"
+solana-poh-config = "=2.2.1"
+solana-pubkey = { version = "=2.2.1", default-features = false }
+solana-rent = "=2.2.1"
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk-ids = { workspace = true }
-solana-signer = { workspace = true }
-solana-stake-interface = { workspace = true }
+solana-sdk-ids = "=2.2.1"
+solana-signer = "=2.2.1"
+solana-stake-interface = "=1.2.1"
 solana-stake-program = { workspace = true }
-solana-time-utils = { workspace = true }
+solana-time-utils = "2.2.1"
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 tempfile = { workspace = true }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -34,41 +34,41 @@ siphasher = { workspace = true }
 solana-bloom = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-client = { workspace = true }
-solana-clock = { workspace = true }
+solana-clock = "=2.2.1"
 solana-connection-cache = { workspace = true }
 solana-entry = { workspace = true }
-solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-epoch-schedule = "=2.2.1"
+solana-frozen-abi = { version = "=2.2.1", optional = true, features = [
     "frozen-abi",
 ] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+solana-frozen-abi-macro = { version = "=2.2.1", optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true }
-solana-keypair = { workspace = true }
+solana-hash = "=2.2.1"
+solana-keypair = "=2.2.1"
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
-solana-native-token = { workspace = true }
+solana-native-token = "=2.2.1"
 solana-net-utils = { workspace = true }
-solana-packet = { workspace = true }
+solana-packet = "=2.2.1"
 solana-perf = { workspace = true }
-solana-pubkey = { workspace = true, features = ["rand"] }
-solana-quic-definitions = { workspace = true }
+solana-pubkey = { version = "=2.2.1", features = ["rand"] }
+solana-quic-definitions = "=2.2.1"
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sanitize = { workspace = true }
-solana-serde-varint = { workspace = true }
-solana-sha256-hasher = { workspace = true }
-solana-short-vec = { workspace = true }
-solana-signature = { workspace = true }
-solana-signer = { workspace = true }
+solana-sanitize = "=2.2.1"
+solana-serde-varint = "=2.2.1"
+solana-sha256-hasher = "=2.2.1"
+solana-short-vec = "=2.2.1"
+solana-signature = { version = "=2.2.1", default-features = false }
+solana-signer = "=2.2.1"
 solana-streamer = { workspace = true }
-solana-time-utils = { workspace = true }
+solana-time-utils = "=2.2.1"
 solana-tpu-client = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = "=2.2.2"
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -31,16 +31,16 @@ serde_yaml = { workspace = true }
 serde_yaml_08 = { package = "serde_yaml", version = "0.8.26" }
 solana-clap-utils = { workspace = true }
 solana-config-program = { workspace = true }
-solana-hash = { workspace = true }
-solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
-solana-message = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-hash = "=2.2.1"
+solana-keypair = "=2.2.1"
+solana-logger = "=2.3.1"
+solana-message = "=2.2.1"
+solana-pubkey = { version = "=2.2.1", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-signature = { workspace = true }
-solana-signer = { workspace = true }
-solana-transaction = { workspace = true }
+solana-signature = { version = "=2.2.1", default-features = false }
+solana-signer = "=2.2.1"
+solana-transaction = "=2.2.2"
 solana-version = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -17,14 +17,14 @@ num_cpus = { workspace = true }
 serde_json = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-cli-config = { workspace = true }
-solana-derivation-path = { workspace = true }
-solana-instruction = { workspace = true }
-solana-keypair = { workspace = true }
-solana-message = { workspace = true, features = ["bincode"] }
-solana-pubkey = { workspace = true }
+solana-derivation-path = "=2.2.1"
+solana-instruction = { version = "=2.2.1", features = ["bincode"] }
+solana-keypair = "=2.2.1"
+solana-message = { version = "=2.2.1", features = ["bincode"] }
+solana-pubkey = { version = "=2.2.1", default-features = false }
 solana-remote-wallet = { workspace = true, features = ["default"] }
-solana-seed-derivable = { workspace = true }
-solana-signer = { workspace = true }
+solana-seed-derivable = "=2.2.1"
+solana-signer = "=2.2.1"
 solana-version = { workspace = true }
 tiny-bip39 = { workspace = true }
 

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -43,14 +43,14 @@ solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-log-collector = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-measure = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true }
 solana-sbpf = { workspace = true, features = ["debugger"] }
-solana-sdk = { workspace = true, features = ["openssl-vendored"] }
+solana-sdk = { version = "=2.2.2", features = ["openssl-vendored"] }
 solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "3.1.5", features = ["cargo"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-version = { workspace = true }
 
 [[bin]]

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -15,7 +15,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 
 [[bin]]
 name = "solana-net-shaper"

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -24,8 +24,8 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 socket2 = { workspace = true }
-solana-logger = { workspace = true, optional = true }
-solana-serde = { workspace = true }
+solana-logger = { version = "=2.3.1", optional = true }
+solana-serde = "=2.2.1"
 solana-version = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -18,9 +18,9 @@ log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 semver = { workspace = true }
-solana-file-download = { workspace = true }
-solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
+solana-file-download = "=2.2.1"
+solana-keypair = "=2.2.1"
+solana-logger = "=2.3.1"
 tar = { workspace = true }
 
 [dev-dependencies]

--- a/platform-tools-sdk/cargo-test-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-test-sbf/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "3.1.5", features = ["cargo"] }
 itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 
 [[bin]]
 name = "cargo-test-sbf"

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -16,7 +16,7 @@ solana-cli-config = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
+solana-sdk = "=2.2.2"
 solana-stake-program = { workspace = true }
 solana-version = { workspace = true }
 

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -24,14 +24,14 @@ solana-core = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-net-utils = { workspace = true }
 solana-program-test = { workspace = true }
 solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk = { workspace = true, features = ["openssl-vendored"] }
+solana-sdk = { version = "=2.2.2", features = ["openssl-vendored"] }
 solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -26,7 +26,7 @@ solana-cli-config = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
+solana-sdk = "=2.2.2"
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 spl-associated-token-account = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -45,7 +45,7 @@ solana-genesis-utils = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
-solana-logger = { workspace = true }
+solana-logger = "=2.3.1"
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-perf = { workspace = true }
@@ -56,7 +56,7 @@ solana-rpc = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk = { workspace = true, features = ["openssl-vendored"] }
+solana-sdk = { version = "=2.2.2", features = ["openssl-vendored"] }
 solana-send-transaction-service = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -16,12 +16,12 @@ log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
-solana-hash = { workspace = true }
-solana-logger = { workspace = true }
+solana-hash = "=2.2.1"
+solana-logger = "=2.3.1"
 solana-metrics = { workspace = true }
-solana-native-token = { workspace = true }
+solana-native-token = "=2.2.1"
 solana-notifier = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { version = "=2.2.1", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-version = { workspace = true }

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -21,8 +21,8 @@ clap = { version = "3.1.5", features = ["cargo", "derive"] }
 dirs-next = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
-solana-seed-derivable = { workspace = true }
-solana-signer = { workspace = true }
+solana-seed-derivable = "=2.2.1"
+solana-signer = "=2.2.1"
 solana-version = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
#### Problem

version pinning in the monorepo restricts dependency options for the remaining public api crates that reside there

eg. try to use `solana-client = "2.2.1"` (monorepo) with `solana-transaction = "2.2.2"` (sdk)

#### Summary of Changes

move all version pinning from workspace to bin crates for sdk dependencies