### PR TITLE
v2.1: ci: ignore RUSTSEC-2025-0024

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -124,6 +124,17 @@ cargo_audit_ignores=(
   # Dependency tree:
   # openssl 0.10.70
   --ignore RUSTSEC-2025-0022
+
+  # Crate:     crossbeam-channel
+  # Version:   0.5.13
+  # Title:     crossbeam-channel: double free on Drop
+  # Date:      2025-04-08
+  # ID:        RUSTSEC-2025-0024
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2025-0024
+  # Solution:  Upgrade to >=0.5.15
+  # Dependency tree:
+  # crossbeam-channel 0.5.13
+  --ignore RUSTSEC-2025-0024
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem

```
Crate:     crossbeam-channel
Version:   0.5.13
Title:     crossbeam-channel: double free on Drop
Date:      2025-04-08
ID:        RUSTSEC-2025-0024
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0024
Solution:  Upgrade to >=0.5.15
Dependency tree:
crossbeam-channel 0.5.13
```

#### Summary of Changes

[from discord](https://discord.com/channels/428295358100013066/560503042458517505/1360644219060097205)

> so for 2.1, we're going from 0.5.13 to 0.5.15, 13-14 is too big a delta to take to stable imo. given this advisory:
> * is a double-free on channel drop
> * we have few ephemeral channels (mostly dropped on proc exit)
> * there aren't (m?)any practical ways for remote inputs to influence channel drops
> * that the issue is so difficult to reproduce so as justify not including a test with the fix
> * that we do not have any occurrences reported
> * that v2.1 is nearing EOL
> 
> i suggest that we ignore the advisory
