### PR TITLE
turbine: add XDP retransmitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-xdp"
+version = "2.3.0"
+dependencies = [
+ "aya",
+ "caps",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1051,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.9.0",
+ "bytes",
+ "libc",
+ "log",
+ "object 0.36.7",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.1",
+ "log",
+ "object 0.36.7",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,7 +1106,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -1836,6 +1879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -2669,6 +2721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3130,11 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -4498,6 +4561,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.1",
+ "indexmap 2.9.0",
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4508,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "solana-streamer",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-turbine",
  "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote-program",
@@ -11015,10 +11016,12 @@ name = "solana-turbine"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "agave-xdp",
  "assert_matches",
  "bincode",
  "bs58",
  "bytes",
+ "caps",
  "crossbeam-channel",
  "futures 0.3.31",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ members = [
     "vote",
     "watchtower",
     "wen-restart",
+    "xdp",
     "zk-keygen",
     "zk-sdk",
     "zk-token-sdk",
@@ -191,11 +192,13 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 Inflector = "0.11.4"
 axum = "0.7.9"
+aya = "0.13"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.0" }
 agave-feature-set = { path = "feature-set", version = "=2.3.0" }
 agave-precompiles = { path = "precompiles", version = "=2.3.0" }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.3.0" }
 agave-transaction-view = { path = "transaction-view", version = "=2.3.0" }
+agave-xdp = { path = "xdp", version = "=2.3.0" }
 aquamarine = "0.6.0"
 aes-gcm-siv = "0.11.1"
 ahash = "0.8.11"

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,5 +1,8 @@
 use {
-    crate::keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
+    crate::{
+        input_parsers::parse_cpu_ranges,
+        keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
+    },
     chrono::DateTime,
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
@@ -435,6 +438,15 @@ where
     } else {
         Ok(())
     }
+}
+
+pub fn validate_cpu_ranges<T>(value: T, err_prefix: &str) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    parse_cpu_ranges(value.as_ref())
+        .map(|_| ())
+        .map_err(|e| format!("{err_prefix} {e}"))
 }
 
 #[cfg(test)]

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -46,7 +46,7 @@ use {
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Keypair},
     solana_streamer::evicting_sender::EvictingSender,
-    solana_turbine::retransmit_stage::RetransmitStage,
+    solana_turbine::{retransmit_stage::RetransmitStage, xdp::XdpConfig},
     std::{
         collections::HashSet,
         net::{SocketAddr, UdpSocket},
@@ -97,6 +97,7 @@ pub struct TvuConfig {
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
     pub shred_sigverify_threads: NonZeroUsize,
+    pub retransmit_xdp: Option<XdpConfig>,
 }
 
 impl Default for TvuConfig {
@@ -110,6 +111,7 @@ impl Default for TvuConfig {
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
+            retransmit_xdp: None,
         }
     }
 }
