### PR TITLE
Adds scan_accounts_without_data() to avoid loading account data

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4941,8 +4941,7 @@ impl AccountsDb {
         self.scan_cache_storage_fallback(slot, cache_map_func, |retval, storage| {
             match scan_account_storage_data {
                 ScanAccountStorageData::NoData => {
-                    storage.scan_accounts(|account| {
-                        let account_without_data = StoredAccountInfoWithoutData::new_from(&account);
+                    storage.scan_accounts_without_data(|account_without_data| {
                         storage_scan_func(retval, &account_without_data, None);
                     });
                 }


### PR DESCRIPTION
#### Problem

`AccountsDb::scan_account_storage()` still loads account data in its back-end impl, even when we specify `ScanAccountStorageData::NoData`.


#### Summary of Changes

Following on from #5840, we can now add a back-end method to not load the account data when scanning a storage. This PR adds `AccountsFile::scan_accounts_without_data()`.