### PR TITLE
Cleanup after `move_stake_and_move_lamports_ixs` feature activation

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -336,42 +336,28 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             Err(InstructionError::InvalidInstructionData)
         }
         StakeInstruction::MoveStake(lamports) => {
-            if invoke_context
-                .get_feature_set()
-                .is_active(&agave_feature_set::move_stake_and_move_lamports_ixs::id())
-            {
-                instruction_context.check_number_of_instruction_accounts(3)?;
-                move_stake(
-                    invoke_context,
-                    transaction_context,
-                    instruction_context,
-                    0,
-                    lamports,
-                    1,
-                    2,
-                )
-            } else {
-                Err(InstructionError::InvalidInstructionData)
-            }
+            instruction_context.check_number_of_instruction_accounts(3)?;
+            move_stake(
+                invoke_context,
+                transaction_context,
+                instruction_context,
+                0,
+                lamports,
+                1,
+                2,
+            )
         }
         StakeInstruction::MoveLamports(lamports) => {
-            if invoke_context
-                .get_feature_set()
-                .is_active(&agave_feature_set::move_stake_and_move_lamports_ixs::id())
-            {
-                instruction_context.check_number_of_instruction_accounts(3)?;
-                move_lamports(
-                    invoke_context,
-                    transaction_context,
-                    instruction_context,
-                    0,
-                    lamports,
-                    1,
-                    2,
-                )
-            } else {
-                Err(InstructionError::InvalidInstructionData)
-            }
+            instruction_context.check_number_of_instruction_accounts(3)?;
+            move_lamports(
+                invoke_context,
+                transaction_context,
+                instruction_context,
+                0,
+                lamports,
+                1,
+                2,
+            )
         }
     }
 });


### PR DESCRIPTION
#### Problem
`move_stake_and_move_lamports_ixs` feature has been active on all clusters. It's cleanup will help reduce calls to `InvokeContext::get_feature_set()`.

#### Summary of Changes
Code cleanup after feature activation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
