### PR TITLE
Further optimizations to ClusterSlots

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -1,4 +1,5 @@
 pub mod cluster_slots;
+pub mod slot_supporters;
 use {
     cluster_slots::ClusterSlots,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -119,12 +119,7 @@ impl ClusterSlotsService {
                 }
             }
             let root_bank = bank_forks.read().unwrap().root_bank();
-            cluster_slots.update(
-                root_bank.slot(),
-                epoch_specs.current_epoch_staked_nodes(),
-                &cluster_info,
-                root_bank.epoch(),
-            );
+            cluster_slots.update(&root_bank, &cluster_info);
             process_cluster_slots_updates_elapsed.stop();
 
             cluster_slots_service_timing.update(

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -31,11 +31,12 @@ const CLUSTER_SLOTS_TRIM_SIZE: usize = 50000;
 type PubkeyHasherBuilder = RandomState;
 pub(crate) type ValidatorStakesMap = HashMap<Pubkey, Stake, PubkeyHasherBuilder>;
 
-///Static snapshot of the information about a given epoch's stake distribution
+/// Static snapshot of the information about a given epoch's stake distribution.
 struct EpochStakeInfo {
     validator_stakes: Arc<ValidatorStakesMap>,
     pubkey_to_index: Arc<HashMap<Pubkey, usize>>,
-    total_stake: Stake, // total amount of stake across all validators in validator_stakes.
+    /// total amount of stake across all validators in `validator_stakes`.
+    total_stake: Stake,
 }
 
 impl From<&EpochStakes> for EpochStakeInfo {

--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -1,0 +1,156 @@
+use {
+    crate::consensus::Stake,
+    crate::replay_stage::DUPLICATE_THRESHOLD,
+    solana_sdk::
+        pubkey::Pubkey
+    ,
+    std::{
+        collections::HashMap,
+        hash::RandomState,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+    },
+};
+
+//This is intended to be switched to solana_pubkey::PubkeyHasherBuilder
+type PubkeyHasherBuilder = RandomState;
+pub(crate) type IndexMap =
+    HashMap</*node:*/ Pubkey, /*index*/ usize, PubkeyHasherBuilder>;
+
+/// Amount of stake that needs to lock the slot for us to stop updating it.
+/// This must be above `DUPLICATE_THRESHOLD` but also high enough to not starve
+/// repair (as it will prefer nodes that have confirmed a slot)
+const FREEZE_THRESHOLD: f64 = 0.9;
+
+// whatever freeze threshold we should be above DUPLICATE_THRESHOLD in order to not break consensus.
+// 1.1 margin is due to us not properly tracking epoch boundaries
+static_assertions::const_assert!(FREEZE_THRESHOLD > DUPLICATE_THRESHOLD * 1.1);
+
+/// Pubkey-stake map for nodes that have confirmed this slot.
+/// Internally, this uses an index array that is shared for all instances 
+/// within an epoch. 
+#[derive(Debug)]
+pub struct SlotSupporters {
+    total_support: AtomicU64, // total support for this slot = supported_stakes.sum()
+    total_stake: u64,         // total staked amount at this slot
+    supporting_stakes: Vec<AtomicU64>, // amount of stake per validator that has confirmed this slot
+    pubkey_to_index_map: Arc<IndexMap>, // map from pubkey to node index in supporting_stakes vector
+}
+
+fn repeat_atomic_u64(count: usize) -> impl Iterator<Item = AtomicU64> {
+    std::iter::repeat_with(|| AtomicU64::new(0)).take(count)
+}
+
+impl SlotSupporters {
+    pub(crate) fn memory_usage(&self) -> usize {
+        self.supporting_stakes.capacity() * std::mem::size_of::<AtomicU64>()
+    }
+
+    #[inline]
+    pub(crate) fn set_support_by_index(&self, index: usize, stake: Stake) {
+        let old = self.supporting_stakes[index].swap(stake, Ordering::Relaxed);
+        if stake > old {
+            self.total_support.fetch_add(stake - old, Ordering::Relaxed);
+        }
+    }
+    /// Current support for this slot (sum of supporting stakes)
+      #[inline]
+    pub(crate) fn total_support(&self)->Stake{
+        self
+        .total_support
+        .load(std::sync::atomic::Ordering::Relaxed)
+    }
+    /// Total staked amount for this slot
+    ///   #[inline]
+    pub(crate) fn total_stake(&self)->Stake{
+        self
+        .total_stake
+    } 
+     #[inline]
+    pub(crate) fn is_frozen(&self) -> bool {
+        let slot_weight_f64 = self.total_support() as f64;
+
+        // once slot is confirmed beyond `FREEZE_THRESHOLD` we should not need
+        // to update the stakes for it anymore
+        slot_weight_f64 / self.total_stake as f64 > FREEZE_THRESHOLD
+    }
+
+    #[inline]
+    pub(crate) fn set_support_by_pubkey(&self, pubkey: &Pubkey, stake: Stake) -> Result<(), ()> {
+        let Some(idx) = self.pubkey_to_index_map.get(pubkey) else {
+            return Err(());
+        };
+        self.set_support_by_index(*idx, stake);
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn get_support_by_index(&self, index: usize) -> Option<Stake> {
+        Some(self.supporting_stakes.get(index)?.load(Ordering::Relaxed))
+    }
+    #[inline]
+    pub(crate) fn get_support_by_pubkey(&self, key: &Pubkey) -> Option<Stake> {
+        let index = self.pubkey_to_index_map.get(key)?;
+        self.get_support_by_index(*index)
+    }
+
+    pub(crate) fn new(total_stake: Stake, index_map: Arc<IndexMap>) -> Self {
+        Self {
+            total_support: AtomicU64::new(0),
+            total_stake,
+            supporting_stakes: Vec::from_iter(repeat_atomic_u64(index_map.len())),
+            pubkey_to_index_map: index_map,
+        }
+    }
+    // recycles the object for new slot. If index_map is not provided,
+    // the old one will be reused (which is fine within the epoch)
+    pub(crate) fn recycle(mut self, total_stake: Stake, index_map: &Arc<IndexMap>) -> Self {
+        self.total_stake = total_stake;
+        self.total_support.store(0, Ordering::Relaxed);
+        let same_epoch = Arc::as_ptr(index_map) == Arc::as_ptr(&self.pubkey_to_index_map);
+        if !same_epoch {
+            let old_len = self.supporting_stakes.len();
+            let new_len = index_map.len();
+            if new_len < old_len * 2 {
+                // if new length is much less than allocation, reallocate
+                self.supporting_stakes = Vec::from_iter(repeat_atomic_u64(new_len));
+            } else {
+                // cut vec to length if needed
+                self.supporting_stakes.truncate(new_len);
+                // reset all old elements to zero
+                self.supporting_stakes
+                    .iter_mut()
+                    .for_each(|v| v.store(0, Ordering::Relaxed));
+                if self.supporting_stakes.len() < new_len {
+                    let num_missing = new_len - self.supporting_stakes.len();
+                    self.supporting_stakes
+                        .extend(repeat_atomic_u64(num_missing));
+                }
+            }
+            self.pubkey_to_index_map = index_map.clone();
+        } else {
+            self.supporting_stakes
+                .iter_mut()
+                .for_each(|v| v.store(0, Ordering::Relaxed));
+        }
+        self
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a Pubkey, Stake)> {
+        self.pubkey_to_index_map
+            .iter()
+            .map(|(pk, &idx)| (pk, self.get_support_by_index(idx).unwrap()))
+    }
+
+    pub fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Pubkey> {
+        self.pubkey_to_index_map.iter().filter_map(|(pk, &idx)| {
+            if self.get_support_by_index(idx).unwrap() > 0 {
+                Some(pk)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -99,6 +99,17 @@ impl SlotSupporters {
             pubkey_to_index_map: index_map,
         }
     }
+    pub(crate) fn new_blank() -> Self {
+        Self {
+            total_support: AtomicU64::new(0),
+            total_stake: 0,
+            supporting_stakes: vec![],
+            pubkey_to_index_map: Arc::new(HashMap::default()),
+        }
+    }
+    pub(crate) fn is_blank(&self) -> bool {
+        self.total_stake == 0
+    }
     // recycles the object for new slot. If index_map is not provided,
     // the old one will be reused (which is fine within the epoch)
     pub(crate) fn recycle(mut self, total_stake: Stake, index_map: &Arc<IndexMap>) -> Self {

--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -1,9 +1,6 @@
 use {
-    crate::consensus::Stake,
-    crate::replay_stage::DUPLICATE_THRESHOLD,
-    solana_sdk::
-        pubkey::Pubkey
-    ,
+    crate::{consensus::Stake, replay_stage::DUPLICATE_THRESHOLD},
+    solana_sdk::pubkey::Pubkey,
     std::{
         collections::HashMap,
         hash::RandomState,
@@ -29,8 +26,8 @@ const FREEZE_THRESHOLD: f64 = 0.9;
 static_assertions::const_assert!(FREEZE_THRESHOLD > DUPLICATE_THRESHOLD * 1.1);
 
 /// Pubkey-stake map for nodes that have confirmed this slot.
-/// Internally, this uses an index array that is shared for all instances 
-/// within an epoch. 
+/// Internally, this uses an index array that is shared for all instances
+/// within an epoch.
 #[derive(Debug)]
 pub struct SlotSupporters {
     total_support: AtomicU64, // total support for this slot = supported_stakes.sum()
@@ -56,19 +53,17 @@ impl SlotSupporters {
         }
     }
     /// Current support for this slot (sum of supporting stakes)
-      #[inline]
-    pub(crate) fn total_support(&self)->Stake{
-        self
-        .total_support
-        .load(std::sync::atomic::Ordering::Relaxed)
+    #[inline]
+    pub(crate) fn total_support(&self) -> Stake {
+        self.total_support
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
     /// Total staked amount for this slot
     ///   #[inline]
-    pub(crate) fn total_stake(&self)->Stake{
-        self
-        .total_stake
-    } 
-     #[inline]
+    pub(crate) fn total_stake(&self) -> Stake {
+        self.total_stake
+    }
+    #[inline]
     pub(crate) fn is_frozen(&self) -> bool {
         let slot_weight_f64 = self.total_support() as f64;
 
@@ -138,13 +133,13 @@ impl SlotSupporters {
         self
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a Pubkey, Stake)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Pubkey, Stake)> {
         self.pubkey_to_index_map
             .iter()
             .map(|(pk, &idx)| (pk, self.get_support_by_index(idx).unwrap()))
     }
 
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = &'a Pubkey> {
+    pub fn keys(&self) -> impl Iterator<Item = &Pubkey> {
         self.pubkey_to_index_map.iter().filter_map(|(pk, &idx)| {
             if self.get_support_by_index(idx).unwrap() > 0 {
                 Some(pk)

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         cluster_info_vote_listener::SlotVoteTracker,
-        cluster_slots_service::cluster_slots::SlotPubkeys,
+        cluster_slots_service::slot_supporters::SlotSupporters,
         consensus::{Stake, ThresholdDecision, VotedStakes},
         replay_stage::SUPERMINORITY_THRESHOLD,
     },
@@ -211,7 +211,7 @@ pub struct PropagatedStats {
     pub is_leader_slot: bool,
     pub prev_leader_slot: Option<Slot>,
     pub slot_vote_tracker: Option<Arc<RwLock<SlotVoteTracker>>>,
-    pub cluster_slot_pubkeys: Option<Arc<RwLock<SlotPubkeys>>>,
+    pub cluster_slot_pubkeys: Option<Arc<SlotSupporters>>,
     pub total_epoch_stake: u64,
 }
 

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -951,7 +951,7 @@ impl RepairService {
             .iter()
             .filter_map(|(pubkey, stake)| {
                 let peer_repair_addr = cluster_info
-                    .lookup_contact_info(&pubkey, |node| node.serve_repair(Protocol::UDP));
+                    .lookup_contact_info(pubkey, |node| node.serve_repair(Protocol::UDP));
                 if let Some(Some(peer_repair_addr)) = peer_repair_addr {
                     trace!("Repair peer {pubkey} has a valid repair socket: {peer_repair_addr:?}");
                     Some((
@@ -1751,7 +1751,8 @@ mod test {
         // a valid target for repair
         let dead_slot = 9;
         let cluster_slots = ClusterSlots::default();
-        cluster_slots.insert_node_id(dead_slot, *valid_repair_peer.pubkey(), Some(42));
+        cluster_slots.fake_epoch_info_for_tests(HashMap::from([(*valid_repair_peer.pubkey(), 42)]));
+        cluster_slots.insert_node_id(dead_slot, *valid_repair_peer.pubkey());
         cluster_info.insert_info(valid_repair_peer);
 
         // Not enough time has passed, should not update the

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -949,9 +949,9 @@ impl RepairService {
         // Filter out any peers that don't have a valid repair socket.
         let repair_peers: Vec<(Pubkey, SocketAddr, u32)> = peers_with_slot
             .iter()
-            .filter_map(|(pubkey, stake)| {                
+            .filter_map(|(pubkey, stake)| {
                 let peer_repair_addr = cluster_info
-                    .lookup_contact_info(pubkey, |node| node.serve_repair(Protocol::UDP));
+                    .lookup_contact_info(&pubkey, |node| node.serve_repair(Protocol::UDP));
                 if let Some(Some(peer_repair_addr)) = peer_repair_addr {
                     trace!("Repair peer {pubkey} has a valid repair socket: {peer_repair_addr:?}");
                     Some((

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -948,11 +948,8 @@ impl RepairService {
 
         // Filter out any peers that don't have a valid repair socket.
         let repair_peers: Vec<(Pubkey, SocketAddr, u32)> = peers_with_slot
-            .read()
-            .unwrap()
             .iter()
-            .filter_map(|(pubkey, stake)| {
-                let stake = stake.load(Ordering::Relaxed);
+            .filter_map(|(pubkey, stake)| {                
                 let peer_repair_addr = cluster_info
                     .lookup_contact_info(pubkey, |node| node.serve_repair(Protocol::UDP));
                 if let Some(Some(peer_repair_addr)) = peer_repair_addr {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3751,7 +3751,7 @@ impl ReplayStage {
             .unwrap_or_default();
 
         let cluster_slot_pubkeys = cluster_slot_pubkeys
-            .map(|v|  v.keys().cloned().collect())
+            .map(|v| v.keys().cloned().collect())
             .unwrap_or_default();
 
         Self::update_fork_propagated_threshold_from_votes(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3751,7 +3751,7 @@ impl ReplayStage {
             .unwrap_or_default();
 
         let cluster_slot_pubkeys = cluster_slot_pubkeys
-            .map(|v| v.read().unwrap().keys().cloned().collect())
+            .map(|v|  v.keys().cloned().collect())
             .unwrap_or_default();
 
         Self::update_fork_propagated_threshold_from_votes(


### PR DESCRIPTION
#### Problem
Followup for clusterslots optimizations https://github.com/anza-xyz/agave/pull/5476

- Implementation had farily high memory consumption upper bound
- Epoch transitions were not well handled (problem inherited from original code)

#### Summary of Changes

- use Vec<AtomicU64> instead of hashmaps as primary storage: reduces memory usage 5x, likely improves speed too (need to measure)
- properly track stake across epoch boundaries
