### PR TITLE
Bump platform tools version to v1.47 (Rust 1.84.1)

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -21,7 +21,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.46";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.47";
 
 #[derive(Debug)]
 struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -18,4 +18,10 @@ solana-pubkey = "=2.2.0"
 [lib]
 crate-type = ["cdylib"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(feature, values("custom-panic", "custom-heap"))'
+]
+
 [workspace]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.46"
+tools-version = "v1.47"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -23,4 +23,10 @@ solana-pubkey = "=2.2.0"
 [lib]
 crate-type = ["cdylib"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(feature, values("custom-panic", "custom-heap"))'
+]
+
 [workspace]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -18,6 +18,12 @@ solana-pubkey = "=2.2.0"
 [lib]
 crate-type = ["cdylib"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(feature, values("custom-panic", "custom-heap"))'
+]
+
 [workspace]
 
 [workspace.metadata.solana]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -21,4 +21,4 @@ crate-type = ["cdylib"]
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.46"
+tools-version = "v1.47"

--- a/platform-tools-sdk/sbf/c/inc/sol/alt_bn128.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/alt_bn128.h
@@ -54,7 +54,7 @@ extern "C" {
  * @return 0 if executed successfully
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/alt_bn128.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_alt_bn128_group_op(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
 #else
 typedef uint64_t(*sol_alt_bn128_group_op_pointer_type)(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/alt_bn128_compression.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/alt_bn128_compression.h
@@ -59,7 +59,7 @@ extern "C" {
  * @return 0 if executed successfully
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/alt_bn128_compression.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_alt_bn128_compression(
         const uint64_t op,
         const uint8_t *input,

--- a/platform-tools-sdk/sbf/c/inc/sol/assert.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/assert.h
@@ -17,7 +17,7 @@ extern "C" {
  * the SBF VM to immediately halt execution. No accounts' data are updated
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/assert.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_panic_(const char *, uint64_t, uint64_t, uint64_t);
 #else
 typedef void(*sol_panic__pointer_type)(const char *, uint64_t, uint64_t, uint64_t);

--- a/platform-tools-sdk/sbf/c/inc/sol/big_mod_exp.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/big_mod_exp.h
@@ -15,7 +15,7 @@ extern "C" {
  * @return 0 if executed successfully
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/big_mod_exp.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_big_mod_exp(const uint8_t *, uint8_t *);
 #else
 typedef uint64_t(*sol_big_mod_exp_pointer_type)(const uint8_t *, uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/blake3.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/blake3.h
@@ -22,7 +22,7 @@ extern "C" {
  * @param result 32 byte array to hold the result
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/blake3.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_blake3(const SolBytes *, int, const uint8_t *);
 #else
 typedef uint64_t(*sol_blake3_pointer_type)(const SolBytes *, int, const uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/compute_units.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/compute_units.h
@@ -15,7 +15,7 @@ extern "C" {
  * Prints a string to stdout
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/compute_units.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_remaining_compute_units();
 #else
 typedef uint64_t(*sol_remaining_compute_units_pointer_type)();

--- a/platform-tools-sdk/sbf/c/inc/sol/cpi.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/cpi.h
@@ -57,7 +57,7 @@ typedef struct {
  * Internal cross-program invocation function
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/cpi.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_invoke_signed_c(
   const SolInstruction *,
   const SolAccountInfo *,

--- a/platform-tools-sdk/sbf/c/inc/sol/keccak.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/keccak.h
@@ -22,7 +22,7 @@ extern "C" {
  * @param result 32 byte array to hold the result
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/keccak.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_keccak256(const SolBytes *, int, uint8_t *);
 #else
 typedef uint64_t(*sol_keccak256_pointer_type)(const SolBytes *, int, uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/last_restart_slot.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/last_restart_slot.h
@@ -13,7 +13,7 @@ extern "C" {
  * Get Last Restart Slot
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/last_restart_slot.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 u64 sol_get_last_restart_slot(uint8_t *result);
 #else
 typedef u64(*sol_get_last_restart_slot_pointer_type)(uint8_t *result);

--- a/platform-tools-sdk/sbf/c/inc/sol/log.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/log.h
@@ -15,7 +15,7 @@ extern "C" {
  * Prints a string to stdout
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_log_(const char *, uint64_t);
 #else
 typedef void(*sol_log__pointer_type)(const char *, uint64_t);
@@ -30,7 +30,7 @@ static void sol_log_(const char * arg1, uint64_t arg2) {
  * Prints a 64 bit values represented in hexadecimal to stdout
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_log_64_(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 #else
 typedef void(*sol_log_64__pointer_type)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
@@ -45,7 +45,7 @@ static void sol_log_64_(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t ar
  * Prints the current compute unit consumption to stdout
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_log_compute_units_();
 #else
 typedef void(*sol_log_compute_units__pointer_type)();
@@ -71,7 +71,7 @@ static void sol_log_array(const uint8_t *array, int len) {
  * Print the base64 representation of some arrays.
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_log_data(SolBytes *, uint64_t);
 #else
 typedef void(*sol_log_data_pointer_type)(SolBytes *, uint64_t);

--- a/platform-tools-sdk/sbf/c/inc/sol/poseidon.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/poseidon.h
@@ -48,7 +48,7 @@ extern "C" {
  * @param result 32 byte array to hold the result
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/poseidon.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_poseidon(
   const uint64_t parameters,
   const uint64_t endianness,

--- a/platform-tools-sdk/sbf/c/inc/sol/pubkey.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/pubkey.h
@@ -27,7 +27,7 @@ typedef struct {
  * @param key The public key to print
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_log_pubkey(const SolPubkey *);
 #else
 typedef void(*sol_log_pubkey_pointer_type)(const SolPubkey *);
@@ -79,7 +79,7 @@ typedef struct {
  * @param program_address Program address created, filled on return
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_create_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *);
 #else
 typedef uint64_t(*sol_create_program_address_pointer_type)(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *);
@@ -99,7 +99,7 @@ static uint64_t sol_create_program_address(const SolSignerSeed * arg1, int arg2,
  * @param bump_seed Bump seed required to create a valid program address
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_try_find_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *, uint8_t *);
 #else
 typedef uint64_t(*sol_try_find_program_address_pointer_type)(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *, uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/return_data.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/return_data.h
@@ -23,7 +23,7 @@ extern "C"
  * @param bytes_len length of byte array. This may not exceed MAX_RETURN_DATA.
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/return_data.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 void sol_set_return_data(const uint8_t *, uint64_t);
 #else
 typedef void(*sol_set_return_data_pointer_type)(const uint8_t *, uint64_t);
@@ -42,7 +42,7 @@ static void sol_set_return_data(const uint8_t * arg1, uint64_t arg2) {
  * @param result length of return data (may exceed bytes_len if the return data is longer)
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/return_data.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_get_return_data(uint8_t *, uint64_t, SolPubkey *);
 #else
 typedef uint64_t(*sol_get_return_data_pointer_type)(uint8_t *, uint64_t, SolPubkey *);

--- a/platform-tools-sdk/sbf/c/inc/sol/secp256k1.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/secp256k1.h
@@ -33,7 +33,7 @@ extern "C" {
  * @return 0 if executed successfully
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/secp256k1.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_secp256k1_recover(const uint8_t *, uint64_t, const uint8_t *, uint8_t *);
 #else
 typedef uint64_t(*sol_secp256k1_recover_pointer_type)(const uint8_t *, uint64_t, const uint8_t *, uint8_t *);

--- a/platform-tools-sdk/sbf/c/inc/sol/sha.h
+++ b/platform-tools-sdk/sbf/c/inc/sol/sha.h
@@ -22,7 +22,7 @@ extern "C" {
  * @param result 32 byte array to hold the result
  */
 /* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/sha.inc AND RUN `cargo run --bin gen-headers` */
-#ifndef SOL_SBFV2
+#ifndef SOL_SBPFV3
 uint64_t sol_sha256(const SolBytes *, int, uint8_t *);
 #else
 typedef uint64_t(*sol_sha256_pointer_type)(const SolBytes *, int, uint8_t *);

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.46
+version=v1.47
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1299,20 +1299,20 @@ fn assert_instruction_count() {
     #[cfg(feature = "sbf_rust")]
     {
         programs.extend_from_slice(&[
-            ("solana_sbf_rust_128bit", 967),
-            ("solana_sbf_rust_alloc", 4940),
-            ("solana_sbf_rust_custom_heap", 286),
+            ("solana_sbf_rust_128bit", 969),
+            ("solana_sbf_rust_alloc", 5077),
+            ("solana_sbf_rust_custom_heap", 304),
             ("solana_sbf_rust_dep_crate", 2),
             ("solana_sbf_rust_iter", 1514),
             ("solana_sbf_rust_many_args", 1290),
             ("solana_sbf_rust_mem", 1302),
-            ("solana_sbf_rust_membuiltins", 327),
-            ("solana_sbf_rust_noop", 275),
+            ("solana_sbf_rust_membuiltins", 331),
+            ("solana_sbf_rust_noop", 314),
             ("solana_sbf_rust_param_passing", 108),
             ("solana_sbf_rust_rand", 278),
             ("solana_sbf_rust_sanity", 51325),
             ("solana_sbf_rust_secp256k1_recover", 89388),
-            ("solana_sbf_rust_sha", 22850),
+            ("solana_sbf_rust_sha", 22855),
         ]);
     }
 
@@ -1713,7 +1713,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
                 // Asserting the instruction number as an upper bound, since the quantity of
                 // instructions depends on the program size, which in turn depends on the SBPF
                 // versions.
-                assert!(instr_no <= 39);
+                assert!(instr_no <= 41);
                 assert_eq!(ty, InstructionError::UnsupportedProgramId);
             } else {
                 panic!("Invalid error type");


### PR DESCRIPTION
#### Problem

The existing version of platform tools is dated, since it ships with Rust 1.79.0.

#### Summary of Changes

Bump the tools version to v1.47, which brings Rust 1.84.1.

