### PR TITLE
Clean up feature: reserve_minimal_cus_for_builtin_instructions

### DIFF
--- a/compute-budget-instruction/src/instructions_processor.rs
+++ b/compute-budget-instruction/src/instructions_processor.rs
@@ -136,7 +136,8 @@ mod tests {
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
             ],
             Ok(ComputeBudgetLimits {
-                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                    + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
                 updated_heap_bytes: 40 * 1024,
                 ..ComputeBudgetLimits::default()
             }),
@@ -191,7 +192,8 @@ mod tests {
                 ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES),
             ],
             Ok(ComputeBudgetLimits {
-                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+                compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                    + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
                 updated_heap_bytes: MAX_HEAP_FRAME_BYTES,
                 ..ComputeBudgetLimits::default()
             }),
@@ -319,7 +321,8 @@ mod tests {
         // budget is set with data_size
         let data_size = 1;
         let expected_result = Ok(ComputeBudgetLimits {
-            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
             loaded_accounts_bytes: NonZeroU32::new(data_size).unwrap(),
             ..ComputeBudgetLimits::default()
         });
@@ -332,12 +335,6 @@ mod tests {
             &FeatureSet::default()
         );
 
-        let expected_result = Ok(ComputeBudgetLimits {
-            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
-                + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
-            loaded_accounts_bytes: NonZeroU32::new(data_size).unwrap(),
-            ..ComputeBudgetLimits::default()
-        });
         test!(
             &[
                 ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size),
@@ -351,7 +348,8 @@ mod tests {
         // budget is set to max data size
         let data_size = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get() + 1;
         let expected_result = Ok(ComputeBudgetLimits {
-            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
             loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
             ..ComputeBudgetLimits::default()
         });
@@ -364,12 +362,6 @@ mod tests {
             &FeatureSet::default()
         );
 
-        let expected_result = Ok(ComputeBudgetLimits {
-            compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
-                + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
-            loaded_accounts_bytes: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-            ..ComputeBudgetLimits::default()
-        });
         test!(
             &[
                 ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size),
@@ -430,7 +422,8 @@ mod tests {
             (
                 FeatureSet::default(),
                 Ok(ComputeBudgetLimits {
-                    compute_unit_limit: 2 * DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+                    compute_unit_limit: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                        + MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
                     ..ComputeBudgetLimits::default()
                 }),
             ),

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
 use {
-    agave_feature_set as feature_set,
-    solana_compute_budget::compute_budget_limits::{
-        DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
-    },
+    solana_compute_budget::compute_budget_limits::MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
     solana_cost_model::cost_model::CostModel,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -83,22 +80,8 @@ impl TestSetup {
         );
     }
 
-    fn execute_test_transaction(
-        &mut self,
-        ixs: &[Instruction],
-        is_simd_170_enabled: bool,
-    ) -> TestResult {
-        let mut root_bank = Bank::new_for_tests(&self.genesis_config);
-
-        if is_simd_170_enabled {
-            root_bank
-                .activate_feature(&feature_set::reserve_minimal_cus_for_builtin_instructions::id());
-        } else {
-            root_bank.deactivate_feature(
-                &feature_set::reserve_minimal_cus_for_builtin_instructions::id(),
-            );
-        }
-
+    fn execute_test_transaction(&mut self, ixs: &[Instruction]) -> TestResult {
+        let root_bank = Bank::new_for_tests(&self.genesis_config);
         let (bank, bank_forks) = root_bank.wrap_with_bank_forks_for_tests();
         let bank = new_bank_from_parent_with_bank_forks(
             &bank_forks,
@@ -244,49 +227,23 @@ fn test_builtin_ix_cost_adjustment_with_cu_limit_too_low() {
     let cu_limit = 1;
 
     // A simple transfer ix, and request cu-limit to 1 cu
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate requested CU Limit `1`
-        // VM Execution: consume `1` CU, then fail
-        // Result: 0 adjustment
-        (
-            true,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Err(TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded,
-                )),
-            },
-        ),
-        // pre #3799:
-        // Cost model: ignores requested CU Limit due to without bpf ixs, reserve CUs for `system` and
-        //   `compute-budget` programs: (150 + 150) = 300;
-        // Compute budget: allocate CU Meter to requested CU Limit `1`.
-        // VM execution: consumed `1` CU, then fail
-        // Result: adjustment = 300 - 1 = 299;
-        (
-            false,
-            TestResult {
-                cost_adjustment: 299,
-                execution_status: Err(TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded,
-                )),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[
-                    test_setup.transfer_ix(),
-                    test_setup.set_cu_limit_ix(cu_limit),
-                ],
-                is_simd_170_enabled
-            )
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate requested CU Limit `1`
+    // VM Execution: consume `1` CU, then fail
+    // Result: 0 adjustment
+    let expected = TestResult {
+        cost_adjustment: 0,
+        execution_status: Err(TransactionError::InstructionError(
+            0,
+            InstructionError::ComputationalBudgetExceeded,
+        )),
+    };
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[
+            test_setup.transfer_ix(),
+            test_setup.set_cu_limit_ix(cu_limit),
+        ])
+    );
 }
 
 #[test]
@@ -295,95 +252,47 @@ fn test_builtin_ix_cost_adjustment_with_cu_limit_high() {
     let cu_limit: u32 = 500_000;
 
     // A simple transfer ix, and request cu-limit to more than needed
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate requested CU Limit `500_000`
-        // VM Execution: consume CUs for `system` and `compute-budget` programs, then success
-        // Result: adjustment = 500_000 - 150 -150
-        (
-            true,
-            TestResult {
-                cost_adjustment: cu_limit as i64
-                    - solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as i64
-                    - solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as i64,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: ignores requested CU Limit due to without bpf ixs, reserve CUs for `system` and
-        //   `compute-budget` programs: (150 + 150) = 300;
-        // Compute budget: allocate CU Meter to requested CU Limit `500_000`.
-        // VM Execution: consume CUs for `system` and `compute-budget` programs, then success
-        // Result: adjustment = 300 - 150 -150 = 0;
-        (
-            false,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[
-                    test_setup.transfer_ix(),
-                    test_setup.set_cu_limit_ix(cu_limit),
-                ],
-                is_simd_170_enabled
-            )
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate requested CU Limit `500_000`
+    // VM Execution: consume CUs for `system` and `compute-budget` programs, then success
+    // Result: adjustment = 500_000 - 150 -150
+    let expected = TestResult {
+        cost_adjustment: cu_limit as i64
+            - solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as i64
+            - solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as i64,
+        execution_status: Ok(()),
+    };
+
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[
+            test_setup.transfer_ix(),
+            test_setup.set_cu_limit_ix(cu_limit),
+        ],)
+    );
 }
 
 #[test]
 fn test_builtin_ix_cost_adjustment_with_memo_no_cu_limit() {
     let mut test_setup = TestSetup::new();
     test_setup.install_memo_program_account();
-    let (memo_ix, memo_ix_cost) = test_setup.memo_ix();
+    let (memo_ix, _memo_ix_cost) = test_setup.memo_ix();
 
     // A simple transfer ix, and a bpf ix (memo_ix) that needs 356_963 CUs
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate CU for 1 builtin and 1 non-builtin
-        //   (3_000 + 200_000) = 203_000 CUs (note: less than memo_ix needs)
-        // VM Execution: consume all allocated CUs, then fail
-        // Result: no adjustment
-        (
-            true,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Err(TransactionError::InstructionError(
-                    1,
-                    InstructionError::ProgramFailedToComplete,
-                )),
-            },
-        ),
-        // pre #3799:
-        // Cost model: reserve CUs for `system` and default 200K for bpf ix
-        //   (150 + 200_000) = 200_150 CUs
-        // Compute budget: allocate default 200K CUs for non-compute-budget ixs:
-        //   (2 * 200_000) = 400_000 (note: more than memo_ix needs)
-        // VM Execution: consume CUs for `system` and bpf programs, then success
-        // Result: adjustment = 200_150 - (150 + 356_963) = -156_963 CUs
-        //   Note: negative adjustment means adjust-up.
-        (
-            false,
-            TestResult {
-                cost_adjustment: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as i64
-                    - memo_ix_cost as i64,
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[test_setup.transfer_ix(), memo_ix.clone()],
-                is_simd_170_enabled
-            )
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate CU for 1 builtin and 1 non-builtin
+    //   (3_000 + 200_000) = 203_000 CUs (note: less than memo_ix needs)
+    // VM Execution: consume all allocated CUs, then fail
+    // Result: no adjustment
+    let expected = TestResult {
+        cost_adjustment: 0,
+        execution_status: Err(TransactionError::InstructionError(
+            1,
+            InstructionError::ProgramFailedToComplete,
+        )),
+    };
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[test_setup.transfer_ix(), memo_ix.clone()],)
+    );
 }
 
 #[test]
@@ -398,84 +307,40 @@ fn test_builtin_ix_cost_adjustment_with_memo_and_cu_limit() {
 
     // A simple transfer ix, and a bpf ix (memo_ix) that needs 356_963 CUs,
     // and a compute-budget instruction that requests exact amount CUs.
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate requested CUs
-        // VM Execution: consume all allocated CUs, then succeed
-        // Result: no adjustment
-        (
-            true,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: reserve requested CUs because there are bpf ix
-        // Compute budget: allocate requested CUs,
-        // VM Execution: consume all allocated CUs, then succeed,
-        // Result: no adjustment
-        (
-            false,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[
-                    test_setup.transfer_ix(),
-                    memo_ix.clone(),
-                    test_setup.set_cu_limit_ix(cu_limit)
-                ],
-                is_simd_170_enabled
-            )
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate requested CUs
+    // VM Execution: consume all allocated CUs, then succeed
+    // Result: no adjustment
+    let expected = TestResult {
+        cost_adjustment: 0,
+        execution_status: Ok(()),
+    };
+
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[
+            test_setup.transfer_ix(),
+            memo_ix.clone(),
+            test_setup.set_cu_limit_ix(cu_limit)
+        ],)
+    );
 }
 
 #[test]
 fn test_builtin_ix_cost_adjustment_with_bpf_v3_no_cu_limit() {
     // A System & BPF Loader v3 ix. The latter CPIs into System.
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate default CU for 1 builtin
-        // VM Execution: consume CUs for 1 BPF_L and 1 System (CPI-ed 1 time), then succeed
-        // Result: adjustment = 3_000 - 2_370 - 150 = 480
-        (
-            true,
-            TestResult {
-                cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64
-                    - solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS as i64
-                    - solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as i64,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: reserve 2_370 CU for 1 BPF_L instruction,
-        // Compute budget: allocate 200K CU for one non-compute-budget instruction
-        // VM Execution: consumeed CU for 1 BPF_L and 1 System, then succeed,
-        // Result: adjustment = 2370 - (2370 + 150) = -150
-        //   Note negative adjustment means adjust-up
-        (
-            false,
-            TestResult {
-                cost_adjustment: -(solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS
-                    as i64),
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        let mut test_setup = TestSetup::new();
-        let ix = test_setup.deploy_with_max_data_len_ix();
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(&[ix], is_simd_170_enabled)
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate default CU for 1 builtin
+    // VM Execution: consume CUs for 1 BPF_L and 1 System (CPI-ed 1 time), then succeed
+    // Result: adjustment = 3_000 - 2_370 - 150 = 480
+    let expected = TestResult {
+        cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64
+            - solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS as i64
+            - solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as i64,
+        execution_status: Ok(()),
+    };
+
+    let mut test_setup = TestSetup::new();
+    let ix = test_setup.deploy_with_max_data_len_ix();
+    assert_eq!(expected, test_setup.execute_test_transaction(&[ix]));
 }
 
 #[test]
@@ -487,90 +352,40 @@ fn test_builtin_ix_cost_adjustment_with_bpf_v3_and_cu_limit_high() {
 
     // A BPF Loader v3 ix only, that CPIs into System instructions; and a compute-budget
     // instruction requests enough CU Limit
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate requested CUs
-        // VM Execution: consume CUs for 1 BPF_L and 1 System (CPI-ed 1 time) and 1 Compute Budget, then succeed
-        // Result: adjustment = 500_000 - 2_370 - 150 - 150 = 497_330
-        (
-            true,
-            TestResult {
-                cost_adjustment: cu_limit as i64 - tx_execution_cost as i64,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: ignores requested CU limit because no bpf instruction, instead
-        //   reserve CUs for 1 BPF_L instruction and 1 Compute Budget instruction,
-        // Compute budget: allocate reuested CUs,
-        // VM Execution: consume CUs for 1 BPF_L and 1 System (CPI-ed 1 time) and 1 Compute Budget, then succeed
-        // Result: adjustment = (BPF_L + CB) - (BPF_L + System + CB) = -150
-        //   Note negative adjustment means adjust-up
-        (
-            false,
-            TestResult {
-                cost_adjustment: -(solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS
-                    as i64),
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        let mut test_setup = TestSetup::new();
-        let ixs = [
-            test_setup.deploy_with_max_data_len_ix(),
-            test_setup.set_cu_limit_ix(cu_limit),
-        ];
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(&ixs, is_simd_170_enabled)
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate requested CUs
+    // VM Execution: consume CUs for 1 BPF_L and 1 System (CPI-ed 1 time) and 1 Compute Budget, then succeed
+    // Result: adjustment = 500_000 - 2_370 - 150 - 150 = 497_330
+
+    let expected = TestResult {
+        cost_adjustment: cu_limit as i64 - tx_execution_cost as i64,
+        execution_status: Ok(()),
+    };
+    let mut test_setup = TestSetup::new();
+    let ixs = [
+        test_setup.deploy_with_max_data_len_ix(),
+        test_setup.set_cu_limit_ix(cu_limit),
+    ];
+    assert_eq!(expected, test_setup.execute_test_transaction(&ixs));
 }
 
 #[test]
 fn test_builtin_ix_set_cu_price_only() {
     let mut test_setup = TestSetup::new();
-    let mut cu_price = 1;
+    let cu_price = 1;
 
     // single Compute Budget instruction to set CU Price
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate default CU for one builtin ix
-        // VM Execution: consume CUs for 1 Compute Budget, then succeed
-        // Result: adjustment = 3_000 - 150 = 2_850
-        (
-            true,
-            TestResult {
-                cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64
-                    - solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as i64,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: reserved CU for 1 compute budget instruction,
-        // Compute budget: allocate zero CU because there is zero non-compute-budget instructions,
-        // VM Execution: no budget to execute, fail.
-        // Result: adjustment = 150 - 0 = 150
-        (
-            false,
-            TestResult {
-                cost_adjustment: solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as i64,
-                execution_status: Err(TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded,
-                )),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[test_setup.set_cu_price_ix(cu_price)],
-                is_simd_170_enabled
-            )
-        );
-        cu_price += 1;
-    }
+    // Cost model & Compute budget: reserve/allocate default CU for one builtin ix
+    // VM Execution: consume CUs for 1 Compute Budget, then succeed
+    // Result: adjustment = 3_000 - 150 = 2_850
+    let expected = TestResult {
+        cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64
+            - solana_compute_budget_program::DEFAULT_COMPUTE_UNITS as i64,
+        execution_status: Ok(()),
+    };
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[test_setup.set_cu_price_ix(cu_price)],)
+    );
 }
 
 #[test]
@@ -578,42 +393,20 @@ fn test_builtin_ix_precompiled() {
     let mut test_setup = TestSetup::new();
 
     // single precompiled instruction
-    for (is_simd_170_enabled, expected) in [
-        // post #3799:
-        // Cost model & Compute budget: reserve/allocate default CU for one builtin ix
-        // VM Execution: consume 0 from CU-meter
-        // Result: adjustment = 3_000
-        (
-            true,
-            TestResult {
-                cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64,
-                execution_status: Ok(()),
-            },
-        ),
-        // pre #3799:
-        // Cost model: reserved 0 CU because precompiles are builtin with native_cost set to `0`.
-        // Compute budget: allocate zero CU because there is no non-compute-budget instructions,
-        // VM Execution: nothing to execute;
-        // Result: no adjustment
-        (
-            false,
-            TestResult {
-                cost_adjustment: 0,
-                execution_status: Ok(()),
-            },
-        ),
-    ] {
-        assert_eq!(
-            expected,
-            test_setup.execute_test_transaction(
-                &[Instruction::new_with_bincode(
-                    solana_sdk::secp256k1_program::id(),
-                    &[0u8],
-                    // Add a dummy account to generate a unique transaction
-                    vec![AccountMeta::new_readonly(Pubkey::new_unique(), false)]
-                )],
-                is_simd_170_enabled
-            )
-        );
-    }
+    // Cost model & Compute budget: reserve/allocate default CU for one builtin ix
+    // VM Execution: consume 0 from CU-meter
+    // Result: adjustment = 3_000
+    let expected = TestResult {
+        cost_adjustment: MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as i64,
+        execution_status: Ok(()),
+    };
+    assert_eq!(
+        expected,
+        test_setup.execute_test_transaction(&[Instruction::new_with_bincode(
+            solana_sdk::secp256k1_program::id(),
+            &[0u8],
+            // Add a dummy account to generate a unique transaction
+            vec![AccountMeta::new_readonly(Pubkey::new_unique(), false)]
+        )],)
+    );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13633,11 +13633,14 @@ fn test_loader_v3_to_v4_migration() {
         .unwrap()
         .copy_from_slice(&elf);
     let message = Message::new(
-        &[solana_loader_v3_interface::instruction::migrate_program(
-            &programdata_address,
-            &program_keypair.pubkey(),
-            &program_keypair.pubkey(),
-        )],
+        &[
+            solana_loader_v3_interface::instruction::migrate_program(
+                &programdata_address,
+                &program_keypair.pubkey(),
+                &program_keypair.pubkey(),
+            ),
+            ComputeBudgetInstruction::set_compute_unit_limit(12_000),
+        ],
         Some(&payer_keypair.pubkey()),
     );
     let signers = &[&payer_keypair, &program_keypair];
@@ -13664,11 +13667,14 @@ fn test_loader_v3_to_v4_migration() {
         .unwrap()
         .copy_from_slice(&elf);
     let message = Message::new(
-        &[solana_loader_v3_interface::instruction::migrate_program(
-            &programdata_address,
-            &program_keypair.pubkey(),
-            &upgrade_authority_keypair.pubkey(),
-        )],
+        &[
+            solana_loader_v3_interface::instruction::migrate_program(
+                &programdata_address,
+                &program_keypair.pubkey(),
+                &upgrade_authority_keypair.pubkey(),
+            ),
+            ComputeBudgetInstruction::set_compute_unit_limit(10_000),
+        ],
         Some(&payer_keypair.pubkey()),
     );
     let signers = &[&payer_keypair, &upgrade_authority_keypair];


### PR DESCRIPTION
#### Problem
Feature is active everywhere:
```
$ sol_feature_status C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH
          Feature                                      | Status                  | Activation Slot | Description
devnet:   C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH | active since epoch 842 | 363744000 | Reserve minimal CUs for builtin instructions SIMD-170 #2562
testnet:  C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH | active since epoch 750 | 318476256 | Reserve minimal CUs for builtin instructions SIMD-170 #2562
mainnet:  C9oAhLxDBm3ssWtJx1yBGzPY55r2rArHmN1pbQn6HogH | active since epoch 758 | 327456000 | Reserve minimal CUs for builtin instructions SIMD-170 #2562
```
but the conditional logic still exists in the code.

#### Summary of Changes
- Remove all (excluding feature-set) references to `reserve_minimal_cus_for_builtin_instructions`
- Fix tests
  - mainly by removing cases where feature was expected to be inactive

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
