### PR TITLE
Always set `stack_height` to `1` at the transaction level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "solana-gossip",
  "solana-hash",
  "solana-inflation",
+ "solana-instruction",
  "solana-keypair",
  "solana-ledger",
  "solana-loader-v3-interface 5.0.0",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -47,6 +47,7 @@ solana-geyser-plugin-manager = { workspace = true }
 solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
+solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-loader-v3-interface = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -45,6 +45,7 @@ use {
     solana_feature_gate_interface::{self as feature, Feature},
     solana_genesis_config::ClusterType,
     solana_inflation::Inflation,
+    solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
     solana_ledger::{
         blockstore::{banking_trace_path, create_new_ledger, Blockstore},
         blockstore_options::{AccessType, LedgerColumnOptions},
@@ -754,7 +755,13 @@ fn record_transactions(
                     let instructions = message
                         .instructions()
                         .iter()
-                        .map(|ix| parse_ui_instruction(ix, &message.account_keys(), None))
+                        .map(|ix| {
+                            parse_ui_instruction(
+                                ix,
+                                &message.account_keys(),
+                                Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32),
+                            )
+                        })
                         .collect();
 
                     let is_simple_vote_tx = tx.is_simple_vote_transaction();

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -9,7 +9,7 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
-    solana_instruction::error::InstructionError,
+    solana_instruction::{error::InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
     solana_message::MessageHeader,
     solana_pubkey::Pubkey,
     solana_rpc_client_api::{
@@ -227,7 +227,7 @@ impl RpcSender for MockSender {
                                         program_id_index: 2,
                                         accounts: vec![0, 1],
                                         data: "3Bxs49DitAvXtoDR".to_string(),
-                                        stack_height: None,
+                                        stack_height: Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32),
                                     }],
                                     address_table_lookups: None,
                                 })

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -26,6 +26,7 @@ use {
     base64::{prelude::BASE64_STANDARD, Engine},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
     solana_message::{
         compiled_instruction::CompiledInstruction,
         v0::{self, LoadedAddresses, LoadedMessage},
@@ -741,7 +742,13 @@ impl Encodable for Message {
                 instructions: self
                     .instructions
                     .iter()
-                    .map(|instruction| parse_ui_instruction(instruction, &account_keys, None))
+                    .map(|instruction| {
+                        parse_ui_instruction(
+                            instruction,
+                            &account_keys,
+                            Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32),
+                        )
+                    })
                     .collect(),
                 address_table_lookups: None,
             })
@@ -753,7 +760,9 @@ impl Encodable for Message {
                 instructions: self
                     .instructions
                     .iter()
-                    .map(|ix| UiCompiledInstruction::from(ix, None))
+                    .map(|ix| {
+                        UiCompiledInstruction::from(ix, Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32))
+                    })
                     .collect(),
                 address_table_lookups: None,
             })
@@ -775,7 +784,13 @@ impl Encodable for v0::Message {
                 instructions: self
                     .instructions
                     .iter()
-                    .map(|instruction| parse_ui_instruction(instruction, &account_keys, None))
+                    .map(|instruction| {
+                        parse_ui_instruction(
+                            instruction,
+                            &account_keys,
+                            Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32),
+                        )
+                    })
                     .collect(),
                 address_table_lookups: None,
             })
@@ -787,7 +802,9 @@ impl Encodable for v0::Message {
                 instructions: self
                     .instructions
                     .iter()
-                    .map(|ix| UiCompiledInstruction::from(ix, None))
+                    .map(|ix| {
+                        UiCompiledInstruction::from(ix, Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32))
+                    })
                     .collect(),
                 address_table_lookups: None,
             })
