### PR TITLE
VoteWorker: ownership of storage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -604,8 +604,15 @@ impl BankingStage {
         Builder::new()
             .name(format!("solBanknStgTx{id:02}"))
             .spawn(move || {
-                VoteWorker::new(decision_maker, packet_receiver, bank_forks, consumer, id)
-                    .run(vote_storage)
+                VoteWorker::new(
+                    decision_maker,
+                    packet_receiver,
+                    vote_storage,
+                    bank_forks,
+                    consumer,
+                    id,
+                )
+                .run()
             })
             .unwrap()
     }


### PR DESCRIPTION
#### Problem
- VoteWorker could not previously own the storage because of the callback used to process storage items.
- The callback was removed in #5626

#### Summary of Changes
- `VoteWorker` has ownership of `VoteStorage` instead of passing it to each function

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
