### PR TITLE
Set build target to minimum supported cpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["-Ctarget-cpu=x86-64-v3"]
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true


### PR DESCRIPTION
#### Problem
Changes the config to set the build target to native or `x86-64-v3`.

#### Summary of Changes

Fixes #5314 
