### PR TITLE
clippy: manual_repeat_n and useless_nonzero_new_unchecked

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -137,14 +137,14 @@ where
     let pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
         .take(num_keys)
         .collect();
-    let accounts_data: Vec<_> = std::iter::repeat(
+    let accounts_data: Vec<_> = std::iter::repeat_n(
         Account {
             lamports: 1,
             ..Default::default()
         }
         .to_account_shared_data(),
+        num_keys,
     )
-    .take(num_keys)
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
     accounts.store_accounts_cached((slot, storable_accounts.as_slice()));

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -53,7 +53,7 @@ pub const BINS_DEFAULT: usize = 8192;
 pub const BINS_FOR_TESTING: usize = 2; // we want > 1, but each bin is a few disk files with a disk based index, so fewer is better
 pub const BINS_FOR_BENCHMARKS: usize = 8192;
 // The unsafe is safe because we're using a fixed, known non-zero value
-pub const FLUSH_THREADS_TESTING: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
+pub const FLUSH_THREADS_TESTING: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -23,7 +23,7 @@ pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) 
     let owner_byte = u8::MAX - data_byte;
     let account = Account {
         lamports: seed,
-        data: std::iter::repeat(data_byte).take(seed as usize).collect(),
+        data: std::iter::repeat_n(data_byte, seed as usize).collect(),
         // this will allow some test account sharing the same owner.
         owner: [owner_byte; 32].into(),
         executable: seed % 2 > 0,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -8878,7 +8878,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 3, 5, 6]).chain(iter::repeat(vec![0, 1, 2, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 3, 5, 6]).chain(iter::repeat_n(vec![0, 1, 2, 4], 2)))
                 .collect()
         };
         let (mut vote_simulator, _blockstore) =
@@ -8960,7 +8960,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let tree = tr(0) / (tr(1) / (tr(3) / (tr(4))) / (tr(2) / (tr(5) / (tr(6)))));
@@ -9026,7 +9026,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let tree = tr(0) / (tr(1) / (tr(3) / (tr(4))) / (tr(2) / (tr(5) / (tr(6)))));
@@ -9093,7 +9093,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let (vote_simulator, _blockstore) =
@@ -9119,7 +9119,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let (vote_simulator, _blockstore) =
@@ -9388,7 +9388,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let tree = tr(0) / (tr(1) / (tr(3) / (tr(4))) / (tr(2) / (tr(5) / (tr(6)))));
@@ -9498,7 +9498,7 @@ pub(crate) mod tests {
         let generate_votes = |pubkeys: Vec<Pubkey>| {
             pubkeys
                 .into_iter()
-                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat(vec![0, 1, 3, 4]).take(2)))
+                .zip(iter::once(vec![0, 1, 2, 5, 6]).chain(iter::repeat_n(vec![0, 1, 3, 4], 2)))
                 .collect()
         };
         let tree = tr(0) / (tr(1) / (tr(3) / (tr(4))) / (tr(2) / (tr(5) / (tr(6)))));

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -136,8 +136,8 @@ const MIN_NUM_STAKED_NODES: usize = 500;
 
 // Must have at least one socket to monitor the TVU port
 // The unsafes are safe because we're using fixed, known non-zero values
