### PR TITLE
Consolidate and cleanup clippy configuration

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,7 +1,0 @@
-too-many-arguments-threshold = 9
-
-# Disallow specific methods from being used
-disallowed-methods = [
-    { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
-    { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,16 @@ check-cfg = [
     'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
 
+[workspace.lints.rust]
+warnings = "deny"
+
+# Clippy lint configuration that can not be applied in clippy.toml
+[workspace.lints.clippy]
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+used_underscore_binding = "deny"
+
 [workspace.dependencies]
 Inflector = "0.11.4"
 axum = "0.7.9"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,7 @@
-deny-attributes = ["warnings", "clippy::default_trait_access", "clippy::arithmetic_side_effects", "clippy::manual_let_else", "clippy::used_underscore_bindings"]
+too-many-arguments-threshold = 9
+
+# Disallow specific methods from being used
+disallowed-methods = [
+    { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
+    { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
+]


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/5673 added `clippy.toml` when we already had `.clippy.toml`. The new file was getting automatically ignored:
```
warning: using config file `/.../solana/.clippy.toml`, `/.../solana/clippy.toml` will be ignored
```
and contained invalid lint configuration:
```
error: error reading Clippy's configuration file: unknown field `deny-attributes`, expected one of
...
```

#### Summary of Changes
- Move invalid config in clippy.toml to Cargo.toml
- Move contents of .clippy.toml to clippy.toml
