### PR TITLE
Arrange client socket and interface binding for connection cacahe

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1091,7 +1091,7 @@ impl Validator {
             let connection_cache = ConnectionCache::new_with_client_options(
                 "connection_cache_tpu_quic",
                 tpu_connection_pool_size,
-                None,
+                Some(node.sockets.tpu_forwards_client),
                 Some((
                     &identity_keypair,
                     node.info
@@ -1115,7 +1115,7 @@ impl Validator {
             let vote_connection_cache = ConnectionCache::new_with_client_options(
                 "connection_cache_vote_quic",
                 tpu_connection_pool_size,
-                None, // client_endpoint
+                Some(node.sockets.tpu_vote_client),
                 Some((
                     &identity_keypair,
                     node.info

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1091,7 +1091,7 @@ impl Validator {
             let connection_cache = ConnectionCache::new_with_client_options(
                 "connection_cache_tpu_quic",
                 tpu_connection_pool_size,
-                Some(node.sockets.tpu_forwards_client),
+                Some(node.sockets.quic_forwards_client),
                 Some((
                     &identity_keypair,
                     node.info
@@ -1115,7 +1115,7 @@ impl Validator {
             let vote_connection_cache = ConnectionCache::new_with_client_options(
                 "connection_cache_vote_quic",
                 tpu_connection_pool_size,
-                Some(node.sockets.tpu_vote_client),
+                Some(node.sockets.quic_vote_client),
                 Some((
                     &identity_keypair,
                     node.info

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2382,10 +2382,11 @@ pub struct Sockets {
     pub tpu_forwards_quic: Vec<UdpSocket>,
     pub tpu_vote_quic: Vec<UdpSocket>,
 
-    /// Client-side socket for ForwardingStage.
+    /// Client-side socket for ForwardingStage
     pub tpu_vote_forwards_client: UdpSocket,
-    /// Connection cache endpoints
+    /// Connection cache endpoint for Forwarding
     pub quic_forwards_client: UdpSocket,
+    /// Connection cache endpoint for QUIC-based Vote
     pub quic_vote_client: UdpSocket,
 }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2384,6 +2384,9 @@ pub struct Sockets {
 
     /// Client-side socket for ForwardingStage.
     pub tpu_vote_forwards_client: UdpSocket,
+    /// Connection cache endpoints
+    pub quic_forwards_client: UdpSocket,
+    pub quic_vote_client: UdpSocket,
 }
 
 pub struct NodeConfig {
@@ -2470,6 +2473,8 @@ impl Node {
         let ancestor_hashes_requests_quic = bind_to_unspecified().unwrap();
 
         let tpu_vote_forwards_client = bind_to_localhost().unwrap();
+        let quic_forwards_client = bind_to_localhost().unwrap();
+        let quic_vote_client = bind_to_localhost().unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,
@@ -2548,6 +2553,8 @@ impl Node {
                 tpu_forwards_quic,
                 tpu_vote_quic,
                 tpu_vote_forwards_client,
+                quic_forwards_client,
+                quic_vote_client,
             },
         }
     }
@@ -2653,6 +2660,8 @@ impl Node {
 
         // These are client sockets, so the port is set to be 0 because it must be ephimeral.
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let quic_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
 
         let addr = gossip_addr.ip();
         let mut info = ContactInfo::new(
@@ -2716,6 +2725,8 @@ impl Node {
                 tpu_forwards_quic,
                 tpu_vote_quic,
                 tpu_vote_forwards_client,
+                quic_vote_client,
+                quic_forwards_client,
             },
         }
     }
@@ -2821,6 +2832,8 @@ impl Node {
 
         // These are client sockets, so the port is set to be 0 because it must be ephimeral.
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let quic_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,
@@ -2866,8 +2879,9 @@ impl Node {
             tpu_forwards_quic,
             tpu_vote_quic,
             tpu_vote_forwards_client,
+            quic_vote_client,
+            quic_forwards_client,
         };
-
         info!("Bound all network sockets as follows: {:#?}", &sockets);
         Node { info, sockets }
     }

--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -14,6 +14,7 @@ use {
         },
         quic_client::QuicClientConnection as BlockingQuicClientConnection,
     },
+    quic_client::get_runtime,
     quinn::{Endpoint, EndpointConfig, TokioRuntime},
     solana_connection_cache::{
         connection_cache::{
@@ -147,6 +148,8 @@ impl QuicConfig {
     }
 
     pub fn update_client_endpoint(&mut self, client_socket: UdpSocket) {
+        let runtime = get_runtime();
+        let _guard = runtime.enter();
         let config = EndpointConfig::default();
         self.client_endpoint = Some(
             quinn::Endpoint::new(config, None, client_socket, Arc::new(TokioRuntime))

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -75,6 +75,10 @@ lazy_static! {
         .unwrap();
 }
 
+pub fn get_runtime() -> &'static Runtime {
+    &RUNTIME
+}
+
 async fn send_data_async(
     connection: Arc<NonblockingQuicConnection>,
     buffer: Vec<u8>,


### PR DESCRIPTION
#### Problem

- Connection cache would not bind to the correct interface, preventing correct operation on doublezero

#### Summary of Changes

- Patch in a pre-bound socket into connection cache instances.

Fixes #
https://github.com/anza-xyz/agave/issues/5821