### PR TITLE
Add vortexor stake updater test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11145,6 +11145,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-client",
  "solana-core",
+ "solana-local-cluster",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -26,7 +26,6 @@ impl StakedNodesUpdaterService {
         staked_nodes: Arc<RwLock<StakedNodes>>,
         staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     ) -> Self {
-        info!("Starting StakedNodesUpdaterService thread");
         let thread_hdl = Builder::new()
             .name("solStakedNodeUd".to_string())
             .spawn(move || {
@@ -36,11 +35,6 @@ impl StakedNodesUpdaterService {
                         root_bank.current_epoch_staked_nodes()
                     };
                     let overrides = staked_nodes_overrides.read().unwrap().clone();
-                    debug!(
-                        "StakedNodesUpdaterService: {} staked nodes: {:?}",
-                        overrides.len(),
-                        stakes
-                    );
                     *staked_nodes.write().unwrap() = StakedNodes::new(stakes, overrides);
                     std::thread::sleep(STAKE_REFRESH_CYCLE);
                 }

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -26,6 +26,7 @@ impl StakedNodesUpdaterService {
         staked_nodes: Arc<RwLock<StakedNodes>>,
         staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     ) -> Self {
+        info!("Starting StakedNodesUpdaterService thread");
         let thread_hdl = Builder::new()
             .name("solStakedNodeUd".to_string())
             .spawn(move || {
@@ -35,6 +36,11 @@ impl StakedNodesUpdaterService {
                         root_bank.current_epoch_staked_nodes()
                     };
                     let overrides = staked_nodes_overrides.read().unwrap().clone();
+                    debug!(
+                        "StakedNodesUpdaterService: {} staked nodes: {:?}",
+                        overrides.len(),
+                        stakes
+                    );
                     *staked_nodes.write().unwrap() = StakedNodes::new(stakes, overrides);
                     std::thread::sleep(STAKE_REFRESH_CYCLE);
                 }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -361,6 +361,10 @@ impl StakedNodes {
             .filter(|&stake| stake > 0);
         let total_stake = values.clone().sum();
         let (min_stake, max_stake) = values.minmax().into_option().unwrap_or_default();
+        info!(
+            "StakedNodes: total_stake: {}, min_stake: {}, max_stake: {}",
+            total_stake, min_stake, max_stake
+        );
         (total_stake, min_stake, max_stake)
     }
 

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -376,6 +376,10 @@ impl StakedNodes {
     }
 
     pub fn get_node_stake(&self, pubkey: &Pubkey) -> Option<u64> {
+        debug!(
+            "get_node_stake: {} stake: {:?} overrides: {:?}",
+            pubkey, self.stakes, self.overrides
+        );
         self.overrides
             .get(pubkey)
             .or_else(|| self.stakes.get(pubkey))

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -376,10 +376,6 @@ impl StakedNodes {
     }
 
     pub fn get_node_stake(&self, pubkey: &Pubkey) -> Option<u64> {
-        debug!(
-            "get_node_stake: {} stake: {:?} overrides: {:?}",
-            pubkey, self.stakes, self.overrides
-        );
         self.overrides
             .get(pubkey)
             .or_else(|| self.stakes.get(pubkey))

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -57,6 +57,7 @@ x509-parser = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-local-cluster = { workspace = true}
 
 [lib]
 crate-type = ["lib"]

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -56,7 +56,7 @@ x509-parser = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-local-cluster = { workspace = true}
+solana-local-cluster = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 
 [lib]

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -56,8 +56,8 @@ x509-parser = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { workspace = true}
+solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 
 [lib]
 crate-type = ["lib"]

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -14,7 +14,7 @@ use {
             PacketBatchSender, DEFAULT_BATCH_SIZE, DEFAULT_RECV_TIMEOUT,
             DEFAULT_SENDER_THREADS_COUNT,
         },
-        stake_updater::StakeUpdater,
+        stake_updater::{StakeUpdater, STAKE_REFRESH_SLEEP_DURATION},
         vortexor::Vortexor,
     },
     std::{
@@ -147,6 +147,7 @@ pub fn main() {
         exit.clone(),
         rpc_load_balancer.clone(),
         staked_nodes.clone(),
+        STAKE_REFRESH_SLEEP_DURATION,
     );
 
     info!(

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::rpc_load_balancer::RpcLoadBalancer,
-    log::{debug, info, warn},
+    log::{info, warn},
     solana_client::client_error,
     solana_sdk::pubkey::Pubkey,
     solana_streamer::streamer::StakedNodes,

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -73,11 +73,6 @@ impl StakeUpdater {
         if last_refresh.is_none() || last_refresh.unwrap().elapsed() > STAKE_REFRESH_INTERVAL {
             let client = rpc_load_balancer.rpc_client();
             let vote_accounts = client.get_vote_accounts()?;
-            debug!(
-                "try_refresh_stake_info: len: {} staked nodes: {:?}",
-                vote_accounts.current.len() + vote_accounts.delinquent.len(),
-                vote_accounts
-            );
 
             let stake_map = Arc::new(
                 vote_accounts
@@ -94,11 +89,6 @@ impl StakeUpdater {
             );
 
             *last_refresh = Some(Instant::now());
-            debug!(
-                "try_refresh_stake_info: {} staked nodes: {:?}",
-                stake_map.len(),
-                stake_map
-            );
             shared_staked_nodes
                 .write()
                 .unwrap()

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -134,6 +134,7 @@ async fn test_stake_update() {
             break;
         }
         info!("Waiting for stake map to be populated for {pubkey:?}...");
+        drop(stakes); // Drop the read lock before sleeping
         std::thread::sleep(std::time::Duration::from_millis(500));
     }
     exit.store(true, Ordering::Relaxed);

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -131,7 +131,7 @@ async fn test_stake_update() {
     while i < 2 {
         let slot = slot_receiver
             .recv_timeout(slot_receive_timeout)
-            .expect(format!("Expected a slot within {slot_receive_timeout:?}").as_str());
+            .unwrap_or_else(|_| panic!("Expected a slot within {slot_receive_timeout:?}"));
         i += 1;
         info!("Received a slot update: {}", slot);
     }

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -88,9 +88,9 @@ async fn test_vortexor() {
 fn get_server_urls(validator: &ClusterValidatorInfo) -> (Url, Url) {
     let rpc_addr = validator.info.contact_info.rpc().unwrap();
     let rpc_pubsub_addr = validator.info.contact_info.rpc_pubsub().unwrap();
-    let rpc_url = Url::parse(format!("http://{}", rpc_addr.to_string()).as_str()).unwrap();
-    let ws_url = Url::parse(format!("ws://{}", rpc_pubsub_addr.to_string()).as_str()).unwrap();
-    return (rpc_url, ws_url);
+    let rpc_url = Url::parse(format!("http://{}", rpc_addr).as_str()).unwrap();
+    let ws_url = Url::parse(format!("ws://{}", rpc_pubsub_addr).as_str()).unwrap();
+    (rpc_url, ws_url)
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -148,8 +148,10 @@ async fn test_stake_update() {
         let stakes = shared_staked_nodes.read().unwrap();
         if let Some(stake) = stakes.get_node_stake(pubkey) {
             info!("Stake for {}: {}", pubkey, stake);
+            assert_eq!(stake, default_node_stake);
             let total_stake = stakes.total_stake();
             info!("total_stake: {}", total_stake);
+            assert!(total_stake >= default_node_stake);
             break;
         }
         info!("Waiting for stake map to be populated for {pubkey:?}...");


### PR DESCRIPTION
Problem

Add test for RpcLoadBalancer and StakeUpdater in vortexor

Summary of Changes

A test is added using local cluster. It starts a cluster of 3 nodes, The test use StakeUpdater and RpcLoadBalancer to watch for slots and stake map update.

Fixes #