### PR TITLE
This is 2025 add clippy.toml

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+deny-attributes = ["warnings", "clippy::default_trait_access", "clippy::arithmetic_side_effects", "clippy::manual_let_else", "clippy::used_underscore_bindings"]

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -24,9 +24,4 @@ source "$here/../ci/rust-version.sh" nightly
 #   ref: https://github.com/rust-lang/rust/issues/66287
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
-  --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
-  --deny=warnings \
-  --deny=clippy::default_trait_access \
-  --deny=clippy::arithmetic_side_effects \
-  --deny=clippy::manual_let_else \
-  --deny=clippy::used_underscore_binding
+  --workspace --all-targets --features dummy-for-ci-check,frozen-abi


### PR DESCRIPTION
This makes the life of folks who live in 2025 and use rust-analyzer a lot less miserable. You're welcome. 