### PR TITLE
Refactor - program-v4 CLI usability

### DIFF
--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -147,7 +147,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("PATH-TO-ELF")
                                 .takes_value(true)
-                                .help("/path/to/program.so"),
+                                .help("./target/deploy/program.so"),
                         )
                         .arg(
                             Arg::with_name("start-offset")
@@ -214,6 +214,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
+                                .required(true)
                                 .help("Executable program's address"),
                         )
                         .arg(
@@ -237,6 +238,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
+                                .required(true)
                                 .help("Executable program's address"),
                         )
                         .arg(
@@ -271,6 +273,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
+                                .required(true)
                                 .help("Executable program's address"),
                         )
                         .arg(
@@ -300,16 +303,16 @@ impl ProgramV4SubCommands for App<'_, '_> {
                     SubCommand::with_name("show")
                         .about("Display information about a buffer or program")
                         .arg(
-                            Arg::with_name("account")
-                                .index(1)
-                                .value_name("ACCOUNT_ADDRESS")
+                            Arg::with_name("program-id")
+                                .long("program-id")
+                                .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Address of the program to show"),
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("all")
                                 .long("all")
-                                .conflicts_with("account")
+                                .conflicts_with("program-id")
                                 .conflicts_with("authority")
                                 .help("Show accounts for all authorities"),
                         )
@@ -325,20 +328,18 @@ impl ProgramV4SubCommands for App<'_, '_> {
                     SubCommand::with_name("dump")
                         .about("Write the program data to a file")
                         .arg(
-                            Arg::with_name("account")
+                            Arg::with_name("path-to-elf")
                                 .index(1)
-                                .value_name("ACCOUNT_ADDRESS")
+                                .value_name("PATH-TO-ELF")
                                 .takes_value(true)
-                                .required(true)
-                                .help("Address of the buffer or program"),
+                                .help("./target/deploy/program.so"),
                         )
                         .arg(
-                            Arg::with_name("output_location")
-                                .index(2)
-                                .value_name("OUTPUT_FILEPATH")
+                            Arg::with_name("program-id")
+                                .long("program-id")
+                                .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .required(true)
-                                .help("/path/to/program.so"),
+                                .help("Executable program's address"),
                         ),
                 ),
         )
@@ -458,7 +459,7 @@ pub fn parse_program_v4_subcommand(
                         .expect("Authority signer is missing"),
                     new_authority_signer_index: signer_info
                         .index_of(new_authority_pubkey)
-                        .expect("Authority signer is missing"),
+                        .expect("New authority signer is missing"),
                 }),
                 signers: signer_info.signers,
             }
@@ -507,15 +508,15 @@ pub fn parse_program_v4_subcommand(
                 };
 
             CliCommandInfo::without_signers(CliCommand::ProgramV4(ProgramV4CliCommand::Show {
-                account_pubkey: pubkey_of(matches, "account"),
+                account_pubkey: pubkey_of(matches, "program-id"),
                 authority,
                 all: matches.is_present("all"),
             }))
         }
         ("dump", Some(matches)) => {
             CliCommandInfo::without_signers(CliCommand::ProgramV4(ProgramV4CliCommand::Dump {
-                account_pubkey: pubkey_of(matches, "account"),
-                output_location: matches.value_of("output_location").unwrap().to_string(),
+                account_pubkey: pubkey_of(matches, "program-id"),
+                output_location: matches.value_of("path-to-elf").unwrap().to_string(),
             }))
         }
         _ => unreachable!(),

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -828,6 +828,18 @@ pub fn process_deploy_program(
             &authority_pubkey,
             upload_address,
         ));
