### PR TITLE
agave-validator: add args tests for run (part 1)

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1734,7 +1734,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_identity_file_short_arg() {
+    fn verify_args_struct_by_command_run_with_identity() {
         let default_args = DefaultArgs::default();
         let default_run_args = RunArgs::default();
 
@@ -1744,38 +1744,28 @@ mod tests {
         let keypair = default_run_args.identity_keypair.insecure_clone();
         solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
-        let matches = create_app_and_get_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
-        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
-        assert_eq!(
-            args,
-            RunArgs {
-                identity_keypair: keypair,
-                ..default_run_args
-            }
-        );
-    }
+        let expected_args = RunArgs {
+            identity_keypair: keypair.insecure_clone(),
+            ..default_run_args
+        };
 
-    #[test]
-    fn verify_args_struct_by_command_run_with_identity_file_long_arg() {
-        let default_args = DefaultArgs::default();
-        let default_run_args = RunArgs::default();
+        // short arg
+        {
+            let matches =
+                create_app_and_get_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
+            let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+            assert_eq!(args, expected_args);
+        }
 
-        // generate a keypair
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let file = tmp_dir.path().join("id.json");
-        let keypair = default_run_args.identity_keypair.insecure_clone();
-        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
-
-        let matches =
-            create_app_and_get_matches(&default_args, vec!["--identity", file.to_str().unwrap()]);
-        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
-        assert_eq!(
-            args,
-            RunArgs {
-                identity_keypair: keypair,
-                ..default_run_args
-            }
-        );
+        // long arg
+        {
+            let matches = create_app_and_get_matches(
+                &default_args,
+                vec!["--identity", file.to_str().unwrap()],
+            );
+            let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+            assert_eq!(args, expected_args);
+        }
     }
 
     fn test_run_command_with_identity_setup(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -21,7 +21,7 @@ use {
     },
     solana_ledger::use_snapshot_archives_at_startup,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
-    solana_sdk::signature::Keypair,
+    solana_sdk::signature::{Keypair, Signer},
     solana_send_transaction_service::send_transaction_service::{
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
@@ -35,6 +35,7 @@ const INCLUDE_KEY: &str = "account-index-include-key";
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
     pub identity: Keypair,
+    pub logfile: String,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -44,7 +45,15 @@ impl FromClapArgMatches for RunArgs {
             clap::ErrorKind::ArgumentNotFound,
         ))?;
 
-        Ok(RunArgs { identity: identity })
+        let logfile = matches
+            .value_of("logfile")
+            .map(|s| s.into())
+            .unwrap_or_else(|| format!("agave-validator-{}.log", identity.pubkey()));
+
+        Ok(RunArgs {
+            identity: identity,
+            logfile: logfile,
+        })
     }
 }
 
@@ -1693,7 +1702,21 @@ mod tests {
     impl Default for RunArgs {
         fn default() -> Self {
             let identity = Keypair::new();
-            RunArgs { identity: identity }
+            let logfile = format!("agave-validator-{}.log", identity.pubkey());
+
+            RunArgs {
+                identity: identity,
+                logfile: logfile,
+            }
+        }
+    }
+
+    impl Clone for RunArgs {
+        fn clone(&self) -> Self {
+            RunArgs {
+                identity: self.identity.insecure_clone(),
+                logfile: self.logfile.clone(),
+            }
         }
     }
 
@@ -1750,6 +1773,60 @@ mod tests {
                 identity: keypair,
                 ..default_run_args
             }
+        );
+    }
+
+    fn test_run_command_with_identity_setup(
+        args: Vec<&str>,
+        default_run_args: RunArgs,
+        expected_args: RunArgs,
+    ) {
+        let default_args = DefaultArgs::default();
+
+        // generate a keypair
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = default_run_args.identity.insecure_clone();
+        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+
+        let args = [&["--identity", file.to_str().unwrap()], &args[..]].concat();
+        let matches = get_run_command_matches(&default_args, args);
+        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_log_default() {
+        let default_run_args = RunArgs::default();
+        let identity = default_run_args.identity.insecure_clone();
+        let expected_args = RunArgs {
+            logfile: "agave-validator-".to_string() + &identity.pubkey().to_string() + ".log",
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(vec![], default_run_args, expected_args);
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_log_short_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            logfile: "-".to_string(),
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(vec!["-o", "-"], default_run_args, expected_args);
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_log_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            logfile: "custom_log.log".to_string(),
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec!["--log", "custom_log.log"],
+            default_run_args,
+            expected_args,
         );
     }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -50,10 +50,7 @@ impl FromClapArgMatches for RunArgs {
             .map(|s| s.into())
             .unwrap_or_else(|| format!("agave-validator-{}.log", identity.pubkey()));
 
-        Ok(RunArgs {
-            identity: identity,
-            logfile: logfile,
-        })
+        Ok(RunArgs { identity, logfile })
     }
 }
 
