### PR TITLE
Deprecate use of `enable_zk_transfer_with_fee` feature

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
 use {
-    agave_feature_set as feature_set,
     bytemuck::Pod,
     solana_instruction::{error::InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
     solana_log_collector::ic_msg,
@@ -49,10 +48,10 @@ where
 
     // if instruction data is exactly 5 bytes, then read proof from an account
     let context_data = if instruction_data.len() == INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT {
-        if !invoke_context
-            .get_feature_set()
-            .is_active(&feature_set::enable_zk_proof_from_account::id())
-        {
+        let enable_zk_proof_from_account = false;
+        // This code is disabled on purpose. If the feature is required to be enabled in future,
+        // a better way to lookup feature_set should be implemented/used.
+        if !enable_zk_proof_from_account {
             return Err(InstructionError::InvalidInstructionData);
         }
 
@@ -182,9 +181,7 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
 }
 
 declare_process_instruction!(Entrypoint, 0, |invoke_context| {
-    let enable_zk_transfer_with_fee = invoke_context
-        .get_feature_set()
-        .is_active(&feature_set::enable_zk_transfer_with_fee::id());
+    let enable_zk_transfer_with_fee = false;
 
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;


### PR DESCRIPTION
#### Problem
`enable_zk_transfer_with_fee` feature is causing dependency on `InvokeContext::get_feature_set()`. This API is about to be deprecated. As per discord discussion, there's no plans to use this zk program, or for the feature to be activated. 

#### Summary of Changes
Removing the use of feature gate in this program, and marking it as inactive by default.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
