### PR TITLE
tpu-client-next: redo certificate update

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -548,6 +548,7 @@ impl TpuClientNextClient {
             Box::new(leader_updater),
             receiver,
             update_certificate_receiver,
+            cancel.clone(),
         );
         // leaking handle to this task, as it will run until the cancel signal is received
         runtime_handle.spawn(scheduler.get_stats().report_to_influxdb(
@@ -555,7 +556,7 @@ impl TpuClientNextClient {
             METRICS_REPORTING_INTERVAL,
             cancel.clone(),
         ));
-        let _handle = runtime_handle.spawn(scheduler.run(config, cancel.clone()));
+        let _handle = runtime_handle.spawn(scheduler.run(config));
         Self { sender }
     }
 

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -553,8 +553,8 @@ impl TpuClientNextClient {
         // For now _update_certificate_sender is unused, will be implemented later.
         let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
         let _handle = runtime_handle.spawn(scheduler.run(
-            config,
             update_certificate_receiver,
+            config,
             cancel.clone(),
         ));
         Self { sender }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -572,7 +572,7 @@ impl TpuClientNextClient {
     ) -> ConnectionWorkersSchedulerConfig {
         ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Socket(bind_socket),
-            stake_identity: stake_identity.map(|identity| StakeIdentity::new(identity)),
+            stake_identity: stake_identity.map(StakeIdentity::new),
             // Cache size of 128 covers all nodes above the P90 slot count threshold,
             // which together account for ~75% of total slots in the epoch.
             num_connections: 128,

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -572,7 +572,7 @@ impl TpuClientNextClient {
     ) -> ConnectionWorkersSchedulerConfig {
         ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Socket(bind_socket),
-            stake_identity: stake_identity.map(Into::into),
+            stake_identity: stake_identity.map(|identity| StakeIdentity::new(identity)),
             // Cache size of 128 covers all nodes above the P90 slot count threshold,
             // which together account for ~75% of total slots in the epoch.
             num_connections: 128,
@@ -602,8 +602,9 @@ impl ForwardingClient for TpuClientNextClient {
 
 impl NotifyKeyUpdate for TpuClientNextClient {
     fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+        let stake_identity = StakeIdentity::new(identity);
         self.update_certificate_sender
-            .send(Some(identity.into()))
+            .send(Some(stake_identity))
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
     }
 }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -41,7 +41,10 @@ use {
         thread::{Builder, JoinHandle},
         time::{Duration, Instant},
     },
-    tokio::{runtime::Handle as RuntimeHandle, sync::mpsc},
+    tokio::{
+        runtime::Handle as RuntimeHandle,
+        sync::{mpsc, watch},
+    },
     tokio_util::sync::CancellationToken,
 };
 
@@ -547,7 +550,13 @@ impl TpuClientNextClient {
             METRICS_REPORTING_INTERVAL,
             cancel.clone(),
         ));
-        let _handle = runtime_handle.spawn(scheduler.run(config, cancel.clone()));
+        // For now _update_certificate_sender is unused, will be implemented later.
+        let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
+        let _handle = runtime_handle.spawn(scheduler.run(
+            config,
+            update_certificate_receiver,
+            cancel.clone(),
+        ));
         Self { sender }
     }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -503,7 +503,7 @@ impl JsonRpcService {
                     config.send_transaction_service_config,
                     config.max_slots,
                     config.leader_schedule_cache,
-                    client.clone(),
+                    client,
                     config.max_complete_transaction_status_slot,
                     config.max_complete_rewards_slot,
                     config.prioritization_fee_cache,

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -79,7 +79,7 @@ where
 
 impl Stoppable for TpuClientNextClient {
     fn stop(&self) {
-        self.cancel().unwrap();
+        self.cancel();
     }
 }
 

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -282,8 +282,8 @@ impl TpuClientNextClient {
         let _handle = runtime_handle.spawn(scheduler.run(config));
         Self {
             runtime_handle,
-            update_certificate_sender,
             sender,
+            update_certificate_sender,
             #[cfg(any(test, feature = "dev-context-only-utils"))]
             cancel,
         }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -232,6 +232,7 @@ pub struct TpuClientNextClient {
     runtime_handle: Handle,
     sender: mpsc::Sender<TransactionBatch>,
     update_certificate_sender: watch::Sender<Option<StakeIdentity>>,
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     cancel: CancellationToken,
 }
 
@@ -283,6 +284,7 @@ impl TpuClientNextClient {
             runtime_handle,
             update_certificate_sender,
             sender,
+            #[cfg(any(test, feature = "dev-context-only-utils"))]
             cancel,
         }
     }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -296,7 +296,7 @@ impl TpuClientNextClient {
     ) -> ConnectionWorkersSchedulerConfig {
         ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Socket(bind_socket),
-            stake_identity: stake_identity.map(|identity| StakeIdentity::new(identity)),
+            stake_identity: stake_identity.map(StakeIdentity::new),
             num_connections: MAX_CONNECTIONS,
             skip_check_transaction_age: true,
             // experimentally found parameter values

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -296,7 +296,7 @@ impl TpuClientNextClient {
     ) -> ConnectionWorkersSchedulerConfig {
         ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Socket(bind_socket),
-            stake_identity: stake_identity.map(Into::into),
+            stake_identity: stake_identity.map(|identity| StakeIdentity::new(identity)),
             num_connections: MAX_CONNECTIONS,
             skip_check_transaction_age: true,
             // experimentally found parameter values
@@ -317,8 +317,9 @@ impl TpuClientNextClient {
 
 impl NotifyKeyUpdate for TpuClientNextClient {
     fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
+        let stake_identity = StakeIdentity::new(identity);
         self.update_certificate_sender
-            .send(Some(identity.into()))
+            .send(Some(stake_identity))
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
     }
 }

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -97,7 +97,6 @@ impl ConnectionWorker {
         send_txs_stats: Arc<SendTransactionStats>,
     ) -> (Self, CancellationToken) {
         let cancel = CancellationToken::new();
-
         let this = Self {
             endpoint,
             peer,

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -16,7 +16,6 @@ use {
     log::*,
     quinn::Endpoint,
     solana_keypair::Keypair,
-    solana_tls_utils::tls_client_config_builder,
     std::{
         net::{SocketAddr, UdpSocket},
         sync::{
@@ -194,8 +193,8 @@ impl ConnectionWorkersScheduler {
     /// over the network.
     pub async fn run(
         self,
-        config: ConnectionWorkersSchedulerConfig,
         update_certificate_receiver: watch::Receiver<Option<StakeIdentity>>,
+        config: ConnectionWorkersSchedulerConfig,
         cancel: CancellationToken,
     ) -> Result<Self, ConnectionWorkersSchedulerError> {
         self.run_with_broadcaster::<NonblockingBroadcaster>(

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -278,7 +278,9 @@ impl ConnectionWorkersScheduler {
                         max_reconnect_attempts,
                         stats.clone(),
                     );
-                    workers.push(peer, worker).map(shutdown_worker);
+                    if let Some(pop_worker) = workers.push(peer, worker) {
+                        shutdown_worker(pop_worker)
+                    }
                 }
             }
 
@@ -374,7 +376,9 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
                 }
                 Err(WorkersCacheError::ReceiverDropped) => {
                     // Remove the worker from the cache, if the peer has disconnected.
-                    workers.pop(*new_leader).map(shutdown_worker);
+                    if let Some(pop_worker) = workers.pop(*new_leader) {
+                        shutdown_worker(pop_worker)
+                    }
                 }
                 Err(err) => {
                     warn!("Connection to {new_leader} was closed, worker error: {err}");

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -133,9 +133,9 @@ impl From<StakeIdentity> for QuicClientCertificate {
     }
 }
 
-impl StakeIdentity {
-    pub fn as_certificate(&self) -> &QuicClientCertificate {
-        &self.0
+impl<'a> From<&'a StakeIdentity> for &'a QuicClientCertificate {
+    fn from(identity: &'a StakeIdentity) -> Self {
+        &identity.0
     }
 }
 
@@ -242,7 +242,7 @@ impl ConnectionWorkersScheduler {
                     let client_config = {
                         let stake_identity = self.update_certificate_receiver.borrow_and_update();
                         let client_certificate = match stake_identity.as_ref() {
-                            Some(identity) => &identity.as_certificate(),
+                            Some(identity) => identity.into(),
                             None => &QuicClientCertificate::new(None),
                         };
                         create_client_config(client_certificate)

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -269,7 +269,7 @@ impl ConnectionWorkersScheduler {
             // add future leaders to the cache to hide the latency of opening
             // the connection.
             for peer in connect_leaders {
-                if !workers.contains_and_valid(&peer) {
+                if !workers.contains(&peer) {
                     let worker = Self::spawn_worker(
                         &endpoint,
                         &peer,
@@ -360,7 +360,7 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
         transaction_batch: TransactionBatch,
     ) -> Result<(), ConnectionWorkersSchedulerError> {
         for new_leader in leaders {
-            if !workers.contains_and_valid(new_leader) {
+            if !workers.contains(new_leader) {
                 warn!("No existing worker for {new_leader:?}, skip sending to this leader.");
                 continue;
             }

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -1,7 +1,7 @@
 //! Utility code to handle quic networking.
 
 use {
-    crate::connection_workers_scheduler::{BindTarget, StakeIdentity},
+    crate::connection_workers_scheduler::BindTarget,
     quinn::{
         crypto::rustls::QuicClientConfig, default_runtime, ClientConfig, Connection, Endpoint,
         EndpointConfig, IdleTimeout, TransportConfig,
@@ -18,37 +18,6 @@ pub use {
     error::{IoErrorWithPartialEq, QuicError},
     solana_tls_utils::QuicClientCertificate,
 };
-
-pub(crate) fn create_client_config2(stake_identity: &Option<StakeIdentity>) -> ClientConfig {
-    let client_certificate = match stake_identity {
-        Some(identity) => &identity.as_certificate(),
-        None => &QuicClientCertificate::new(None),
-    };
-    let mut crypto = tls_client_config_builder()
-        .with_client_auth_cert(
-            vec![client_certificate.certificate.clone()],
-            client_certificate.key.clone_key(),
-        )
-        .expect("Failed to set QUIC client certificates");
-    crypto.enable_early_data = true;
-    crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
-
-    let transport_config = {
-        let mut res = TransportConfig::default();
-
-        let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
-        res.max_idle_timeout(Some(timeout));
-        res.keep_alive_interval(Some(QUIC_KEEP_ALIVE));
-        res.send_fairness(QUIC_SEND_FAIRNESS);
-
-        res
-    };
-
-    let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(crypto).unwrap()));
-    config.transport_config(Arc::new(transport_config));
-
-    config
-}
 
 pub(crate) fn create_client_config(client_certificate: &QuicClientCertificate) -> ClientConfig {
     let mut crypto = tls_client_config_builder()

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -163,12 +163,12 @@ impl WorkersCache {
                 "Failed to deliver transaction batch for leader {}, drop batch.",
                 peer.ip()
             );
-            workers.pop(peer).map(|current_worker| {
+            if let Some(current_worker) = workers.pop(peer) {
                 shutdown_worker(ShutdownWorker {
                     leader: *peer,
                     worker: current_worker,
                 })
-            });
+            }
         }
 
         send_res
@@ -199,12 +199,12 @@ impl WorkersCache {
             let send_res = current_worker.send_transactions(txs_batch).await;
             if let Err(WorkersCacheError::ReceiverDropped) = send_res {
                 // Remove the worker from the cache, if the peer has disconnected.
-                workers.pop(peer).map(|current_worker| {
+                if let Some(current_worker) = workers.pop(peer) {
                     shutdown_worker(ShutdownWorker {
                         leader: *peer,
                         worker: current_worker,
                     })
-                });
+                }
             }
 
             send_res

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -103,11 +103,8 @@ impl WorkersCache {
 
     /// Checks if the worker for a given peer exists and it hasn't been
     /// cancelled.
-    pub fn contains_and_valid(&self, peer: &SocketAddr) -> bool {
-        self.workers
-            .peek(peer)
-            .map(|worker| !worker.cancel.is_cancelled())
-            .unwrap_or(false)
+    pub fn contains(&self, peer: &SocketAddr) -> bool {
+        self.workers.contains(peer)
     }
 
     pub(crate) fn push(

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -10,7 +10,7 @@ use {
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::TrySendError},
-        task::JoinHandle,
+        task::{JoinHandle, JoinSet},
     },
     tokio_util::sync::CancellationToken,
 };
@@ -20,7 +20,6 @@ use {
 pub struct WorkerInfo {
     sender: mpsc::Sender<TransactionBatch>,
     handle: JoinHandle<()>,
-    generation: u64,
     cancel: CancellationToken,
 }
 
@@ -28,13 +27,11 @@ impl WorkerInfo {
     pub fn new(
         sender: mpsc::Sender<TransactionBatch>,
         handle: JoinHandle<()>,
-        generation: u64,
         cancel: CancellationToken,
     ) -> Self {
         Self {
             sender,
             handle,
-            generation,
             cancel,
         }
     }
@@ -106,10 +103,10 @@ impl WorkersCache {
 
     /// Checks if the worker for a given peer exists and it hasn't been
     /// cancelled.
-    pub fn contains_and_valid(&self, peer: &SocketAddr, generation: u64) -> bool {
+    pub fn contains_and_valid(&self, peer: &SocketAddr) -> bool {
         self.workers
             .peek(peer)
-            .map(|worker| !worker.cancel.is_cancelled() && worker.generation == generation)
+            .map(|worker| !worker.cancel.is_cancelled())
             .unwrap_or(false)
     }
 
@@ -218,17 +215,37 @@ impl WorkersCache {
             .unwrap_or(Err(WorkersCacheError::ShutdownError))
     }
 
+    /// Flushes the cache and asynchronously shuts down all workers. This method
+    /// doesn't wait for the completion of all the shutdown tasks.
+    pub(crate) fn flush(&mut self) {
+        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+            maybe_shutdown_worker(Some(ShutdownWorker {
+                leader: peer,
+                worker: current_worker,
+            }));
+        }
+    }
+
     /// Closes and removes all workers in the cache. This is typically done when
     /// shutting down the system.
+    ///
+    /// The method awaits the completion of all shutdown tasks, ensuring that
+    /// each worker is properly terminated.
     pub(crate) async fn shutdown(&mut self) {
         // Interrupt any outstanding `send_transactions()` calls.
         self.cancel.cancel();
 
-        while let Some((leader, worker)) = self.workers.pop_lru() {
-            //TODO(klykov): why not doing it using maybe_shutdown_worker?
-            let res = worker.shutdown().await;
+        let mut tasks = JoinSet::new();
+        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+            let shutdown_worker = ShutdownWorker {
+                leader: peer,
+                worker: current_worker,
+            };
+            tasks.spawn(shutdown_worker.shutdown());
+        }
+        while let Some(res) = tasks.join_next().await {
             if let Err(err) = res {
-                debug!("Error while shutting down worker for {leader}: {err}");
+                debug!("A shutdown task failed: {}", err);
             }
         }
     }

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -670,11 +670,11 @@ async fn test_rate_limiting_establish_connection() {
     server_handle.await.unwrap();
 }
 
-// Check that certificate is updated successfully using corresponding channel.
+// Check that identity is updated successfully using corresponding channel.
 //
-// Since the certificate update and the transactions are sent concurrently to their channels
+// Since the identity update and the transactions are sent concurrently to their channels
 // and scheduler selects randomly which channel to handle first, we cannot
-// guarantee in this test that the certificate has been updated before we start
+// guarantee in this test that the identity has been updated before we start
 // sending transactions. Hence, instead of checking that all the transactions
 // have been delivered, we check that at least some have been.
 #[tokio::test]
@@ -696,6 +696,7 @@ async fn test_update_identity() {
             // `max_staked_connections` and `max_unstaked_connections` are
             // cumulative for all the endpoints.
             max_staked_connections: 10,
+            // Deny all unstaked connections.
             max_unstaked_connections: 0,
             ..Default::default()
         },

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -658,3 +658,9 @@ async fn test_rate_limiting_establish_connection() {
     exit.store(true, Ordering::Relaxed);
     server_handle.await.unwrap();
 }
+
+// TODO(klykov): add test that checks that if worker is cancelled, it will not
+// receive any transactions. How to simulate: create worker which fails to
+// connect and breaks it's loop. Next send it new transaction when the server is
+// ready and check that they are received by server which would mean that a new
+// worker has been added and the old one is pop.

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -45,7 +45,7 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
     let address = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0);
     ConnectionWorkersSchedulerConfig {
         bind: BindTarget::Address(address),
-        stake_identity: stake_identity.map(Into::into),
+        stake_identity: stake_identity.map(|identity| StakeIdentity::new(&identity)),
         num_connections: 1,
         skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -63,12 +63,12 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
 }
 
 async fn setup_connection_worker_scheduler(
-    update_certificate_receiver: watch::Receiver<Option<StakeIdentity>>,
     tpu_address: SocketAddr,
     transaction_receiver: Receiver<TransactionBatch>,
     stake_identity: Option<Keypair>,
 ) -> (
     JoinHandle<Result<Arc<SendTransactionStats>, ConnectionWorkersSchedulerError>>,
+    watch::Sender<Option<StakeIdentity>>,
     CancellationToken,
 ) {
     let json_rpc_url = "http://127.0.0.1:8899";
@@ -85,16 +85,17 @@ async fn setup_connection_worker_scheduler(
         .expect("Leader updates was successfully created");
 
     let cancel = CancellationToken::new();
-    let config = test_config(stake_identity);
+    let (update_identity_sender, update_identity_receiver) = watch::channel(None);
     let scheduler = ConnectionWorkersScheduler::new(
         leader_updater,
         transaction_receiver,
-        update_certificate_receiver,
+        update_identity_receiver,
         cancel.clone(),
     );
+    let config = test_config(stake_identity);
     let scheduler = tokio::spawn(scheduler.run(config));
 
-    (scheduler, cancel)
+    (scheduler, update_identity_sender, cancel)
 }
 
 async fn join_scheduler(
@@ -206,14 +207,10 @@ async fn test_basic_transactions_sending() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(10));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, update_identity_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
+    // dropping sender will not lead to stop the scheduler.
+    drop(update_identity_sender);
 
     // Check results
     let mut received_data = Vec::with_capacity(expected_num_txs);
@@ -309,14 +306,8 @@ async fn test_connection_denied_until_allowed() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_identity_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     // Check results
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
@@ -374,14 +365,8 @@ async fn test_connection_pruned_and_reopened() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_identity_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     sleep(Duration::from_millis(400)).await;
     let _connection_to_prune_client = make_client_endpoint(&server_address, None).await;
@@ -442,14 +427,8 @@ async fn test_staked_connection() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        Some(stake_identity),
-    )
-    .await;
+    let (scheduler_handle, _update_certificate_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, Some(stake_identity)).await;
 
     // Check results
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
@@ -494,14 +473,8 @@ async fn test_connection_throttling() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(1));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_certificate_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     // Check results
     let actual_num_packets =
@@ -542,14 +515,8 @@ async fn test_no_host() {
         ..
     } = spawn_tx_sender(tx_size, max_send_attempts, Duration::from_millis(10));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, _scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_certificate_sender, _scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     // Wait for all the transactions to be sent, and some extra time for the delivery to be
     // attempted.
@@ -602,14 +569,8 @@ async fn test_rate_limiting() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(100));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_certificate_sender, scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
     assert_eq!(actual_num_packets, 0);
@@ -666,14 +627,8 @@ async fn test_rate_limiting_establish_connection() {
         ..
     } = spawn_tx_sender(tx_size, expected_num_txs, Duration::from_millis(1000));
 
-    let (_update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-    let (scheduler_handle, scheduler_cancel) = setup_connection_worker_scheduler(
-        update_certificate_receiver,
-        server_address,
-        tx_receiver,
-        None,
-    )
-    .await;
+    let (scheduler_handle, _update_certificate_sender, scheduler_cancel) =
+        setup_connection_worker_scheduler(server_address, tx_receiver, None).await;
 
     let actual_num_packets =
         count_received_packets_for(receiver, tx_size, Duration::from_secs(70)).await;
@@ -715,8 +670,72 @@ async fn test_rate_limiting_establish_connection() {
     server_handle.await.unwrap();
 }
 
-// TODO(klykov): add test that checks that if worker is cancelled, it will not
-// receive any transactions. How to simulate: create worker which fails to
-// connect and breaks it's loop. Next send it new transaction when the server is
-// ready and check that they are received by server which would mean that a new
-// worker has been added and the old one is pop.
+// Check that certificate is updated successfully using corresponding channel.
+//
+// Since the certificate update and the transactions are sent concurrently to their channels
+// and scheduler selects randomly which channel to handle first, we cannot
+// guarantee in this test that the certificate has been updated before we start
+// sending transactions. Hence, instead of checking that all the transactions
+// have been delivered, we check that at least some have been.
+#[tokio::test]
+async fn test_update_identity() {
+    let stake_identity = Keypair::new();
+    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
+
+    let SpawnTestServerResult {
+        join_handle: server_handle,
+        exit,
+        receiver,
+        server_address,
+        stats: _stats,
+    } = setup_quic_server(
+        Some(staked_nodes),
+        TestServerConfig {
+            // Must use at least the number of endpoints (10) because
+            // `max_staked_connections` and `max_unstaked_connections` are
+            // cumulative for all the endpoints.
+            max_staked_connections: 10,
+            max_unstaked_connections: 0,
+            ..Default::default()
+        },
+    );
+
+    // Setup sending txs
+    let tx_size = 1;
+    let num_txs: usize = 100;
+    let SpawnTxGenerator {
+        tx_receiver,
+        tx_sender_shutdown,
+        ..
+    } = spawn_tx_sender(tx_size, num_txs, Duration::from_millis(50));
+
+    let (scheduler_handle, update_identity_sender, scheduler_cancel) =
+        setup_connection_worker_scheduler(
+            server_address,
+            tx_receiver,
+            // Create scheduler with unstaked identity.
+            None,
+        )
+        .await;
+    // Update identity.
+    update_identity_sender
+        .send(Some(StakeIdentity::new(&stake_identity)))
+        .unwrap();
+
+    let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
+    assert!(actual_num_packets > 0);
+
+    // Stop the sender.
+    tx_sender_shutdown.await;
+
+    // And the scheduler.
+    scheduler_cancel.cancel();
+
+    let stats = join_scheduler(scheduler_handle).await;
+    assert!(stats.successfully_sent > 0);
+
+    // Exit server
+    exit.store(true, Ordering::Relaxed);
+    server_handle.await.unwrap();
+}

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -86,9 +86,13 @@ async fn setup_connection_worker_scheduler(
 
     let cancel = CancellationToken::new();
     let config = test_config(stake_identity);
-    let scheduler = ConnectionWorkersScheduler::new(leader_updater, transaction_receiver);
-    let scheduler =
-        tokio::spawn(scheduler.run(update_certificate_receiver, config, cancel.clone()));
+    let scheduler = ConnectionWorkersScheduler::new(
+        leader_updater,
+        transaction_receiver,
+        update_certificate_receiver,
+        cancel.clone(),
+    );
+    let scheduler = tokio::spawn(scheduler.run(config));
 
     (scheduler, cancel)
 }


### PR DESCRIPTION
#### Problem

Redo the way tpu-client-next updates Endpoints' certificate when triggered by `NotifyUpdate` call

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
