### PR TITLE
Inform about correct crate type usage

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -628,20 +628,8 @@ fn build_solana_package(
             .collect::<Vec<_>>();
 
         match cdylib_targets.len() {
-            0 => {
-                info!(
-                    "Note: {} crate is a library to be imported by other solana programs",
-                    package.name
-                );
-                None
-            }
-            1 => {
-                info!(
-                    "Note: {} crate is a solana program ready for deployment",
-                    package.name
-                );
-                Some(cdylib_targets[0].replace('-', "_"))
-            }
+            0 => None,
+            1 => Some(cdylib_targets[0].replace('-', "_")),
             _ => {
                 error!(
                     "{} crate contains multiple cdylib targets: {:?}",

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -605,7 +605,7 @@ fn build_solana_package(
             .iter()
             .filter_map(|target| {
                 if target.crate_types.contains(&"cdylib".to_string()) {
-                    let other_crate = if target.crate_types.contains(&"rlib".to_string()) {
+                    let other_crate_type = if target.crate_types.contains(&"rlib".to_string()) {
                         Some("rlib")
                     } else if target.crate_types.contains(&"lib".to_string()) {
                         Some("lib")
@@ -613,7 +613,7 @@ fn build_solana_package(
                         None
                     };
 
-                    if let Some(other_crate) = other_crate {
+                    if let Some(other_crate) = other_crate_type {
                         warn!("Package '{}' has two crate types defined: cdylib and {}. \
                         This setting precludes link-time optimizations (LTO). Use cdylib for programs \
                         to be deployed and rlib for packages to be imported by other programs as libraries.",

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -615,7 +615,7 @@ fn build_solana_package(
 
                     if let Some(other_crate) = other_crate {
                         warn!("Package '{}' has two crate types defined: cdylib and {}. \
-                        This setting precludes compiler optimizations. Use cdylib for programs \
+                        This setting precludes link-time optimizations (LTO). Use cdylib for programs \
                         to be deployed and rlib for packages to be imported by other programs as libraries.",
                         package.name, other_crate);
                     }


### PR DESCRIPTION
#### Problem

The mixed usage of both cdylib and rlib crate types in SBF programs prevents the compiler from running LTO in multiple programs.

#### Summary of Changes

Include a message in cargo-build-sbf instructing developers about the correct usage of crate types for Solana programs and libraries.
