### PR TITLE
Configure number of BV and BP threads separately

### DIFF
--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -49,6 +49,7 @@ pub(crate) fn ensure_banking_stage_setup(
     cluster_info: &impl LikeClusterInfo,
     poh_recorder: &Arc<RwLock<PohRecorder>>,
     transaction_recorder: TransactionRecorder,
+    num_threads: u32,
 ) {
     let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
     let unified_receiver = channels.unified_receiver().clone();
@@ -87,6 +88,7 @@ pub(crate) fn ensure_banking_stage_setup(
     );
 
     pool.register_banking_stage(
+        Some(num_threads.try_into().unwrap()),
         unified_receiver,
         banking_packet_handler,
         transaction_recorder,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -5,7 +5,7 @@ use {
     itertools::Itertools,
     log::*,
     solana_core::{
-        banking_stage::unified_scheduler::ensure_banking_stage_setup,
+        banking_stage::{unified_scheduler::ensure_banking_stage_setup, BankingStage},
         banking_trace::BankingTracer,
         consensus::{
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
@@ -251,6 +251,7 @@ fn test_scheduler_producing_blocks() {
         &cluster_info,
         &poh_recorder,
         transaction_recorder,
+        BankingStage::num_threads(),
     );
     bank_forks.write().unwrap().install_scheduler_pool(pool);
 


### PR DESCRIPTION
#### Problem

Currently, it's not possible to configure the number of handler threads of unified scheduler for bv and bp independently.

#### Summary of Changes

Make it possible for ease of benchmarking and wiring to the existing `BankingStage::num_threads()`.

also note that there should be no functional change to block verification scheduler behavior.

extracted from #3946