### PR TITLE
force x86_64-v2 cpu for linux builds (fixup for #5674)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-linux-gnu]
+# When building for linux, target the minimal supported CPU
+rustflags = ["-Ctarget-cpu=x86-64-v2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[build]
-rustflags = ["-Ctarget-cpu=x86-64-v3"]
-
 [profile.release-with-debug]
 inherits = "release"
 debug = true


### PR DESCRIPTION
#### Problem
Idea in https://github.com/anza-xyz/agave/pull/5674 was good, execution was "as usual" 

#### Summary of Changes

Actually force target CPU