### PR TITLE
Refactor: move processing loop from VoteStorage to VoteWorker

### DIFF
--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -406,7 +406,7 @@ impl LatestUnprocessedVotes {
     /// Drains all votes yet to be processed sorted by a weighted random ordering by stake
     /// Do not touch votes that are for a different fork from `bank` as we know they will fail,
     /// however the next bank could be built on a different fork and consume these votes.
-    pub fn drain_unprocessed(&self, bank: Arc<Bank>) -> Vec<Arc<ImmutableDeserializedPacket>> {
+    pub fn drain_unprocessed(&self, bank: &Bank) -> Vec<Arc<ImmutableDeserializedPacket>> {
         let slot_hashes = bank
             .get_account(&sysvar::slot_hashes::id())
             .and_then(|account| from_account::<SlotHashes, _>(&account));

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -461,7 +461,7 @@ impl LatestUnprocessedVotes {
             });
     }
 
-    pub(super) fn should_deprecate_legacy_vote_ixs(&self) -> bool {
+    pub fn should_deprecate_legacy_vote_ixs(&self) -> bool {
         self.deprecate_legacy_vote_ixs.load(Ordering::Relaxed)
     }
 }

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -461,7 +461,7 @@ impl LatestUnprocessedVotes {
             });
     }
 
-    pub fn should_deprecate_legacy_vote_ixs(&self) -> bool {
+    pub(super) fn should_deprecate_legacy_vote_ixs(&self) -> bool {
         self.deprecate_legacy_vote_ixs.load(Ordering::Relaxed)
     }
 }

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -1,26 +1,15 @@
 use {
     super::{
-        consumer::Consumer,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{
             LatestUnprocessedVotes, LatestValidatorVotePacket, VoteBatchInsertionMetrics,
             VoteSource,
         },
-        leader_slot_metrics::LeaderSlotMetricsTracker,
-        BankingStageStats,
     },
-    arrayvec::ArrayVec,
-    solana_accounts_db::account_locks::validate_account_locks,
-    solana_measure::measure_us,
     solana_runtime::bank::Bank,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_sdk::transaction::SanitizedTransaction,
-    solana_svm::transaction_error_metrics::TransactionErrorMetrics,
-    std::sync::{atomic::Ordering, Arc},
+    std::sync::Arc,
 };
 
-// Step-size set to be 64, equal to the maximum batch/entry size.
-pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 64;
 /// Maximum number of votes a single receive call will accept
 const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 
@@ -28,59 +17,6 @@ const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 pub struct VoteStorage {
     latest_unprocessed_votes: Arc<LatestUnprocessedVotes>,
     vote_source: VoteSource,
-}
-
-fn consume_scan_should_process_packet(
-    bank: &Bank,
-    banking_stage_stats: &BankingStageStats,
-    packet: &ImmutableDeserializedPacket,
-    reached_end_of_slot: bool,
-    error_counters: &mut TransactionErrorMetrics,
-    sanitized_transactions: &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
-    slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
-) -> bool {
-    // If end of the slot, return should process (quick loop after reached end of slot)
-    if reached_end_of_slot {
-        return true;
-    }
-
-    // Try to sanitize the packet. Ignore deactivation slot since we are
-    // immediately attempting to process the transaction.
-    let (maybe_sanitized_transaction, sanitization_time_us) = measure_us!(packet
-        .build_sanitized_transaction(
-            bank.vote_only_bank(),
-            bank,
-            bank.get_reserved_account_keys(),
-        )
-        .map(|(tx, _deactivation_slot)| tx));
-
-    slot_metrics_tracker.increment_transactions_from_packets_us(sanitization_time_us);
-    banking_stage_stats
-        .packet_conversion_elapsed
-        .fetch_add(sanitization_time_us, Ordering::Relaxed);
-
-    if let Some(sanitized_transaction) = maybe_sanitized_transaction {
-        let message = sanitized_transaction.message();
-
-        // Check the number of locks and whether there are duplicates
-        if validate_account_locks(
-            message.account_keys(),
-            bank.get_transaction_account_lock_limit(),
-        )
-        .is_err()
-        {
-            return false;
-        }
-
-        if Consumer::check_fee_payer_unlocked(bank, &sanitized_transaction, error_counters).is_err()
-        {
-            return false;
-        }
-        sanitized_transactions.push(sanitized_transaction);
-        true
-    } else {
-        false
-    }
 }
 
 impl VoteStorage {
@@ -126,96 +62,31 @@ impl VoteStorage {
         )
     }
 
