### PR TITLE
Allows scanning slot and getting stored account info without data

### DIFF
--- a/accounts-db/src/account_storage/stored_account_info.rs
+++ b/accounts-db/src/account_storage/stored_account_info.rs
@@ -19,6 +19,30 @@ impl StoredAccountInfo<'_> {
     }
 }
 
+impl<'storage> StoredAccountInfo<'storage> {
+    /// Constructs a new StoredAccountInfo from a StoredAccountInfoWithoutData and data
+    ///
+    /// Use this ctor when `other_stored_account` is going out of scope, *but not* the underlying
+    /// `'storage`.  This facilitates incremental improvements towards not reading account data
+    /// unnecessarily, by changing out the front-end code separately from the back-end.
+    pub fn new_from<'other>(
+        other_stored_account: &'other StoredAccountInfoWithoutData<'storage>,
+        data: &'storage [u8],
+    ) -> Self {
+        // Note that we must use the pubkey/owner fields directly so that we can get the `'storage`
+        // lifetime of `other_stored_account`, and *not* its `'other` lifetime.
+        assert_eq!(other_stored_account.data_len, data.len());
+        Self {
+            pubkey: other_stored_account.pubkey,
+            lamports: other_stored_account.lamports,
+            owner: other_stored_account.owner,
+            data,
+            executable: other_stored_account.executable,
+            rent_epoch: other_stored_account.rent_epoch,
+        }
+    }
+}
+
 impl ReadableAccount for StoredAccountInfo<'_> {
     fn lamports(&self) -> u64 {
         self.lamports
@@ -34,5 +58,44 @@ impl ReadableAccount for StoredAccountInfo<'_> {
     }
     fn rent_epoch(&self) -> Epoch {
         self.rent_epoch
+    }
+}
+
+/// Account type with fields that reference into a storage, *without* data
+///
+/// Used then scanning the accounts of a single storage.
+#[derive(Debug, Clone)]
+pub struct StoredAccountInfoWithoutData<'storage> {
+    pub pubkey: &'storage Pubkey,
+    pub lamports: u64,
+    pub owner: &'storage Pubkey,
+    pub data_len: usize,
+    pub executable: bool,
+    pub rent_epoch: Epoch,
+}
+
+impl StoredAccountInfoWithoutData<'_> {
+    pub fn pubkey(&self) -> &Pubkey {
+        self.pubkey
+    }
+}
+
+impl<'storage> StoredAccountInfoWithoutData<'storage> {
+    /// Constructs a new StoredAccountInfoWithoutData from a StoredAccountInfo
+    ///
+    /// Use this ctor when `other_stored_account` is going out of scope, *but not* the underlying
+    /// `'storage`.  This facilitates incremental improvements towards not reading account data
+    /// unnecessarily, by changing out the front-end code separately from the back-end.
+    pub fn new_from<'other>(other_stored_account: &'other StoredAccountInfo<'storage>) -> Self {
+        // Note that we must use the pubkey/owner fields directly so that we can get the `'storage`
+        // lifetime of `other_stored_account`, and *not* its `'other` lifetime.
+        Self {
+            pubkey: other_stored_account.pubkey,
+            lamports: other_stored_account.lamports,
+            owner: other_stored_account.owner,
+            data_len: other_stored_account.data.len(),
+            executable: other_stored_account.executable,
+            rent_epoch: other_stored_account.rent_epoch,
+        }
     }
 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4418,8 +4418,8 @@ fn test_accounts_db_cache_clean_dead_slots() {
         if let ScanStorageResult::Stored(slot_accounts) = accounts_db.scan_account_storage(
             *slot as Slot,
             |_| Some(0),
-            |slot_accounts: &mut HashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
-                slot_accounts.insert(*loaded_account.pubkey());
+            |slot_accounts: &mut HashSet<Pubkey>, stored_account, _data| {
+                slot_accounts.insert(*stored_account.pubkey());
             },
             ScanAccountStorageData::NoData,
         ) {
@@ -4452,8 +4452,8 @@ fn test_accounts_db_cache_clean() {
         if let ScanStorageResult::Stored(slot_account) = accounts_db.scan_account_storage(
             *slot as Slot,
             |_| Some(0),
-            |slot_account: &mut Pubkey, loaded_account: &LoadedAccount, _data| {
-                *slot_account = *loaded_account.pubkey();
+            |slot_account: &mut Pubkey, stored_account, _data| {
+                *slot_account = *stored_account.pubkey();
             },
             ScanAccountStorageData::NoData,
         ) {
@@ -4507,7 +4507,7 @@ fn run_test_accounts_db_cache_clean_max_root(
     for slot in &slots {
         let slot_accounts = accounts_db.scan_account_storage(
             *slot as Slot,
-            |loaded_account: &LoadedAccount| {
+            |loaded_account| {
                 assert!(
                     !is_cache_at_limit,
                     "When cache is at limit, all roots should have been flushed to storage"
@@ -4517,8 +4517,8 @@ fn run_test_accounts_db_cache_clean_max_root(
                 assert!(*slot > requested_flush_root);
                 Some(*loaded_account.pubkey())
             },
-            |slot_accounts: &mut HashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
-                slot_accounts.insert(*loaded_account.pubkey());
+            |slot_accounts: &mut HashSet<Pubkey>, stored_account, _data| {
+                slot_accounts.insert(*stored_account.pubkey());
                 if !is_cache_at_limit {
                     // Only true when the limit hasn't been reached and there are still
                     // slots left in the cache
@@ -4628,8 +4628,8 @@ fn run_flush_rooted_accounts_cache(should_clean: bool) {
         let ScanStorageResult::Stored(slot_accounts) = accounts_db.scan_account_storage(
             *slot as Slot,
             |_| Some(0),
-            |slot_account: &mut HashSet<Pubkey>, loaded_account: &LoadedAccount, _data| {
-                slot_account.insert(*loaded_account.pubkey());
+            |slot_account: &mut HashSet<Pubkey>, stored_account, _data| {
+                slot_account.insert(*stored_account.pubkey());
             },
             ScanAccountStorageData::NoData,
         ) else {


### PR DESCRIPTION
#### Problem

The `scan_account_storage()` function (reproduced below) has a `scan_account_storage_data` parameter to indicate if the caller wants the account data or not. Unfortunately this parameter is not respected; we *always* load the account data. We should not do that.

```rust
    /// Scan a specific slot through all the account storage
    pub(crate) fn scan_account_storage<R, B>(
        &self,
        slot: Slot,
        cache_map_func: impl Fn(&LoadedAccount) -> Option<R> + Sync,
        storage_scan_func: impl Fn(&B, &LoadedAccount, Option<&[u8]>) + Sync,
        scan_account_storage_data: ScanAccountStorageData,
    ) -> ScanStorageResult<R, B>
```


#### Summary of Changes

This PR allows the caller of `scan_account_storage()` to specify if they want account data or not, and have the choice be respected.

This PR introduces a new type, `StoredAccountInfoWithoutData`, that is used in the `storage_scan_func` parameter, which replaces the current `LoadedAccount`. Now this "account" parameter is strictly without data, and the trailing `Option<&[u8]>` must be properly requested in order to access account data.

This PR does *not* change the back-end code used to scan the storage itself—that will be done in a follow up PR.