### PR TITLE
solana_version: gen random u32 if commit not set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11075,6 +11075,7 @@ name = "solana-version"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "rand 0.8.5",
  "semver 1.0.26",
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9171,6 +9171,7 @@ name = "solana-version"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "rand 0.8.5",
  "semver",
  "serde",
  "serde_derive",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8512,6 +8512,7 @@ name = "solana-version"
 version = "2.3.0"
 dependencies = [
  "agave-feature-set",
+ "rand 0.8.5",
  "semver",
  "serde",
  "serde_derive",

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 agave-feature-set = { workspace = true }
+rand = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/version/build.rs
+++ b/version/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+    if let Ok(git_output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
+        if git_output.status.success() {
+            if let Ok(git_commit_hash) = String::from_utf8(git_output.stdout) {
+                let trimmed_hash = git_commit_hash.trim().to_string();
+                println!("cargo:rustc-env=GIT_COMMIT_HASH={}", trimmed_hash);
+            }
+        }
+    }
+}

--- a/version/build.rs
+++ b/version/build.rs
@@ -5,7 +5,7 @@ fn main() {
         if git_output.status.success() {
             if let Ok(git_commit_hash) = String::from_utf8(git_output.stdout) {
                 let trimmed_hash = git_commit_hash.trim().to_string();
-                println!("cargo:rustc-env=GIT_COMMIT_HASH={}", trimmed_hash);
+                println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={}", trimmed_hash);
             }
         }
     }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate serde_derive;
 pub use self::legacy::{LegacyVersion1, LegacyVersion2};
 use {
+    rand::{thread_rng, Rng},
     serde_derive::{Deserialize, Serialize},
     solana_sanitize::Sanitize,
     solana_serde_varint as serde_varint,
@@ -61,7 +62,8 @@ impl Default for Version {
             major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
             minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-            commit: compute_commit(option_env!("CI_COMMIT")).unwrap_or_default(),
+            commit: compute_commit(option_env!("CI_COMMIT"))
+                .unwrap_or_else(|| thread_rng().gen::<u32>()),
             feature_set,
             // Other client implementations need to modify this line.
             client: u16::try_from(ClientId::Agave).unwrap(),

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -63,6 +63,7 @@ impl Default for Version {
             minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
             commit: compute_commit(option_env!("CI_COMMIT"))
+                .or(compute_commit(option_env!("GIT_COMMIT_HASH")))
                 .unwrap_or_else(|| thread_rng().gen::<u32>()),
             feature_set,
             // Other client implementations need to modify this line.

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -63,7 +63,7 @@ impl Default for Version {
             minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
             commit: compute_commit(option_env!("CI_COMMIT"))
-                .or(compute_commit(option_env!("GIT_COMMIT_HASH")))
+                .or(compute_commit(option_env!("AGAVE_GIT_COMMIT_HASH")))
                 .unwrap_or_else(|| thread_rng().gen::<u32>()),
             feature_set,
             // Other client implementations need to modify this line.


### PR DESCRIPTION
#### Problem
A significant number of validator/rpc operators build from source. As a result, the `CI_COMMIT` env variable is not set, leaving ContactInfo::version::commit set to all zeros. This makes it hard to tell when a node has upgraded or restarted. 

#### Summary of Changes
Default to a random `u32` in `Version::commit` if `CI_COMMIT` or `GIT_COMMIT_HASH` not set in `solana_version`.

Thoughts
1) Could we just rely on validator-new metric? That will tell us when a node has restarted but it won't persist within the running validator state. Also not all nodes report metrics.
2) Could we just use ContactInfo::outset for this? We only change outset when we boot up a validator or when an Admin used the `AdminRpc` interface to change the node's pubkey. So it's possible that we could get a false positive (aka false node upgrade) when the node's outset changes even though the only thing that happened was the keypair was updated.