+    // Re-insert re-tryable packets.
+    pub(crate) fn reinsert_packets(
+        &mut self,
+        packets: impl Iterator<Item = Arc<ImmutableDeserializedPacket>>,
+    ) {
+        self.latest_unprocessed_votes.insert_batch(
+            packets.filter_map(|packet| {
+                LatestValidatorVotePacket::new_from_immutable(
+                    packet,
+                    self.vote_source,
+                    self.should_deprecate_legacy_vote_ixs(),
+                )
+                .ok()
+            }),
+            true, // should_replenish_taken_votes
+        );
+    }
+
     pub fn drain_unprocessed(&self, bank: &Bank) -> Vec<Arc<ImmutableDeserializedPacket>> {
         self.latest_unprocessed_votes.drain_unprocessed(bank)
     }
 
-    // returns `true` if the end of slot is reached
-    pub fn process_packets<F>(
-        &mut self,
-        bank: &Bank,
-        banking_stage_stats: &BankingStageStats,
-        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
-        mut processing_function: F,
-    ) -> bool
-    where
-        F: FnMut(
-            usize,
-            &mut bool,
-            &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
-            &mut LeaderSlotMetricsTracker,
-        ) -> Option<Vec<usize>>,
-    {
-        if matches!(self.vote_source, VoteSource::Gossip) {
-            panic!("Gossip vote thread should not be processing transactions");
-        }
-
-        // Based on the stake distribution present in the supplied bank, drain the unprocessed votes
-        // from each validator using a weighted random ordering. Votes from validators with
-        // 0 stake are ignored.
-        let all_vote_packets = self.latest_unprocessed_votes.drain_unprocessed(bank);
-
-        let deprecate_legacy_vote_ixs = self
-            .latest_unprocessed_votes
-            .should_deprecate_legacy_vote_ixs();
-
-        let mut reached_end_of_slot = false;
-
-        let mut sanitized_transactions = Vec::with_capacity(UNPROCESSED_BUFFER_STEP_SIZE);
-
-        let mut error_counters: TransactionErrorMetrics = TransactionErrorMetrics::default();
-
-        let mut vote_packets =
-            ArrayVec::<Arc<ImmutableDeserializedPacket>, UNPROCESSED_BUFFER_STEP_SIZE>::new();
-        for chunk in all_vote_packets.chunks(UNPROCESSED_BUFFER_STEP_SIZE) {
-            vote_packets.clear();
-            chunk.iter().for_each(|packet| {
-                if consume_scan_should_process_packet(
-                    bank,
-                    banking_stage_stats,
-                    packet,
-                    reached_end_of_slot,
-                    &mut error_counters,
-                    &mut sanitized_transactions,
-                    slot_metrics_tracker,
-                ) {
-                    vote_packets.push(packet.clone());
-                }
-            });
-
-            if let Some(retryable_vote_indices) = processing_function(
-                vote_packets.len(),
-                &mut reached_end_of_slot,
-                &mut sanitized_transactions,
-                slot_metrics_tracker,
-            ) {
-                self.latest_unprocessed_votes.insert_batch(
-                    retryable_vote_indices.iter().filter_map(|i| {
-                        LatestValidatorVotePacket::new_from_immutable(
-                            vote_packets[*i].clone(),
-                            self.vote_source,
-                            deprecate_legacy_vote_ixs,
-                        )
-                        .ok()
-                    }),
-                    true, // should_replenish_taken_votes
-                );
-            } else {
-                self.latest_unprocessed_votes.insert_batch(
-                    vote_packets.drain(..).filter_map(|packet| {
-                        LatestValidatorVotePacket::new_from_immutable(
-                            packet,
-                            self.vote_source,
-                            deprecate_legacy_vote_ixs,
-                        )
-                        .ok()
-                    }),
-                    true, // should_replenish_taken_votes
-                );
-            }
-        }
-
-        reached_end_of_slot
+    pub fn should_deprecate_legacy_vote_ixs(&self) -> bool {
+        self.latest_unprocessed_votes
+            .should_deprecate_legacy_vote_ixs()
     }
 
     pub fn clear(&mut self) {
@@ -253,7 +124,7 @@ mod tests {
     };
 
     #[test]
-    fn test_process_packets_retryable_indexes_reinserted() -> Result<(), Box<dyn Error>> {
+    fn test_reinsert_packets() -> Result<(), Box<dyn Error>> {
         let node_keypair = Keypair::new();
         let genesis_config =
             genesis_utils::create_genesis_config_with_leader(100, &node_keypair.pubkey(), 200)
@@ -281,20 +152,9 @@ mod tests {
         transaction_storage.insert_batch(vec![ImmutableDeserializedPacket::new(&vote)?]);
         assert_eq!(1, transaction_storage.len());
 
-        // When processing packets, return all packets as retryable so that they
-        // are reinserted into storage
-        let _ = transaction_storage.process_packets(
-            &bank,
-            &BankingStageStats::default(),
-            &mut LeaderSlotMetricsTracker::new(0),
-            |packets_to_process_len,
-             _reached_end_of_slot,
-             _sanitized_transactions,
-             _slot_metrics_tracker| {
-                // Return all packets indexes as retryable
-                Some((0..packets_to_process_len).collect())
-            },
-        );
+        // Drain all packets, then re-insert.
+        let packets = transaction_storage.drain_unprocessed(&bank);
+        transaction_storage.reinsert_packets(packets.into_iter());
 
         // All packets should remain in the transaction storage
         assert_eq!(1, transaction_storage.len());

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -126,6 +126,10 @@ impl VoteStorage {
         )
     }
 
+    pub fn drain_unprocessed(&self, bank: &Bank) -> Vec<Arc<ImmutableDeserializedPacket>> {
+        self.latest_unprocessed_votes.drain_unprocessed(bank)
+    }
+
     // returns `true` if the end of slot is reached
     pub fn process_packets<F>(
         &mut self,

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -72,7 +72,8 @@ impl VoteStorage {
                 LatestValidatorVotePacket::new_from_immutable(
                     packet,
                     self.vote_source,
-                    self.should_deprecate_legacy_vote_ixs(),
+                    self.latest_unprocessed_votes
+                        .should_deprecate_legacy_vote_ixs(),
                 )
                 .ok()
             }),
@@ -82,11 +83,6 @@ impl VoteStorage {
 
     pub fn drain_unprocessed(&self, bank: &Bank) -> Vec<Arc<ImmutableDeserializedPacket>> {
         self.latest_unprocessed_votes.drain_unprocessed(bank)
-    }
-
-    pub fn should_deprecate_legacy_vote_ixs(&self) -> bool {
-        self.latest_unprocessed_votes
-            .should_deprecate_legacy_vote_ixs()
     }
 
     pub fn clear(&mut self) {

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -2,6 +2,7 @@ use {
     super::{
         consumer::Consumer,
         decision_maker::{BufferedPacketsDecision, DecisionMaker},
+        immutable_deserialized_packet::ImmutableDeserializedPacket,
         leader_slot_metrics::{
             CommittedTransactionsCounts, LeaderSlotMetricsTracker, ProcessTransactionsSummary,
         },
@@ -14,7 +15,9 @@ use {
         ExecuteAndCommitTransactionsOutput, ProcessTransactionBatchOutput,
         TARGET_NUM_TRANSACTIONS_PER_BATCH,
     },
+    arrayvec::ArrayVec,
     crossbeam_channel::RecvTimeoutError,
+    solana_accounts_db::account_locks::validate_account_locks,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::poh_recorder::{BankStart, PohRecorderError},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -35,6 +38,9 @@ use {
         time::Instant,
     },
 };
+
+// Step-size set to be 64, equal to the maximum batch/entry size.
+pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 64;
 
 pub struct VoteWorker {
     decision_maker: DecisionMaker,
@@ -150,30 +156,19 @@ impl VoteWorker {
         if vote_storage.is_empty() {
             return;
         }
-        let mut rebuffered_packet_count = 0;
+
         let mut consumed_buffered_packets_count = 0;
+        let mut rebuffered_packet_count = 0;
         let mut proc_start = Measure::start("consume_buffered_process");
         let num_packets_to_process = vote_storage.len();
 
-        let reached_end_of_slot = vote_storage.process_packets(
-            &bank_start.working_bank,
+        let reached_end_of_slot = self.process_packets(
+            vote_storage,
+            bank_start,
+            &mut consumed_buffered_packets_count,
+            &mut rebuffered_packet_count,
             banking_stage_stats,
             slot_metrics_tracker,
-            |packets_to_process_len,
-             reached_end_of_slot_par,
-             sanitized_transaction,
-             slot_metrics_tracker| {
-                self.do_process_packets(
-                    bank_start,
-                    reached_end_of_slot_par,
-                    sanitized_transaction,
-                    banking_stage_stats,
-                    &mut consumed_buffered_packets_count,
-                    &mut rebuffered_packet_count,
-                    packets_to_process_len,
-                    slot_metrics_tracker,
-                )
-            },
         );
 
         if reached_end_of_slot {
@@ -199,6 +194,65 @@ impl VoteWorker {
         banking_stage_stats
             .consumed_buffered_packets_count
             .fetch_add(consumed_buffered_packets_count, Ordering::Relaxed);
+    }
+
+    // returns `true` if the end of slot is reached
+    pub fn process_packets(
+        &mut self,
+        vote_storage: &mut VoteStorage,
+        bank_start: &BankStart,
+        consumed_buffered_packets_count: &mut usize,
+        rebuffered_packet_count: &mut usize,
+        banking_stage_stats: &BankingStageStats,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
+    ) -> bool {
+        // Based on the stake distribution present in the supplied bank, drain the unprocessed votes
+        // from each validator using a weighted random ordering. Votes from validators with
+        // 0 stake are ignored.
+        let all_vote_packets = vote_storage.drain_unprocessed(&bank_start.working_bank);
+
+        let mut reached_end_of_slot = false;
+        let mut sanitized_transactions = Vec::with_capacity(UNPROCESSED_BUFFER_STEP_SIZE);
+        let mut error_counters: TransactionErrorMetrics = TransactionErrorMetrics::default();
+        let mut vote_packets =
+            ArrayVec::<Arc<ImmutableDeserializedPacket>, UNPROCESSED_BUFFER_STEP_SIZE>::new();
+        for chunk in all_vote_packets.chunks(UNPROCESSED_BUFFER_STEP_SIZE) {
+            vote_packets.clear();
+            chunk.iter().for_each(|packet| {
+                if consume_scan_should_process_packet(
+                    &bank_start.working_bank,
+                    banking_stage_stats,
+                    packet,
+                    reached_end_of_slot,
+                    &mut error_counters,
+                    &mut sanitized_transactions,
+                    slot_metrics_tracker,
+                ) {
+                    vote_packets.push(packet.clone());
+                }
+            });
+
+            if let Some(retryable_vote_indices) = self.do_process_packets(
+                bank_start,
+                &mut reached_end_of_slot,
+                &mut sanitized_transactions,
+                banking_stage_stats,
+                consumed_buffered_packets_count,
+                rebuffered_packet_count,
+                vote_packets.len(),
+                slot_metrics_tracker,
+            ) {
+                vote_storage.reinsert_packets(
+                    retryable_vote_indices
+                        .into_iter()
+                        .map(|index| vote_packets[index].clone()),
+                );
+            } else {
+                vote_storage.reinsert_packets(vote_packets.drain(..));
+            }
+        }
+
+        reached_end_of_slot
     }
 
     fn do_process_packets(
@@ -460,6 +514,59 @@ impl VoteWorker {
             .enumerate()
             .filter_map(|(index, res)| res.as_ref().ok().map(|_| index))
             .collect()
+    }
+}
+
+fn consume_scan_should_process_packet(
+    bank: &Bank,
+    banking_stage_stats: &BankingStageStats,
+    packet: &ImmutableDeserializedPacket,
+    reached_end_of_slot: bool,
+    error_counters: &mut TransactionErrorMetrics,
+    sanitized_transactions: &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
+    slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
+) -> bool {
+    // If end of the slot, return should process (quick loop after reached end of slot)
+    if reached_end_of_slot {
+        return true;
+    }
+
+    // Try to sanitize the packet. Ignore deactivation slot since we are
+    // immediately attempting to process the transaction.
+    let (maybe_sanitized_transaction, sanitization_time_us) = measure_us!(packet
+        .build_sanitized_transaction(
+            bank.vote_only_bank(),
+            bank,
+            bank.get_reserved_account_keys(),
+        )
+        .map(|(tx, _deactivation_slot)| tx));
+
+    slot_metrics_tracker.increment_transactions_from_packets_us(sanitization_time_us);
+    banking_stage_stats
+        .packet_conversion_elapsed
+        .fetch_add(sanitization_time_us, Ordering::Relaxed);
+
+    if let Some(sanitized_transaction) = maybe_sanitized_transaction {
+        let message = sanitized_transaction.message();
+
+        // Check the number of locks and whether there are duplicates
+        if validate_account_locks(
+            message.account_keys(),
+            bank.get_transaction_account_lock_limit(),
+        )
+        .is_err()
+        {
+            return false;
+        }
+
+        if Consumer::check_fee_payer_unlocked(bank, &sanitized_transaction, error_counters).is_err()
+        {
+            return false;
+        }
+        sanitized_transactions.push(sanitized_transaction);
+        true
+    } else {
+        false
     }
 }
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -197,7 +197,7 @@ impl VoteWorker {
     }
 
     // returns `true` if the end of slot is reached
-    pub fn process_packets(
+    fn process_packets(
         &mut self,
         vote_storage: &mut VoteStorage,
         bank_start: &BankStart,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -156,7 +156,7 @@ impl VoteWorker {
         let num_packets_to_process = vote_storage.len();
 
         let reached_end_of_slot = vote_storage.process_packets(
-            bank_start.working_bank.clone(),
+            &bank_start.working_bank,
             banking_stage_stats,
             slot_metrics_tracker,
             |packets_to_process_len,


### PR DESCRIPTION
#### Problem
- Ongoing work in #2184
- 4th step: Move processing loop from VoteStorage to VoteWorker

#### Summary of Changes
- Move the processing loop in `VoteStorage` into the `VoteWorker`