### PR TITLE
Calls `shrink` every loop of AccountsBackgroundService

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -641,6 +641,10 @@ impl AccountsBackgroundService {
                             // as any later snapshots that are taken are of
                             // slots >= bank.slot()
                             bank.flush_accounts_cache_if_needed();
+                            if bank.is_startup_verification_complete() {
+                                // See justification above for why we skip 'shrink' here.
+                                bank.shrink_candidate_slots();
+                            }
                         }
                         stats.record_and_maybe_submit(start_time.elapsed());
                         sleep(Duration::from_millis(INTERVAL_MS));


### PR DESCRIPTION
#### Problem

PR #5563 moved calling `shrink` in AccountsBackgroundService from every loop iteration to every ~100 slots (like flush, clean, and ancient squash). This has had quite a noticeable impact on `shrink` and the system/disk stats.

It's not clear if #5563 is strictly worse yet, but it *is* clear that the impacts of #5563 were not understood before merging.

We should revert #5563 until we've tested/studied it sufficiently to ensure the behavior change is beneficial.


#### Summary of Changes

Call shrink every loop iteration of ABS, effectively reverting #5563.