### PR TITLE
blockstore: Remove unused ProgramCosts column

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -132,7 +132,6 @@ fn analyze_storage(blockstore: &Blockstore) -> Result<()> {
     analyze_column(blockstore, Blocktime::NAME)?;
     analyze_column(blockstore, PerfSamples::NAME)?;
     analyze_column(blockstore, BlockHeight::NAME)?;
-    analyze_column(blockstore, ProgramCosts::NAME)?;
     analyze_column(blockstore, OptimisticSlots::NAME)
 }
 
@@ -161,7 +160,6 @@ fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
         cf::Blocktime::NAME => Some(cf::Blocktime::slot(cf::Blocktime::index(key))),
         cf::PerfSamples::NAME => Some(cf::PerfSamples::slot(cf::PerfSamples::index(key))),
         cf::BlockHeight::NAME => Some(cf::BlockHeight::slot(cf::BlockHeight::index(key))),
-        cf::ProgramCosts::NAME => None, // does not implement slot()
         cf::OptimisticSlots::NAME => {
             Some(cf::OptimisticSlots::slot(cf::OptimisticSlots::index(key)))
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -262,7 +262,6 @@ pub struct Blockstore {
     optimistic_slots_cf: LedgerColumn<cf::OptimisticSlots>,
     orphans_cf: LedgerColumn<cf::Orphans>,
     perf_samples_cf: LedgerColumn<cf::PerfSamples>,
-    program_costs_cf: LedgerColumn<cf::ProgramCosts>,
     rewards_cf: LedgerColumn<cf::Rewards>,
     roots_cf: LedgerColumn<cf::Root>,
     transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
@@ -410,7 +409,6 @@ impl Blockstore {
         let optimistic_slots_cf = db.column();
         let orphans_cf = db.column();
         let perf_samples_cf = db.column();
-        let program_costs_cf = db.column();
         let rewards_cf = db.column();
         let roots_cf = db.column();
         let transaction_memos_cf = db.column();
@@ -445,7 +443,6 @@ impl Blockstore {
             optimistic_slots_cf,
             orphans_cf,
             perf_samples_cf,
-            program_costs_cf,
             rewards_cf,
             roots_cf,
             transaction_memos_cf,
@@ -866,7 +863,6 @@ impl Blockstore {
         self.blocktime_cf.submit_rocksdb_cf_metrics();
         self.perf_samples_cf.submit_rocksdb_cf_metrics();
         self.block_height_cf.submit_rocksdb_cf_metrics();
-        self.program_costs_cf.submit_rocksdb_cf_metrics();
         self.bank_hash_cf.submit_rocksdb_cf_metrics();
         self.optimistic_slots_cf.submit_rocksdb_cf_metrics();
         self.merkle_root_meta_cf.submit_rocksdb_cf_metrics();
@@ -3557,26 +3553,6 @@ impl Blockstore {
         let bytes =
             serialize(&perf_sample).expect("`PerfSampleV2` can be serialized with `bincode`");
         self.perf_samples_cf.put_bytes(index, &bytes)
-    }
-
-    pub fn read_program_costs(&self) -> Result<Vec<(Pubkey, u64)>> {
-        Ok(self
-            .program_costs_cf
-            .iter(IteratorMode::End)?
-            .map(|(pubkey, data)| {
-                let program_cost: ProgramCost = deserialize(&data).unwrap();
-                (pubkey, program_cost.cost)
-            })
-            .collect())
-    }
-
-    pub fn write_program_cost(&self, key: &Pubkey, value: &u64) -> Result<()> {
-        self.program_costs_cf
-            .put(*key, &ProgramCost { cost: *value })
-    }
-
-    pub fn delete_program_cost(&self, key: &Pubkey) -> Result<()> {
-        self.program_costs_cf.delete(*key)
     }
 
     /// Returns the entry vector for the slot starting with `shred_start_index`
@@ -11105,124 +11081,6 @@ pub mod tests {
             }
 
             assert!(Arc::strong_count(&blockstore) == 1);
-        }
-    }
-
-    #[test]
-    fn test_read_write_cost_table() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let num_entries: usize = 10;
-        let mut cost_table: HashMap<Pubkey, u64> = HashMap::new();
-        for x in 1..num_entries + 1 {
-            cost_table.insert(Pubkey::new_unique(), (x + 100) as u64);
-        }
-
-        // write to db
-        for (key, cost) in cost_table.iter() {
-            blockstore
-                .write_program_cost(key, cost)
-                .expect("write a program");
-        }
-
-        // read back from db
-        let read_back = blockstore.read_program_costs().expect("read programs");
-        // verify
-        assert_eq!(read_back.len(), cost_table.len());
-        for (read_key, read_cost) in read_back {
-            assert_eq!(read_cost, *cost_table.get(&read_key).unwrap());
-        }
-
-        // update value, write to db
-        for val in cost_table.values_mut() {
-            *val += 100;
-        }
-        for (key, cost) in cost_table.iter() {
-            blockstore
-                .write_program_cost(key, cost)
-                .expect("write a program");
-        }
-        // add a new record
-        let new_program_key = Pubkey::new_unique();
-        let new_program_cost = 999;
-        blockstore
-            .write_program_cost(&new_program_key, &new_program_cost)
-            .unwrap();
-
-        // confirm value updated
-        let read_back = blockstore.read_program_costs().expect("read programs");
-        // verify
-        assert_eq!(read_back.len(), cost_table.len() + 1);
-        for (key, cost) in cost_table.iter() {
-            assert_eq!(*cost, read_back.iter().find(|(k, _v)| k == key).unwrap().1);
-        }
-        assert_eq!(
-            new_program_cost,
-            read_back
-                .iter()
-                .find(|(k, _v)| *k == new_program_key)
-                .unwrap()
-                .1
-        );
-
-        // test delete
-        blockstore
-            .delete_program_cost(&new_program_key)
-            .expect("delete a progrma");
-        let read_back = blockstore.read_program_costs().expect("read programs");
-        // verify
-        assert_eq!(read_back.len(), cost_table.len());
-        for (read_key, read_cost) in read_back {
-            assert_eq!(read_cost, *cost_table.get(&read_key).unwrap());
-        }
-    }
-
-    #[test]
-    fn test_delete_old_records_from_cost_table() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let num_entries: usize = 10;
-        let mut cost_table: HashMap<Pubkey, u64> = HashMap::new();
-        for x in 1..num_entries + 1 {
-            cost_table.insert(Pubkey::new_unique(), (x + 100) as u64);
-        }
-
-        // write to db
-        for (key, cost) in cost_table.iter() {
-            blockstore
-                .write_program_cost(key, cost)
-                .expect("write a program");
-        }
-
-        // remove a record
-        let mut removed_key = Pubkey::new_unique();
-        for (key, cost) in cost_table.iter() {
-            if *cost == 101_u64 {
-                removed_key = *key;
-                break;
-            }
-        }
-        cost_table.remove(&removed_key);
-
-        // delete records from blockstore if they are no longer in cost_table
-        let db_records = blockstore.read_program_costs().expect("read programs");
-        db_records.iter().for_each(|(pubkey, _)| {
-            if !cost_table.iter().any(|(key, _)| key == pubkey) {
-                assert_eq!(*pubkey, removed_key);
-                blockstore
-                    .delete_program_cost(pubkey)
-                    .expect("delete old program");
-            }
-        });
-
-        // read back from db
-        let read_back = blockstore.read_program_costs().expect("read programs");
-        // verify
-        assert_eq!(read_back.len(), cost_table.len());
-        for (read_key, read_cost) in read_back {
-            assert_eq!(read_cost, *cost_table.get(&read_key).unwrap());
         }
     }
 

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -14,6 +14,8 @@ use {
     solana_storage_proto::convert::generated,
 };
 
+pub(crate) const DEPRECATED_PROGRAM_COSTS_COLUMN_NAME: &str = "program_costs";
+
 // To add a new column, declare the type below and implement the applicable
 // traits for it. At the very least, Column and ColumnName will be necessary.
 //
@@ -188,13 +190,6 @@ pub mod columns {
     /// * index type: `u64` (see [`SlotColumn`])
     /// * value type: `u64`
     pub struct BlockHeight;
-
-    #[derive(Debug)]
-    /// The program costs column
-    ///
-    /// * index type: [`Pubkey`]
-    /// * value type: [`blockstore_meta::ProgramCost`]
-    pub struct ProgramCosts;
 
     #[derive(Debug)]
     /// The optimistic slot column
@@ -607,34 +602,6 @@ impl ColumnName for columns::BlockHeight {
 }
 impl TypedColumn for columns::BlockHeight {
     type Type = u64;
-}
-
-impl ColumnName for columns::ProgramCosts {
-    const NAME: &'static str = "program_costs";
-}
-impl TypedColumn for columns::ProgramCosts {
-    type Type = blockstore_meta::ProgramCost;
-}
-impl Column for columns::ProgramCosts {
-    type Index = Pubkey;
-    type Key = [u8; PUBKEY_BYTES];
-
-    #[inline]
-    fn key(pubkey: &Self::Index) -> Self::Key {
-        pubkey.to_bytes()
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key, 0..32 => Pubkey::from)
-    }
-
-    fn slot(_index: Self::Index) -> Slot {
-        unimplemented!()
-    }
-
-    fn as_index(_index: u64) -> Self::Index {
-        Pubkey::default()
-    }
 }
 
 impl Column for columns::ShredCode {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -4,6 +4,7 @@ use {
         blockstore::{
             column::{
                 columns, Column, ColumnIndexDeprecation, ColumnName, ProtobufColumn, TypedColumn,
+                DEPRECATED_PROGRAM_COSTS_COLUMN_NAME,
             },
             error::{BlockstoreError, Result},
         },
@@ -119,7 +120,7 @@ impl Rocks {
         let column_options = Arc::from(options.column_options);
 
         // Open the database
-        let db = match options.access_type {
+        let mut db = match options.access_type {
             AccessType::Primary | AccessType::PrimaryForMaintenance => {
                 DB::open_cf_descriptors(&db_options, &path, cf_descriptors)?
             }
@@ -138,6 +139,12 @@ impl Rocks {
                 )?
             }
         };
+
+        // Delete the now unused program_costs column if it is present
+        if db.cf_handle(DEPRECATED_PROGRAM_COSTS_COLUMN_NAME).is_some() {
+            db.drop_cf(DEPRECATED_PROGRAM_COSTS_COLUMN_NAME)?;
+        }
+
         let rocks = Rocks {
             db,
             path,
@@ -185,7 +192,6 @@ impl Rocks {
             new_cf_descriptor::<columns::Blocktime>(options, oldest_slot),
             new_cf_descriptor::<columns::PerfSamples>(options, oldest_slot),
             new_cf_descriptor::<columns::BlockHeight>(options, oldest_slot),
-            new_cf_descriptor::<columns::ProgramCosts>(options, oldest_slot),
             new_cf_descriptor::<columns::OptimisticSlots>(options, oldest_slot),
             new_cf_descriptor::<columns::MerkleRootMeta>(options, oldest_slot),
         ];
@@ -236,7 +242,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 21] {
+    const fn columns() -> [&'static str; 20] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -256,7 +262,6 @@ impl Rocks {
             columns::Blocktime::NAME,
             columns::PerfSamples::NAME,
             columns::BlockHeight::NAME,
-            columns::ProgramCosts::NAME,
             columns::OptimisticSlots::NAME,
             columns::MerkleRootMeta::NAME,
         ]
@@ -1375,6 +1380,55 @@ pub mod tests {
             };
             let _ = Rocks::open(db_path.to_path_buf(), options).unwrap();
         }
+    }
+
+    #[test]
+    fn test_remove_deprecated_progam_costs_column_compat() {
+        solana_logger::setup();
+
+        fn is_program_costs_column_present(path: &Path) -> bool {
+            DB::list_cf(&Options::default(), path)
+                .unwrap()
+                .iter()
+                .any(|column_name| column_name == DEPRECATED_PROGRAM_COSTS_COLUMN_NAME)
+        }
+
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path();
+
+        let options = BlockstoreOptions {
+            access_type: AccessType::Primary,
+            enforce_ulimit_nofile: false,
+            ..BlockstoreOptions::default()
+        };
+
+        // Create a new database
+        {
+            let _rocks = Rocks::open(db_path.to_path_buf(), options.clone()).unwrap();
+        }
+
+        // The newly created database should not contain the deprecated column
+        assert!(!is_program_costs_column_present(db_path));
+
+        // Create a program_costs column to simulate an old database that had the column
+        {
+            let mut rocks = Rocks::open(db_path.to_path_buf(), options.clone()).unwrap();
+            rocks
+                .db
+                .create_cf(DEPRECATED_PROGRAM_COSTS_COLUMN_NAME, &Options::default())
+                .unwrap();
+        }
+
+        // Ensure the column we just created is detected
+        assert!(is_program_costs_column_present(db_path));
+
+        // Reopen the database which has logic to delete program_costs column
+        {
+            let _rocks = Rocks::open(db_path.to_path_buf(), options.clone()).unwrap();
+        }
+
+        // The deprecated column should have been dropped by Rocks::open()
+        assert!(!is_program_costs_column_present(db_path));
     }
 
     impl<C> LedgerColumn<C>

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -839,11 +839,6 @@ pub struct PerfSampleV2 {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ProgramCost {
-    pub cost: u64,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct OptimisticSlotMetaV0 {
     pub hash: Hash,
     pub timestamp: UnixTimestamp,


### PR DESCRIPTION
#### Problem
The column is no longer used, so stop creating it and add logic to delete the column from a blockstore that may have had the column created by an older software version

#### Summary of Changes
Remove the unused column + add unit test to exercise new logic to drop the deprecated column.

As for version compatibility:
- Assuming this change lands in v2.3, the unit test demonstrates the forward compatibility case of opening a v2.2 blockstore that still has the column with v2.3
- I manually tested the backwards compatibility case of opening a v2.3 blockstore without the column with v2.2. This also works since we have this option set
https://github.com/anza-xyz/agave/blob/d7da5fb5d051237421c98512ae5943b489ac3baf/ledger/src/blockstore_db.rs#L1150-L1152

So, operators will be able to seamlessly upgrade/downgrade between v2.2 and v2.3
