### PR TITLE
Allows scanning slot and getting stored account info without data

### DIFF
--- a/accounts-db/src/account_storage/stored_account_info.rs
+++ b/accounts-db/src/account_storage/stored_account_info.rs
@@ -36,3 +36,57 @@ impl ReadableAccount for StoredAccountInfo<'_> {
         self.rent_epoch
     }
 }
+
+/// Account type with fields that reference into a storage, *without* data
+///
+/// Used then scanning the accounts of a single storage.
+#[derive(Debug, Clone)]
+pub struct StoredAccountInfoWithoutData<'storage> {
+    pub pubkey: &'storage Pubkey,
+    pub lamports: u64,
+    pub owner: &'storage Pubkey,
+    pub data_len: usize,
+    pub executable: bool,
+    pub rent_epoch: Epoch,
+}
+
+impl StoredAccountInfoWithoutData<'_> {
+    pub fn pubkey(&self) -> &Pubkey {
+        self.pubkey
+    }
+    pub fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    pub fn owner(&self) -> &Pubkey {
+        self.owner
+    }
+    pub fn data_len(&self) -> usize {
+        self.data_len
+    }
+    pub fn executable(&self) -> bool {
+        self.executable
+    }
+    pub fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+impl<'storage> StoredAccountInfoWithoutData<'storage> {
+    /// Constructs a new StoredAccountInfoWithoutData from a StoredAccountInfo
+    ///
+    /// Use this ctor when `stored_account_info` is going out of scope, *but not* the underlying
+    /// `'storage`.  This facilitates incremental improvements towards not reading account data
+    /// unnecessarily, by changing out the front-end code separately from the back-end.
+    pub fn new_from<'other>(stored_account_info: &'other StoredAccountInfo<'storage>) -> Self {
+        // Note that we must use the pubkey/owner fields directly so that we can get the `'storage`
+        // lifetime of `stored_account_info`, and *not* its `'other` lifetime.
+        Self {
+            pubkey: stored_account_info.pubkey,
+            lamports: stored_account_info.lamports,
+            owner: stored_account_info.owner,
+            data_len: stored_account_info.data.len(),
+            executable: stored_account_info.executable,
+            rent_epoch: stored_account_info.rent_epoch,
+        }
+    }
+}

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -215,13 +215,13 @@ impl Accounts {
                 // Cache only has one version per key, don't need to worry about versioning
                 func(loaded_account)
             },
-            |accum: &DashMap<Pubkey, B>, loaded_account: &LoadedAccount, _data| {
+            |accum: &DashMap<Pubkey, B>, loaded_account: &LoadedAccount| {
                 let loaded_account_pubkey = *loaded_account.pubkey();
                 if let Some(val) = func(loaded_account) {
                     accum.insert(loaded_account_pubkey, val);
                 }
             },
-            ScanAccountStorageData::NoData,
+            ScanAccountStorageData::DataRefForStorage,
         );
 
         match scan_result {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4418,7 +4418,7 @@ fn test_accounts_db_cache_clean_dead_slots() {
         if let ScanStorageResult::Stored(slot_accounts) = accounts_db.scan_account_storage(
             *slot as Slot,
             |_| Some(0),
-            |slot_accounts: &DashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
+            |slot_accounts: &DashSet<Pubkey>, loaded_account: &LoadedAccount| {
                 slot_accounts.insert(*loaded_account.pubkey());
             },
             ScanAccountStorageData::NoData,
@@ -4452,7 +4452,7 @@ fn test_accounts_db_cache_clean() {
         if let ScanStorageResult::Stored(slot_account) = accounts_db.scan_account_storage(
             *slot as Slot,
             |_| Some(0),
-            |slot_account: &RwLock<Pubkey>, loaded_account: &LoadedAccount, _data| {
+            |slot_account: &RwLock<Pubkey>, loaded_account: &LoadedAccount| {
                 *slot_account.write().unwrap() = *loaded_account.pubkey();
             },
             ScanAccountStorageData::NoData,
@@ -4517,7 +4517,7 @@ fn run_test_accounts_db_cache_clean_max_root(
                 assert!(*slot > requested_flush_root);
                 Some(*loaded_account.pubkey())
             },
-            |slot_accounts: &DashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
+            |slot_accounts: &DashSet<Pubkey>, loaded_account: &LoadedAccount| {
                 slot_accounts.insert(*loaded_account.pubkey());
                 if !is_cache_at_limit {
                     // Only true when the limit hasn't been reached and there are still
@@ -4629,7 +4629,7 @@ fn run_flush_rooted_accounts_cache(should_clean: bool) {
             .scan_account_storage(
                 *slot as Slot,
                 |_| Some(0),
-                |slot_account: &DashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
+                |slot_account: &DashSet<Pubkey>, loaded_account: &LoadedAccount| {
                     slot_account.insert(*loaded_account.pubkey());
                 },
                 ScanAccountStorageData::NoData,


### PR DESCRIPTION
#### Problem

The `scan_account_storage()` function (reproduced below) has a `scan_account_storage_data` parameter to indicate if the caller wants the account data or not. Unfortunately this parameter is not respected; we *always* load the account data. We should not do that.

```rust
    /// Scan a specific slot through all the account storage
    pub(crate) fn scan_account_storage<R, B>(
        &self,
        slot: Slot,
        cache_map_func: impl Fn(&LoadedAccount) -> Option<R> + Sync,
        storage_scan_func: impl Fn(&B, &LoadedAccount, Option<&[u8]>) + Sync,
        scan_account_storage_data: ScanAccountStorageData,
    ) -> ScanStorageResult<R, B>
```


#### Summary of Changes

This PR introduces a new enum variant, `LoadedAccount::StoredNoData`, to indicate we have loaded an account from a storage file, but *without* its account data.

This means the LoadedAccount itself may not have `data()`, which revealed that the current code does not respect the `ScanAccountStorageData::NoData` value at all, since the non-test code all needs the account data.

This PR does *not* change the back-end code used to scan the storage itself—that will be done in a follow up PR. This PR allows the caller of `scan_account_storage()` to specify if they want account data or not, and have the choice be respected.