### PR TITLE
Remove old program feature from `cargo-build-sbf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Release channels have their own copy of this changelog:
 * Although the solana rust toolchain still supports the `sbf-solana-solana` target, the new `cargo-build-sbf` version target defaults to `sbpf-solana-solana`. The generated programs will be available on `target/deploy` and `target/sbpf-solana-solana/release`.
 * If the `sbf-solana-solana` target folder is still necessary, use `cargo +solana build --triple sbf-solana-solana --release`.
 * The target triple changes as well for the new SBPF versions. Triples will be `sbpfv1-solana-solana` for version `v1`, `sbpfv2-solana-solana` for `v2`, and `sbpfv3-solana-solana` for `v3`. Generated programs are available on both the `target/deploy` folder and the `target/<triple>/release` folder. The binary in `target/deploy` has smaller size, since we strip unnecessary sections from the one available in `target/<triple>/release`.
-* `cargo-build-sbf` stopped supporting the Solana SDK versions earlier than v1.3 as program dependencies.
+* `cargo-build-sbf` no longer automatically enables the `program` feature to the `solana-sdk` dependency. This feature allowed `solana-sdk` to work in on-chain programs. Users must enable the `program` feature explicitly or use `solana-program` instead. This new behavior only breaks programs using `solana-sdk` v1.3 and earlier.
 
 ### CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Release channels have their own copy of this changelog:
 * Although the solana rust toolchain still supports the `sbf-solana-solana` target, the new `cargo-build-sbf` version target defaults to `sbpf-solana-solana`. The generated programs will be available on `target/deploy` and `target/sbpf-solana-solana/release`.
 * If the `sbf-solana-solana` target folder is still necessary, use `cargo +solana build --triple sbf-solana-solana --release`.
 * The target triple changes as well for the new SBPF versions. Triples will be `sbpfv1-solana-solana` for version `v1`, `sbpfv2-solana-solana` for `v2`, and `sbpfv3-solana-solana` for `v3`. Generated programs are available on both the `target/deploy` folder and the `target/<triple>/release` folder. The binary in `target/deploy` has smaller size, since we strip unnecessary sections from the one available in `target/<triple>/release`.
+* `cargo-build-sbf` stopped supporting the Solana SDK versions earlier than v1.3 as program dependencies.
 
 ### CLI
 

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -640,7 +640,6 @@ fn build_solana_package(
         }
     };
 
-    let legacy_program_feature_present = package.name == "solana-sdk";
     let root_package_dir = &package.manifest_path.parent().unwrap_or_else(|| {
         error!("Unable to get directory of {}", package.manifest_path);
         exit(1);
@@ -690,9 +689,6 @@ fn build_solana_package(
     }
     if !config.features.is_empty() {
         info!("Features: {}", config.features.join(" "));
-    }
-    if legacy_program_feature_present {
-        info!("Legacy program feature detected");
     }
     let arch = if cfg!(target_arch = "aarch64") {
         "aarch64"
@@ -824,12 +820,6 @@ fn build_solana_package(
     for feature in &config.features {
         cargo_build_args.push("--features");
         cargo_build_args.push(feature);
-    }
-    if legacy_program_feature_present {
-        if !config.no_default_features {
-            cargo_build_args.push("--no-default-features");
-        }
-        cargo_build_args.push("--features=program");
     }
     if config.verbose {
         cargo_build_args.push("--verbose");


### PR DESCRIPTION
#### Problem

For context, `cargo-build-sbf --workspace` is painfully slow to run, since it compiles each Solana package separately and does not re-use intermediate build objects. Invoking `cargo +solana --workspace` works flawlessly for the SBF target and is our choice for CI for a couple of months now. I am refactoring the tool to use the `--workspace` cargo argument instead of building each package individually.

One of the barriers now is the `legacy_program_feature_present` boolean used to include the `--features=program` to cargo when building the Solana-program package from a time when it was part of Solana SDK crate. Solana-program became a separate crate in Solana v1.3 (see https://github.com/solana-labs/solana/pull/12989) in October 2020.

It has been more than enough time for programs to adapt and migrate to newer Solana versions that won't need the extra argument anymore, so I deem safe to remove the feature by now. 

#### Summary of Changes

Remove the `legacy_program_feature_present` check and update the Changelog.
