### PR TITLE
rolls out chained Merkle shreds to 100% of mainnet slots

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -483,12 +483,11 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_chain_merkle_shreds(slot: Slot, cluster_type: ClusterType) -> bool {
+fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
     match cluster_type {
         ClusterType::Development => true,
         ClusterType::Devnet => true,
-        // Roll out chained Merkle shreds to ~53% of mainnet slots.
-        ClusterType::MainnetBeta => slot % 19 < 10,
+        ClusterType::MainnetBeta => true,
         ClusterType::Testnet => true,
     }
 }


### PR DESCRIPTION
this completes the rollout of chained merkle shreds to the mainnet beta cluster

---

requires #5734 