### PR TITLE
Unrevert - v2.2: If the account length is zero, no data region is present (backport of #5122)

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -696,8 +696,9 @@ pub mod delay_visibility_of_program_deployment {
 pub mod apply_cost_tracker_during_replay {
     solana_pubkey::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
+
 pub mod bpf_account_data_direct_mapping {
-    solana_pubkey::declare_id!("AjX3A4Nv2rzUuATEUWLP4rrBaBropyUnHxEvFDj1dKbx");
+    solana_pubkey::declare_id!("1ncomp1ete111111111111111111111111111111111");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {

--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -532,7 +532,7 @@ impl<'a> Iterator for MemoryChunkIterator<'a> {
                     account_index = account_index.saturating_add(1);
                     self.account_index = Some(account_index);
                 } else {
-                    region_is_account = region.vm_addr == account_addr
+                    region_is_account = (account.original_data_len != 0 && region.vm_addr == account_addr)
                         // unaligned programs do not have a resize area
                         || (self.resize_area && region.vm_addr == resize_addr);
                     break;
@@ -606,7 +606,7 @@ impl DoubleEndedIterator for MemoryChunkIterator<'_> {
 
                 self.account_index = Some(account_index);
             } else {
-                region_is_account = region.vm_addr == account_addr
+                region_is_account = (account.original_data_len != 0 && region.vm_addr == account_addr)
                     // unaligned programs do not have a resize area
                     || (self.resize_area && region.vm_addr == resize_addr);
                 break;

--- a/programs/sbf/rust/account_mem/src/lib.rs
+++ b/programs/sbf/rust/account_mem/src/lib.rs
@@ -60,8 +60,15 @@ pub fn process_instruction(
             sol_memset(&mut data[data_len.saturating_sub(2)..], 0, 3);
         }
         5 => {
+            // memcmp overlaps begining
+            #[allow(clippy::manual_memcpy)]
+            for i in 0..3 {
+                buf[i] = too_early(2)[i];
+            }
+
             // memset overlaps begin of account area
             sol_memset(too_early(2), 3, 3);
+            sol_memcpy(too_early(2), &buf, 3);
         }
         6 => {
             // memcpy src overlaps end of account

--- a/programs/sbf/rust/account_mem_deprecated/src/lib.rs
+++ b/programs/sbf/rust/account_mem_deprecated/src/lib.rs
@@ -25,7 +25,7 @@ pub fn process_instruction(
     let mut too_early = |before: usize| -> &mut [u8] {
         let data = data.as_mut_ptr().wrapping_sub(before);
 
-        unsafe { std::slice::from_raw_parts_mut(data, data_len) }
+        unsafe { std::slice::from_raw_parts_mut(data, data_len.wrapping_add(100)) }
     };
 
     match instruction_data[0] {
@@ -40,11 +40,11 @@ pub fn process_instruction(
         2 => {
             // memcmp overlaps begining
             #[allow(clippy::manual_memcpy)]
-            for i in 0..500 {
+            for i in 0..90 {
                 buf[i] = too_early(8)[i];
             }
 
-            sol_memcmp(too_early(8), &buf, 500);
+            sol_memcmp(too_early(8), &buf, 90);
         }
         3 => {
             // memcmp overlaps begining


### PR DESCRIPTION
#### Problem
#5136 was reverted in #5270 because of the chaos around the feature set returning from the SDK.

#### Summary of Changes
- Reapply #5136
- Backport #5655