### PR TITLE
clippy: next_back

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -203,7 +203,7 @@ mod tests {
                     None
                 }
             })
-            .last()
+            .next_back()
             .unwrap()
             .unwrap();
 

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -3295,7 +3295,7 @@ mod tests {
             generated_record
                 .path
                 .split('-')
-                .last()
+                .next_back()
                 .unwrap()
                 .split('.')
                 .next()


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is `double_ended_iterator_last`: https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last.

#### Summary of Changes

Fix 'em.