### PR TITLE
Introduce scan_stored_accounts_no_data method to AppendVec

### DIFF
--- a/accounts-db/src/account_storage/meta.rs
+++ b/accounts-db/src/account_storage/meta.rs
@@ -77,14 +77,6 @@ impl<'storage> StoredAccountMeta<'storage> {
             Self::Hot(_) => unreachable!(),
         }
     }
-
-    pub(crate) fn sanitize(&self) -> bool {
-        match self {
-            Self::AppendVec(av) => av.sanitize(),
-            // Hot account currently doesn't have the concept of sanitization.
-            Self::Hot(_) => unimplemented!(),
-        }
-    }
 }
 
 impl ReadableAccount for StoredAccountMeta<'_> {


### PR DESCRIPTION
#### Problem

`AppendVec::scan_accounts` is widely used across the codebase to provide iterative access to accounts managed by `AccountsDb`. In the `AppendVec` case, this method can be extremely slow if accounts with large data sections are present. This method must also heap allocate to be able to accommodate these large data accounts, and may allocate up to ~10 MiB in the worst case. A majority of calls to `scan_accounts` don't actually utilize account data, and just reference data that is available in the fixed size portion of the account. 

A simple example of this is the sanitization of layout and length of the `AppendVec`:
https://github.com/anza-xyz/agave/blob/8b354f1c347253cb0fe85674612a3aa3684550b2/accounts-db/src/append_vec.rs#L600-L623

The data of the account is not needed to perform this check, making this significantly more expensive than necessary.

#### Summary of Changes

This branch introduces a new internal method to `AppendVec`, `scan_stored_accounts_no_data`, which provides iterative access to the fixed sized data portion of the accounts managed by `AccountsDb`. It provides everything `scan_accounts` provides except for the data, and as such it can be stack allocated and avoid a ton of disk io.

A benchmark of `scan_accounts` on a file with 10000 accounts with a 1% distribution `MAX_PERMITTED_DATA_LENGTH` accounts reports an average 114.39ms to complete.
```
append_vec_file_scan_accounts/10000
                        time:   [114.39 ms 115.22 ms 116.05 ms]
                        thrpt:  [86.170 Kelem/s 86.793 Kelem/s 87.419 Kelem/s]
```

Contrast this to `scan_stored_accounts_no_data` on the same file, which reports an average 361.13µs.
```
append_vec_file_scan_stored_accounts_no_data/10000
                        time:   [361.13 µs 365.90 µs 370.75 µs]
                        thrpt:  [26.972 Melem/s 27.330 Melem/s 27.691 Melem/s]
```

This PR does not update all call sites of `scan_accounts` external to `AppendVec` to use the new method, it simply lays the groundwork for a follow up PR that will be concerned with those changes and updates a few internals to use it. Methods like `scan_index` and `scan_pubkeys` are able to leverage `scan_stored_accounts_no_data` since they use identical scanning logic and `scan_stored_accounts_no_data` is strictly more general. Sanitization also uses this new method.

Note, the new struct `StoredAccountNoData` is not meant to be consumed externally (it is private). In a following PR, a new struct, `AccountNoData`, will be created to facilitate external consumption of accounts without data fields. This will also leverage `scan_stored_accounts_no_data`'s scanning logic.