@@ -816,7 +833,13 @@ impl EncodableWithMeta for v0::Message {
                 instructions: self
                     .instructions
                     .iter()
-                    .map(|instruction| parse_ui_instruction(instruction, &account_keys, None))
+                    .map(|instruction| {
+                        parse_ui_instruction(
+                            instruction,
+                            &account_keys,
+                            Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32),
+                        )
+                    })
                     .collect(),
                 address_table_lookups: Some(
                     self.address_table_lookups.iter().map(Into::into).collect(),
@@ -834,7 +857,9 @@ impl EncodableWithMeta for v0::Message {
             instructions: self
                 .instructions
                 .iter()
-                .map(|ix| UiCompiledInstruction::from(ix, None))
+                .map(|ix| {
+                    UiCompiledInstruction::from(ix, Some(TRANSACTION_LEVEL_STACK_HEIGHT as u32))
+                })
                 .collect(),
             address_table_lookups: Some(
                 self.address_table_lookups.iter().map(Into::into).collect(),


### PR DESCRIPTION
#### Problem

The only `stackHeight` that the RPC ever encounters is `null` or `>=2`. This is because we don't set a stack height of `1` at the base of the transaction.

#### Summary of Changes

Hard code the `stack_height` to `TRANSACTION_LEVEL_STACK_HEIGHT` when encoding transaction _messages_, because instructions declared in transaction messages are by definition at the bottom of the call stack.

#### Test Plan

Fire up the `solana-test-validator` and grab a transaction using the RPC API. Observe that instructions at the bottom of the call stack now report a `stackHeight` of `1` instead of `null`

```
$ curl http://localhost:8899 -s -X   POST -H "Content-Type: application/json" -d ' 
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getTransaction",
    "params": [
      "3q8BdBE1deSudJA9DVKhh8zCXaLBgrfEVTo1GhNAUXhx3AYhCocUfXN8LQ1ME5B8VDBMqaf7GJY28kGdEpkjoU2G",
      "json"
    ]
  }
' | jq
{
  "jsonrpc": "2.0",
  "result": {
    "blockTime": 1744228013,
    "meta": {
      "computeUnitsConsumed": 2100,
      "err": null,
      "fee": 10000,
      "innerInstructions": [],
      "loadedAddresses": {
        "readonly": [],
        "writable": []
      },
      "logMessages": [
        "Program Vote111111111111111111111111111111111111111 invoke [1]",
        "Program Vote111111111111111111111111111111111111111 success"
      ],
      "postBalances": [
        499976100000,
        1000000000000000,
        1
      ],
      "postTokenBalances": [],
      "preBalances": [
        499976110000,
        1000000000000000,
        1
      ],
      "preTokenBalances": [],
      "rewards": [],
      "status": {
        "Ok": null
      }
    },
    "slot": 4785,
    "transaction": {
      "message": {
        "accountKeys": [
          "3jSivXpqhL8YXyEjSMWFsFpUpLRieycw8fXEaevG6yUh",
          "EcBrbtLfWfNa2jT3G6No3BBAwofXfHx5RW9nogs38Xmm",
          "Vote111111111111111111111111111111111111111"
        ],
        "header": {
          "numReadonlySignedAccounts": 0,
          "numReadonlyUnsignedAccounts": 1,
          "numRequiredSignatures": 2
        },
        "instructions": [
          {
            "accounts": [
              1,
              1
            ],
            "data": "67MGn8FGRGypi4prk7T3GCmTDPg6enaN6bgmY6iyA5uvS3zkAt2hf5v7w5f77Xo9NGnKoZG4A9sUU75uTXTf3bbHEMnX1E5gFC574UbRWkCEWCVsgNKyV671VGvB4yVHN3poupGcbshHS4JSsd6ne55ob1qbEhgKccqRbVpSEUk74eHNnkZcmQPSmBQnAyHyhMDG42Abcs",
            "programIdIndex": 2,
            "stackHeight": 1
          }
        ],
        "recentBlockhash": "9HjALndAZq7HNDySMdse6cuAVnL8QZqa1PUmYHTkSZY5"
      },
      "signatures": [
        "3q8BdBE1deSudJA9DVKhh8zCXaLBgrfEVTo1GhNAUXhx3AYhCocUfXN8LQ1ME5B8VDBMqaf7GJY28kGdEpkjoU2G",
        "eRAn41FDYhwzytPQoKTPwy6aozZq38GD9RmXWaxMNAFdJz1EiuTYJgQzhrJNriaZxCm1ryFbF1f78JsWRQVxMcE"
      ]
    }
  },
  "id": 1
}
```