-pub const MINIMUM_NUM_TVU_SOCKETS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
-pub const DEFAULT_NUM_TVU_SOCKETS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(8) };
+pub const MINIMUM_NUM_TVU_SOCKETS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
+pub const DEFAULT_NUM_TVU_SOCKETS: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClusterInfoError {

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -526,7 +526,7 @@ fn get_fec_set_offsets(
         }
         let num_chunks = (num_shreds / min_chunk_size).max(1);
         let chunk_size = num_shreds.div_ceil(num_chunks);
-        let offsets = std::iter::repeat(offset).take(chunk_size);
+        let offsets = std::iter::repeat_n(offset, chunk_size);
         num_shreds -= chunk_size;
         offset += chunk_size;
         Some(offsets)

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -12,7 +12,13 @@ use {
         sigverify::{self, count_packets_in_batches, TxOffset},
     },
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signature},
-    std::{collections::HashMap, iter::repeat, mem::size_of, ops::Range, sync::RwLock},
+    std::{
+        collections::HashMap,
+        iter::{self, repeat},
+        mem::size_of,
+        ops::Range,
+        sync::RwLock,
+    },
 };
 #[cfg(test)]
 use {
@@ -320,7 +326,9 @@ pub fn verify_shreds_gpu(
     trace!("out buf {:?}", out);
 
     // Each shred has exactly one signature.
-    let v_sig_lens = batches.iter().map(|batch| repeat(1u32).take(batch.len()));
+    let v_sig_lens = batches
+        .iter()
+        .map(|batch| iter::repeat_n(1u32, batch.len()));
     let mut rvs: Vec<_> = batches.iter().map(|batch| vec![0u8; batch.len()]).collect();
     sigverify::copy_return_values(v_sig_lens, &out, &mut rvs);
 

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -46,9 +46,7 @@ fn bench_dedup_same_small_packets(bencher: &mut Bencher) {
     let small_packet = test_packet_with_size(128, &mut rng);
 
     let batches = to_packet_batches(
-        &std::iter::repeat(small_packet)
-            .take(NUM)
-            .collect::<Vec<_>>(),
+        &std::iter::repeat_n(small_packet, NUM).collect::<Vec<_>>(),
         128,
     );
 
@@ -62,7 +60,7 @@ fn bench_dedup_same_big_packets(bencher: &mut Bencher) {
     let big_packet = test_packet_with_size(1024, &mut rng);
 
     let batches = to_packet_batches(
-        &std::iter::repeat(big_packet).take(NUM).collect::<Vec<_>>(),
+        &std::iter::repeat_n(big_packet, NUM).collect::<Vec<_>>(),
         128,
     );
 

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -17,7 +17,7 @@ fn bench_discard(bencher: &mut Bencher) {
 
     // generate packet vector
     let batches = to_packet_batches(
-        &std::iter::repeat(tx).take(num_packets).collect::<Vec<_>>(),
+        &std::iter::repeat_n(tx, num_packets).collect::<Vec<_>>(),
         10,
     );
 

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -24,7 +24,7 @@ fn bench_sigverify_simple(bencher: &mut Bencher) {
 
     // generate packet vector
     let mut batches = to_packet_batches(
-        &std::iter::repeat(tx).take(num_packets).collect::<Vec<_>>(),
+        &std::iter::repeat_n(tx, num_packets).collect::<Vec<_>>(),
         128,
     );
 
@@ -177,8 +177,7 @@ fn bench_get_offsets(bencher: &mut Bencher) {
     let tx = test_tx();
 
     // generate packet vector
-    let mut batches =
-        to_packet_batches(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 1024);
+    let mut batches = to_packet_batches(&std::iter::repeat_n(tx, 1024).collect::<Vec<_>>(), 1024);
 
     let recycler = Recycler::default();
     // verify packets

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -127,7 +127,7 @@ mod tests {
         let tx = test_tx();
 
         let mut batches =
-            to_packet_batches(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 128);
+            to_packet_batches(&std::iter::repeat_n(tx, 1024).collect::<Vec<_>>(), 128);
         let packet_count = sigverify::count_packets_in_batches(&batches);
         let mut rng = rand::thread_rng();
         let filter = Deduper::<2, [u8]>::new(&mut rng, /*num_bits:*/ 63_999_979);

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1699,10 +1699,22 @@ mod tests {
         let leader_d_pubkey = Pubkey::new_unique();
         let consecutive_leader_slots = NUM_CONSECUTIVE_LEADER_SLOTS as usize;
         let mut slot_leaders = Vec::with_capacity(consecutive_leader_slots * 3);
-        slot_leaders.extend(std::iter::repeat(leader_a_pubkey).take(consecutive_leader_slots));
-        slot_leaders.extend(std::iter::repeat(leader_b_pubkey).take(consecutive_leader_slots));
-        slot_leaders.extend(std::iter::repeat(leader_c_pubkey).take(consecutive_leader_slots));
-        slot_leaders.extend(std::iter::repeat(leader_d_pubkey).take(consecutive_leader_slots));
+        slot_leaders.extend(std::iter::repeat_n(
+            leader_a_pubkey,
+            consecutive_leader_slots,
+        ));
+        slot_leaders.extend(std::iter::repeat_n(
+            leader_b_pubkey,
+            consecutive_leader_slots,
+        ));
+        slot_leaders.extend(std::iter::repeat_n(
+            leader_c_pubkey,
+            consecutive_leader_slots,
+        ));
+        slot_leaders.extend(std::iter::repeat_n(
+            leader_d_pubkey,
+            consecutive_leader_slots,
+        ));
         let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
         let fixed_schedule = solana_ledger::leader_schedule::FixedSchedule {
             leader_schedule: Arc::new(Box::new(

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -27,7 +27,7 @@ pub const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
 /// The total accounts data a transaction can load is limited to 64MiB to not break
 /// anyone in Mainnet-beta today. It can be set by set_loaded_accounts_data_size_limit instruction
 pub const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES: NonZeroU32 =
-    unsafe { NonZeroU32::new_unchecked(64 * 1024 * 1024) };
+    NonZeroU32::new(64 * 1024 * 1024).unwrap();
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SVMTransactionExecutionBudget {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -81,9 +81,9 @@ pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
 // - Necessary in order to have a plain NonZeroUsize as the constant, NonZeroUsize
 //   returns an Option<NonZeroUsize> and we can't .unwrap() at compile time
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
-    unsafe { NonZeroUsize::new_unchecked(2) };
+    NonZeroUsize::new(2).unwrap();
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
-    unsafe { NonZeroUsize::new_unchecked(4) };
+    NonZeroUsize::new(4).unwrap();
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz|tar\.lz4)$";
 

--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -443,7 +443,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let c = util::inner_product(&a, &b).unwrap();
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, n).collect();
 
         let y_inv = Scalar::random(&mut OsRng);
         let H_factors: Vec<Scalar> = util::exp_iter(y_inv).take(n).collect();
@@ -480,7 +480,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::ONE).take(n),
+                iter::repeat_n(Scalar::ONE, n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -495,7 +495,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::ONE).take(n),
+                iter::repeat_n(Scalar::ONE, n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -255,7 +255,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * &(*G);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
+        let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
         // generate challenge `c` for consistency with the verifier's transcript

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -444,7 +444,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let c = util::inner_product(&a, &b).unwrap();
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, n).collect();
 
         let y_inv = Scalar::random(&mut OsRng);
         let H_factors: Vec<Scalar> = util::exp_iter(y_inv).take(n).collect();
@@ -481,7 +481,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::ONE).take(n),
+                iter::repeat_n(Scalar::ONE, n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -496,7 +496,7 @@ mod tests {
         assert!(proof
             .verify(
                 n,
-                iter::repeat(Scalar::ONE).take(n),
+                iter::repeat_n(Scalar::ONE, n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -224,7 +224,7 @@ impl RangeProof {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * &(*G);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
+        let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
         // generate challenge `c` for consistency with the verifier's transcript


### PR DESCRIPTION
#### Problem

While working on upgrading rust to 1.86.0, there are new clippy lints that need to be addressed.

##### `manual_repeat_n`
```
error: this `repeat().take()` can be written more concisely
   --> zk-token-sdk/src/range_proof/mod.rs:227:38
    |
227 |         let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(nm).collect();
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(Scalar::ONE, nm)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n
    = note: `-D clippy::manual-repeat-n` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_repeat_n)]`
```

##### `useless_nonzero_new_unchecked`
```
error: `NonZeroU32::new()` and `Option::unwrap()` can be safely used in a `const` context
  --> program-runtime/src/execution_budget.rs:30:5
   |
30 |     unsafe { NonZeroU32::new_unchecked(64 * 1024 * 1024) };
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use instead: `NonZeroU32::new(64 * 1024 * 1024).unwrap()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_nonzero_new_unchecked
   = note: `-D clippy::useless-nonzero-new-unchecked` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_nonzero_new_unchecked)]`
```

#### Summary of Changes

Do `cargo clippy --fix`.