### PR TITLE
clippy: doc_overindented_list_items

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2543,10 +2543,8 @@ impl AccountsDb {
     }
 
     /// Construct a list of candidates for cleaning from:
-    /// - dirty_stores      -- set of stores which had accounts
-    ///                        removed or recently rooted;
-    /// - uncleaned_pubkeys -- the delta set of updated pubkeys in
-    ///                        rooted slots from the last clean.
+    /// - dirty_stores      -- set of stores which had accounts removed or recently rooted
+    /// - uncleaned_pubkeys -- the delta set of updated pubkeys in rooted slots from the last clean
     ///
     /// The function also returns the minimum slot we encountered.
     fn construct_candidate_clean_keys(
@@ -3281,27 +3279,26 @@ impl AccountsDb {
     ///
     /// # Arguments
     /// * `reclaims` - The accounts to remove from storage entries' "count". Note here
-    ///    that we should not remove cache entries, only entries for accounts actually
-    ///    stored in a storage entry.
-    ///
+    ///   that we should not remove cache entries, only entries for accounts actually
+    ///   stored in a storage entry.
     /// * `expected_single_dead_slot` - A correctness assertion. If this is equal to `Some(S)`,
-    ///    then the function will check that the only slot being cleaned up in `reclaims`
-    ///    is the slot == `S`. This is true for instance when `handle_reclaims` is called
-    ///    from store or slot shrinking, as those should only touch the slot they are
-    ///    currently storing to or shrinking.
-    ///
+    ///   then the function will check that the only slot being cleaned up in `reclaims`
+    ///   is the slot == `S`. This is true for instance when `handle_reclaims` is called
+    ///   from store or slot shrinking, as those should only touch the slot they are
+    ///   currently storing to or shrinking.
     /// * `reset_accounts` - Reset the append_vec store when the store is dead (count==0)
-    ///    From the clean and shrink paths it should be false since there may be an in-progress
-    ///    hash operation and the stores may hold accounts that need to be unref'ed.
-    /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging dead slots if
-    ///    value is `ProcessDeadSlots`.
-    ///    Otherwise, there can be no dead slots
-    ///    that happen as a result of this call, and the function will check that no slots are
-    ///    cleaned up/removed via `process_dead_slots`. For instance, on store, no slots should
-    ///    be cleaned up, but during the background clean accounts purges accounts from old rooted
-    ///    slots, so outdated slots may be removed.
+    ///   From the clean and shrink paths it should be false since there may be an in-progress
+    ///   hash operation and the stores may hold accounts that need to be unref'ed.
+    /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the
+    ///   accounts index and should not be unref'd. If they exist in the accounts index,
+    ///   they are NEW.
+    /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging
+    ///   dead slots if value is `ProcessDeadSlots`.
+    ///   Otherwise, there can be no dead slots
+    ///   that happen as a result of this call, and the function will check that no slots are
+    ///   cleaned up/removed via `process_dead_slots`. For instance, on store, no slots should
+    ///   be cleaned up, but during the background clean accounts purges accounts from old rooted
+    ///   slots, so outdated slots may be removed.
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: Option<I>,
@@ -5677,9 +5674,9 @@ impl AccountsDb {
 
     /// This should only be called after the `Bank::drop()` runs in bank.rs, See BANK_DROP_SAFETY
     /// comment below for more explanation.
-    ///   * `is_serialized_with_abs` - indicates whether this call runs sequentially with all other
-    ///        accounts_db relevant calls, such as shrinking, purging etc., in account background
-    ///        service.
+    /// * `is_serialized_with_abs` - indicates whether this call runs sequentially
+    ///   with all other accounts_db relevant calls, such as shrinking, purging etc.,
+    ///   in accounts background service.
     pub fn purge_slot(&self, slot: Slot, bank_id: BankId, is_serialized_with_abs: bool) {
         if self.is_bank_drop_callback_enabled.load(Ordering::Acquire) && !is_serialized_with_abs {
             panic!(

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -568,7 +568,7 @@ pub struct SignerFromPathConfig {
 /// the following schemes are supported:
 ///
 /// - `file:` &mdash; Read the keypair from a JSON keypair file. The path portion
-///    of the URI is the file path.
+///   of the URI is the file path.
 ///
 /// - `stdin:` &mdash; Read the keypair from stdin, in the JSON format used by
 ///   the keypair file.

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -424,7 +424,7 @@ pub struct SignerFromPathConfig {
 /// the following schemes are supported:
 ///
 /// - `file:` &mdash; Read the keypair from a JSON keypair file. The path portion
-///    of the URI is the file path.
+///   of the URI is the file path.
 ///
 /// - `stdin:` &mdash; Read the keypair from stdin, in the JSON format used by
 ///   the keypair file.

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -46,16 +46,16 @@ impl GeyserPluginService {
     /// # Arguments
     /// * `confirmed_bank_receiver` - The receiver for confirmed bank notification
     /// * `geyser_plugin_always_enabled` -- Subscribe on all types of notifiactions, even if
-    ///    no config files are passed
+    ///   no config files are passed
     /// * `geyser_plugin_config_file` - The config file path for the plugin. The
-    ///    config file controls the plugin responsible
-    ///    for transporting the data to external data stores. It is defined in JSON format.
-    ///    The `libpath` field should be pointed to the full path of the dynamic shared library
-    ///    (.so file) to be loaded. The shared library must implement the `GeyserPlugin`
-    ///    trait. And the shared library shall export a `C` function `_create_plugin` which
-    ///    shall create the implementation of `GeyserPlugin` and returns to the caller.
-    ///    The rest of the JSON fields' definition is up to to the concrete plugin implementation
-    ///    It is usually used to configure the connection information for the external data store.
+    ///   config file controls the plugin responsible
+    ///   for transporting the data to external data stores. It is defined in JSON format.
+    ///   The `libpath` field should be pointed to the full path of the dynamic shared library
+    ///   (.so file) to be loaded. The shared library must implement the `GeyserPlugin`
+    ///   trait. And the shared library shall export a `C` function `_create_plugin` which
+    ///   shall create the implementation of `GeyserPlugin` and returns to the caller.
+    ///   The rest of the JSON fields' definition is up to to the concrete plugin implementation
+    ///   It is usually used to configure the connection information for the external data store.
     pub fn new(
         confirmed_bank_receiver: Receiver<SlotNotification>,
         geyser_plugin_always_enabled: bool,


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for `doc_overindented_list_items`:
```
error: doc list item overindented
    --> accounts-db/src/accounts_db.rs:2547:9
     |
2547 |     ///                        removed or recently rooted;
     |         ^^^^^^^^^^^^^^^^^^^^^^^ help: try using `  ` (2 spaces)
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
     = note: `-D clippy::doc-overindented-list-items` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::doc_overindented_list_items)]`
```


#### Summary of Changes

Fix 'em.