### PR TITLE
clippy: repeat_n

### DIFF
--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -182,7 +182,7 @@ impl RunLengthEncoding {
             .iter()
             .map(|bit_count| usize::from(bit_count.0))
             .zip([1, 0].iter().cycle())
-            .flat_map(|(bit_count, bit)| std::iter::repeat(bit).take(bit_count))
+            .flat_map(|(bit_count, bit)| std::iter::repeat_n(bit, bit_count))
             .enumerate()
             .filter(|(_, bit)| **bit == 1)
             .map_while(|(offset, _)| {


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for `manual_repeat_n`: https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n.

#### Summary of Changes

Fix 'em.