### PR TITLE
make test-validator bind to localhost by default

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2572,7 +2572,7 @@ impl Node {
         bind_in_range_with_config(bind_ip_addr, port_range, config).expect("Failed to bind")
     }
 
-    #[deprecated(since = "2.3.0", note = "unneeded, use `new_with_external_ip`")]
+    #[deprecated(since = "2.3.0", note = "Please use `new_with_external_ip` instead.")]
     pub fn new_single_bind(
         pubkey: &Pubkey,
         gossip_addr: &SocketAddr,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2572,6 +2572,7 @@ impl Node {
         bind_in_range_with_config(bind_ip_addr, port_range, config).expect("Failed to bind")
     }
 
+    #[deprecated(since = "2.3.0", note = "unneeded, use `new_with_external_ip`")]
     pub fn new_single_bind(
         pubkey: &Pubkey,
         gossip_addr: &SocketAddr,
@@ -2774,8 +2775,7 @@ impl Node {
                 .expect("tpu_vote multi_bind");
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
-            Self::bind_with_config(bind_ip_addr, port_range, socket_config);
-
+            Self::bind_with_config(bind_ip_addr, port_range, socket_config_reuseport);
         let tpu_vote_quic = bind_more_with_config(
             tpu_vote_quic,
             num_quic_endpoints.get(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -20,7 +20,7 @@ use {
         geyser_plugin_manager::GeyserPluginManager, GeyserPluginManagerRequest,
     },
     solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
+        cluster_info::{ClusterInfo, Node, NodeConfig},
         contact_info::Protocol,
         gossip_service::discover_cluster,
         socketaddr,
@@ -29,7 +29,7 @@ use {
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
         create_new_tmp_ledger,
     },
-    solana_net_utils::PortRange,
+    solana_net_utils::{find_available_port_in_range, PortRange},
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client::{nonblocking, rpc_client::RpcClient},
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
@@ -63,6 +63,7 @@ use {
         fs::{self, remove_dir_all, File},
         io::Read,
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZero,
         path::{Path, PathBuf},
         str::FromStr,
         sync::{Arc, RwLock},
@@ -97,7 +98,7 @@ impl Default for TestValidatorNodeConfig {
         const MIN_PORT_RANGE: u16 = 1024;
         const MAX_PORT_RANGE: u16 = 65535;
 
-        let bind_ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = (MIN_PORT_RANGE, MAX_PORT_RANGE);
 
         Self {
@@ -948,16 +949,28 @@ impl TestValidator {
                 .unwrap(),
         )?;
 
-        let mut node = Node::new_single_bind(
-            &validator_identity.pubkey(),
-            &config.node_config.gossip_addr,
-            config.node_config.port_range,
-            config.node_config.bind_ip_addr,
-        );
+        let node_config = NodeConfig {
+            gossip_addr: config.node_config.gossip_addr.clone(),
+            port_range: config.node_config.port_range.clone(),
+            bind_ip_addr: config.node_config.bind_ip_addr.clone(),
+            public_tpu_addr: None,
+            public_tpu_forwards_addr: None,
+            num_quic_endpoints: NonZero::new(1).unwrap(),
+            num_tvu_receive_sockets: NonZero::new(1).unwrap(),
+            num_tvu_retransmit_sockets: NonZero::new(1).unwrap(),
+        };
+
+        let port_range = node_config.port_range;
+        let mut node = Node::new_with_external_ip(&validator_identity.pubkey(), node_config);
+        let addr = node.info.gossip().unwrap().ip();
         if let Some((rpc, rpc_pubsub)) = config.rpc_ports {
-            let addr = node.info.gossip().unwrap().ip();
             node.info.set_rpc((addr, rpc)).unwrap();
             node.info.set_rpc_pubsub((addr, rpc_pubsub)).unwrap();
+        } else {
+            let rpc_port = find_available_port_in_range(addr, port_range).unwrap();
+            let rpc_pubsub_port = find_available_port_in_range(addr, port_range).unwrap();
+            node.info.set_rpc((addr, rpc_port)).unwrap();
+            node.info.set_rpc_pubsub((addr, rpc_pubsub_port)).unwrap();
         }
 
         let vote_account_address = validator_vote_account.pubkey();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -950,9 +950,9 @@ impl TestValidator {
         )?;
 
         let node_config = NodeConfig {
-            gossip_addr: config.node_config.gossip_addr.clone(),
-            port_range: config.node_config.port_range.clone(),
-            bind_ip_addr: config.node_config.bind_ip_addr.clone(),
+            gossip_addr: config.node_config.gossip_addr,
+            port_range: config.node_config.port_range,
+            bind_ip_addr: config.node_config.bind_ip_addr,
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
             num_quic_endpoints: NonZero::new(1).unwrap(),

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -175,7 +175,7 @@ fn main() {
     let bind_address = solana_net_utils::parse_host(
         matches
             .value_of("bind_address")
-            .expect("Bind addresshas default value"),
+            .expect("Bind address has default value"),
     )
     .unwrap_or_else(|err| {
         eprintln!("Failed to parse --bind-address: {err}");

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -172,12 +172,16 @@ fn main() {
             exit(1);
         })
     });
-    let bind_address = matches.value_of("bind_address").map(|bind_address| {
-        solana_net_utils::parse_host(bind_address).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --bind-address: {err}");
-            exit(1);
-        })
+    let bind_address = solana_net_utils::parse_host(
+        matches
+            .value_of("bind_address")
+            .expect("Bind addresshas default value"),
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to parse --bind-address: {err}");
+        exit(1);
     });
+
     let compute_unit_limit = value_t!(matches, "compute_unit_limit", u64).ok();
 
     let faucet_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), faucet_port);
@@ -552,9 +556,7 @@ fn main() {
         genesis.port_range(dynamic_port_range);
     }
 
-    if let Some(bind_address) = bind_address {
-        genesis.bind_ip_addr(bind_address);
-    }
+    genesis.bind_ip_addr(bind_address);
 
     if matches.is_present("geyser_plugin_config") {
         genesis.geyser_plugin_config_files = Some(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -863,8 +863,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .default_value("0.0.0.0")
-                .help("IP address to bind the validator ports [default: 0.0.0.0]"),
+                .default_value("127.0.0.1")
+                .help("IP address to bind the validator ports [default: 127.0.0.1]"),
         )
         .arg(
             Arg::with_name("clone_account")


### PR DESCRIPTION
#### Problem

- Test-validator had its own bespoke networking setup config at start for no good reason
- It would bind to all interfaces by default which is insecure 

#### Summary of Changes

- Change it to reuse the functions from normal validator startup process to reduce code duplication
- make binding to localhost the default, with option to specify any address via bind-address cli

