### PR TITLE
refactor: rm unused accounts_hash_debug_verify field

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -301,11 +301,8 @@ impl SnapshotRequestHandler {
             // We have to use the index version here.
             // We cannot calculate the non-index way because cache
             // has not been flushed and stores don't match reality.
-            snapshot_root_bank.update_accounts_hash(
-                CalcAccountsHashDataSource::IndexForTests,
-                false,
-                false,
-            )
+            snapshot_root_bank
+                .update_accounts_hash(CalcAccountsHashDataSource::IndexForTests, false)
         });
 
         let mut flush_accounts_cache_time = Measure::start("flush_accounts_cache_time");

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3519,7 +3519,7 @@ fn test_bank_hash_internal_state(is_accounts_lt_hash_enabled: bool) {
     bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
     bank2.squash();
     bank2.force_flush_accounts_cache();
-    bank2.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+    bank2.update_accounts_hash(CalcAccountsHashDataSource::Storages, false);
     assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test(), None,));
 }
 
@@ -12636,7 +12636,7 @@ fn test_bank_verify_accounts_hash_with_base() {
     // update the base accounts hash
     bank.squash();
     bank.force_flush_accounts_cache();
-    bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+    bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false);
     let base_slot = bank.slot();
     let base_capitalization = bank.capitalization();
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -947,7 +947,7 @@ fn bank_to_full_snapshot_archive_with(
         MerkleOrLatticeAccountsHash::Lattice
     } else {
         let calculated_accounts_hash =
-            bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false, false);
+            bank.update_accounts_hash(CalcAccountsHashDataSource::Storages, false);
         let accounts_hash = bank
             .get_accounts_hash()
             .expect("accounts hash is required for snapshot");

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -41,9 +41,6 @@ pub struct SnapshotConfig {
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
     pub maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
 
-    /// This is the `debug_verify` parameter to use when calling `update_accounts_hash()`
-    pub accounts_hash_debug_verify: bool,
-
     // Thread niceness adjustment for snapshot packager service
     pub packager_thread_niceness_adj: i8,
 }
@@ -67,7 +64,6 @@ impl Default for SnapshotConfig {
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            accounts_hash_debug_verify: false,
             packager_thread_niceness_adj: 0,
         }
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -977,7 +977,6 @@ pub fn execute(
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
-        accounts_hash_debug_verify: validator_config.accounts_db_test_hash_calculation,
         packager_thread_niceness_adj: snapshot_packager_niceness_adj,
     };
 


### PR DESCRIPTION
#### Problem
The `accounts_hash_debug_verify` field in `SnapshotConfig` is unused (`accounts_db_test_hash_calculation` config is passed directly to `fn AccountsBackgroundService::new`)

#### Summary of Changes
Remove it

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
