### PR TITLE
Prevent the shredder from making oversized batches

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5679,6 +5679,31 @@ pub mod tests {
     }
 
     #[test]
+    fn test_batch_size() {
+        let slot = 1;
+        let num_entries = 5000;
+        let entries = create_ticks(num_entries, 1, Hash::new_unique());
+        let (d, c) = Shredder::new(slot, 0, 0, 0).unwrap().entries_to_shreds(
+            &Keypair::new(),
+            &entries,
+            false,
+            // chained_merkle_root
+            Some(Hash::new_from_array(rand::thread_rng().gen())),
+            0, // next_shred_index,
+            0, // next_code_index
+            true,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+        for s in d {
+            assert!(s.index() - s.fec_set_index() <= DATA_SHREDS_PER_FEC_BLOCK as u32);
+        }
+        for s in c {
+            assert!(s.index() - s.fec_set_index() <= DATA_SHREDS_PER_FEC_BLOCK as u32);
+        }
+    }
+
+    #[test]
     fn test_read_shred_bytes() {
         let slot = 0;
         let (shreds, _) = make_slot_entries(slot, 0, 100, /*merkle_variant:*/ true);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -11996,14 +11996,14 @@ pub mod tests {
             setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
                 slot,
                 parent_slot,
-                200,
+                200, // make sure at most one coding batch is made
                 fec_set_index,
                 // Do not set merkle root, so shreds are not signed
                 None,
                 true,
             );
         assert!(first_data_shreds.len() > DATA_SHREDS_PER_FEC_BLOCK);
-        let block_id = first_data_shreds[0].merkle_root().unwrap();
+        let block_id = first_data_shreds.last().unwrap().merkle_root().unwrap();
         blockstore
             .insert_shreds(first_data_shreds, None, false)
             .unwrap();

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1178,7 +1178,8 @@ pub(super) fn make_shreds_from_data(
     };
     // Split the data into erasure batches and initialize
     // data and coding shreds for each batch.
-    while data.len() >= 2 * chunk_size || data.len() == chunk_size {
+    while data.len() >= chunk_size {
+        //while data.len() >= 2 * chunk_size || data.len() == chunk_size {
         let (chunk, rest) = data.split_at(chunk_size);
         debug_assert_eq!(chunk.len(), DATA_SHREDS_PER_FEC_BLOCK * data_buffer_size);
         common_header_data.fec_set_index = common_header_data.index;
@@ -1203,6 +1204,8 @@ pub(super) fn make_shreds_from_data(
     }
     // If shreds.is_empty() then the data argument was empty. In that case we
     // want to generate one data shred with empty data.
+    // If data is not empty, this means we have misalignment between data amount
+    // and FEC batch size, so we need to make a special, smaller batch.
     if !data.is_empty() || shreds.is_empty() {
         // Should generate at least one data shred (which may have no data).
         // Last erasure batch should also be padded with empty data shreds to

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -1249,19 +1249,17 @@ mod tests {
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
-        const MIN_CHUNK_SIZE: usize = DATA_SHREDS_PER_FEC_BLOCK;
+        const MAX_CHUNK_SIZE: usize = DATA_SHREDS_PER_FEC_BLOCK;
         let chunks: Vec<_> = data_shreds
             .iter()
             .group_by(|shred| shred.fec_set_index())
             .into_iter()
             .map(|(fec_set_index, chunk)| (fec_set_index, chunk.count()))
             .collect();
+        assert!(chunks.iter().all(|(_, chunk_size)| *chunk_size >= 1));
         assert!(chunks
             .iter()
-            .all(|(_, chunk_size)| *chunk_size >= MIN_CHUNK_SIZE));
-        assert!(chunks
-            .iter()
-            .all(|(_, chunk_size)| *chunk_size < 2 * MIN_CHUNK_SIZE));
+            .all(|(_, chunk_size)| *chunk_size <= MAX_CHUNK_SIZE));
         assert_eq!(chunks[0].0, start_index);
         assert!(chunks.iter().tuple_windows().all(
             |((fec_set_index, chunk_size), (next_fec_set_index, _chunk_size))| fec_set_index


### PR DESCRIPTION
#### Problem
Shredder would make oversized (>64 shreds) batches whenever finishing a given batch of Events (e.g. it would make 3 batches of 64 and one of 59 shreds). However, under low-ish load, most Event batches are small enough to always result in >64 shred batches. This resulted in a higher load on the RSC and merkle tree decoders and also is not really what people reading the specs expect.

Note: Apparently this was done intentionally, i.e. not a bug. There is some chance we should not be doing this.

#### Summary of Changes

- Modify the batch formation code to stick to the 64 shreds per batch limit. 
- Modify tests that expected >32 shred batches

