### PR TITLE
Adds get_stored_account_callback() for when get_stored_account_meta_callback() can be avoided

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1046,20 +1046,11 @@ impl LoadedAccountAccessor<'_> {
                 maybe_storage_entry
                     .as_ref()
                     .and_then(|(storage_entry, offset)| {
-                        storage_entry.accounts.get_stored_account_meta_callback(
-                            *offset,
-                            |stored_account_meta| {
-                                let account = StoredAccountInfo {
-                                    pubkey: stored_account_meta.pubkey(),
-                                    lamports: stored_account_meta.lamports(),
-                                    owner: stored_account_meta.owner(),
-                                    data: stored_account_meta.data(),
-                                    executable: stored_account_meta.executable(),
-                                    rent_epoch: stored_account_meta.rent_epoch(),
-                                };
+                        storage_entry
+                            .accounts
+                            .get_stored_account_callback(*offset, |account| {
                                 callback(LoadedAccount::Stored(account))
-                            },
-                        )
+                            })
                     })
             }
         }

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -158,6 +158,28 @@ impl AccountsFile {
     }
 
     /// calls `callback` with the account located at the specified index offset.
+    pub fn get_stored_account_callback<Ret>(
+        &self,
+        offset: usize,
+        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
+    ) -> Option<Ret> {
+        self.get_stored_account_meta_callback(offset, |stored_account_meta| {
+            let account = StoredAccountInfo {
+                pubkey: stored_account_meta.pubkey(),
+                lamports: stored_account_meta.lamports(),
+                owner: stored_account_meta.owner(),
+                data: stored_account_meta.data(),
+                executable: stored_account_meta.executable(),
+                rent_epoch: stored_account_meta.rent_epoch(),
+            };
+            callback(account)
+        })
+    }
+
+    /// calls `callback` with the account located at the specified index offset.
+    ///
+    /// Prefer get_stored_account_callback() when possible, as it does not contain file format
+    /// implementation details, and thus potentially can read less and be faster.
     pub fn get_stored_account_meta_callback<Ret>(
         &self,
         offset: usize,


### PR DESCRIPTION
#### Problem

LoadedAccountAccessor::get_loaded_account() for a stored account calls `get_stored_account_meta_callback()`, even though it only needs a StoredAccountInfo and not a StoredAccountMeta.

When we only had AppendVecs, and only with mmaps, passing around StoredAccountMeta was no problem, since it was basically free. With file io and tiered storage, we'd like to avoid copying fields unnecessarily. Additionally, we'd like to avoid leaking the AppendVec file format implementation details around when they are unneeded.


#### Summary of Changes

Add get_stored_account_callback(), which returns a StoredAccountInfo, and then use that in LoadedAccountAccessor::get_loaded_account().