### PR TITLE
AccountsDb::store: use StorableAccounts::data_len for total data metric

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8131,9 +8131,7 @@ impl AccountsDb {
 
         let mut total_data = 0;
         (0..accounts.len()).for_each(|index| {
-            accounts.account(index, |account| {
-                total_data += account.data().len();
-            })
+            total_data += accounts.data_len(index);
         });
 
         self.stats


### PR DESCRIPTION
#### Problem
Similar to #5879, `AccountsDb::store` calls `StorableAccounts::account`, which will read the account from disk, including its data, if it's backed by `StorableAccountsBySlot`.

#### Summary of Changes

The data length is available without hitting the underlying storage mechanism via `StorableAccount::data_len`. This updates the call site to use that instead.


