### PR TITLE
Marks scan_accounts_stored_meta() and get_stored_account_meta_callback() as DCOU

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "dev-context-only-utils")]
+use crate::account_storage::meta::StoredAccountMeta;
 use {
     crate::{
         account_info::AccountInfo,
-        account_storage::{meta::StoredAccountMeta, stored_account_info::StoredAccountInfo},
+        account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::AccountsFileId,
         accounts_update_notifier_interface::AccountForGeyser,
         append_vec::{AppendVec, AppendVecError, IndexInfo},
@@ -161,25 +163,27 @@ impl AccountsFile {
     pub fn get_stored_account_callback<Ret>(
         &self,
         offset: usize,
-        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
+        callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
     ) -> Option<Ret> {
-        self.get_stored_account_meta_callback(offset, |stored_account_meta| {
-            let account = StoredAccountInfo {
-                pubkey: stored_account_meta.pubkey(),
-                lamports: stored_account_meta.lamports(),
-                owner: stored_account_meta.owner(),
-                data: stored_account_meta.data(),
-                executable: stored_account_meta.executable(),
-                rent_epoch: stored_account_meta.rent_epoch(),
-            };
-            callback(account)
-        })
+        match self {
+            Self::AppendVec(av) => av.get_stored_account_callback(offset, callback),
+            Self::TieredStorage(ts) => {
+                // Note: The conversion here is needed as the AccountsDB currently
+                // assumes all offsets are multiple of 8 while TieredStorage uses
+                // IndexOffset that is equivalent to AccountInfo::reduced_offset.
+                let index_offset = IndexOffset(AccountInfo::get_reduced_offset(offset));
+                ts.reader()?
+                    .get_stored_account_callback(index_offset, callback)
+                    .ok()?
+            }
+        }
     }
 
     /// calls `callback` with the account located at the specified index offset.
     ///
     /// Prefer get_stored_account_callback() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn get_stored_account_meta_callback<Ret>(
         &self,
         offset: usize,
@@ -261,24 +265,22 @@ impl AccountsFile {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub fn scan_accounts(&self, mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>)) {
-        self.scan_accounts_stored_meta(|stored_account_meta| {
-            let account = StoredAccountInfo {
-                pubkey: stored_account_meta.pubkey(),
-                lamports: stored_account_meta.lamports(),
-                owner: stored_account_meta.owner(),
-                data: stored_account_meta.data(),
-                executable: stored_account_meta.executable(),
-                rent_epoch: stored_account_meta.rent_epoch(),
-            };
-            callback(account)
-        })
+    pub fn scan_accounts(&self, callback: impl for<'local> FnMut(StoredAccountInfo<'local>)) {
+        match self {
+            Self::AppendVec(av) => av.scan_accounts(callback),
+            Self::TieredStorage(ts) => {
+                if let Some(reader) = ts.reader() {
+                    _ = reader.scan_accounts(callback);
+                }
+            }
+        }
     }
 
     /// Iterate over all accounts and call `callback` with each account.
     ///
     /// Prefer scan_accounts() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn scan_accounts_stored_meta(
         &self,
         callback: impl for<'local> FnMut(StoredAccountMeta<'local>),


### PR DESCRIPTION
#### Problem

There are now no more non-tests that call scan_accounts_stored_meta() and get_stored_account_meta_callback() (woohoo!), and we don't want new code to call them, so we can mark these functions as DCOU.


#### Summary of Changes

Mark 'em DCOU.