### PR TITLE
Stop propagating ContactInfo with wrong shred version in PullResponse

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1704,6 +1704,7 @@ impl ClusterInfo {
                         value, stakes, /*drop_unstaked_node_instance:*/ true,
                     )
                 },
+                self.my_shred_version(),
                 &self.stats,
             )
         };

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -236,6 +236,7 @@ impl CrdsGossip {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
+        self_shred_version: u16,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         CrdsGossipPull::generate_pull_responses(
@@ -245,6 +246,7 @@ impl CrdsGossip {
             output_size_limit,
             now,
             should_retain_crds_value,
+            self_shred_version,
             stats,
         )
     }

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -612,6 +612,7 @@ fn network_run_pull(
                                 usize::MAX, // output_size_limit
                                 now,
                                 |_| true, // should_retain_crds_value
+                                0,        // network shred version
                                 &GossipStats::default(),
                             )
                             .into_iter()


### PR DESCRIPTION
#### Problem
We accept ContactInfo with invalid shred versions. We first need to stop propagating ContactInfo with the wrong shred version via PullResponse (This PR) before we stop accepting ContactInfo with the wrong shred version altogether (https://github.com/anza-xyz/agave/pull/5659)

#### Summary of Changes
Filter out ContactInfo with the wrong shred version from PullResponses

Note: This is has been tested and is compatible with wen-restart