### PR TITLE
Single banking stage thread for votes

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -581,8 +581,8 @@ impl BankingStage {
         log_messages_bytes_limit: Option<usize>,
         vote_storage: VoteStorage,
     ) -> JoinHandle<()> {
-        let tpu_receiver = PacketReceiver::new(1, tpu_receiver);
-        let gossip_receiver = PacketReceiver::new(0, gossip_receiver);
+        let tpu_receiver = PacketReceiver::new(tpu_receiver);
+        let gossip_receiver = PacketReceiver::new(gossip_receiver);
         let consumer = Consumer::new(
             committer,
             transaction_recorder,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -409,7 +409,7 @@ impl BankingStage {
         // Keeps track of extraneous vote transactions for the vote threads
         let latest_unprocessed_votes = {
             let bank = bank_forks.read().unwrap().working_bank();
-            Arc::new(LatestUnprocessedVotes::new(&bank))
+            LatestUnprocessedVotes::new(&bank)
         };
 
         let decision_maker = DecisionMaker::new(cluster_info.id(), poh_recorder.clone());
@@ -431,7 +431,7 @@ impl BankingStage {
             committer.clone(),
             transaction_recorder.clone(),
             log_messages_bytes_limit,
-            VoteStorage::new(latest_unprocessed_votes.clone()),
+            VoteStorage::new(latest_unprocessed_votes),
         ));
 
         match transaction_struct {

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -30,7 +30,7 @@ impl LeaderExecuteAndCommitTimings {
 
     pub fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-vote_leader_slot_execute_and_commit_timings",
+            "banking_stage-leader_slot_vote_execute_and_commit_timings",
             ("slot", slot as i64, i64),
             ("collect_balances_us", self.collect_balances_us as i64, i64),
             ("load_execute_us", self.load_execute_us as i64, i64),
@@ -45,7 +45,7 @@ impl LeaderExecuteAndCommitTimings {
         );
 
         datapoint_info!(
-            "banking_stage-vote_leader_slot_record_timings",
+            "banking_stage-leader_slot_vote_record_timings",
             ("slot", slot as i64, i64),
             (
                 "processing_results_to_transactions_us",
@@ -144,7 +144,7 @@ impl OuterLoopTimings {
 
     fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-vote_leader_slot_loop_timings",
+            "banking_stage-leader_slot_vote_loop_timings",
             ("slot", slot as i64, i64),
             (
                 "bank_detected_to_slot_end_detected_us",
@@ -184,7 +184,7 @@ pub(crate) struct ProcessBufferedPacketsTimings {
 impl ProcessBufferedPacketsTimings {
     fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-vote_leader_slot_process_buffered_packets_timings",
+            "banking_stage-leader_slot_vote_process_buffered_packets_timings",
             ("slot", slot as i64, i64),
             ("make_decision_us", self.make_decision_us as i64, i64),
             (
@@ -205,7 +205,7 @@ pub(crate) struct ConsumeBufferedPacketsTimings {
 impl ConsumeBufferedPacketsTimings {
     fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-vote_leader_slot_consume_buffered_packets_timings",
+            "banking_stage-leader_slot_vote_consume_buffered_packets_timings",
             ("slot", slot as i64, i64),
             (
                 "process_packets_transactions_us",
@@ -236,7 +236,7 @@ pub(crate) struct ProcessPacketsTimings {
 impl ProcessPacketsTimings {
     fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-vote_leader_slot_process_packets_timings",
+            "banking_stage-leader_slot_vote_process_packets_timings",
             ("slot", slot as i64, i64),
             (
                 "transactions_from_packets_us",

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -28,10 +28,9 @@ impl LeaderExecuteAndCommitTimings {
         self.execute_timings.accumulate(&other.execute_timings);
     }
 
-    pub fn report(&self, id: &str, slot: Slot) {
+    pub fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-leader_slot_execute_and_commit_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_execute_and_commit_timings",
             ("slot", slot as i64, i64),
             ("collect_balances_us", self.collect_balances_us as i64, i64),
             ("load_execute_us", self.load_execute_us as i64, i64),
@@ -46,13 +45,13 @@ impl LeaderExecuteAndCommitTimings {
         );
 
         datapoint_info!(
-            "banking_stage-leader_slot_record_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_record_timings",
             ("slot", slot as i64, i64),
             (
                 "processing_results_to_transactions_us",
                 self.record_transactions_timings
-                    .processing_results_to_transactions_us.0 as i64,
+                    .processing_results_to_transactions_us
+                    .0 as i64,
                 i64
             ),
             (
@@ -91,12 +90,12 @@ impl LeaderSlotTimingMetrics {
         }
     }
 
-    pub(crate) fn report(&self, id: &str, slot: Slot) {
-        self.outer_loop_timings.report(id, slot);
-        self.process_buffered_packets_timings.report(id, slot);
-        self.consume_buffered_packets_timings.report(id, slot);
-        self.process_packets_timings.report(id, slot);
-        self.execute_and_commit_timings.report(id, slot);
+    pub(crate) fn report(&self, slot: Slot) {
+        self.outer_loop_timings.report(slot);
+        self.process_buffered_packets_timings.report(slot);
+        self.consume_buffered_packets_timings.report(slot);
+        self.process_packets_timings.report(slot);
+        self.execute_and_commit_timings.report(slot);
     }
 
     pub(crate) fn mark_slot_end_detected(&mut self) {
@@ -143,10 +142,9 @@ impl OuterLoopTimings {
             self.bank_detected_time.elapsed().as_micros() as u64;
     }
 
-    fn report(&self, id: &str, slot: Slot) {
+    fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-leader_slot_loop_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_loop_timings",
             ("slot", slot as i64, i64),
             (
                 "bank_detected_to_slot_end_detected_us",
@@ -184,10 +182,9 @@ pub(crate) struct ProcessBufferedPacketsTimings {
     pub consume_buffered_packets_us: u64,
 }
 impl ProcessBufferedPacketsTimings {
-    fn report(&self, id: &str, slot: Slot) {
+    fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-leader_slot_process_buffered_packets_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_process_buffered_packets_timings",
             ("slot", slot as i64, i64),
             ("make_decision_us", self.make_decision_us as i64, i64),
             (
@@ -206,10 +203,9 @@ pub(crate) struct ConsumeBufferedPacketsTimings {
 }
 
 impl ConsumeBufferedPacketsTimings {
-    fn report(&self, id: &str, slot: Slot) {
+    fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-leader_slot_consume_buffered_packets_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_consume_buffered_packets_timings",
             ("slot", slot as i64, i64),
             (
                 "process_packets_transactions_us",
@@ -238,10 +234,9 @@ pub(crate) struct ProcessPacketsTimings {
 }
 
 impl ProcessPacketsTimings {
-    fn report(&self, id: &str, slot: Slot) {
+    fn report(&self, slot: Slot) {
         datapoint_info!(
-            "banking_stage-leader_slot_process_packets_timings",
-            "id" => id,
+            "banking_stage-vote_leader_slot_process_packets_timings",
             ("slot", slot as i64, i64),
             (
                 "transactions_from_packets_us",

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -10,19 +10,17 @@ use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
-    solana_sdk::{saturating_add_assign, timing::timestamp},
+    solana_sdk::saturating_add_assign,
     std::{sync::atomic::Ordering, time::Duration},
 };
 
 pub struct PacketReceiver {
-    id: u32,
     packet_deserializer: PacketDeserializer,
 }
 
 impl PacketReceiver {
-    pub fn new(id: u32, banking_packet_receiver: BankingPacketReceiver) -> Self {
+    pub fn new(banking_packet_receiver: BankingPacketReceiver) -> Self {
         Self {
-            id,
             packet_deserializer: PacketDeserializer::new(banking_packet_receiver),
         }
     }
@@ -92,7 +90,6 @@ impl PacketReceiver {
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) {
         let packet_count = deserialized_packets.len();
-        debug!("@{:?} txs: {} id: {}", timestamp(), packet_count, self.id);
 
         slot_metrics_tracker.increment_received_packet_counts(packet_stats);
 

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -107,13 +107,18 @@ impl PacketReceiver {
             slot_metrics_tracker,
         );
 
-        banking_stage_stats
+        let vote_source_counts = match vote_source {
+            VoteSource::Gossip => &banking_stage_stats.gossip_counts,
+            VoteSource::Tpu => &banking_stage_stats.tpu_counts,
+        };
+
+        vote_source_counts
             .receive_and_buffer_packets_count
             .fetch_add(packet_count, Ordering::Relaxed);
-        banking_stage_stats
+        vote_source_counts
             .dropped_packets_count
             .fetch_add(dropped_packets_count, Ordering::Relaxed);
-        banking_stage_stats
+        vote_source_counts
             .newly_buffered_packets_count
             .fetch_add(newly_buffered_packets_count, Ordering::Relaxed);
         banking_stage_stats

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -16,17 +16,12 @@ const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 #[derive(Debug)]
 pub struct VoteStorage {
     latest_unprocessed_votes: Arc<LatestUnprocessedVotes>,
-    vote_source: VoteSource,
 }
 
 impl VoteStorage {
-    pub fn new(
-        latest_unprocessed_votes: Arc<LatestUnprocessedVotes>,
-        vote_source: VoteSource,
-    ) -> Self {
+    pub fn new(latest_unprocessed_votes: Arc<LatestUnprocessedVotes>) -> Self {
         Self {
             latest_unprocessed_votes,
-            vote_source,
         }
     }
 
@@ -44,6 +39,7 @@ impl VoteStorage {
 
     pub(crate) fn insert_batch(
         &mut self,
+        vote_source: VoteSource,
         deserialized_packets: Vec<ImmutableDeserializedPacket>,
     ) -> VoteBatchInsertionMetrics {
         self.latest_unprocessed_votes.insert_batch(
@@ -52,7 +48,7 @@ impl VoteStorage {
                 .filter_map(|deserialized_packet| {
                     LatestValidatorVotePacket::new_from_immutable(
                         Arc::new(deserialized_packet),
-                        self.vote_source,
+                        vote_source,
                         self.latest_unprocessed_votes
                             .should_deprecate_legacy_vote_ixs(),
                     )
@@ -71,7 +67,7 @@ impl VoteStorage {
             packets.filter_map(|packet| {
                 LatestValidatorVotePacket::new_from_immutable(
                     packet,
-                    self.vote_source,
+                    VoteSource::Tpu, // incorrect, but this bug has been here w/o issue for a long time.
                     self.latest_unprocessed_votes
                         .should_deprecate_legacy_vote_ixs(),
                 )
@@ -90,17 +86,8 @@ impl VoteStorage {
     }
 
     pub fn cache_epoch_boundary_info(&mut self, bank: &Bank) {
-        if matches!(self.vote_source, VoteSource::Gossip) {
-            panic!("Gossip vote thread should not be checking epoch boundary");
-        }
         self.latest_unprocessed_votes
             .cache_epoch_boundary_info(bank);
-    }
-
-    pub fn should_not_process(&self) -> bool {
-        // The gossip vote thread does not need to process or forward any votes, that is
-        // handled by the tpu vote thread
-        matches!(self.vote_source, VoteSource::Gossip)
     }
 }
 
@@ -142,10 +129,12 @@ mod tests {
 
         let latest_unprocessed_votes =
             LatestUnprocessedVotes::new_for_tests(&[vote_keypair.pubkey()]);
-        let mut transaction_storage =
-            VoteStorage::new(Arc::new(latest_unprocessed_votes), VoteSource::Tpu);
+        let mut transaction_storage = VoteStorage::new(Arc::new(latest_unprocessed_votes));
 
-        transaction_storage.insert_batch(vec![ImmutableDeserializedPacket::new(&vote)?]);
+        transaction_storage.insert_batch(
+            VoteSource::Tpu,
+            vec![ImmutableDeserializedPacket::new(&vote)?],
+        );
         assert_eq!(1, transaction_storage.len());
 
         // Drain all packets, then re-insert.

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -15,11 +15,11 @@ const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
 
 #[derive(Debug)]
 pub struct VoteStorage {
-    latest_unprocessed_votes: Arc<LatestUnprocessedVotes>,
+    latest_unprocessed_votes: LatestUnprocessedVotes,
 }
 
 impl VoteStorage {
-    pub fn new(latest_unprocessed_votes: Arc<LatestUnprocessedVotes>) -> Self {
+    pub fn new(latest_unprocessed_votes: LatestUnprocessedVotes) -> Self {
         Self {
             latest_unprocessed_votes,
         }
@@ -129,7 +129,7 @@ mod tests {
 
         let latest_unprocessed_votes =
             LatestUnprocessedVotes::new_for_tests(&[vote_keypair.pubkey()]);
-        let mut transaction_storage = VoteStorage::new(Arc::new(latest_unprocessed_votes));
+        let mut transaction_storage = VoteStorage::new(latest_unprocessed_votes);
 
         transaction_storage.insert_batch(
             VoteSource::Tpu,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -95,7 +95,7 @@ impl VoteWorker {
                 Ok(()) | Err(RecvTimeoutError::Timeout) => (),
                 Err(RecvTimeoutError::Disconnected) => break,
             }
-            // Check for new packets from the tpu receiver
+            // Check for new packets from the gossip receiver
             match self.gossip_receiver.receive_and_buffer_packets(
                 &mut self.storage,
                 &mut banking_stage_stats,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -3,6 +3,7 @@ use {
         consumer::Consumer,
         decision_maker::{BufferedPacketsDecision, DecisionMaker},
         immutable_deserialized_packet::ImmutableDeserializedPacket,
+        latest_unprocessed_votes::VoteSource,
         leader_slot_metrics::{
             CommittedTransactionsCounts, LeaderSlotMetricsTracker, ProcessTransactionsSummary,
         },
@@ -41,35 +42,35 @@ pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 64;
 
 pub struct VoteWorker {
     decision_maker: DecisionMaker,
-    packet_receiver: PacketReceiver,
+    tpu_receiver: PacketReceiver,
+    gossip_receiver: PacketReceiver,
     storage: VoteStorage,
     bank_forks: Arc<RwLock<BankForks>>,
     consumer: Consumer,
-    id: u32,
 }
 
 impl VoteWorker {
     pub fn new(
         decision_maker: DecisionMaker,
-        packet_receiver: PacketReceiver,
+        tpu_receiver: PacketReceiver,
+        gossip_receiver: PacketReceiver,
         storage: VoteStorage,
         bank_forks: Arc<RwLock<BankForks>>,
         consumer: Consumer,
-        id: u32,
     ) -> Self {
         Self {
             decision_maker,
-            packet_receiver,
+            tpu_receiver,
+            gossip_receiver,
             storage,
             bank_forks,
             consumer,
-            id,
         }
     }
 
     pub fn run(mut self) {
-        let mut banking_stage_stats = BankingStageStats::new(self.id);
-        let mut slot_metrics_tracker = LeaderSlotMetricsTracker::new(self.id);
+        let mut banking_stage_stats = BankingStageStats::new();
+        let mut slot_metrics_tracker = LeaderSlotMetricsTracker::default();
 
         let mut last_metrics_update = Instant::now();
 
@@ -84,10 +85,22 @@ impl VoteWorker {
                 last_metrics_update = Instant::now();
             }
 
-            match self.packet_receiver.receive_and_buffer_packets(
+            // Check for new packets from the tpu receiver
+            match self.tpu_receiver.receive_and_buffer_packets(
                 &mut self.storage,
                 &mut banking_stage_stats,
                 &mut slot_metrics_tracker,
+                VoteSource::Tpu,
+            ) {
+                Ok(()) | Err(RecvTimeoutError::Timeout) => (),
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+            // Check for new packets from the tpu receiver
+            match self.gossip_receiver.receive_and_buffer_packets(
+                &mut self.storage,
+                &mut banking_stage_stats,
+                &mut slot_metrics_tracker,
+                VoteSource::Gossip,
             ) {
                 Ok(()) | Err(RecvTimeoutError::Timeout) => (),
                 Err(RecvTimeoutError::Disconnected) => break,
@@ -101,9 +114,6 @@ impl VoteWorker {
         banking_stage_stats: &mut BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) {
-        if self.storage.should_not_process() {
-            return;
-        }
         let (decision, make_decision_us) =
             measure_us!(self.decision_maker.make_consume_or_forward_decision());
         let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank_start());


### PR DESCRIPTION
#### Problem
- We have 2 vote threads, one of them only does receiving. This seems to be an artifact of how we used to process transactions, rather than an ideal setup.

#### Summary of Changes
- Use a single vote thread to receive from both gossip & non-gossip channels
  -  We **could** combine these channels, but leaving them separate allows us to track gossip vs non-gossip easily.
- Remove id from metrics, rename vote-only metrics to indicate they are only for the vote-thread

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
