### PR TITLE
ci: bump mozilla-actions/sccache-action to 0.0.8

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 
@@ -91,7 +91,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 
@@ -130,7 +130,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/svm-exampls.yml
+++ b/.github/workflows/svm-exampls.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.8
         with:
           version: "v0.9.1"
 


### PR DESCRIPTION
#### Problem

the version of `mozilla-actions/sccache-action` we're currently using depends on a deprecated version of github `actions/cache`. the current phase of deprecation involves service brownouts, which are blocking ci

#### Summary of Changes

bump `mozilla-actions/sccache-action` to 0.0.8 and pray?