### PR TITLE
Makes uses of AppendVec::get_type() all consistent

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -778,9 +778,9 @@ impl AppendVec {
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
-                let (meta, next): (&StoredMeta, _) = Self::get_type(slice, offset)?;
-                let (account_meta, next): (&AccountMeta, _) = Self::get_type(slice, next)?;
-                let (hash, next): (&AccountHash, _) = Self::get_type(slice, next)?;
+                let (meta, next) = Self::get_type::<StoredMeta>(slice, offset)?;
+                let (account_meta, next) = Self::get_type::<AccountMeta>(slice, next)?;
+                let (hash, next) = Self::get_type::<AccountHash>(slice, next)?;
                 let (data, next) = Self::get_slice(slice, next, meta.data_len as usize)?;
                 let stored_size = next - offset;
                 Some(callback(StoredAccountMeta::AppendVec(
@@ -806,9 +806,9 @@ impl AppendVec {
                 let valid_bytes = ValidSlice(unsafe {
                     slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
                 });
-                let (meta, next): (&StoredMeta, _) = Self::get_type(valid_bytes, 0)?;
-                let (account_meta, next): (&AccountMeta, _) = Self::get_type(valid_bytes, next)?;
-                let (hash, next): (&AccountHash, _) = Self::get_type(valid_bytes, next)?;
+                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+                let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
+                let (hash, next) = Self::get_type::<AccountHash>(valid_bytes, next)?;
                 let data_len = meta.data_len;
                 let remaining_bytes_for_data = bytes_read - next;
                 Some(if remaining_bytes_for_data >= data_len as usize {
@@ -866,8 +866,8 @@ impl AppendVec {
         match &self.backing {
             AppendVecFileBacking::Mmap(mmap) => {
                 let slice = self.get_valid_slice_from_mmap(mmap);
-                let (meta, next): (&StoredMeta, _) = Self::get_type(slice, offset)?;
-                let (account_meta, _): (&AccountMeta, _) = Self::get_type(slice, next)?;
+                let (meta, next) = Self::get_type::<StoredMeta>(slice, offset)?;
+                let (account_meta, _) = Self::get_type::<AccountMeta>(slice, next)?;
                 let stored_size = aligned_stored_size_checked(meta.data_len as usize)?;
 
                 Some(callback(StoredAccountNoData {
@@ -888,8 +888,8 @@ impl AppendVec {
                 let valid_bytes = ValidSlice(unsafe {
                     slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
                 });
-                let (meta, next): (&StoredMeta, _) = Self::get_type(valid_bytes, 0)?;
-                let (account_meta, _): (&AccountMeta, _) = Self::get_type(valid_bytes, next)?;
+                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+                let (account_meta, _) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
                 let stored_size = aligned_stored_size_checked(meta.data_len as usize)?;
 
                 Some(callback(StoredAccountNoData {
@@ -920,9 +920,9 @@ impl AppendVec {
                 let valid_bytes = ValidSlice(unsafe {
                     slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
                 });
-                let (meta, next): (&StoredMeta, _) = Self::get_type(valid_bytes, 0)?;
-                let (account_meta, next): (&AccountMeta, _) = Self::get_type(valid_bytes, next)?;
-                let (hash, next): (&AccountHash, _) = Self::get_type(valid_bytes, next)?;
+                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+                let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
+                let (hash, next) = Self::get_type::<AccountHash>(valid_bytes, next)?;
                 let data_len = meta.data_len;
                 let remaining_bytes_for_data = bytes_read - next;
                 Some(if remaining_bytes_for_data >= data_len as usize {
@@ -1092,11 +1092,10 @@ impl AppendVec {
                 let mut data_overflow_buffer = vec![];
                 while let Ok(BufferedReaderStatus::Success) = reader.read() {
                     let (offset, bytes_subset) = reader.get_offset_and_data();
-                    let (meta, next): (&StoredMeta, _) = Self::get_type(bytes_subset, 0).unwrap();
-                    let (account_meta, next): (&AccountMeta, _) =
-                        Self::get_type(bytes_subset, next).unwrap();
-                    let (hash, next): (&AccountHash, _) =
-                        Self::get_type(bytes_subset, next).unwrap();
+                    let (meta, next) = Self::get_type::<StoredMeta>(bytes_subset, 0).unwrap();
+                    let (account_meta, next) =
+                        Self::get_type::<AccountMeta>(bytes_subset, next).unwrap();
+                    let (hash, next) = Self::get_type::<AccountHash>(bytes_subset, next).unwrap();
                     let data_len = meta.data_len as usize;
                     let leftover = bytes_subset.len() - next;
                     if leftover >= data_len {


### PR DESCRIPTION
#### Problem

There are two styles used for picking the return type when calling AppendVec::get_type(). 

style 1:
```rust
let (account_meta, next): (&AccountMeta, _) = Self::get_type(slice, next)?;
```

style 2:
```rust
let (account_meta, next) = Self::get_type::<AccountMeta>(slice, next)?;
```

Both are used within `append_vec.rs`, but I'd argue using a single style within the file is preferable.


#### Summary of Changes

Use style 2 in the whole file.

I've gone with style 2 because it's fewer characters, there are no superfluous types that need to be ignored, and imo it reads nicer.