### PR TITLE
clippy: obfuscated_if_else

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -620,8 +620,8 @@ impl BankForks {
 impl ForkGraph for BankForks {
     fn relationship(&self, a: Slot, b: Slot) -> BlockRelation {
         let known_slot_range = self.root()..=self.highest_slot();
-        (known_slot_range.contains(&a) && known_slot_range.contains(&b))
-            .then(|| {
+        if known_slot_range.contains(&a) && known_slot_range.contains(&b) {
+            {
                 (a == b)
                     .then_some(BlockRelation::Equal)
                     .or_else(|| {
@@ -637,8 +637,10 @@ impl ForkGraph for BankForks {
                         })
                     })
                     .unwrap_or(BlockRelation::Unrelated)
-            })
-            .unwrap_or(BlockRelation::Unknown)
+            }
+        } else {
+            BlockRelation::Unknown
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem

There are new clippy lints to resolve before we can upgrade rust to 1.86.0.

This PR is for `obfuscated_if_else`:
```
error: this method chain can be written more clearly with `if .. else ..`
   --> runtime/src/bank_forks.rs:623:9
    |
623 | /         (known_slot_range.contains(&a) && known_slot_range.contains(&b))
624 | |             .then(|| {
625 | |                 (a == b)
626 | |                     .then_some(BlockRelation::Equal)
...   |
640 | |             })
641 | |             .unwrap_or(BlockRelation::Unknown)
    | |______________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else
    = note: `-D clippy::obfuscated-if-else` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::obfuscated_if_else)]`
help: try
    |
623 ~         if known_slot_range.contains(&a) && known_slot_range.contains(&b) { {
624 +                 (a == b)
625 +                     .then_some(BlockRelation::Equal)
626 +                     .or_else(|| {
627 +                         self.banks.get(&b).and_then(|bank| {
628 +                             bank.ancestors
629 +                                 .contains_key(&a)
630 +                                 .then_some(BlockRelation::Ancestor)
631 +                         })
632 +                     })
633 +                     .or_else(|| {
634 +                         self.descendants.get(&b).and_then(|slots| {
635 +                             slots.contains(&a).then_some(BlockRelation::Descendant)
636 +                         })
637 +                     })
638 +                     .unwrap_or(BlockRelation::Unrelated)
639 +             } } else { BlockRelation::Unknown }
    |
```


#### Summary of Changes

Fix 'em.