### PR TITLE
 Remove SVM dep on agave-precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6885,7 +6885,6 @@ name = "solana-bpf-loader-program"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "assert_matches",
  "bincode",
  "criterion",
@@ -9145,7 +9144,6 @@ name = "solana-program-runtime"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "assert_matches",
  "base64 0.22.1",
  "bincode",
@@ -9723,6 +9721,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
+ "solana-precompile-error",
  "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
@@ -10331,7 +10330,6 @@ name = "solana-svm"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "agave-reserved-account-keys",
  "ahash 0.8.11",
  "assert_matches",
@@ -10375,6 +10373,7 @@ dependencies = [
  "solana-native-token",
  "solana-nonce",
  "solana-nonce-account",
+ "solana-precompile-error",
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rent",
@@ -10409,6 +10408,7 @@ name = "solana-svm-callback"
 version = "2.3.0"
 dependencies = [
  "solana-account",
+ "solana-precompile-error",
  "solana-pubkey",
 ]
 

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [dependencies]
 agave-feature-set = { workspace = true }
-agave-precompiles = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 enum-iterator = { workspace = true }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -30,7 +30,7 @@ use {
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader, sysvar,
     },
     solana_stable_layout::stable_instruction::StableInstruction,
-    solana_svm_callback::EpochStakeCallback,
+    solana_svm_callback::InvokeContextCallback,
     solana_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_transaction_context::{
         IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
@@ -146,7 +146,7 @@ impl BpfAllocator {
 pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
     pub blockhash_lamports_per_signature: u64,
-    epoch_stake_callback: &'a dyn EpochStakeCallback,
+    epoch_stake_callback: &'a dyn InvokeContextCallback,
     pub feature_set: Arc<FeatureSet>,
     sysvar_cache: &'a SysvarCache,
 }
@@ -154,7 +154,7 @@ impl<'a> EnvironmentConfig<'a> {
     pub fn new(
         blockhash: Hash,
         blockhash_lamports_per_signature: u64,
-        epoch_stake_callback: &'a dyn EpochStakeCallback,
+        epoch_stake_callback: &'a dyn InvokeContextCallback,
         feature_set: Arc<FeatureSet>,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
@@ -740,7 +740,7 @@ macro_rules! with_mock_invoke_context {
         use {
             agave_feature_set::FeatureSet,
             solana_log_collector::LogCollector,
-            solana_svm_callback::EpochStakeCallback,
+            solana_svm_callback::InvokeContextCallback,
             solana_type_overrides::sync::Arc,
             $crate::{
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
@@ -751,8 +751,8 @@ macro_rules! with_mock_invoke_context {
             },
         };
 
-        struct MockEpochStakeCallback {}
-        impl EpochStakeCallback for MockEpochStakeCallback {}
+        struct MockInvokeContextCallback {}
+        impl InvokeContextCallback for MockInvokeContextCallback {}
 
         let compute_budget = SVMTransactionExecutionBudget::default();
         let mut $transaction_context = TransactionContext::new(
@@ -782,7 +782,7 @@ macro_rules! with_mock_invoke_context {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
-            &MockEpochStakeCallback {},
+            &MockInvokeContextCallback {},
             Arc::new(FeatureSet::all_enabled()),
             &sysvar_cache,
         );

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [dependencies]
 agave-feature-set = { workspace = true }
-agave-precompiles = { workspace = true }
 bincode = { workspace = true }
 libsecp256k1 = { workspace = true }
 num-traits = { workspace = true }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1069,9 +1069,7 @@ fn check_authorized_program(
                         instruction_data,
                     ))
                 || bpf_loader_upgradeable::is_close_instruction(instruction_data)))
-        || is_precompile(program_id, |feature_id: &Pubkey| {
-            invoke_context.get_feature_set().is_active(feature_id)
-        })
+        || invoke_context.is_precompile(program_id)
     {
         return Err(Box::new(SyscallError::ProgramNotSupported(*program_id)));
     }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4914,7 +4914,7 @@ mod tests {
         const EXPECTED_TOTAL_STAKE: u64 = 200_000_000_000_000;
 
         struct MockCallback {}
-        impl EpochStakeCallback for MockCallback {
+        impl InvokeContextCallback for MockCallback {
             fn get_epoch_stake(&self) -> u64 {
                 EXPECTED_TOTAL_STAKE
             }
@@ -4967,7 +4967,7 @@ mod tests {
         const EXPECTED_EPOCH_STAKE: u64 = 55_000_000_000;
 
         struct MockCallback {}
-        impl EpochStakeCallback for MockCallback {
+        impl InvokeContextCallback for MockCallback {
             // Total stake is not needed for this test.
             fn get_epoch_stake_for_vote_account(&self, vote_address: &Pubkey) -> u64 {
                 if *vote_address == TARGET_VOTE_ADDRESS {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -24,7 +24,6 @@ use {
         last_restart_slot_sysvar, reenable_sbpf_v0_execution,
         remaining_compute_units_syscall_enabled, FeatureSet,
     },
-    agave_precompiles::is_precompile,
     solana_account_info::AccountInfo,
     solana_big_mod_exp::{big_mod_exp, BigModExpParams},
     solana_blake3_hasher as blake3,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5546,7 +5546,6 @@ name = "solana-bpf-loader-program"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "bincode",
  "libsecp256k1 0.6.0",
  "num-traits",
@@ -7148,7 +7147,6 @@ name = "solana-program-runtime"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "base64 0.22.1",
  "bincode",
  "enum-iterator",
@@ -7620,6 +7618,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
+ "solana-precompile-error",
  "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
@@ -8658,7 +8657,6 @@ name = "solana-svm"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "ahash 0.8.11",
  "itertools 0.12.1",
  "log",
@@ -8702,6 +8700,7 @@ name = "solana-svm-callback"
 version = "2.3.0"
 dependencies = [
  "solana-account",
+ "solana-precompile-error",
  "solana-pubkey",
 ]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -71,6 +71,7 @@ solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-perf = { workspace = true }
+solana-precompile-error = { workspace = true }
 solana-program = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true }
@@ -123,7 +124,7 @@ solana-runtime-transaction = { workspace = true, features = [
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
 solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils" ] }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -59,7 +59,7 @@ use {
     },
     accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
     agave_feature_set::{self as feature_set, FeatureSet},
-    agave_precompiles::get_precompiles,
+    agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
     ahash::AHashSet,
     dashmap::{DashMap, DashSet},
@@ -137,6 +137,7 @@ use {
         native_loader,
         native_token::LAMPORTS_PER_SOL,
         packet::PACKET_DATA_SIZE,
+        precompiles::PrecompileError,
         pubkey::Pubkey,
         rent_collector::{CollectedInfo, RentCollector},
         rent_debits::RentDebits,
@@ -6950,6 +6951,27 @@ impl EpochStakeCallback for Bank {
             .get(vote_address)
             .map(|(stake, _)| (*stake))
             .unwrap_or(0)
+    }
+
+    fn is_precompile(&self, program_id: &Pubkey) -> bool {
+        is_precompile(program_id, |feature_id: &Pubkey| {
+            self.feature_set.is_active(feature_id)
+        })
+    }
+
+    fn process_precompile(
+        &self,
+        program_id: &Pubkey,
+        data: &[u8],
+        instruction_datas: Vec<&[u8]>,
+    ) -> std::result::Result<(), PrecompileError> {
+        if let Some(precompile) = get_precompile(program_id, |feature_id: &Pubkey| {
+            self.feature_set.is_active(feature_id)
+        }) {
+            precompile.verify(data, &instruction_datas, &self.feature_set)
+        } else {
+            Err(PrecompileError::InvalidPublicKey)
+        }
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -172,7 +172,7 @@ use {
             TransactionProcessingConfig, TransactionProcessingEnvironment,
         },
     },
-    solana_svm_callback::{AccountState, EpochStakeCallback, TransactionProcessingCallback},
+    solana_svm_callback::{AccountState, InvokeContextCallback, TransactionProcessingCallback},
     solana_svm_transaction::svm_message::SVMMessage,
     solana_timings::{ExecuteTimingType, ExecuteTimings},
     solana_transaction_context::{TransactionAccount, TransactionReturnData},
@@ -6941,7 +6941,7 @@ impl Bank {
     }
 }
 
-impl EpochStakeCallback for Bank {
+impl InvokeContextCallback for Bank {
     fn get_epoch_stake(&self) -> u64 {
         self.get_current_epoch_total_stake()
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -20,7 +20,7 @@ use {
         instruction::InstructionError,
         pubkey::Pubkey,
     },
-    solana_svm_callback::EpochStakeCallback,
+    solana_svm_callback::InvokeContextCallback,
     solana_transaction_context::TransactionContext,
     source_buffer::SourceBuffer,
     std::{cmp::Ordering, sync::atomic::Ordering::Relaxed},
@@ -160,7 +160,7 @@ impl Bank {
             );
 
             struct MockCallback {}
-            impl EpochStakeCallback for MockCallback {}
+            impl InvokeContextCallback for MockCallback {}
 
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,

--- a/svm-callback/Cargo.toml
+++ b/svm-callback/Cargo.toml
@@ -11,6 +11,7 @@ readme = false
 
 [dependencies]
 solana-account = { workspace = true }
+solana-precompile-error = { workspace = true }
 solana-pubkey = { workspace = true }
 
 [lints]

--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -1,4 +1,7 @@
-use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
+use {
+    solana_account::AccountSharedData, solana_precompile_error::PrecompileError,
+    solana_pubkey::Pubkey,
+};
 
 /// Callback for obtaining the cluster's current epoch stake.
 pub trait EpochStakeCallback {
@@ -10,6 +13,21 @@ pub trait EpochStakeCallback {
     /// Returns the current epoch stake for the given vote account.
     fn get_epoch_stake_for_vote_account(&self, _vote_address: &Pubkey) -> u64 {
         0
+    }
+
+    /// Returns true if the program_id corresponds to a precompiled program
+    fn is_precompile(&self, _program_id: &Pubkey) -> bool {
+        false
+    }
+
+    /// Calls the precompiled program corresponding to the given program ID.
+    fn process_precompile(
+        &self,
+        _program_id: &Pubkey,
+        _data: &[u8],
+        _instruction_datas: Vec<&[u8]>,
+    ) -> Result<(), PrecompileError> {
+        Err(PrecompileError::InvalidPublicKey)
     }
 }
 

--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -3,8 +3,8 @@ use {
     solana_pubkey::Pubkey,
 };
 
-/// Callback for obtaining the cluster's current epoch stake.
-pub trait EpochStakeCallback {
+/// Callback used by InvokeContext in SVM
+pub trait InvokeContextCallback {
     /// Returns the total current epoch stake for the network.
     fn get_epoch_stake(&self) -> u64 {
         0
@@ -32,7 +32,7 @@ pub trait EpochStakeCallback {
 }
 
 /// Runtime callbacks for transaction processing.
-pub trait TransactionProcessingCallback: EpochStakeCallback {
+pub trait TransactionProcessingCallback: InvokeContextCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
@@ -44,7 +44,7 @@ pub trait TransactionProcessingCallback: EpochStakeCallback {
 
     #[deprecated(
         since = "2.3.0",
-        note = "Use `get_epoch_stake_for_vote_account` on the `EpochStakeCallback` trait instead"
+        note = "Use `get_epoch_stake_for_vote_account` on the `InvokeContextCallback` trait instead"
     )]
     fn get_current_epoch_vote_account_stake(&self, vote_address: &Pubkey) -> u64 {
         Self::get_epoch_stake_for_vote_account(self, vote_address)

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -11,7 +11,6 @@ edition = { workspace = true }
 
 [dependencies]
 agave-feature-set = { workspace = true }
-agave-precompiles = { workspace = true }
 ahash = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -81,6 +80,7 @@ solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
 solana-native-token = { workspace = true }
+solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
@@ -97,7 +97,7 @@ solana-system-program = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils" ] }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5404,7 +5404,6 @@ name = "solana-bpf-loader-program"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "bincode",
  "libsecp256k1",
  "num-traits",
@@ -6972,7 +6971,6 @@ name = "solana-program-runtime"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "base64 0.22.1",
  "bincode",
  "enum-iterator",
@@ -7444,6 +7442,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-nonce-account",
  "solana-perf",
+ "solana-precompile-error",
  "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
@@ -7979,7 +7978,6 @@ name = "solana-svm"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
- "agave-precompiles",
  "ahash 0.8.11",
  "itertools 0.12.1",
  "log",
@@ -8022,6 +8020,7 @@ name = "solana-svm-callback"
 version = "2.3.0"
 dependencies = [
  "solana-account",
+ "solana-precompile-error",
  "solana-pubkey",
 ]
 

--- a/svm/examples/json-rpc/server/src/svm_bridge.rs
+++ b/svm/examples/json-rpc/server/src/svm_bridge.rs
@@ -31,7 +31,7 @@ use {
         transaction_processing_result::TransactionProcessingResult,
         transaction_processor::TransactionBatchProcessor,
     },
-    solana_svm_callback::{EpochStakeCallback, TransactionProcessingCallback},
+    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
     std::{
         collections::HashMap,
         sync::{Arc, RwLock},
@@ -59,7 +59,7 @@ pub struct MockBankCallback {
     pub account_shared_data: RwLock<HashMap<Pubkey, AccountSharedData>>,
 }
 
-impl EpochStakeCallback for MockBankCallback {}
+impl InvokeContextCallback for MockBankCallback {}
 
 impl TransactionProcessingCallback for MockBankCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {

--- a/svm/examples/paytube/src/loader.rs
+++ b/svm/examples/paytube/src/loader.rs
@@ -11,7 +11,7 @@ use {
         account::{AccountSharedData, ReadableAccount},
         pubkey::Pubkey,
     },
-    solana_svm_callback::{EpochStakeCallback, TransactionProcessingCallback},
+    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
     std::{collections::HashMap, sync::RwLock},
 };
 
@@ -39,7 +39,7 @@ impl<'a> PayTubeAccountLoader<'a> {
 /// ability to load accounts.
 ///
 /// In the Agave validator, this implementation is Bank, powered by AccountsDB.
-impl EpochStakeCallback for PayTubeAccountLoader<'_> {}
+impl InvokeContextCallback for PayTubeAccountLoader<'_> {}
 impl TransactionProcessingCallback for PayTubeAccountLoader<'_> {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         if let Some(account) = self.cache.read().unwrap().get(pubkey) {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -697,7 +697,7 @@ mod tests {
         },
         solana_signature::Signature,
         solana_signer::Signer,
-        solana_svm_callback::{EpochStakeCallback, TransactionProcessingCallback},
+        solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
         solana_system_transaction::transfer,
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_transaction_context::{TransactionAccount, TransactionContext},
@@ -713,7 +713,7 @@ mod tests {
             RefCell<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>,
     }
 
-    impl EpochStakeCallback for TestCallbacks {}
+    impl InvokeContextCallback for TestCallbacks {}
 
     impl TransactionProcessingCallback for TestCallbacks {
         fn account_matches_owners(&self, _account: &Pubkey, _owners: &[Pubkey]) -> Option<usize> {

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -140,13 +140,13 @@ mod tests {
         solana_sdk_ids::{ed25519_program, native_loader, secp256k1_program, system_program},
         solana_secp256k1_program::new_secp256k1_instruction,
         solana_secp256r1_program::new_secp256r1_instruction,
-        solana_svm_callback::EpochStakeCallback,
+        solana_svm_callback::InvokeContextCallback,
         solana_transaction_context::TransactionContext,
         std::sync::Arc,
     };
 
     struct MockCallback {}
-    impl EpochStakeCallback for MockCallback {}
+    impl InvokeContextCallback for MockCallback {}
 
     fn create_loadable_account_for_test(name: &str) -> AccountSharedData {
         let (lamports, rent_epoch) = DUMMY_INHERITABLE_ACCOUNT_FIELDS;
@@ -666,7 +666,7 @@ mod tests {
         );
 
         struct MockCallback {}
-        impl EpochStakeCallback for MockCallback {
+        impl InvokeContextCallback for MockCallback {
             fn is_precompile(&self, program_id: &Pubkey) -> bool {
                 program_id == &secp256k1_program::id()
                     || program_id == &ed25519_program::id()

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -1,5 +1,4 @@
 use {
-    agave_precompiles::get_precompile,
     solana_account::WritableAccount,
     solana_instructions_sysvar as instructions,
     solana_measure::measure_us,
@@ -69,11 +68,9 @@ pub(crate) fn process_message(
 
         let mut compute_units_consumed = 0;
         let (result, process_instruction_us) = measure_us!({
-            if let Some(precompile) = get_precompile(program_id, |feature_id| {
-                invoke_context.get_feature_set().is_active(feature_id)
-            }) {
+            if invoke_context.is_precompile(program_id) {
                 invoke_context.process_precompile(
-                    precompile,
+                    program_id,
                     instruction.data,
                     &instruction_accounts,
                     program_indices,
@@ -130,6 +127,7 @@ mod tests {
         solana_hash::Hash,
         solana_instruction::{error::InstructionError, AccountMeta, Instruction},
         solana_message::{AccountKeys, Message, SanitizedMessage},
+        solana_precompile_error::PrecompileError,
         solana_program_runtime::{
             declare_process_instruction,
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
@@ -666,6 +664,29 @@ mod tests {
             mock_program_id,
             Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::vm)),
         );
+
+        struct MockCallback {}
+        impl EpochStakeCallback for MockCallback {
+            fn is_precompile(&self, program_id: &Pubkey) -> bool {
+                program_id == &secp256k1_program::id()
+                    || program_id == &ed25519_program::id()
+                    || program_id == &solana_secp256r1_program::id()
+            }
+
+            fn process_precompile(
+                &self,
+                program_id: &Pubkey,
+                _data: &[u8],
+                _instruction_datas: Vec<&[u8]>,
+            ) -> std::result::Result<(), PrecompileError> {
+                if self.is_precompile(program_id) {
+                    Ok(())
+                } else {
+                    Err(PrecompileError::InvalidPublicKey)
+                }
+            }
+        }
+
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -257,7 +257,7 @@ mod tests {
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
-        solana_svm_callback::EpochStakeCallback,
+        solana_svm_callback::InvokeContextCallback,
         std::{
             cell::RefCell,
             collections::HashMap,
@@ -280,7 +280,7 @@ mod tests {
         pub(crate) account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
-    impl EpochStakeCallback for MockBankCallback {}
+    impl InvokeContextCallback for MockBankCallback {}
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1091,7 +1091,7 @@ mod tests {
         solana_rent_debits::RentDebits,
         solana_sdk_ids::{bpf_loader, system_program, sysvar},
         solana_signature::Signature,
-        solana_svm_callback::{AccountState, EpochStakeCallback},
+        solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_transaction_context::TransactionContext,
         solana_transaction_error::{TransactionError, TransactionError::DuplicateInstruction},
@@ -1121,7 +1121,7 @@ mod tests {
             Arc<RwLock<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>>,
     }
 
-    impl EpochStakeCallback for MockBankCallback {}
+    impl InvokeContextCallback for MockBankCallback {}
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -30,7 +30,7 @@ use {
         sysvar::SysvarId,
     },
     solana_svm::transaction_processor::TransactionBatchProcessor,
-    solana_svm_callback::{AccountState, EpochStakeCallback, TransactionProcessingCallback},
+    solana_svm_callback::{AccountState, InvokeContextCallback, TransactionProcessingCallback},
     solana_svm_transaction::svm_message::SVMMessage,
     solana_type_overrides::sync::{Arc, RwLock},
     std::{
@@ -67,7 +67,7 @@ pub struct MockBankCallback {
         Arc<RwLock<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>>,
 }
 
-impl EpochStakeCallback for MockBankCallback {}
+impl InvokeContextCallback for MockBankCallback {}
 
 impl TransactionProcessingCallback for MockBankCallback {
     fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {


### PR DESCRIPTION
#### Problem
Currently SVM is dependent on `agave-precompiles`. Since precompiles are Agave specific, they should stay in monorepo. So, the dependency needs to be resolved otherwise it'll cause cyclic deps between monorepo and SVM repo.

#### Summary of Changes
Use callbacks to call into precompiles.
The callbacks are implemented via `Bank`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
