### PR TITLE
Add svm-callback to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,6 @@
 /svm-transaction/ @anza-xyz/svm
 /svm/ @anza-xyz/svm
 /svm/examples/Cargo.lock
+/svm-callback/ @anza-xyz/svm
 /transaction-context/ @anza-xyz/svm
 /transaction-view/ @anza-xyz/tx-metadata


### PR DESCRIPTION
#### Problem
`svm-callback` crate is owned by SVM. The CODEOWNERS file needs an update.

#### Summary of Changes
Add svm-callback to CODEOWNERS

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
