### PR TITLE
clippy: is_empty

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -649,7 +649,7 @@ impl ServeRepair {
         let identity_keypair = self.cluster_info.keypair().clone();
         let my_id = identity_keypair.pubkey();
 
-        let max_buffered_packets = if self.repair_whitelist.read().unwrap().len() > 0 {
+        let max_buffered_packets = if !self.repair_whitelist.read().unwrap().is_empty() {
             4 * MAX_REQUESTS_PER_ITERATION
         } else {
             2 * MAX_REQUESTS_PER_ITERATION


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for `len_zero`: https://rust-lang.github.io/rust-clippy/master/index.html#len_zero.

#### Summary of Changes

Fix 'em.