### PR TITLE
Adds TieredStorage impl for get_stored_account_callback()

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         account_info::AccountInfo,
-        account_storage::meta::StoredAccountMeta,
+        account_storage::{meta::StoredAccountMeta, stored_account_info::StoredAccountInfo},
         accounts_file::{MatchAccountOwnerError, StoredAccountsInfo},
         append_vec::{IndexInfo, IndexInfoInner},
         tiered_storage::{
@@ -520,6 +520,32 @@ impl HotStorageReader {
         )?;
 
         Ok(data)
+    }
+
+    /// calls `callback` with the account located at the specified index offset.
+    pub fn get_stored_account_callback<Ret>(
+        &self,
+        index_offset: IndexOffset,
+        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
+    ) -> TieredStorageResult<Option<Ret>> {
+        if index_offset.0 >= self.footer.account_entry_count {
+            return Ok(None);
+        }
+
+        let account_offset = self.get_account_offset(index_offset)?;
+        let meta = self.get_account_meta_from_offset(account_offset)?;
+        let account_block = self.get_account_block(account_offset, index_offset)?;
+
+        let stored_account = StoredAccountInfo {
+            pubkey: self.get_account_address(index_offset)?,
+            lamports: meta.lamports(),
+            owner: self.get_owner_address(meta.owner_offset())?,
+            data: meta.account_data(account_block),
+            executable: meta.flags().executable(),
+            rent_epoch: meta.final_rent_epoch(account_block),
+        };
+
+        Ok(Some(callback(stored_account)))
     }
 
     /// calls `callback` with the account located at the specified index offset.
@@ -1425,6 +1451,40 @@ mod tests {
                 owner_addresses[account_meta.owner_offset().0 as usize]
             );
         }
+    }
+
+    #[test]
+    fn test_get_stored_account_callback() {
+        const NUM_ACCOUNTS: usize = 20;
+        const NUM_OWNERS: usize = 10;
+        let test_info = write_test_file(NUM_ACCOUNTS, NUM_OWNERS);
+
+        let file = TieredReadableFile::new(&test_info.file_path).unwrap();
+        let hot_storage = HotStorageReader::new(file).unwrap();
+
+        for i in 0..NUM_ACCOUNTS {
+            hot_storage
+                .get_stored_account_callback(IndexOffset(i as u32), |stored_account| {
+                    assert_eq!(stored_account.lamports(), test_info.metas[i].lamports());
+                    assert_eq!(stored_account.data().len(), test_info.datas[i].len());
+                    assert_eq!(stored_account.data(), test_info.datas[i]);
+                    assert_eq!(
+                        *stored_account.owner(),
+                        test_info.owners[test_info.metas[i].owner_offset().0 as usize]
+                    );
+                    assert_eq!(*stored_account.pubkey(), test_info.addresses[i]);
+                })
+                .unwrap()
+                .unwrap();
+        }
+        // Make sure it returns None on NUM_ACCOUNTS to allow termination on
+        // while loop in actual accounts-db read case.
+        assert!(matches!(
+            hot_storage.get_stored_account_callback(IndexOffset(NUM_ACCOUNTS as u32), |_| {
+                panic!("unexpected");
+            }),
+            Ok(None),
+        ));
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -103,19 +103,11 @@ impl TieredStorageReader {
     pub fn get_stored_account_callback<Ret>(
         &self,
         index_offset: IndexOffset,
-        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
+        callback: impl for<'local> FnMut(StoredAccountInfo<'local>) -> Ret,
     ) -> TieredStorageResult<Option<Ret>> {
-        self.get_stored_account_meta_callback(index_offset, |stored_account_meta| {
-            let account = StoredAccountInfo {
-                pubkey: stored_account_meta.pubkey(),
-                lamports: stored_account_meta.lamports(),
-                owner: stored_account_meta.owner(),
-                data: stored_account_meta.data(),
-                executable: stored_account_meta.executable(),
-                rent_epoch: stored_account_meta.rent_epoch(),
-            };
-            callback(account)
-        })
+        match self {
+            Self::Hot(hot) => hot.get_stored_account_callback(index_offset, callback),
+        }
     }
 
     /// calls `callback` with the account located at the specified index offset.


### PR DESCRIPTION
#### Problem

Trying to remove StoredAccountMeta from everywhere.

This PR removes the need for the TieredStorage to use the stored_account_meta method as the underlying impl.


#### Summary of Changes

Add a proper impl of get_stored_account_callback() for TieredStorage that doesn't use StoredAccountMeta as the underlying impl.