### PR TITLE
Revert "rolls out chained Merkle shreds to 100% of mainnet slots (#5088)"

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -11,7 +11,9 @@ use {
         blockstore,
         shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
     },
-    solana_sdk::{hash::Hash, signature::Keypair, timing::AtomicInterval},
+    solana_sdk::{
+        genesis_config::ClusterType, hash::Hash, signature::Keypair, timing::AtomicInterval,
+    },
     std::{borrow::Cow, sync::RwLock, time::Duration},
     tokio::sync::mpsc::Sender as AsyncSender,
 };
@@ -74,6 +76,7 @@ impl StandardBroadcastRun {
         &mut self,
         keypair: &Keypair,
         max_ticks_in_slot: u8,
+        cluster_type: ClusterType,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
         if self.completed {
@@ -88,7 +91,8 @@ impl StandardBroadcastRun {
                     keypair,
                     &[],  // entries
                     true, // is_last_in_slot,
-                    Some(self.chained_merkle_root),
+                    should_chain_merkle_shreds(self.slot, cluster_type)
+                        .then_some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     &self.reed_solomon_cache,
@@ -111,6 +115,7 @@ impl StandardBroadcastRun {
         entries: &[Entry],
         reference_tick: u8,
         is_slot_end: bool,
+        cluster_type: ClusterType,
         process_stats: &mut ProcessShredsStats,
         max_data_shreds_per_slot: u32,
         max_code_shreds_per_slot: u32,
@@ -122,7 +127,8 @@ impl StandardBroadcastRun {
                     keypair,
                     entries,
                     is_slot_end,
-                    Some(self.chained_merkle_root),
+                    should_chain_merkle_shreds(self.slot, cluster_type)
+                        .then_some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     &self.reed_solomon_cache,
@@ -187,12 +193,17 @@ impl StandardBroadcastRun {
         let mut process_stats = ProcessShredsStats::default();
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
+        let cluster_type = bank.cluster_type();
 
         if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.
             if !self.completed {
-                let shreds =
-                    self.finish_prev_slot(keypair, bank.ticks_per_slot() as u8, &mut process_stats);
+                let shreds = self.finish_prev_slot(
+                    keypair,
+                    bank.ticks_per_slot() as u8,
+                    cluster_type,
+                    &mut process_stats,
+                );
                 debug_assert!(shreds.iter().all(|shred| shred.slot() == self.slot));
                 // Broadcast shreds for the interrupted slot.
                 let batch_info = Some(BroadcastShredBatchInfo {
@@ -259,6 +270,7 @@ impl StandardBroadcastRun {
                 &receive_results.entries,
                 reference_tick as u8,
                 is_last_in_slot,
+                cluster_type,
                 &mut process_stats,
                 blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
                 shred_code::MAX_CODE_SHREDS_PER_SLOT as u32,
@@ -471,6 +483,16 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
+fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
+    match cluster_type {
+        ClusterType::Development => true,
+        ClusterType::Devnet => true,
+        // Roll out chained Merkle shreds to ~53% of mainnet slots.
+        ClusterType::MainnetBeta => slot % 19 < 10,
+        ClusterType::Testnet => true,
+    }
+}
+
 #[cfg(test)]
 mod test {
     use {
@@ -558,6 +580,7 @@ mod test {
         let shreds = run.finish_prev_slot(
             &keypair,
             0, // max_ticks_in_slot
+            ClusterType::Development,
             &mut ProcessShredsStats::default(),
         );
         assert!(run.completed);
@@ -807,6 +830,7 @@ mod test {
                 &entries[0..entries.len() - 2],
                 0,
                 false,
+                ClusterType::Development,
                 &mut stats,
                 1000,
                 1000,
@@ -818,7 +842,16 @@ mod test {
         assert!(!data.is_empty());
         assert!(!coding.is_empty());
 
-        let r = bs.entries_to_shreds(&keypair, &entries, 0, false, &mut stats, 10, 10);
+        let r = bs.entries_to_shreds(
+            &keypair,
+            &entries,
+            0,
+            false,
+            ClusterType::Development,
+            &mut stats,
+            10,
+            10,
+        );
         info!("{:?}", r);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
     }


### PR DESCRIPTION
#### Problem

#5088 both activates chained merkle shreds for 100% of shreds _and_ removes the activation logic. we would prefer to only backport the activation, while leaving the logic removal to ride master

#### Summary of Changes

revert #5088. we'll put it back shortly as two prs