### PR TITLE
off-by-1 error introduced in 

### DIFF
--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -91,7 +91,7 @@ impl ClusterSlots {
         root_epoch: u64,
     ) {
         let current_slot = self.current_slot.load(Ordering::Relaxed);
-        if current_slot > root_slot {
+        if current_slot > root_slot + 1 {
             error!("Invalid update call to ClusterSlots, can not roll time backwards!");
             return;
         }


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/5476 introduced an off-by-1 error which prevented clusterslots from being updated more then once within a slot.

#### Summary of Changes

- Relax the constraint.

