### PR TITLE
Remove --transaction-structure view option from validator CLI

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -10,7 +10,7 @@ use {
     solana_core::{
         banking_stage::{update_bank_forks_and_poh_recorder_for_new_tpu_bank, BankingStage},
         banking_trace::{BankingTracer, Channels, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
-        validator::{BlockProductionMethod, TransactionStructure},
+        validator::{BlockProductionMethod, TransactionStructure, TransactionStructureCli},
     },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -293,8 +293,8 @@ fn main() {
                 .long("transaction-structure")
                 .value_name("STRUCT")
                 .takes_value(true)
-                .possible_values(TransactionStructure::cli_names())
-                .help(TransactionStructure::cli_message()),
+                .possible_values(TransactionStructureCli::cli_names())
+                .help(TransactionStructureCli::cli_message()),
         )
         .arg(
             Arg::new("num_banking_threads")

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -212,13 +212,12 @@ impl BlockProductionMethod {
 
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
-pub enum TransactionStructure {
+pub enum TransactionStructureCli {
     #[default]
     Sdk,
-    View,
 }
 
-impl TransactionStructure {
+impl TransactionStructureCli {
     pub const fn cli_names() -> &'static [&'static str] {
         Self::VARIANTS
     }
@@ -227,12 +226,28 @@ impl TransactionStructure {
         lazy_static! {
             static ref MESSAGE: String = format!(
                 "Switch internal transaction structure/representation [default: {}]",
-                TransactionStructure::default()
+                TransactionStructureCli::default()
             );
         };
 
         &MESSAGE
     }
+}
+
+impl From<TransactionStructureCli> for TransactionStructure {
+    fn from(cli: TransactionStructureCli) -> Self {
+        match cli {
+            TransactionStructureCli::Sdk => TransactionStructure::Sdk,
+        }
+    }
+}
+
+#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum TransactionStructure {
+    #[default]
+    Sdk,
+    View,
 }
 
 /// Configuration for the block generator invalidator for replay.

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -12,7 +12,7 @@ use {
     },
     solana_core::{
         banking_trace::DirByteLimit,
-        validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructure},
+        validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructureCli},
     },
     solana_ledger::use_snapshot_archives_at_startup,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
@@ -1583,8 +1583,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("transaction-structure")
             .value_name("STRUCT")
             .takes_value(true)
-            .possible_values(TransactionStructure::cli_names())
-            .help(TransactionStructure::cli_message()),
+            .possible_values(TransactionStructureCli::cli_names())
+            .help(TransactionStructureCli::cli_message()),
     )
     .arg(
         Arg::with_name("unified_scheduler_handler_threads")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -29,7 +29,7 @@ use {
         tpu::DEFAULT_TPU_COALESCE,
         validator::{
             is_snapshot_config_valid, BlockProductionMethod, BlockVerificationMethod,
-            TransactionStructure, Validator, ValidatorConfig, ValidatorError,
+            TransactionStructureCli, Validator, ValidatorConfig, ValidatorError,
             ValidatorStartProgress, ValidatorTpuConfig,
         },
     },
@@ -1032,9 +1032,10 @@ pub fn execute(
     validator_config.transaction_struct = value_t!(
         matches, // comment to align formatting...
         "transaction_struct",
-        TransactionStructure
+        TransactionStructureCli
     )
-    .unwrap_or_default();
+    .unwrap_or_default()
+    .into();
     validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();
     validator_config.unified_scheduler_handler_threads =
         value_t!(matches, "unified_scheduler_handler_threads", usize).ok();


### PR DESCRIPTION
#### Problem
- Bug exposed by `transaction-view`
- Want to disable option while bug is fixed

#### Summary of Changes
- Create new `TransactionStructureCli`
    - This is to minimize change-set, so I don't need to rip out BankingStage stuff, and we can still test the view type internally.
- Remove `View` from CLI exposed `TransactionStructureCli`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
