### PR TITLE
Make BP sessions race-free with poh by (un)pausing

### DIFF
--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -279,6 +279,7 @@ fn test_scheduler_producing_blocks() {
         .write()
         .unwrap()
         .set_bank(tpu_bank.clone_with_scheduler(), false);
+    tpu_bank.unpause_new_block_production_scheduler();
     let tpu_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     assert_eq!(tpu_bank.transaction_count(), 0);
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7506,6 +7506,7 @@ dependencies = [
  "ahash 0.8.11",
  "aquamarine",
  "arrayref",
+ "assert_matches",
  "base64 0.22.1",
  "bincode",
  "blake3",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,7 @@ agave-reserved-account-keys = { workspace = true }
 ahash = { workspace = true }
 aquamarine = { workspace = true }
 arrayref = { workspace = true }
+assert_matches = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
@@ -106,7 +107,6 @@ name = "solana_runtime"
 
 [dev-dependencies]
 agave-transaction-view = { workspace = true }
-assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
 memoffset = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7330,6 +7330,7 @@ dependencies = [
  "ahash 0.8.11",
  "aquamarine",
  "arrayref",
+ "assert_matches",
  "base64 0.22.1",
  "bincode",
  "blake3",


### PR DESCRIPTION
#### Problem

Much like #5651, there's possibility of poh-related race condition for block producing unified scheduler; this time, around session start.

#### Summary of Changes

Fix it.

naming is deliberately chosen so that the whole new code-path is special cased by itself.

also note that there should be no functional change to block verification scheduler behavior.

extracted from #3946