### PR TITLE
add compute_budget_instruction_details to InstructionMeta

### DIFF
--- a/compute-budget-instruction/src/builtin_programs_filter.rs
+++ b/compute-budget-instruction/src/builtin_programs_filter.rs
@@ -28,6 +28,12 @@ pub(crate) struct BuiltinProgramsFilter {
     program_kind: [Option<ProgramKind>; FILTER_SIZE as usize],
 }
 
+impl Default for BuiltinProgramsFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BuiltinProgramsFilter {
     pub(crate) fn new() -> Self {
         BuiltinProgramsFilter {

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -303,6 +303,8 @@ mod test {
         let expected_details = Ok(ComputeBudgetInstructionDetails {
             requested_compute_unit_limit: Some((1, u32::MAX)),
             num_non_compute_budget_instructions: Saturating(2),
+            num_non_builtin_instructions: Saturating(2),
+            num_non_migratable_builtin_instructions: Saturating(1),
             ..ComputeBudgetInstructionDetails::default()
         });
         assert_eq!(

--- a/compute-budget-instruction/src/compute_budget_program_id_filter.rs
+++ b/compute-budget-instruction/src/compute_budget_program_id_filter.rs
@@ -11,6 +11,12 @@ pub(crate) struct ComputeBudgetProgramIdFilter {
     flags: [Option<bool>; FILTER_SIZE as usize],
 }
 
+impl Default for ComputeBudgetProgramIdFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ComputeBudgetProgramIdFilter {
     pub(crate) fn new() -> Self {
         ComputeBudgetProgramIdFilter {

--- a/runtime-transaction/src/instruction_meta.rs
+++ b/runtime-transaction/src/instruction_meta.rs
@@ -3,6 +3,9 @@ use {
         instruction_data_len::InstructionDataLenBuilder,
         signature_details::{PrecompileSignatureDetails, PrecompileSignatureDetailsBuilder},
     },
+    solana_compute_budget_instruction::compute_budget_instruction_details::{
+        ComputeBudgetInstructionDetails, ComputeBudgetInstructionDetailsBuilder,
+    },
     solana_pubkey::Pubkey,
     solana_svm_transaction::instruction::SVMInstruction,
     solana_transaction_error::TransactionError,
@@ -11,6 +14,7 @@ use {
 pub struct InstructionMeta {
     pub precompile_signature_details: PrecompileSignatureDetails,
     pub instruction_data_len: u16,
+    pub compute_budget_instruction_details: ComputeBudgetInstructionDetails,
 }
 
 impl InstructionMeta {
@@ -19,14 +23,19 @@ impl InstructionMeta {
     ) -> Result<Self, TransactionError> {
         let mut precompile_signature_details_builder = PrecompileSignatureDetailsBuilder::default();
         let mut instruction_data_len_builder = InstructionDataLenBuilder::default();
+        let mut compute_budget_instruction_details_builder =
+            ComputeBudgetInstructionDetailsBuilder::default();
         for (program_id, instruction) in instructions {
             precompile_signature_details_builder.process_instruction(program_id, &instruction);
             instruction_data_len_builder.process_instruction(program_id, &instruction);
+            compute_budget_instruction_details_builder
+                .process_instruction(program_id, &instruction)?;
         }
 
         Ok(Self {
             precompile_signature_details: precompile_signature_details_builder.build(),
             instruction_data_len: instruction_data_len_builder.build(),
+            compute_budget_instruction_details: compute_budget_instruction_details_builder.build(),
         })
     }
 }

--- a/runtime-transaction/src/instruction_meta.rs
+++ b/runtime-transaction/src/instruction_meta.rs
@@ -25,11 +25,14 @@ impl InstructionMeta {
         let mut instruction_data_len_builder = InstructionDataLenBuilder::default();
         let mut compute_budget_instruction_details_builder =
             ComputeBudgetInstructionDetailsBuilder::default();
-        for (program_id, instruction) in instructions {
+        for (index, (program_id, instruction)) in instructions.enumerate() {
             precompile_signature_details_builder.process_instruction(program_id, &instruction);
             instruction_data_len_builder.process_instruction(program_id, &instruction);
-            compute_budget_instruction_details_builder
-                .process_instruction(program_id, &instruction)?;
+            compute_budget_instruction_details_builder.process_instruction(
+                index,
+                program_id,
+                &instruction,
+            )?;
         }
 
         Ok(Self {

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -1,5 +1,5 @@
 use {
-    super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
+    super::RuntimeTransaction,
     crate::{
         instruction_meta::InstructionMeta,
         transaction_meta::{StaticMeta, TransactionMeta},
@@ -33,6 +33,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
         let InstructionMeta {
             precompile_signature_details,
             instruction_data_len,
+            compute_budget_instruction_details,
         } = InstructionMeta::try_new(
             sanitized_versioned_tx
                 .get_message()
@@ -51,12 +52,6 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             precompile_signature_details.num_ed25519_instruction_signatures,
             precompile_signature_details.num_secp256r1_instruction_signatures,
         );
-        let compute_budget_instruction_details = ComputeBudgetInstructionDetails::try_from(
-            sanitized_versioned_tx
-                .get_message()
-                .program_instructions_iter()
-                .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
-        )?;
 
         Ok(Self {
             transaction: sanitized_versioned_tx,

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -1,5 +1,5 @@
 use {
-    super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
+    super::RuntimeTransaction,
     crate::{
         instruction_meta::InstructionMeta,
         transaction_meta::{StaticMeta, TransactionMeta},
@@ -54,6 +54,7 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
         let InstructionMeta {
             precompile_signature_details,
             instruction_data_len,
+            compute_budget_instruction_details,
         } = InstructionMeta::try_new(transaction.program_instructions_iter())?;
 
         let signature_details = TransactionSignatureDetails::new(
@@ -62,8 +63,6 @@ impl<D: TransactionData> RuntimeTransaction<SanitizedTransactionView<D>> {
             precompile_signature_details.num_ed25519_instruction_signatures,
             precompile_signature_details.num_secp256r1_instruction_signatures,
         );
-        let compute_budget_instruction_details =
-            ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?;
 
         Ok(Self {
             transaction,


### PR DESCRIPTION
#### Problem
- Doing multiple loops to gather compute-budget instruction details

#### Summary of Changes
- Do a single loop within `InstructionMeta`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
