### PR TITLE
clippy: manual_ok_err

### DIFF
--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -39,10 +39,7 @@ impl TransactionProcessingResultExtensions for TransactionProcessingResult {
     }
 
     fn processed_transaction(&self) -> Option<&ProcessedTransaction> {
-        match self {
-            Ok(processed_tx) => Some(processed_tx),
-            Err(_) => None,
-        }
+        self.as_ref().ok()
     }
 
     fn flattened_result(&self) -> TransactionResult<()> {


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for `manual_ok_err`:
```
error: manual implementation of `ok`
  --> svm/src/transaction_processing_result.rs:42:9
   |
42 | /         match self {
43 | |             Ok(processed_tx) => Some(processed_tx),
44 | |             Err(_) => None,
45 | |         }
   | |_________^ help: replace with: `self.ok()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err
   = note: `-D clippy::manual-ok-err` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_ok_err)]`
```


#### Summary of Changes

Fix 'em.