### PR TITLE
Adds scan_accounts() for when scan_accounts_stored_meta() can be avoided

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -9,6 +9,7 @@ use {
 };
 
 pub mod meta;
+pub mod stored_account_info;
 
 pub type AccountStorageMap = DashMap<Slot, Arc<AccountStorageEntry>, BuildNoHashHasher<Slot>>;
 

--- a/accounts-db/src/account_storage/stored_account_info.rs
+++ b/accounts-db/src/account_storage/stored_account_info.rs
@@ -1,0 +1,38 @@
+use {solana_account::ReadableAccount, solana_clock::Epoch, solana_pubkey::Pubkey};
+
+/// Account type with fields that reference into a storage
+///
+/// Used then scanning the accounts of a single storage.
+#[derive(Debug, Clone)]
+pub struct StoredAccountInfo<'storage> {
+    pub pubkey: &'storage Pubkey,
+    pub lamports: u64,
+    pub owner: &'storage Pubkey,
+    pub data: &'storage [u8],
+    pub executable: bool,
+    pub rent_epoch: Epoch,
+}
+
+impl StoredAccountInfo<'_> {
+    pub fn pubkey(&self) -> &Pubkey {
+        self.pubkey
+    }
+}
+
+impl ReadableAccount for StoredAccountInfo<'_> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn owner(&self) -> &Pubkey {
+        self.owner
+    }
+    fn data(&self) -> &[u8] {
+        self.data
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2714,9 +2714,9 @@ impl AccountsDb {
                 return;
             }
             if let Some(storage) = self.storage.get_slot_storage_entry(slot) {
-                storage
-                    .accounts
-                    .scan_pubkeys(|pubkey| match pubkey_refcount.entry(*pubkey) {
+                storage.accounts.scan_accounts(|account| {
+                    let pk = account.pubkey();
+                    match pubkey_refcount.entry(*pk) {
                         dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
                             if !occupied_entry.get().iter().any(|s| s == &slot) {
                                 occupied_entry.get_mut().push(slot);
@@ -2725,7 +2725,8 @@ impl AccountsDb {
                         dashmap::mapref::entry::Entry::Vacant(vacant_entry) => {
                             vacant_entry.insert(vec![slot]);
                         }
-                    });
+                    }
+                });
             }
         });
         let total = pubkey_refcount.len();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2714,7 +2714,7 @@ impl AccountsDb {
                 return;
             }
             if let Some(storage) = self.storage.get_slot_storage_entry(slot) {
-                storage.accounts.scan_accounts(|account| {
+                storage.accounts.scan_accounts_stored_meta(|account| {
                     let pk = account.pubkey();
                     match pubkey_refcount.entry(*pk) {
                         dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
@@ -4975,7 +4975,7 @@ impl AccountsDb {
                 .storage
                 .get_slot_storage_entry_shrinking_in_progress_ok(slot)
             {
-                storage.accounts.scan_accounts(|account| {
+                storage.accounts.scan_accounts_stored_meta(|account| {
                     let loaded_account = LoadedAccount::Stored(account);
                     let data = (scan_account_storage_data
                         == ScanAccountStorageData::DataRefForStorage)
@@ -6815,11 +6815,15 @@ impl AccountsDb {
         let mut lt_hash = storages
             .par_iter()
             .fold(LtHash::identity, |mut accum, storage| {
-                storage.accounts.scan_accounts(|stored_account_meta| {
-                    let account_lt_hash =
-                        Self::lt_hash_account(&stored_account_meta, stored_account_meta.pubkey());
-                    accum.mix_in(&account_lt_hash.0);
-                });
+                storage
+                    .accounts
+                    .scan_accounts_stored_meta(|stored_account_meta| {
+                        let account_lt_hash = Self::lt_hash_account(
+                            &stored_account_meta,
+                            stored_account_meta.pubkey(),
+                        );
+                        accum.mix_in(&account_lt_hash.0);
+                    });
                 accum
             })
             .reduce(LtHash::identity, |mut accum, elem| {
@@ -8533,15 +8537,17 @@ impl AccountsDb {
         };
         if secondary {
             // scan storage a second time to update the secondary index
-            storage.accounts.scan_accounts(|stored_account| {
-                stored_size_alive += stored_account.stored_size();
-                let pubkey = stored_account.pubkey();
-                self.accounts_index.update_secondary_indexes(
-                    pubkey,
-                    &stored_account,
-                    &self.account_indexes,
-                );
-            });
+            storage
+                .accounts
+                .scan_accounts_stored_meta(|stored_account| {
+                    stored_size_alive += stored_account.stored_size();
+                    let pubkey = stored_account.pubkey();
+                    self.accounts_index.update_secondary_indexes(
+                        pubkey,
+                        &stored_account,
+                        &self.account_indexes,
+                    );
+                });
         }
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
@@ -8721,7 +8727,7 @@ impl AccountsDb {
                             // verify index matches expected and measure the time to get all items
                             assert!(verify);
                             let mut lookup_time = Measure::start("lookup_time");
-                            storage.accounts.scan_accounts(|account_info| {
+                            storage.accounts.scan_accounts_stored_meta(|account_info| {
                                 let key = account_info.pubkey();
                                 let index_entry = self.accounts_index.get_cloned(key).unwrap();
                                 let slot_list = index_entry.slot_list.read().unwrap();
@@ -9429,7 +9435,7 @@ impl AccountsDb {
     pub fn sizes_of_accounts_in_storage_for_tests(&self, slot: Slot) -> Vec<usize> {
         let mut sizes = Vec::default();
         if let Some(storage) = self.storage.get_slot_storage_entry(slot) {
-            storage.accounts.scan_accounts(|account| {
+            storage.accounts.scan_accounts_stored_meta(|account| {
                 sizes.push(account.stored_size());
             });
         }

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -679,7 +679,7 @@ mod tests {
                     let slot = storage.slot();
                     let copied_storage = accounts_db.create_and_insert_store(slot, 10000, "test");
                     let mut all_accounts = Vec::default();
-                    storage.accounts.scan_accounts_stored_meta(|acct| {
+                    storage.accounts.scan_accounts(|acct| {
                         all_accounts.push((*acct.pubkey(), acct.to_account_shared_data()));
                     });
                     let accounts = all_accounts
@@ -713,7 +713,7 @@ mod tests {
                 let slot = storage.slot() + max_slot;
                 let copied_storage = accounts_db.create_and_insert_store(slot, 10000, "test");
                 let mut all_accounts = Vec::default();
-                storage.accounts.scan_accounts_stored_meta(|acct| {
+                storage.accounts.scan_accounts(|acct| {
                     all_accounts.push((*acct.pubkey(), acct.to_account_shared_data()));
                 });
                 let accounts = all_accounts

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -353,7 +353,7 @@ impl AccountsDb {
     where
         S: AppendVecScan,
     {
-        storage.accounts.scan_accounts(|account| {
+        storage.accounts.scan_accounts_stored_meta(|account| {
             if scanner.filter(account.pubkey()) {
                 scanner.found_account(&LoadedAccount::Stored(account))
             }
@@ -679,7 +679,7 @@ mod tests {
                     let slot = storage.slot();
                     let copied_storage = accounts_db.create_and_insert_store(slot, 10000, "test");
                     let mut all_accounts = Vec::default();
-                    storage.accounts.scan_accounts(|acct| {
+                    storage.accounts.scan_accounts_stored_meta(|acct| {
                         all_accounts.push((*acct.pubkey(), acct.to_account_shared_data()));
                     });
                     let accounts = all_accounts
@@ -713,7 +713,7 @@ mod tests {
                 let slot = storage.slot() + max_slot;
                 let copied_storage = accounts_db.create_and_insert_store(slot, 10000, "test");
                 let mut all_accounts = Vec::default();
-                storage.accounts.scan_accounts(|acct| {
+                storage.accounts.scan_accounts_stored_meta(|acct| {
                     all_accounts.push((*acct.pubkey(), acct.to_account_shared_data()));
                 });
                 let accounts = all_accounts

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -7046,7 +7046,7 @@ fn get_all_accounts_from_storages<'a>(
     storages
         .flat_map(|storage| {
             let mut vec = Vec::default();
-            storage.accounts.scan_accounts_stored_meta(|account| {
+            storage.accounts.scan_accounts(|account| {
                 vec.push((*account.pubkey(), account.to_account_shared_data()));
             });
             // make sure scan_pubkeys results match

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4173,7 +4173,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
     // Flushing cache should only create one storage entry
     let storage0 = accounts_db.get_and_assert_single_storage(slot);
 
-    storage0.accounts.scan_accounts(|account| {
+    storage0.accounts.scan_accounts_stored_meta(|account| {
         let before_size = storage0.alive_bytes();
         let account_info = accounts_db
             .accounts_index
@@ -7046,7 +7046,7 @@ fn get_all_accounts_from_storages<'a>(
     storages
         .flat_map(|storage| {
             let mut vec = Vec::default();
-            storage.accounts.scan_accounts(|account| {
+            storage.accounts.scan_accounts_stored_meta(|account| {
                 vec.push((*account.pubkey(), account.to_account_shared_data()));
             });
             // make sure scan_pubkeys results match
@@ -7554,7 +7554,7 @@ fn test_combine_ancient_slots_append() {
 fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
     slots.into_iter().for_each(|slot| {
         if let Some(storage) = db.get_storage_for_slot(slot) {
-            storage.accounts.scan_accounts(|account| {
+            storage.accounts.scan_accounts_stored_meta(|account| {
                 let info = AccountInfo::new(
                     StorageLocation::AppendVec(storage.id(), account.offset()),
                     account.is_zero_lamport(),

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         account_info::AccountInfo,
-        account_storage::meta::StoredAccountMeta,
+        account_storage::{meta::StoredAccountMeta, stored_account_info::StoredAccountInfo},
         accounts_db::AccountsFileId,
         accounts_update_notifier_interface::AccountForGeyser,
         append_vec::{AppendVec, AppendVecError, IndexInfo},
@@ -223,6 +223,24 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
+    pub fn scan_accounts(&self, mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>)) {
+        self.scan_accounts_stored_meta(|stored_account_meta| {
+            let account = StoredAccountInfo {
+                pubkey: stored_account_meta.pubkey(),
+                lamports: stored_account_meta.lamports(),
+                owner: stored_account_meta.owner(),
+                data: stored_account_meta.data(),
+                executable: stored_account_meta.executable(),
+                rent_epoch: stored_account_meta.rent_epoch(),
+            };
+            callback(account)
+        })
+    }
+
+    /// Iterate over all accounts and call `callback` with each account.
+    ///
+    /// Prefer scan_accounts() when possible, as it does not contain file format
+    /// implementation details, and thus potentially can read less and be faster.
     pub fn scan_accounts_stored_meta(
         &self,
         callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
@@ -243,14 +261,14 @@ impl AccountsFile {
         &self,
         mut callback: impl for<'local> FnMut(AccountForGeyser<'local>),
     ) {
-        self.scan_accounts_stored_meta(|stored_account_meta| {
+        self.scan_accounts(|account| {
             let account_for_geyser = AccountForGeyser {
-                pubkey: stored_account_meta.pubkey(),
-                lamports: stored_account_meta.lamports(),
-                owner: stored_account_meta.owner(),
-                executable: stored_account_meta.executable(),
-                rent_epoch: stored_account_meta.rent_epoch(),
-                data: stored_account_meta.data(),
+                pubkey: account.pubkey(),
+                lamports: account.lamports(),
+                owner: account.owner(),
+                executable: account.executable(),
+                rent_epoch: account.rent_epoch(),
+                data: account.data(),
             };
             callback(account_for_geyser)
         })

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -223,12 +223,15 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub fn scan_accounts(&self, callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
+    pub fn scan_accounts_stored_meta(
+        &self,
+        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
+    ) {
         match self {
-            Self::AppendVec(av) => av.scan_accounts(callback),
+            Self::AppendVec(av) => av.scan_accounts_stored_meta(callback),
             Self::TieredStorage(ts) => {
                 if let Some(reader) = ts.reader() {
-                    _ = reader.scan_accounts(callback);
+                    _ = reader.scan_accounts_stored_meta(callback);
                 }
             }
         }
@@ -240,7 +243,7 @@ impl AccountsFile {
         &self,
         mut callback: impl for<'local> FnMut(AccountForGeyser<'local>),
     ) {
-        self.scan_accounts(|stored_account_meta| {
+        self.scan_accounts_stored_meta(|stored_account_meta| {
             let account_for_geyser = AccountForGeyser {
                 pubkey: stored_account_meta.pubkey(),
                 lamports: stored_account_meta.lamports(),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2181,7 +2181,7 @@ pub mod tests {
             shrink_in_progress
                 .new_storage()
                 .accounts
-                .scan_accounts_stored_meta(|_| {
+                .scan_accounts(|_| {
                     count += 1;
                 });
             assert_eq!(count, 1);
@@ -2342,7 +2342,7 @@ pub mod tests {
                 })
                 .unwrap();
             let mut count = 0;
-            storage.accounts.scan_accounts_stored_meta(|_| {
+            storage.accounts.scan_accounts(|_| {
                 count += 1;
             });
             assert_eq!(count, 2);
@@ -3379,7 +3379,7 @@ pub mod tests {
                                 .1
                                 .new_storage()
                                 .accounts
-                                .scan_accounts_stored_meta(|meta| {
+                                .scan_accounts(|meta| {
                                     two.push((*meta.pubkey(), meta.to_account_shared_data()));
                                 });
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2181,7 +2181,7 @@ pub mod tests {
             shrink_in_progress
                 .new_storage()
                 .accounts
-                .scan_accounts(|_| {
+                .scan_accounts_stored_meta(|_| {
                     count += 1;
                 });
             assert_eq!(count, 1);
@@ -2342,7 +2342,7 @@ pub mod tests {
                 })
                 .unwrap();
             let mut count = 0;
-            storage.accounts.scan_accounts(|_| {
+            storage.accounts.scan_accounts_stored_meta(|_| {
                 count += 1;
             });
             assert_eq!(count, 2);
@@ -3300,7 +3300,7 @@ pub mod tests {
                             .iter()
                             .map(|storage| {
                                 let mut accounts = Vec::default();
-                                storage.accounts.scan_accounts(|account| {
+                                storage.accounts.scan_accounts_stored_meta(|account| {
                                     accounts.push(AccountFromStorage::new(&account));
                                 });
                                 (storage.slot(), accounts)
@@ -3379,7 +3379,7 @@ pub mod tests {
                                 .1
                                 .new_storage()
                                 .accounts
-                                .scan_accounts(|meta| {
+                                .scan_accounts_stored_meta(|meta| {
                                     two.push((*meta.pubkey(), meta.to_account_shared_data()));
                                 });
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1060,7 +1060,10 @@ impl AppendVec {
 
     /// Iterate over all accounts and call `callback` with each account.
     #[allow(clippy::blocks_in_conditions)]
-    pub fn scan_accounts(&self, mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>)) {
+    pub fn scan_accounts_stored_meta(
+        &self,
+        mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
+    ) {
         match &self.backing {
             AppendVecFileBacking::Mmap(_mmap) => {
                 let mut offset = 0;
@@ -1622,7 +1625,7 @@ pub mod tests {
         /// return how many accounts in the storage
         fn accounts_count(&self) -> usize {
             let mut count = 0;
-            self.scan_accounts(|_| {
+            self.scan_accounts_stored_meta(|_| {
                 count += 1;
             });
             count
@@ -1671,7 +1674,7 @@ pub mod tests {
         let mut sample = 0;
         assert_eq!(av.accounts_count(), size);
         assert_eq!(av.store_accounts_no_data_count(), size);
-        av.scan_accounts(|v| {
+        av.scan_accounts_stored_meta(|v| {
             let account = create_test_account(sample + 1);
             let recovered = v.to_account_shared_data();
             assert_eq!(recovered, account.1);

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -384,7 +384,7 @@ mod tests {
         let mut max_pubkey = MIN_PUBKEY;
 
         reader
-            .scan_accounts(|stored_account_meta| {
+            .scan_accounts_stored_meta(|stored_account_meta| {
                 if let Some(account) = expected_accounts_map.get(stored_account_meta.pubkey()) {
                     verify_test_account_with_footer(
                         &stored_account_meta,

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -126,7 +126,7 @@ impl TieredStorageReader {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub(crate) fn scan_accounts(
+    pub(crate) fn scan_accounts_stored_meta(
         &self,
         callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> TieredStorageResult<()> {

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -125,7 +125,7 @@ fn do_inspect(file: impl AsRef<Path>, verbose: bool) -> Result<(), String> {
     let mut num_accounts = Saturating(0usize);
     let mut stored_accounts_size = Saturating(0);
     let mut lamports = Saturating(0);
-    storage.scan_accounts(|account| {
+    storage.scan_accounts_stored_meta(|account| {
         if verbose {
             println!("{account:?}");
         } else {
@@ -191,7 +191,7 @@ fn do_search(
         let storage = ManuallyDrop::new(storage);
 
         let file_name = Path::new(file.file_name().expect("path is a file"));
-        storage.scan_accounts(|account| {
+        storage.scan_accounts_stored_meta(|account| {
             if addresses.contains(account.pubkey()) {
                 if verbose {
                     println!("storage: {}, {account:?}", file_name.display());

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -886,14 +886,16 @@ mod tests {
         // get all the lt hashes for each version of all accounts
         let mut stored_accounts_map = HashMap::<_, Vec<_>>::new();
         for storage in &storages {
-            storage.accounts.scan_accounts(|stored_account_meta| {
-                let pubkey = stored_account_meta.pubkey();
-                let account_lt_hash = AccountsDb::lt_hash_account(&stored_account_meta, pubkey);
-                stored_accounts_map
-                    .entry(*pubkey)
-                    .or_default()
-                    .push(account_lt_hash)
-            });
+            storage
+                .accounts
+                .scan_accounts_stored_meta(|stored_account_meta| {
+                    let pubkey = stored_account_meta.pubkey();
+                    let account_lt_hash = AccountsDb::lt_hash_account(&stored_account_meta, pubkey);
+                    stored_accounts_map
+                        .entry(*pubkey)
+                        .or_default()
+                        .push(account_lt_hash)
+                });
         }
 
         // calculate the duplicates lt hash by skipping the first version (latest) of each account,

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -886,16 +886,14 @@ mod tests {
         // get all the lt hashes for each version of all accounts
         let mut stored_accounts_map = HashMap::<_, Vec<_>>::new();
         for storage in &storages {
-            storage
-                .accounts
-                .scan_accounts_stored_meta(|stored_account_meta| {
-                    let pubkey = stored_account_meta.pubkey();
-                    let account_lt_hash = AccountsDb::lt_hash_account(&stored_account_meta, pubkey);
-                    stored_accounts_map
-                        .entry(*pubkey)
-                        .or_default()
-                        .push(account_lt_hash)
-                });
+            storage.accounts.scan_accounts(|account| {
+                let pubkey = account.pubkey();
+                let account_lt_hash = AccountsDb::lt_hash_account(&account, pubkey);
+                stored_accounts_map
+                    .entry(*pubkey)
+                    .or_default()
+                    .push(account_lt_hash)
+            });
         }
 
         // calculate the duplicates lt hash by skipping the first version (latest) of each account,


### PR DESCRIPTION
#### Problem

When scanning a storage file, we don't always need the full `StoredAccountMeta` per account. When we only had AppendVecs, and only with mmaps, passing around StoredAccountMeta was no problem, since it was basically free. With file io and tiered storage, we'd like to avoid copying fields unnecessarily. Additionally, we'd like to avoid leaking the AppendVec file format implementation details around when they are unneeded.


#### Summary of Changes

As a first step, add a `AccountsFile::scan_accounts()` method that returns only the in-protocol fields of an account. This is its address, owner, balance, data, rent epoch, and executable flag. The old method has been renamed to `scan_accounts_stored_meta()`, and we can now see when the stored meta version is needed and work towards removing them (I'm looking at you, LoadedAccount).

Note, this PR purposely does not optimize the implementation of the new `scan_accounts()`. That can be done in a subsequent PR.