### PR TITLE
remove shred_version 0 from transaction-dos. discover shred version from cluster if not passed in

### DIFF
--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -556,17 +556,21 @@ fn main() {
             exit(1)
         });
     }
-    let shred_version = if !skip_gossip {
-        if let Ok(shred_version) = value_t!(matches, "shred_version", u16) {
-            shred_version
+    let shred_version: Option<u16> = if !skip_gossip {
+        if let Ok(version) = value_t!(matches, "shred_version", u16) {
+            Some(version)
         } else {
-            solana_net_utils::get_cluster_shred_version(&entrypoint_addr).unwrap_or_else(|err| {
-                eprintln!("Failed to get shred version: {}", err);
-                exit(1);
-            })
+            Some(
+                solana_net_utils::get_cluster_shred_version(&entrypoint_addr).unwrap_or_else(
+                    |err| {
+                        eprintln!("Failed to get shred version: {}", err);
+                        exit(1);
+                    },
+                ),
+            )
         }
     } else {
-        0
+        None
     };
 
     let just_calculate_fees = matches.is_present("just_calculate_fees");
@@ -622,7 +626,7 @@ fn main() {
             None,                    // find_node_by_pubkey
             Some(&entrypoint_addr),  // find_node_by_gossip_addr
             None,                    // my_gossip_addr
-            shred_version,           // my_shred_version
+            shred_version.unwrap(),  // my_shred_version
             SocketAddrSpace::Unspecified,
         )
         .unwrap_or_else(|err| {

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -526,6 +526,14 @@ fn main() {
                 .help("Just use entrypoint address directly"),
         )
         .arg(
+            Arg::with_name("shred_version")
+                .long("shred-version")
+                .takes_value(true)
+                .value_name("VERSION")
+                .requires("check_gossip")
+                .help("The shred version to use for node discovery"),
+        )
+        .arg(
             Arg::with_name("just_calculate_fees")
                 .long("just-calculate-fees")
                 .help("Just print the necessary fees and exit"),
@@ -540,8 +548,6 @@ fn main() {
         .get_matches();
 
     let skip_gossip = !matches.is_present("check_gossip");
-    let just_calculate_fees = matches.is_present("just_calculate_fees");
-
     let port = if skip_gossip { DEFAULT_RPC_PORT } else { 8001 };
     let mut entrypoint_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     if let Some(addr) = matches.value_of("entrypoint") {
@@ -550,6 +556,20 @@ fn main() {
             exit(1)
         });
     }
+    let shred_version = if !skip_gossip {
+        if let Ok(shred_version) = value_t!(matches, "shred_version", u16) {
+            shred_version
+        } else {
+            solana_net_utils::get_cluster_shred_version(&entrypoint_addr).unwrap_or_else(|err| {
+                eprintln!("Failed to get shred version: {}", err);
+                exit(1);
+            })
+        }
+    } else {
+        0
+    };
+
+    let just_calculate_fees = matches.is_present("just_calculate_fees");
     let mut faucet_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, FAUCET_PORT));
     if let Some(addr) = matches.value_of("faucet_addr") {
         faucet_addr = solana_net_utils::parse_host_port(addr).unwrap_or_else(|e| {
@@ -602,7 +622,7 @@ fn main() {
             None,                    // find_node_by_pubkey
             Some(&entrypoint_addr),  // find_node_by_gossip_addr
             None,                    // my_gossip_addr
-            0,                       // my_shred_version
+            shred_version,           // my_shred_version
             SocketAddrSpace::Unspecified,
         )
         .unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem
We are in the process of removing the special `shred_version == 0` case where validators can pull from any node if they set the shred version to 0

#### Summary of Changes
Update `transaction-dos` to to take in a `shred_version` flag. If no shred version flag passed in, try to discover shred version from the entrypoint