+        let mut lamports_to_retrive = upload_account
+            .as_ref()
+            .map(|account| account.lamports)
+            .unwrap_or(0);
+        if upload_signer_index.is_some() {
+            lamports_to_retrive = lamports_to_retrive.saturating_add(lamports_required);
+        }
+        instructions.push(system_instruction::transfer(
+            upload_address,
+            &payer_pubkey,
+            lamports_to_retrive,
+        ));
         vec![instructions]
     } else {
         // Deploy new program or redeploy without a buffer account

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -410,7 +410,7 @@ pub fn parse_program_v4_subcommand(
                     additional_cli_config: AdditionalCliConfig::from_matches(matches),
                     program_address: program_address.or(program_pubkey).unwrap(),
                     buffer_address: buffer_pubkey,
-                    upload_signer_index,
+                    upload_signer_index: path_to_elf.as_ref().and(upload_signer_index),
                     authority_signer_index,
                     path_to_elf,
                     upload_range: value_t!(matches, "start-offset", usize).ok()
@@ -764,7 +764,7 @@ pub fn process_deploy_program(
     }
 
     let mut write_messages = vec![];
-    if upload_range.is_empty() {
+    if upload_signer_index.is_none() {
         if upload_account.is_none() {
             return Err(format!(
                 "No ELF was provided or uploaded to the account {:?}",
@@ -773,6 +773,10 @@ pub fn process_deploy_program(
             .into());
         }
     } else {
+        if upload_range.is_empty() {
+            return Err(format!("Attempting to upload empty range {:?}", upload_range).into());
+        }
+
         // Create and add set_program_length message
         if let Some(upload_account) = upload_account.as_ref() {
             let (set_program_length_instructions, _lamports_required) =
@@ -2061,7 +2065,7 @@ mod tests {
                     additional_cli_config: AdditionalCliConfig::default(),
                     program_address: program_keypair.pubkey(),
                     buffer_address: Some(buffer_keypair.pubkey()),
-                    upload_signer_index: Some(1),
+                    upload_signer_index: None,
                     authority_signer_index: 2,
                     path_to_elf: None,
                     upload_range: None..None,

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -325,8 +325,8 @@ impl ProgramV4SubCommands for App<'_, '_> {
                         )),
                 )
                 .subcommand(
-                    SubCommand::with_name("dump")
-                        .about("Write the program data to a file")
+                    SubCommand::with_name("download")
+                        .about("Download the executable of a program to a file")
                         .arg(
                             Arg::with_name("path-to-elf")
                                 .index(1)
@@ -513,7 +513,7 @@ pub fn parse_program_v4_subcommand(
                 all: matches.is_present("all"),
             }))
         }
-        ("dump", Some(matches)) => {
+        ("download", Some(matches)) => {
             CliCommandInfo::without_signers(CliCommand::ProgramV4(ProgramV4CliCommand::Dump {
                 account_pubkey: pubkey_of(matches, "program-id"),
                 output_location: matches.value_of("path-to-elf").unwrap().to_string(),

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -16,7 +16,6 @@ use {
     solana_client::rpc_config::RpcSendTransactionConfig,
     solana_commitment_config::CommitmentConfig,
     solana_faucet::faucet::run_local_faucet,
-    solana_message::Message,
     solana_rpc::rpc::JsonRpcConfig,
     solana_rpc_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient},
     solana_rpc_client_api::config::RpcTransactionConfig,
@@ -31,7 +30,7 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         signature::{Keypair, NullSigner, Signature, Signer},
-        system_instruction, system_program,
+        system_program,
         transaction::Transaction,
     },
     solana_sdk_ids::loader_v4,
@@ -3163,19 +3162,9 @@ fn test_cli_program_v4() {
     let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.owner, loader_v4::id());
     assert!(program_account.executable);
-    let response = rpc_client.send_and_confirm_transaction(&Transaction::new(
-        &[&payer_keypair, &buffer_keypair],
-        Message::new(
-            &[system_instruction::transfer(
-                &buffer_keypair.pubkey(),
-                &payer_keypair.pubkey(),
-                program_account.lamports,
-            )],
-            Some(&payer_keypair.pubkey()),
-        ),
-        rpc_client.get_latest_blockhash().unwrap(),
-    ));
-    assert!(response.is_ok());
+    let _error = rpc_client
+        .get_account(&buffer_keypair.pubkey())
+        .unwrap_err();
 
     // Two-step redeployment with buffer
     config.command = CliCommand::ProgramV4(ProgramV4CliCommand::Deploy {
@@ -3204,6 +3193,9 @@ fn test_cli_program_v4() {
     let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.owner, loader_v4::id());
     assert!(program_account.executable);
+    let _error = rpc_client
+        .get_account(&buffer_keypair.pubkey())
+        .unwrap_err();
 
     // Transfer authority over program
     config.command = CliCommand::ProgramV4(ProgramV4CliCommand::TransferAuthority {

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3116,6 +3116,11 @@ fn test_cli_program_v4() {
         lamports: 10000000,
     };
     process_command(&config).unwrap();
+    config.command = CliCommand::Airdrop {
+        pubkey: Some(program_keypair.pubkey()),
+        lamports: 1000,
+    };
+    process_command(&config).unwrap();
 
     // Initial deployment
     config.output_format = OutputFormat::JsonCompact;

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3218,10 +3218,11 @@ fn test_cli_program_v4() {
     assert!(program_account.executable);
 
     // Close program
-    config.command = CliCommand::ProgramV4(ProgramV4CliCommand::Close {
+    config.command = CliCommand::ProgramV4(ProgramV4CliCommand::Retract {
         additional_cli_config: AdditionalCliConfig::default(),
         program_address: program_keypair.pubkey(),
         authority_signer_index: 2,
+        close_program_entirely: true,
     });
     assert!(process_command(&config).is_ok());
     let _error = rpc_client


### PR DESCRIPTION
#### Problem
While writing the docs for the program-v4 CLI I noticed a whole array of rough edges which I would like to polish.

#### Summary of Changes
- Makes CLI arguments more consistent. Name it `--program-id` in all subcommands.
- Renames subcommand `dump` to `download`.
- Adds support for retracting without closing and a flag `--close-program-entriely`.
- Allows only supplying a `--buffer` argument for in `deploy`.
- Simplifies message signing code.
- Automatically retrieves funds from buffer after upload is complete.
- Only add an upload signer if there is something to upload.
- Makes "not owned by loader-v4" error message consistent across subcommands.
- Allows deployment to pre-funded accounts.
- Uses less messages by packing instructions in fewer transactions.