### PR TITLE
Refactor - Marks `TransactionAccounts::get()` as private.

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -144,7 +144,7 @@ solana-svm = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-timings = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-status = { workspace = true }
 solana-type-overrides = { workspace = true }
 solana-vote = { workspace = true }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -97,7 +97,7 @@ impl TransactionAccounts {
         self.accounts.len()
     }
 
-    pub fn get(&self, index: IndexOfAccount) -> Option<&RefCell<AccountSharedData>> {
+    fn get(&self, index: IndexOfAccount) -> Option<&RefCell<AccountSharedData>> {
         self.accounts.get(index as usize)
     }
 


### PR DESCRIPTION
#### Problem

#5698 missed one more sneaky way to get direct access to `AccountSharedData`.

#### Summary of Changes

- Marks `TransactionAccounts::get()` as private
- Replaces `TransactionAccounts::get()` with `InstructionContext::try_borrow_instruction_account()` in `test_cpi_change_account_data_memory_allocation()`