### PR TITLE
tpu-client-next: support bind UdpSocket

### DIFF
--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -8,7 +8,7 @@ use {
     solana_measure::measure::Measure,
     solana_sdk::quic::NotifyKeyUpdate,
     solana_tpu_client_next::{
-        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
+        connection_workers_scheduler::{BindTarget, ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::LeaderUpdater,
         transaction_batch::TransactionBatch,
         ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
@@ -287,8 +287,9 @@ impl TpuClientNextClient {
         stake_identity: Option<&Keypair>,
         leader_forward_count: usize,
     ) -> ConnectionWorkersSchedulerConfig {
+        let address = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);
         ConnectionWorkersSchedulerConfig {
-            bind: SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0),
+            bind: BindTarget::Address(address),
             stake_identity: stake_identity.map(Into::into),
             num_connections: MAX_CONNECTIONS,
             skip_check_transaction_age: true,

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -15,7 +15,7 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
-        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, Fanout},
+        connection_workers_scheduler::{BindTarget, ConnectionWorkersSchedulerConfig, Fanout},
         leader_updater::create_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
         transaction_batch::TransactionBatch,
@@ -40,8 +40,9 @@ use {
 };
 
 fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerConfig {
+    let address = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0);
     ConnectionWorkersSchedulerConfig {
-        bind: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
+        bind: BindTarget::Address(address),
         stake_identity: stake_identity.map(Into::into),
         num_connections: 1,
         skip_check_transaction_age: false,


### PR DESCRIPTION
#### Problem

Currently, server-side sockets are created in the cluster_info module while client-side sockets are created everywhere. This makes it hard to track that they use the bind address specified by user instead of UNSPECIFIED and generally complicated tracking of opened sockets.

#### Summary of Changes

This PR adds `BindTarget` enum that allows to use `SocketAddr` or `UdpSocket` to bind the client.
In the follow up PR I will get rid of `0.0.0.0` in SendTransacitonService.