### PR TITLE
Renames bin_start_and_len()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -378,17 +378,17 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// returns the start bin and the number of bins to scan
-    fn bin_start_and_range<R>(&self, range: &R) -> (usize, usize)
+    fn bin_start_and_len<R>(&self, range: &R) -> (usize, usize)
     where
         R: RangeBounds<Pubkey> + Debug + Sync,
     {
         let (start_bin, end_bin_inclusive) = self.bin_start_end_inclusive(range);
-        let bin_range = if start_bin > end_bin_inclusive {
+        let bins_len = if start_bin > end_bin_inclusive {
             0
         } else {
             end_bin_inclusive - start_bin + 1
         };
-        (start_bin, bin_range)
+        (start_bin, bins_len)
     }
 
     #[allow(clippy::type_complexity)]
@@ -1049,11 +1049,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     where
         R: RangeBounds<Pubkey> + Debug + Sync,
     {
-        let (start_bin, bin_range) = self.bin_start_and_range(range);
-        // the idea is this range shouldn't be more than a few buckets, but the process of loading from disk buckets is very slow
-        // so, parallelize the bucket loads
+        let (start_bin, bins_len) = self.bin_start_and_len(range);
+        // the idea is this range shouldn't be more than a few buckets, but the process of loading
+        // from disk buckets is very slow, so, parallelize the bucket loads
         thread_pool.install(|| {
-            (0..bin_range).into_par_iter().for_each(|idx| {
+            (0..bins_len).into_par_iter().for_each(|idx| {
                 let map = &self.account_maps[idx + start_bin];
                 map.hold_range_in_memory(range, start_holding);
             });
@@ -3530,20 +3530,20 @@ pub mod tests {
     fn test_bin_start_and_range() {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let range = (Unbounded::<Pubkey>, Unbounded);
-        assert_eq!((0, BINS_FOR_TESTING), index.bin_start_and_range(&range));
+        assert_eq!((0, BINS_FOR_TESTING), index.bin_start_and_len(&range));
 
         let key_0 = Pubkey::from([0; 32]);
         let key_ff = Pubkey::from([0xff; 32]);
 
         let range = (Included(key_0), Included(key_ff));
         let bins = index.bins();
-        assert_eq!((0, bins), index.bin_start_and_range(&range));
+        assert_eq!((0, bins), index.bin_start_and_len(&range));
         let range = (Included(key_ff), Included(key_0));
-        assert_eq!((bins - 1, 0), index.bin_start_and_range(&range));
+        assert_eq!((bins - 1, 0), index.bin_start_and_len(&range));
         let range = (Included(key_0), Unbounded);
-        assert_eq!((0, BINS_FOR_TESTING), index.bin_start_and_range(&range));
+        assert_eq!((0, BINS_FOR_TESTING), index.bin_start_and_len(&range));
         let range = (Included(key_ff), Unbounded);
-        assert_eq!((bins - 1, 1), index.bin_start_and_range(&range));
+        assert_eq!((bins - 1, 1), index.bin_start_and_len(&range));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

The `bin_start_and_range()` returns the starting bin (index) and the number of bins to scan. It does not return a range, like the function name might imply.


#### Summary of Changes

Rename the function.