### PR TITLE
Remove Precompile Alignment check/requirement

### DIFF
--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
-bytemuck = { workspace = true }
 digest = { workspace = true }
 ed25519-dalek = { workspace = true }
 lazy_static = { workspace = true }
@@ -28,6 +27,7 @@ solana-secp256k1-program = { workspace = true, features = ["serde"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 
 [dev-dependencies]
+bytemuck = { workspace = true }
 hex = { workspace = true }
 rand0-7 = { workspace = true }
 solana-instruction = { workspace = true }

--- a/precompiles/src/ed25519.rs
+++ b/precompiles/src/ed25519.rs
@@ -121,7 +121,30 @@ pub mod tests {
             new_ed25519_instruction, offsets_to_ed25519_instruction, DATA_START,
         },
         solana_instruction::Instruction,
+        std::vec,
     };
+
+    fn test_verify_with_alignment(
+        instruction_data: &[u8],
+        instruction_datas: &[&[u8]],
+        feature_set: &FeatureSet,
+    ) -> Result<(), PrecompileError> {
+        // Copy instruction data.
+        let mut instruction_data_copy = vec![0u8; instruction_data.len().checked_add(1).unwrap()];
+        instruction_data_copy[0..instruction_data.len()].copy_from_slice(instruction_data);
+        // Verify the instruction data.
+        let result = verify(
+            &instruction_data_copy[..instruction_data.len()],
+            instruction_datas,
+            feature_set,
+        );
+
+        // Shift alignment by 1 to test `verify` does not rely on alignment.
+        instruction_data_copy[1..].copy_from_slice(instruction_data);
+        let result_shifted = verify(&instruction_data_copy[1..], instruction_datas, feature_set);
+        assert_eq!(result, result_shifted);
+        result
+    }
 
     pub fn new_ed25519_instruction_raw(
         pubkey: &[u8],
@@ -190,7 +213,7 @@ pub mod tests {
         instruction_data[0..SIGNATURE_OFFSETS_START].copy_from_slice(bytes_of(&num_signatures));
         instruction_data[SIGNATURE_OFFSETS_START..DATA_START].copy_from_slice(bytes_of(offsets));
 
-        verify(
+        test_verify_with_alignment(
             &instruction_data,
             &[&[0u8; 100]],
             &FeatureSet::all_enabled(),
@@ -208,7 +231,7 @@ pub mod tests {
         instruction_data.truncate(instruction_data.len() - 1);
 
         assert_eq!(
-            verify(
+            test_verify_with_alignment(
                 &instruction_data,
                 &[&[0u8; 100]],
                 &FeatureSet::all_enabled(),
@@ -338,7 +361,10 @@ pub mod tests {
         let mut instruction = new_ed25519_instruction(&privkey, message_arr);
         let feature_set = FeatureSet::all_enabled();
 
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         let index = loop {
             let index = thread_rng().gen_range(0, instruction.data.len());
@@ -349,7 +375,10 @@ pub mod tests {
         };
 
         instruction.data[index] = instruction.data[index].wrapping_add(12);
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_err());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_err()
+        );
     }
 
     #[test]
@@ -395,7 +424,10 @@ pub mod tests {
 
         let feature_set = FeatureSet::all_enabled();
 
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         let index = loop {
             let index = thread_rng().gen_range(0, instruction.data.len());
@@ -406,7 +438,10 @@ pub mod tests {
         };
 
         instruction.data[index] = instruction.data[index].wrapping_add(12);
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_err());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_err()
+        );
     }
 
     #[test]
@@ -419,10 +454,16 @@ pub mod tests {
         let instruction = new_ed25519_instruction(&privkey, message_arr);
 
         let feature_set = FeatureSet::default();
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         let feature_set = FeatureSet::all_enabled();
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         // malleable sig: verify_strict does NOT pass
         // for example, test number 5:
@@ -436,10 +477,16 @@ pub mod tests {
         let instruction = new_ed25519_instruction_raw(pubkey, signature, message);
 
         let feature_set = FeatureSet::default();
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         // verify_strict does NOT pass
         let feature_set = FeatureSet::all_enabled();
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_err());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_err()
+        );
     }
 }

--- a/precompiles/src/ed25519.rs
+++ b/precompiles/src/ed25519.rs
@@ -31,11 +31,13 @@ pub fn verify(
         let start = i
             .saturating_mul(SIGNATURE_OFFSETS_SERIALIZED_SIZE)
             .saturating_add(SIGNATURE_OFFSETS_START);
-        let end = start.saturating_add(SIGNATURE_OFFSETS_SERIALIZED_SIZE);
 
-        // bytemuck wants structures aligned
-        let offsets: &Ed25519SignatureOffsets = bytemuck::try_from_bytes(&data[start..end])
-            .map_err(|_| PrecompileError::InvalidDataOffsets)?;
+        // SAFETY:
+        // - data[start..] is guaranteed to be >= size of Ed25519SignatureOffsets
+        // - Ed25519SignatureOffsets is a POD type, so we can safely read it as an unaligned struct
+        let offsets = unsafe {
+            core::ptr::read_unaligned(data.as_ptr().add(start) as *const Ed25519SignatureOffsets)
+        };
 
         // Parse out signature
         let signature = get_data_slice(

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -119,3 +119,27 @@ pub fn verify_if_precompile(
     }
     Ok(())
 }
+
+#[cfg(test)]
+pub(crate) fn test_verify_with_alignment(
+    verify: Verify,
+    instruction_data: &[u8],
+    instruction_datas: &[&[u8]],
+    feature_set: &FeatureSet,
+) -> Result<(), PrecompileError> {
+    // Copy instruction data.
+    let mut instruction_data_copy = vec![0u8; instruction_data.len().checked_add(1).unwrap()];
+    instruction_data_copy[0..instruction_data.len()].copy_from_slice(instruction_data);
+    // Verify the instruction data.
+    let result = verify(
+        &instruction_data_copy[..instruction_data.len()],
+        instruction_datas,
+        feature_set,
+    );
+
+    // Shift alignment by 1 to test `verify` does not rely on alignment.
+    instruction_data_copy[1..].copy_from_slice(instruction_data);
+    let result_shifted = verify(&instruction_data_copy[1..], instruction_datas, feature_set);
+    assert_eq!(result, result_shifted);
+    result
+}

--- a/precompiles/src/secp256k1.rs
+++ b/precompiles/src/secp256k1.rs
@@ -135,6 +135,28 @@ pub mod tests {
         solana_secp256k1_program::{new_secp256k1_instruction, DATA_START},
     };
 
+    fn test_verify_with_alignment(
+        instruction_data: &[u8],
+        instruction_datas: &[&[u8]],
+        feature_set: &FeatureSet,
+    ) -> Result<(), PrecompileError> {
+        // Copy instruction data.
+        let mut instruction_data_copy = vec![0u8; instruction_data.len().checked_add(1).unwrap()];
+        instruction_data_copy[0..instruction_data.len()].copy_from_slice(instruction_data);
+        // Verify the instruction data.
+        let result = verify(
+            &instruction_data_copy[..instruction_data.len()],
+            instruction_datas,
+            feature_set,
+        );
+
+        // Shift alignment by 1 to test `verify` does not rely on alignment.
+        instruction_data_copy[1..].copy_from_slice(instruction_data);
+        let result_shifted = verify(&instruction_data_copy[1..], instruction_datas, feature_set);
+        assert_eq!(result, result_shifted);
+        result
+    }
+
     fn test_case(
         num_signatures: u8,
         offsets: &SecpSignatureOffsets,
@@ -144,7 +166,7 @@ pub mod tests {
         let writer = std::io::Cursor::new(&mut instruction_data[1..]);
         bincode::serialize_into(writer, &offsets).unwrap();
         let feature_set = FeatureSet::all_enabled();
-        verify(&instruction_data, &[&[0u8; 100]], &feature_set)
+        test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set)
     }
 
     #[test]
@@ -160,7 +182,7 @@ pub mod tests {
         let feature_set = FeatureSet::all_enabled();
 
         assert_eq!(
-            verify(&instruction_data, &[&[0u8; 100]], &feature_set),
+            test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
 
@@ -289,7 +311,7 @@ pub mod tests {
         let feature_set = FeatureSet::all_enabled();
 
         assert_eq!(
-            verify(&instruction_data, &[&[0u8; 100]], &feature_set),
+            test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
     }
@@ -307,11 +329,17 @@ pub mod tests {
         let message_arr = b"hello";
         let mut instruction = new_secp256k1_instruction(&secp_privkey, message_arr);
         let feature_set = FeatureSet::all_enabled();
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         let index = thread_rng().gen_range(0, instruction.data.len());
         instruction.data[index] = instruction.data[index].wrapping_add(12);
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_err());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_err()
+        );
     }
 
     // Signatures are malleable.
@@ -376,7 +404,7 @@ pub mod tests {
 
         instruction_data.extend(data);
 
-        verify(
+        test_verify_with_alignment(
             &instruction_data,
             &[&instruction_data],
             &FeatureSet::all_enabled(),

--- a/precompiles/src/secp256k1.rs
+++ b/precompiles/src/secp256k1.rs
@@ -130,32 +130,11 @@ fn get_data_slice<'a>(
 pub mod tests {
     use {
         super::*,
+        crate::test_verify_with_alignment,
         rand0_7::{thread_rng, Rng},
         solana_keccak_hasher as keccak,
         solana_secp256k1_program::{new_secp256k1_instruction, DATA_START},
     };
-
-    fn test_verify_with_alignment(
-        instruction_data: &[u8],
-        instruction_datas: &[&[u8]],
-        feature_set: &FeatureSet,
-    ) -> Result<(), PrecompileError> {
-        // Copy instruction data.
-        let mut instruction_data_copy = vec![0u8; instruction_data.len().checked_add(1).unwrap()];
-        instruction_data_copy[0..instruction_data.len()].copy_from_slice(instruction_data);
-        // Verify the instruction data.
-        let result = verify(
-            &instruction_data_copy[..instruction_data.len()],
-            instruction_datas,
-            feature_set,
-        );
-
-        // Shift alignment by 1 to test `verify` does not rely on alignment.
-        instruction_data_copy[1..].copy_from_slice(instruction_data);
-        let result_shifted = verify(&instruction_data_copy[1..], instruction_datas, feature_set);
-        assert_eq!(result, result_shifted);
-        result
-    }
 
     fn test_case(
         num_signatures: u8,
@@ -166,7 +145,7 @@ pub mod tests {
         let writer = std::io::Cursor::new(&mut instruction_data[1..]);
         bincode::serialize_into(writer, &offsets).unwrap();
         let feature_set = FeatureSet::all_enabled();
-        test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set)
+        test_verify_with_alignment(verify, &instruction_data, &[&[0u8; 100]], &feature_set)
     }
 
     #[test]
@@ -182,7 +161,7 @@ pub mod tests {
         let feature_set = FeatureSet::all_enabled();
 
         assert_eq!(
-            test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set),
+            test_verify_with_alignment(verify, &instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
 
@@ -311,7 +290,7 @@ pub mod tests {
         let feature_set = FeatureSet::all_enabled();
 
         assert_eq!(
-            test_verify_with_alignment(&instruction_data, &[&[0u8; 100]], &feature_set),
+            test_verify_with_alignment(verify, &instruction_data, &[&[0u8; 100]], &feature_set),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
     }
@@ -329,17 +308,23 @@ pub mod tests {
         let message_arr = b"hello";
         let mut instruction = new_secp256k1_instruction(&secp_privkey, message_arr);
         let feature_set = FeatureSet::all_enabled();
-        assert!(
-            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
-                .is_ok()
-        );
+        assert!(test_verify_with_alignment(
+            verify,
+            &instruction.data,
+            &[&instruction.data],
+            &feature_set
+        )
+        .is_ok());
 
         let index = thread_rng().gen_range(0, instruction.data.len());
         instruction.data[index] = instruction.data[index].wrapping_add(12);
-        assert!(
-            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
-                .is_err()
-        );
+        assert!(test_verify_with_alignment(
+            verify,
+            &instruction.data,
+            &[&instruction.data],
+            &feature_set
+        )
+        .is_err());
     }
 
     // Signatures are malleable.
@@ -405,6 +390,7 @@ pub mod tests {
         instruction_data.extend(data);
 
         test_verify_with_alignment(
+            verify,
             &instruction_data,
             &[&instruction_data],
             &FeatureSet::all_enabled(),

--- a/precompiles/src/secp256r1.rs
+++ b/precompiles/src/secp256r1.rs
@@ -171,6 +171,28 @@ mod tests {
         solana_secp256r1_program::{new_secp256r1_instruction, DATA_START, SECP256R1_ORDER},
     };
 
+    fn test_verify_with_alignment(
+        instruction_data: &[u8],
+        instruction_datas: &[&[u8]],
+        feature_set: &FeatureSet,
+    ) -> Result<(), PrecompileError> {
+        // Copy instruction data.
+        let mut instruction_data_copy = vec![0u8; instruction_data.len().checked_add(1).unwrap()];
+        instruction_data_copy[0..instruction_data.len()].copy_from_slice(instruction_data);
+        // Verify the instruction data.
+        let result = verify(
+            &instruction_data_copy[..instruction_data.len()],
+            instruction_datas,
+            feature_set,
+        );
+
+        // Shift alignment by 1 to test `verify` does not rely on alignment.
+        instruction_data_copy[1..].copy_from_slice(instruction_data);
+        let result_shifted = verify(&instruction_data_copy[1..], instruction_datas, feature_set);
+        assert_eq!(result, result_shifted);
+        result
+    }
+
     fn test_case(
         num_signatures: u16,
         offsets: &Secp256r1SignatureOffsets,
@@ -183,7 +205,7 @@ mod tests {
         let mut instruction_data = vec![0u8; DATA_START];
         instruction_data[0..SIGNATURE_OFFSETS_START].copy_from_slice(bytes_of(&num_signatures));
         instruction_data[SIGNATURE_OFFSETS_START..DATA_START].copy_from_slice(bytes_of(offsets));
-        verify(
+        test_verify_with_alignment(
             &instruction_data,
             &[&[0u8; 100]],
             &FeatureSet::all_enabled(),
@@ -201,7 +223,7 @@ mod tests {
         instruction_data.truncate(instruction_data.len() - 1);
 
         assert_eq!(
-            verify(
+            test_verify_with_alignment(
                 &instruction_data,
                 &[&[0u8; 100]],
                 &FeatureSet::all_enabled()
@@ -244,7 +266,7 @@ mod tests {
         // Test data.len() < SIGNATURE_OFFSETS_START
         let small_data = vec![0u8; SIGNATURE_OFFSETS_START - 1];
         assert_eq!(
-            verify(&small_data, &[&[]], &FeatureSet::all_enabled()),
+            test_verify_with_alignment(&small_data, &[&[]], &FeatureSet::all_enabled()),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
 
@@ -252,7 +274,7 @@ mod tests {
         let mut zero_sigs_data = vec![0u8; DATA_START];
         zero_sigs_data[0] = 0; // Set num_signatures to 0
         assert_eq!(
-            verify(&zero_sigs_data, &[&[]], &FeatureSet::all_enabled()),
+            test_verify_with_alignment(&zero_sigs_data, &[&[]], &FeatureSet::all_enabled()),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
 
@@ -260,7 +282,7 @@ mod tests {
         let mut too_many_sigs = vec![0u8; DATA_START];
         too_many_sigs[0] = 9; // Set num_signatures to 9
         assert_eq!(
-            verify(&too_many_sigs, &[&[]], &FeatureSet::all_enabled()),
+            test_verify_with_alignment(&too_many_sigs, &[&[]], &FeatureSet::all_enabled()),
             Err(PrecompileError::InvalidInstructionDataSize)
         );
     }
@@ -358,7 +380,10 @@ mod tests {
         let mut instruction = new_secp256r1_instruction(message_arr, signing_key).unwrap();
         let feature_set = FeatureSet::all_enabled();
 
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_ok()
+        );
 
         // The message is the last field in the instruction data so
         // changing its last byte will also change the signature validity
@@ -366,7 +391,10 @@ mod tests {
         instruction.data[message_byte_index] =
             instruction.data[message_byte_index].wrapping_add(12);
 
-        assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_err());
+        assert!(
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set)
+                .is_err()
+        );
     }
 
     #[test]
@@ -379,7 +407,7 @@ mod tests {
 
         // To double check that the untampered low-S value signature passes
         let feature_set = FeatureSet::all_enabled();
-        let tx_pass = verify(
+        let tx_pass = test_verify_with_alignment(
             instruction.data.as_slice(),
             &[instruction.data.as_slice()],
             &feature_set,
@@ -401,7 +429,8 @@ mod tests {
         // Replace the S value in the signature with our high S
         instruction.data[s_offset..s_offset + FIELD_SIZE].copy_from_slice(&high_s.to_vec());
 
-        let tx_fail = verify(&instruction.data, &[&instruction.data], &feature_set);
+        let tx_fail =
+            test_verify_with_alignment(&instruction.data, &[&instruction.data], &feature_set);
         assert!(tx_fail.unwrap_err() == PrecompileError::InvalidSignature);
     }
     #[test]
@@ -430,7 +459,12 @@ mod tests {
             if r_bytes.len() == 31 || s_bytes.len() == 31 {
                 // Once found, verify the signature and break out of the loop
                 let feature_set = FeatureSet::all_enabled();
-                assert!(verify(&instruction.data, &[&instruction.data], &feature_set).is_ok());
+                assert!(test_verify_with_alignment(
+                    &instruction.data,
+                    &[&instruction.data],
+                    &feature_set
+                )
+                .is_ok());
                 break;
             }
         }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -100,7 +100,6 @@ version = "2.3.0"
 dependencies = [
  "agave-feature-set",
  "bincode",
- "bytemuck",
  "digest 0.10.7",
  "ed25519-dalek",
  "lazy_static",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -100,7 +100,6 @@ version = "2.3.0"
 dependencies = [
  "agave-feature-set",
  "bincode",
- "bytemuck",
  "digest 0.10.7",
  "ed25519-dalek",
  "lazy_static",


### PR DESCRIPTION
#### Problem
- 2 of the precompile implementations assume instruction data having a specific alignment

#### Summary of Changes
- Remove alignment requirements from precompiles
- Add tests w/ intentionally messed up alignment 