### PR TITLE
Start test validator bound to localhost by default (rather than all interfaces)

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -172,11 +172,14 @@ fn main() {
             exit(1);
         })
     });
-    let bind_address = matches.value_of("bind_address").map(|bind_address| {
-        solana_net_utils::parse_host(bind_address).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --bind-address: {err}");
-            exit(1);
-        })
+    let bind_address = solana_net_utils::parse_host(
+        matches
+            .value_of("bind_address")
+            .expect("Bind address has default value"),
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to parse --bind-address: {err}");
+        exit(1);
     });
     let compute_unit_limit = value_t!(matches, "compute_unit_limit", u64).ok();
 
@@ -552,9 +555,7 @@ fn main() {
         genesis.port_range(dynamic_port_range);
     }
 
-    if let Some(bind_address) = bind_address {
-        genesis.bind_ip_addr(bind_address);
-    }
+    genesis.bind_ip_addr(bind_address);
 
     if matches.is_present("geyser_plugin_config") {
         genesis.geyser_plugin_config_files = Some(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -863,8 +863,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .default_value("0.0.0.0")
-                .help("IP address to bind the validator ports [default: 0.0.0.0]"),
+                .default_value("127.0.0.1")
+                .help("IP address to bind the validator ports [default: 127.0.0.1]"),
         )
         .arg(
             Arg::with_name("clone_account")


### PR DESCRIPTION
#### Problem

    Test-validator would bind to all interfaces by default which is insecure

#### Summary of Changes

-  Change test-validator to bind to localhost by default

#### Context
https://github.com/anza-xyz/agave/pull/5802 tried to do the same but was poorly scoped and as a result had a problematic change which made it possible to get binding of ports on top of already bound ones. 
This resulted in https://github.com/anza-xyz/agave/pull/5856 to revert, but RCA there was not correct (test-validator binding had nothing to do with the issues there). 

The logic changes to cluster-info moved into separate PR https://github.com/anza-xyz/agave/pull/5832