### PR TITLE
prevent overflow in port allocation logic for tests

### DIFF
--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -155,7 +155,7 @@ fn retransmit_to(
 #[test]
 fn gossip_ring() {
     solana_logger::setup();
-    run_gossip_topo(50, |listen| {
+    run_gossip_topo(40, |listen| {
         let num = listen.len();
         for n in 0..num {
             let y = n % listen.len();

--- a/nextest.toml
+++ b/nextest.toml
@@ -5,6 +5,9 @@ dir = "target/nextest"
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
 retries = { backoff = "fixed", count = 3, delay = "1s" }
+# Prevent nextest from using > 64 processes at once
+# setting this higher may break port allocation logic in net-utils
+max-threads = 64
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/5865 did not allow for sufficiently high number of nextest slots. CI machines have 64 cores => 64 slots and logic only worked correctly for ~59 slots causing sporadic test failures.

#### Summary of Changes

- Constraint the number of concurrent tests < 64 (in case we get threadripper CI runners)
- Fix allocation logic to not overflow with 64 slots
- Reduce number of nodes in one gossip test from 50 to 40 (so we can fit in 47  20-port slices available per test process). 

#### Fixes

Flakes like this one https://buildkite.com/anza/agave/builds/22593#01964750-dee6-49c7-8225-5a744952947f