@@ -223,6 +225,7 @@ impl Tvu {
             max_slots.clone(),
             Some(rpc_subscriptions.clone()),
             slot_status_notifier.clone(),
+            tvu_config.retransmit_xdp.clone(),
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -127,7 +127,7 @@ use {
     solana_tpu_client::tpu_client::{
         DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
     },
-    solana_turbine::{self, broadcast_stage::BroadcastStageType},
+    solana_turbine::{self, broadcast_stage::BroadcastStageType, xdp::XdpConfig},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_vote_program::vote_state,
     solana_wen_restart::wen_restart::{wait_for_wen_restart, WenRestartConfig},
@@ -314,6 +314,7 @@ pub struct ValidatorConfig {
     pub tvu_shred_sigverify_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
     pub use_tpu_client_next: bool,
+    pub retransmit_xdp: Option<XdpConfig>,
 }
 
 impl Default for ValidatorConfig {
@@ -387,6 +388,7 @@ impl Default for ValidatorConfig {
             tvu_shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             delay_leader_block_for_pending_fork: false,
             use_tpu_client_next: false,
+            retransmit_xdp: None,
         }
     }
 }
@@ -1522,6 +1524,7 @@ impl Validator {
                 replay_forks_threads: config.replay_forks_threads,
                 replay_transactions_threads: config.replay_transactions_threads,
                 shred_sigverify_threads: config.tvu_shred_sigverify_threads,
+                retransmit_xdp: config.retransmit_xdp.clone(),
             },
             &max_slots,
             block_metadata_notifier,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -74,6 +74,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
         use_tpu_client_next: config.use_tpu_client_next,
+        retransmit_xdp: config.retransmit_xdp.clone(),
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "solana-streamer",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-turbine",
  "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote-program",
@@ -204,6 +205,18 @@ dependencies = [
  "thiserror 2.0.12",
  "tikv-jemallocator",
  "tokio",
+]
+
+[[package]]
+name = "agave-xdp"
+version = "2.3.0"
+dependencies = [
+ "aya",
+ "caps",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -646,6 +659,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.9.0",
+ "bytes",
+ "libc",
+ "log",
+ "object 0.36.7",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.1",
+ "log",
+ "object 0.36.7",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,7 +714,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -1180,6 +1224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -1898,6 +1951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2279,11 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -3640,6 +3704,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.1",
+ "indexmap 2.9.0",
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -9044,8 +9120,10 @@ name = "solana-turbine"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "agave-xdp",
  "bincode",
  "bytes",
+ "caps",
  "crossbeam-channel",
  "futures 0.3.31",
  "itertools 0.12.1",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -141,6 +141,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-xdp"
+version = "2.3.0"
+dependencies = [
+ "aya",
+ "caps",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +574,37 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.9.0",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.2",
+ "log",
+ "object",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1093,6 +1136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -3520,6 +3572,9 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.2",
+ "indexmap 2.9.0",
  "memchr",
 ]
 
@@ -8385,8 +8440,10 @@ name = "solana-turbine"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "agave-xdp",
  "bincode",
  "bytes",
+ "caps",
  "crossbeam-channel",
  "futures 0.3.31",
  "itertools 0.12.1",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-xdp = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -43,6 +44,9 @@ solana-tls-utils = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/turbine/src/lib.rs
+++ b/turbine/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cluster_nodes;
 pub mod quic_endpoint;
 pub mod retransmit_stage;
 pub mod sigverify_shreds;
+pub mod xdp;
 
 #[macro_use]
 extern crate log;

--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -1,0 +1,185 @@
+// re-export since this is needed at validator startup
+pub use agave_xdp::set_cpu_affinity;
+#[cfg(target_os = "linux")]
+use {
+    agave_xdp::{
+        device::{NetworkDevice, QueueId},
+        load_xdp_program,
+        tx_loop::tx_loop,
+    },
+    crossbeam_channel::TryRecvError,
+    std::{sync::Arc, thread::Builder, time::Duration},
+};
+use {
+    crossbeam_channel::{Sender, TrySendError},
+    solana_ledger::shred,
+    std::{error::Error, net::SocketAddr, thread},
+};
+
+#[derive(Clone, Debug)]
+pub struct XdpConfig {
+    pub interface: Option<String>,
+    pub cpus: Vec<usize>,
+    pub zero_copy: bool,
+    // The capacity of the channel that sits between retransmit stage and each XDP thread that
+    // enqueues packets to the NIC.
+    pub rtx_channel_cap: usize,
+}
+
+impl XdpConfig {
+    // A nice round number
+    const DEFAULT_RTX_CHANNEL_CAP: usize = 1_000_000;
+}
+
+impl Default for XdpConfig {
+    fn default() -> Self {
+        Self {
+            interface: None,
+            cpus: vec![],
+            zero_copy: false,
+            rtx_channel_cap: Self::DEFAULT_RTX_CHANNEL_CAP,
+        }
+    }
+}
+
+impl XdpConfig {
+    pub fn new(interface: Option<impl Into<String>>, cpus: Vec<usize>, zero_copy: bool) -> Self {
+        Self {
+            interface: interface.map(|s| s.into()),
+            cpus,
+            zero_copy,
+            rtx_channel_cap: XdpConfig::DEFAULT_RTX_CHANNEL_CAP,
+        }
+    }
+}
+
+pub(crate) struct XdpSender {
+    senders: Vec<Sender<(Vec<SocketAddr>, shred::Payload)>>,
+}
+
+impl XdpSender {
+    #[inline]
+    pub(crate) fn try_send(
+        &self,
+        sender_index: u32,
+        addr: Vec<SocketAddr>,
+        payload: shred::Payload,
+    ) -> Result<(), TrySendError<(Vec<SocketAddr>, shred::Payload)>> {
+        self.senders[sender_index as usize % self.senders.len()].try_send((addr.clone(), payload))
+    }
+}
+
+pub(crate) struct XdpRetransmitter {
+    threads: Vec<thread::JoinHandle<()>>,
+}
+
+impl XdpRetransmitter {
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn new(
+        _config: XdpConfig,
+        _src_port: u16,
+    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+        Err("XDP is only supported on Linux".into())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn new(
+        config: XdpConfig,
+        src_port: u16,
+    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+        use caps::{
+            CapSet,
+            Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW},
+        };
+
+        // switch to higher caps while we setup XDP. We assume that an error in
+        // this function is irrecoverable so we don't try to drop on errors.
+        for cap in [CAP_NET_ADMIN, CAP_NET_RAW, CAP_BPF] {
+            caps::raise(None, CapSet::Effective, cap)
+                .map_err(|e| format!("failed to raise {cap:?} capability: {e}"))?;
+        }
+
+        let dev = Arc::new(if let Some(interface) = config.interface {
+            NetworkDevice::new(interface).unwrap()
+        } else {
+            NetworkDevice::new_from_default_route().unwrap()
+        });
+
+        let ebpf = if config.zero_copy {
+            Some(
+                load_xdp_program(dev.if_index())
+                    .map_err(|e| format!("failed to attach xdp program: {e}"))?,
+            )
+        } else {
+            None
+        };
+
+        for cap in [CAP_NET_ADMIN, CAP_NET_RAW, CAP_BPF] {
+            caps::drop(None, CapSet::Effective, cap).unwrap();
+        }
+
+        let (senders, receivers) = (0..config.cpus.len())
+            .map(|_| crossbeam_channel::bounded(config.rtx_channel_cap))
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let mut threads = vec![];
+
+        let (drop_sender, drop_receiver) = crossbeam_channel::bounded(1_000_000);
+        threads.push(
+            Builder::new()
+                .name("solRetransmDrop".to_owned())
+                .spawn(move || {
+                    loop {
+                        // drop shreds in a dedicated thread so that we never lock/madvise() from
+                        // the xdp thread
+                        match drop_receiver.try_recv() {
+                            Ok(i) => {
+                                drop(i);
+                            }
+                            Err(TryRecvError::Empty) => {
+                                thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(TryRecvError::Disconnected) => break,
+                        }
+                    }
+                    // move the ebpf program here so it stays attached until we exit
+                    drop(ebpf);
+                })
+                .unwrap(),
+        );
+
+        for (i, (receiver, cpu_id)) in receivers
+            .into_iter()
+            .zip(config.cpus.into_iter())
+            .enumerate()
+        {
+            let dev = Arc::clone(&dev);
+            let drop_sender = drop_sender.clone();
+            threads.push(
+                Builder::new()
+                    .name(format!("solRetransmIO{i:02}"))
+                    .spawn(move || {
+                        tx_loop(
+                            &dev,
+                            src_port,
+                            QueueId(i as u64),
+                            config.zero_copy,
+                            cpu_id,
+                            receiver,
+                            drop_sender,
+                        )
+                    })
+                    .unwrap(),
+            );
+        }
+
+        Ok((Self { threads }, XdpSender { senders }))
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        for handle in self.threads {
+            handle.join()?;
+        }
+        Ok(())
+    }
+}

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -62,6 +62,7 @@ solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-turbine = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -5,7 +5,8 @@ use {
         hidden_unless_forced,
         input_validators::{
             is_keypair_or_ask_keyword, is_parsable, is_pow2, is_pubkey, is_pubkey_or_keypair,
-            is_slot, is_within_range, validate_maximum_full_snapshot_archives_to_retain,
+            is_slot, is_within_range, validate_cpu_ranges,
+            validate_maximum_full_snapshot_archives_to_retain,
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
@@ -1648,5 +1649,33 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                 "Specifies the pubkey of the leader used in wen restart. \
                 May get stuck if the leader used is different from others.",
             ),
+    )
+    .arg(
+        Arg::with_name("retransmit_xdp_interface")
+            .hidden(hidden_unless_forced())
+            .long("experimental-retransmit-xdp-interface")
+            .takes_value(true)
+            .value_name("INTERFACE")
+            .requires("retransmit_xdp_cpu_cores")
+            .help("EXPERIMENTAL: The network interface to use for XDP retransmit"),
+    )
+    .arg(
+        Arg::with_name("retransmit_xdp_cpu_cores")
+            .hidden(hidden_unless_forced())
+            .long("experimental-retransmit-xdp-cpu-cores")
+            .takes_value(true)
+            .value_name("CPU_LIST")
+            .validator(|value| {
+                validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
+            })
+            .help("EXPERIMENTAL: Enable XDP retransmit on the specified CPU cores"),
+    )
+    .arg(
+        Arg::with_name("retransmit_xdp_zero_copy")
+            .hidden(hidden_unless_forced())
+            .long("experimental-retransmit-xdp-zero-copy")
+            .takes_value(false)
+            .requires("retransmit_xdp_cpu_cores")
+            .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
     )
 }

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "agave-xdp"
+description = "Agave XDP implementation"
+version = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+crossbeam-channel = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = { workspace = true }
+caps = { workspace = true }

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -1,0 +1,495 @@
+use {
+    crate::{
+        route::Router,
+        umem::{Frame, FrameOffset},
+    },
+    libc::{ifreq, ioctl, mmap, munmap, xdp_ring_offset, IF_NAMESIZE, SIOCGIFADDR, SIOCGIFHWADDR},
+    std::{
+        ffi::{c_char, CStr, CString},
+        io::{self, ErrorKind},
+        marker::PhantomData,
+        mem,
+        net::Ipv4Addr,
+        os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd, RawFd},
+        ptr, slice,
+        sync::atomic::{AtomicU32, Ordering},
+    },
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct QueueId(pub u64);
+
+pub struct NetworkDevice {
+    if_index: u32,
+    if_name: String,
+}
+
+impl NetworkDevice {
+    pub fn new(name: impl Into<String>) -> Result<Self, io::Error> {
+        let if_name = name.into();
+        let if_name_c = CString::new(if_name.as_bytes())
+            .map_err(|_| io::Error::new(ErrorKind::InvalidInput, "Invalid interface name"))?;
+
+        let if_index = unsafe { libc::if_nametoindex(if_name_c.as_ptr()) };
+
+        if if_index == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self { if_index, if_name })
+    }
+
+    pub fn new_from_index(if_index: u32) -> Result<Self, io::Error> {
+        let mut buf = [0u8; 1024];
+        let ret = unsafe { libc::if_indextoname(if_index, buf.as_mut_ptr() as *mut c_char) };
+        if ret.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let cstr = unsafe { CStr::from_ptr(ret) };
+        let if_name = String::from_utf8_lossy(cstr.to_bytes()).to_string();
+
+        Ok(Self { if_index, if_name })
+    }
+
+    pub fn new_from_default_route() -> Result<Self, io::Error> {
+        let router = Router::new()?;
+        let default_route = router.default().unwrap();
+        NetworkDevice::new_from_index(default_route.if_index)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.if_name
+    }
+
+    pub fn if_index(&self) -> u32 {
+        self.if_index
+    }
+
+    pub fn mac_addr(&self) -> Result<[u8; 6], io::Error> {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        let mut req: ifreq = unsafe { mem::zeroed() };
+        let if_name = CString::new(self.if_name.as_bytes()).unwrap();
+
+        let if_name_bytes = if_name.as_bytes_with_nul();
+        let len = std::cmp::min(if_name_bytes.len(), IF_NAMESIZE);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                if_name_bytes.as_ptr() as *const c_char,
+                req.ifr_name.as_mut_ptr(),
+                len,
+            );
+        }
+
+        let result = unsafe { ioctl(fd.as_raw_fd(), SIOCGIFHWADDR, &mut req) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(unsafe {
+            slice::from_raw_parts(req.ifr_ifru.ifru_hwaddr.sa_data.as_ptr() as *const u8, 6)
+        }
+        .try_into()
+        .unwrap())
+    }
+
+    pub fn ipv4_addr(&self) -> Result<Ipv4Addr, io::Error> {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+        let mut req: ifreq = unsafe { mem::zeroed() };
+        let if_name = CString::new(self.if_name.as_bytes()).unwrap();
+
+        let if_name_bytes = if_name.as_bytes_with_nul();
+        let len = std::cmp::min(if_name_bytes.len(), IF_NAMESIZE);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                if_name_bytes.as_ptr() as *const c_char,
+                req.ifr_name.as_mut_ptr(),
+                len,
+            );
+        }
+
+        let result = unsafe { libc::ioctl(fd.as_raw_fd(), SIOCGIFADDR, &mut req) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let addr = unsafe {
+            let addr_ptr = &req.ifr_ifru.ifru_addr as *const libc::sockaddr;
+            let sin_addr = (*(addr_ptr as *const libc::sockaddr_in)).sin_addr;
+            Ipv4Addr::from(sin_addr.s_addr.to_ne_bytes())
+        };
+        Ok(addr)
+    }
+
+    pub fn open_queue(&self, queue_id: QueueId) -> DeviceQueue {
+        DeviceQueue::new(self.if_index, queue_id)
+    }
+}
+
+pub struct DeviceQueue {
+    if_index: u32,
+    queue_id: QueueId,
+    completion: Option<TxCompletionRing>,
+}
+
+impl DeviceQueue {
+    pub fn new(if_index: u32, queue_id: QueueId) -> Self {
+        Self {
+            if_index,
+            queue_id,
+            completion: None,
+        }
+    }
+
+    pub fn if_index(&self) -> u32 {
+        self.if_index
+    }
+
+    pub fn id(&self) -> QueueId {
+        self.queue_id
+    }
+
+    pub fn tx_completion(&mut self) -> Option<&TxCompletionRing> {
+        self.completion.as_ref()
+    }
+}
+
+pub(crate) struct RingConsumer {
+    producer: *mut AtomicU32,
+    cached_producer: u32,
+    consumer: *mut AtomicU32,
+    cached_consumer: u32,
+}
+
+impl RingConsumer {
+    pub fn new(producer: *mut AtomicU32, consumer: *mut AtomicU32) -> Self {
+        Self {
+            producer,
+            cached_producer: unsafe { (*producer).load(Ordering::Acquire) },
+            consumer,
+            cached_consumer: unsafe { (*consumer).load(Ordering::Relaxed) },
+        }
+    }
+
+    #[cfg(test)]
+    pub fn available(&self) -> u32 {
+        self.cached_producer.wrapping_sub(self.cached_consumer)
+    }
+
+    pub fn consume(&mut self) -> Option<u32> {
+        if self.cached_consumer == self.cached_producer {
+            return None;
+        }
+
+        let index = self.cached_consumer;
+        self.cached_consumer = self.cached_consumer.wrapping_add(1);
+        Some(index)
+    }
+
+    pub fn commit(&mut self) {
+        unsafe { (*self.consumer).store(self.cached_consumer, Ordering::Release) };
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        if commit {
+            self.commit();
+        }
+        self.cached_producer = unsafe { (*self.producer).load(Ordering::Acquire) };
+    }
+}
+
+pub(crate) struct RingProducer {
+    producer: *mut AtomicU32,
+    cached_producer: u32,
+    consumer: *mut AtomicU32,
+    cached_consumer: u32,
+    size: u32,
+}
+
+impl RingProducer {
+    pub fn new(producer: *mut AtomicU32, consumer: *mut AtomicU32, size: u32) -> Self {
+        Self {
+            producer,
+            cached_producer: unsafe { (*producer).load(Ordering::Relaxed) },
+            consumer,
+            cached_consumer: unsafe { (*consumer).load(Ordering::Acquire) },
+            size,
+        }
+    }
+
+    pub fn available(&self) -> u32 {
+        self.size
+            .saturating_sub(self.cached_producer.wrapping_sub(self.cached_consumer))
+    }
+
+    pub fn produce(&mut self) -> Option<u32> {
+        if self.available() == 0 {
+            return None;
+        }
+
+        let index = self.cached_producer;
+        self.cached_producer = self.cached_producer.wrapping_add(1);
+        Some(index)
+    }
+
+    pub fn commit(&mut self) {
+        unsafe { (*self.producer).store(self.cached_producer, Ordering::Release) };
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        if commit {
+            self.commit();
+        }
+        self.cached_consumer = unsafe { (*self.consumer).load(Ordering::Acquire) };
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub(crate) struct XdpDesc {
+    pub(crate) addr: u64,
+    pub(crate) len: u32,
+    pub(crate) options: u32,
+}
+
+pub struct TxCompletionRing {
+    mmap: RingMmap<u64>,
+    consumer: RingConsumer,
+    size: u32,
+}
+
+impl TxCompletionRing {
+    pub(crate) fn new(mmap: RingMmap<u64>, size: u32) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            consumer: RingConsumer::new(mmap.producer, mmap.consumer),
+            mmap,
+            size,
+        }
+    }
+
+    pub fn read(&mut self) -> Option<FrameOffset> {
+        let index = self.consumer.consume()? & self.size.saturating_sub(1);
+        let index = unsafe { *self.mmap.desc.add(index as usize) } as usize;
+        Some(FrameOffset(index))
+    }
+
+    pub fn commit(&mut self) {
+        self.consumer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.consumer.sync(commit);
+    }
+}
+
+pub struct RxFillRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    _fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+impl<F: Frame> RxFillRing<F> {
+    pub(crate) fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            _fd: fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), io::Error> {
+        let Some(index) = self.producer.produce() else {
+            return Err(ErrorKind::StorageFull.into());
+        };
+        let index = index & self.size.saturating_sub(1);
+        let desc = unsafe { self.mmap.desc.add(index as usize) };
+        // Safety: index is within the ring so the pointer is valid
+        unsafe {
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}
+
+pub struct RingMmap<T> {
+    pub mmap: *const u8,
+    pub mmap_len: usize,
+    pub producer: *mut AtomicU32,
+    pub consumer: *mut AtomicU32,
+    pub desc: *mut T,
+    pub flags: *mut AtomicU32,
+}
+
+impl<T> Drop for RingMmap<T> {
+    fn drop(&mut self) {
+        unsafe {
+            munmap(self.mmap as *mut _, self.mmap_len);
+        }
+    }
+}
+
+pub(crate) unsafe fn mmap_ring<T>(
+    fd: i32,
+    size: usize,
+    offsets: &xdp_ring_offset,
+    ring_type: u64,
+) -> Result<RingMmap<T>, io::Error> {
+    let map_size = (offsets.desc as usize).saturating_add(size);
+    let map_addr = mmap(
+        ptr::null_mut(),
+        map_size,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_SHARED | libc::MAP_POPULATE,
+        fd,
+        ring_type as i64,
+    );
+    if map_addr == libc::MAP_FAILED {
+        return Err(io::Error::last_os_error());
+    }
+    let producer = map_addr.add(offsets.producer as usize) as *mut AtomicU32;
+    let consumer = map_addr.add(offsets.consumer as usize) as *mut AtomicU32;
+    let desc = map_addr.add(offsets.desc as usize) as *mut T;
+    let flags = map_addr.add(offsets.flags as usize) as *mut AtomicU32;
+    // V1
+    // let flags = map_addr.add(offsets.consumer as usize + mem::size_of::<u32>()) as *mut AtomicU32;
+    Ok(RingMmap {
+        mmap: map_addr as *const u8,
+        mmap_len: map_size,
+        producer,
+        consumer,
+        desc,
+        flags,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ring_producer() {
+        let mut producer = AtomicU32::new(0);
+        let mut consumer = AtomicU32::new(0);
+        let size = 16;
+        let mut ring = RingProducer::new(&mut producer as *mut _, &mut consumer as *mut _, size);
+        assert_eq!(ring.available(), size);
+
+        for i in 0..size {
+            assert_eq!(ring.produce(), Some(i));
+            assert_eq!(ring.available(), size - i - 1);
+        }
+        assert_eq!(ring.produce(), None);
+
+        consumer.store(1, Ordering::Release);
+        assert_eq!(ring.produce(), None);
+        ring.commit();
+        assert_eq!(ring.produce(), None);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(16));
+        assert_eq!(ring.produce(), None);
+
+        consumer.store(2, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(17));
+    }
+
+    #[test]
+    fn test_ring_producer_wrap_around() {
+        let size = 16;
+        let mut producer = AtomicU32::new(u32::MAX - 1);
+        let mut consumer = AtomicU32::new(u32::MAX - size - 1);
+        let mut ring = RingProducer::new(&mut producer as *mut _, &mut consumer as *mut _, size);
+        assert_eq!(ring.available(), 0);
+
+        consumer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(u32::MAX - 1));
+        consumer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(u32::MAX));
+        consumer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(0));
+        consumer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.produce(), Some(1));
+    }
+
+    #[test]
+    fn test_ring_consumer() {
+        let mut producer = AtomicU32::new(0);
+        let mut consumer = AtomicU32::new(0);
+        let size = 16;
+        let mut ring = RingConsumer::new(&mut producer as *mut _, &mut consumer as *mut _);
+        assert_eq!(ring.available(), 0);
+
+        producer.store(1, Ordering::Release);
+        assert_eq!(ring.available(), 0);
+        ring.sync(true);
+        assert_eq!(ring.available(), 1);
+
+        producer.store(size, Ordering::Release);
+        ring.sync(true);
+
+        for i in 0..size {
+            assert_eq!(ring.consume(), Some(i));
+            assert_eq!(ring.available(), size - i - 1);
+        }
+        assert_eq!(ring.consume(), None);
+    }
+
+    #[test]
+    fn test_ring_consumer_wrap_around() {
+        let mut producer = AtomicU32::new(u32::MAX - 1);
+        let mut consumer = AtomicU32::new(u32::MAX - 1);
+        let mut ring = RingConsumer::new(&mut producer as *mut _, &mut consumer as *mut _);
+        assert_eq!(ring.available(), 0);
+        assert_eq!(ring.consume(), None);
+
+        producer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.consume(), Some(u32::MAX - 1));
+
+        producer.store(0, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.available(), 1);
+        assert_eq!(ring.consume(), Some(u32::MAX));
+
+        producer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.consume(), Some(0));
+
+        producer.fetch_add(1, Ordering::Release);
+        ring.sync(true);
+        assert_eq!(ring.consume(), Some(1));
+    }
+}

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -1,0 +1,47 @@
+#[cfg(target_os = "linux")]
+pub mod device;
+#[cfg(target_os = "linux")]
+pub mod netlink;
+#[cfg(target_os = "linux")]
+pub mod packet;
+#[cfg(target_os = "linux")]
+mod program;
+#[cfg(target_os = "linux")]
+pub mod route;
+#[cfg(target_os = "linux")]
+pub mod socket;
+#[cfg(target_os = "linux")]
+pub mod tx_loop;
+#[cfg(target_os = "linux")]
+pub mod umem;
+
+#[cfg(target_os = "linux")]
+pub use program::load_xdp_program;
+use std::io;
+
+#[cfg(target_os = "linux")]
+pub fn set_cpu_affinity(cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
+    unsafe {
+        let mut cpu_set = std::mem::zeroed();
+
+        for cpu in cpus {
+            libc::CPU_SET(cpu, &mut cpu_set);
+        }
+
+        let result = libc::sched_setaffinity(
+            0,
+            std::mem::size_of::<libc::cpu_set_t>(),
+            &cpu_set as *const libc::cpu_set_t,
+        );
+        if result != 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_cpu_affinity(_cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
+    unimplemented!()
+}

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -1,0 +1,578 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    libc::{
+        getsockname, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
+        AF_INET, AF_INET6, AF_NETLINK, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE,
+        NLA_ALIGNTO, NLA_TYPE_MASK, NLMSG_DONE, NLMSG_ERROR, NLM_F_DUMP, NLM_F_MULTI,
+        NLM_F_REQUEST, NUD_PERMANENT, NUD_REACHABLE, NUD_STALE, RTA_DST, RTA_GATEWAY, RTA_IIF,
+        RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETNEIGH, RTM_GETROUTE, RTM_NEWNEIGH,
+        RTM_NEWROUTE, RT_TABLE_MAIN, SOCK_RAW, SOL_NETLINK,
+    },
+    std::{
+        collections::HashMap,
+        io, mem,
+        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        os::fd::{AsRawFd, FromRawFd, OwnedFd},
+        ptr, slice,
+    },
+    thiserror::Error,
+};
+
+const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
+
+pub struct NetlinkSocket {
+    sock: OwnedFd,
+    _nl_pid: u32,
+}
+
+impl NetlinkSocket {
+    fn open() -> Result<Self, io::Error> {
+        // Safety: libc wrapper
+        let sock = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
+        if sock < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `socket` returns a file descriptor.
+        let sock = unsafe { OwnedFd::from_raw_fd(sock) };
+
+        let enable = 1i32;
+        // Safety: libc wrapper
+        if unsafe {
+            setsockopt(
+                sock.as_raw_fd(),
+                SOL_NETLINK,
+                NETLINK_EXT_ACK,
+                &enable as *const _ as *const _,
+                mem::size_of::<i32>() as u32,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safety: sockaddr_nl is POD so this is safe
+        let mut addr = unsafe { mem::zeroed::<sockaddr_nl>() };
+        addr.nl_family = AF_NETLINK as u16;
+        let mut addr_len = mem::size_of::<sockaddr_nl>() as u32;
+        // Safety: libc wrapper
+        if unsafe {
+            getsockname(
+                sock.as_raw_fd(),
+                &mut addr as *mut _ as *mut _,
+                &mut addr_len as *mut _,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            sock,
+            _nl_pid: addr.nl_pid,
+        })
+    }
+
+    fn send(&self, msg: &[u8]) -> Result<(), io::Error> {
+        if unsafe {
+            send(
+                self.sock.as_raw_fd(),
+                msg.as_ptr() as *const _,
+                msg.len(),
+                0,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn recv(&self) -> Result<Vec<NetlinkMessage>, io::Error> {
+        let mut buf = [0u8; 4096];
+        let mut messages = Vec::new();
+        let mut multipart = true;
+        'out: while multipart {
+            multipart = false;
+            // Safety: libc wrapper
+            let len = unsafe {
+                recv(
+                    self.sock.as_raw_fd(),
+                    buf.as_mut_ptr() as *mut _,
+                    buf.len(),
+                    0,
+                )
+            };
+            if len < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if len == 0 {
+                break;
+            }
+
+            let len = len as usize;
+            let mut offset = 0;
+            while offset < len {
+                let message = NetlinkMessage::read(&buf[offset..])?;
+                offset += align_to(message.header.nlmsg_len as usize, NLMSG_ALIGNTO as usize);
+                multipart = message.header.nlmsg_flags & NLM_F_MULTI as u16 != 0;
+                match message.header.nlmsg_type as i32 {
+                    NLMSG_ERROR => {
+                        let err = message.error.unwrap();
+                        if err.error == 0 {
+                            // this is an ACK
+                            continue;
+                        }
+                        return Err(io::Error::from_raw_os_error(-err.error));
+                    }
+                    NLMSG_DONE => break 'out,
+                    _ => messages.push(message),
+                }
+            }
+        }
+
+        Ok(messages)
+    }
+}
+
+pub struct NetlinkMessage {
+    header: nlmsghdr,
+    data: Vec<u8>,
+    error: Option<nlmsgerr>,
+}
+
+impl NetlinkMessage {
+    fn read(buf: &[u8]) -> Result<Self, io::Error> {
+        if mem::size_of::<nlmsghdr>() > buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "buffer smaller than nlmsghdr",
+            ));
+        }
+
+        // Safety: nlmsghdr is POD so read is safe
+        let header = unsafe { ptr::read_unaligned(buf.as_ptr() as *const nlmsghdr) };
+        let msg_len = header.nlmsg_len as usize;
+        if msg_len < mem::size_of::<nlmsghdr>() || msg_len > buf.len() {
+            return Err(io::Error::new(io::ErrorKind::Other, "invalid nlmsg_len"));
+        }
+
+        let data_offset = align_to(mem::size_of::<nlmsghdr>(), NLMSG_ALIGNTO as usize);
+        if data_offset >= buf.len() {
+            return Err(io::Error::new(io::ErrorKind::Other, "need more data"));
+        }
+
+        let (data, error) = if header.nlmsg_type == NLMSG_ERROR as u16 {
+            if data_offset + mem::size_of::<nlmsgerr>() > buf.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "NLMSG_ERROR but not enough space for nlmsgerr",
+                ));
+            }
+            (
+                Vec::new(),
+                // Safety: nlmsgerr is POD so read is safe
+                Some(unsafe {
+                    ptr::read_unaligned(buf[data_offset..].as_ptr() as *const nlmsgerr)
+                }),
+            )
+        } else {
+            (buf[data_offset..msg_len].to_vec(), None)
+        };
+
+        Ok(Self {
+            header,
+            data,
+            error,
+        })
+    }
+}
+
+const fn align_to(v: usize, align: usize) -> usize {
+    (v + (align - 1)) & !(align - 1)
+}
+
+struct NlAttrsIterator<'a> {
+    attrs: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> NlAttrsIterator<'a> {
+    fn new(attrs: &'a [u8]) -> Self {
+        Self { attrs, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for NlAttrsIterator<'a> {
+    type Item = Result<NlAttr<'a>, NlAttrError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buf = &self.attrs[self.offset..];
+        if buf.is_empty() {
+            return None;
+        }
+
+        if NLA_HDR_LEN > buf.len() {
+            self.offset = buf.len();
+            return Some(Err(NlAttrError::InvalidBufferLength {
+                size: buf.len(),
+                expected: NLA_HDR_LEN,
+            }));
+        }
+
+        let attr = unsafe { ptr::read_unaligned(buf.as_ptr() as *const nlattr) };
+        let len = attr.nla_len as usize;
+        let align_len = align_to(len, NLA_ALIGNTO as usize);
+        if len < NLA_HDR_LEN {
+            return Some(Err(NlAttrError::InvalidHeaderLength(len)));
+        }
+        if align_len > buf.len() {
+            return Some(Err(NlAttrError::InvalidBufferLength {
+                size: buf.len(),
+                expected: align_len,
+            }));
+        }
+
+        let data = &buf[NLA_HDR_LEN..len];
+
+        self.offset += align_len;
+        Some(Ok(NlAttr { header: attr, data }))
+    }
+}
+
+fn parse_attrs(buf: &[u8]) -> Result<HashMap<u16, NlAttr<'_>>, NlAttrError> {
+    let mut attrs = HashMap::new();
+    for attr in NlAttrsIterator::new(buf) {
+        let attr = attr?;
+        attrs.insert(attr.header.nla_type & NLA_TYPE_MASK as u16, attr);
+    }
+    Ok(attrs)
+}
+
+#[derive(Clone)]
+struct NlAttr<'a> {
+    header: nlattr,
+    data: &'a [u8],
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+enum NlAttrError {
+    #[error("invalid buffer size `{size}`, expected `{expected}`")]
+    InvalidBufferLength { size: usize, expected: usize },
+
+    #[error("invalid nlattr header length `{0}`")]
+    InvalidHeaderLength(usize),
+}
+
+impl From<NlAttrError> for io::Error {
+    fn from(e: NlAttrError) -> Self {
+        Self::new(io::ErrorKind::Other, e)
+    }
+}
+
+fn bytes_of<T>(val: &T) -> &[u8] {
+    let size = mem::size_of::<T>();
+    unsafe { slice::from_raw_parts(slice::from_ref(val).as_ptr().cast(), size) }
+}
+
+const NLMSG_ALIGNTO: u32 = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacAddress(pub [u8; 6]);
+
+impl MacAddress {
+    pub fn new(bytes: [u8; 6]) -> Self {
+        MacAddress(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 6] {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MacAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5]
+        )
+    }
+}
+
+/// Represents an entry in the neighbor table (ARP/NDP cache)
+#[derive(Debug, Clone)]
+pub struct NeighborEntry {
+    // IPv4 or IPv6 address
+    pub destination: Option<IpAddr>,
+    // MAC address
+    pub lladdr: Option<MacAddress>,
+    // Interface index
+    pub ifindex: i32,
+    // NUD_* state
+    pub state: u16,
+}
+
+impl NeighborEntry {
+    /// Returns true if this neighbor entry is valid and usable
+    pub fn is_valid(&self) -> bool {
+        self.lladdr.is_some() && (self.state & (NUD_REACHABLE | NUD_PERMANENT | NUD_STALE)) != 0
+    }
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct ndmsg {
+    ndm_family: u8,
+    ndm_pad1: u8,
+    ndm_pad2: u16,
+    ndm_ifindex: i32,
+    ndm_state: u16,
+    ndm_flags: u8,
+    ndm_type: u8,
+}
+
+#[repr(C)]
+struct NeighRequest {
+    header: nlmsghdr,
+    ndm: ndmsg,
+}
+
+/// fetch the kernel's neighbor table (ARP/NDP cache)
+pub fn netlink_get_neighbors(
+    if_index: Option<i32>,
+    family: u8,
+) -> Result<Vec<NeighborEntry>, io::Error> {
+    let sock = NetlinkSocket::open()?;
+
+    // Safety: NeighRequest is POD
+    let mut req = unsafe { mem::zeroed::<NeighRequest>() };
+
+    let nlmsg_len = mem::size_of::<nlmsghdr>() + mem::size_of::<ndmsg>();
+    req.header = nlmsghdr {
+        nlmsg_len: nlmsg_len as u32,
+        nlmsg_flags: (NLM_F_REQUEST | NLM_F_DUMP) as u16,
+        nlmsg_type: RTM_GETNEIGH,
+        nlmsg_pid: 0,
+        nlmsg_seq: 1,
+    };
+
+    req.ndm.ndm_family = family;
+    if let Some(idx) = if_index {
+        req.ndm.ndm_ifindex = idx;
+    }
+
+    sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
+
+    let mut neighbors = Vec::new();
+
+    for msg in sock.recv()? {
+        if msg.header.nlmsg_type != RTM_NEWNEIGH {
+            continue;
+        }
+
+        if msg.data.len() < mem::size_of::<ndmsg>() {
+            continue;
+        }
+
+        let Some(neighbor) = parse_rtm_newneigh(msg, if_index) else {
+            continue;
+        };
+
+        neighbors.push(neighbor);
+    }
+
+    Ok(neighbors)
+}
+
+pub fn parse_rtm_newneigh(msg: NetlinkMessage, if_index: Option<i32>) -> Option<NeighborEntry> {
+    let nd_msg = unsafe { ptr::read_unaligned(msg.data.as_ptr() as *const ndmsg) };
+    if let Some(idx) = if_index {
+        if nd_msg.ndm_ifindex != idx {
+            return None;
+        }
+    }
+    let Ok(attrs) = parse_attrs(&msg.data[mem::size_of::<ndmsg>()..]) else {
+        return None;
+    };
+    let mut neighbor = NeighborEntry {
+        destination: None,
+        lladdr: None,
+        ifindex: nd_msg.ndm_ifindex,
+        state: nd_msg.ndm_state,
+    };
+    if let Some(dst_attr) = attrs.get(&NDA_DST) {
+        neighbor.destination = parse_ip_address(dst_attr.data, nd_msg.ndm_family);
+    }
+    if let Some(lladdr_attr) = attrs.get(&NDA_LLADDR) {
+        if lladdr_attr.data.len() >= 6 {
+            let mut mac = [0u8; 6];
+            mac.copy_from_slice(&lladdr_attr.data[0..6]);
+            neighbor.lladdr = Some(MacAddress(mac));
+        }
+    }
+    Some(neighbor)
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteEntry {
+    pub destination: Option<IpAddr>,
+    pub gateway: Option<IpAddr>,
+    pub pref_src: Option<IpAddr>,
+    pub out_if_index: Option<i32>,
+    pub in_if_index: Option<i32>,
+    pub priority: Option<u32>,
+    pub table: Option<u32>,
+    pub protocol: u8,
+    pub scope: u8,
+    pub type_: u8,
+    pub family: u8,
+    pub dst_len: u8,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct rtmsg {
+    rtm_family: u8,
+    rtm_dst_len: u8,
+    rtm_src_len: u8,
+    rtm_tos: u8,
+    rtm_table: u8,
+    rtm_protocol: u8,
+    rtm_scope: u8,
+    rtm_type: u8,
+    rtm_flags: u32,
+}
+
+#[repr(C)]
+struct RouteRequest {
+    header: nlmsghdr,
+    rtm: rtmsg,
+}
+
+fn parse_ip_address(data: &[u8], family: u8) -> Option<IpAddr> {
+    match family as i32 {
+        AF_INET if data.len() == 4 => Some(IpAddr::V4(Ipv4Addr::new(
+            data[0], data[1], data[2], data[3],
+        ))),
+        AF_INET6 if data.len() == 16 => {
+            let mut segments = [0u16; 8];
+            for i in 0..8 {
+                segments[i] = ((data[i * 2] as u16) << 8) | (data[i * 2 + 1] as u16);
+            }
+            Some(IpAddr::V6(Ipv6Addr::from(segments)))
+        }
+        _ => None,
+    }
+}
+
+pub fn netlink_get_routes(family: u8) -> Result<Vec<RouteEntry>, io::Error> {
+    let sock = NetlinkSocket::open()?;
+
+    // Safety: RouteRequest is POD
+    let mut req = unsafe { mem::zeroed::<RouteRequest>() };
+
+    let nlmsg_len = mem::size_of::<nlmsghdr>() + mem::size_of::<rtmsg>();
+    req.header = nlmsghdr {
+        nlmsg_len: nlmsg_len as u32,
+        nlmsg_flags: (NLM_F_REQUEST | NLM_F_DUMP) as u16,
+        nlmsg_type: RTM_GETROUTE,
+        nlmsg_pid: 0,
+        nlmsg_seq: 1,
+    };
+
+    req.rtm.rtm_family = family;
+    req.rtm.rtm_table = RT_TABLE_MAIN;
+
+    sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
+
+    let mut routes = Vec::new();
+
+    for msg in sock.recv()? {
+        if msg.header.nlmsg_type != RTM_NEWROUTE {
+            continue;
+        }
+
+        if msg.data.len() < mem::size_of::<rtmsg>() {
+            continue;
+        }
+
+        let Some(route) = parse_rtm_newroute(msg) else {
+            continue;
+        };
+
+        routes.push(route);
+    }
+
+    Ok(routes)
+}
+
+pub fn parse_rtm_newroute(msg: NetlinkMessage) -> Option<RouteEntry> {
+    let rt_msg = unsafe { ptr::read_unaligned(msg.data.as_ptr() as *const rtmsg) };
+    let Ok(attrs) = parse_attrs(&msg.data[mem::size_of::<rtmsg>()..]) else {
+        return None;
+    };
+    let mut route = RouteEntry {
+        destination: None,
+        gateway: None,
+        pref_src: None,
+        out_if_index: None,
+        in_if_index: None,
+        priority: None,
+        table: None,
+        protocol: rt_msg.rtm_protocol,
+        scope: rt_msg.rtm_scope,
+        type_: rt_msg.rtm_type,
+        family: rt_msg.rtm_family,
+        dst_len: rt_msg.rtm_dst_len,
+    };
+    if let Some(dst_attr) = attrs.get(&RTA_DST) {
+        route.destination = parse_ip_address(dst_attr.data, rt_msg.rtm_family);
+    }
+    if let Some(gateway_attr) = attrs.get(&RTA_GATEWAY) {
+        route.gateway = parse_ip_address(gateway_attr.data, rt_msg.rtm_family);
+    }
+
+    let u32_from_ne_bytes = |data: &[u8]| -> Option<u32> {
+        data.get(..4)
+            .map(|data| u32::from_ne_bytes([data[0], data[1], data[2], data[3]]))
+    };
+
+    if let Some(oif_attr) = attrs.get(&RTA_OIF) {
+        route.out_if_index = u32_from_ne_bytes(oif_attr.data).map(|i| i as i32);
+    }
+    if let Some(iif_attr) = attrs.get(&RTA_IIF) {
+        route.in_if_index = u32_from_ne_bytes(iif_attr.data).map(|i| i as i32);
+    }
+    if let Some(priority_attr) = attrs.get(&RTA_PRIORITY) {
+        route.priority = u32_from_ne_bytes(priority_attr.data);
+    }
+    if let Some(table_attr) = attrs.get(&RTA_TABLE) {
+        route.table = u32_from_ne_bytes(table_attr.data);
+    }
+    if let Some(prefsrc_attr) = attrs.get(&RTA_PREFSRC) {
+        route.pref_src = parse_ip_address(prefsrc_attr.data, rt_msg.rtm_family);
+    }
+    Some(route)
+}
+
+pub fn netlink_get_default_gateway(family: u8) -> Result<Option<RouteEntry>, io::Error> {
+    let routes = netlink_get_routes(family)?;
+
+    for route in routes {
+        let is_default_destination = match (route.destination, family as i32) {
+            (None, _) => true,
+            // 0.0.0.0
+            (Some(IpAddr::V4(addr)), AF_INET) => addr.is_unspecified() && route.dst_len == 0,
+            // ::/0
+            (Some(IpAddr::V6(addr)), AF_INET6) => addr.is_unspecified() && route.dst_len == 0,
+            _ => false,
+        };
+
+        if is_default_destination && route.gateway.is_some() {
+            return Ok(Some(route));
+        }
+    }
+
+    Ok(None)
+}

--- a/xdp/src/packet.rs
+++ b/xdp/src/packet.rs
@@ -1,0 +1,114 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {libc::ETH_P_IP, std::net::Ipv4Addr};
+
+pub const ETH_HEADER_SIZE: usize = 14;
+pub const IP_HEADER_SIZE: usize = 20;
+pub const UDP_HEADER_SIZE: usize = 8;
+
+pub fn write_eth_header(packet: &mut [u8], src_mac: &[u8; 6], dst_mac: &[u8; 6]) {
+    packet[0..6].copy_from_slice(dst_mac);
+    packet[6..12].copy_from_slice(src_mac);
+    packet[12..14].copy_from_slice(&(ETH_P_IP as u16).to_be_bytes());
+}
+
+pub fn write_ip_header(packet: &mut [u8], src_ip: &Ipv4Addr, dst_ip: &Ipv4Addr, udp_len: u16) {
+    let total_len = IP_HEADER_SIZE + udp_len as usize;
+
+    // version (4) and IHL (5)
+    packet[0] = 0x45;
+    // tos
+    packet[1] = 0;
+    packet[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+    // identification
+    packet[4..6].copy_from_slice(&0u16.to_be_bytes());
+    // flags & frag offset
+    packet[6..8].copy_from_slice(&0u16.to_be_bytes());
+    // TTL
+    packet[8] = 64;
+    // protocol (UDP = 17)
+    packet[9] = 17;
+    // checksum
+    packet[10..12].copy_from_slice(&0u16.to_be_bytes());
+    packet[12..16].copy_from_slice(&src_ip.octets());
+    packet[16..20].copy_from_slice(&dst_ip.octets());
+
+    let checksum = calculate_ip_checksum(&packet[..IP_HEADER_SIZE]);
+    packet[10..12].copy_from_slice(&checksum.to_be_bytes());
+}
+
+pub fn write_udp_header(
+    packet: &mut [u8],
+    src_ip: &Ipv4Addr,
+    src_port: u16,
+    dst_ip: &Ipv4Addr,
+    dst_port: u16,
+    payload_len: u16,
+    csum: bool,
+) {
+    let udp_len = UDP_HEADER_SIZE + payload_len as usize;
+
+    packet[0..2].copy_from_slice(&src_port.to_be_bytes());
+    packet[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    packet[4..6].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    packet[6..8].copy_from_slice(&0u16.to_be_bytes());
+
+    if csum {
+        let checksum = calculate_udp_checksum(&packet[..udp_len], src_ip, dst_ip);
+        packet[6..8].copy_from_slice(&checksum.to_be_bytes());
+    }
+}
+
+fn calculate_udp_checksum(udp_packet: &[u8], src_ip: &Ipv4Addr, dst_ip: &Ipv4Addr) -> u16 {
+    let udp_len = udp_packet.len();
+
+    let mut sum: u32 = 0;
+
+    let src_ip = src_ip.octets();
+    let dst_ip = dst_ip.octets();
+
+    sum += (u32::from(src_ip[0]) << 8) | u32::from(src_ip[1]);
+    sum += (u32::from(src_ip[2]) << 8) | u32::from(src_ip[3]);
+    sum += (u32::from(dst_ip[0]) << 8) | u32::from(dst_ip[1]);
+    sum += (u32::from(dst_ip[2]) << 8) | u32::from(dst_ip[3]);
+    sum += 17; // UDP
+    sum += udp_len as u32;
+
+    for i in 0..udp_len / 2 {
+        // skip the checksum field
+        if i * 2 == 6 {
+            continue;
+        }
+        let word = ((udp_packet[i * 2] as u32) << 8) | (udp_packet[i * 2 + 1] as u32);
+        sum += word;
+    }
+
+    if udp_len % 2 == 1 {
+        sum += (udp_packet[udp_len - 1] as u32) << 8;
+    }
+
+    while sum >> 16 != 0 {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+
+    !(sum as u16)
+}
+
+fn calculate_ip_checksum(header: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+
+    for i in 0..header.len() / 2 {
+        let word = ((header[i * 2] as u32) << 8) | (header[i * 2 + 1] as u32);
+        sum += word;
+    }
+
+    if header.len() % 2 == 1 {
+        sum += (header[header.len() - 1] as u32) << 8;
+    }
+
+    while sum >> 16 != 0 {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+
+    !(sum as u16)
+}

--- a/xdp/src/program.rs
+++ b/xdp/src/program.rs
@@ -1,0 +1,203 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(target_os = "linux")]
+use aya::{programs::Xdp, Ebpf};
+use std::io::{Cursor, Write};
+
+macro_rules! write_fields {
+    ($w:expr, $($x:expr),*) => {
+        $(
+            $w.write_all(&$x.to_le_bytes())?;
+        )*
+    };
+}
+
+const SHT_NULL: u32 = 0;
+// text section
+const SHT_PROGBITS: u32 = 1;
+// symbol table
+const SHT_SYMTAB: u32 = 2;
+// string table
+const SHT_STRTAB: u32 = 3;
+
+// flags required for the text section
+const SHF_ALLOC: u64 = 1 << 1;
+const SHF_EXECINSTR: u64 = 1 << 2;
+
+// symbol visibility
+const STB_GLOBAL: u8 = 1 << 4;
+// symbol type
+const STT_FUNC: u8 = 2;
+
+// we just let all packets in
+const XDP_PROG: &[u8] = &[
+    0xb7, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // r0 = XDP_PASS
+    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+];
+
+// the string table
+const STRTAB: &[u8] = b"\0xdp\0.symtab\0.strtab\0";
+
+pub fn load_xdp_program(if_index: u32) -> Result<Ebpf, Box<dyn std::error::Error>> {
+    let elf = generate_xdp_elf();
+    let mut ebpf = Ebpf::load(&elf).unwrap();
+    let p: &mut Xdp = ebpf.program_mut("xdp").unwrap().try_into().unwrap();
+    p.load()?;
+
+    p.attach_to_if_index(if_index, aya::programs::xdp::XdpFlags::DRV_MODE)?;
+
+    Ok(ebpf)
+}
+
+fn generate_xdp_elf() -> Vec<u8> {
+    let mut buffer = vec![0u8; 4096];
+    let mut cursor = Cursor::new(&mut buffer);
+
+    // start after the header
+    let xdp_off = 64;
+    cursor.set_position(xdp_off);
+    cursor.write_all(XDP_PROG).unwrap();
+    let xdp_size = cursor.position() - xdp_off;
+
+    // write the string table
+    let strtab_off = cursor.position();
+    cursor.write_all(STRTAB).unwrap();
+    let strtab_size = cursor.position() - strtab_off;
+
+    // write the symbol table
+    let symtab_off = align_cursor(&mut cursor, 8);
+    write_symbol(&mut cursor, 0, 0, 0, 0, 0, 0).unwrap();
+    write_symbol(
+        &mut cursor,
+        1, // index
+        0,
+        XDP_PROG.len() as u64,
+        STB_GLOBAL | STT_FUNC,
+        0,
+        1, // section index
+    )
+    .unwrap();
+    let symtab_size = cursor.position() - symtab_off;
+
+    // write the section headers
+    let shdrs_off = align_cursor(&mut cursor, 8);
+    write_section_headers(
+        &mut cursor,
+        xdp_off,
+        xdp_size,
+        strtab_off,
+        strtab_size,
+        symtab_off,
+        symtab_size,
+    )
+    .unwrap();
+
+    // finally go back and write the header
+    const SECTIONS: u16 = 4;
+    const STRTAB_INDEX: u16 = 2;
+    cursor.set_position(0);
+    write_elf_header(&mut cursor, shdrs_off, SECTIONS, STRTAB_INDEX).unwrap();
+
+    buffer
+}
+
+fn align_cursor(cursor: &mut Cursor<&mut Vec<u8>>, alignment: usize) -> u64 {
+    let pos = cursor.position() as usize;
+    let padding = (alignment - (pos % alignment)) % alignment;
+    cursor.set_position((pos + padding) as u64);
+    cursor.position()
+}
+
+fn write_elf_header(
+    w: &mut impl Write,
+    sh_offset: u64,
+    sh_num: u16,
+    sh_strndx: u16,
+) -> std::io::Result<()> {
+    let mut header = [
+        0x7f, 0x45, 0x4c, 0x46, // EI_MAG: 0x7F 'ELF'
+        0x02, 0x01, 0x01, 0x00, // CLASS64, LSB, Version1
+        0x00, 0x00, 0x00, 0x00, // EI_PAD
+        0x00, 0x00, 0x00, 0x00, // EI_PAD
+        0x01, 0x00, // e_type: ET_REL
+        0xf7, 0x00, // e_machine: EM_BPF
+        0x01, 0x00, 0x00, 0x00, // e_version: EV_CURRENT
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // e_entry
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // e_phoff
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // e_shoff
+        0x00, 0x00, 0x00, 0x00, // e_flags
+        0x40, 0x00, // e_ehsize: 64
+        0x00, 0x00, // e_phentsize
+        0x00, 0x00, // e_phnum
+        0x40, 0x00, // e_shentsize: 64
+        0x00, 0x00, // e_shnum
+        0x00, 0x00, // e_shstrndx
+    ];
+
+    header[40..48].copy_from_slice(&sh_offset.to_le_bytes());
+    header[60..62].copy_from_slice(&sh_num.to_le_bytes());
+    header[62..64].copy_from_slice(&sh_strndx.to_le_bytes());
+
+    w.write_all(&header)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_section_header(
+    w: &mut impl Write,
+    name: u32,
+    type_: u32,
+    flags: u64,
+    addr: u64,
+    offset: u64,
+    size: u64,
+    link: u32,
+    info: u32,
+    addralign: u64,
+    entsize: u64,
+) -> std::io::Result<()> {
+    write_fields!(w, name, type_, flags, addr, offset, size, link, info, addralign, entsize);
+
+    Ok(())
+}
+
+fn write_symbol(
+    w: &mut impl Write,
+    name: u32,
+    value: u64,
+    size: u64,
+    info: u8,
+    other: u8,
+    shndx: u16,
+) -> std::io::Result<()> {
+    write_fields!(
+        w,
+        name,
+        ((other as u16) << 8) | info as u16,
+        shndx,
+        value,
+        size
+    );
+
+    Ok(())
+}
+
+// don't format the write_section_headers calls 1-2 digit arguments are annoying
+#[rustfmt::skip]
+fn write_section_headers(
+    w: &mut impl Write,
+    xdp_off: u64,
+    xdp_size: u64,
+    strtab_off: u64,
+    strtab_size: u64,
+    symtab_off: u64,
+    symtab_size: u64,
+) -> std::io::Result<()> {
+    const STRTAB_XDP_OFF: u32 = 1;
+    const STRTAB_SYMTAB_OFF: u32 = 5;
+    const STRTAB_STRTAB_OFF: u32 = 13;
+    write_section_header(w, 0, SHT_NULL, 0, 0, 0, 0, 0, 0, 0, 0)?;
+    write_section_header(w, STRTAB_XDP_OFF, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR, 0, xdp_off, xdp_size, 0, 0, 0, 0)?;
+    write_section_header(w, STRTAB_STRTAB_OFF, SHT_STRTAB, 0, 0, strtab_off, strtab_size, 0, 0, 0, 0)?;
+    write_section_header(w, STRTAB_SYMTAB_OFF, SHT_SYMTAB, 0, 0, symtab_off, symtab_size, 2, 1, 0, 0)?;
+    Ok(())
+}

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -1,0 +1,252 @@
+use {
+    crate::netlink::{
+        netlink_get_neighbors, netlink_get_routes, MacAddress, NeighborEntry, RouteEntry,
+    },
+    libc::{AF_INET, AF_INET6},
+    std::{
+        io,
+        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    },
+    thiserror::Error,
+};
+
+#[derive(Debug, Error)]
+pub enum RouteError {
+    #[error("no route found to destination {0}")]
+    NoRouteFound(IpAddr),
+
+    #[error("missing output interface in route")]
+    MissingOutputInterface,
+
+    #[error("could not resolve MAC address")]
+    MacResolutionError,
+}
+
+#[derive(Debug)]
+pub struct NextHop {
+    pub mac_addr: Option<MacAddress>,
+    pub ip_addr: IpAddr,
+    pub if_index: u32,
+}
+
+fn lookup_route(routes: &[RouteEntry], dest: IpAddr) -> Option<&RouteEntry> {
+    let mut best_match = None;
+
+    let family = match dest {
+        IpAddr::V4(_) => AF_INET as u8,
+        IpAddr::V6(_) => AF_INET6 as u8,
+    };
+
+    for route in routes.iter().filter(|r| r.family == family) {
+        match (dest, route.destination) {
+            // this is the default route
+            (_, None) => {
+                if best_match.is_none() {
+                    best_match = Some((route, 0));
+                }
+            }
+
+            (IpAddr::V4(dest_addr), Some(IpAddr::V4(route_addr))) => {
+                let prefix_len = route.dst_len;
+                if !is_ipv4_match(dest_addr, route_addr, prefix_len) {
+                    continue;
+                }
+
+                if best_match.is_none() || prefix_len > best_match.unwrap().1 {
+                    best_match = Some((route, prefix_len));
+                }
+            }
+
+            (IpAddr::V6(dest_addr), Some(IpAddr::V6(route_addr))) => {
+                let prefix_len = route.dst_len;
+                if !is_ipv6_match(dest_addr, route_addr, prefix_len) {
+                    continue;
+                }
+
+                if best_match.is_none() || prefix_len > best_match.unwrap().1 {
+                    best_match = Some((route, prefix_len));
+                }
+            }
+
+            // mixed address families - can't match
+            _ => continue,
+        }
+    }
+
+    best_match.map(|(route, _)| route)
+}
+
+fn is_ipv4_match(addr: Ipv4Addr, network: Ipv4Addr, prefix_len: u8) -> bool {
+    if prefix_len == 0 {
+        return true;
+    }
+
+    let mask = 0xFFFFFFFF << 32u32.saturating_sub(prefix_len as u32);
+    let addr_bits = u32::from(addr) & mask;
+    let network_bits = u32::from(network) & mask;
+
+    addr_bits == network_bits
+}
+
+fn is_ipv6_match(addr: Ipv6Addr, network: Ipv6Addr, prefix_len: u8) -> bool {
+    if prefix_len == 0 {
+        return true;
+    }
+
+    let addr_segments = addr.segments();
+    let network_segments = network.segments();
+
+    let full_segments = (prefix_len / 16) as usize;
+    if addr_segments[..full_segments] != network_segments[..full_segments] {
+        return false;
+    }
+
+    if let Some(remaining_bits) = prefix_len.checked_rem(16).filter(|&b| b != 0) {
+        let mask = 0xFFFF_u16 << 16u16.saturating_sub(remaining_bits as u16);
+        if (addr_segments[full_segments] & mask) != (network_segments[full_segments] & mask) {
+            return false;
+        }
+    }
+
+    true
+}
+
+pub struct Router {
+    arp_table: ArpTable,
+    routes: Vec<RouteEntry>,
+}
+
+impl Router {
+    pub fn new() -> Result<Self, io::Error> {
+        Ok(Self {
+            arp_table: ArpTable::new()?,
+            routes: netlink_get_routes(AF_INET as u8)?,
+        })
+    }
+
+    pub fn default(&self) -> Result<NextHop, RouteError> {
+        let default_route = self
+            .routes
+            .iter()
+            .find(|r| r.destination.is_none())
+            .ok_or(RouteError::NoRouteFound(IpAddr::V4(Ipv4Addr::UNSPECIFIED)))?;
+
+        let if_index = default_route
+            .out_if_index
+            .ok_or(RouteError::MissingOutputInterface)? as u32;
+
+        let next_hop_ip = match default_route.gateway {
+            Some(gateway) => gateway,
+            None => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+
+        let mac_addr = self.arp_table.lookup(next_hop_ip).cloned();
+
+        Ok(NextHop {
+            ip_addr: next_hop_ip,
+            mac_addr,
+            if_index,
+        })
+    }
+
+    pub fn route(&self, dest_ip: IpAddr) -> Result<NextHop, RouteError> {
+        let route = lookup_route(&self.routes, dest_ip).ok_or(RouteError::NoRouteFound(dest_ip))?;
+
+        let if_index = route
+            .out_if_index
+            .ok_or(RouteError::MissingOutputInterface)? as u32;
+
+        let next_hop_ip = match route.gateway {
+            Some(gateway) => gateway,
+            None => dest_ip,
+        };
+
+        let mac_addr = self.arp_table.lookup(next_hop_ip).cloned();
+
+        Ok(NextHop {
+            ip_addr: next_hop_ip,
+            mac_addr,
+            if_index,
+        })
+    }
+}
+
+struct ArpTable {
+    neighbors: Vec<NeighborEntry>,
+}
+
+impl ArpTable {
+    pub fn new() -> Result<Self, io::Error> {
+        let neighbors = netlink_get_neighbors(None, AF_INET as u8)?;
+        Ok(Self { neighbors })
+    }
+
+    pub fn lookup(&self, ip: IpAddr) -> Option<&MacAddress> {
+        self.neighbors
+            .iter()
+            .find(|n| n.destination == Some(ip))
+            .and_then(|n| n.lladdr.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ipv4_match() {
+        assert!(is_ipv4_match(
+            Ipv4Addr::new(192, 168, 1, 10),
+            Ipv4Addr::new(192, 168, 1, 0),
+            24
+        ));
+
+        assert!(!is_ipv4_match(
+            Ipv4Addr::new(192, 168, 2, 10),
+            Ipv4Addr::new(192, 168, 1, 0),
+            24
+        ));
+
+        // Match with default route
+        assert!(is_ipv4_match(
+            Ipv4Addr::new(1, 2, 3, 4),
+            Ipv4Addr::new(0, 0, 0, 0),
+            0
+        ));
+    }
+
+    #[test]
+    fn test_ipv6_match() {
+        assert!(is_ipv6_match(
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789),
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5678, 0, 0, 0, 0),
+            64
+        ));
+
+        assert!(!is_ipv6_match(
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1235, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789),
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5678, 0, 0, 0, 0),
+            64
+        ));
+
+        // Match with partial segment
+        assert!(is_ipv6_match(
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6700, 0, 0, 0, 0),
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6600, 0, 0, 0, 0),
+            52
+        ));
+
+        assert!(!is_ipv6_match(
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6700, 0, 0, 0, 0),
+            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5600, 0, 0, 0, 0),
+            52
+        ));
+    }
+
+    #[test]
+    fn test_router() {
+        let router = Router::new().unwrap();
+        let next_hop = router.route("1.1.1.1".parse().unwrap()).unwrap();
+        eprintln!("{:?}", next_hop);
+    }
+}

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -1,0 +1,278 @@
+use {
+    crate::{
+        device::{
+            mmap_ring, DeviceQueue, RingMmap, RingProducer, RxFillRing, TxCompletionRing, XdpDesc,
+        },
+        umem::{Frame, Umem},
+    },
+    libc::{
+        bind, getsockopt, sa_family_t, sendto, setsockopt, sockaddr, sockaddr_xdp, socket,
+        socklen_t, xdp_mmap_offsets, xdp_umem_reg, AF_XDP, SOCK_RAW, SOL_XDP, XDP_COPY,
+        XDP_MMAP_OFFSETS, XDP_PGOFF_TX_RING, XDP_RING_NEED_WAKEUP, XDP_TX_RING,
+        XDP_UMEM_COMPLETION_RING, XDP_UMEM_FILL_RING, XDP_UMEM_PGOFF_COMPLETION_RING,
+        XDP_UMEM_PGOFF_FILL_RING, XDP_USE_NEED_WAKEUP, XDP_ZEROCOPY,
+    },
+    std::{
+        io,
+        marker::PhantomData,
+        mem,
+        os::fd::{AsFd, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd, RawFd},
+        ptr,
+        sync::atomic::Ordering,
+    },
+};
+
+pub struct Socket<U: Umem> {
+    fd: OwnedFd,
+    dev_queue: DeviceQueue,
+    umem: U,
+}
+
+impl<U: Umem> Socket<U> {
+    #[allow(clippy::type_complexity)]
+    pub fn new(
+        dev_queue: DeviceQueue,
+        umem: U,
+        zero_copy: bool,
+        rx_fill_ring_size: usize,
+        _rx_ring_size: usize,
+        tx_completion_ring_size: usize,
+        tx_ring_size: usize,
+    ) -> Result<(Self, Rx<U::Frame>, Tx<U::Frame>), io::Error> {
+        unsafe {
+            let fd = socket(AF_XDP, SOCK_RAW, 0);
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let fd = OwnedFd::from_raw_fd(fd);
+
+            let reg = xdp_umem_reg {
+                addr: umem.as_ptr() as u64,
+                len: umem.len() as u64,
+                chunk_size: umem.frame_size() as u32,
+                headroom: 0,
+                flags: 0,
+                tx_metadata_len: 0,
+            };
+
+            if setsockopt(
+                fd.as_raw_fd(),
+                libc::SOL_XDP,
+                libc::XDP_UMEM_REG,
+                &reg as *const _ as *const libc::c_void,
+                mem::size_of::<xdp_umem_reg>() as libc::socklen_t,
+            ) < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            for (ring, size) in [
+                (XDP_UMEM_COMPLETION_RING, tx_completion_ring_size),
+                (XDP_UMEM_FILL_RING, rx_fill_ring_size),
+                (XDP_TX_RING, tx_ring_size),
+            ] {
+                if setsockopt(
+                    fd.as_raw_fd(),
+                    SOL_XDP,
+                    ring,
+                    &size as *const _ as *const libc::c_void,
+                    mem::size_of::<u32>() as socklen_t,
+                ) < 0
+                {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+
+            let mut offsets: xdp_mmap_offsets = mem::zeroed();
+            let mut optlen = mem::size_of::<xdp_mmap_offsets>() as socklen_t;
+            if getsockopt(
+                fd.as_raw_fd(),
+                SOL_XDP,
+                XDP_MMAP_OFFSETS,
+                &mut offsets as *mut _ as *mut libc::c_void,
+                &mut optlen,
+            ) < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            let tx_completion_ring = TxCompletionRing::new(
+                mmap_ring(
+                    fd.as_raw_fd(),
+                    tx_completion_ring_size.saturating_mul(mem::size_of::<u64>()),
+                    &offsets.cr,
+                    XDP_UMEM_PGOFF_COMPLETION_RING,
+                )?,
+                tx_completion_ring_size as u32,
+            );
+
+            let rx_fill_ring = RxFillRing::new(
+                mmap_ring(
+                    fd.as_raw_fd(),
+                    rx_fill_ring_size.saturating_mul(mem::size_of::<u64>()),
+                    &offsets.fr,
+                    XDP_UMEM_PGOFF_FILL_RING,
+                )?,
+                rx_fill_ring_size as u32,
+                fd.as_raw_fd(),
+            );
+
+            let tx_ring = Some(TxRing::new(
+                mmap_ring(
+                    fd.as_raw_fd(),
+                    tx_ring_size.saturating_mul(mem::size_of::<XdpDesc>()),
+                    &offsets.tx,
+                    XDP_PGOFF_TX_RING as u64,
+                )?,
+                tx_ring_size as u32,
+                fd.as_raw_fd(),
+            ));
+
+            let sxdp = sockaddr_xdp {
+                sxdp_family: AF_XDP as sa_family_t,
+                // do NEED_WAKEUP and don't do zero copy for now for maximum compatibility
+                sxdp_flags: XDP_USE_NEED_WAKEUP | if zero_copy { XDP_ZEROCOPY } else { XDP_COPY },
+                sxdp_ifindex: dev_queue.if_index(),
+                sxdp_queue_id: dev_queue.id().0 as u32,
+                sxdp_shared_umem_fd: 0,
+            };
+
+            if bind(
+                fd.as_raw_fd(),
+                &sxdp as *const _ as *const sockaddr,
+                mem::size_of::<sockaddr_xdp>() as socklen_t,
+            ) < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            let tx = Tx {
+                completion: tx_completion_ring,
+                ring: tx_ring,
+            };
+            let rx = Rx { fill: rx_fill_ring };
+            Ok((
+                Self {
+                    fd,
+                    dev_queue,
+                    umem,
+                },
+                rx,
+                tx,
+            ))
+        }
+    }
+
+    pub fn tx(
+        queue: DeviceQueue,
+        umem: U,
+        zero_copy: bool,
+        completion_size: usize,
+        ring_size: usize,
+    ) -> Result<(Self, Tx<U::Frame>), io::Error> {
+        let (socket, _, tx) = Self::new(queue, umem, zero_copy, 1, 0, completion_size, ring_size)?;
+        Ok((socket, tx))
+    }
+
+    pub fn rx(
+        queue: DeviceQueue,
+        umem: U,
+        zero_copy: bool,
+        fill_size: usize,
+        ring_size: usize,
+    ) -> Result<(Self, Rx<U::Frame>), io::Error> {
+        let (socket, rx, _) = Self::new(queue, umem, zero_copy, fill_size, ring_size, 0, 0)?;
+        Ok((socket, rx))
+    }
+
+    pub fn queue(&self) -> &DeviceQueue {
+        &self.dev_queue
+    }
+
+    pub fn umem(&mut self) -> &mut U {
+        &mut self.umem
+    }
+}
+
+impl<U: Umem> AsFd for Socket<U> {
+    fn as_fd(&self) -> BorrowedFd {
+        self.fd.as_fd()
+    }
+}
+
+pub struct Tx<F: Frame> {
+    pub completion: TxCompletionRing,
+    pub ring: Option<TxRing<F>>,
+}
+
+pub struct Rx<F: Frame> {
+    pub fill: RxFillRing<F>,
+}
+
+pub struct TxRing<F: Frame> {
+    mmap: RingMmap<XdpDesc>,
+    producer: RingProducer,
+    size: u32,
+    fd: RawFd,
+    _frame: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub struct RingFull<F: Frame>(pub F);
+
+impl<F: Frame> TxRing<F> {
+    fn new(mmap: RingMmap<XdpDesc>, size: u32, fd: RawFd) -> Self {
+        debug_assert!(size.is_power_of_two());
+        Self {
+            producer: RingProducer::new(mmap.producer, mmap.consumer, size),
+            mmap,
+            size,
+            fd,
+            _frame: PhantomData,
+        }
+    }
+
+    pub fn write(&mut self, frame: F, options: u32) -> Result<(), RingFull<F>> {
+        let Some(index) = self.producer.produce() else {
+            return Err(RingFull(frame));
+        };
+        let index = index & self.size.saturating_sub(1);
+        unsafe {
+            let desc = self.mmap.desc.add(index as usize);
+            desc.write(XdpDesc {
+                addr: frame.offset().0 as u64,
+                len: frame.len() as u32,
+                options,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn needs_wakeup(&self) -> bool {
+        unsafe { (*self.mmap.flags).load(Ordering::Relaxed) & XDP_RING_NEED_WAKEUP != 0 }
+    }
+
+    pub fn wake(&self) -> Result<u64, io::Error> {
+        let result = unsafe { sendto(self.fd, ptr::null(), 0, libc::MSG_DONTWAIT, ptr::null(), 0) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(result as u64)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.size as usize
+    }
+
+    pub fn available(&self) -> usize {
+        self.producer.available() as usize
+    }
+
+    pub fn commit(&mut self) {
+        self.producer.commit();
+    }
+
+    pub fn sync(&mut self, commit: bool) {
+        self.producer.sync(commit);
+    }
+}

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -1,0 +1,295 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    crate::{
+        device::{NetworkDevice, QueueId},
+        netlink::MacAddress,
+        packet::{
+            write_eth_header, write_ip_header, write_udp_header, ETH_HEADER_SIZE, IP_HEADER_SIZE,
+            UDP_HEADER_SIZE,
+        },
+        route::Router,
+        set_cpu_affinity,
+        socket::{Socket, Tx, TxRing},
+        umem::{Frame as _, PageAlignedMemory, SliceUmem, SliceUmemFrame, Umem as _},
+    },
+    caps::{
+        CapSet,
+        Capability::{CAP_NET_ADMIN, CAP_NET_RAW},
+    },
+    crossbeam_channel::{Receiver, Sender, TryRecvError},
+    libc::{sysconf, _SC_PAGESIZE},
+    std::{
+        net::{IpAddr, SocketAddr},
+        thread,
+        time::Duration,
+    },
+};
+
+pub fn tx_loop<T: AsRef<[u8]>>(
+    dev: &NetworkDevice,
+    src_port: u16,
+    queue_id: QueueId,
+    zero_copy: bool,
+    cpu_id: usize,
+    receiver: Receiver<(Vec<SocketAddr>, T)>,
+    drop_sender: Sender<(Vec<SocketAddr>, T)>,
+) {
+    log::info!(
+        "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
+        dev.name()
+    );
+
+    // each queue is bound to its own CPU core
+    set_cpu_affinity([cpu_id]).unwrap();
+
+    let src_mac = dev.mac_addr().unwrap();
+    let src_ip = dev.ipv4_addr().unwrap();
+
+    // some drivers require frame_size=page_size
+    let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
+    const FRAME_COUNT: usize = 4096;
+
+    // try to allocate huge pages first, then fall back to regular pages
+    const HUGE_2MB: usize = 2 * 1024 * 1024;
+    let mut memory =
+        PageAlignedMemory::alloc_with_page_size(frame_size, FRAME_COUNT, HUGE_2MB, true)
+            .or_else(|_| {
+                log::warn!("huge page alloc failed, falling back to regular page size");
+                PageAlignedMemory::alloc(frame_size, FRAME_COUNT)
+            })
+            .unwrap();
+    let umem = SliceUmem::new(&mut memory, frame_size as u32).unwrap();
+
+    // we need NET_ADMIN and NET_RAW for the socket
+    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+        caps::raise(None, CapSet::Effective, cap).unwrap();
+    }
+
+    // A nice round number. This is the size used by kernel selftests, so likely to work with all
+    // drivers.
+    const RING_SIZE: usize = 2048;
+
+    let Ok((mut socket, tx)) = Socket::tx(
+        dev.open_queue(queue_id),
+        umem,
+        zero_copy,
+        RING_SIZE,
+        RING_SIZE,
+    ) else {
+        panic!("failed to create AF_XDP socket on queue {queue_id:?}");
+    };
+
+    let umem = socket.umem();
+    let Tx {
+        // this is where we'll queue frames
+        ring,
+        // this is where we'll get completion events once frames have been picked up by the NIC
+        mut completion,
+    } = tx;
+    let mut ring = ring.unwrap();
+
+    // get the routing table from netlink
+    let router = Router::new().expect("failed to create router");
+
+    // we don't need higher caps anymore
+    for cap in [CAP_NET_ADMIN, CAP_NET_RAW] {
+        caps::drop(None, CapSet::Effective, cap).unwrap();
+    }
+
+    // How long we sleep waiting to receive shreds from the channel.
+    const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
+
+    const MAX_TIMEOUTS: usize = 500;
+
+    // We try to collect _at least_ BATCH_SIZE packets before queueing into the NIC. This is to
+    // avoid introducing too much per-packet overhead and giving the NIC time to complete work
+    // before we queue the next chunk of packets.
+    const BATCH_SIZE: usize = 64;
+
+    // Local buffer where we store packets before sending themi.
+    let mut batched_items = Vec::with_capacity(BATCH_SIZE);
+
+    // How many packets we've batched. This is _not_ batched_items.len(), but item * peers. For
+    // example if we have 3 packets to transmit to 2 destination addresses each, we have 6 batched
+    // packets.
+    let mut batched_packets = 0;
+
+    // With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver
+    // once we want the NIC to do something.
+    let kick = |ring: &TxRing<SliceUmemFrame<'_>>| {
+        if !ring.needs_wakeup() {
+            return;
+        }
+
+        if let Err(e) = ring.wake() {
+            match e.raw_os_error() {
+                // these are non-fatal errors
+                Some(libc::EBUSY | libc::ENOBUFS | libc::EAGAIN) => {}
+                // this can temporarily happen with some drivers when changing
+                // settings (eg with ethtool)
+                Some(libc::ENETDOWN) => {
+                    log::warn!("network interface is down")
+                }
+                // we should never get here, hopefully the driver recovers?
+                _ => {
+                    log::error!("network interface driver error: {e:?}");
+                }
+            }
+        }
+    };
+
+    let mut timeouts = 0;
+    loop {
+        match receiver.try_recv() {
+            Ok((addrs, payload)) => {
+                batched_packets += addrs.len();
+                batched_items.push((addrs, payload));
+                timeouts = 0;
+                if batched_packets < BATCH_SIZE {
+                    continue;
+                }
+            }
+            Err(TryRecvError::Empty) => {
+                if timeouts < MAX_TIMEOUTS {
+                    timeouts += 1;
+                    thread::sleep(RECV_TIMEOUT);
+                } else {
+                    timeouts = 0;
+                    // we haven't received anything in a while, kick the driver
+                    ring.commit();
+                    kick(&ring);
+                }
+            }
+            Err(TryRecvError::Disconnected) => {
+                // keep looping until we've flushed all the packets
+                if batched_packets == 0 {
+                    break;
+                }
+            }
+        };
+
+        // this is the number of packets after which we commit the ring and kick the driver if
+        // necessary
+        let mut chunk_remaining = BATCH_SIZE.min(batched_packets);
+
+        for (addrs, payload) in batched_items.drain(..) {
+            for addr in &addrs {
+                // loop until we have space for the next packet
+                loop {
+                    completion.sync(true);
+                    // we haven't written any frames so we only need to sync the consumer position
+                    ring.sync(false);
+
+                    // check if any frames were completed
+                    while let Some(frame_offset) = completion.read() {
+                        umem.release(frame_offset);
+                    }
+
+                    if ring.available() > 0 && umem.available() > 0 {
+                        // we have a frame and a slot in the ring
+                        break;
+                    }
+
+                    // queues are full, if NEEDS_WAKEUP is set kick the driver so hopefully it'll
+                    // complete some work
+                    kick(&ring);
+                }
+
+                // at this point we're guaranteed to have a frame to write the next packet into and
+                // a slot in the ring to submit it
+                let mut frame = umem.reserve().unwrap();
+                let IpAddr::V4(dst_ip) = addr.ip() else {
+                    panic!("IPv6 not supported");
+                };
+
+                let next_hop = router.route(addr.ip()).unwrap();
+                // sanity check that the address is routable through our NIC
+                if next_hop.if_index != dev.if_index() {
+                    log::warn!(
+                        "turbine peer {} must be routed through if_index: {} our if_index: {}",
+                        addr,
+                        next_hop.if_index,
+                        dev.if_index()
+                    );
+                    batched_packets -= 1;
+                    umem.release(frame.offset());
+                    continue;
+                }
+                const PACKET_HEADER_SIZE: usize =
+                    ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
+                let len = payload.as_ref().len();
+                frame.set_len(PACKET_HEADER_SIZE + len);
+                let packet = umem.map_frame_mut(&frame);
+
+                // write the payload first as it's needed for checksum calculation (if enabled)
+                packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload.as_ref());
+
+                write_eth_header(
+                    packet,
+                    &src_mac,
+                    // the unwrap case is for loopback interfaces which don't have a mac address
+                    &next_hop.mac_addr.unwrap_or(MacAddress([0u8; 6])).0,
+                );
+
+                write_ip_header(
+                    &mut packet[ETH_HEADER_SIZE..],
+                    &src_ip,
+                    &dst_ip,
+                    (UDP_HEADER_SIZE + len) as u16,
+                );
+
+                write_udp_header(
+                    &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
+                    &src_ip,
+                    src_port,
+                    &dst_ip,
+                    addr.port(),
+                    len as u16,
+                    // don't do checksums
+                    false,
+                );
+
+                // write the packet into the ring
+                ring.write(frame, 0)
+                    .map_err(|_| "ring full")
+                    // this should never happen as we check for available slots above
+                    .expect("failed to write to ring");
+
+                batched_packets -= 1;
+                chunk_remaining -= 1;
+
+                // check if it's time to commit the ring and kick the driver
+                if chunk_remaining == 0 {
+                    chunk_remaining = BATCH_SIZE.min(batched_packets);
+
+                    // commit new frames
+                    ring.commit();
+                    kick(&ring);
+                }
+            }
+            let _ = drop_sender.try_send((addrs, payload));
+        }
+        debug_assert_eq!(batched_packets, 0);
+    }
+    assert_eq!(batched_packets, 0);
+
+    // drain the ring
+    while umem.available() < umem.capacity() || ring.available() < ring.capacity() {
+        log::debug!(
+            "draining xdp ring umem {}/{} ring {}/{}",
+            umem.available(),
+            umem.capacity(),
+            ring.available(),
+            ring.capacity()
+        );
+
+        completion.sync(true);
+        while let Some(frame_offset) = completion.read() {
+            umem.release(frame_offset);
+        }
+
+        ring.sync(false);
+        kick(&ring);
+    }
+}

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -1,0 +1,212 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    libc::{munmap, sysconf, _SC_PAGESIZE},
+    std::{
+        ffi::c_void,
+        io,
+        marker::PhantomData,
+        ops::{Deref, DerefMut},
+        ptr, slice,
+    },
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct FrameOffset(pub(crate) usize);
+
+pub trait Frame {
+    fn offset(&self) -> FrameOffset;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+pub trait Umem {
+    type Frame: Frame;
+
+    fn as_ptr(&self) -> *const u8;
+    fn as_mut_ptr(&mut self) -> *mut u8;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn frame_size(&self) -> usize;
+
+    fn map_frame(&self, frame: &Self::Frame) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.as_ptr().add(frame.offset().0), frame.len()) }
+    }
+
+    fn map_frame_mut(&mut self, frame: &Self::Frame) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr().add(frame.offset().0), frame.len()) }
+    }
+}
+
+pub struct SliceUmemFrame<'a> {
+    offset: usize,
+    len: usize,
+    _buf: PhantomData<&'a mut [u8]>,
+}
+
+impl SliceUmemFrame<'_> {
+    pub fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
+}
+
+impl Frame for SliceUmemFrame<'_> {
+    fn offset(&self) -> FrameOffset {
+        FrameOffset(self.offset)
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+pub struct SliceUmem<'a> {
+    buffer: &'a mut [u8],
+    frame_size: u32,
+    available_frames: Vec<u64>,
+    capacity: usize,
+}
+
+impl<'a> SliceUmem<'a> {
+    pub fn new(buffer: &'a mut [u8], frame_size: u32) -> Result<Self, io::Error> {
+        debug_assert!(frame_size.is_power_of_two());
+        let capacity = buffer.len() / frame_size as usize;
+        Ok(Self {
+            available_frames: Vec::from_iter(0..capacity as u64),
+            capacity,
+            frame_size,
+            buffer,
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn available(&self) -> usize {
+        self.available_frames.len()
+    }
+
+    pub fn reserve(&mut self) -> Option<SliceUmemFrame<'a>> {
+        let index = self.available_frames.pop()?;
+
+        Some(SliceUmemFrame {
+            offset: index as usize * self.frame_size as usize,
+            len: 0,
+            _buf: PhantomData,
+        })
+    }
+
+    pub fn release(&mut self, frame: FrameOffset) {
+        let index = frame.0 / self.frame_size as usize;
+        self.available_frames.push(index as u64);
+    }
+}
+
+impl<'a> Umem for SliceUmem<'a> {
+    type Frame = SliceUmemFrame<'a>;
+
+    fn as_ptr(&self) -> *const u8 {
+        self.buffer.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.buffer.as_mut_ptr()
+    }
+
+    fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn frame_size(&self) -> usize {
+        self.frame_size as usize
+    }
+}
+
+#[derive(Debug)]
+pub struct AllocError;
+
+pub struct PageAlignedMemory {
+    ptr: *mut u8,
+    len: usize,
+}
+
+impl PageAlignedMemory {
+    pub fn alloc(frame_size: usize, frame_count: usize) -> Result<Self, AllocError> {
+        Self::alloc_with_page_size(
+            frame_size,
+            frame_count,
+            // Safety: just a libc wrapper
+            unsafe { sysconf(_SC_PAGESIZE) as usize },
+            false,
+        )
+    }
+
+    pub fn alloc_with_page_size(
+        frame_size: usize,
+        frame_count: usize,
+        page_size: usize,
+        huge: bool,
+    ) -> Result<Self, AllocError> {
+        debug_assert!(frame_size.is_power_of_two());
+        debug_assert!(frame_count.is_power_of_two());
+        debug_assert!(page_size.is_power_of_two());
+        let memory_size = frame_count * frame_size;
+        let aligned_size = (memory_size + page_size - 1) & !(page_size - 1);
+
+        // Safety:
+        // doing an ANONYMOUS alloc. addr=NULL is ok, fd is not used.
+        let ptr = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                aligned_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | if huge { libc::MAP_HUGETLB } else { 0 },
+                -1,
+                0,
+            )
+        };
+
+        if ptr == libc::MAP_FAILED {
+            return Err(AllocError);
+        }
+
+        // Safety: ptr is valid for aligned_size bytes
+        unsafe {
+            ptr::write_bytes(ptr as *mut u8, 0, aligned_size);
+        }
+
+        Ok(Self {
+            ptr: ptr as *mut u8,
+            len: aligned_size,
+        })
+    }
+}
+
+impl Drop for PageAlignedMemory {
+    fn drop(&mut self) {
+        // Safety:
+        // ptr is a valid pointer returned by mmap
+        unsafe {
+            munmap(self.ptr as *mut c_void, self.len);
+        }
+    }
+}
+
+impl Deref for PageAlignedMemory {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl DerefMut for PageAlignedMemory {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}


### PR DESCRIPTION
This adds an opt-in XDP based retransmitter to retransmit stage. The following validator options are introduced:

        --experimental-retransmit-xdp-interface
        --experimental-retransmit-xdp-cpu-cores
        --experimental-retransmit-xdp-zero-copy

cpu-cores takes a cpu list eg: 0,3,6-8 to enable CPUs 0, 3, 6 7 and 8. When passed, XDP is enabled and the specified CPUs are reserved for driving NIC queues.

If an interface is not passed, the default output interface is used (the interface for the 0.0.0.0 route). By default XDP is used in SKB mode. If zero copy is enabled, full bypass is used instead which requires hardware support.

SKB mode provides 7-10Gbps per core depending on clock speed. Zero copy mode can typically saturate the NIC on a single core.