### PR TITLE
Adds AtomicRefCount alias

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -73,6 +73,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
 pub type RefCount = u64;
+pub type AtomicRefCount = AtomicU64;
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub(crate) struct GenerateIndexResult<T: IndexValue> {


### PR DESCRIPTION
#### Problem

Normally I'm pretty against type aliases. For opaque types, I think they can be ok. More so, I value consistency.

We already have a `RefCount` alias, but it is not used everywhere. And we sometimes need an atomic version of RefCount, but we use AtomicU64 currently. I think we should either have both be aliases or neither.


#### Summary of Changes

Add an AtomicRefCount alias and use it.