### PR TITLE
RPC/STS: use client UdpSocket created in client_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9944,6 +9944,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-runtime",
  "solana-sdk",
  "solana-tpu-client-next",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1182,7 +1182,10 @@ impl Validator {
                 max_complete_rewards_slot,
                 prioritization_fee_cache: prioritization_fee_cache.clone(),
                 client_option: if config.use_tpu_client_next {
-                    ClientOption::TpuClientNext(Arc::as_ref(&identity_keypair))
+                    ClientOption::TpuClientNext(
+                        Arc::as_ref(&identity_keypair),
+                        node.sockets.rpc_sts_client,
+                    )
                 } else {
                     ClientOption::ConnectionCache(connection_cache.clone())
                 },

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2388,6 +2388,8 @@ pub struct Sockets {
     pub quic_forwards_client: UdpSocket,
     /// Connection cache endpoint for QUIC-based Vote
     pub quic_vote_client: UdpSocket,
+    /// Client-side socket for RPC/SendTransactionService.
+    pub rpc_sts_client: UdpSocket,
 }
 
 pub struct NodeConfig {
@@ -2476,6 +2478,7 @@ impl Node {
         let tpu_vote_forwards_client = bind_to_localhost().unwrap();
         let quic_forwards_client = bind_to_localhost().unwrap();
         let quic_vote_client = bind_to_localhost().unwrap();
+        let rpc_sts_client = bind_to_localhost().unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,
@@ -2556,6 +2559,7 @@ impl Node {
                 tpu_vote_forwards_client,
                 quic_forwards_client,
                 quic_vote_client,
+                rpc_sts_client,
             },
         }
     }
@@ -2663,6 +2667,7 @@ impl Node {
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
         let quic_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
         let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let rpc_sts_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
 
         let addr = gossip_addr.ip();
         let mut info = ContactInfo::new(
@@ -2728,6 +2733,7 @@ impl Node {
                 tpu_vote_forwards_client,
                 quic_vote_client,
                 quic_forwards_client,
+                rpc_sts_client,
             },
         }
     }
@@ -2835,6 +2841,7 @@ impl Node {
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
         let quic_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
         let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let rpc_sts_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,
@@ -2882,6 +2889,7 @@ impl Node {
             tpu_vote_forwards_client,
             quic_vote_client,
             quic_forwards_client,
+            rpc_sts_client,
         };
         info!("Bound all network sockets as follows: {:#?}", &sockets);
         Node { info, sockets }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -44,7 +44,7 @@ use {
     },
     solana_storage_bigtable::CredentialType,
     std::{
-        net::SocketAddr,
+        net::{SocketAddr, UdpSocket},
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -409,7 +409,7 @@ pub struct JsonRpcServiceConfig<'a> {
 ///       requires a reference to a [`Keypair`].
 pub enum ClientOption<'a> {
     ConnectionCache(Arc<ConnectionCache>),
-    TpuClientNext(&'a Keypair),
+    TpuClientNext(&'a Keypair, UdpSocket),
 }
 
 impl JsonRpcService {
@@ -466,7 +466,7 @@ impl JsonRpcService {
                 )?;
                 Ok(json_rpc_service)
             }
-            ClientOption::TpuClientNext(identity_keypair) => {
+            ClientOption::TpuClientNext(identity_keypair, tpu_client_socket) => {
                 let my_tpu_address = config
                     .cluster_info
                     .my_contact_info()
@@ -482,6 +482,7 @@ impl JsonRpcService {
                     leader_info,
                     config.send_transaction_service_config.leader_forward_count,
                     Some(identity_keypair),
+                    tpu_client_socket,
                 );
 
                 let json_rpc_service = Self::new_with_client(

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -19,6 +19,7 @@ solana-connection-cache = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-net-utils = { workspace = true, optional = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-tpu-client-next = { workspace = true, features = ["metrics"] }
@@ -27,10 +28,11 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-net-utils"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -52,6 +52,8 @@ impl CreateClient for TpuClientNextClient {
     ) -> Self {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
+        let bind_socket = solana_net_utils::bind_to_localhost()
+            .expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,
             my_tpu_address,
@@ -59,6 +61,7 @@ impl CreateClient for TpuClientNextClient {
             None,
             leader_forward_count,
             None,
+            bind_socket,
         )
     }
 }


### PR DESCRIPTION
#### Problem

Currently, server-side sockets are created in the cluster_info module while client-side sockets are created everywhere. This makes it hard to track that they use the bind address specified by user instead of UNSPECIFIED and generally complicated tracking of opened sockets.

#### Summary of Changes

Create socket for the TpuClient  in SendTransactionService in cluster_info where all the other sockets are opened.