### PR TITLE
turbine: removes chained merkle shreds activation logic

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -11,9 +11,7 @@ use {
         blockstore,
         shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
     },
-    solana_sdk::{
-        genesis_config::ClusterType, hash::Hash, signature::Keypair, timing::AtomicInterval,
-    },
+    solana_sdk::{hash::Hash, signature::Keypair, timing::AtomicInterval},
     std::{borrow::Cow, sync::RwLock, time::Duration},
     tokio::sync::mpsc::Sender as AsyncSender,
 };
@@ -76,7 +74,6 @@ impl StandardBroadcastRun {
         &mut self,
         keypair: &Keypair,
         max_ticks_in_slot: u8,
-        cluster_type: ClusterType,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
         if self.completed {
@@ -91,8 +88,7 @@ impl StandardBroadcastRun {
                     keypair,
                     &[],  // entries
                     true, // is_last_in_slot,
-                    should_chain_merkle_shreds(self.slot, cluster_type)
-                        .then_some(self.chained_merkle_root),
+                    Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     &self.reed_solomon_cache,
@@ -115,7 +111,6 @@ impl StandardBroadcastRun {
         entries: &[Entry],
         reference_tick: u8,
         is_slot_end: bool,
-        cluster_type: ClusterType,
         process_stats: &mut ProcessShredsStats,
         max_data_shreds_per_slot: u32,
         max_code_shreds_per_slot: u32,
@@ -127,8 +122,7 @@ impl StandardBroadcastRun {
                     keypair,
                     entries,
                     is_slot_end,
-                    should_chain_merkle_shreds(self.slot, cluster_type)
-                        .then_some(self.chained_merkle_root),
+                    Some(self.chained_merkle_root),
                     self.next_shred_index,
                     self.next_code_index,
                     &self.reed_solomon_cache,
@@ -193,17 +187,12 @@ impl StandardBroadcastRun {
         let mut process_stats = ProcessShredsStats::default();
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
-        let cluster_type = bank.cluster_type();
 
         if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.
             if !self.completed {
-                let shreds = self.finish_prev_slot(
-                    keypair,
-                    bank.ticks_per_slot() as u8,
-                    cluster_type,
-                    &mut process_stats,
-                );
+                let shreds =
+                    self.finish_prev_slot(keypair, bank.ticks_per_slot() as u8, &mut process_stats);
                 debug_assert!(shreds.iter().all(|shred| shred.slot() == self.slot));
                 // Broadcast shreds for the interrupted slot.
                 let batch_info = Some(BroadcastShredBatchInfo {
@@ -270,7 +259,6 @@ impl StandardBroadcastRun {
                 &receive_results.entries,
                 reference_tick as u8,
                 is_last_in_slot,
-                cluster_type,
                 &mut process_stats,
                 blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
                 shred_code::MAX_CODE_SHREDS_PER_SLOT as u32,
@@ -483,15 +471,6 @@ impl BroadcastRun for StandardBroadcastRun {
     }
 }
 
-fn should_chain_merkle_shreds(_slot: Slot, cluster_type: ClusterType) -> bool {
-    match cluster_type {
-        ClusterType::Development => true,
-        ClusterType::Devnet => true,
-        ClusterType::MainnetBeta => true,
-        ClusterType::Testnet => true,
-    }
-}
-
 #[cfg(test)]
 mod test {
     use {
@@ -579,7 +558,6 @@ mod test {
         let shreds = run.finish_prev_slot(
             &keypair,
             0, // max_ticks_in_slot
-            ClusterType::Development,
             &mut ProcessShredsStats::default(),
         );
         assert!(run.completed);
@@ -829,7 +807,6 @@ mod test {
                 &entries[0..entries.len() - 2],
                 0,
                 false,
-                ClusterType::Development,
                 &mut stats,
                 1000,
                 1000,
@@ -841,16 +818,7 @@ mod test {
         assert!(!data.is_empty());
         assert!(!coding.is_empty());
 
-        let r = bs.entries_to_shreds(
-            &keypair,
-            &entries,
-            0,
-            false,
-            ClusterType::Development,
-            &mut stats,
-            10,
-            10,
-        );
+        let r = bs.entries_to_shreds(&keypair, &entries, 0, false, &mut stats, 10, 10);
         info!("{:?}", r);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
     }


### PR DESCRIPTION
#### Problem

#5735 fully activates chained merkle shreds on mainnet-beta, the last public cluster. we no longer need the activation logic

#### Summary of Changes

removes activation logic for chained merkle shreds

---

requires #5734 and #5735