### PR TITLE
deps: Relax spl dependencies

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   check:
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -76,7 +76,7 @@ jobs:
           cargo check
 
   test_cli:
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -106,7 +106,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    if: false
+    if: github.repository == 'anza-xyz/agave'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -580,7 +580,7 @@ solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.3.0" }
 spl-associated-token-account = "6.0.0"
 spl-generic-token = "1.0.1"
-spl-instruction-padding = "0.3"
+spl-instruction-padding = "0.3.0"
 spl-memo = "6.0.0"
 spl-pod = "0.5.1"
 spl-token = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -578,16 +578,16 @@ solana-zk-keygen = { path = "zk-keygen", version = "=2.3.0" }
 solana-zk-sdk = { path = "zk-sdk", version = "=2.3.0" }
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.3.0" }
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.3.0" }
-spl-associated-token-account = "=6.0.0"
+spl-associated-token-account = "6.0.0"
 spl-generic-token = "1.0.1"
 spl-instruction-padding = "0.3"
-spl-memo = "=6.0.0"
-spl-pod = "=0.5.1"
-spl-token = "=8.0.0"
-spl-token-2022 = "=8.0.0"
+spl-memo = "6.0.0"
+spl-pod = "0.5.1"
+spl-token = "8.0.0"
+spl-token-2022 = "8.0.0"
 spl-token-confidential-transfer-proof-extraction = "0.3.0"
-spl-token-group-interface = "=0.6.0"
-spl-token-metadata-interface = "=0.7.0"
+spl-token-group-interface = "0.6.0"
+spl-token-metadata-interface = "0.7.0"
 static_assertions = "1.1.0"
 stream-cancel = "0.8.2"
 strum = "0.24"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -43,7 +43,7 @@ solana-tps-client = { workspace = true }
 solana-tpu-client = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
-spl-instruction-padding = { workspace = true }
+spl-instruction-padding = { version = "=0.3.0", features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -85,7 +85,7 @@ solana-transaction-status = { workspace = true }
 solana-udp-client = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
-spl-memo = { workspace = true, features = ["no-entrypoint"] }
+spl-memo = { version = "=6.0.0", features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -32,7 +32,7 @@ solana-system-interface = "=1.0"
 solana-system-transaction = "=2.2.1"
 solana-transaction = "=2.2.2"
 solana-version = { workspace = true }
-spl-memo = { workspace = true, features = ["no-entrypoint"] }
+spl-memo = { version = "=6.0.0", features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -46,9 +46,9 @@ solana-version = { path = "../../version" }
 solana-test-validator = { path = "../../test-validator" }
 solana-transaction-context = { path = "../../transaction-context" }
 solana-transaction-status = { path = "../../transaction-status" }
-spl-associated-token-account = "=6.0.0"
-spl-token = "=8.0.0"
-spl-token-2022 = "=8.0.0"
+spl-associated-token-account = "6.0.0"
+spl-token = "8.0.0"
+spl-token-2022 = "8.0.0"
 termcolor = "1.4.1"
 thiserror = "1.0.68"
 tokio = "1.29.1"

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -29,8 +29,8 @@ solana-rpc-client-api = { workspace = true }
 solana-sdk = "=2.2.2"
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
-spl-associated-token-account = { workspace = true }
-spl-token = { workspace = true, features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "=6.0.0", features = ["no-entrypoint"] }
+spl-token = { version = "=8.0.0", features = ["no-entrypoint"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 


### PR DESCRIPTION
#### Problem

The sdk dependencies are now relaxed for non-binary crates in Agave, but the spl crates are still pinned, which can lead to downstream build issues like
[this CI run](https://github.com/anza-xyz/agave/actions/runs/14316385404/job/40123415833?pr=5629).

#### Summary of changes

Relax the SPL dependencies in the whole agave repo. Binary crates with direct non-dev dependencies on SPL crates pin the version. The list of binaries includes:

* bench-tps (for instruction-padding)
* CLI (for spl-memo)
* faucet (for spl-memo)
* tokens (for spl-token)


NOTE: Since we're considering backporting #5594, I also put the backport label here.