### PR TITLE
Clippy: fix warning in release build of test-validator

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -29,7 +29,7 @@ use {
         blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
         create_new_tmp_ledger,
     },
-    solana_net_utils::{sockets::localhost_port_range_for_tests, PortRange},
+    solana_net_utils::PortRange,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client::{nonblocking, rpc_client::RpcClient},
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
@@ -98,7 +98,7 @@ impl Default for TestValidatorNodeConfig {
         #[cfg(not(debug_assertions))]
         let port_range = solana_net_utils::VALIDATOR_PORT_RANGE;
         #[cfg(debug_assertions)]
-        let port_range = localhost_port_range_for_tests();
+        let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
         Self {
             gossip_addr: socketaddr!(Ipv4Addr::LOCALHOST, port_range.0),
             port_range,


### PR DESCRIPTION
#### Problem

Clippy warning due to unused import of `localhost_port_range_for_tests`

#### Summary of Changes

Properly gate the import

