### PR TITLE
Add a sanity assert for stored_size at index generation time.

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7898,8 +7898,8 @@ impl AccountsDb {
 
             // sanity check that stored_size is not larger than the u64 aligned size of the accounts files.
             // Note that the stored_size is aligned, so it can be larger than the size of the accounts file.
-            assert!(info.stored_size <= u64_align!(storage.accounts.len()), "
-                Stored size ({}) is larger than the size of the accounts file ({}) for store_id: {}",
+            assert!(info.stored_size <= u64_align!(storage.accounts.len()),
+                "Stored size ({}) is larger than the size of the accounts file ({}) for store_id: {}",
                 info.stored_size, storage.accounts.len(), store_id
             );
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -72,7 +72,7 @@ use {
         read_only_accounts_cache::ReadOnlyAccountsCache,
         sorted_storages::SortedStorages,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
-        utils,
+        u64_align, utils,
         verify_accounts_hash_in_background::VerifyAccountsHashInBackground,
     },
     crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError},
@@ -7896,8 +7896,9 @@ impl AccountsDb {
             info.stored_size += stored_size_alive;
             info.count += generate_index_results.count;
 
-            // sanity check that stored_size is not larger than the size of the accounts files.
-            assert!(info.stored_size <= storage.accounts.len(), "
+            // sanity check that stored_size is not larger than the u64 aligned size of the accounts files.
+            // Note that the stored_size is aligned, so it can be larger than the size of the accounts file.
+            assert!(info.stored_size <= u64_align!(storage.accounts.len()), "
                 Stored size ({}) is larger than the size of the accounts file ({}) for store_id: {}",
                 info.stored_size, storage.accounts.len(), store_id
             );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7895,6 +7895,12 @@ impl AccountsDb {
             let mut info = storage_info.entry(store_id).or_default();
             info.stored_size += stored_size_alive;
             info.count += generate_index_results.count;
+
+            // sanity check that stored_size is not larger than the size of the accounts files.
+            assert!(info.stored_size <= storage.accounts.len(), "
+                Stored size ({}) is larger than the size of the accounts file ({}) for store_id: {}",
+                info.stored_size, storage.accounts.len(), store_id
+            );
         }
 
         // dirty_pubkeys will contain a pubkey if an item has multiple rooted entries for


### PR DESCRIPTION
#### Problem

We have recently fixed a bug related to stored_size in #5778. 

In the review comments, we discussed that it would be useful to add a sanity check for the "alive accounts size".

https://github.com/anza-xyz/agave/pull/5778#pullrequestreview-2761673218



#### Summary of Changes

Add a sanity assert for `stored_size` at index generation time. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
