### PR TITLE
globally unique port allocation for unittests 

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -54,8 +54,8 @@ use {
         bind_common_in_range_with_config, bind_common_with_config, bind_in_range,
         bind_in_range_with_config, bind_more_with_config, bind_to_localhost, bind_to_unspecified,
         bind_to_with_config, bind_two_in_range_with_offset_and_config,
-        find_available_port_in_range, multi_bind_in_range_with_config, PortRange, SocketConfig,
-        VALIDATOR_PORT_RANGE,
+        find_available_port_in_range, multi_bind_in_range_with_config,
+        sockets::localhost_port_range_for_tests, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
         data_budget::DataBudget,
@@ -2425,8 +2425,7 @@ impl Node {
         num_quic_endpoints: usize,
     ) -> Self {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port_range = (1024, 65535);
-
+        let port_range = localhost_port_range_for_tests();
         let udp_config = SocketConfig::default();
         let quic_config = SocketConfig::default().reuseport(true);
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -54,7 +54,7 @@ use {
         bind_common_in_range_with_config, bind_common_with_config, bind_in_range,
         bind_in_range_with_config, bind_more_with_config, bind_to_localhost, bind_to_unspecified,
         bind_to_with_config, bind_two_in_range_with_offset_and_config,
-        find_available_port_in_range, multi_bind_in_range_with_config,
+        find_available_ports_in_range, multi_bind_in_range_with_config,
         sockets::localhost_port_range_for_tests, PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
@@ -2461,10 +2461,9 @@ impl Node {
 
         let repair = bind_to_localhost().unwrap();
         let repair_quic = bind_to_localhost().unwrap();
-        let rpc_port = find_available_port_in_range(localhost_ip_addr, port_range).unwrap();
-        let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_port);
-        let rpc_pubsub_port = find_available_port_in_range(localhost_ip_addr, port_range).unwrap();
-        let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_pubsub_port);
+        let rpc_ports = find_available_ports_in_range(localhost_ip_addr, port_range, 2).unwrap();
+        let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[0]);
+        let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[1]);
         let broadcast = vec![bind_to_unspecified().unwrap()];
         let retransmit_socket = bind_to_unspecified().unwrap();
         let serve_repair = bind_to_localhost().unwrap();
