### PR TITLE
Move EvictingSender into the streamer crate for reuse

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -42,7 +42,7 @@ use {
         },
         weighted_shuffle::WeightedShuffle,
     },
-    crossbeam_channel::{bounded, Receiver, SendError, Sender, TryRecvError, TrySendError},
+    crossbeam_channel::{Receiver, TrySendError},
     itertools::{Either, Itertools},
     rand::{seq::SliceRandom, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
@@ -204,75 +204,6 @@ fn should_retain_crds_value(
                 stake.unwrap_or_default() >= MIN_STAKE_FOR_GOSSIP
             }
         }
-    }
-}
-
-/// A sender implementation that evicts the oldest message when the channel is full.
-#[derive(Clone)]
-pub(crate) struct EvictingSender<T> {
-    sender: Sender<T>,
-    receiver: Receiver<T>,
-}
-
-impl<T> EvictingSender<T> {
-    /// Create a new evicting sender with provided sender, receiver.
-    #[inline]
-    pub(crate) fn new(sender: Sender<T>, receiver: Receiver<T>) -> Self {
-        Self { sender, receiver }
-    }
-
-    /// Create a new `EvictingSender` with a bounded channel of the specified capacity.
-    #[inline]
-    pub(crate) fn new_bounded(capacity: usize) -> (Self, Receiver<T>) {
-        let (sender, receiver) = bounded(capacity);
-        (Self::new(sender, receiver.clone()), receiver)
-    }
-}
-
-impl<T> ChannelSend<T> for EvictingSender<T>
-where
-    T: Send + 'static,
-{
-    #[inline]
-    fn send(&self, msg: T) -> std::result::Result<(), SendError<T>> {
-        self.sender.send(msg)
-    }
-
-    fn try_send(&self, msg: T) -> std::result::Result<(), TrySendError<T>> {
-        let Err(e) = self.sender.try_send(msg) else {
-            return Ok(());
-        };
-
-        match e {
-            // Prefer newer messages over older messages.
-            TrySendError::Full(msg) => match self.receiver.try_recv() {
-                Ok(older) => {
-                    // Attempt to requeue the newer message.
-                    // NB: if multiple senders are used, and another sender is faster than us to send() after we've popped `older`,
-                    // our try_send() will fail with Full(msg), in which case we drop the new message.
-                    self.sender.try_send(msg)?;
-                    // Propagate the error _with the older message_.
-                    Err(TrySendError::Full(older))
-                }
-                // Unlikely race condition -- it was just indicated that the channel is full.
-                // Attempt to requeue the message.
-                Err(TryRecvError::Empty) => self.sender.try_send(msg),
-                // Unreachable in practice since we maintain a reference to both the sender and receiver.
-                Err(TryRecvError::Disconnected) => unreachable!(),
-            },
-            // Unreachable in practice since we maintain a reference to both the sender and receiver.
-            TrySendError::Disconnected(_) => unreachable!(),
-        }
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.receiver.is_empty()
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.receiver.len()
     }
 }
 

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        cluster_info::{ClusterInfo, EvictingSender, GOSSIP_CHANNEL_CAPACITY},
+        cluster_info::{ClusterInfo, GOSSIP_CHANNEL_CAPACITY},
         cluster_info_metrics::submit_gossip_stats,
         contact_info::ContactInfo,
         epoch_specs::EpochSpecs,
@@ -18,6 +18,7 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_signer::Signer,
     solana_streamer::{
+        evicting_sender::EvictingSender,
         socket::SocketAddrSpace,
         streamer::{self, StreamerReceiveStats},
     },

--- a/streamer/src/evicting_sender.rs
+++ b/streamer/src/evicting_sender.rs
@@ -1,0 +1,73 @@
+use {
+    crate::streamer::ChannelSend,
+    crossbeam_channel::{bounded, Receiver, SendError, Sender, TryRecvError, TrySendError},
+};
+
+/// A sender implementation that evicts the oldest message when the channel is full.
+#[derive(Clone)]
+pub struct EvictingSender<T> {
+    sender: Sender<T>,
+    receiver: Receiver<T>,
+}
+
+impl<T> EvictingSender<T> {
+    /// Create a new evicting sender with provided sender, receiver.
+    #[inline]
+    pub fn new(sender: Sender<T>, receiver: Receiver<T>) -> Self {
+        Self { sender, receiver }
+    }
+
+    /// Create a new `EvictingSender` with a bounded channel of the specified capacity.
+    #[inline]
+    pub fn new_bounded(capacity: usize) -> (Self, Receiver<T>) {
+        let (sender, receiver) = bounded(capacity);
+        (Self::new(sender, receiver.clone()), receiver)
+    }
+}
+
+impl<T> ChannelSend<T> for EvictingSender<T>
+where
+    T: Send + 'static,
+{
+    #[inline]
+    fn send(&self, msg: T) -> std::result::Result<(), SendError<T>> {
+        self.sender.send(msg)
+    }
+
+    fn try_send(&self, msg: T) -> std::result::Result<(), TrySendError<T>> {
+        let Err(e) = self.sender.try_send(msg) else {
+            return Ok(());
+        };
+
+        match e {
+            // Prefer newer messages over older messages.
+            TrySendError::Full(msg) => match self.receiver.try_recv() {
+                Ok(older) => {
+                    // Attempt to requeue the newer message.
+                    // NB: if multiple senders are used, and another sender is faster than us to send() after we've popped `older`,
+                    // our try_send() will fail with Full(msg), in which case we drop the new message.
+                    self.sender.try_send(msg)?;
+                    // Propagate the error _with the older message_.
+                    Err(TrySendError::Full(older))
+                }
+                // Unlikely race condition -- it was just indicated that the channel is full.
+                // Attempt to requeue the message.
+                Err(TryRecvError::Empty) => self.sender.try_send(msg),
+                // Unreachable in practice since we maintain a reference to both the sender and receiver.
+                Err(TryRecvError::Disconnected) => unreachable!(),
+            },
+            // Unreachable in practice since we maintain a reference to both the sender and receiver.
+            TrySendError::Disconnected(_) => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.receiver.is_empty()
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.receiver.len()
+    }
+}

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
+pub mod evicting_sender;
 pub mod msghdr;
 pub mod nonblocking;
 pub mod packet;


### PR DESCRIPTION
#### Problem
EvictingSender is generally useful outside of gossip, but is currently in contact_info.rs
This is a split-off from https://github.com/anza-xyz/agave/pull/5091

#### Summary of Changes
Move EvictingSender to streamer (which defines the key trait it implements)


