### PR TITLE
Fix incorrect array size in C SDK

### DIFF
--- a/platform-tools-sdk/sbf/c/inc/sol/deserialize.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/deserialize.h
@@ -126,6 +126,9 @@ static bool sol_deserialize(
 
   params->program_id = (SolPubkey *) input;
   input += sizeof(SolPubkey);
+  if (params->ka_num > ka_num) {
+    params->ka_num = ka_num;
+  }
 
   return true;
 }


### PR DESCRIPTION
#### Problem

The C SDK function `sol_deserialize` allows us to pass in an array of accounts whose size is less than the number of accounts we are about to deserialize. In this case, the deserialization function simply jumps over the incoming accounts and does not touch the array (see below), while assigning `ka_num` the number of accounts available in the input.

https://github.com/anza-xyz/agave/blob/b35f5bee58828b4ab8f69a6c62256f44c0664dc3/platform-tools-sdk/sbf/c/inc/sol/deserialize.h#L50-L68

https://github.com/anza-xyz/agave/blob/b35f5bee58828b4ab8f69a6c62256f44c0664dc3/platform-tools-sdk/sbf/c/inc/sol/deserialize.h#L43

When this circumstance happens, the length of `SolAccountInfo* ka` in `struct SolParameters` diverges from `uint64_t ka_num` (also in `struct SolParameters`).

https://github.com/anza-xyz/agave/blob/b35f5bee58828b4ab8f69a6c62256f44c0664dc3/platform-tools-sdk/sbf/c/inc/sol/entrypoint.h#L32-L39


That makes the `sol_log_params` function incorrect, since it utilizes `ka_num` to traverse the array `SolAccountInfo *ka` when printing the parameters.

The new clang-19, which ships with Rust 1.84.1, changed the stack layout making the C sanity tests result in a segmentation fault because of that. Those tests have `ka_num = 2`, while `SolParameters` has only one element allocated. (At first I thought it was a compiler bug).

#### Summary of Changes

Set `ka_num` to be the minimum between the array size and the accounts in the input.

