### PR TITLE
Refactor - `TransactionContext` guards `AccountSharedData`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10830,6 +10830,7 @@ dependencies = [
  "solana-account",
  "solana-account-info",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-pubkey",
  "solana-rent",
  "solana-signature",

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -992,8 +992,9 @@ mod tests {
                 .set_owner(bpf_loader_deprecated::id());
             invoke_context
                 .transaction_context
-                .accounts()
-                .try_borrow_mut(0)
+                .get_account_at_index(0)
+                .unwrap()
+                .try_borrow_mut()
                 .unwrap()
                 .set_owner(bpf_loader_deprecated::id());
 
@@ -1189,8 +1190,9 @@ mod tests {
                 .set_owner(bpf_loader_deprecated::id());
             invoke_context
                 .transaction_context
-                .accounts()
-                .try_borrow_mut(0)
+                .get_account_at_index(0)
+                .unwrap()
+                .try_borrow_mut()
                 .unwrap()
                 .set_owner(bpf_loader_deprecated::id());
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -11,7 +11,6 @@ use {
         enable_loader_v4, mask_out_rent_epoch_in_vm_serialization,
         remove_accounts_executable_flag_checks,
     },
-    solana_account::WritableAccount,
     solana_bincode::limited_deserialize,
     solana_clock::Slot,
     solana_instruction::{error::InstructionError, AccountMeta},
@@ -38,7 +37,7 @@ use {
         ebpf::{self, MM_HEAP_START},
         elf::Executable,
         error::{EbpfError, ProgramResult},
-        memory_region::{AccessType, MemoryCowCallback, MemoryMapping, MemoryRegion},
+        memory_region::{AccessType, MemoryMapping, MemoryRegion},
         program::BuiltinProgram,
         verifier::RequisiteVerifier,
         vm::{ContextObject, EbpfVm},
@@ -251,30 +250,12 @@ fn create_vm<'a, 'b>(
 ) -> Result<EbpfVm<'a, InvokeContext<'b>>, Box<dyn std::error::Error>> {
     let stack_size = stack.len();
     let heap_size = heap.len();
-    let accounts = Rc::clone(invoke_context.transaction_context.accounts());
     let memory_mapping = create_memory_mapping(
         program,
         stack,
         heap,
         regions,
-        Some(Box::new(move |index_in_transaction| {
-            // The two calls below can't really fail. If they fail because of a bug,
-            // whatever is writing will trigger an EbpfError::AccessViolation like
-            // if the region was readonly, and the transaction will fail gracefully.
-            let mut account = accounts
-                .try_borrow_mut(index_in_transaction as IndexOfAccount)
-                .map_err(|_| ())?;
-            accounts
-                .touch(index_in_transaction as IndexOfAccount)
-                .map_err(|_| ())?;
-
-            if account.is_shared() {
-                // See BorrowedAccount::make_data_mut() as to why we reserve extra
-                // MAX_PERMITTED_DATA_INCREASE bytes here.
-                account.reserve(MAX_PERMITTED_DATA_INCREASE);
-            }
-            Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
-        })),
+        invoke_context.transaction_context,
     )?;
     invoke_context.set_syscall_context(SyscallContext {
         allocator: BpfAllocator::new(heap_size as u64),
@@ -353,7 +334,7 @@ fn create_memory_mapping<'a, 'b, C: ContextObject>(
     stack: &'b mut [u8],
     heap: &'b mut [u8],
     additional_regions: Vec<MemoryRegion>,
-    cow_cb: Option<MemoryCowCallback>,
+    transaction_context: &TransactionContext,
 ) -> Result<MemoryMapping<'a>, Box<dyn std::error::Error>> {
     let config = executable.get_config();
     let sbpf_version = executable.get_sbpf_version();
@@ -374,11 +355,12 @@ fn create_memory_mapping<'a, 'b, C: ContextObject>(
     .chain(additional_regions)
     .collect();
 
-    Ok(if let Some(cow_cb) = cow_cb {
-        MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version)?
-    } else {
-        MemoryMapping::new(regions, config, sbpf_version)?
-    })
+    Ok(MemoryMapping::new_with_cow(
+        regions,
+        transaction_context.account_data_write_access_handler(),
+        config,
+        sbpf_version,
+    )?)
 }
 
 declare_builtin_function!(

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -2210,8 +2210,9 @@ mod tests {
         {
             let mut account = invoke_context
                 .transaction_context
-                .accounts()
-                .try_borrow_mut(1)
+                .get_account_at_index(1)
+                .unwrap()
+                .try_borrow_mut()
                 .unwrap();
             account.set_data(b"baz".to_vec());
         }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8963,6 +8963,7 @@ dependencies = [
  "serde_derive",
  "solana-account",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-pubkey",
  "solana-rent",
  "solana-signature",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8304,6 +8304,7 @@ dependencies = [
  "serde_derive",
  "solana-account",
  "solana-instruction",
+ "solana-instructions-sysvar",
  "solana-pubkey",
  "solana-rent",
  "solana-signature",

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -1,6 +1,4 @@
 use {
-    solana_account::WritableAccount,
-    solana_instructions_sysvar as instructions,
     solana_measure::measure_us,
     solana_program_runtime::invoke_context::InvokeContext,
     solana_svm_transaction::svm_message::SVMMessage,
@@ -22,28 +20,11 @@ pub(crate) fn process_message(
     accumulated_consumed_units: &mut u64,
 ) -> Result<(), TransactionError> {
     debug_assert_eq!(program_indices.len(), message.num_instructions());
-    for (instruction_index, ((program_id, instruction), program_indices)) in message
+    for (top_level_instruction_index, ((program_id, instruction), program_indices)) in message
         .program_instructions_iter()
         .zip(program_indices.iter())
         .enumerate()
     {
-        // Fixup the special instructions key if present
-        // before the account pre-values are taken care of
-        if let Some(account_index) = invoke_context
-            .transaction_context
-            .find_index_of_account(&instructions::id())
-        {
-            let mut mut_account_ref = invoke_context
-                .transaction_context
-                .accounts()
-                .try_borrow_mut(account_index)
-                .map_err(|_| TransactionError::InvalidAccountIndex)?;
-            instructions::store_current_index(
-                mut_account_ref.data_as_mut_slice(),
-                instruction_index as u16,
-            );
-        }
-
         let mut instruction_accounts = Vec::with_capacity(instruction.accounts.len());
         for (instruction_account_index, index_in_transaction) in
             instruction.accounts.iter().enumerate()
@@ -104,7 +85,9 @@ pub(crate) fn process_message(
             .process_instructions
             .total_us += process_instruction_us;
 
-        result.map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
+        result.map_err(|err| {
+            TransactionError::InstructionError(top_level_instruction_index as u8, err)
+        })?;
     }
     Ok(())
 }
@@ -121,7 +104,8 @@ mod tests {
         },
         rand0_7::thread_rng,
         solana_account::{
-            Account, AccountSharedData, ReadableAccount, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
+            Account, AccountSharedData, ReadableAccount, WritableAccount,
+            DUMMY_INHERITABLE_ACCOUNT_FIELDS,
         },
         solana_ed25519_program::new_ed25519_instruction,
         solana_hash::Hash,

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
+solana-instructions-sysvar = { workspace = true }
 solana-pubkey = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -132,17 +132,6 @@ impl TransactionAccounts {
             .map_err(|_| InstructionError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_mut(
-        &self,
-        index: IndexOfAccount,
-    ) -> Result<RefMut<'_, AccountSharedData>, InstructionError> {
-        self.accounts
-            .get(index as usize)
-            .ok_or(InstructionError::MissingAccount)?
-            .try_borrow_mut()
-            .map_err(|_| InstructionError::AccountBorrowFailed)
-    }
-
     pub fn into_accounts(self) -> Vec<AccountSharedData> {
         self.accounts
             .into_iter()


### PR DESCRIPTION
#### Problem
Currently the general program runtime has mutable / write access to `AccountSharedData`. It would be better if only the `TransactionContext` had direct access to it and everything else would have to go through `TransactionContext`, `InstructionContext` and `BorrowedAccount`. This way all the rules around account modifications would be enforced in one place and in one file, making it a lot easier to reason about. The only exception is the overwriting of bytes in memory mapped regions of account data via the SBPF vm.

#### Summary of Changes
- Puts `TransactionContext::get_account_at_index()` behind the `dev-context-only-utils` CFG feature.
- Moves call of `instructions::store_current_index()` from `process_message()` into `TransactionContext::push()`.
- Moves `account_data_write_access_handler()` from `create_vm()` into `TransactionContext`.
- Removes `TransactionAccounts::try_borrow_mut()`.