### PR TITLE
docs: Add a description to `banking_stage::Commiter`

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -41,6 +41,10 @@ pub(super) struct PreBalanceInfo {
     pub mint_decimals: HashMap<Pubkey, u8>,
 }
 
+/// Adds transactions to bank, which would eventually get it committed into the AccountDB as well.
+///
+/// Note that this does not cause the transaction to be included in the PoH stream.  Use
+/// [`solana_poh::transaction_recorder::TransactionRecorder`] for that.
 #[derive(Clone)]
 pub struct Committer {
     transaction_status_sender: Option<TransactionStatusSender>,


### PR DESCRIPTION
It helps to have a short summary for each abstraction that is a bit longer than just the abstraction name.

Also, shows in the LSP hints and gives the readers an overview without requiring them to reverse engineer the intent from the implementation.

---

I do not know if a note about the `TransactionRecorder` is relevant here.
It is related to my personal confusion, so it would have helped to see it here.
But it is quite possible that this is not the right spot to talk about the PoH hashes.