### PR TITLE
docs: Add a description to `TransactionRecorder`

### DIFF
--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -40,6 +40,7 @@ pub struct RecordTransactionsSummary {
     pub starting_transaction_index: Option<usize>,
 }
 
+/// Adds transactions into the PoH stream, by sending them to the PoH service.
 #[derive(Clone, Debug)]
 pub struct TransactionRecorder {
     // shared by all users of PohRecorder


### PR DESCRIPTION
While one can look at the methods that `TransactionRecorder` provides and infer what it does, it does not hurt to have a small note at the type definition itself.  It shows up in the LSP hints and is immediately visible when one looks at the type, without a need to look at the implementation details.