### PR TITLE
CI: Disable downstream jobs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -76,7 +76,7 @@ jobs:
           cargo check
 
   test_cli:
-    if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -106,7 +106,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
#### Problem

The spl-stake-pool repo upgraded to spl-token-2022 8.0.1, but the monorepo is still on v8.0.0, which causes the downstream job to fail when choosing a version of spl-token-2022.

#### Summary of changes

The real fix is to relax the spl dependencies with #5704, but in the meantime, just disable the downstream jobs.