### PR TITLE
Optimize Dashmap for reward calculation - use more shards

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -315,9 +315,10 @@ impl Bank {
 
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let estimated_num_vote_accounts = cached_vote_accounts.len();
-        let vote_account_rewards: VoteRewards = DashMap::with_capacity_and_hasher(
+        let vote_account_rewards: VoteRewards = DashMap::with_capacity_and_hasher_and_shard_amount(
             estimated_num_vote_accounts,
             AHashRandomState::default(),
+            1024, // shard amount
         );
 
         let total_stake_rewards = AtomicU64::default();
@@ -1100,5 +1101,11 @@ mod tests {
 
         bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
+    }
+
+    #[test]
+    fn test_foo() {
+        let d: DashMap<i8, i8> = DashMap::<i8, i8>::new();
+        println!("{}", d.shards().len());
     }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1102,10 +1102,4 @@ mod tests {
         bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
     }
-
-    #[test]
-    fn test_foo() {
-        let d: DashMap<i8, i8> = DashMap::<i8, i8>::new();
-        println!("{}", d.shards().len());
-    }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -319,6 +319,7 @@ impl Bank {
             estimated_num_vote_accounts,
             AHashRandomState::default(),
         );
+
         let total_stake_rewards = AtomicU64::default();
         let (stake_rewards, measure_stake_rewards_us) = measure_us!(thread_pool.install(|| {
             stake_delegations


### PR DESCRIPTION
#### Problem

The default `dashmap` for storing vote rewards in reward calculation can be optimized. 

~We can preallocate dashmap with the number of vote accounts to save extra allocations.~
~We can use a cheaper `ahash`  as the hasher instead of the default hasher.~
We can increase the number of shards to reduce the lock contention.





#### Summary of Changes

- ~preallocate dashmap~ #5941
- ~use `ahash` for dashmap~ #5942 
- use 1k for the number of shards.

Experiment on mainnet shows nearly 150ms calculation time reduction.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
