### PR TITLE
Remove use of `stake_raise_minimum_delegation_to_1_sol` in stake program

### DIFF
--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -520,8 +520,7 @@ mod tests {
             &mint_keypair,
             &vote_account,
             &validator_identity,
-            bootstrap_validator_stake_lamports()
-                + solana_stake_program::get_minimum_delegation(&bank.feature_set),
+            bootstrap_validator_stake_lamports() + solana_stake_program::get_minimum_delegation(),
         );
         let node_pubkey = validator_identity.pubkey();
 

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,15 +1,11 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
+use solana_genesis_config::GenesisConfig;
 #[deprecated(
     since = "1.8.0",
     note = "Please use `solana_sdk_ids::sysvar::stake::id` instead"
 )]
 pub use solana_sdk_ids::stake::{check_id, id};
-use {
-    agave_feature_set::{self as feature_set, FeatureSet},
-    solana_genesis_config::GenesisConfig,
-    solana_native_token::LAMPORTS_PER_SOL,
-};
 
 pub mod config;
 #[deprecated(since = "2.2.0")]
@@ -25,11 +21,6 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
 /// NOTE: This is also used to calculate the minimum balance of a delegated stake account,
 /// which is the rent exempt reserve _plus_ the minimum stake delegation.
 #[inline(always)]
-pub fn get_minimum_delegation(feature_set: &FeatureSet) -> u64 {
-    if feature_set.is_active(&feature_set::stake_raise_minimum_delegation_to_1_sol::id()) {
-        const MINIMUM_DELEGATION_SOL: u64 = 1;
-        MINIMUM_DELEGATION_SOL * LAMPORTS_PER_SOL
-    } else {
-        1
-    }
+pub fn get_minimum_delegation() -> u64 {
+    1
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2380,8 +2380,7 @@ impl JsonRpcRequestProcessor {
 
     fn get_stake_minimum_delegation(&self, config: RpcContextConfig) -> Result<RpcResponse<u64>> {
         let bank = self.get_bank_with_config(config)?;
-        let stake_minimum_delegation =
-            solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let stake_minimum_delegation = solana_stake_program::get_minimum_delegation();
         Ok(new_response(&bank, stake_minimum_delegation))
     }
 
@@ -9033,9 +9032,7 @@ pub mod tests {
     #[test]
     fn test_rpc_get_stake_minimum_delegation() {
         let rpc = RpcHandler::start();
-        let bank = rpc.working_bank();
-        let expected_stake_minimum_delegation =
-            solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let expected_stake_minimum_delegation = solana_stake_program::get_minimum_delegation();
 
         let request = create_test_request("getStakeMinimumDelegation", None);
         let response: RpcResponse<u64> = parse_success_result(rpc.handle_request_sync(request));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2451,8 +2451,7 @@ impl Bank {
         {
             let num_stake_delegations = stakes.stake_delegations().len();
             let min_stake_delegation =
-                solana_stake_program::get_minimum_delegation(&self.feature_set)
-                    .max(LAMPORTS_PER_SOL);
+                solana_stake_program::get_minimum_delegation().max(LAMPORTS_PER_SOL);
 
             let (stake_delegations, filter_time_us) = measure_us!(stakes
                 .stake_delegations()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4479,7 +4479,7 @@ fn test_bank_cloned_stake_delegations() {
         let rent = &bank.rent_collector().rent;
         let vote_rent_exempt_reserve = rent.minimum_balance(VoteState::size_of());
         let stake_rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation();
         (
             vote_rent_exempt_reserve,
             stake_rent_exempt_reserve + minimum_delegation,

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -156,7 +156,7 @@ fn test_stake_create_and_split_single_signature() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation();
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -228,7 +228,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     let lamports = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation();
         2 * (rent_exempt_reserve + minimum_delegation)
     };
 
@@ -320,7 +320,7 @@ fn test_stake_account_lifetime() {
         (
             rent.minimum_balance(VoteState::size_of()),
             rent.minimum_balance(StakeStateV2::size_of()),
-            solana_stake_program::get_minimum_delegation(&bank.feature_set),
+            solana_stake_program::get_minimum_delegation(),
         )
     };
 
@@ -635,7 +635,7 @@ fn test_create_stake_account_from_seed() {
     let (balance, delegation) = {
         let rent = &bank.rent_collector().rent;
         let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let minimum_delegation = solana_stake_program::get_minimum_delegation(&bank.feature_set);
+        let minimum_delegation = solana_stake_program::get_minimum_delegation();
         (rent_exempt_reserve + minimum_delegation, minimum_delegation)
     };
 


### PR DESCRIPTION
#### Problem
`stake_raise_minimum_delegation_to_1_sol` feature will not be used as part of the builtin stake program. But, this is causing a dependency on `InvokeContext::get_feature_set()`. This dependency needs to be removed as part of SVM repo migration.

#### Summary of Changes
Remove the feature usage from the builtin stake program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