@@ -2656,8 +2655,9 @@ impl Node {
         let (_, ancestor_hashes_requests_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let rpc_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
-        let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, port_range).unwrap();
+        let rpc_ports = find_available_ports_in_range(bind_ip_addr, port_range, 2).unwrap();
+        let rpc_port = rpc_ports[0];
+        let rpc_pubsub_port = rpc_ports[1];
 
         // These are client sockets, so the port is set to be 0 because it must be ephimeral.
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -614,7 +614,7 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
 
 /// Searches for several ports on a given binding ip_addr in the provided range.
 ///
-/// This will start at a random point in the range provided, and search sequenctially.
+/// This will start at a random point in the range provided, and search sequencially.
 /// If it can not find anything, an Error is returned.
 pub fn find_available_ports_in_range(
     ip_addr: IpAddr,

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,6 +1,7 @@
 //! The `net_utils` module assists with networking
 mod ip_echo_client;
 mod ip_echo_server;
+pub mod sockets;
 
 #[cfg(feature = "dev-context-only-utils")]
 pub mod tooling_for_tests;
@@ -605,7 +606,22 @@ pub fn bind_two_in_range_with_offset_and_config(
 ///
 /// This will start at a random point in the range provided, and search sequenctially.
 /// If it can not find anything, an Error is returned.
+///
+/// Keep in mind this will not reserve the port for you, only find one that is empty.
 pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Result<u16> {
+    find_available_ports_in_range(ip_addr, range, 1).map(|v| *v.first().unwrap())
+}
+
+/// Searches for several ports on a given binding ip_addr in the provided range.
+///
+/// This will start at a random point in the range provided, and search sequenctially.
+/// If it can not find anything, an Error is returned.
+pub fn find_available_ports_in_range(
+    ip_addr: IpAddr,
+    range: PortRange,
+    mut num: usize,
+) -> io::Result<Vec<u16>> {
+    let mut result = vec![];
     let range = range.0..range.1;
     let mut next_port_to_try = range
         .clone()
@@ -613,11 +629,12 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
         .skip(thread_rng().gen_range(range.clone()) as usize) // skip to random position
         .take(range.len()) // never take the same value twice
         .peekable();
-    loop {
+    while num > 0 {
         let port_to_try = next_port_to_try.next().unwrap(); // this unwrap never fails since we exit earlier
         match bind_common(ip_addr, port_to_try) {
             Ok(_) => {
-                return Ok(port_to_try);
+                num -= 1;
+                result.push(port_to_try);
             }
             Err(err) => {
                 if next_port_to_try.peek().is_none() {
@@ -626,6 +643,7 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
             }
         }
     }
+    Ok(result)
 }
 
 pub fn bind_more_with_config(
@@ -753,20 +771,23 @@ mod tests {
 
     #[test]
     fn test_bind() {
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        assert_eq!(bind_in_range(ip_addr, (2000, 2001)).unwrap().0, 2000);
+        let s = bind_in_range(ip_addr, (pr_s, pr_e)).unwrap();
+        assert_eq!(s.0, pr_s, "bind_in_range should use first available port");
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let config = SocketConfig::default().reuseport(true);
-        let x = bind_to_with_config(ip_addr, 2002, config).unwrap();
-        let y = bind_to_with_config(ip_addr, 2002, config).unwrap();
+        let x = bind_to_with_config(ip_addr, pr_s + 1, config).unwrap();
+        let y = bind_to_with_config(ip_addr, pr_s + 1, config).unwrap();
         assert_eq!(
             x.local_addr().unwrap().port(),
             y.local_addr().unwrap().port()
         );
-        bind_to(ip_addr, 2002, false).unwrap_err();
-        bind_in_range(ip_addr, (2002, 2003)).unwrap_err();
+        bind_to(ip_addr, pr_s, false).unwrap_err();
+        bind_in_range(ip_addr, (pr_s, pr_s + 2)).unwrap_err();
 
-        let (port, v) = multi_bind_in_range_with_config(ip_addr, (2010, 2110), config, 10).unwrap();
+        let (port, v) =
+            multi_bind_in_range_with_config(ip_addr, (pr_s + 5, pr_e), config, 10).unwrap();
         for sock in &v {
             assert_eq!(port, sock.local_addr().unwrap().port());
         }
@@ -793,13 +814,14 @@ mod tests {
 
     #[test]
     fn test_find_available_port_in_range() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         assert_eq!(
-            find_available_port_in_range(ip_addr, (3000, 3001)).unwrap(),
-            3000
+            find_available_port_in_range(ip_addr, (pr_s, pr_s + 1)).unwrap(),
+            pr_s
         );
-        let port = find_available_port_in_range(ip_addr, (3000, 3050)).unwrap();
-        assert!((3000..3050).contains(&port));
+        let port = find_available_port_in_range(ip_addr, (pr_s, pr_e)).unwrap();
+        assert!((pr_s..pr_e).contains(&port));
 
         let _socket = bind_to(ip_addr, port, false).unwrap();
         find_available_port_in_range(ip_addr, (port, port + 1)).unwrap_err();
@@ -807,11 +829,12 @@ mod tests {
 
     #[test]
     fn test_bind_common_in_range() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (port, _sockets) =
-            bind_common_in_range_with_config(ip_addr, (3100, 3150), config).unwrap();
-        assert!((3100..3150).contains(&port));
+            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
+        assert!((pr_s..pr_e).contains(&port));
 
         bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
     }
@@ -819,10 +842,11 @@ mod tests {
     #[test]
     fn test_get_public_ip_addr_none() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
@@ -843,12 +867,13 @@ mod tests {
     #[test]
     fn test_get_public_ip_addr_reachable() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let port_range = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
         let (_client_port, (client_udp_socket, client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
@@ -878,16 +903,17 @@ mod tests {
     #[test]
     fn test_verify_ports_tcp_unreachable() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let port_range = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
 
         // make the socket unreachable by not running the ip echo server!
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
 
         let (_, (_client_udp_socket, client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
 
         let rt = runtime();
         assert!(!rt.block_on(ip_echo_client::verify_all_reachable_tcp(
@@ -900,16 +926,17 @@ mod tests {
     #[test]
     fn test_verify_ports_udp_unreachable() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let port_range = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
 
         // make the socket unreachable by not running the ip echo server!
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
 
         let (_correct_client_port, (client_udp_socket, _client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, port_range, config).unwrap();
 
         let rt = runtime();
         assert!(!rt.block_on(ip_echo_client::verify_all_reachable_udp(
@@ -923,18 +950,18 @@ mod tests {
     #[test]
     fn test_verify_many_ports_reachable() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfig::default();
         let mut tcp_listeners = vec![];
         let mut udp_sockets = vec![];
 
         let (_server_port, (_, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (3200, 3300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, (2200, 2300), config).unwrap();
         for _ in 0..MAX_PORT_VERIFY_THREADS * 2 {
             let (_client_port, (client_udp_socket, client_tcp_listener)) =
                 bind_common_in_range_with_config(
                     ip_addr,
-                    (3300, 3300 + (MAX_PORT_VERIFY_THREADS * 3) as u16),
+                    (2300, 2300 + (MAX_PORT_VERIFY_THREADS * 3) as u16),
                     config,
                 )
                 .unwrap();

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -1,0 +1,56 @@
+use {
+    crate::{bind_common_in_range_with_config, bind_common_with_config, PortRange, SocketConfig},
+    std::{
+        net::{IpAddr, SocketAddr, TcpListener, UdpSocket},
+        sync::atomic::{AtomicU16, Ordering},
+    },
+};
+
+const BASE_PORT: u16 = 5000;
+
+/// Retrieve a free 20-port slice for unit tests
+///
+/// When running under nextest, this will try to provide
+/// a unique slice of port numbers (assuming no other nextest processes
+/// are running on the same host) based on NEXTEST_TEST_GLOBAL_SLOT variable
+/// The port ranges will be reused following nextest logic.
+///
+/// When running without nextest, this will only bump an atomic and eventually
+/// panic when it runs out of port numbers to assign.
+pub fn localhost_port_range_for_tests() -> (u16, u16) {
+    static SLICE: AtomicU16 = AtomicU16::new(0);
+    let offset = SLICE.fetch_add(20, Ordering::Relaxed);
+    let start = offset
+        + match std::env::var("NEXTEST_TEST_GLOBAL_SLOT") {
+            Ok(slot) => {
+                let slot: u16 = slot.parse().unwrap();
+                assert!(
+                    offset < 1000,
+                    "Overrunning into the port range of another test!"
+                );
+
+                BASE_PORT + slot * 1000
+            }
+            Err(_) => BASE_PORT,
+        };
+    assert!(start < 65500, "ran out of port numbers!");
+    (start, start + 20)
+}
+
+pub fn get_gossip_port(
+    gossip_addr: &SocketAddr,
+    port_range: PortRange,
+    bind_ip_addr: IpAddr,
+) -> (u16, (UdpSocket, TcpListener)) {
+    let config = SocketConfig::default();
+    if gossip_addr.port() != 0 {
+        (
+            gossip_addr.port(),
+            bind_common_with_config(bind_ip_addr, gossip_addr.port(), config).unwrap_or_else(|e| {
+                panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e)
+            }),
+        )
+    } else {
+        bind_common_in_range_with_config(bind_ip_addr, port_range, config).expect("Failed to bind")
+    }
+}

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -29,7 +29,7 @@ use {
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
         create_new_tmp_ledger,
     },
-    solana_net_utils::PortRange,
+    solana_net_utils::{sockets::localhost_port_range_for_tests, PortRange},
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client::{nonblocking, rpc_client::RpcClient},
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
@@ -94,14 +94,13 @@ pub struct TestValidatorNodeConfig {
 
 impl Default for TestValidatorNodeConfig {
     fn default() -> Self {
-        const MIN_PORT_RANGE: u16 = 1024;
-        const MAX_PORT_RANGE: u16 = 65535;
-
-        let bind_ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let port_range = (MIN_PORT_RANGE, MAX_PORT_RANGE);
-
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        #[cfg(not(debug_assertions))]
+        let port_range = solana_net_utils::VALIDATOR_PORT_RANGE;
+        #[cfg(debug_assertions)]
+        let port_range = localhost_port_range_for_tests();
         Self {
-            gossip_addr: socketaddr!(Ipv4Addr::LOCALHOST, 0),
+            gossip_addr: socketaddr!(Ipv4Addr::LOCALHOST, port_range.0),
             port_range,
             bind_ip_addr,
         }


### PR DESCRIPTION
#### Problem
We can not rely on port ranges not intersecting during test runs, and we need bindings with fixed offsets for QUIC ports. 
This PR ensures all bindings use non-overlapping port ranges.

#### Summary of Changes

- Added "port range allocator" logic that works with nextest

