### PR TITLE
Remove usage of new_warmup_cooldown_rate_epoch from stake program

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -137,7 +137,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             instruction_context.check_number_of_instruction_accounts(5)?;
             drop(me);
             delegate(
-                invoke_context,
                 transaction_context,
                 instruction_context,
                 0,
@@ -210,14 +209,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 } else {
                     None
                 },
-                new_warmup_cooldown_rate_epoch(invoke_context),
+                new_warmup_cooldown_rate_epoch(),
             )
         }
         StakeInstruction::Deactivate => {
             let mut me = get_stake_account()?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
-            deactivate(invoke_context, &mut me, &clock, &signers)
+            deactivate(&mut me, &clock, &signers)
         }
         StakeInstruction::SetLockup(lockup) => {
             let mut me = get_stake_account()?;


### PR DESCRIPTION
#### Problem
The use of `new_warmup_cooldown_rate_epoch` in stake program causes a dependency on SVM's `InvokeContext::get_feature_set()`. We are trying to remove FeatureSet usage from SVM code. This is blocking the refactor.

#### Summary of Changes
Remove the usage of this function and replicate the logic from BPF version of the Stake program (https://github.com/solana-program/stake/blob/bcec951fda5f2a30b1f4a058706d2e9ed23a8429/program/src/lib.rs#L32)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
