### PR TITLE
optimize vote reward store

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2513,7 +2513,7 @@ impl Bank {
                         commission: Some(commission),
                     },
                 ));
-                result.accounts_to_store.push(vote_account);
+                result.accounts_to_store.push((vote_pubkey, vote_account));
                 result.total_vote_rewards_lamports += vote_rewards;
             },
         );

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -67,7 +67,7 @@ pub(super) struct VoteRewardsAccounts {
     /// This type is used by `update_reward_history()`
     pub(super) rewards: Vec<(Pubkey, RewardInfo)>,
     /// account to be stored, corresponds to pubkey in `rewards`
-    pub(super) accounts_to_store: Vec<AccountSharedData>,
+    pub(super) accounts_to_store: Vec<(Pubkey, AccountSharedData)>,
     /// total lamports across all `vote_rewards`
     pub(super) total_vote_rewards_lamports: u64,
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12983,7 +12983,7 @@ fn test_calc_vote_accounts_to_store_normal() {
             assert_eq!(result.rewards.len(), result.accounts_to_store.len());
             assert_eq!(result.rewards.len(), 1);
             let rewards = &result.rewards[0];
-            let account = &result.accounts_to_store[0];
+            let account = &result.accounts_to_store[0].1;
             _ = vote_account.checked_add_lamports(vote_rewards);
             assert!(accounts_equal(account, &vote_account));
             assert_eq!(


### PR DESCRIPTION
#### Problem

The current vote reward storage at epoch boundary can be optimized. During reward calculation, only the vote account is populated. When storing, the pubkey is also required, leading to reallocation and repopulation. To improve efficiency, populate the pubkey alongside the account during reward calculation, eliminating the need for subsequent reallocation and repopulation


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
