### PR TITLE
move bank tests

### DIFF
--- a/runtime/src/bank/tests/mod.rs
+++ b/runtime/src/bank/tests/mod.rs
@@ -12418,7 +12418,8 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
 
     // Program Setup
     let program_keypair = Keypair::new();
-    let program_data = include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    let program_data =
+        include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
     let program_account = AccountSharedData::from(Account {
         lamports: Rent::default().minimum_balance(program_data.len()).min(1),
         data: program_data.to_vec(),
@@ -12527,7 +12528,8 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     // Program Setup
     let program_keypair = Keypair::new();
-    let program_data = include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    let program_data =
+        include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
     let program_account = AccountSharedData::from(Account {
         lamports: Rent::default().minimum_balance(program_data.len()).min(1),
         data: program_data.to_vec(),

--- a/runtime/src/bank/tests/mod.rs
+++ b/runtime/src/bank/tests/mod.rs
@@ -12418,7 +12418,7 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
 
     // Program Setup
     let program_keypair = Keypair::new();
-    let program_data = include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    let program_data = include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
     let program_account = AccountSharedData::from(Account {
         lamports: Rent::default().minimum_balance(program_data.len()).min(1),
         data: program_data.to_vec(),
@@ -12527,7 +12527,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 
     // Program Setup
     let program_keypair = Keypair::new();
-    let program_data = include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    let program_data = include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
     let program_account = AccountSharedData::from(Account {
         lamports: Rent::default().minimum_balance(program_data.len()).min(1),
         data: program_data.to_vec(),


### PR DESCRIPTION
#### Problem
`runtime/src/bank/tests.rs` has grown so large that it's not rendering syntax on Github. Need to break it up into more files

#### Summary of Changes

1. Move to `runtime/src/bank/tests/mod.rs` file as a first step. Idea is that will allow for creating more files in the `runtime/src/bank/tests` folder to start splitting off groups of tests
2. Fix up small breakage in how we hard code relative path to `programs` folder