### PR TITLE
agave-install: swap lazy_static import with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,6 @@ dependencies = [
  "ctrlc",
  "dirs-next",
  "indicatif",
- "lazy_static",
  "nix",
  "reqwest 0.12.15",
  "scopeguard",

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -20,7 +20,6 @@ crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true, features = ["termination"] }
 dirs-next = { workspace = true }
 indicatif = { workspace = true }
-lazy_static = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 scopeguard = { workspace = true }

--- a/install/src/defaults.rs
+++ b/install/src/defaults.rs
@@ -1,22 +1,24 @@
+use std::sync::LazyLock;
+
 pub const JSON_RPC_URL: &str = "http://api.devnet.solana.com";
 
-lazy_static! {
-    pub static ref CONFIG_FILE: Option<String> = {
-        dirs_next::home_dir().map(|mut path| {
-            path.extend([".config", "solana", "install", "config.yml"]);
-            path.to_str().unwrap().to_string()
-        })
-    };
-    pub static ref USER_KEYPAIR: Option<String> = {
-        dirs_next::home_dir().map(|mut path| {
-            path.extend([".config", "solana", "id.json"]);
-            path.to_str().unwrap().to_string()
-        })
-    };
-    pub static ref DATA_DIR: Option<String> = {
-        dirs_next::home_dir().map(|mut path| {
-            path.extend([".local", "share", "solana", "install"]);
-            path.to_str().unwrap().to_string()
-        })
-    };
-}
+pub static CONFIG_FILE: LazyLock<Option<String>> = LazyLock::new(|| {
+    dirs_next::home_dir().map(|mut path| {
+        path.extend([".config", "solana", "install", "config.yml"]);
+        path.to_str().unwrap().to_string()
+    })
+});
+
+pub static USER_KEYPAIR: LazyLock<Option<String>> = LazyLock::new(|| {
+    dirs_next::home_dir().map(|mut path| {
+        path.extend([".config", "solana", "id.json"]);
+        path.to_str().unwrap().to_string()
+    })
+});
+
+pub static DATA_DIR: LazyLock<Option<String>> = LazyLock::new(|| {
+    dirs_next::home_dir().map(|mut path| {
+        path.extend([".local", "share", "solana", "install"]);
+        path.to_str().unwrap().to_string()
+    })
+});

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -1,7 +1,4 @@
 #![allow(clippy::arithmetic_side_effects)]
-#[macro_use]
-extern crate lazy_static;
-
 use {
     clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
     solana_clap_utils::{


### PR DESCRIPTION
#### Problem

We could have one import less by replacing lazy_static with standard library one.

#### Summary of Changes

Swapped lazy_static import by standard library.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
