### PR TITLE
Feature Gated: remove obsoleted FeeRateGovernor from fee calculation

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -450,7 +450,7 @@ impl Consumer {
         );
         let fee = solana_fee::calculate_fee(
             transaction,
-            bank.get_lamports_per_signature() == 0,
+            bank.is_zero_fees_for_test(),
             bank.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1116,6 +1116,10 @@ pub mod reenable_zk_elgamal_proof_program {
     solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
 }
 
+pub mod remove_fee_rate_governor_from_bank {
+    solana_pubkey::declare_id!("2dsTvEsgS6K5eV82Bn6hNCDm76rZUWcWeKvHjGqtUmgE");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1355,6 +1359,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (alpenglow::id(), "Enable Alpenglow"),
         (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
+        (remove_fee_rate_governor_from_bank::id(), "Remove obsoleted FeeRateGovernor from bank #3303"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1116,7 +1116,7 @@ pub mod reenable_zk_elgamal_proof_program {
     solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
 }
 
-pub mod remove_fee_rate_governor_from_bank {
+pub mod remove_fee_rate_governor_from_fee_calculation {
     solana_pubkey::declare_id!("2dsTvEsgS6K5eV82Bn6hNCDm76rZUWcWeKvHjGqtUmgE");
 }
 
@@ -1359,7 +1359,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (alpenglow::id(), "Enable Alpenglow"),
         (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
-        (remove_fee_rate_governor_from_bank::id(), "Remove obsoleted FeeRateGovernor from bank #3303"),
+        (remove_fee_rate_governor_from_fee_calculation::id(), "Remove obsoleted FeeRateGovernor from fee calculation #5782"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2886,6 +2886,12 @@ impl Bank {
         (last_hash, last_lamports_per_signature)
     }
 
+    pub fn is_zero_fees_for_test(&self) -> bool {
+        let (_last_hash, last_lamports_per_signature) =
+            self.last_blockhash_and_lamports_per_signature();
+        last_lamports_per_signature == 0
+    }
+
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         blockhash_queue.is_hash_valid_for_age(hash, MAX_PROCESSING_AGE)
@@ -2893,10 +2899,6 @@ impl Bank {
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
         self.rent_collector.rent.minimum_balance(data_len).max(1)
-    }
-
-    pub fn get_lamports_per_signature(&self) -> u64 {
-        self.fee_rate_governor.lamports_per_signature
     }
 
     pub fn get_lamports_per_signature_for_blockhash(&self, hash: &Hash) -> Option<u64> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3035,7 +3035,7 @@ impl Bank {
 
         let recent_lamports_per_signature = if self
             .feature_set
-            .is_active(&agave_feature_set::remove_fee_rate_governor_from_bank::id())
+            .is_active(&agave_feature_set::remove_fee_rate_governor_from_fee_calculation::id())
         {
             // lamports_per_signature stored in blockhash_queue is not used for fee calculation
             // but only for determining zero_fees_for_test mode (lamports_per_signature == 0).
@@ -3093,7 +3093,7 @@ impl Bank {
     ) {
         let recent_lamports_per_signature = if self
             .feature_set
-            .is_active(&agave_feature_set::remove_fee_rate_governor_from_bank::id())
+            .is_active(&agave_feature_set::remove_fee_rate_governor_from_fee_calculation::id())
         {
             // lamports_per_signature stored in blockhash_queue is not used for fee calculation
             // but only for determining zero_fees_for_test mode (lamports_per_signature == 0).

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -66,11 +66,9 @@ impl Bank {
         transaction: &impl TransactionWithMeta,
         fee_budget_limits: &FeeBudgetLimits,
     ) -> u64 {
-        let (_last_hash, last_lamports_per_signature) =
-            self.last_blockhash_and_lamports_per_signature();
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
-            last_lamports_per_signature == 0,
+            self.is_zero_fees_for_test(),
             self.fee_structure().lamports_per_signature,
             fee_budget_limits.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5699,7 +5699,7 @@ fn test_bank_hash_consistency() {
     genesis_config.cluster_type = ClusterType::MainnetBeta;
     activate_feature(
         &mut genesis_config,
-        agave_feature_set::remove_fee_rate_governor_from_bank::id(),
+        agave_feature_set::remove_fee_rate_governor_from_fee_calculation::id(),
     );
 
     // Set the feature set to all enabled so that we detect any inconsistencies
@@ -5726,7 +5726,7 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 0);
             assert_eq!(
                 bank.hash().to_string(),
-                "CNa64RPuBM1b4sicZCkMeiuhcMhLpfvh7GxhLQZnhRcs"
+                "21uu53PtWcbdKui4zoBmR86WyW5mTPmHud32yNFM7D9T"
             );
         }
 
@@ -5734,14 +5734,14 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 1);
             assert_eq!(
                 bank.hash().to_string(),
-                "ApbSYzbXgNBobjzp8ytimvVsMBUxtuJR9nFieePdpwj3"
+                "DHNFJRf1Vrfj18FTNafax4Y2HDc81BCsgygJxKXcAn33"
             );
         }
         if bank.slot == 128 {
             assert_eq!(bank.epoch(), 2);
             assert_eq!(
                 bank.hash().to_string(),
-                "6jy3Rg765h8byc94FPAt2FDzZhFRgZdDprer1i1g2dkt"
+                "8TwCL1HkVoTqzoUZnWHbwinCnAR4MEboPx9uPojNsqoZ"
             );
             break;
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2133,10 +2133,10 @@ fn test_bank_tx_compute_unit_fee() {
     );
 }
 
-#[test]
-fn test_bank_blockhash_fee_structure() {
-    //solana_logger::setup();
-
+#[test_case(0; "zero fees for tests")]
+#[test_case(10000; "default target lamports per signature")]
+#[test_case(1; "random non-zero target lamports per signature")]
+fn test_bank_transaction_fee(target_lamports_per_signature: u64) {
     let leader = solana_pubkey::new_rand();
     let GenesisConfigInfo {
         mut genesis_config,
@@ -2145,115 +2145,47 @@ fn test_bank_blockhash_fee_structure() {
     } = create_genesis_config_with_leader(1_000_000, &leader, 3);
     genesis_config
         .fee_rate_governor
-        .target_lamports_per_signature = 5000;
+        .target_lamports_per_signature = target_lamports_per_signature;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
-    let cheap_blockhash = bank.last_blockhash();
-    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
-    assert_eq!(cheap_lamports_per_signature, 0);
+    let early_blockhash = bank.last_blockhash();
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
-    let expensive_blockhash = bank.last_blockhash();
-    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
-    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
+    let later_blockhash = bank.last_blockhash();
 
     let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
 
-    // Send a transfer using cheap_blockhash
-    let key = solana_pubkey::new_rand();
-    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
-    assert_eq!(bank.process_transaction(&tx), Ok(()));
-    assert_eq!(bank.get_balance(&key), 1);
-    let cheap_fee = calculate_test_fee(
+    // transaction fee for same transaction must be consistent bewteen block hashs; it is
+    // either `0` if set up for zero_fees_for_test, or a non-zeo fee.
+    let tx_fee = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        cheap_lamports_per_signature,
+        target_lamports_per_signature,
         bank.fee_structure(),
     );
-    assert_eq!(
-        bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - cheap_fee
-    );
 
-    // Send a transfer using expensive_blockhash
+    // Send a transfer using early_blockhash
     let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, early_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
-    let expensive_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        expensive_lamports_per_signature,
-        bank.fee_structure(),
-    );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - expensive_fee
+        initial_mint_balance - 1 - tx_fee
     );
-}
 
-#[test]
-fn test_bank_blockhash_compute_unit_fee_structure() {
-    //solana_logger::setup();
-
-    let leader = solana_pubkey::new_rand();
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(1_000_000_000, &leader, 3);
-    genesis_config
-        .fee_rate_governor
-        .target_lamports_per_signature = 1000;
-    genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    goto_end_of_slot(bank.clone());
-    let cheap_blockhash = bank.last_blockhash();
-    let cheap_lamports_per_signature = bank.get_lamports_per_signature();
-    assert_eq!(cheap_lamports_per_signature, 0);
-
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 1);
-    goto_end_of_slot(bank.clone());
-    let expensive_blockhash = bank.last_blockhash();
-    let expensive_lamports_per_signature = bank.get_lamports_per_signature();
-    assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
-
-    let bank = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank, &leader, 2);
-
-    // Send a transfer using cheap_blockhash
+    // Send a transfer using later_blockhash
     let key = solana_pubkey::new_rand();
     let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, cheap_blockhash);
+    let tx = system_transaction::transfer(&mint_keypair, &key, 1, later_blockhash);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
-    let cheap_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        cheap_lamports_per_signature,
-        bank.fee_structure(),
-    );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - cheap_fee
-    );
-
-    // Send a transfer using expensive_blockhash
-    let key = solana_pubkey::new_rand();
-    let initial_mint_balance = bank.get_balance(&mint_keypair.pubkey());
-    let tx = system_transaction::transfer(&mint_keypair, &key, 1, expensive_blockhash);
-    assert_eq!(bank.process_transaction(&tx), Ok(()));
-    assert_eq!(bank.get_balance(&key), 1);
-    let expensive_fee = calculate_test_fee(
-        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
-        expensive_lamports_per_signature,
-        bank.fee_structure(),
-    );
-    assert_eq!(
-        bank.get_balance(&mint_keypair.pubkey()),
-        initial_mint_balance - 1 - expensive_fee
+        initial_mint_balance - 1 - tx_fee
     );
 }
 
@@ -5018,7 +4950,12 @@ fn test_nonce_fee_calculator_updates() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    assert_ne!(stored_fee_calculator, fee_calculator);
+    // stored lamports_per_signature isn't used to calculate transaction fee, but to determine if
+    // zero_fees_for_test, only assess if the flag is same.
+    assert_eq!(
+        stored_fee_calculator.lamports_per_signature == 0,
+        fee_calculator.lamports_per_signature == 0
+    );
 }
 
 #[test]
@@ -5067,7 +5004,8 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
     );
     bank.process_transaction(&nonce_tx).unwrap();
 
-    // Grab the new hash and fee_calculator; both should be updated
+    // Grab the new hash and fee_calculator; hash shoudl be updated, and lamports_per_signature
+    // should remain same in respect to zero_fees_for_test
     let (nonce_hash, fee_calculator) = bank
         .get_account(&nonce_pubkey)
         .and_then(|acc| {
@@ -5082,7 +5020,10 @@ fn test_nonce_fee_calculator_updates_tx_wide_cap() {
         .unwrap();
 
     assert_ne!(stored_nonce_hash, nonce_hash);
-    assert_ne!(stored_fee_calculator, fee_calculator);
+    assert_eq!(
+        stored_fee_calculator.lamports_per_signature == 0,
+        fee_calculator.lamports_per_signature == 0
+    );
 }
 
 #[test]
@@ -5756,6 +5697,10 @@ fn test_bank_hash_consistency() {
     // Override the creation time to ensure bank hash consistency
     genesis_config.creation_time = 0;
     genesis_config.cluster_type = ClusterType::MainnetBeta;
+    activate_feature(
+        &mut genesis_config,
+        agave_feature_set::remove_fee_rate_governor_from_bank::id(),
+    );
 
     // Set the feature set to all enabled so that we detect any inconsistencies
     // in the hash computation that may arise from feature set changes
@@ -5781,7 +5726,7 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 0);
             assert_eq!(
                 bank.hash().to_string(),
-                "AyXhbqmPsC46x7MHAuW89pQcNZVrUZnAND6ABWJ24svx",
+                "CNa64RPuBM1b4sicZCkMeiuhcMhLpfvh7GxhLQZnhRcs"
             );
         }
 
@@ -5796,7 +5741,7 @@ fn test_bank_hash_consistency() {
             assert_eq!(bank.epoch(), 2);
             assert_eq!(
                 bank.hash().to_string(),
-                "FxaFn1Dj7fetY1SXWWi6DyEYidoiDLZexe3hM1tNvkwJ"
+                "6jy3Rg765h8byc94FPAt2FDzZhFRgZdDprer1i1g2dkt"
             );
             break;
         }


### PR DESCRIPTION
#### Problem
- `lamports_per_signature` in `blockhash_queue` and nonce accounts is not used for fee calculation.
- Actual fees are fixed via `bank.fee_structure.lamports_per_signature = 5_000`.
- The only role of `lamports_per_signature` in the blockhash_queue is to enable test-mode zero fees when it's set to zero.
- Current behavior derives this value through `fee_rate_governor`, which is overly complex and introduces inconsistency, especially in early banks. ([example](https://github.com/anza-xyz/agave/blob/b7615921caeed2e80d89e24b88ce71bcc6c03220/test-validator/src/lib.rs#L1064-L1067))

#### Summary of Changes
- At genesis, store `target_lamports_per_signature` from genesis_config into the blockhash queue.
- For subsequent banks, copy `lamports_per_signature` from the parent bank.
- This keeps the intended behavior (e.g., zero-fee testing) and removes reliance on fee_rate_governor.
- Feature Gated, to avoid unintended fork divergence, this change is behind a feature gate (see #5454).

#### Note: impact on testnet

<details><summary>Genesis Config for three public clusters</summary> 

```
Creation time: 2020-03-16T14:29:00+00:00
Cluster type: MainnetBeta
Genesis hash: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
...
FeeRateGovernor { lamports_per_signature: 0, target_lamports_per_signature: 10000, ... }

Creation time: 2020-02-04T16:35:32+00:00
Cluster type: Testnet
Genesis hash: 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY
...
FeeRateGovernor { lamports_per_signature: 0, target_lamports_per_signature: 0, ... }

Creation time: 2020-08-10T17:36:56+00:00
Cluster type: Devnet
Genesis hash: EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG
...
FeeRateGovernor { lamports_per_signature: 0, target_lamports_per_signature: 10000, ... }
```
</details>

Notice that testnet sets `target_lamports_per_signature` to 0 in its genesis config, but it is not a zero-fee environment today. (At some point, the lamports_per_signature value in the blockhash queue was updated to a non-zero value.)

With this PR enabled, a validator restarted from an existing snapshot will inherit the non-zero `lamports_per_signature` from its parent bank and continue charging normal fees.

However, if the validator were to restart from genesis, it would enter a zero-fee mode, since the genesis bank would initialize the blockhash queue with `lamports_per_signature = 0`.

Fixes #5782 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
