### PR TITLE
refactor: rm unnecessary vote_needs_store field

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -952,7 +952,6 @@ struct VoteReward {
     vote_account: AccountSharedData,
     commission: u8,
     vote_rewards: u64,
-    vote_needs_store: bool,
 }
 
 type VoteRewards = DashMap<Pubkey, VoteReward>;
@@ -2498,7 +2497,6 @@ impl Bank {
                     mut vote_account,
                     commission,
                     vote_rewards,
-                    vote_needs_store,
                 },
             )| {
                 if let Err(err) = vote_account.checked_add_lamports(vote_rewards) {
@@ -2515,9 +2513,7 @@ impl Bank {
                         commission: Some(commission),
                     },
                 ));
-                result
-                    .accounts_to_store
-                    .push(vote_needs_store.then_some(vote_account));
+                result.accounts_to_store.push(vote_account);
                 result.total_vote_rewards_lamports += vote_rewards;
             },
         );

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -66,10 +66,8 @@ pub(super) struct VoteRewardsAccounts {
     /// reward info for each vote account pubkey.
     /// This type is used by `update_reward_history()`
     pub(super) rewards: Vec<(Pubkey, RewardInfo)>,
-    /// corresponds to pubkey in `rewards`
-    /// Some if account is to be stored.
-    /// None if to be skipped.
-    pub(super) accounts_to_store: Vec<Option<AccountSharedData>>,
+    /// account to be stored, corresponds to pubkey in `rewards`
+    pub(super) accounts_to_store: Vec<AccountSharedData>,
     /// total lamports across all `vote_rewards`
     pub(super) total_vote_rewards_lamports: u64,
 }


### PR DESCRIPTION
#### Problem
Inflation reward calculation tracks a `vote_needs_store` field which is always set to `true` adding unnecessary code complexity.

#### Summary of Changes
Remove the unnecessary field

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