@@ -1704,10 +1701,7 @@ mod tests {
             let identity = Keypair::new();
             let logfile = format!("agave-validator-{}.log", identity.pubkey());
 
-            RunArgs {
-                identity: identity,
-                logfile: logfile,
-            }
+            RunArgs { identity, logfile }
         }
     }
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1722,7 +1722,7 @@ mod tests {
         }
     }
 
-    fn get_run_command_matches<'a>(
+    fn create_app_and_get_matches<'a>(
         default_args: &'a DefaultArgs,
         args: Vec<&str>,
     ) -> ArgMatches<'a> {
@@ -1744,7 +1744,7 @@ mod tests {
         let keypair = default_run_args.identity_keypair.insecure_clone();
         solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
-        let matches = get_run_command_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
+        let matches = create_app_and_get_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
         let args = RunArgs::from_clap_arg_match(&matches).unwrap();
         assert_eq!(
             args,
@@ -1767,7 +1767,7 @@ mod tests {
         solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let matches =
-            get_run_command_matches(&default_args, vec!["--identity", file.to_str().unwrap()]);
+            create_app_and_get_matches(&default_args, vec!["--identity", file.to_str().unwrap()]);
         let args = RunArgs::from_clap_arg_match(&matches).unwrap();
         assert_eq!(
             args,
@@ -1792,7 +1792,7 @@ mod tests {
         solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let args = [&["--identity", file.to_str().unwrap()], &args[..]].concat();
-        let matches = get_run_command_matches(&default_args, args);
+        let matches = create_app_and_get_matches(&default_args, args);
         let args = RunArgs::from_clap_arg_match(&matches).unwrap();
         assert_eq!(args, expected_args);
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1789,13 +1789,12 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_log() {
         let default_run_args = RunArgs::default();
-        let identity_keypair = default_run_args.identity_keypair.insecure_clone();
 
         // default
         {
             let expected_args = RunArgs {
                 logfile: "agave-validator-".to_string()
-                    + &identity_keypair.pubkey().to_string()
+                    + &default_run_args.identity_keypair.pubkey().to_string()
                     + ".log",
                 ..default_run_args.clone()
             };

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1788,39 +1788,45 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_log_default() {
+    fn verify_args_struct_by_command_run_with_log() {
         let default_run_args = RunArgs::default();
         let identity_keypair = default_run_args.identity_keypair.insecure_clone();
-        let expected_args = RunArgs {
-            logfile: "agave-validator-".to_string()
-                + &identity_keypair.pubkey().to_string()
-                + ".log",
-            ..default_run_args.clone()
-        };
-        test_run_command_with_identity_setup(vec![], default_run_args, expected_args);
-    }
 
-    #[test]
-    fn verify_args_struct_by_command_run_with_log_short_arg() {
-        let default_run_args = RunArgs::default();
-        let expected_args = RunArgs {
-            logfile: "-".to_string(),
-            ..default_run_args.clone()
-        };
-        test_run_command_with_identity_setup(vec!["-o", "-"], default_run_args, expected_args);
-    }
+        // default
+        {
+            let expected_args = RunArgs {
+                logfile: "agave-validator-".to_string()
+                    + &identity_keypair.pubkey().to_string()
+                    + ".log",
+                ..default_run_args.clone()
+            };
+            test_run_command_with_identity_setup(vec![], default_run_args.clone(), expected_args);
+        }
 
-    #[test]
-    fn verify_args_struct_by_command_run_with_log_long_arg() {
-        let default_run_args = RunArgs::default();
-        let expected_args = RunArgs {
-            logfile: "custom_log.log".to_string(),
-            ..default_run_args.clone()
-        };
-        test_run_command_with_identity_setup(
-            vec!["--log", "custom_log.log"],
-            default_run_args,
-            expected_args,
-        );
+        // short arg
+        {
+            let expected_args = RunArgs {
+                logfile: "-".to_string(),
+                ..default_run_args.clone()
+            };
+            test_run_command_with_identity_setup(
+                vec!["-o", "-"],
+                default_run_args.clone(),
+                expected_args,
+            );
+        }
+
+        // long arg
+        {
+            let expected_args = RunArgs {
+                logfile: "custom_log.log".to_string(),
+                ..default_run_args.clone()
+            };
+            test_run_command_with_identity_setup(
+                vec!["--log", "custom_log.log"],
+                default_run_args.clone(),
+                expected_args,
+            );
+        }
     }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1722,8 +1722,8 @@ mod tests {
         }
     }
 
-    fn verify_args_struct_by_command<'a>(
-        default_args: &'a DefaultArgs,
+    fn verify_args_struct_by_command(
+        default_args: &DefaultArgs,
         args: Vec<&str>,
         expected_args: RunArgs,
     ) {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1769,9 +1769,9 @@ mod tests {
         }
     }
 
-    fn test_run_command_with_identity_setup(
-        args: Vec<&str>,
+    fn verify_args_struct_by_command_run_with_identity_setup(
         default_run_args: RunArgs,
+        args: Vec<&str>,
         expected_args: RunArgs,
     ) {
         let default_args = DefaultArgs::default();
@@ -1798,7 +1798,11 @@ mod tests {
                     + ".log",
                 ..default_run_args.clone()
             };
-            test_run_command_with_identity_setup(vec![], default_run_args.clone(), expected_args);
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args.clone(),
+                vec![],
+                expected_args,
+            );
         }
 
         // short arg
@@ -1807,9 +1811,9 @@ mod tests {
                 logfile: "-".to_string(),
                 ..default_run_args.clone()
             };
-            test_run_command_with_identity_setup(
-                vec!["-o", "-"],
+            verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
+                vec!["-o", "-"],
                 expected_args,
             );
         }
@@ -1820,9 +1824,9 @@ mod tests {
                 logfile: "custom_log.log".to_string(),
                 ..default_run_args.clone()
             };
-            test_run_command_with_identity_setup(
-                vec!["--log", "custom_log.log"],
+            verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
+                vec!["--log", "custom_log.log"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1722,15 +1722,16 @@ mod tests {
         }
     }
 
-    fn create_app_and_get_matches<'a>(
+    fn verify_args_struct_by_command<'a>(
         default_args: &'a DefaultArgs,
         args: Vec<&str>,
-    ) -> ArgMatches<'a> {
-        let app_name = "run_command";
-        let app = App::new(app_name);
-        let app = add_args(app, default_args);
-        let args = [&[app_name], &args[..]].concat();
-        app.get_matches_from(args)
+        expected_args: RunArgs,
+    ) {
+        crate::commands::tests::verify_args_struct_by_command::<RunArgs>(
+            add_args(App::new("run_command"), default_args),
+            [&["run_command"], &args[..]].concat(),
+            expected_args,
+        );
     }
 
     #[test]
@@ -1751,20 +1752,20 @@ mod tests {
 
         // short arg
         {
-            let matches =
-                create_app_and_get_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
-            let args = RunArgs::from_clap_arg_match(&matches).unwrap();
-            assert_eq!(args, expected_args);
+            verify_args_struct_by_command(
+                &default_args,
+                vec!["-i", file.to_str().unwrap()],
+                expected_args.clone(),
+            );
         }
 
         // long arg
         {
-            let matches = create_app_and_get_matches(
+            verify_args_struct_by_command(
                 &default_args,
                 vec!["--identity", file.to_str().unwrap()],
+                expected_args.clone(),
             );
-            let args = RunArgs::from_clap_arg_match(&matches).unwrap();
-            assert_eq!(args, expected_args);
         }
     }
 
@@ -1782,9 +1783,7 @@ mod tests {
         solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let args = [&["--identity", file.to_str().unwrap()], &args[..]].concat();
-        let matches = create_app_and_get_matches(&default_args, args);
-        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
-        assert_eq!(args, expected_args);
+        verify_args_struct_by_command(&default_args, args, expected_args);
     }
 
     #[test]

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1,8 +1,12 @@
 use {
-    crate::cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
-    clap::{App, Arg},
+    crate::{
+        cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{App, Arg, ArgMatches},
     solana_clap_utils::{
         hidden_unless_forced,
+        input_parsers::keypair_of,
         input_validators::{
             is_keypair_or_ask_keyword, is_parsable, is_pow2, is_pubkey, is_pubkey_or_keypair,
             is_slot, is_within_range, validate_cpu_ranges,
@@ -17,6 +21,7 @@ use {
     },
     solana_ledger::use_snapshot_archives_at_startup,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
+    solana_sdk::signature::Keypair,
     solana_send_transaction_service::send_transaction_service::{
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
@@ -26,6 +31,22 @@ use {
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
+
+#[derive(Debug, PartialEq)]
+pub struct RunArgs {
+    pub identity: Keypair,
+}
+
+impl FromClapArgMatches for RunArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let identity = keypair_of(matches, "identity").ok_or(clap::Error::with_description(
+            "The --identity <KEYPAIR> argument is required",
+            clap::ErrorKind::ArgumentNotFound,
+        ))?;
+
+        Ok(RunArgs { identity: identity })
+    }
+}
 
 pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 'a> {
     app
@@ -1663,4 +1684,72 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                 tpu-client-next is used by default.",
             ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Default for RunArgs {
+        fn default() -> Self {
+            let identity = Keypair::new();
+            RunArgs { identity: identity }
+        }
+    }
+
+    fn get_run_command_matches<'a>(
+        default_args: &'a DefaultArgs,
+        args: Vec<&str>,
+    ) -> ArgMatches<'a> {
+        let app_name = "run_command";
+        let app = App::new(app_name);
+        let app = add_args(app, default_args);
+        let args = [&[app_name], &args[..]].concat();
+        app.get_matches_from(args)
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_identity_file_short_arg() {
+        let default_args = DefaultArgs::default();
+        let default_run_args = RunArgs::default();
+
+        // generate a keypair
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = default_run_args.identity.insecure_clone();
+        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+
+        let matches = get_run_command_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
+        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+        assert_eq!(
+            args,
+            RunArgs {
+                identity: keypair,
+                ..default_run_args
+            }
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_identity_file_long_arg() {
+        let default_args = DefaultArgs::default();
+        let default_run_args = RunArgs::default();
+
+        // generate a keypair
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = default_run_args.identity.insecure_clone();
+        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+
+        let matches =
+            get_run_command_matches(&default_args, vec!["--identity", file.to_str().unwrap()]);
+        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+        assert_eq!(
+            args,
+            RunArgs {
+                identity: keypair,
+                ..default_run_args
+            }
+        );
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -19,12 +19,13 @@ use {
         banking_trace::DirByteLimit,
         validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructure},
     },
+    solana_keypair::Keypair,
     solana_ledger::use_snapshot_archives_at_startup,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
-    solana_sdk::signature::{Keypair, Signer},
     solana_send_transaction_service::send_transaction_service::{
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
+    solana_signer::Signer,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::str::FromStr,
 };
@@ -1734,7 +1735,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let file = tmp_dir.path().join("id.json");
         let keypair = default_run_args.identity.insecure_clone();
-        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let matches = get_run_command_matches(&default_args, vec!["-i", file.to_str().unwrap()]);
         let args = RunArgs::from_clap_arg_match(&matches).unwrap();
@@ -1756,7 +1757,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let file = tmp_dir.path().join("id.json");
         let keypair = default_run_args.identity.insecure_clone();
-        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let matches =
             get_run_command_matches(&default_args, vec!["--identity", file.to_str().unwrap()]);
@@ -1781,7 +1782,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let file = tmp_dir.path().join("id.json");
         let keypair = default_run_args.identity.insecure_clone();
-        solana_sdk::signature::write_keypair_file(&keypair, &file).unwrap();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
 
         let args = [&["--identity", file.to_str().unwrap()], &args[..]].concat();
         let matches = get_run_command_matches(&default_args, args);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -121,18 +121,12 @@ pub fn execute(
 
     let identity_keypair = Arc::new(run_args.identity);
 
-    let logfile = {
-        let logfile = matches
-            .value_of("logfile")
-            .map(|s| s.into())
-            .unwrap_or_else(|| format!("agave-validator-{}.log", identity_keypair.pubkey()));
-
-        if logfile == "-" {
-            None
-        } else {
-            println!("log file: {logfile}");
-            Some(logfile)
-        }
+    let logfile = run_args.logfile;
+    let logfile = if logfile == "-" {
+        None
+    } else {
+        println!("log file: {logfile}");
+        Some(logfile)
     };
     let use_progress_bar = logfile.is_none();
     let _logger_thread = redirect_stderr_to_file(logfile);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -3,6 +3,7 @@ use {
         admin_rpc_service::{self, load_staked_nodes_overrides, StakedNodesOverrides},
         bootstrap,
         cli::{self},
+        commands::{run::args::RunArgs, FromClapArgMatches},
         ledger_lockfile, lock_ledger,
     },
     clap::{crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit, ArgMatches},
@@ -100,6 +101,8 @@ pub fn execute(
     ledger_path: &Path,
     operation: Operation,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let run_args = RunArgs::from_clap_arg_match(matches)?;
+
     let cli::thread_args::NumThreadConfig {
         accounts_db_clean_threads,
         accounts_db_foreground_threads,
@@ -116,13 +119,7 @@ pub fn execute(
         tvu_sigverify_threads,
     } = cli::thread_args::parse_num_threads_args(matches);
 
-    let identity_keypair = keypair_of(matches, "identity").unwrap_or_else(|| {
-        clap::Error::with_description(
-            "The --identity <KEYPAIR> argument is required",
-            clap::ErrorKind::ArgumentNotFound,
-        )
-        .exit();
-    });
+    let identity_keypair = Arc::new(run_args.identity);
 
     let logfile = {
         let logfile = matches
@@ -1245,8 +1242,6 @@ pub fn execute(
     solana_entry::entry::init_poh();
     snapshot_utils::remove_tmp_snapshot_archives(&full_snapshot_archives_dir);
     snapshot_utils::remove_tmp_snapshot_archives(&incremental_snapshot_archives_dir);
-
-    let identity_keypair = Arc::new(identity_keypair);
 
     let should_check_duplicate_instance = true;
     if !cluster_entrypoints.is_empty() {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -119,7 +119,7 @@ pub fn execute(
         tvu_sigverify_threads,
     } = cli::thread_args::parse_num_threads_args(matches);
 
-    let identity_keypair = Arc::new(run_args.identity);
+    let identity_keypair = Arc::new(run_args.identity_keypair);
 
     let logfile = run_args.logfile;
     let logfile = if logfile == "-" {


### PR DESCRIPTION
### Problem

https://github.com/anza-xyz/agave/issues/4082

the `run` command is very large and messy. try splitting it into smaller pieces to improve readability. it might become a long journey, but I believe it’s worth it. 

this PR only includes 2 arguments as a starting point, and I hope I can fan out PRs after this one is merged 🤞 

### Summary of Changes

#### identity

move `let identity_keypair = Arc::new(run_args.identity);` eariler

#### logfile

move the default value assignment into the argument struct parsing logic
