### PR TITLE
Remove feature mask_out_rent_epoch_in_vm_serialization lookup in ledger-tool

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -538,9 +538,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             &instruction_data,
         );
     invoke_context.push().unwrap();
-    let mask_out_rent_epoch_in_vm_serialization = invoke_context
-        .get_feature_set()
-        .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
     let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,
         invoke_context
@@ -548,7 +545,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         true, // copy_account_data
-        mask_out_rent_epoch_in_vm_serialization,
+        true, // for mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 


### PR DESCRIPTION
#### Problem
The features in ledger-tool are unconditionally set to active. So, the lookup of feature `mask_out_rent_epoch_in_vm_serialization` is unnecessary. The lookup is causing a dependency on `InvokeContext::get_feature_set()`, which is set to be decreated.

#### Summary of Changes
Remove the feature set lookup.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
