### PR TITLE
Removes convenience wrapper for get_account_shared_data()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -986,7 +986,7 @@ impl LoadedAccountAccessor<'_> {
                 // was still in the storage map. This means even if the storage entry is removed
                 // from the storage map after we grabbed the storage entry, the recycler should not
                 // reset the storage entry until we drop the reference to the storage entry.
-                maybe_storage_entry.get_account_shared_data(*offset).expect(
+                maybe_storage_entry.accounts.get_account_shared_data(*offset).expect(
                     "If a storage entry was found in the storage map, it must not have been reset \
                      yet",
                 )
@@ -1354,10 +1354,6 @@ impl AccountStorageEntry {
 
     pub fn flush(&self) -> Result<(), AccountsFileError> {
         self.accounts.flush()
-    }
-
-    fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
-        self.accounts.get_account_shared_data(offset)
     }
 
     fn add_accounts(&self, num_accounts: usize, num_bytes: usize) {


### PR DESCRIPTION
#### Problem

AccountStorageEntry has a method, `get_account_shared_data()`, that is a wrapper around `AccountsFile::get_account_shared_data()`. It directly calls the inner function, so it's just wasted indirection (imo). I think it's also cleaner to keep all the functions that get or scan accounts inside `AccountsFile`, and not on other types unnecessarily.


#### Summary of Changes

Remove the wrapper.
