### PR TITLE
Replace usage of FeatureSet in SVM with FeatureSetLookup trait

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -9,6 +9,12 @@ use {
     std::sync::LazyLock,
 };
 
+pub trait FeatureSetLookup {
+    fn is_active(&self, pubkey: &Pubkey) -> bool;
+
+    fn activated_slot(&self, feature_id: &Pubkey) -> Option<u64>;
+}
+
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
@@ -23,6 +29,16 @@ impl Default for FeatureSet {
             active: AHashMap::new(),
             inactive: AHashSet::from_iter((*FEATURE_NAMES).keys().cloned()),
         }
+    }
+}
+
+impl FeatureSetLookup for FeatureSet {
+    fn is_active(&self, feature_id: &Pubkey) -> bool {
+        self.active.contains_key(feature_id)
+    }
+
+    fn activated_slot(&self, feature_id: &Pubkey) -> Option<u64> {
+        self.active.get(feature_id).copied()
     }
 }
 

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -521,7 +521,7 @@ mod tests {
             &vote_account,
             &validator_identity,
             bootstrap_validator_stake_lamports()
-                + solana_stake_program::get_minimum_delegation(&bank.feature_set),
+                + solana_stake_program::get_minimum_delegation(&*bank.feature_set),
         );
         let node_pubkey = validator_identity.pubkey();
 

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -5,7 +5,7 @@ use {
     solana_account::{create_account_shared_data_for_test, AccountSharedData, WritableAccount},
     solana_clock::{Clock, Epoch},
     solana_instruction::AccountMeta,
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::mock_process_instruction_with_feature_set,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::sysvar::{clock, rent, stake_history},
@@ -124,7 +124,7 @@ impl TestSetup {
             (withdraw_authority_address, AccountSharedData::default()),
         ];
 
-        let accounts = mock_process_instruction(
+        let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             &instruction.data,
@@ -132,10 +132,9 @@ impl TestSetup {
             instruction.accounts.clone(),
             Ok(()),
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::clone(&self.feature_set));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            &*self.feature_set,
         );
         // update stake account
         self.transaction_accounts[0] = (self.stake_address, accounts[0].clone());
@@ -165,7 +164,7 @@ impl TestSetup {
             ),
         ];
 
-        let accounts = mock_process_instruction(
+        let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             &instruction.data,
@@ -173,10 +172,9 @@ impl TestSetup {
             instruction.accounts.clone(),
             Ok(()),
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::clone(&self.feature_set));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            &*self.feature_set,
         );
         self.stake_account = accounts[0].clone();
         self.stake_account.set_lamports(ACCOUNT_BALANCE * 2);
@@ -184,7 +182,7 @@ impl TestSetup {
     }
 
     fn run(&self, instruction_data: &[u8]) {
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             instruction_data,
@@ -192,10 +190,9 @@ impl TestSetup {
             self.instruction_accounts.clone(),
             Ok(()), //expected_result,
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::clone(&self.feature_set));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            &*self.feature_set,
         );
     }
 }

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -6,7 +6,7 @@
 )]
 pub use solana_sdk_ids::stake::{check_id, id};
 use {
-    agave_feature_set::{self as feature_set, FeatureSet},
+    agave_feature_set::{self as feature_set, FeatureSetLookup},
     solana_genesis_config::GenesisConfig,
     solana_native_token::LAMPORTS_PER_SOL,
 };
@@ -25,7 +25,7 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
 /// NOTE: This is also used to calculate the minimum balance of a delegated stake account,
 /// which is the rent exempt reserve _plus_ the minimum stake delegation.
 #[inline(always)]
