### PR TITLE
Bump platform tools version to v1.46

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -21,7 +21,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.45";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.46";
 
 #[derive(Debug)]
 struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.45"
+tools-version = "v1.46"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -21,4 +21,4 @@ crate-type = ["cdylib"]
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.45"
+tools-version = "v1.46"

--- a/platform-tools-sdk/sbf/c/sbf.mk
+++ b/platform-tools-sdk/sbf/c/sbf.mk
@@ -101,6 +101,7 @@ SBF_LLD_FLAGS := \
   $(LOCAL_PATH)sbf.ld \
   --entry entrypoint \
   -L $(STD_LIB_DIRS) \
+  -z max-page-size=4096 \
   -lc \
 
 OBJ_DUMP_FLAGS := \

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.45
+version=v1.46
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

PR #5606 uncovered a bug in the way we were lowering function call argument in the SBF code gen. It only affects SBPFv2 and SBPFv3. Refer to https://github.com/anza-xyz/llvm-project/pull/142 for the bug description and fix.

#### Summary of Changes

This PR brings platform tools v1.46 (still on Rust 1.79) with the bug fix. The idea of another release of the old toolchain is to facilitate back port.
