### PR TITLE
feature-set: Remove dead partitioned epoch rewards gate

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -436,9 +436,6 @@ pub mod fix_recent_blockhashes {
 pub mod update_rewards_from_cached_accounts {
     solana_pubkey::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
-pub mod enable_partitioned_epoch_reward {
-    solana_pubkey::declare_id!("9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK");
-}
 
 pub mod partitioned_epoch_rewards_superfeature {
     solana_pubkey::declare_id!("PERzQrt5gBD1XEe2c9XdFWqwgHY3mr7cYWbm5V772V8");
@@ -1116,7 +1113,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (executables_incur_cpi_data_cost::id(), "Executables incur CPI data costs"),
         (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
         (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
-        (enable_partitioned_epoch_reward::id(), "enable partitioned rewards at epoch boundary #32166"),
         (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
         (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
         (default_units_per_instruction::id(), "Default max tx-wide compute units calculated per instruction"),


### PR DESCRIPTION
#### Problem
This feature was replaced by a feature that has been activated:
https://github.com/anza-xyz/agave/blob/761bbc776bdeefc1cfb27d0a1121fbc0ec7f2253/feature-set/src/lib.rs#L1244

#### Summary of Changes
The feature being removed does not gate any logic in Agave, and it has not (nor will it ever) be activated. So, remove it from the list

```
$ solana feature status 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK -ud
Feature                                      | Status                  | Activation Slot | Description
9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK | inactive                | NA              | enable partitioned rewards at epoch boundary #32166

$ solana feature status 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK -ut
Feature                                      | Status                  | Activation Slot | Description
9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK | inactive                | NA              | enable partitioned rewards at epoch boundary #32166

$ solana feature status 9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK -um
Feature                                      | Status                  | Activation Slot | Description
9bn2vTJUsUcnpiZWbu2woSKtTGW3ErZC9ERv88SDqQjK | inactive                | NA              | enable partitioned rewards at epoch boundary #32166
```