-pub fn get_minimum_delegation(feature_set: &FeatureSet) -> u64 {
+pub fn get_minimum_delegation(feature_set: &dyn FeatureSetLookup) -> u64 {
     if feature_set.is_active(&feature_set::stake_raise_minimum_delegation_to_1_sol::id()) {
         const MINIMUM_DELEGATION_SOL: u64 = 1;
         MINIMUM_DELEGATION_SOL * LAMPORTS_PER_SOL

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -8,7 +8,9 @@ use {
     solana_clock::{Clock, Slot},
     solana_hash::Hash,
     solana_instruction::AccountMeta,
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::{
+        mock_process_instruction, mock_process_instruction_with_feature_set,
+    },
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
@@ -20,7 +22,6 @@ use {
             MAX_LOCKOUT_HISTORY,
         },
     },
-    std::sync::Arc,
     test::Bencher,
 };
 
@@ -101,8 +102,10 @@ fn bench_process_deprecated_vote_instruction(
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {
+    let mut deprecated_feature_set = FeatureSet::all_enabled();
+    deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
     bencher.iter(|| {
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &solana_vote_program::id(),
             Vec::new(),
             &instruction_data,
@@ -110,12 +113,9 @@ fn bench_process_deprecated_vote_instruction(
             instruction_account_metas.clone(),
             Ok(()),
             solana_vote_program::vote_processor::Entrypoint::vm,
-            |invoke_context| {
-                let mut deprecated_feature_set = FeatureSet::all_enabled();
-                deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
-                invoke_context.mock_set_feature_set(Arc::new(deprecated_feature_set));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            &deprecated_feature_set,
         );
     });
 }

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -7,7 +7,9 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta},
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::{
+        mock_process_instruction, mock_process_instruction_with_feature_set,
+    },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk::sysvar,
@@ -23,7 +25,6 @@ use {
             VoteStateUpdate, VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
-    std::sync::Arc,
 };
 
 fn create_default_rent_account() -> AccountSharedData {
@@ -176,7 +177,9 @@ fn process_deprecated_instruction(
     instruction_accounts: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
 ) -> Vec<AccountSharedData> {
-    mock_process_instruction(
+    let mut deprecated_feature_set = FeatureSet::all_enabled();
+    deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
+    mock_process_instruction_with_feature_set(
         &id(),
         Vec::new(),
         instruction_data,
@@ -184,12 +187,9 @@ fn process_deprecated_instruction(
         instruction_accounts,
         expected_result,
         Entrypoint::vm,
-        |invoke_context| {
-            let mut deprecated_feature_set = FeatureSet::all_enabled();
-            deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
-            invoke_context.mock_set_feature_set(Arc::new(deprecated_feature_set));
-        },
         |_invoke_context| {},
+        |_invoke_context| {},
+        &deprecated_feature_set,
     )
 }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2381,7 +2381,7 @@ impl JsonRpcRequestProcessor {
     fn get_stake_minimum_delegation(&self, config: RpcContextConfig) -> Result<RpcResponse<u64>> {
         let bank = self.get_bank_with_config(config)?;
         let stake_minimum_delegation =
-            solana_stake_program::get_minimum_delegation(&bank.feature_set);
+            solana_stake_program::get_minimum_delegation(&*bank.feature_set);
         Ok(new_response(&bank, stake_minimum_delegation))
     }
 
@@ -9035,7 +9035,7 @@ pub mod tests {
         let rpc = RpcHandler::start();
         let bank = rpc.working_bank();
         let expected_stake_minimum_delegation =
-            solana_stake_program::get_minimum_delegation(&bank.feature_set);
+            solana_stake_program::get_minimum_delegation(&*bank.feature_set);
 
         let request = create_test_request("getStakeMinimumDelegation", None);
         let response: RpcResponse<u64> = parse_success_result(rpc.handle_request_sync(request));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2451,7 +2451,7 @@ impl Bank {
         {
             let num_stake_delegations = stakes.stake_delegations().len();
             let min_stake_delegation =
-                solana_stake_program::get_minimum_delegation(&self.feature_set)
+                solana_stake_program::get_minimum_delegation(&*self.feature_set)
                     .max(LAMPORTS_PER_SOL);
 
             let (stake_delegations, filter_time_us) = measure_us!(stakes
@@ -3436,7 +3436,7 @@ impl Bank {
             blockhash,
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
-            feature_set: Arc::clone(&self.feature_set),
+            feature_set: &*self.feature_set,
             rent_collector: Some(&rent_collector_with_metrics),
         };
 
@@ -4173,7 +4173,7 @@ impl Bank {
         for (pubkey, account, _loaded_slot) in accounts.iter_mut() {
             let rent_epoch_pre = account.rent_epoch();
             let (rent_collected_info, collect_rent_us) = measure_us!(collect_rent_from_account(
-                &self.feature_set,
+                &*self.feature_set,
                 &self.rent_collector,
                 pubkey,
                 account
@@ -4966,7 +4966,7 @@ impl Bank {
             .configure_program_runtime_environments(
                 Some(Arc::new(
                     create_program_runtime_environment_v1(
-                        &self.feature_set,
+                        &*self.feature_set,
                         &self.compute_budget().unwrap_or_default().to_budget(),
                         false, /* deployment */
                         false, /* debugging_features */

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -169,7 +169,7 @@ impl Bank {
                     Hash::default(),
                     0,
                     &MockCallback {},
-                    self.feature_set.clone(),
+                    &*self.feature_set,
                     &sysvar_cache,
                 ),
                 None,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4479,7 +4479,7 @@ fn test_bank_cloned_stake_delegations() {
         let rent = &bank.rent_collector().rent;
         let vote_rent_exempt_reserve = rent.minimum_balance(VoteState::size_of());
         let stake_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation(&*bank.feature_set);
         (
             vote_rent_exempt_reserve,
             stake_rent_exempt_reserve + minimum_delegation,

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -156,7 +156,7 @@ fn test_stake_create_and_split_single_signature() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation(&*bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -228,7 +228,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation(&*bank.feature_set);
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -320,7 +320,7 @@ fn test_stake_account_lifetime() {
         (
             rent.minimum_balance(VoteState::size_of()),
             rent.minimum_balance(StakeStateV2::size_of()),
-            solana_stake_program::get_minimum_delegation(&bank.feature_set),
+            solana_stake_program::get_minimum_delegation(&*bank.feature_set),
         )
     };
 
@@ -635,7 +635,7 @@ fn test_create_stake_account_from_seed() {
     let (balance, delegation) = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation(&*bank.feature_set);
         (rent_exempt_reserve + minimum_delegation, minimum_delegation)
     };
 

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -544,7 +544,7 @@ impl JsonRpcRequestProcessor {
             blockhash,
             blockhash_lamports_per_signature: lamports_per_signature,
             epoch_total_stake: 0,
-            feature_set: Arc::clone(&bank.feature_set),
+            feature_set: &*bank.feature_set,
             rent_collector: None,
         };
 

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -149,7 +149,7 @@ impl PayTubeChannel {
             blockhash: Hash::default(),
             blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
             epoch_total_stake: 0,
-            feature_set: Arc::new(feature_set),
+            feature_set: &feature_set,
             rent_collector: Some(&rent_collector),
         };
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -237,11 +237,12 @@ mod tests {
             ]),
         ));
         let sysvar_cache = SysvarCache::default();
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -291,11 +292,12 @@ mod tests {
                 ),
             ]),
         ));
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -335,11 +337,12 @@ mod tests {
                 ),
             ]),
         ));
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -470,11 +473,12 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -509,11 +513,12 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -545,11 +550,12 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -671,11 +677,12 @@ mod tests {
             }
         }
 
+        let feature_set = FeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(FeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::ProgramCacheEntryType,
+        invoke_context::MockFeatureSet, loaded_programs::ProgramCacheEntryType,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -263,11 +263,19 @@ fn svm_concurrent() {
             let check_tx_data = std::mem::take(&mut check_data[idx]);
 
             thread::spawn(move || {
+                let feature_set = MockFeatureSet::default();
+                let processing_environment = TransactionProcessingEnvironment {
+                    blockhash: Hash::default(),
+                    blockhash_lamports_per_signature: 0,
+                    epoch_total_stake: 0,
+                    feature_set: &feature_set,
+                    rent_collector: None,
+                };
                 let result = local_batch.load_and_execute_sanitized_transactions(
                     &*local_bank,
                     &th_txs,
                     check_results,
-                    &TransactionProcessingEnvironment::default(),
+                    &processing_environment,
                     &processing_config,
                 );
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -352,7 +352,7 @@ fn execute_fixture_as_instr(
         blockhash,
         lamports_per_signature,
         mock_bank,
-        mock_bank.feature_set.clone(),
+        &*mock_bank.feature_set,
         sysvar_cache,
     );
 


### PR DESCRIPTION
#### Problem
SVM doesn't need access to the full `FeatureSet` implementation. It only looks up feature's activation status.

#### Summary of Changes
- Define a new trait, that returns the status of a given feature.
- Replace usage of FeatureSet in SVM with FeatureSetLookup trait
- In a future PR, the new trait, FeatureSetLookup, can be moved to SDK, as it's deps are minimal
- The runtime feature IDs can be moved to SVM, and exported from there to the global feature set

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
