### PR TITLE
Add scheduler benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7664,6 +7664,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util 0.7.15",
  "trees",

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -219,14 +219,6 @@ impl ComputeBudgetInstructionDetails {
     }
 }
 
-impl ComputeBudgetInstructionDetails {
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn requested_loaded_accounts_data_size_limit(&self) -> Option<u32> {
-        self.requested_loaded_accounts_data_size_limit
-            .map(|(_, v)| v)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use {

--- a/compute-budget-instruction/src/compute_budget_instruction_details.rs
+++ b/compute-budget-instruction/src/compute_budget_instruction_details.rs
@@ -219,6 +219,14 @@ impl ComputeBudgetInstructionDetails {
     }
 }
 
+impl ComputeBudgetInstructionDetails {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn requested_loaded_accounts_data_size_limit(&self) -> Option<u32> {
+        self.requested_loaded_accounts_data_size_limit
+            .map(|(_, v)| v)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -116,6 +116,7 @@ trees = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 criterion = { workspace = true }
 fs_extra = { workspace = true }
+jemallocator = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
@@ -181,6 +182,10 @@ name = "sigverify_stage"
 
 [[bench]]
 name = "receive_and_buffer"
+harness = false
+
+[[bench]]
+name = "scheduler"
 harness = false
 
 [package.metadata.docs.rs]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -116,7 +116,6 @@ trees = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 criterion = { workspace = true }
 fs_extra = { workspace = true }
-jemallocator = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
@@ -145,6 +144,9 @@ test-case = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 sysctl = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
 
 [features]
 dev-context-only-utils = [

--- a/core/benches/receive_and_buffer.rs
+++ b/core/benches/receive_and_buffer.rs
@@ -1,209 +1,37 @@
+#[path = "receive_and_buffer_utils.rs"]
+mod utils;
 use {
-    agave_banking_stage_ingress_types::BankingPacketBatch,
     criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
-    crossbeam_channel::{unbounded, Receiver},
-    rand::prelude::*,
-    solana_core::banking_stage::{
-        decision_maker::BufferedPacketsDecision,
-        packet_deserializer::PacketDeserializer,
-        transaction_scheduler::{
-            receive_and_buffer::{
-                ReceiveAndBuffer, SanitizedTransactionReceiveAndBuffer,
-                TransactionViewReceiveAndBuffer,
-            },
-            scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
-            transaction_state_container::StateContainer,
+    solana_core::banking_stage::transaction_scheduler::{
+        receive_and_buffer::{
+            ReceiveAndBuffer, SanitizedTransactionReceiveAndBuffer, TransactionViewReceiveAndBuffer,
         },
+        scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
+        transaction_state_container::StateContainer,
     },
-    solana_keypair::Keypair,
-    solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
-    solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
-    solana_poh::poh_recorder::BankStart,
-    solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_sdk::{
-        account::AccountSharedData,
-        compute_budget::ComputeBudgetInstruction,
-        genesis_config::GenesisConfig,
-        hash::Hash,
-        instruction::{AccountMeta, Instruction},
-        message::{Message, VersionedMessage},
-        signer::Signer,
-        transaction::VersionedTransaction,
-    },
-    solana_sdk_ids::system_program,
-    std::{
-        sync::{Arc, RwLock},
-        time::{Duration, Instant},
-    },
+    std::time::{Duration, Instant},
 };
 
-// the max number of instructions of given type that we can put into packet.
-const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 204;
-
-fn create_accounts(num_accounts: usize, genesis_config: &mut GenesisConfig) -> Vec<Keypair> {
-    let owner = &system_program::id();
-
-    let account_keypairs: Vec<Keypair> = (0..num_accounts).map(|_| Keypair::new()).collect();
-    for keypair in account_keypairs.iter() {
-        genesis_config.add_account(keypair.pubkey(), AccountSharedData::new(10000, 0, owner));
-    }
-    account_keypairs
-}
-
-/// Structure that returns correct provided blockhash or some incorrect hash
-/// with given probability.
-pub struct FaultyBlockhash {
-    blockhash: Hash,
-    probability_invalid_blockhash: f64,
-}
-
-impl FaultyBlockhash {
-    /// Create a new faulty hash generator
-    pub fn new(blockhash: Hash, probability_invalid_blockhash: f64) -> Self {
-        Self {
-            blockhash,
-            probability_invalid_blockhash,
-        }
-    }
-
-    pub fn get<R: Rng>(&self, rng: &mut R) -> Hash {
-        if rng.gen::<f64>() < self.probability_invalid_blockhash {
-            Hash::default()
-        } else {
-            self.blockhash
-        }
-    }
-}
-
-fn generate_transactions(
-    num_txs: usize,
-    bank: Arc<Bank>,
-    fee_payers: &[Keypair],
-    num_instructions_per_tx: usize,
-    probability_invalid_blockhash: f64,
-    set_rand_cu_price: bool,
-) -> BankingPacketBatch {
-    assert!(num_instructions_per_tx <= MAX_INSTRUCTIONS_PER_TRANSACTION);
-    if set_rand_cu_price {
-        assert!(num_instructions_per_tx > 0,
-            "`num_instructions_per_tx` must be at least 1 when `set_rand_cu_price` flag is set to count\
-             the set_compute_unit_price instruction.");
-    }
-    let blockhash = FaultyBlockhash::new(bank.last_blockhash(), probability_invalid_blockhash);
-
-    let mut rng = rand::thread_rng();
-
-    let mut fee_payers = fee_payers.iter().cycle();
-
-    let txs: Vec<VersionedTransaction> = (0..num_txs)
-        .map(|_| {
-            let fee_payer = fee_payers.next().unwrap();
-            let program_id = Pubkey::new_unique();
-
-            let mut instructions = Vec::with_capacity(num_instructions_per_tx);
-            if set_rand_cu_price {
-                // Experiments with different distributions didn't show much of the effect on the performance.
-                let compute_unit_price = rng.gen_range(0..1000);
-                instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
-                    compute_unit_price,
-                ));
-            }
-            for _ in 0..num_instructions_per_tx.saturating_sub(1) {
-                instructions.push(Instruction::new_with_bytes(
-                    program_id,
-                    &[0],
-                    vec![AccountMeta {
-                        pubkey: fee_payer.pubkey(),
-                        is_signer: true,
-                        is_writable: true,
-                    }],
-                ));
-            }
-            VersionedTransaction::try_new(
-                VersionedMessage::Legacy(Message::new_with_blockhash(
-                    &instructions,
-                    Some(&fee_payer.pubkey()),
-                    &blockhash.get(&mut rng),
-                )),
-                &[&fee_payer],
-            )
-            .unwrap()
-        })
-        .collect();
-
-    BankingPacketBatch::new(to_packet_batches(&txs, NUM_PACKETS))
-}
-
-trait ReceiveAndBufferCreator {
-    fn create(
-        receiver: Receiver<Arc<Vec<PacketBatch>>>,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self;
-}
-
-impl ReceiveAndBufferCreator for TransactionViewReceiveAndBuffer {
-    fn create(
-        receiver: Receiver<Arc<Vec<PacketBatch>>>,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self {
-        TransactionViewReceiveAndBuffer {
-            receiver,
-            bank_forks,
-        }
-    }
-}
-
-impl ReceiveAndBufferCreator for SanitizedTransactionReceiveAndBuffer {
-    fn create(
-        receiver: Receiver<Arc<Vec<PacketBatch>>>,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self {
-        SanitizedTransactionReceiveAndBuffer::new(PacketDeserializer::new(receiver), bank_forks)
-    }
-}
-
-fn bench_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
+fn bench_receive_and_buffer<T: ReceiveAndBuffer + utils::ReceiveAndBufferCreator>(
     c: &mut Criterion,
     bench_name: &str,
     num_instructions_per_tx: usize,
     probability_invalid_blockhash: f64,
     set_rand_cu_price: bool,
 ) {
-    let GenesisConfigInfo {
-        mut genesis_config, ..
-    } = create_genesis_config(100_000);
     let num_txs = 16 * 1024;
-    // This doesn't change the time to execute
-    let num_fee_payers = 1;
-    // fee payers will be verified, so have to create them properly
-    let fee_payers = create_accounts(num_fee_payers, &mut genesis_config);
-
-    let (bank, bank_forks) =
-        Bank::new_for_benches(&genesis_config).wrap_with_bank_forks_for_tests();
-    let bank_start = BankStart {
-        working_bank: bank.clone(),
-        bank_creation_time: Arc::new(Instant::now()),
-    };
-
-    let (sender, receiver) = unbounded();
-
-    let mut rb = T::create(receiver, bank_forks);
-
-    const TOTAL_BUFFERED_PACKETS: usize = 100_000;
-    let mut count_metrics = SchedulerCountMetrics::default();
-    let mut timing_metrics = SchedulerTimingMetrics::default();
-    let decision = BufferedPacketsDecision::Consume(bank_start);
-
-    let txs = generate_transactions(
+    let utils::ReceiveAndBufferSetup {
+        txs,
+        sender,
+        mut container,
+        mut receive_and_buffer,
+        decision,
+    }: utils::ReceiveAndBufferSetup<T> = utils::setup_receive_and_buffer(
         num_txs,
-        bank.clone(),
-        &fee_payers,
         num_instructions_per_tx,
         probability_invalid_blockhash,
         set_rand_cu_price,
     );
-    let mut container = <T as ReceiveAndBuffer>::Container::with_capacity(TOTAL_BUFFERED_PACKETS);
 
     let mut group = c.benchmark_group("receive_and_buffer");
     group.throughput(Throughput::Elements(num_txs as u64));
@@ -212,6 +40,8 @@ fn bench_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
             let mut total: Duration = std::time::Duration::ZERO;
             for _ in 0..iters {
                 // Setup
+                let mut count_metrics = SchedulerCountMetrics::default();
+                let mut timing_metrics = SchedulerTimingMetrics::default();
                 {
                     if sender.send(txs.clone()).is_err() {
                         panic!("Unexpectedly dropped receiver!");
@@ -223,7 +53,7 @@ fn bench_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
 
                 let start = Instant::now();
                 {
-                    let res = rb.receive_and_buffer_packets(
+                    let res = receive_and_buffer.receive_and_buffer_packets(
                         &mut container,
                         &mut timing_metrics,
                         &mut count_metrics,
@@ -244,7 +74,7 @@ fn bench_sanitized_transaction_receive_and_buffer(c: &mut Criterion) {
     bench_receive_and_buffer::<SanitizedTransactionReceiveAndBuffer>(
         c,
         "sanitized_transaction_max_instructions",
-        MAX_INSTRUCTIONS_PER_TRANSACTION,
+        utils::MAX_INSTRUCTIONS_PER_TRANSACTION,
         0.0,
         true,
     );
@@ -261,7 +91,7 @@ fn bench_transaction_view_receive_and_buffer(c: &mut Criterion) {
     bench_receive_and_buffer::<TransactionViewReceiveAndBuffer>(
         c,
         "transaction_view_max_instructions",
-        MAX_INSTRUCTIONS_PER_TRANSACTION,
+        utils::MAX_INSTRUCTIONS_PER_TRANSACTION,
         0.0,
         true,
     );

--- a/core/benches/receive_and_buffer.rs
+++ b/core/benches/receive_and_buffer.rs
@@ -31,6 +31,7 @@ fn bench_receive_and_buffer<T: ReceiveAndBuffer + utils::ReceiveAndBufferCreator
         num_instructions_per_tx,
         probability_invalid_blockhash,
         set_rand_cu_price,
+        true, // single fee payer for all transactions
     );
 
     let mut group = c.benchmark_group("receive_and_buffer");

--- a/core/benches/receive_and_buffer_utils.rs
+++ b/core/benches/receive_and_buffer_utils.rs
@@ -180,12 +180,12 @@ pub fn setup_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
     num_instructions_per_tx: usize,
     probability_invalid_blockhash: f64,
     set_rand_cu_price: bool,
+    use_single_payer: bool,
 ) -> ReceiveAndBufferSetup<T> {
     let GenesisConfigInfo {
         mut genesis_config, ..
     } = create_genesis_config(100_000);
-    // This doesn't change the time to execute
-    let num_fee_payers = 1;
+    let num_fee_payers = if use_single_payer { 1 } else { num_txs };
     // fee payers will be verified, so have to create them properly
     let fee_payers = create_accounts(num_fee_payers, &mut genesis_config);
 

--- a/core/benches/receive_and_buffer_utils.rs
+++ b/core/benches/receive_and_buffer_utils.rs
@@ -1,0 +1,222 @@
+use {
+    agave_banking_stage_ingress_types::BankingPacketBatch,
+    crossbeam_channel::{unbounded, Receiver, Sender},
+    rand::prelude::*,
+    solana_core::banking_stage::{
+        decision_maker::BufferedPacketsDecision,
+        packet_deserializer::PacketDeserializer,
+        transaction_scheduler::{
+            receive_and_buffer::{
+                ReceiveAndBuffer, SanitizedTransactionReceiveAndBuffer,
+                TransactionViewReceiveAndBuffer,
+            },
+            transaction_state_container::StateContainer,
+        },
+        TOTAL_BUFFERED_PACKETS,
+    },
+    solana_keypair::Keypair,
+    solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
+    solana_poh::poh_recorder::BankStart,
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_sdk::{
+        account::AccountSharedData,
+        compute_budget::ComputeBudgetInstruction,
+        genesis_config::GenesisConfig,
+        hash::Hash,
+        instruction::{AccountMeta, Instruction},
+        message::{Message, VersionedMessage},
+        signer::Signer,
+        transaction::VersionedTransaction,
+    },
+    solana_sdk_ids::system_program,
+    std::{
+        sync::{Arc, RwLock},
+        time::Instant,
+    },
+};
+
+// the max number of instructions of given type that we can put into packet.
+pub const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 204;
+
+fn create_accounts(num_accounts: usize, genesis_config: &mut GenesisConfig) -> Vec<Keypair> {
+    let owner = &system_program::id();
+
+    let account_keypairs: Vec<Keypair> = (0..num_accounts).map(|_| Keypair::new()).collect();
+    for keypair in account_keypairs.iter() {
+        genesis_config.add_account(keypair.pubkey(), AccountSharedData::new(10000, 0, owner));
+    }
+    account_keypairs
+}
+
+/// Structure that returns correct provided blockhash or some incorrect hash
+/// with given probability.
+pub struct FaultyBlockhash {
+    blockhash: Hash,
+    probability_invalid_blockhash: f64,
+}
+
+impl FaultyBlockhash {
+    /// Create a new faulty hash generator
+    pub fn new(blockhash: Hash, probability_invalid_blockhash: f64) -> Self {
+        Self {
+            blockhash,
+            probability_invalid_blockhash,
+        }
+    }
+
+    pub fn get<R: Rng>(&self, rng: &mut R) -> Hash {
+        if rng.gen::<f64>() < self.probability_invalid_blockhash {
+            Hash::default()
+        } else {
+            self.blockhash
+        }
+    }
+}
+
+fn generate_transactions(
+    num_txs: usize,
+    bank: Arc<Bank>,
+    fee_payers: &[Keypair],
+    num_instructions_per_tx: usize,
+    probability_invalid_blockhash: f64,
+    set_rand_cu_price: bool,
+) -> BankingPacketBatch {
+    assert!(num_instructions_per_tx <= MAX_INSTRUCTIONS_PER_TRANSACTION);
+    if set_rand_cu_price {
+        assert!(num_instructions_per_tx > 0,
+            "`num_instructions_per_tx` must be at least 1 when `set_rand_cu_price` flag is set to count\
+             the set_compute_unit_price instruction.");
+    }
+    let blockhash = FaultyBlockhash::new(bank.last_blockhash(), probability_invalid_blockhash);
+
+    let mut rng = rand::thread_rng();
+
+    let mut fee_payers = fee_payers.iter().cycle();
+
+    let txs: Vec<VersionedTransaction> = (0..num_txs)
+        .map(|_| {
+            let fee_payer = fee_payers.next().unwrap();
+            let program_id = Pubkey::new_unique();
+
+            let mut instructions = Vec::with_capacity(num_instructions_per_tx);
+            if set_rand_cu_price {
+                // Experiments with different distributions didn't show much of the effect on the performance.
+                let compute_unit_price = rng.gen_range(0..1000);
+                instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
+                    compute_unit_price,
+                ));
+            }
+            for _ in 0..num_instructions_per_tx.saturating_sub(1) {
+                instructions.push(Instruction::new_with_bytes(
+                    program_id,
+                    &[0],
+                    vec![AccountMeta {
+                        pubkey: fee_payer.pubkey(),
+                        is_signer: true,
+                        is_writable: true,
+                    }],
+                ));
+            }
+            VersionedTransaction::try_new(
+                VersionedMessage::Legacy(Message::new_with_blockhash(
+                    &instructions,
+                    Some(&fee_payer.pubkey()),
+                    &blockhash.get(&mut rng),
+                )),
+                &[&fee_payer],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    BankingPacketBatch::new(to_packet_batches(&txs, NUM_PACKETS))
+}
+
+pub trait ReceiveAndBufferCreator {
+    fn create(
+        receiver: Receiver<Arc<Vec<PacketBatch>>>,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> Self;
+}
+
+impl ReceiveAndBufferCreator for TransactionViewReceiveAndBuffer {
+    fn create(
+        receiver: Receiver<Arc<Vec<PacketBatch>>>,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> Self {
+        TransactionViewReceiveAndBuffer {
+            receiver,
+            bank_forks,
+        }
+    }
+}
+
+impl ReceiveAndBufferCreator for SanitizedTransactionReceiveAndBuffer {
+    fn create(
+        receiver: Receiver<Arc<Vec<PacketBatch>>>,
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> Self {
+        SanitizedTransactionReceiveAndBuffer::new(PacketDeserializer::new(receiver), bank_forks)
+    }
+}
+
+pub struct ReceiveAndBufferSetup<T: ReceiveAndBuffer> {
+    // prepared transaction batches
+    pub txs: BankingPacketBatch,
+    // to send prepared transaction batches
+    pub sender: Sender<Arc<Vec<PacketBatch>>>,
+    // received transactions will be inserted into container
+    pub container: <T as ReceiveAndBuffer>::Container,
+    // receive_and_buffer for sdk or transaction_view
+    pub receive_and_buffer: T,
+    // hardcoded for bench to always Consume
+    pub decision: BufferedPacketsDecision,
+}
+
+pub fn setup_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
+    num_txs: usize,
+    num_instructions_per_tx: usize,
+    probability_invalid_blockhash: f64,
+    set_rand_cu_price: bool,
+) -> ReceiveAndBufferSetup<T> {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = create_genesis_config(100_000);
+    // This doesn't change the time to execute
+    let num_fee_payers = 1;
+    // fee payers will be verified, so have to create them properly
+    let fee_payers = create_accounts(num_fee_payers, &mut genesis_config);
+
+    let (bank, bank_forks) =
+        Bank::new_for_benches(&genesis_config).wrap_with_bank_forks_for_tests();
+    let bank_start = BankStart {
+        working_bank: bank.clone(),
+        bank_creation_time: Arc::new(Instant::now()),
+    };
+
+    let (sender, receiver) = unbounded();
+
+    let receive_and_buffer = T::create(receiver, bank_forks);
+
+    let decision = BufferedPacketsDecision::Consume(bank_start);
+
+    let txs = generate_transactions(
+        num_txs,
+        bank.clone(),
+        &fee_payers,
+        num_instructions_per_tx,
+        probability_invalid_blockhash,
+        set_rand_cu_price,
+    );
+    let container = <T as ReceiveAndBuffer>::Container::with_capacity(TOTAL_BUFFERED_PACKETS);
+
+    ReceiveAndBufferSetup {
+        txs,
+        sender,
+        container,
+        receive_and_buffer,
+        decision,
+    }
+}

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -1,9 +1,10 @@
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+use jemallocator::Jemalloc;
 #[path = "receive_and_buffer_utils.rs"]
 mod utils;
 use {
     criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
     crossbeam_channel::{unbounded, Receiver, Sender},
-    jemallocator::Jemalloc,
     solana_core::banking_stage::{
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
         transaction_scheduler::{
@@ -23,9 +24,9 @@ use {
     std::time::{Duration, Instant},
 };
 
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
-
 // a bench consumer worker that quickly drain work channel, then send a OK back via completed-work
 // channel
 // NOTE: Avoid creating PingPong within bench iter since joining threads at its eol would

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -328,8 +328,7 @@ impl<Tx: TransactionWithMeta + Send + Sync + 'static> BenchEnv<Tx> {
     ) {
         // each bench measurement is to schedule everything in the container
         while !container.is_empty() {
-            // TODO - should call this, but it panics
-            // scheduler.receive_completed(&mut container).unwrap();
+            scheduler.receive_completed(&mut container).unwrap();
 
             let result = scheduler
                 .schedule(&mut container, self.filter_1, self.filter_2)
@@ -345,9 +344,6 @@ impl<Tx: TransactionWithMeta + Send + Sync + 'static> BenchEnv<Tx> {
 }
 
 fn bench_prio_graph_scheuler(c: &mut Criterion) {
-    let mut stats = BenchStats::default();
-    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
-
     let mut group = c.benchmark_group("bench_prio_graph_scheduler_with_sdk_transactions");
     group.sample_size(10);
 
@@ -368,6 +364,7 @@ fn bench_prio_graph_scheuler(c: &mut Criterion) {
     for (txs_builder_type, txs_builder) in &txs_builders {
         for (conflict_condition_type, conflict_condition) in &conflict_conditions {
             for (tx_count_type, tx_count) in &tx_counts {
+                let mut stats = BenchStats::default();
                 let bench_name =
                     format!("{txs_builder_type}/{conflict_condition_type}/{tx_count_type}");
                 group.throughput(Throughput::Elements(*tx_count as u64));
@@ -376,6 +373,8 @@ fn bench_prio_graph_scheuler(c: &mut Criterion) {
                         let mut execute_time: Duration = std::time::Duration::ZERO;
                         for _i in 0..iters {
                             // setup new Scheduler and Container for each iteration of execution
+                            let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> =
+                                BenchEnv::new(&mut stats);
                             let (scheduler, container) = {
                                 let container = fill_container(
                                     txs_builder
@@ -411,9 +410,6 @@ fn bench_prio_graph_scheuler(c: &mut Criterion) {
 }
 
 fn bench_greedy_scheuler(c: &mut Criterion) {
-    let mut stats = BenchStats::default();
-    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
-
     let mut group = c.benchmark_group("bench_greedy_scheduler_with_sdk_transactions");
     group.sample_size(10);
 
@@ -434,6 +430,7 @@ fn bench_greedy_scheuler(c: &mut Criterion) {
     for (txs_builder_type, txs_builder) in &txs_builders {
         for (conflict_condition_type, conflict_condition) in &conflict_conditions {
             for (tx_count_type, tx_count) in &tx_counts {
+                let mut stats = BenchStats::default();
                 let bench_name =
                     format!("{txs_builder_type}/{conflict_condition_type}/{tx_count_type}");
                 group.throughput(Throughput::Elements(*tx_count as u64));
@@ -442,6 +439,8 @@ fn bench_greedy_scheuler(c: &mut Criterion) {
                         let mut execute_time: Duration = std::time::Duration::ZERO;
                         for _i in 0..iters {
                             // setup new Scheduler and Container for each iteration of execution
+                            let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> =
+                                BenchEnv::new(&mut stats);
                             let (scheduler, container) = {
                                 let container = fill_container(
                                     txs_builder

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -1,131 +1,31 @@
+#[path = "receive_and_buffer_utils.rs"]
+mod utils;
 use {
     criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput},
     crossbeam_channel::{unbounded, Receiver, Sender},
     jemallocator::Jemalloc,
     solana_core::banking_stage::{
-        scheduler_messages::{ConsumeWork, FinishedConsumeWork, MaxAge},
+        scheduler_messages::{ConsumeWork, FinishedConsumeWork},
         transaction_scheduler::{
             greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
-            prio_graph_scheduler::{PrioGraphScheduler, PrioGraphSchedulerConfig},
+            //prio_graph_scheduler::{PrioGraphScheduler, PrioGraphSchedulerConfig},
+            receive_and_buffer::{
+                ReceiveAndBuffer, SanitizedTransactionReceiveAndBuffer,
+                TransactionViewReceiveAndBuffer,
+            },
             scheduler::{PreLockFilterAction, Scheduler},
+            scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
             transaction_state::TransactionState,
-            transaction_state_container::{StateContainer, TransactionStateContainer},
+            transaction_state_container::StateContainer,
         },
-        TOTAL_BUFFERED_PACKETS,
+        //TOTAL_BUFFERED_PACKETS,
     },
-    solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
-    },
-    solana_sdk::{
-        compute_budget::ComputeBudgetInstruction,
-        hash::Hash,
-        instruction::Instruction,
-        message::Message,
-        pubkey::Pubkey,
-        signature::Keypair,
-        signer::Signer,
-        system_instruction,
-        transaction::{SanitizedTransaction, Transaction},
-    },
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::time::{Duration, Instant},
 };
 
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
-
-trait TestTxsBuilder {
-    fn build(
-        &self,
-        count: usize,
-        is_single_payer: bool,
-    ) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
-        let mut transactions = Vec::with_capacity(count);
-
-        let compute_unit_price = 1_000;
-        let single_payer = Keypair::new();
-        for _n in 0..count {
-            let payer = if is_single_payer {
-                &single_payer
-            } else {
-                &Keypair::new()
-            };
-            let mut ixs = self.prepare_instructions(payer);
-            let prioritization =
-                ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
-            ixs.push(prioritization);
-            let message = Message::new(&ixs, Some(&payer.pubkey()));
-            let tx = Transaction::new(&[payer], message, Hash::default());
-            let transaction = RuntimeTransaction::from_transaction_for_tests(tx);
-
-            transactions.push(transaction);
-        }
-
-        transactions
-    }
-
-    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction>;
-}
-
-struct SimpleTransferTxBuilder;
-impl TestTxsBuilder for SimpleTransferTxBuilder {
-    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction> {
-        let to_pubkey = Pubkey::new_unique();
-        vec![system_instruction::transfer(&payer.pubkey(), &to_pubkey, 1)]
-    }
-}
-
-struct ManyTransfersTxBuilder;
-impl TestTxsBuilder for ManyTransfersTxBuilder {
-    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction> {
-        const MAX_TRANSFERS_PER_TX: usize = 35;
-        let to = Vec::from_iter(
-            std::iter::repeat_with(|| (Pubkey::new_unique(), 1)).take(MAX_TRANSFERS_PER_TX),
-        );
-        system_instruction::transfer_many(&payer.pubkey(), &to)
-    }
-}
-
-struct PackedNoopsTxBuilder;
-impl TestTxsBuilder for PackedNoopsTxBuilder {
-    fn prepare_instructions(&self, _payer: &Keypair) -> Vec<Instruction> {
-        // Creating noop instructions to maximize the number of instructions per
-        // transaction. We can fit up to 355 noops.
-        const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 355;
-        let program_id = Pubkey::new_unique();
-        (0..MAX_INSTRUCTIONS_PER_TRANSACTION)
-            .map(|_| Instruction::new_with_bytes(program_id, &[], vec![]))
-            .collect()
-    }
-}
-
-fn fill_container<Tx: TransactionWithMeta>(
-    transactions: impl Iterator<Item = Tx>,
-) -> TransactionStateContainer<Tx> {
-    let mut container = TransactionStateContainer::with_capacity(TOTAL_BUFFERED_PACKETS);
-    for transaction in transactions {
-        let compute_unit_price =
-            transaction
-                .compute_budget_instruction_details()
-                .sanitize_and_convert_to_compute_budget_limits(
-                    &agave_feature_set::FeatureSet::default(),
-                )
-                .unwrap()
-                .compute_unit_price;
-
-        // NOTE - setting transaction cost to be `0` for now, so it doesn't bother block_limits
-        // when scheduling.
-        const TEST_TRANSACTION_COST: u64 = 0;
-        if container.insert_new_transaction(
-            transaction,
-            MaxAge::MAX,
-            compute_unit_price,
-            TEST_TRANSACTION_COST,
-        ) {
-            unreachable!("test is setup to fill the Container to fullness");
-        }
-    }
-    container
-}
 
 // a bench consumer worker that quickly drain work channel, then send a OK back via completed-work
 // channel
@@ -208,136 +108,97 @@ impl<Tx: TransactionWithMeta + Send + Sync + 'static> BenchEnv<Tx> {
     fn test_pre_lock_filter(_tx: &TransactionState<Tx>) -> PreLockFilterAction {
         PreLockFilterAction::AttemptToSchedule
     }
-
-    fn run(
-        &self,
-        scheduler: &mut impl Scheduler<Tx>,
-        container: &mut TransactionStateContainer<Tx>,
-    ) {
-        // each bench measurement is to schedule everything in the container
-        while !container.is_empty() {
-            scheduler.receive_completed(container).unwrap();
-
-            scheduler
-                .schedule(container, self.filter_1, self.filter_2)
-                .unwrap();
-        }
-    }
 }
 
-fn bench_prio_graph_scheduler(c: &mut Criterion) {
-    let mut group = c.benchmark_group("bench_prio_graph_scheduler_with_sdk_transactions");
+// TODO - support both schedulers
+fn bench_scheduler_impl<T: ReceiveAndBuffer + utils::ReceiveAndBufferCreator>(
+    c: &mut Criterion,
+    bench_name: &str,
+) where
+    <T as ReceiveAndBuffer>::Transaction: 'static,
+{
+    let mut group = c.benchmark_group("bench_greedy_scheduler");
     group.sample_size(10);
 
-    let txs_builders: Vec<(&str, Box<dyn TestTxsBuilder>)> = vec![
-        ("simple_transfer", Box::new(SimpleTransferTxBuilder)),
-        ("many_transfer", Box::new(ManyTransfersTxBuilder)),
-        ("packed_noop", Box::new(PackedNoopsTxBuilder)),
+    let tx_counts: Vec<(usize, &str)> = vec![(16 * 1024, "16K_txs")]; //TOTAL_BUFFERED_PACKETS took too
+                                                                      //long
+    let ix_counts: Vec<(usize, &str)> = vec![
+        (1, "single_ix"),
+        (utils::MAX_INSTRUCTIONS_PER_TRANSACTION, "max_ixs"),
     ];
+    // TODO - add tx accounts conflict config
 
-    let conflict_conditions: Vec<(&str, bool)> =
-        vec![("non-conflict", false), ("full-conflict", true)];
+    for (ix_count, ix_count_desc) in &ix_counts {
+        for (tx_count, tx_count_desc) in &tx_counts {
+            let bench_name = format!("{bench_name}/{ix_count_desc}/{tx_count_desc}");
+            group.throughput(Throughput::Elements(*tx_count as u64));
+            group.bench_function(&bench_name, |bencher| {
+                bencher.iter_custom(|iters| {
+                    let utils::ReceiveAndBufferSetup {
+                        txs,
+                        sender,
+                        mut container,
+                        mut receive_and_buffer,
+                        decision,
+                    }: utils::ReceiveAndBufferSetup<T> =
+                        utils::setup_receive_and_buffer(*tx_count, *ix_count, 0.0, true);
 
-    let tx_counts: Vec<(&str, usize)> = vec![
-        ("empty_container", 0),
-        ("full_container", TOTAL_BUFFERED_PACKETS),
-    ];
+                    let mut execute_time: Duration = std::time::Duration::ZERO;
+                    for _i in 0..iters {
+                        // setup new Scheduler and Container for each iteration of execution
+                        let bench_env: BenchEnv<T::Transaction> = BenchEnv::new();
+                        let scheduler = GreedyScheduler::new(
+                            bench_env.consume_work_senders.clone(),
+                            bench_env.finished_consume_work_receiver.clone(),
+                            GreedySchedulerConfig::default(),
+                        );
+                        let mut scheduler = black_box(scheduler);
 
-    for (txs_builder_type, txs_builder) in &txs_builders {
-        for (conflict_condition_type, conflict_condition) in &conflict_conditions {
-            for (tx_count_type, tx_count) in &tx_counts {
-                let bench_name =
-                    format!("{txs_builder_type}/{conflict_condition_type}/{tx_count_type}");
-                group.throughput(Throughput::Elements(*tx_count as u64));
-                group.bench_function(&bench_name, |bencher| {
-                    bencher.iter_custom(|iters| {
-                        let mut execute_time: Duration = std::time::Duration::ZERO;
-                        for _i in 0..iters {
-                            // setup new Scheduler and Container for each iteration of execution
-                            let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> =
-                                BenchEnv::new();
-                            let mut container = fill_container(
-                                txs_builder
-                                    .build(*tx_count, *conflict_condition)
-                                    .into_iter(),
-                            );
-                            let mut scheduler = PrioGraphScheduler::new(
-                                bench_env.consume_work_senders.clone(),
-                                bench_env.finished_consume_work_receiver.clone(),
-                                PrioGraphSchedulerConfig::default(),
-                            );
-
-                            // execute with custom timing
-                            let start = Instant::now();
-                            {
-                                bench_env.run(black_box(&mut scheduler), black_box(&mut container));
-                            }
-                            execute_time = execute_time.saturating_add(start.elapsed());
+                        // reset/refill container
+                        if sender.send(txs.clone()).is_err() {
+                            panic!("Unexpectedly dropped receiver!");
                         }
-                        execute_time
-                    })
-                });
-            }
+                        container.clear();
+                        let mut count_metrics = SchedulerCountMetrics::default();
+                        let mut timing_metrics = SchedulerTimingMetrics::default();
+                        let res = receive_and_buffer.receive_and_buffer_packets(
+                            &mut container,
+                            &mut timing_metrics,
+                            &mut count_metrics,
+                            &decision,
+                        );
+                        assert!(res.unwrap() == *tx_count && !container.is_empty());
+
+                        // execute with custom timing
+                        let start = Instant::now();
+                        {
+                            while !container.is_empty() {
+                                scheduler
+                                    .receive_completed(black_box(&mut container))
+                                    .unwrap();
+
+                                scheduler
+                                    .schedule(
+                                        black_box(&mut container),
+                                        bench_env.filter_1,
+                                        bench_env.filter_2,
+                                    )
+                                    .unwrap();
+                            }
+                        }
+                        execute_time = execute_time.saturating_add(start.elapsed());
+                    }
+                    execute_time
+                })
+            });
         }
     }
 }
 
-fn bench_greedy_scheuler(c: &mut Criterion) {
-    let mut group = c.benchmark_group("bench_greedy_scheduler_with_sdk_transactions");
-    group.sample_size(10);
-
-    let txs_builders: Vec<(&str, Box<dyn TestTxsBuilder>)> = vec![
-        ("simple_transfer", Box::new(SimpleTransferTxBuilder)),
-        ("many_transfer", Box::new(ManyTransfersTxBuilder)),
-        ("packed_noop", Box::new(PackedNoopsTxBuilder)),
-    ];
-
-    let conflict_conditions: Vec<(&str, bool)> =
-        vec![("non-conflict", false), ("full-conflict", true)];
-
-    let tx_counts: Vec<(&str, usize)> = vec![
-        ("empty_container", 0),
-        ("full_container", TOTAL_BUFFERED_PACKETS),
-    ];
-
-    for (txs_builder_type, txs_builder) in &txs_builders {
-        for (conflict_condition_type, conflict_condition) in &conflict_conditions {
-            for (tx_count_type, tx_count) in &tx_counts {
-                let bench_name =
-                    format!("{txs_builder_type}/{conflict_condition_type}/{tx_count_type}");
-                group.throughput(Throughput::Elements(*tx_count as u64));
-                group.bench_function(&bench_name, |bencher| {
-                    bencher.iter_custom(|iters| {
-                        let mut execute_time: Duration = std::time::Duration::ZERO;
-                        for _i in 0..iters {
-                            // setup new Scheduler and Container for each iteration of execution
-                            let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> =
-                                BenchEnv::new();
-                            let mut container = fill_container(
-                                txs_builder
-                                    .build(*tx_count, *conflict_condition)
-                                    .into_iter(),
-                            );
-                            let mut scheduler = GreedyScheduler::new(
-                                bench_env.consume_work_senders.clone(),
-                                bench_env.finished_consume_work_receiver.clone(),
-                                GreedySchedulerConfig::default(),
-                            );
-
-                            // execute with custom timing
-                            let start = Instant::now();
-                            {
-                                bench_env.run(black_box(&mut scheduler), black_box(&mut container));
-                            }
-                            execute_time = execute_time.saturating_add(start.elapsed());
-                        }
-                        execute_time
-                    })
-                });
-            }
-        }
-    }
+fn bench_greedy_scheduler(c: &mut Criterion) {
+    bench_scheduler_impl::<SanitizedTransactionReceiveAndBuffer>(c, "sdk_transaction");
+    bench_scheduler_impl::<TransactionViewReceiveAndBuffer>(c, "transaction_view");
 }
 
-criterion_group!(benches, bench_prio_graph_scheduler, bench_greedy_scheuler,);
+criterion_group!(benches, bench_greedy_scheduler,);
 criterion_main!(benches);

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -78,10 +78,9 @@ trait TestTxsBuilder {
         let single_payer = Keypair::new();
         for _n in 1..count {
             let payer = if is_single_payer {
-                // recreate keypair from single_payer
-                Keypair::from_bytes(&single_payer.to_bytes()).expect("Failed to create Keypair")
+                &single_payer
             } else {
-                Keypair::new()
+                &Keypair::new()
             };
             let mut ixs = self.prepare_instructions(&payer);
             let prioritization =

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -1,0 +1,574 @@
+use {
+    criterion::{black_box, criterion_group, criterion_main, Criterion},
+    crossbeam_channel::{unbounded, Receiver, Sender},
+    jemallocator::Jemalloc,
+    solana_core::banking_stage::{
+        scheduler_messages::{ConsumeWork, FinishedConsumeWork, MaxAge},
+        transaction_scheduler::{
+            greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
+            prio_graph_scheduler::{PrioGraphScheduler, PrioGraphSchedulerConfig},
+            scheduler::{PreLockFilterAction, Scheduler},
+            transaction_state::TransactionState,
+            transaction_state_container::{StateContainer, TransactionStateContainer},
+        },
+        TOTAL_BUFFERED_PACKETS,
+    },
+    solana_runtime_transaction::{
+        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+    },
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction,
+        hash::Hash,
+        instruction::Instruction,
+        message::Message,
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+        system_instruction,
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+// A non-contend low-prio tx, aka Tracer, is tag with this requested_loaded_accounts_data_size_limit
+const TAG_NUMBER: u32 = 1234;
+
+fn is_tracer<Tx: TransactionWithMeta + Send + Sync + 'static>(tx: &Tx) -> bool {
+    matches!(
+        tx.compute_budget_instruction_details()
+            .requested_loaded_accounts_data_size_limit(),
+        Some(TAG_NUMBER)
+    )
+}
+
+trait TestTxsBuilder {
+    // Tracer is a non-contend low-prio transfer transaction, it'd usually be inserted into the bottom
+    // of Container due to its low prio, but it should be scheduled early for better UX, if its reward
+    // is adequate from bolcker builder perspective.
+    fn build_tracer_transaction() -> RuntimeTransaction<SanitizedTransaction> {
+        let payer = Keypair::new();
+        let to_pubkey = Pubkey::new_unique();
+        let mut ixs = vec![system_instruction::transfer(&payer.pubkey(), &to_pubkey, 1)];
+        ixs.push(ComputeBudgetInstruction::set_compute_unit_price(4));
+        ixs.push(ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(TAG_NUMBER));
+        let message = Message::new(&ixs, Some(&payer.pubkey()));
+        let tx = Transaction::new(&[payer], message, Hash::default());
+        RuntimeTransaction::from_transaction_for_tests(tx)
+    }
+
+    fn build(&self) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
+        let mut transactions = Vec::with_capacity(self.count());
+        // non-contend low-prio tx is first received
+        transactions.push(Self::build_tracer_transaction());
+
+        let compute_unit_price = 1_000;
+        let single_payer = Keypair::new();
+        for _n in 1..self.count() {
+            let payer = if self.is_single_payer() {
+                // recreate keypair from single_payer
+                Keypair::from_bytes(&single_payer.to_bytes()).expect("Failed to create Keypair")
+            } else {
+                Keypair::new()
+            };
+            let mut ixs = self.prepare_instructions(&payer);
+            let prioritization =
+                ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
+            ixs.push(prioritization);
+            let message = Message::new(&ixs, Some(&payer.pubkey()));
+            let tx = Transaction::new(&[payer], message, Hash::default());
+            let transaction = RuntimeTransaction::from_transaction_for_tests(tx);
+
+            transactions.push(transaction);
+        }
+
+        transactions
+    }
+
+    fn count(&self) -> usize;
+    fn is_single_payer(&self) -> bool;
+    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction>;
+}
+
+struct SimpleTransferTxBuilder {
+    count: usize,
+    is_single_payer: bool,
+}
+
+impl SimpleTransferTxBuilder {
+    fn new(count: usize, is_single_payer: bool) -> Self {
+        Self {
+            count,
+            is_single_payer,
+        }
+    }
+}
+
+impl TestTxsBuilder for SimpleTransferTxBuilder {
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn is_single_payer(&self) -> bool {
+        self.is_single_payer
+    }
+    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction> {
+        let to_pubkey = Pubkey::new_unique();
+        vec![system_instruction::transfer(&payer.pubkey(), &to_pubkey, 1)]
+    }
+}
+
+struct ManyTransfersTxBuilder {
+    count: usize,
+    is_single_payer: bool,
+}
+
+impl ManyTransfersTxBuilder {
+    fn new(count: usize, is_single_payer: bool) -> Self {
+        Self {
+            count,
+            is_single_payer,
+        }
+    }
+}
+
+impl TestTxsBuilder for ManyTransfersTxBuilder {
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn is_single_payer(&self) -> bool {
+        self.is_single_payer
+    }
+    fn prepare_instructions(&self, payer: &Keypair) -> Vec<Instruction> {
+        const MAX_TRANSFERS_PER_TX: usize = 58;
+        let to = Vec::from_iter(
+            std::iter::repeat_with(|| (Pubkey::new_unique(), 1)).take(MAX_TRANSFERS_PER_TX),
+        );
+        system_instruction::transfer_many(&payer.pubkey(), &to)
+    }
+}
+
+struct PackedNoopsTxBuilder {
+    count: usize,
+    is_single_payer: bool,
+}
+
+impl PackedNoopsTxBuilder {
+    fn new(count: usize, is_single_payer: bool) -> Self {
+        Self {
+            count,
+            is_single_payer,
+        }
+    }
+}
+
+impl TestTxsBuilder for PackedNoopsTxBuilder {
+    fn count(&self) -> usize {
+        self.count
+    }
+    fn is_single_payer(&self) -> bool {
+        self.is_single_payer
+    }
+    fn prepare_instructions(&self, _payer: &Keypair) -> Vec<Instruction> {
+        // Creating noop instructions to maximize the number of instructions per
+        // transaction. We can fit up to 355 noops.
+        const MAX_INSTRUCTIONS_PER_TRANSACTION: usize = 355;
+        let program_id = Pubkey::new_unique();
+        (0..MAX_INSTRUCTIONS_PER_TRANSACTION)
+            .map(|_| Instruction::new_with_bytes(program_id, &[], vec![]))
+            .collect()
+    }
+}
+
+struct BenchContainer<Tx: TransactionWithMeta> {
+    container: TransactionStateContainer<Tx>,
+}
+
+impl<Tx: TransactionWithMeta> BenchContainer<Tx> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            container: TransactionStateContainer::with_capacity(capacity),
+        }
+    }
+
+    fn fill_container(&mut self, transactions: impl Iterator<Item = Tx>) {
+        for transaction in transactions {
+            let compute_unit_price = transaction
+                .compute_budget_instruction_details()
+                .sanitize_and_convert_to_compute_budget_limits(
+                    &agave_feature_set::FeatureSet::default(),
+                )
+                .unwrap()
+                .compute_unit_price;
+
+            // NOTE - setting transaction cost to be `0` for now, so it doesn't bother block_limits
+            // when scheduling.
+            const TEST_TRANSACTION_COST: u64 = 0;
+            if self.container.insert_new_transaction(
+                transaction,
+                MaxAge::MAX,
+                compute_unit_price,
+                TEST_TRANSACTION_COST,
+            ) {
+                unreachable!("test is setup to fill the Container to fullness");
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct BenchStats {
+    bench_iter_count: usize,
+    num_of_scheduling: usize,
+    // worker reports:
+    num_works: Arc<AtomicUsize>,
+    num_transaction: Arc<AtomicUsize>, // = bench_iter_count * container_capacity
+    tracer_placement: Arc<AtomicUsize>, // > 0
+    // from scheduler().result:
+    num_scheduled: usize, // = num_transaction
+}
+
+impl BenchStats {
+    fn print_and_reset(&mut self) {
+        println!(
+            "== Averaged per bench stats to empty Container ==
+            number of scheduling: {}
+            number of Works: {}
+            number of transactions scheduled: {}
+            number of transactions per work: {}
+            Tracer placement: {}",
+            self.num_of_scheduling
+                .checked_div(self.bench_iter_count)
+                .unwrap_or(0),
+            self.num_works
+                .load(Ordering::Relaxed)
+                .checked_div(self.bench_iter_count)
+                .unwrap_or(0),
+            self.num_transaction
+                .load(Ordering::Relaxed)
+                .checked_div(self.bench_iter_count)
+                .unwrap_or(0),
+            self.num_transaction
+                .load(Ordering::Relaxed)
+                .checked_div(self.num_works.load(Ordering::Relaxed))
+                .unwrap_or(0),
+            self.tracer_placement.load(Ordering::Relaxed)
+        );
+        self.num_works.swap(0, Ordering::Relaxed);
+        self.num_transaction.swap(0, Ordering::Relaxed);
+        self.tracer_placement.swap(0, Ordering::Relaxed);
+        self.bench_iter_count = 0;
+        self.num_of_scheduling = 0;
+        self.num_scheduled = 0;
+    }
+}
+
+// a bench consumer worker that quickly drain work channel, then send a OK back via completed-work
+// channel
+// NOTE: Avoid creating PingPong within bench iter since joining threads at its eol would
+// introducing variance to bench timing.
+#[allow(dead_code)]
+struct PingPong {
+    threads: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl PingPong {
+    fn new<Tx: TransactionWithMeta + Send + Sync + 'static>(
+        work_receivers: Vec<Receiver<ConsumeWork<Tx>>>,
+        completed_work_sender: Sender<FinishedConsumeWork<Tx>>,
+        num_works: Arc<AtomicUsize>,
+        num_transaction: Arc<AtomicUsize>,
+        tracer_placement: Arc<AtomicUsize>,
+    ) -> Self {
+        let mut threads = Vec::with_capacity(work_receivers.len());
+
+        for receiver in work_receivers {
+            let completed_work_sender_clone = completed_work_sender.clone();
+            let num_works_clone = num_works.clone();
+            let num_transaction_clone = num_transaction.clone();
+            let tracer_placement_clone = tracer_placement.clone();
+
+            let handle = std::thread::spawn(move || {
+                Self::service_loop(
+                    receiver,
+                    completed_work_sender_clone,
+                    num_works_clone,
+                    num_transaction_clone,
+                    tracer_placement_clone,
+                );
+            });
+            threads.push(handle);
+        }
+
+        Self { threads }
+    }
+
+    fn service_loop<Tx: TransactionWithMeta + Send + Sync + 'static>(
+        work_receiver: Receiver<ConsumeWork<Tx>>,
+        completed_work_sender: Sender<FinishedConsumeWork<Tx>>,
+        num_works: Arc<AtomicUsize>,
+        num_transaction: Arc<AtomicUsize>,
+        tracer_placement: Arc<AtomicUsize>,
+    ) {
+        // NOTE: will blocking recv() impact benchmark quality? Perhaps making worker threads
+        // hot spinning?
+        while let Ok(work) = work_receiver.recv() {
+            num_works.fetch_add(1, Ordering::Relaxed);
+            let mut tx_count =
+                num_transaction.fetch_add(work.transactions.len(), Ordering::Relaxed);
+            if tracer_placement.load(Ordering::Relaxed) == 0 {
+                work.transactions.iter().for_each(|tx| {
+                    tx_count += 1;
+                    if is_tracer(tx) {
+                        tracer_placement.store(tx_count, Ordering::Relaxed)
+                    }
+                });
+            }
+
+            if completed_work_sender
+                .send(FinishedConsumeWork {
+                    work,
+                    retryable_indexes: vec![],
+                })
+                .is_err()
+            {
+                // kill this worker if finished_work channel is broken
+                break;
+            }
+        }
+    }
+}
+
+struct BenchEnv<Tx: TransactionWithMeta + Send + Sync + 'static> {
+    pingpong_worker: PingPong,
+    filter_1: fn(&[&Tx], &mut [bool]),
+    filter_2: fn(&TransactionState<Tx>) -> PreLockFilterAction,
+    consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
+    finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
+}
+
+impl<Tx: TransactionWithMeta + Send + Sync + 'static> BenchEnv<Tx> {
+    fn new(stats: &mut BenchStats) -> Self {
+        let num_workers = 4;
+
+        let (consume_work_senders, consume_work_receivers) =
+            (0..num_workers).map(|_| unbounded()).unzip();
+        let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
+        let pingpong_worker = PingPong::new(
+            consume_work_receivers,
+            finished_consume_work_sender,
+            stats.num_works.clone(),
+            stats.num_transaction.clone(),
+            stats.tracer_placement.clone(),
+        );
+
+        Self {
+            pingpong_worker,
+            filter_1: Self::test_pre_graph_filter,
+            filter_2: Self::test_pre_lock_filter,
+            consume_work_senders,
+            finished_consume_work_receiver,
+        }
+    }
+
+    fn test_pre_graph_filter(_txs: &[&Tx], results: &mut [bool]) {
+        results.fill(true);
+    }
+
+    fn test_pre_lock_filter(_tx: &TransactionState<Tx>) -> PreLockFilterAction {
+        PreLockFilterAction::AttemptToSchedule
+    }
+
+    fn run(
+        &self,
+        mut scheduler: impl Scheduler<Tx>,
+        mut container: TransactionStateContainer<Tx>,
+        stats: &mut BenchStats,
+    ) {
+        // each bench measurement is to schedule everything in the container
+        while !container.is_empty() {
+            scheduler.receive_completed(&mut container).unwrap();
+
+            let result = scheduler
+                .schedule(&mut container, self.filter_1, self.filter_2)
+                .unwrap();
+
+            // do some VERY QUICK stats collecting to print/assert at end of bench
+            stats.num_of_scheduling += 1;
+            stats.num_scheduled += result.num_scheduled;
+        }
+
+        stats.bench_iter_count += 1;
+    }
+}
+
+fn bench_empty_container(c: &mut Criterion) {
+    let mut stats = BenchStats::default();
+    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
+
+    c.benchmark_group("bench_empty_container")
+        .bench_function("sdk_transaction_type", |bencher| {
+            bencher.iter_with_setup(
+                || {
+                    let bench_container = BenchContainer::new(0);
+                    let scheduler = PrioGraphScheduler::new(
+                        bench_env.consume_work_senders.clone(),
+                        bench_env.finished_consume_work_receiver.clone(),
+                        PrioGraphSchedulerConfig::default(),
+                    );
+                    (scheduler, bench_container.container)
+                },
+                |(scheduler, container)| {
+                    black_box(bench_env.run(scheduler, container, &mut stats));
+                    //stats.print_and_reset();
+                },
+            )
+        });
+    stats.print_and_reset();
+}
+
+fn bench_prio_graph_non_contend_transactions(c: &mut Criterion) {
+    let capacity = TOTAL_BUFFERED_PACKETS;
+    let mut stats = BenchStats::default();
+    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
+
+    c.benchmark_group("bench_prio_graph_non_contend_transactions")
+        .sample_size(10)
+        .bench_function("sdk_transaction_type", |bencher| {
+            bencher.iter_with_setup(
+                || {
+                    let mut bench_container = BenchContainer::new(capacity);
+                    bench_container.fill_container(
+                        ManyTransfersTxBuilder::new(capacity, false)
+                            .build()
+                            .into_iter(),
+                    );
+                    let scheduler = PrioGraphScheduler::new(
+                        bench_env.consume_work_senders.clone(),
+                        bench_env.finished_consume_work_receiver.clone(),
+                        PrioGraphSchedulerConfig::default(),
+                    );
+                    (scheduler, bench_container.container)
+                },
+                |(scheduler, container)| {
+                    black_box(bench_env.run(scheduler, container, &mut stats));
+                    //stats.print_and_reset();
+                },
+            )
+        });
+
+    stats.print_and_reset();
+}
+
+fn bench_prio_graph_fully_contend_transactions(c: &mut Criterion) {
+    let capacity = TOTAL_BUFFERED_PACKETS;
+    let mut stats = BenchStats::default();
+    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
+
+    c.benchmark_group("bench_prio_graph_fully_contend_transactions")
+        .sample_size(10)
+        .bench_function("sdk_transaction_type", |bencher| {
+            bencher.iter_with_setup(
+                || {
+                    let mut bench_container = BenchContainer::new(capacity);
+                    bench_container.fill_container(
+                        ManyTransfersTxBuilder::new(capacity, true)
+                            .build()
+                            .into_iter(),
+                    );
+                    let scheduler = PrioGraphScheduler::new(
+                        bench_env.consume_work_senders.clone(),
+                        bench_env.finished_consume_work_receiver.clone(),
+                        PrioGraphSchedulerConfig::default(),
+                    );
+                    (scheduler, bench_container.container)
+                },
+                |(scheduler, container)| {
+                    black_box(bench_env.run(scheduler, container, &mut stats));
+                    //stats.print_and_reset();
+                },
+            )
+        });
+
+    stats.print_and_reset();
+}
+
+fn bench_greedy_non_contend_transactions(c: &mut Criterion) {
+    let capacity = TOTAL_BUFFERED_PACKETS;
+    let mut stats = BenchStats::default();
+    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
+
+    c.benchmark_group("bench_greedy_non_contend_transactions")
+        .sample_size(10)
+        .bench_function("sdk_transaction_type", |bencher| {
+            bencher.iter_with_setup(
+                || {
+                    let mut bench_container = BenchContainer::new(capacity);
+                    bench_container.fill_container(
+                        ManyTransfersTxBuilder::new(capacity, false)
+                            .build()
+                            .into_iter(),
+                    );
+                    let scheduler = GreedyScheduler::new(
+                        bench_env.consume_work_senders.clone(),
+                        bench_env.finished_consume_work_receiver.clone(),
+                        GreedySchedulerConfig::default(),
+                    );
+                    (scheduler, bench_container.container)
+                },
+                |(scheduler, container)| {
+                    black_box(bench_env.run(scheduler, container, &mut stats));
+                    //stats.print_and_reset();
+                },
+            )
+        });
+
+    stats.print_and_reset();
+}
+
+fn bench_greedy_fully_contend_transactions(c: &mut Criterion) {
+    let capacity = TOTAL_BUFFERED_PACKETS;
+    let mut stats = BenchStats::default();
+    let bench_env: BenchEnv<RuntimeTransaction<SanitizedTransaction>> = BenchEnv::new(&mut stats);
+
+    c.benchmark_group("bench_greedy_fully_contend_transactions")
+        .sample_size(10)
+        .bench_function("sdk_transaction_type", |bencher| {
+            bencher.iter_with_setup(
+                || {
+                    let mut bench_container = BenchContainer::new(capacity);
+                    bench_container.fill_container(
+                        ManyTransfersTxBuilder::new(capacity, true)
+                            .build()
+                            .into_iter(),
+                    );
+                    let scheduler = GreedyScheduler::new(
+                        bench_env.consume_work_senders.clone(),
+                        bench_env.finished_consume_work_receiver.clone(),
+                        GreedySchedulerConfig::default(),
+                    );
+                    (scheduler, bench_container.container)
+                },
+                |(scheduler, container)| {
+                    black_box(bench_env.run(scheduler, container, &mut stats));
+                    //stats.print_and_reset();
+                },
+            )
+        });
+
+    stats.print_and_reset();
+}
+// */
+criterion_group!(
+    benches,
+    bench_empty_container,
+    //    bench_prio_graph_non_contend_transactions,
+    //    bench_prio_graph_fully_contend_transactions,
+    //    bench_greedy_non_contend_transactions,
+    //    bench_greedy_fully_contend_transactions,
+);
+criterion_main!(benches);

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -183,7 +183,7 @@ struct BenchStats {
 impl BenchStats {
     fn print_and_reset(&mut self) {
         println!(
-            "== Averaged per bench stats to empty Container ==
+            "per bench stats:
             number of scheduling: {}
             number of Works: {}
             number of transactions scheduled: {}
@@ -262,8 +262,6 @@ impl PingPong {
         num_transaction: Arc<AtomicUsize>,
         tracer_placement: Arc<AtomicUsize>,
     ) {
-        // NOTE: will blocking recv() impact benchmark quality? Perhaps making worker threads
-        // hot spinning?
         while let Ok(work) = work_receiver.recv() {
             num_works.fetch_add(1, Ordering::Relaxed);
             let mut tx_count =
@@ -412,18 +410,16 @@ fn bench_prio_graph_scheuler(c: &mut Criterion) {
                                     black_box(container),
                                     &mut stats,
                                 );
-                                //stats.print_and_reset();
                             }
                             execute_time = execute_time.saturating_add(start.elapsed());
                         }
                         execute_time
                     })
                 });
+                stats.print_and_reset();
             }
         }
     }
-
-    stats.print_and_reset();
 }
 
 fn bench_greedy_scheuler(c: &mut Criterion) {
@@ -482,18 +478,16 @@ fn bench_greedy_scheuler(c: &mut Criterion) {
                                     black_box(container),
                                     &mut stats,
                                 );
-                                //stats.print_and_reset();
                             }
                             execute_time = execute_time.saturating_add(start.elapsed());
                         }
                         execute_time
                     })
                 });
+                stats.print_and_reset();
             }
         }
     }
-
-    stats.print_and_reset();
 }
 
 criterion_group!(benches, bench_prio_graph_scheuler, bench_greedy_scheuler,);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -83,6 +83,7 @@ conditional_vis_mod!(unified_scheduler, feature = "dev-context-only-utils", pub,
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 6;
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 const TOTAL_BUFFERED_PACKETS: usize = 100_000;
 
 const NUM_VOTE_PROCESSING_THREADS: u32 = 2;

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     super::{
         scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
@@ -22,6 +24,7 @@ use {
     solana_sdk::saturating_add_assign,
 };
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct GreedySchedulerConfig {
     pub target_scheduled_cus: u64,
     pub max_scanned_transactions_per_scheduling_pass: usize,
@@ -49,6 +52,7 @@ pub struct GreedyScheduler<Tx: TransactionWithMeta> {
 }
 
 impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(
         consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,16 +1,16 @@
 use conditional_mod::conditional_vis_mod;
 
 mod batch_id_generator;
-pub(crate) mod greedy_scheduler;
+conditional_vis_mod!(greedy_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
 mod in_flight_tracker;
-pub(crate) mod prio_graph_scheduler;
+conditional_vis_mod!(prio_graph_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
 conditional_vis_mod!(receive_and_buffer, feature = "dev-context-only-utils", pub, pub(crate));
-pub(crate) mod scheduler;
+conditional_vis_mod!(scheduler, feature = "dev-context-only-utils", pub, pub(crate));
 pub(crate) mod scheduler_common;
 pub(crate) mod scheduler_controller;
 pub(crate) mod scheduler_error;
 conditional_vis_mod!(scheduler_metrics, feature = "dev-context-only-utils", pub);
 mod thread_aware_account_locks;
 mod transaction_priority_id;
-mod transaction_state;
+conditional_vis_mod!(transaction_state, feature = "dev-context-only-utils", pub, pub(crate));
 conditional_vis_mod!(transaction_state_container, feature = "dev-context-only-utils", pub, pub(crate));

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     super::{
         scheduler::{PreLockFilterAction, Scheduler, SchedulingSummary},
@@ -42,6 +44,7 @@ type SchedulerPrioGraph = PrioGraph<
     fn(&TransactionPriorityId, &GraphNode<TransactionPriorityId>) -> TransactionPriorityId,
 >;
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct PrioGraphSchedulerConfig {
     pub max_scheduled_cus: u64,
     pub max_scanned_transactions_per_scheduling_pass: usize,
@@ -60,6 +63,7 @@ impl Default for PrioGraphSchedulerConfig {
     }
 }
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct PrioGraphScheduler<Tx> {
     common: SchedulingCommon<Tx>,
     prio_graph: SchedulerPrioGraph,
@@ -67,6 +71,7 @@ pub(crate) struct PrioGraphScheduler<Tx> {
 }
 
 impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(
         consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -9,6 +9,7 @@ use {
     solana_sdk::saturating_add_assign,
 };
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
     /// Schedule transactions from `container`.
     /// pre-graph and pre-lock filters may be passed to be applied
@@ -47,6 +48,7 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
 }
 
 /// Action to be taken by pre-lock filter.
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) enum PreLockFilterAction {
     /// Attempt to schedule the transaction.
     AttemptToSchedule,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     super::{
         in_flight_tracker::InFlightTracker,
@@ -107,6 +109,7 @@ pub fn select_thread<Tx>(
 }
 
 /// Common scheduler communication structure.
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct SchedulingCommon<Tx> {
     pub(crate) consume_work_senders: Vec<Sender<ConsumeWork<Tx>>>,
     pub(crate) finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -191,6 +191,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
 impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
     /// Insert a new transaction into the container's queues and maps.
     /// Returns `true` if a packet was dropped due to capacity limits.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn insert_new_transaction(
         &mut self,
         transaction: Tx,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6000,6 +6000,7 @@ dependencies = [
  "sysctl",
  "tempfile",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util 0.7.15",
  "trees",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5837,6 +5837,7 @@ dependencies = [
  "sysctl",
  "tempfile",
  "thiserror 2.0.12",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util 0.7.15",
  "trees",
@@ -9693,6 +9694,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

To bench scheduler implementations.

#### Summary of Changes
- change module and function's visibilities with `dev-context-only-utils`
- add bench for both prio-graph and greedy scheduler, with different tx compositions.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
