### PR TITLE
clippy: div_ceil

### DIFF
--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -399,7 +399,7 @@ mod test {
         // Round-trip with no inserts.
         let bloom: ConcurrentBloom<_> = bloom.into();
         assert_eq!(bloom.num_bits, 9731);
-        assert_eq!(bloom.bits.len(), (9731 + 63) / 64);
+        assert_eq!(bloom.bits.len(), 9731_usize.div_ceil(64));
         for hash_value in &hash_values {
             assert!(bloom.contains(hash_value));
         }
@@ -428,7 +428,7 @@ mod test {
             .collect();
         let bloom: ConcurrentBloom<_> = bloom.into();
         assert_eq!(bloom.num_bits, 9731);
-        assert_eq!(bloom.bits.len(), (9731 + 63) / 64);
+        assert_eq!(bloom.bits.len(), 9731_usize.div_ceil(64));
         more_hash_values.par_iter().for_each(|v| {
             bloom.add(v);
         });

--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -28,7 +28,7 @@ pub fn set_ancestor_hash_repair_sample_size_for_tests_only(sample_size: usize) {
 // another, the chance of >= 11 of the 21 sampled being from the 52% portion is
 // about 57%, so we should be able to find a correct sample in a reasonable amount of time.
 pub fn get_minimum_ancestor_agreement_size() -> usize {
-    (get_ancestor_hash_repair_sample_size() + 1) / 2
+    get_ancestor_hash_repair_sample_size().div_ceil(2)
 }
 const RETRY_INTERVAL_SECONDS: usize = 5;
 

--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -165,7 +165,7 @@ impl RunLengthEncoding {
             .dedup_with_count()
             .map_while(|(count, _)| u16::try_from(count).ok())
             .scan(0, |current_bytes, count| {
-                *current_bytes += ((u16::BITS - count.leading_zeros() + 6) / 7).max(1) as usize;
+                *current_bytes += (u16::BITS - count.leading_zeros()).div_ceil(7).max(1) as usize;
                 (*current_bytes <= RestartLastVotedForkSlots::MAX_BYTES).then_some(U16(count))
             })
             .collect();

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -306,7 +306,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     let mut total_bytes = bytes_tx;
     let mut ts = timestamp();
     for _ in 1..num {
-        let start = ((ts + 99) / 100) as usize;
+        let start = ts.div_ceil(100) as usize;
         let end = start + 10;
         let now = (start * 100) as u64;
         ts += 1000;

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -68,7 +68,7 @@ impl MerkleTree {
         if level_len == 1 {
             0
         } else {
-            (level_len + 1) / 2
+            level_len.div_ceil(2)
         }
     }
 


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for reimplementing div_ceil().
```
error: manually reimplementing `div_ceil`
  --> merkle-tree/src/merkle_tree.rs:71:13
   |
71 |             (level_len + 1) / 2
   |             ^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `level_len.div_ceil(2)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
   = note: `-D clippy::manual-div-ceil` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_div_ceil)]`
```

#### Summary of Changes

Fix 'em.