### PR TITLE
core/tpu: Add `BytesPacket`, a zero-copy packet implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Release channels have their own copy of this changelog:
 
 ### Validator
 
+#### Breaking
+* ABI of `TimedTracedEvent` changed, since `PacketBatch` became an enum, which carries different packet batch types. (#5646)
+
 #### Changes
 * Account notifications for Geyser are no longer deduplicated when restorting from a snapshot.
 * Add `--no-snapshots` to disable generating snapshots.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytesize"
@@ -9109,6 +9112,7 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bv",
+ "bytes",
  "caps",
  "curve25519-dalek 4.1.3",
  "dlopen2",

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -5,7 +5,7 @@ use {
     crossbeam_channel::unbounded,
     solana_net_utils::{bind_to_unspecified, SocketConfig},
     solana_streamer::{
-        packet::{Packet, PacketBatch, PacketBatchRecycler, PACKET_DATA_SIZE},
+        packet::{Packet, PacketBatchRecycler, PinnedPacketBatch, PACKET_DATA_SIZE},
         sendmmsg::batch_send,
         streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
     },
@@ -32,7 +32,7 @@ fn producer(dest_addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<usize> 
         packet.meta_mut().set_socket_addr(dest_addr);
         packet
     };
-    let mut packet_batch = PacketBatch::with_capacity(batch_size);
+    let mut packet_batch = PinnedPacketBatch::with_capacity(batch_size);
     packet_batch.resize(batch_size, packet);
 
     spawn(move || {

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -223,7 +223,7 @@ fn bench_banking(
     let vote_packets = vote_txs.map(|vote_txs| {
         let mut packet_batches = to_packet_batches(&vote_txs, PACKETS_PER_BATCH);
         for batch in packet_batches.iter_mut() {
-            for packet in batch.iter_mut() {
+            for mut packet in batch.iter_mut() {
                 packet.meta_mut().set_simple_vote(true);
             }
         }

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -48,7 +48,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
 
     for batch in batches.iter_mut() {
         total += batch.len();
-        for p in batch.iter_mut() {
+        for mut p in batch.iter_mut() {
             let ip_index = thread_rng().gen_range(0..ips.len());
             p.meta_mut().addr = ips[ip_index];
         }
@@ -59,7 +59,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
         SigVerifyStage::discard_excess_packets(&mut batches, 10_000);
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
-            for p in batch.iter_mut() {
+            for mut p in batch.iter_mut() {
                 if !p.meta().discard() {
                     num_packets += 1;
                 }
@@ -93,7 +93,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
     let mut batches = to_packet_batches(&vec![test_tx(); SIZE], CHUNK_SIZE);
     let spam_addr = new_rand_addr(&mut rng);
     for batch in batches.iter_mut() {
-        for packet in batch.iter_mut() {
+        for mut packet in batch.iter_mut() {
             // One spam address, ~1000 unique addresses.
             packet.meta_mut().addr = if rng.gen_ratio(1, 30) {
                 new_rand_addr(&mut rng)
@@ -106,7 +106,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         SigVerifyStage::discard_excess_packets(&mut batches, 10_000);
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
-            for packet in batch.iter_mut() {
+            for mut packet in batch.iter_mut() {
                 if !packet.meta().discard() {
                     num_packets += 1;
                 }
@@ -216,7 +216,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 
     let mut c = 0;
     batches.iter_mut().for_each(|batch| {
-        batch.iter_mut().for_each(|p| {
+        batch.iter_mut().for_each(|mut p| {
             let throw = die.sample(&mut rng);
             if throw < discard_factor {
                 p.meta_mut().set_discard(true);
@@ -237,9 +237,9 @@ fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32)
     let mut total_verify_time = 0;
 
     bencher.iter(|| {
-        let mut batches = batches0.clone();
-        let (pre_shrink_time_us, _pre_shrink_total) =
-            SigVerifyStage::maybe_shrink_batches(&mut batches);
+        let batches = batches0.clone();
+        let (pre_shrink_time_us, _pre_shrink_total, batches) =
+            SigVerifyStage::maybe_shrink_batches(batches);
 
         let mut verify_time = Measure::start("sigverify_batch_time");
         let _batches = verifier.verify_batches(batches, num_valid_packets);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -933,7 +933,11 @@ mod tests {
 
         // send 'em over
         let mut packet_batches = to_packet_batches(&[tx_no_ver, tx_anf, tx], 3);
-        packet_batches[0][0].meta_mut().set_discard(true); // set discard on `tx_no_ver`
+        packet_batches[0]
+            .first_mut()
+            .unwrap()
+            .meta_mut()
+            .set_discard(true); // set discard on `tx_no_ver`
 
         // glad they all fit
         assert_eq!(packet_batches.len(), 1);

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -233,7 +233,11 @@ mod tests {
         let transactions = vec![random_transfer(), random_transfer()];
         let mut packet_batches = to_packet_batches(&transactions, 1);
         assert_eq!(packet_batches.len(), 2);
-        packet_batches[0][0].meta_mut().set_discard(true);
+        packet_batches[0]
+            .first_mut()
+            .unwrap()
+            .meta_mut()
+            .set_discard(true);
 
         let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
         let results = PacketDeserializer::deserialize_and_collect_packets(

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -345,7 +345,7 @@ mod tests {
         solana_genesis_config::GenesisConfig,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_perf::packet::{Packet, PacketFlags},
+        solana_perf::packet::{BytesPacket, PacketFlags},
         solana_runtime::genesis_utils::{self, ValidatorVoteKeypairs},
         solana_signer::Signer,
         solana_vote::vote_transaction::new_tower_sync_transaction,
@@ -357,7 +357,7 @@ mod tests {
         slots: Vec<(u64, u32)>,
         keypairs: &ValidatorVoteKeypairs,
         timestamp: Option<UnixTimestamp>,
-    ) -> Packet {
+    ) -> BytesPacket {
         let mut vote = TowerSync::from(slots);
         vote.timestamp = timestamp;
         let vote_tx = new_tower_sync_transaction(
@@ -368,7 +368,7 @@ mod tests {
             &keypairs.vote_keypair,
             None,
         );
-        let mut packet = Packet::from_data(None, vote_tx).unwrap();
+        let mut packet = BytesPacket::from_data(None, vote_tx).unwrap();
         packet
             .meta_mut()
             .flags
@@ -384,7 +384,7 @@ mod tests {
         timestamp: Option<UnixTimestamp>,
     ) -> LatestValidatorVotePacket {
         let packet = packet_from_slots(slots, keypairs, timestamp);
-        LatestValidatorVotePacket::new(&packet, vote_source, true).unwrap()
+        LatestValidatorVotePacket::new(packet.as_ref(), vote_source, true).unwrap()
     }
 
     #[test]
@@ -395,7 +395,7 @@ mod tests {
                 .genesis_config;
         let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let vote_keypair = Keypair::new();
-        let mut vote = Packet::from_data(
+        let mut vote = BytesPacket::from_data(
             None,
             new_tower_sync_transaction(
                 TowerSync::default(),
@@ -411,7 +411,7 @@ mod tests {
         let mut vote_storage = VoteStorage::new_for_tests(&[vote_keypair.pubkey()]);
         vote_storage.insert_batch(
             VoteSource::Tpu,
-            std::iter::once(ImmutableDeserializedPacket::new(&vote)?),
+            std::iter::once(ImmutableDeserializedPacket::new(vote.as_ref())?),
         );
         assert_eq!(1, vote_storage.len());
 
@@ -676,10 +676,10 @@ mod tests {
         let vote_c = packet_from_slots(vec![(vote_c_slot, 1)], &keypair_c, None);
         let vote_d = packet_from_slots(vec![(4, 1)], &keypair_d, None);
         let votes = vec![
-            ImmutableDeserializedPacket::new(&vote_a).unwrap(),
-            ImmutableDeserializedPacket::new(&vote_b).unwrap(),
-            ImmutableDeserializedPacket::new(&vote_c).unwrap(),
-            ImmutableDeserializedPacket::new(&vote_d).unwrap(),
+            ImmutableDeserializedPacket::new(vote_a.as_ref()).unwrap(),
+            ImmutableDeserializedPacket::new(vote_b.as_ref()).unwrap(),
+            ImmutableDeserializedPacket::new(vote_c.as_ref()).unwrap(),
+            ImmutableDeserializedPacket::new(vote_d.as_ref()).unwrap(),
         ];
 
         let bank_0 = Bank::new_for_tests(&GenesisConfig::default());

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -63,7 +63,7 @@ pub struct BankingTracer {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "DAdZnX6ijBWaxKAyksq4nJa6PAZqT4RShZqLWTtNvyAM")
+    frozen_abi(digest = "91baCBT3aY2nXSAuzY3S5dnMhWabVsHowgWqYPLjfyg7")
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -292,7 +292,7 @@ impl ClusterInfoVoteListener {
             .filter(|(_, packet_batch)| {
                 // to_packet_batches() above splits into 1 packet long batches
                 assert_eq!(packet_batch.len(), 1);
-                !packet_batch[0].meta().discard()
+                !packet_batch.get(0).unwrap().meta().discard()
             })
             .filter_map(|(tx, packet_batch)| {
                 let (vote_account_key, vote, ..) = vote_parser::parse_vote_transaction(&tx)?;

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -5,8 +5,11 @@ use {
     crossbeam_channel::{unbounded, RecvTimeoutError},
     solana_clock::{DEFAULT_TICKS_PER_SLOT, HOLD_TRANSACTIONS_SLOT_OFFSET},
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
-    solana_packet::{Packet, PacketFlags},
-    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
+    solana_packet::PacketFlags,
+    solana_perf::{
+        packet::{PacketBatchRecycler, PacketRefMut},
+        recycler::Recycler,
+    },
     solana_poh::poh_recorder::PohRecorder,
     solana_streamer::streamer::{
         self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats,
@@ -98,7 +101,7 @@ impl FetchStage {
         sendr: &PacketBatchSender,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
     ) -> Result<()> {
-        let mark_forwarded = |packet: &mut Packet| {
+        let mark_forwarded = |mut packet: PacketRefMut| {
             packet.meta_mut().flags |= PacketFlags::FORWARDED;
         };
 

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -87,14 +87,14 @@ mod test {
         packet.meta_mut().flags |= PacketFlags::REPAIR;
 
         let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
-        assert!(verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(verify_shred_cpu((&packet).into(), &leader_slots, &cache));
 
         let wrong_keypair = Keypair::new();
         let leader_slots = HashMap::from([(slot, wrong_keypair.pubkey())]);
-        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
 
         let leader_slots = HashMap::new();
-        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
     }
 
     #[test]

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -36,7 +36,7 @@ use {
     solana_packet::PACKET_DATA_SIZE,
     solana_perf::{
         data_budget::DataBudget,
-        packet::{Packet, PacketBatch, PacketBatchRecycler},
+        packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     },
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
     solana_runtime::{bank_forks::BankForks, root_bank_cache::RootBankCache},
@@ -1036,8 +1036,8 @@ impl ServeRepair {
 
         if !pending_pings.is_empty() {
             stats.pings_sent += pending_pings.len();
-            let batch = PacketBatch::new(pending_pings);
-            let _ = packet_batch_sender.send(batch);
+            let batch = PinnedPacketBatch::new(pending_pings);
+            let _ = packet_batch_sender.send(batch.into());
         }
     }
 
@@ -1217,7 +1217,7 @@ impl ServeRepair {
         stats: &mut ShredFetchStats,
     ) {
         let mut pending_pongs = Vec::default();
-        for packet in packet_batch.iter_mut() {
+        for mut packet in packet_batch.iter_mut() {
             if packet.meta().size != REPAIR_RESPONSE_SERIALIZED_PING_BYTES {
                 continue;
             }
@@ -1301,11 +1301,14 @@ impl ServeRepair {
             from_addr,
             nonce,
         )?;
-        Some(PacketBatch::new_unpinned_with_recycler_data(
-            recycler,
-            "run_window_request",
-            vec![packet],
-        ))
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_window_request",
+                vec![packet],
+            )
+            .into(),
+        )
     }
 
     fn run_highest_window_request(
@@ -1327,11 +1330,14 @@ impl ServeRepair {
                 from_addr,
                 nonce,
             )?;
-            return Some(PacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_highest_window_request",
-                vec![packet],
-            ));
+            return Some(
+                PinnedPacketBatch::new_unpinned_with_recycler_data(
+                    recycler,
+                    "run_highest_window_request",
+                    vec![packet],
+                )
+                .into(),
+            );
         }
         None
     }
@@ -1345,7 +1351,7 @@ impl ServeRepair {
         nonce: Nonce,
     ) -> Option<PacketBatch> {
         let mut res =
-            PacketBatch::new_unpinned_with_recycler(recycler, max_responses, "run_orphan");
+            PinnedPacketBatch::new_unpinned_with_recycler(recycler, max_responses, "run_orphan");
         // Try to find the next "n" parent slots of the input slot
         let packets = std::iter::successors(blockstore.meta(slot).ok()?, |meta| {
             blockstore.meta(meta.parent_slot?).ok()?
@@ -1362,7 +1368,7 @@ impl ServeRepair {
         for packet in packets.take(max_responses) {
             res.push(packet);
         }
-        (!res.is_empty()).then_some(res)
+        (!res.is_empty()).then_some(res.into())
     }
 
     fn run_ancestor_hashes(
@@ -1391,11 +1397,14 @@ impl ServeRepair {
             from_addr,
             nonce,
         )?;
-        Some(PacketBatch::new_unpinned_with_recycler_data(
-            recycler,
-            "run_ancestor_hashes",
-            vec![packet],
-        ))
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_ancestor_hashes",
+                vec![packet],
+            )
+            .into(),
+        )
     }
 }
 
@@ -1452,7 +1461,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             shred::{max_ticks_per_n_shreds, Shred, ShredFlags},
         },
-        solana_perf::packet::{deserialize_from_with_limit, Packet, PacketFlags},
+        solana_perf::packet::{deserialize_from_with_limit, Packet, PacketFlags, PacketRef},
         solana_pubkey::Pubkey,
         solana_runtime::bank::Bank,
         solana_streamer::socket::SocketAddrSpace,
@@ -1914,10 +1923,10 @@ mod tests {
 
         let rv: Vec<Shred> = rv
             .iter_mut()
-            .map(|packet| {
+            .map(|mut packet| {
                 packet.meta_mut().flags |= PacketFlags::REPAIR;
                 let (shred, repair_nonce) =
-                    shred::layout::get_shred_and_repair_nonce(packet).unwrap();
+                    shred::layout::get_shred_and_repair_nonce(packet.as_ref()).unwrap();
                 assert_eq!(repair_nonce.unwrap(), nonce);
                 Shred::new_from_serialized_shred(shred.to_vec()).unwrap()
             })
@@ -1978,10 +1987,10 @@ mod tests {
         verify_responses(&request, rv.iter());
         let rv: Vec<Shred> = rv
             .iter_mut()
-            .map(|packet| {
+            .map(|mut packet| {
                 packet.meta_mut().flags |= PacketFlags::REPAIR;
                 let (shred, repair_nonce) =
-                    shred::layout::get_shred_and_repair_nonce(packet).unwrap();
+                    shred::layout::get_shred_and_repair_nonce(packet.as_ref()).unwrap();
                 assert_eq!(repair_nonce.unwrap(), nonce);
                 Shred::new_from_serialized_shred(shred.to_vec()).unwrap()
             })
@@ -2140,7 +2149,7 @@ mod tests {
 
         // For a orphan request for `slot + num_slots - 1`, we should return the highest shreds
         // from slots in the range [slot, slot + num_slots - 1]
-        let rv: Vec<_> = ServeRepair::run_orphan(
+        let rv = ServeRepair::run_orphan(
             &recycler,
             &socketaddr_any!(),
             &blockstore,
@@ -2148,10 +2157,7 @@ mod tests {
             5,
             nonce,
         )
-        .expect("run_orphan packets")
-        .iter()
-        .cloned()
-        .collect();
+        .expect("run_orphan packets");
 
         // Verify responses
         let request = ShredRepairType::Orphan(slot + num_slots - 1);
@@ -2170,6 +2176,7 @@ mod tests {
                 )
             })
             .collect();
+        let expected = PacketBatch::Pinned(PinnedPacketBatch::new(expected));
         assert_eq!(rv, expected);
     }
 
@@ -2205,28 +2212,25 @@ mod tests {
         // Orphan request for slot 2 should only return slot 1 since
         // calling `repair_response_packet` on slot 1's shred will
         // be corrupted
-        let rv: Vec<_> =
-            ServeRepair::run_orphan(&recycler, &socketaddr_any!(), &blockstore, 2, 5, nonce)
-                .expect("run_orphan packets")
-                .iter()
-                .cloned()
-                .collect();
+        let rv = ServeRepair::run_orphan(&recycler, &socketaddr_any!(), &blockstore, 2, 5, nonce)
+            .expect("run_orphan packets");
 
         // Verify responses
-        let expected = vec![repair_response::repair_response_packet(
+        let expected = PinnedPacketBatch::new(vec![repair_response::repair_response_packet(
             &blockstore,
             2,
             31, // shred_index
             &socketaddr_any!(),
             nonce,
         )
-        .unwrap()];
+        .unwrap()])
+        .into();
         assert_eq!(rv, expected);
     }
 
     #[test]
     fn test_run_ancestor_hashes() {
-        fn deserialize_ancestor_hashes_response(packet: &Packet) -> AncestorHashesResponse {
+        fn deserialize_ancestor_hashes_response(packet: PacketRef) -> AncestorHashesResponse {
             packet
                 .deserialize_slice(..packet.meta().size - SIZE_OF_NONCE)
                 .unwrap()
@@ -2259,7 +2263,7 @@ mod tests {
         )
         .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
-        let packet = &rv[0];
+        let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
         match ancestor_hashes_response {
             AncestorHashesResponse::Hashes(hashes) => {
@@ -2281,7 +2285,7 @@ mod tests {
         )
         .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
-        let packet = &rv[0];
+        let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
         match ancestor_hashes_response {
             AncestorHashesResponse::Hashes(hashes) => {
@@ -2310,7 +2314,7 @@ mod tests {
         )
         .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
-        let packet = &rv[0];
+        let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
         match ancestor_hashes_response {
             AncestorHashesResponse::Hashes(hashes) => {
@@ -2460,7 +2464,10 @@ mod tests {
         assert!(!request.verify_response(shred.payload()));
     }
 
-    fn verify_responses<'a>(request: &ShredRepairType, packets: impl Iterator<Item = &'a Packet>) {
+    fn verify_responses<'a>(
+        request: &ShredRepairType,
+        packets: impl Iterator<Item = PacketRef<'a>>,
+    ) {
         for packet in packets {
             let shred = shred::layout::get_shred(packet).unwrap();
             assert!(request.verify_response(shred));

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -122,6 +122,7 @@ solana-account-decoder = { workspace = true }
 solana-ledger = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
+solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -8,7 +8,7 @@ use {
     solana_metrics::inc_new_counter_debug,
     solana_perf::{
         cuda_runtime::PinnedVec,
-        packet::{Packet, PacketBatch},
+        packet::{Packet, PacketBatch, PacketRef},
         perf_libs,
         recycler_cache::RecyclerCache,
         sigverify::{self, count_packets_in_batches, TxOffset},
@@ -16,6 +16,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     std::{
+        borrow::Cow,
         collections::HashMap,
         iter::{self, repeat},
         mem::size_of,
@@ -27,6 +28,7 @@ use {
 use {
     sha2::{Digest, Sha512},
     solana_keypair::Keypair,
+    solana_perf::packet::PacketRefMut,
     solana_signer::Signer,
     std::sync::Arc,
 };
@@ -38,7 +40,7 @@ pub type LruCache = lazy_lru::LruCache<(Signature, Pubkey, /*merkle root:*/ Hash
 
 #[must_use]
 pub fn verify_shred_cpu(
-    packet: &Packet,
+    packet: PacketRef,
     slot_leaders: &HashMap<Slot, Pubkey>,
     cache: &RwLock<LruCache>,
 ) -> bool {
@@ -299,7 +301,18 @@ pub fn verify_shreds_gpu(
         elems_from_buffer(&pubkeys),
         elems_from_buffer(&merkle_roots),
     ];
-    elems.extend(batches.iter().map(|batch| perf_libs::Elems {
+    // `BytesPacketBatch` cannot be directly used in CUDA. We have to retrieve
+    // and convert byte batches to pinned batches. We must collect here so that
+    // we keep the batches created by `BytesPacketBatch::to_pinned_packet_batch()`
+    // alive.
+    let pinned_batches = batches
+        .iter()
+        .map(|batch| match batch {
+            PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
+            PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+        })
+        .collect::<Vec<_>>();
+    elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {
         elems: batch.as_ptr().cast::<u8>(),
         num: batch.len() as u32,
     }));
@@ -341,9 +354,9 @@ pub fn verify_shreds_gpu(
 }
 
 #[cfg(test)]
-fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
+fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
     let sig = shred::layout::get_signature_range();
-    let msg = shred::layout::get_shred(packet)
+    let msg = shred::layout::get_shred(packet.as_ref())
         .and_then(shred::layout::get_signed_data)
         .unwrap();
     assert!(
@@ -352,7 +365,12 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
     );
     let signature = keypair.sign_message(msg.as_ref());
     trace!("signature {:?}", signature);
-    packet.buffer_mut()[sig].copy_from_slice(signature.as_ref());
+    let mut buffer = packet
+        .data(..)
+        .expect("packet should not be discarded")
+        .to_vec();
+    buffer[sig].copy_from_slice(signature.as_ref());
+    packet.copy_from_slice(&buffer);
 }
 
 #[cfg(test)]
@@ -361,9 +379,9 @@ fn sign_shreds_cpu(thread_pool: &ThreadPool, keypair: &Keypair, batches: &mut [P
     debug!("CPU SHRED ECDSA for {}", packet_count);
     thread_pool.install(|| {
         batches.par_iter_mut().for_each(|batch| {
-            batch[..]
+            batch
                 .par_iter_mut()
-                .for_each(|p| sign_shred_cpu(keypair, p));
+                .for_each(|mut p| sign_shred_cpu(keypair, &mut p));
         });
     });
     inc_new_counter_debug!("ed25519_shred_sign_cpu", packet_count);
@@ -435,7 +453,18 @@ fn sign_shreds_gpu(
         elems_from_buffer(pinned_keypair),
         elems_from_buffer(&merkle_roots),
     ];
-    elems.extend(batches.iter().map(|batch| perf_libs::Elems {
+    // `BytesPacketBatch` cannot be directly used in CUDA. We have to retrieve
+    // and convert byte batches to pinned batches. We must collect here so that
+    // we keep the batches created by `BytesPacketBatch::to_pinned_packet_batch()`
+    // alive.
+    let pinned_batches = batches
+        .iter_mut()
+        .map(|batch| match batch {
+            PacketBatch::Pinned(batch) => Cow::Borrowed(batch),
+            PacketBatch::Bytes(batch) => Cow::Owned(batch.to_pinned_packet_batch()),
+        })
+        .collect::<Vec<_>>();
+    elems.extend(pinned_batches.iter().map(|batch| perf_libs::Elems {
         elems: batch.as_ptr().cast::<u8>(),
         num: batch.len() as u32,
     }));
@@ -477,15 +506,19 @@ fn sign_shreds_gpu(
             .par_iter_mut()
             .zip(num_packets)
             .for_each(|(batch, num_packets)| {
-                batch[..]
+                batch
                     .par_iter_mut()
                     .enumerate()
-                    .for_each(|(packet_ix, packet)| {
+                    .for_each(|(packet_ix, mut packet)| {
                         let sig_ix = packet_ix + num_packets;
                         let sig_start = sig_ix * sig_size;
                         let sig_end = sig_start + sig_size;
-                        packet.buffer_mut()[..sig_size]
-                            .copy_from_slice(&signatures_out[sig_start..sig_end]);
+                        let mut buffer = packet
+                            .data(..)
+                            .expect("expected the packet to not be discarded")
+                            .to_vec();
+                        buffer[..sig_size].copy_from_slice(&signatures_out[sig_start..sig_end]);
+                        packet.copy_from_slice(&buffer);
                     });
             });
     });
@@ -506,6 +539,7 @@ mod tests {
         solana_entry::entry::Entry,
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_perf::packet::PinnedPacketBatch,
         solana_signer::Signer,
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
@@ -535,14 +569,14 @@ mod tests {
         packet.meta_mut().size = shred.payload().len();
 
         let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
-        assert!(verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(verify_shred_cpu((&packet).into(), &leader_slots, &cache));
 
         let wrong_keypair = Keypair::new();
         let leader_slots = HashMap::from([(slot, wrong_keypair.pubkey())]);
-        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
 
         let leader_slots = HashMap::new();
-        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
     }
 
     #[test]
@@ -552,7 +586,7 @@ mod tests {
 
     fn run_test_sigverify_shreds_cpu(thread_pool: &ThreadPool, slot: Slot) {
         solana_logger::setup();
-        let mut batches = [PacketBatch::default()];
+        let mut batch = PinnedPacketBatch::default();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let mut shred = Shred::new_from_data(
             slot,
@@ -566,9 +600,11 @@ mod tests {
         );
         let keypair = Keypair::new();
         shred.sign(&keypair);
-        batches[0].resize(1, Packet::default());
-        batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batch.resize(1, Packet::default());
+        batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[0].meta_mut().size = shred.payload().len();
+        let batch = PacketBatch::from(batch);
+        let mut batches = [batch];
 
         let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
         let rv = verify_shreds_cpu(thread_pool, &batches, &leader_slots, &cache);
@@ -584,7 +620,7 @@ mod tests {
         assert_eq!(rv, vec![vec![0]]);
 
         let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
-        batches[0][0].meta_mut().size = 0;
+        batches[0].first_mut().unwrap().meta_mut().size = 0;
         let rv = verify_shreds_cpu(thread_pool, &batches, &leader_slots, &cache);
         assert_eq!(rv, vec![vec![0]]);
     }
@@ -600,7 +636,7 @@ mod tests {
         let recycler_cache = RecyclerCache::default();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
 
-        let mut batches = [PacketBatch::default()];
+        let mut batch = PinnedPacketBatch::default();
         let mut shred = Shred::new_from_data(
             slot,
             0xc0de,
@@ -613,9 +649,11 @@ mod tests {
         );
         let keypair = Keypair::new();
         shred.sign(&keypair);
-        batches[0].resize(1, Packet::default());
-        batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batch.resize(1, Packet::default());
+        batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[0].meta_mut().size = shred.payload().len();
+        let batch = PacketBatch::from(batch);
+        let mut batches = [batch];
 
         let leader_slots = HashMap::from([(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]);
         let rv = verify_shreds_gpu(
@@ -651,7 +689,7 @@ mod tests {
         );
         assert_eq!(rv, vec![vec![0]]);
 
-        batches[0][0].meta_mut().size = 0;
+        batches[0].first_mut().unwrap().meta_mut().size = 0;
         let leader_slots = HashMap::from([(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]);
         let rv = verify_shreds_gpu(
             thread_pool,
@@ -676,7 +714,7 @@ mod tests {
 
         let num_packets = 32;
         let num_batches = 100;
-        let mut packet_batch = PacketBatch::with_capacity(num_packets);
+        let mut packet_batch = PinnedPacketBatch::with_capacity(num_packets);
         packet_batch.resize(num_packets, Packet::default());
 
         for (i, p) in packet_batch.iter_mut().enumerate() {
@@ -692,6 +730,7 @@ mod tests {
             );
             shred.copy_to_packet(p);
         }
+        let packet_batch = PacketBatch::from(packet_batch);
         let mut batches = vec![packet_batch; num_batches];
         let keypair = Keypair::new();
         let pinned_keypair = sign_shreds_gpu_pinned_keypair(&keypair, &recycler_cache);
@@ -724,7 +763,7 @@ mod tests {
     fn run_test_sigverify_shreds_sign_cpu(thread_pool: &ThreadPool, slot: Slot) {
         solana_logger::setup();
 
-        let mut batches = [PacketBatch::default()];
+        let mut batch = PinnedPacketBatch::default();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
         let shred = Shred::new_from_data(
@@ -737,9 +776,11 @@ mod tests {
             0,
             0xc0de,
         );
-        batches[0].resize(1, Packet::default());
-        batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        batch.resize(1, Packet::default());
+        batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[0].meta_mut().size = shred.payload().len();
+        let batch = PacketBatch::from(batch);
+        let mut batches = [batch];
 
         let pubkeys = HashMap::from([(slot, keypair.pubkey()), (u64::MAX, Pubkey::default())]);
         //unsigned
@@ -849,11 +890,11 @@ mod tests {
             shred.copy_to_packet(&mut packet);
             packet
         });
-        let packets: Vec<_> = repeat_with(|| {
+        let packets: Vec<PacketBatch> = repeat_with(|| {
             let size = rng.gen_range(0..16);
             let packets = packets.by_ref().take(size).collect();
-            let batch = PacketBatch::new(packets);
-            (size == 0 || !batch.is_empty()).then_some(batch)
+            let batch = PinnedPacketBatch::new(packets);
+            (size == 0 || !batch.is_empty()).then_some(batch.into())
         })
         .while_some()
         .collect();
@@ -896,6 +937,9 @@ mod tests {
         let out: Vec<_> = packets
             .iter_mut()
             .map(|packets| {
+                let PacketBatch::Pinned(packets) = packets else {
+                    unreachable!()
+                };
                 packets
                     .iter_mut()
                     .map(|packet| {

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 ahash = { workspace = true }
 bincode = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
+bytes = { workspace = true, features = ["serde"] }
 curve25519-dalek = { workspace = true }
 dlopen2 = { workspace = true }
 fnv = { workspace = true }

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -33,9 +33,10 @@ fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) 
             0.001,                  // false_positive_rate
             Duration::from_secs(2), // reset_cycle
         );
-        batches
-            .iter_mut()
-            .for_each(|b| b.iter_mut().for_each(|p| p.meta_mut().set_discard(false)));
+        batches.iter_mut().for_each(|b| {
+            b.iter_mut()
+                .for_each(|mut p| p.meta_mut().set_discard(false))
+        });
     });
 }
 

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -280,6 +280,14 @@ impl<T: Sized + Default + Clone> Drop for PinnedVec<T> {
     }
 }
 
+impl<T: Sized + Default + Clone + PartialEq> PartialEq for PinnedVec<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.x.eq(&other.x)
+    }
+}
+
+impl<T: Sized + Default + Clone + PartialEq + Eq> Eq for PinnedVec<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -92,7 +92,7 @@ pub fn dedup_packets_and_count_discards<const K: usize>(
     batches
         .iter_mut()
         .flat_map(|batch| batch.iter_mut())
-        .map(|packet| {
+        .map(|mut packet| {
             if !packet.meta().discard()
                 && packet
                     .data(..)

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -18,13 +18,18 @@ pub fn discard_batches_randomly(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::packet::Packet};
+    use {
+        super::*,
+        crate::packet::{BytesPacket, BytesPacketBatch, Meta},
+        bytes::Bytes,
+    };
 
     #[test]
     fn test_batch_discard_random() {
         solana_logger::setup();
-        let mut batch = PacketBatch::default();
-        batch.resize(1, Packet::default());
+        let mut batch = BytesPacketBatch::new();
+        batch.resize(1, BytesPacket::new(Bytes::new(), Meta::default()));
+        let batch = PacketBatch::from(batch);
         let num_batches = 100;
         let mut batches = vec![batch; num_batches];
         let max = 5;

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -1,9 +1,14 @@
 //! The `packet` module defines data structures and methods to pull data from the network.
-pub use solana_packet::{self, Meta, Packet, PacketFlags, PACKET_DATA_SIZE};
+#[cfg(feature = "dev-context-only-utils")]
+use bytes::{BufMut, BytesMut};
 use {
     crate::{cuda_runtime::PinnedVec, recycler::Recycler},
     bincode::config::Options,
-    rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator},
+    bytes::Bytes,
+    rayon::{
+        iter::{IndexedParallelIterator, ParallelIterator},
+        prelude::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator},
+    },
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         borrow::Borrow,
@@ -13,21 +18,596 @@ use {
         slice::{Iter, SliceIndex},
     },
 };
+pub use {
+    bytes,
+    solana_packet::{self, Meta, Packet, PacketFlags, PACKET_DATA_SIZE},
+};
 
 pub const NUM_PACKETS: usize = 1024 * 8;
 
 pub const PACKETS_PER_BATCH: usize = 64;
 pub const NUM_RCVMMSGS: usize = 64;
 
+/// Representation of a packet used in TPU.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct PacketBatch {
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BytesPacket {
+    buffer: Bytes,
+    meta: Meta,
+}
+
+impl BytesPacket {
+    pub fn new(buffer: Bytes, meta: Meta) -> Self {
+        Self { buffer, meta }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn empty() -> Self {
+        Self {
+            buffer: Bytes::new(),
+            meta: Meta::default(),
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn from_bytes(dest: Option<&SocketAddr>, buffer: Bytes) -> Self {
+        let mut meta = Meta {
+            size: buffer.len(),
+            ..Default::default()
+        };
+        if let Some(dest) = dest {
+            meta.set_socket_addr(dest);
+        }
+
+        Self { buffer, meta }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn from_data<T>(dest: Option<&SocketAddr>, data: T) -> bincode::Result<Self>
+    where
+        T: solana_packet::Encode,
+    {
+        let buffer = BytesMut::with_capacity(PACKET_DATA_SIZE);
+        let mut writer = buffer.writer();
+        data.encode(&mut writer)?;
+        let buffer = writer.into_inner();
+        let buffer = buffer.freeze();
+
+        let mut meta = Meta {
+            size: buffer.len(),
+            ..Default::default()
+        };
+        if let Some(dest) = dest {
+            meta.set_socket_addr(dest);
+        }
+
+        Ok(Self { buffer, meta })
+    }
+
+    #[inline]
+    pub fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        if self.meta.discard() {
+            None
+        } else {
+            self.buffer.get(index)
+        }
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        &self.meta
+    }
+
+    #[inline]
+    pub fn meta_mut(&mut self) -> &mut Meta {
+        &mut self.meta
+    }
+
+    pub fn deserialize_slice<T, I>(&self, index: I) -> bincode::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+        I: SliceIndex<[u8], Output = [u8]>,
+    {
+        let bytes = self.data(index).ok_or(bincode::ErrorKind::SizeLimit)?;
+        bincode::options()
+            .with_limit(self.meta().size as u64)
+            .with_fixint_encoding()
+            .reject_trailing_bytes()
+            .deserialize(bytes)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn copy_from_slice(&mut self, slice: &[u8]) {
+        self.buffer = Bytes::from(slice.to_vec());
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> PacketRef<'_> {
+        PacketRef::Bytes(self)
+    }
+
+    #[inline]
+    pub fn as_mut(&mut self) -> PacketRefMut<'_> {
+        PacketRefMut::Bytes(self)
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PacketBatch {
+    Pinned(PinnedPacketBatch),
+    Bytes(BytesPacketBatch),
+}
+
+impl PacketBatch {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn first(&self) -> Option<PacketRef<'_>> {
+        match self {
+            Self::Pinned(batch) => batch.first().map(PacketRef::from),
+            Self::Bytes(batch) => batch.first().map(PacketRef::from),
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn first_mut(&mut self) -> Option<PacketRefMut<'_>> {
+        match self {
+            Self::Pinned(batch) => batch.first_mut().map(PacketRefMut::from),
+            Self::Bytes(batch) => batch.first_mut().map(PacketRefMut::from),
+        }
+    }
+
+    /// Returns `true` if the batch contains no elements.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Pinned(batch) => batch.is_empty(),
+            Self::Bytes(batch) => batch.is_empty(),
+        }
+    }
+
+    /// Returns a reference to an element.
+    pub fn get(&self, index: usize) -> Option<PacketRef<'_>> {
+        match self {
+            Self::Pinned(batch) => batch.get(index).map(PacketRef::from),
+            Self::Bytes(batch) => batch.get(index).map(PacketRef::from),
+        }
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<PacketRefMut<'_>> {
+        match self {
+            Self::Pinned(batch) => batch.get_mut(index).map(PacketRefMut::from),
+            Self::Bytes(batch) => batch.get_mut(index).map(PacketRefMut::from),
+        }
+    }
+
+    pub fn iter(&self) -> PacketBatchIter<'_> {
+        match self {
+            Self::Pinned(batch) => PacketBatchIter::Pinned(batch.iter()),
+            Self::Bytes(batch) => PacketBatchIter::Bytes(batch.iter()),
+        }
+    }
+
+    pub fn iter_mut(&mut self) -> PacketBatchIterMut<'_> {
+        match self {
+            Self::Pinned(batch) => PacketBatchIterMut::Pinned(batch.iter_mut()),
+            Self::Bytes(batch) => PacketBatchIterMut::Bytes(batch.iter_mut()),
+        }
+    }
+
+    pub fn par_iter(&self) -> PacketBatchParIter {
+        match self {
+            Self::Pinned(batch) => {
+                PacketBatchParIter::Pinned(batch.par_iter().map(PacketRef::from))
+            }
+            Self::Bytes(batch) => PacketBatchParIter::Bytes(batch.par_iter().map(PacketRef::from)),
+        }
+    }
+
+    pub fn par_iter_mut(&mut self) -> PacketBatchParIterMut {
+        match self {
+            Self::Pinned(batch) => {
+                PacketBatchParIterMut::Pinned(batch.par_iter_mut().map(PacketRefMut::from))
+            }
+            Self::Bytes(batch) => {
+                PacketBatchParIterMut::Bytes(batch.par_iter_mut().map(PacketRefMut::from))
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Pinned(batch) => batch.len(),
+            Self::Bytes(batch) => batch.len(),
+        }
+    }
+}
+
+impl From<PinnedPacketBatch> for PacketBatch {
+    fn from(batch: PinnedPacketBatch) -> Self {
+        Self::Pinned(batch)
+    }
+}
+
+impl From<BytesPacketBatch> for PacketBatch {
+    fn from(batch: BytesPacketBatch) -> Self {
+        Self::Bytes(batch)
+    }
+}
+
+impl From<Vec<BytesPacket>> for PacketBatch {
+    fn from(batch: Vec<BytesPacket>) -> Self {
+        Self::Bytes(BytesPacketBatch::from(batch))
+    }
+}
+
+impl<'a> IntoIterator for &'a PacketBatch {
+    type Item = PacketRef<'a>;
+    type IntoIter = PacketBatchIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut PacketBatch {
+    type Item = PacketRefMut<'a>;
+    type IntoIter = PacketBatchIterMut<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a PacketBatch {
+    type Iter = PacketBatchParIter<'a>;
+    type Item = PacketRef<'a>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a mut PacketBatch {
+    type Iter = PacketBatchParIterMut<'a>;
+    type Item = PacketRefMut<'a>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter_mut()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq)]
+pub enum PacketRef<'a> {
+    Packet(&'a Packet),
+    Bytes(&'a BytesPacket),
+}
+
+impl PartialEq for PacketRef<'_> {
+    fn eq(&self, other: &PacketRef<'_>) -> bool {
+        self.meta().eq(other.meta()) && self.data(..).eq(&other.data(..))
+    }
+}
+
+impl<'a> From<&'a Packet> for PacketRef<'a> {
+    fn from(packet: &'a Packet) -> Self {
+        Self::Packet(packet)
+    }
+}
+
+impl<'a> From<&'a mut Packet> for PacketRef<'a> {
+    fn from(packet: &'a mut Packet) -> Self {
+        Self::Packet(packet)
+    }
+}
+
+impl<'a> From<&'a BytesPacket> for PacketRef<'a> {
+    fn from(packet: &'a BytesPacket) -> Self {
+        Self::Bytes(packet)
+    }
+}
+
+impl<'a> From<&'a mut BytesPacket> for PacketRef<'a> {
+    fn from(packet: &'a mut BytesPacket) -> Self {
+        Self::Bytes(packet)
+    }
+}
+
+impl<'a> PacketRef<'a> {
+    pub fn data<I>(&self, index: I) -> Option<&'a <I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        match self {
+            Self::Packet(packet) => packet.data(index),
+            Self::Bytes(packet) => packet.data(index),
+        }
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        match self {
+            Self::Packet(packet) => packet.meta(),
+            Self::Bytes(packet) => packet.meta(),
+        }
+    }
+
+    pub fn deserialize_slice<T, I>(&self, index: I) -> bincode::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+        I: SliceIndex<[u8], Output = [u8]>,
+    {
+        match self {
+            Self::Packet(packet) => packet.deserialize_slice(index),
+            Self::Bytes(packet) => packet.deserialize_slice(index),
+        }
+    }
+
+    pub fn to_packet(&self) -> Packet {
+        let size = self.meta().size;
+        let mut packet = Packet::default();
+        if let Some(data) = self.data(..) {
+            packet.buffer_mut()[..size].copy_from_slice(data);
+        }
+        *packet.meta_mut() = self.meta().clone();
+        packet.meta_mut().size = size;
+        packet
+    }
+}
+
+#[derive(Debug, Eq)]
+pub enum PacketRefMut<'a> {
+    Packet(&'a mut Packet),
+    Bytes(&'a mut BytesPacket),
+}
+
+impl<'a> PartialEq for PacketRefMut<'a> {
+    fn eq(&self, other: &PacketRefMut<'a>) -> bool {
+        self.data(..).eq(&other.data(..)) && self.meta().eq(other.meta())
+    }
+}
+
+impl<'a> From<&'a mut Packet> for PacketRefMut<'a> {
+    fn from(packet: &'a mut Packet) -> Self {
+        Self::Packet(packet)
+    }
+}
+
+impl<'a> From<&'a mut BytesPacket> for PacketRefMut<'a> {
+    fn from(packet: &'a mut BytesPacket) -> Self {
+        Self::Bytes(packet)
+    }
+}
+
+impl PacketRefMut<'_> {
+    pub fn data<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        match self {
+            Self::Packet(packet) => packet.data(index),
+            Self::Bytes(packet) => packet.data(index),
+        }
+    }
+
+    #[inline]
+    pub fn meta(&self) -> &Meta {
+        match self {
+            Self::Packet(packet) => packet.meta(),
+            Self::Bytes(packet) => packet.meta(),
+        }
+    }
+
+    #[inline]
+    pub fn meta_mut(&mut self) -> &mut Meta {
+        match self {
+            Self::Packet(packet) => packet.meta_mut(),
+            Self::Bytes(packet) => packet.meta_mut(),
+        }
+    }
+
+    pub fn deserialize_slice<T, I>(&self, index: I) -> bincode::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+        I: SliceIndex<[u8], Output = [u8]>,
+    {
+        match self {
+            Self::Packet(packet) => packet.deserialize_slice(index),
+            Self::Bytes(packet) => packet.deserialize_slice(index),
+        }
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    #[inline]
+    pub fn copy_from_slice(&mut self, src: &[u8]) {
+        match self {
+            Self::Packet(packet) => {
+                let size = src.len();
+                packet.buffer_mut()[..size].copy_from_slice(src);
+            }
+            Self::Bytes(packet) => packet.copy_from_slice(src),
+        }
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> PacketRef<'_> {
+        match self {
+            Self::Packet(packet) => PacketRef::Packet(packet),
+            Self::Bytes(packet) => PacketRef::Bytes(packet),
+        }
+    }
+}
+
+pub enum PacketBatchIter<'a> {
+    Pinned(std::slice::Iter<'a, Packet>),
+    Bytes(std::slice::Iter<'a, BytesPacket>),
+}
+
+impl DoubleEndedIterator for PacketBatchIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Pinned(iter) => iter.next_back().map(PacketRef::Packet),
+            Self::Bytes(iter) => iter.next_back().map(PacketRef::Bytes),
+        }
+    }
+}
+
+impl<'a> Iterator for PacketBatchIter<'a> {
+    type Item = PacketRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Pinned(iter) => iter.next().map(PacketRef::Packet),
+            Self::Bytes(iter) => iter.next().map(PacketRef::Bytes),
+        }
+    }
+}
+
+pub enum PacketBatchIterMut<'a> {
+    Pinned(std::slice::IterMut<'a, Packet>),
+    Bytes(std::slice::IterMut<'a, BytesPacket>),
+}
+
+impl DoubleEndedIterator for PacketBatchIterMut<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Pinned(iter) => iter.next_back().map(PacketRefMut::Packet),
+            Self::Bytes(iter) => iter.next_back().map(PacketRefMut::Bytes),
+        }
+    }
+}
+
+impl<'a> Iterator for PacketBatchIterMut<'a> {
+    type Item = PacketRefMut<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Pinned(iter) => iter.next().map(PacketRefMut::Packet),
+            Self::Bytes(iter) => iter.next().map(PacketRefMut::Bytes),
+        }
+    }
+}
+
+type PacketParIter<'a> = rayon::slice::Iter<'a, Packet>;
+type BytesPacketParIter<'a> = rayon::slice::Iter<'a, BytesPacket>;
+
+pub enum PacketBatchParIter<'a> {
+    Pinned(
+        rayon::iter::Map<
+            PacketParIter<'a>,
+            fn(<PacketParIter<'a> as ParallelIterator>::Item) -> PacketRef<'a>,
+        >,
+    ),
+    Bytes(
+        rayon::iter::Map<
+            BytesPacketParIter<'a>,
+            fn(<BytesPacketParIter<'a> as ParallelIterator>::Item) -> PacketRef<'a>,
+        >,
+    ),
+}
+
+impl<'a> ParallelIterator for PacketBatchParIter<'a> {
+    type Item = PacketRef<'a>;
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        match self {
+            Self::Pinned(iter) => iter.drive_unindexed(consumer),
+            Self::Bytes(iter) => iter.drive_unindexed(consumer),
+        }
+    }
+}
+
+impl IndexedParallelIterator for PacketBatchParIter<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Pinned(iter) => iter.len(),
+            Self::Bytes(iter) => iter.len(),
+        }
+    }
+
+    fn drive<C: rayon::iter::plumbing::Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        match self {
+            Self::Pinned(iter) => iter.drive(consumer),
+            Self::Bytes(iter) => iter.drive(consumer),
+        }
+    }
+
+    fn with_producer<CB: rayon::iter::plumbing::ProducerCallback<Self::Item>>(
+        self,
+        callback: CB,
+    ) -> CB::Output {
+        match self {
+            Self::Pinned(iter) => iter.with_producer(callback),
+            Self::Bytes(iter) => iter.with_producer(callback),
+        }
+    }
+}
+
+type PacketParIterMut<'a> = rayon::slice::IterMut<'a, Packet>;
+type BytesPacketParIterMut<'a> = rayon::slice::IterMut<'a, BytesPacket>;
+
+pub enum PacketBatchParIterMut<'a> {
+    Pinned(
+        rayon::iter::Map<
+            PacketParIterMut<'a>,
+            fn(<PacketParIterMut<'a> as ParallelIterator>::Item) -> PacketRefMut<'a>,
+        >,
+    ),
+    Bytes(
+        rayon::iter::Map<
+            BytesPacketParIterMut<'a>,
+            fn(<BytesPacketParIterMut<'a> as ParallelIterator>::Item) -> PacketRefMut<'a>,
+        >,
+    ),
+}
+
+impl<'a> ParallelIterator for PacketBatchParIterMut<'a> {
+    type Item = PacketRefMut<'a>;
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        match self {
+            Self::Pinned(iter) => iter.drive_unindexed(consumer),
+            Self::Bytes(iter) => iter.drive_unindexed(consumer),
+        }
+    }
+}
+
+impl IndexedParallelIterator for PacketBatchParIterMut<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Pinned(iter) => iter.len(),
+            Self::Bytes(iter) => iter.len(),
+        }
+    }
+
+    fn drive<C: rayon::iter::plumbing::Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        match self {
+            Self::Pinned(iter) => iter.drive(consumer),
+            Self::Bytes(iter) => iter.drive(consumer),
+        }
+    }
+
+    fn with_producer<CB: rayon::iter::plumbing::ProducerCallback<Self::Item>>(
+        self,
+        callback: CB,
+    ) -> CB::Output {
+        match self {
+            Self::Pinned(iter) => iter.with_producer(callback),
+            Self::Bytes(iter) => iter.with_producer(callback),
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PinnedPacketBatch {
     packets: PinnedVec<Packet>,
 }
 
 pub type PacketBatchRecycler = Recycler<PinnedVec<Packet>>;
 
-impl PacketBatch {
+impl PinnedPacketBatch {
     pub fn new(packets: Vec<Packet>) -> Self {
         let packets = PinnedVec::from_vec(packets);
         Self { packets }
@@ -124,7 +704,7 @@ impl PacketBatch {
     }
 }
 
-impl Deref for PacketBatch {
+impl Deref for PinnedPacketBatch {
     type Target = PinnedVec<Packet>;
 
     fn deref(&self) -> &Self::Target {
@@ -132,13 +712,13 @@ impl Deref for PacketBatch {
     }
 }
 
-impl DerefMut for PacketBatch {
+impl DerefMut for PinnedPacketBatch {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.packets
     }
 }
 
-impl<I: SliceIndex<[Packet]>> Index<I> for PacketBatch {
+impl<I: SliceIndex<[Packet]>> Index<I> for PinnedPacketBatch {
     type Output = I::Output;
 
     #[inline]
@@ -147,14 +727,14 @@ impl<I: SliceIndex<[Packet]>> Index<I> for PacketBatch {
     }
 }
 
-impl<I: SliceIndex<[Packet]>> IndexMut<I> for PacketBatch {
+impl<I: SliceIndex<[Packet]>> IndexMut<I> for PinnedPacketBatch {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         &mut self.packets[index]
     }
 }
 
-impl<'a> IntoIterator for &'a PacketBatch {
+impl<'a> IntoIterator for &'a PinnedPacketBatch {
     type Item = &'a Packet;
     type IntoIter = Iter<'a, Packet>;
 
@@ -163,7 +743,7 @@ impl<'a> IntoIterator for &'a PacketBatch {
     }
 }
 
-impl<'a> IntoParallelIterator for &'a PacketBatch {
+impl<'a> IntoParallelIterator for &'a PinnedPacketBatch {
     type Iter = rayon::slice::Iter<'a, Packet>;
     type Item = &'a Packet;
     fn into_par_iter(self) -> Self::Iter {
@@ -171,7 +751,7 @@ impl<'a> IntoParallelIterator for &'a PacketBatch {
     }
 }
 
-impl<'a> IntoParallelIterator for &'a mut PacketBatch {
+impl<'a> IntoParallelIterator for &'a mut PinnedPacketBatch {
     type Iter = rayon::slice::IterMut<'a, Packet>;
     type Item = &'a mut Packet;
     fn into_par_iter(self) -> Self::Iter {
@@ -179,8 +759,8 @@ impl<'a> IntoParallelIterator for &'a mut PacketBatch {
     }
 }
 
-impl From<PacketBatch> for Vec<Packet> {
-    fn from(batch: PacketBatch) -> Self {
+impl From<PinnedPacketBatch> for Vec<Packet> {
+    fn from(batch: PinnedPacketBatch) -> Self {
         batch.packets.into()
     }
 }
@@ -189,12 +769,12 @@ pub fn to_packet_batches<T: Serialize>(items: &[T], chunk_size: usize) -> Vec<Pa
     items
         .chunks(chunk_size)
         .map(|batch_items| {
-            let mut batch = PacketBatch::with_capacity(batch_items.len());
+            let mut batch = PinnedPacketBatch::with_capacity(batch_items.len());
             batch.resize(batch_items.len(), Packet::default());
             for (item, packet) in batch_items.iter().zip(batch.packets.iter_mut()) {
                 Packet::populate_packet(packet, None, item).expect("serialize request");
             }
-            batch
+            batch.into()
         })
         .collect()
 }
@@ -202,6 +782,90 @@ pub fn to_packet_batches<T: Serialize>(items: &[T], chunk_size: usize) -> Vec<Pa
 #[cfg(test)]
 fn to_packet_batches_for_tests<T: Serialize>(items: &[T]) -> Vec<PacketBatch> {
     to_packet_batches(items, NUM_PACKETS)
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BytesPacketBatch {
+    packets: Vec<BytesPacket>,
+}
+
+impl BytesPacketBatch {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let packets = Vec::with_capacity(capacity);
+        Self { packets }
+    }
+
+    pub fn to_pinned_packet_batch(&self) -> PinnedPacketBatch {
+        let mut batch = PinnedPacketBatch::new_pinned_with_capacity(self.len());
+        for bytes_packet in self.iter() {
+            let mut packet = Packet::default();
+            let size = bytes_packet.meta().size;
+            *packet.meta_mut() = bytes_packet.meta().clone();
+            packet.meta_mut().size = size;
+            packet.buffer_mut()[..size].copy_from_slice(&bytes_packet.buffer);
+
+            batch.push(packet);
+        }
+
+        batch
+    }
+}
+
+impl Deref for BytesPacketBatch {
+    type Target = Vec<BytesPacket>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.packets
+    }
+}
+
+impl DerefMut for BytesPacketBatch {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.packets
+    }
+}
+
+impl From<Vec<BytesPacket>> for BytesPacketBatch {
+    fn from(packets: Vec<BytesPacket>) -> Self {
+        Self { packets }
+    }
+}
+
+impl FromIterator<BytesPacket> for BytesPacketBatch {
+    fn from_iter<T: IntoIterator<Item = BytesPacket>>(iter: T) -> Self {
+        let packets = Vec::from_iter(iter);
+        Self { packets }
+    }
+}
+
+impl<'a> IntoIterator for &'a BytesPacketBatch {
+    type Item = &'a BytesPacket;
+    type IntoIter = Iter<'a, BytesPacket>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packets.iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a BytesPacketBatch {
+    type Iter = rayon::slice::Iter<'a, BytesPacket>;
+    type Item = &'a BytesPacket;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a mut BytesPacketBatch {
+    type Iter = rayon::slice::IterMut<'a, BytesPacket>;
+    type Item = &'a mut BytesPacket;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter_mut()
+    }
 }
 
 pub fn deserialize_from_with_limit<R, T>(reader: R) -> bincode::Result<T>
@@ -250,7 +914,8 @@ mod tests {
     fn test_to_packets_pinning() {
         let recycler = PacketBatchRecycler::default();
         for i in 0..2 {
-            let _first_packets = PacketBatch::new_with_recycler(&recycler, i + 1, "first one");
+            let _first_packets =
+                PinnedPacketBatch::new_with_recycler(&recycler, i + 1, "first one");
         }
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -988,6 +988,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -7004,6 +7007,7 @@ dependencies = [
  "ahash 0.8.11",
  "bincode",
  "bv",
+ "bytes",
  "caps",
  "curve25519-dalek 4.1.3",
  "dlopen2",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -900,6 +900,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -6806,6 +6809,7 @@ dependencies = [
  "ahash 0.8.11",
  "bincode",
  "bv",
+ "bytes",
  "caps",
  "curve25519-dalek 4.1.3",
  "dlopen2",

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -24,6 +24,8 @@ solana-signature = { workspace = true }
 [dev-dependencies]
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
+solana-packet = { workspace = true, features = ["dev-context-only-utils"] }
+solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -85,7 +85,7 @@ impl Vortexor {
     }
 
     pub fn create_sigverify_stage(
-        tpu_receiver: Receiver<solana_perf::packet::PacketBatch>,
+        tpu_receiver: Receiver<PacketBatch>,
         non_vote_sender: TracedSender,
     ) -> SigVerifyStage {
         let verifier = TransactionSigVerifier::new(non_vote_sender, None);


### PR DESCRIPTION
#### Problem

The `Packet` struct stores the payload in a byte array. QUIC servers, based on quinn, provide received data into `bytes::Bytes`[0]. The usage of `Packet` across the TPU code requires a copy from `Bytes` to `Packet`.

That defeats the biggest advantage of `Bytes` - its zero-copy abstraction, where calling `clone()` doesn't make an actual copy of the underyling packet data and all instances point to the same memory.

[0] https://docs.rs/bytes/1.10.1/bytes/struct.Bytes.html

#### Summary of Changes

Fix that by providing a new packet type - `BytesPacket` - which uses `Bytes` for storing the payload. That new type of packet is used in QUIC servers of TPU.

Rename `PacketBatch` to `PinnedPacketBatch`. Add a new `BytesPacketBatch` type, which is a vector of `BytesPacket`.

To make sigverify work with both types of packets (`Packet` and `BytesPacket`), provide the abstraction:

* `PacketBatch` enum, carrying `PinnedPacketBatch` and `BytesPacketBatch` as variants. That enum proxies all the methods of both bath types.
* `PacketRef` and `PacketRefMut` enums, serving as wrapper types carrying references to an underlying packet instance.
* `PacketBatchIter` and `PacketBatchIterMut` enums, which implement `Iterator` and `ParallelIterator` and allow an uniform way of iteration over `PacketBatch`, regardless of the underlying variant.

CUDA sigverify still requires `Packet` and `PinnedPacketBatch`. The conversion of all packet batches to `PinnedPacketBatch` is made right before calling CUDA. In case of a `PacketBatch` being `Bytes`-based, that means making one copy.

Runtime performance measured with bench-tps before:

```
[2025-04-08T14:36:46.839311824Z INFO  solana_bench_tps::bench]  Average TPS: 39760.926
[2025-04-08T14:40:58.179215413Z INFO  solana_bench_tps::bench]  Average TPS: 40663.043
[2025-04-08T14:45:15.177018118Z INFO  solana_bench_tps::bench]  Average TPS: 40991.656
```

After:

```
[2025-04-08T13:40:02.752295366Z INFO  solana_bench_tps::bench]  Average TPS: 42082.766
[2025-04-08T14:05:26.344333577Z INFO  solana_bench_tps::bench]  Average TPS: 42563.508
[2025-04-08T14:09:32.239322132Z INFO  solana_bench_tps::bench]  Average TPS: 41061.234
```

Memory profile before:

<img width="1622" alt="Screenshot 2025-04-10 at 3 55 53 pm" src="https://github.com/user-attachments/assets/6a98cd04-2598-4f96-bc09-a1de11cbb88b" />

After:

<img width="2015" alt="Screenshot 2025-04-10 at 3 58 41 pm" src="https://github.com/user-attachments/assets/a387e978-5f01-4c62-8764-a6026c29ec6e" />
<img width="1850" alt="Screenshot 2025-04-10 at 4 00 49 pm" src="https://github.com/user-attachments/assets/9b29f750-1a91-44e7-ab78-5636f5dc575c" />

In master we allocate 3.2GB. The `PacketBatch` allocation is the largest allocation at 2.6G. With this PR we allocate 733MB in total, the `PacketBatch` allocation takes 124MB.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
