### PR TITLE
Print port config into logs at startup

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2853,7 +2853,7 @@ impl Node {
             tpu_vote_quic,
         };
 
-        info!("Bound all network sockets as follows:{:#?}", &sockets);
+        info!("Bound all network sockets as follows: {:#?}", &sockets);
         Node { info, sockets }
     }
 }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2832,30 +2832,29 @@ impl Node {
             .unwrap();
 
         trace!("new ContactInfo: {:?}", info);
+        let sockets = Sockets {
+            gossip,
+            tvu: tvu_sockets,
+            tvu_quic,
+            tpu: tpu_sockets,
+            tpu_forwards: tpu_forwards_sockets,
+            tpu_vote: tpu_vote_sockets,
+            broadcast,
+            repair,
+            repair_quic,
+            retransmit_sockets,
+            serve_repair,
+            serve_repair_quic,
+            ip_echo: Some(ip_echo),
+            ancestor_hashes_requests,
+            ancestor_hashes_requests_quic,
+            tpu_quic,
+            tpu_forwards_quic,
+            tpu_vote_quic,
+        };
 
-        Node {
-            info,
-            sockets: Sockets {
-                gossip,
-                tvu: tvu_sockets,
-                tvu_quic,
-                tpu: tpu_sockets,
-                tpu_forwards: tpu_forwards_sockets,
-                tpu_vote: tpu_vote_sockets,
-                broadcast,
-                repair,
-                repair_quic,
-                retransmit_sockets,
-                serve_repair,
-                serve_repair_quic,
-                ip_echo: Some(ip_echo),
-                ancestor_hashes_requests,
-                ancestor_hashes_requests_quic,
-                tpu_quic,
-                tpu_forwards_quic,
-                tpu_vote_quic,
-            },
-        }
+        info!("Bound all network sockets as follows:{:#?}", &sockets);
+        Node { info, sockets }
     }
 }
 


### PR DESCRIPTION
#### Problem

- It may be tricky to figure out which ports the validator is using for what purpose, this makes debugging harder then it needs to be

#### Summary of Changes

- Dump all bound ports at startup into the log
