### PR TITLE
fix release reverting to draft during asset push

### DIFF
--- a/.github/workflows/publish-windows-tarball.yml
+++ b/.github/workflows/publish-windows-tarball.yml
@@ -108,6 +108,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.windows-build.outputs.tag }}
-          draft: true
           files: |
             windows-release/${{ needs.windows-build.outputs.tag }}/*


### PR DESCRIPTION
#### Problem

Releases created by pushing tags get their status changed to draft during artifact push.

#### Summary of Changes

Remove unnecessary draft step from windows tarball publish step. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
https://github.com/anza-xyz/devops/issues/93
