### PR TITLE
Avoid reading account from storage for when retrieving pubkey

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6589,12 +6589,10 @@ impl AccountsDb {
             .can_slot_be_in_cache(accounts.target_slot())
         {
             (0..accounts.len()).for_each(|index| {
-                accounts.account(index, |account| {
-                    // based on the patterns of how a validator writes accounts, it is almost always the case that there is no read only cache entry
-                    // for this pubkey and slot. So, we can give that hint to the `remove` for performance.
-                    self.read_only_accounts_cache
-                        .remove_assume_not_present(*account.pubkey());
-                })
+                // based on the patterns of how a validator writes accounts, it is almost always the case that there is no read only cache entry
+                // for this pubkey and slot. So, we can give that hint to the `remove` for performance.
+                self.read_only_accounts_cache
+                    .remove_assume_not_present(*accounts.pubkey(index));
             });
         }
         calc_stored_meta_time.stop();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -64,6 +64,9 @@ where
     ) -> Ret {
         callback(self.1[index].1.into())
     }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        self.1[index].0
+    }
     fn slot(&self, index: usize) -> Slot {
         // note that this could be different than 'target_slot()' PER account
         self.1[index].2

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -47,6 +47,9 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
     fn data_len(&self, index: usize) -> usize {
         self.1[index].stake_account.data().len()
     }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        &self.1[index].stake_pubkey
+    }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
         self.target_slot()

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -113,6 +113,8 @@ pub trait StorableAccounts<'a>: Sync {
     fn is_zero_lamport(&self, index: usize) -> bool;
     /// data length of account at 'index'
     fn data_len(&self, index: usize) -> usize;
+    /// pubkey of account at 'index'
+    fn pubkey(&self, index: usize) -> &Pubkey;
     /// None if account is zero lamports
     fn account_default_if_zero_lamport<Ret>(
         &self,
@@ -162,6 +164,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
     fn data_len(&self, index: usize) -> usize {
         self.1[index].1.data().len()
     }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        self.1[index].0
+    }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
         self.target_slot()
@@ -187,6 +192,9 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, AccountSharedData
     }
     fn data_len(&self, index: usize) -> usize {
         self.1[index].1.data().len()
+    }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        &self.1[index].0
     }
     fn slot(&self, _index: usize) -> Slot {
         // per-index slot is not unique per slot when per-account slot is not included in the source data
@@ -314,6 +322,10 @@ impl<'a> StorableAccounts<'a> for StorableAccountsBySlot<'a> {
         let indexes = self.find_internal_index(index);
         self.slots_and_accounts[indexes.0].1[indexes.1].data_len()
     }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        let indexes = self.find_internal_index(index);
+        self.slots_and_accounts[indexes.0].1[indexes.1].pubkey()
+    }
     fn slot(&self, index: usize) -> Slot {
         let indexes = self.find_internal_index(index);
         self.slots_and_accounts[indexes.0].0
@@ -373,6 +385,9 @@ pub mod tests {
         fn data_len(&self, index: usize) -> usize {
             self.1[index].data_len()
         }
+        fn pubkey(&self, index: usize) -> &Pubkey {
+            self.1[index].pubkey()
+        }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
             self.0
@@ -402,6 +417,9 @@ pub mod tests {
         }
         fn data_len(&self, index: usize) -> usize {
             self.1[index].1.data().len()
+        }
+        fn pubkey(&self, index: usize) -> &Pubkey {
+            &self.1[index].0
         }
         fn slot(&self, _index: usize) -> Slot {
             // per-index slot is not unique per slot when per-account slot is not included in the source data
@@ -441,6 +459,9 @@ pub mod tests {
         }
         fn data_len(&self, index: usize) -> usize {
             self.1[index].data_len()
+        }
+        fn pubkey(&self, index: usize) -> &Pubkey {
+            self.1[index].pubkey()
         }
         fn slot(&self, _index: usize) -> Slot {
             // same other slot for all accounts


### PR DESCRIPTION
#### Problem
`AccountsDb::store_accounts_to` performs an optimization where it removes the accounts-to-store from the `read_only_accounts_cache`. This calls `StorableAccounts::account`, which will read the account from disk, including its data, if it's backed by `StorableAccountsBySlot`.

#### Summary of Changes

`read_only_accounts_cache.remove_assume_not_present` actually only needs the account pubkey, which is available without actually hitting any underlying storage mechanisms. This adds a new method to `StorableAccounts` that retrieves the pubkey for the implementing data structure.
