### PR TITLE
Fixes storage alive size with secondary indexes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8539,7 +8539,6 @@ impl AccountsDb {
             storage
                 .accounts
                 .scan_accounts_stored_meta(|stored_account| {
-                    stored_size_alive += stored_account.stored_size();
                     let pubkey = stored_account.pubkey();
                     self.accounts_index.update_secondary_indexes(
                         pubkey,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6,7 +6,7 @@ use {
         account_storage::meta::{AccountMeta, StoredMeta},
         accounts_file::AccountsFileProvider,
         accounts_hash::MERKLE_FANOUT,
-        accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
+        accounts_index::{tests::*, AccountIndex, AccountSecondaryIndexesIncludeExclude},
         ancient_append_vecs,
         append_vec::{
             aligned_stored_size, test_utils::TempFile, AppendVec, AppendVecStoredAccountMeta,
@@ -235,6 +235,29 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
         0,
         append_vec.alive_bytes_exclude_zero_lamport_single_ref_accounts()
     );
+}
+
+#[test]
+fn test_generate_index_duplicates_within_slot_with_secondary_indexes() {
+    let secondary_indexes = AccountSecondaryIndexes {
+        keys: None,
+        indexes: HashSet::from([
+            AccountIndex::ProgramId,
+            AccountIndex::SplTokenMint,
+            AccountIndex::SplTokenOwner,
+        ]),
+    };
+    let accounts_db_config = AccountsDbConfig {
+        account_indexes: Some(secondary_indexes),
+        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+    };
+    let accounts_db = AccountsDb::new_with_config(
+        Vec::new(),
+        Some(accounts_db_config),
+        None,
+        AtomicBool::new(false).into(),
+    );
+    run_generate_index_duplicates_within_slot_test(accounts_db, false);
 }
 
 fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {


### PR DESCRIPTION
#### Problem

When generating the index with secondary indexes, the AccountStorageEntry's alive bytes is incorrectly set (approximately double). This likely causes issues later, e.g. not shrinking when they should.


#### Summary of Changes

Fix it.

Note, I intend to backport this fix to v2.2.