### PR TITLE
Create bind UdpSocket for VoteClient in Node

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -71,6 +71,8 @@ pub struct TpuSockets {
     pub transactions_quic: Vec<UdpSocket>,
     pub transactions_forwards_quic: Vec<UdpSocket>,
     pub vote_quic: Vec<UdpSocket>,
+    /// Client-side socket for the forwarding votes.
+    pub vote_forwards_client: UdpSocket,
 }
 
 pub struct Tpu {
@@ -140,6 +142,7 @@ impl Tpu {
             transactions_quic: transactions_quic_sockets,
             transactions_forwards_quic: transactions_forwards_quic_sockets,
             vote_quic: tpu_vote_quic_sockets,
+            vote_forwards_client: vote_forwards_client_socket,
         } = sockets;
 
         let (packet_sender, packet_receiver) = unbounded();
@@ -283,6 +286,7 @@ impl Tpu {
         let forwarding_stage = spawn_forwarding_stage(
             forward_stage_receiver,
             connection_cache.clone(),
+            vote_forwards_client_socket,
             RootBankCache::new(bank_forks.clone()),
             ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),
             DataBudget::default(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1576,6 +1576,7 @@ impl Validator {
                 transactions_quic: node.sockets.tpu_quic,
                 transactions_forwards_quic: node.sockets.tpu_forwards_quic,
                 vote_quic: node.sockets.tpu_vote_quic,
+                vote_forwards_client: node.sockets.tpu_vote_forwards_client,
             },
             &rpc_subscriptions,
             transaction_status_sender,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -53,8 +53,9 @@ use {
     solana_net_utils::{
         bind_common_in_range_with_config, bind_common_with_config, bind_in_range,
         bind_in_range_with_config, bind_more_with_config, bind_to_localhost, bind_to_unspecified,
-        bind_two_in_range_with_offset_and_config, find_available_port_in_range,
-        multi_bind_in_range_with_config, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
+        bind_to_with_config, bind_two_in_range_with_offset_and_config,
+        find_available_port_in_range, multi_bind_in_range_with_config, PortRange, SocketConfig,
+        VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
         data_budget::DataBudget,
@@ -2380,6 +2381,9 @@ pub struct Sockets {
     pub tpu_quic: Vec<UdpSocket>,
     pub tpu_forwards_quic: Vec<UdpSocket>,
     pub tpu_vote_quic: Vec<UdpSocket>,
+
+    /// Client-side socket for ForwardingStage.
+    pub tpu_vote_forwards_client: UdpSocket,
 }
 
 pub struct NodeConfig {
@@ -2465,6 +2469,8 @@ impl Node {
         let ancestor_hashes_requests = bind_to_unspecified().unwrap();
         let ancestor_hashes_requests_quic = bind_to_unspecified().unwrap();
 
+        let tpu_vote_forwards_client = bind_to_localhost().unwrap();
+
         let mut info = ContactInfo::new(
             *pubkey,
             timestamp(), // wallclock
@@ -2541,6 +2547,7 @@ impl Node {
                 tpu_quic,
                 tpu_forwards_quic,
                 tpu_vote_quic,
+                tpu_vote_forwards_client,
             },
         }
     }
@@ -2643,6 +2650,9 @@ impl Node {
         let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
         let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
 
+        // These are client sockets, so the port is set to be 0 because it must be ephimeral.
+        let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+
         let addr = gossip_addr.ip();
         let mut info = ContactInfo::new(
             *pubkey,
@@ -2704,6 +2714,7 @@ impl Node {
                 tpu_quic,
                 tpu_forwards_quic,
                 tpu_vote_quic,
+                tpu_vote_forwards_client,
             },
         }
     }
@@ -2808,6 +2819,9 @@ impl Node {
         let (_, ancestor_hashes_requests_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
+        // These are client sockets, so the port is set to be 0 because it must be ephimeral.
+        let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+
         let mut info = ContactInfo::new(
             *pubkey,
             timestamp(), // wallclock
@@ -2854,6 +2868,7 @@ impl Node {
                 tpu_quic,
                 tpu_forwards_quic,
                 tpu_vote_quic,
+                tpu_vote_forwards_client,
             },
         }
     }


### PR DESCRIPTION
#### Problem

Currently, server-side sockets are created in the `cluster_info` module while client-side sockets are created everywhere. This makes it hard to track that they use the bind address specified by user instead of `UNSPECIFIED` and generally complicated tracking of opened sockets.

#### Summary of Changes

Create socket for the `VoteClient` in `ForwardingStage` in `cluster_info` where all the other sockets are opened.

