### PR TITLE
Uses scan_index() during index verification

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8722,8 +8722,8 @@ impl AccountsDb {
                             // verify index matches expected and measure the time to get all items
                             assert!(verify);
                             let mut lookup_time = Measure::start("lookup_time");
-                            storage.accounts.scan_accounts_stored_meta(|account_info| {
-                                let key = account_info.pubkey();
+                            storage.accounts.scan_index(|account_info| {
+                                let key = &account_info.index_info.pubkey;
                                 let index_entry = self.accounts_index.get_cloned(key).unwrap();
                                 let slot_list = index_entry.slot_list.read().unwrap();
                                 let mut count = 0;
@@ -8733,7 +8733,7 @@ impl AccountsDb {
                                         let ai = AccountInfo::new(
                                             StorageLocation::AppendVec(
                                                 store_id,
-                                                account_info.offset(),
+                                                account_info.index_info.offset,
                                             ), // will never be cached
                                             account_info.is_zero_lamport(),
                                         );


### PR DESCRIPTION
#### Problem

Continuing on the quest to not read account data unless absolutely necessary, during index generation when doing the second pass to verify, we scan the storages to make sure the index agrees. This verify pass currently reads the account data while scanning the storages, but the account data is not needed so we can use a different scan function instead.


#### Summary of Changes

Use `scan_index()` during the second pass of index generation where we perform verification.
