### PR TITLE
Uses scan_accounts() while generating the secondary indexes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8536,16 +8536,13 @@ impl AccountsDb {
         };
         if secondary {
             // scan storage a second time to update the secondary index
-            storage
-                .accounts
-                .scan_accounts_stored_meta(|stored_account| {
-                    let pubkey = stored_account.pubkey();
-                    self.accounts_index.update_secondary_indexes(
-                        pubkey,
-                        &stored_account,
-                        &self.account_indexes,
-                    );
-                });
+            storage.accounts.scan_accounts(|stored_account| {
+                self.accounts_index.update_secondary_indexes(
+                    stored_account.pubkey(),
+                    &stored_account,
+                    &self.account_indexes,
+                );
+            });
         }
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {


### PR DESCRIPTION
#### Problem

When generating secondary account indexes, we scan storages and pass each account to `update_secondary_indexes()`. This function needs a pubkey and a `ReadableAccount` per account in the storage, but currently we load/pass around the whole StoredAccountMeta. This struct should be avoided when possible, as it contains AppendVec file format implementation details. And since we don't need any of those file format details, we should use a different function for scanning the storages.


#### Summary of Changes

Uses scan_accounts() while generating the secondary indexes.