### PR TITLE
fix: in banking stage, enforce max num checks in clean_queue

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -245,7 +245,10 @@ where
         const MAX_TRANSACTION_CHECKS: usize = 10_000;
         let mut transaction_ids = Vec::with_capacity(MAX_TRANSACTION_CHECKS);
 
-        while let Some(id) = self.container.pop() {
+        while transaction_ids.len() < MAX_TRANSACTION_CHECKS {
+            let Some(id) = self.container.pop() else {
+                break
+            };
             transaction_ids.push(id);
         }
 


### PR DESCRIPTION
#### Problem
clean_queue does not enforce max num checks

#### Summary of Changes
enforce max num checks
