### PR TITLE
remove shred_version 0 from dos. discover shred version from cluster if not passed in

### DIFF
--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -45,6 +45,13 @@ pub struct DosClientParameters {
     #[clap(long, help = "Just use entrypoint address directly")]
     pub skip_gossip: bool,
 
+    #[clap(
+        long,
+        conflicts_with("skip-gossip"),
+        help = "The shred version to use for gossip discovery. If not provided, will be discovered from the network"
+    )]
+    pub shred_version: Option<u16>,
+
     #[clap(long, help = "Allow contacting private ip addresses")]
     pub allow_private_addr: bool,
 
@@ -214,6 +221,8 @@ mod tests {
             "get-account-info",
             "--data-input",
             &pubkey_str,
+            "--shred-version",
+            "42",
         ])
         .unwrap();
         assert_eq!(
@@ -225,6 +234,7 @@ mod tests {
                 data_type: DataType::GetAccountInfo,
                 data_input: Some(pubkey),
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 transaction_params: TransactionParams::default(),
                 tpu_use_quic: false,
@@ -250,6 +260,8 @@ mod tests {
             "--tpu-use-quic",
             "--send-batch-size",
             "1",
+            "--shred-version",
+            "42",
         ])
         .unwrap();
         assert_eq!(
@@ -261,6 +273,7 @@ mod tests {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -294,6 +307,8 @@ mod tests {
             "1",
             "--send-batch-size",
             "1",
+            "--shred-version",
+            "42",
         ])
         .unwrap();
         assert_eq!(
@@ -305,6 +320,7 @@ mod tests {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -331,6 +347,8 @@ mod tests {
             "transfer",
             "--num-instructions",
             "8",
+            "--shred-version",
+            "42",
         ]);
         assert!(result.is_err());
         assert_eq!(
@@ -353,6 +371,8 @@ mod tests {
             "8",
             "--send-batch-size",
             "1",
+            "--shred-version",
+            "42",
         ])
         .unwrap();
         assert_eq!(
@@ -364,6 +384,7 @@ mod tests {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -395,6 +416,8 @@ mod tests {
             "account-creation",
             "--send-batch-size",
             "1",
+            "--shred-version",
+            "42",
         ])
         .unwrap();
         assert_eq!(
@@ -406,6 +429,7 @@ mod tests {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -438,6 +462,8 @@ mod tests {
             "8",
             "--num-instructions",
             "1",
+            "--shred-version",
+            "42",
         ]);
         assert!(result.is_err());
     }

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -760,7 +760,18 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
 
 fn main() {
     solana_logger::setup_with_default_filter();
-    let cmd_params = build_cli_parameters();
+    let mut cmd_params = build_cli_parameters();
+
+    if !cmd_params.skip_gossip && cmd_params.shred_version.is_none() {
+        // Try to get shred version from the entrypoint
+        cmd_params.shred_version = Some(
+            solana_net_utils::get_cluster_shred_version(&cmd_params.entrypoint_addr)
+                .unwrap_or_else(|err| {
+                    eprintln!("Failed to get shred version: {}", err);
+                    exit(1);
+                }),
+        );
+    }
 
     let (nodes, client) = if !cmd_params.skip_gossip {
         info!("Finding cluster entry: {:?}", cmd_params.entrypoint_addr);
@@ -773,7 +784,7 @@ fn main() {
             None,                              // find_nodes_by_pubkey
             Some(&cmd_params.entrypoint_addr), // find_node_by_gossip_addr
             None,                              // my_gossip_addr
-            0,                                 // my_shred_version
+            cmd_params.shred_version.unwrap(), // my_shred_version
             socket_addr_space,
         )
         .unwrap_or_else(|err| {
@@ -859,6 +870,7 @@ pub mod test {
                 data_type: DataType::Random,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
@@ -880,6 +892,7 @@ pub mod test {
                 data_type: DataType::RepairHighest,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
@@ -898,6 +911,7 @@ pub mod test {
                 data_type: DataType::RepairShred,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
@@ -916,6 +930,7 @@ pub mod test {
                 data_type: DataType::GetAccountInfo,
                 data_input: Some(Pubkey::default()),
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
@@ -949,6 +964,7 @@ pub mod test {
                 data_type: DataType::Random,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
@@ -990,6 +1006,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1017,6 +1034,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1044,6 +1062,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1125,6 +1144,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1154,6 +1174,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1182,6 +1203,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {
@@ -1210,6 +1232,7 @@ pub mod test {
                 data_type: DataType::Transaction,
                 data_input: None,
                 skip_gossip: false,
+                shred_version: Some(42),
                 allow_private_addr: false,
                 num_gen_threads: 1,
                 transaction_params: TransactionParams {


### PR DESCRIPTION
#### Problem
We are in the process of removing the special `shred_version == 0` case where validators can pull from any node if they set the shred version to 0

#### Summary of Changes
Update `dos` to to take in a `shred_version` flag. If no shred version flag passed in, try to discover shred version from the entrypoint