### PR TITLE
ci: bump sccache version in Github Actions

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       # took the workaround from https://github.com/sfackler/rust-openssl/issues/2149
       - name: Set Perl environment variables

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       - shell: bash
         run: |

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       - shell: bash
         run: |
@@ -93,7 +93,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       - shell: bash
         run: |
@@ -132,7 +132,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 
@@ -91,7 +91,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 
@@ -130,7 +130,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/svm-exampls.yml
+++ b/.github/workflows/svm-exampls.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           .github/scripts/purge-ubuntu-runner.sh
 
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: "v0.9.1"
 

--- a/.github/workflows/svm-exampls.yml
+++ b/.github/workflows/svm-exampls.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: "v0.9.1"
+          version: "v0.10.0"
 
       - shell: bash
         run: |


### PR DESCRIPTION
#### Problem

Github is shutting down the old cache service. looks like we need this new environment varaible

<img width="375" alt="Screenshot 2025-04-02 at 16 26 45" src="https://github.com/user-attachments/assets/594372b8-2e47-4a3b-a5d3-79c78954b8c4" />

https://github.com/Mozilla-Actions/sccache-action/blob/7d986dd989559c6ecdb630a3fd2557667be217ad/src/setup.ts#L69-L70


context: 
- https://discord.com/channels/428295358100013066/560503042458517505/1356677900971020380
- https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts



#### Summary of Changes

- bump mozilla-actions/sccache-action from 0.0.5 to 0.0.9
- bump sccache version to 0.10.0 in Github Actions

---

close https://github.com/anza-xyz/agave/pull/5607