### PR TITLE
Marks StoredAccountMeta fn as AppendVec-only

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4196,11 +4196,11 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
     // Flushing cache should only create one storage entry
     let storage0 = accounts_db.get_and_assert_single_storage(slot);
 
-    storage0.accounts.scan_accounts_stored_meta(|account| {
+    storage0.accounts.scan_index(|account| {
         let before_size = storage0.alive_bytes();
         let account_info = accounts_db
             .accounts_index
-            .get_cloned(account.pubkey())
+            .get_cloned(&account.index_info.pubkey)
             .unwrap()
             .slot_list
             .read()
@@ -4217,7 +4217,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
             // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
             assert_eq!(after_size, 0);
         } else {
-            assert_eq!(before_size, after_size + account.stored_size());
+            assert_eq!(before_size, after_size + account.stored_size_aligned);
         }
     });
 });

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -191,16 +191,9 @@ impl AccountsFile {
     ) -> Option<Ret> {
         match self {
             Self::AppendVec(av) => av.get_stored_account_meta_callback(offset, callback),
-            // Note: The conversion here is needed as the AccountsDB currently
-            // assumes all offsets are multiple of 8 while TieredStorage uses
-            // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-            Self::TieredStorage(ts) => ts
-                .reader()?
-                .get_stored_account_meta_callback(
-                    IndexOffset(AccountInfo::get_reduced_offset(offset)),
-                    callback,
-                )
-                .ok()?,
+            Self::TieredStorage(_) => {
+                unimplemented!("StoredAccountMeta is only implemented for AppendVec")
+            }
         }
     }
 
@@ -307,10 +300,8 @@ impl AccountsFile {
     ) {
         match self {
             Self::AppendVec(av) => av.scan_accounts_stored_meta(callback),
-            Self::TieredStorage(ts) => {
-                if let Some(reader) = ts.reader() {
-                    _ = reader.scan_accounts_stored_meta(callback);
-                }
+            Self::TieredStorage(_) => {
+                unimplemented!("StoredAccountMeta is only implemented for AppendVec")
             }
         }
     }


### PR DESCRIPTION
#### Problem

`StoredAccountMeta` is the implementation of AppendVec, and really shouldn't be used by other file formats. Recent PRs have made the AccountsFile functions that use StoredAccountMeta to be test-only, which paves the way for further removal.

The tests that use StoredAccountMeta use only AppendVec, so we can explicitly prevent use for TieredStorage (and then later remove StoredAccountMeta from TieredStorage entirely).


#### Summary of Changes

The AccountsFile functions that use StoredAccountMeta are only for AppendVec.