### PR TITLE
Use ref for SVMFeatureSet instead of an Arc

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -782,7 +782,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
             Hash::default(),
             0,
             &MockInvokeContextCallback {},
-            &$feature_set,
+            $feature_set,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
@@ -805,7 +805,7 @@ macro_rules! with_mock_invoke_context {
         $transaction_accounts:expr $(,)?
     ) => {
         use $crate::with_mock_invoke_context_with_feature_set;
-        let feature_set = solana_svm_feature_set::SVMFeatureSet::default();
+        let feature_set = &solana_svm_feature_set::SVMFeatureSet::default();
         with_mock_invoke_context_with_feature_set!(
             $invoke_context,
             $transaction_context,
@@ -829,7 +829,7 @@ pub fn mock_process_instruction_with_feature_set<
     builtin_function: BuiltinFunctionWithContext,
     mut pre_adjustments: F,
     mut post_adjustments: G,
-    feature_set: SVMFeatureSet,
+    feature_set: &SVMFeatureSet,
 ) -> Vec<AccountSharedData> {
     let mut instruction_accounts: Vec<InstructionAccount> =
         Vec::with_capacity(instruction_account_metas.len());
@@ -923,7 +923,7 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
         builtin_function,
         pre_adjustments,
         post_adjustments,
-        SVMFeatureSet::all_enabled(),
+        &SVMFeatureSet::all_enabled(),
     )
 }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -145,7 +145,7 @@ pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
     pub blockhash_lamports_per_signature: u64,
     epoch_stake_callback: &'a dyn InvokeContextCallback,
-    feature_set: Arc<SVMFeatureSet>,
+    feature_set: &'a SVMFeatureSet,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
@@ -153,7 +153,7 @@ impl<'a> EnvironmentConfig<'a> {
         blockhash: Hash,
         blockhash_lamports_per_signature: u64,
         epoch_stake_callback: &'a dyn InvokeContextCallback,
-        feature_set: Arc<SVMFeatureSet>,
+        feature_set: &'a SVMFeatureSet,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
@@ -642,15 +642,7 @@ impl<'a> InvokeContext<'a> {
 
     /// Get the current feature set.
     pub fn get_feature_set(&self) -> &SVMFeatureSet {
-        &self.environment_config.feature_set
-    }
-
-    /// Set feature set.
-    ///
-    /// Only use for tests and benchmarks.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn mock_set_feature_set(&mut self, feature_set: Arc<SVMFeatureSet>) {
-        self.environment_config.feature_set = feature_set;
+        self.environment_config.feature_set
     }
 
     pub fn is_stake_raise_minimum_delegation_to_1_sol_active(&self) -> bool {
@@ -739,17 +731,16 @@ impl<'a> InvokeContext<'a> {
 }
 
 #[macro_export]
-macro_rules! with_mock_invoke_context {
+macro_rules! with_mock_invoke_context_with_feature_set {
     (
         $invoke_context:ident,
         $transaction_context:ident,
+        $feature_set:ident,
         $transaction_accounts:expr $(,)?
     ) => {
         use {
             solana_log_collector::LogCollector,
             solana_svm_callback::InvokeContextCallback,
-            solana_svm_feature_set::SVMFeatureSet,
-            solana_type_overrides::sync::Arc,
             $crate::{
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
                 execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
@@ -791,7 +782,7 @@ macro_rules! with_mock_invoke_context {
             Hash::default(),
             0,
             &MockInvokeContextCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &$feature_set,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
@@ -806,7 +797,29 @@ macro_rules! with_mock_invoke_context {
     };
 }
 
-pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut InvokeContext)>(
+#[macro_export]
+macro_rules! with_mock_invoke_context {
+    (
+        $invoke_context:ident,
+        $transaction_context:ident,
+        $transaction_accounts:expr $(,)?
+    ) => {
+        use $crate::with_mock_invoke_context_with_feature_set;
+        let feature_set = solana_svm_feature_set::SVMFeatureSet::default();
+        with_mock_invoke_context_with_feature_set!(
+            $invoke_context,
+            $transaction_context,
+            feature_set,
+            $transaction_accounts
+        )
+    };
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn mock_process_instruction_with_feature_set<
+    F: FnMut(&mut InvokeContext),
+    G: FnMut(&mut InvokeContext),
+>(
     loader_id: &Pubkey,
     mut program_indices: Vec<IndexOfAccount>,
     instruction_data: &[u8],
@@ -816,6 +829,7 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     builtin_function: BuiltinFunctionWithContext,
     mut pre_adjustments: F,
     mut post_adjustments: G,
+    feature_set: SVMFeatureSet,
 ) -> Vec<AccountSharedData> {
     let mut instruction_accounts: Vec<InstructionAccount> =
         Vec::with_capacity(instruction_account_metas.len());
@@ -858,7 +872,12 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     } else {
         false
     };
-    with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+    with_mock_invoke_context_with_feature_set!(
+        invoke_context,
+        transaction_context,
+        feature_set,
+        transaction_accounts
+    );
     let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
     program_cache_for_tx_batch.replenish(
         *loader_id,
@@ -881,6 +900,31 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     }
     transaction_accounts.pop();
     transaction_accounts
+}
+
+pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut InvokeContext)>(
+    loader_id: &Pubkey,
+    program_indices: Vec<IndexOfAccount>,
+    instruction_data: &[u8],
+    transaction_accounts: Vec<TransactionAccount>,
+    instruction_account_metas: Vec<AccountMeta>,
+    expected_result: Result<(), InstructionError>,
+    builtin_function: BuiltinFunctionWithContext,
+    pre_adjustments: F,
+    post_adjustments: G,
+) -> Vec<AccountSharedData> {
+    mock_process_instruction_with_feature_set(
+        loader_id,
+        program_indices,
+        instruction_data,
+        transaction_accounts,
+        instruction_account_metas,
+        expected_result,
+        builtin_function,
+        pre_adjustments,
+        post_adjustments,
+        SVMFeatureSet::all_enabled(),
+    )
 }
 
 #[cfg(test)]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1808,11 +1808,13 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_instruction::{error::InstructionError, AccountMeta},
         solana_program_runtime::{
-            invoke_context::mock_process_instruction, with_mock_invoke_context,
+            invoke_context::{mock_process_instruction, mock_process_instruction_with_feature_set},
+            with_mock_invoke_context,
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_sdk_ids::sysvar,
+        solana_svm_feature_set::SVMFeatureSet,
         std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
     };
 
@@ -1927,8 +1929,11 @@ mod tests {
             |_invoke_context| {},
         );
 
+        let mut feature_set = SVMFeatureSet::all_enabled();
+        feature_set.remove_accounts_executable_flag_checks = false;
+
         // Case: Account not a program
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &loader_id,
             vec![0],
             &[],
@@ -1937,12 +1942,10 @@ mod tests {
             Err(InstructionError::IncorrectProgramId),
             Entrypoint::vm,
             |invoke_context| {
-                let mut feature_set = *invoke_context.get_feature_set();
-                feature_set.remove_accounts_executable_flag_checks = false;
-                invoke_context.mock_set_feature_set(Arc::new(feature_set));
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},
+            feature_set,
         );
         process_instruction(
             &loader_id,
@@ -2622,7 +2625,11 @@ mod tests {
         );
         *instruction_accounts.get_mut(1).unwrap() = instruction_accounts.get(2).unwrap().clone();
         let instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
-        mock_process_instruction(
+
+        let mut feature_set = SVMFeatureSet::all_enabled();
+        feature_set.remove_accounts_executable_flag_checks = false;
+
+        mock_process_instruction_with_feature_set(
             &bpf_loader_upgradeable::id(),
             Vec::new(),
             &instruction_data,
@@ -2631,12 +2638,10 @@ mod tests {
             Err(InstructionError::AccountNotExecutable),
             Entrypoint::vm,
             |invoke_context| {
-                let mut feature_set = *invoke_context.get_feature_set();
-                feature_set.remove_accounts_executable_flag_checks = false;
-                invoke_context.mock_set_feature_set(Arc::new(feature_set));
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},
+            feature_set,
         );
         process_instruction(
             transaction_accounts.clone(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1945,7 +1945,7 @@ mod tests {
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},
-            feature_set,
+            &feature_set,
         );
         process_instruction(
             &loader_id,
@@ -2641,7 +2641,7 @@ mod tests {
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},
-            feature_set,
+            &feature_set,
         );
         process_instruction(
             transaction_accounts.clone(),

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1634,7 +1634,7 @@ mod tests {
         solana_clock::Epoch,
         solana_instruction::Instruction,
         solana_program_runtime::{
-            invoke_context::SerializedAccountMetadata, with_mock_invoke_context,
+            invoke_context::SerializedAccountMetadata, with_mock_invoke_context_with_feature_set,
         },
         solana_sbpf::{
             ebpf::MM_INPUT_START, memory_region::MemoryRegion, program::SBPFVersion, vm::Config,
@@ -1675,10 +1675,14 @@ mod tests {
                 .into_iter()
                 .map(|a| (a.0, a.1))
                 .collect::<Vec<TransactionAccount>>();
-            with_mock_invoke_context!($invoke_context, $transaction_context, transaction_accounts);
             let mut feature_set = SVMFeatureSet::all_enabled();
             feature_set.bpf_account_data_direct_mapping = false;
-            $invoke_context.mock_set_feature_set(Arc::new(feature_set));
+            with_mock_invoke_context_with_feature_set!(
+                $invoke_context,
+                $transaction_context,
+                feature_set,
+                transaction_accounts
+            );
             $invoke_context
                 .transaction_context
                 .get_next_instruction_context()

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1677,6 +1677,7 @@ mod tests {
                 .collect::<Vec<TransactionAccount>>();
             let mut feature_set = SVMFeatureSet::all_enabled();
             feature_set.bpf_account_data_direct_mapping = false;
+            let feature_set = &feature_set;
             with_mock_invoke_context_with_feature_set!(
                 $invoke_context,
                 $transaction_context,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4900,11 +4900,12 @@ mod tests {
         compute_budget.compute_unit_limit = expected_cus;
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+        let feature_set = SVMFeatureSet::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::<SVMFeatureSet>::default(),
+            &feature_set,
             &sysvar_cache,
         );
 
@@ -4961,11 +4962,12 @@ mod tests {
         compute_budget.compute_unit_limit = expected_cus;
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+        let feature_set = SVMFeatureSet::default();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::<SVMFeatureSet>::default(),
+            &feature_set,
             &sysvar_cache,
         );
 

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -134,7 +134,7 @@ impl TestSetup {
             stake_instruction::Entrypoint::vm,
             |_invoke_context| {},
             |_invoke_context| {},
-            self.feature_set.runtime_features(),
+            &self.feature_set.runtime_features(),
         );
         // update stake account
         self.transaction_accounts[0] = (self.stake_address, accounts[0].clone());
@@ -174,7 +174,7 @@ impl TestSetup {
             stake_instruction::Entrypoint::vm,
             |_invoke_context| {},
             |_invoke_context| {},
-            self.feature_set.runtime_features(),
+            &self.feature_set.runtime_features(),
         );
         self.stake_account = accounts[0].clone();
         self.stake_account.set_lamports(ACCOUNT_BALANCE * 2);
@@ -192,7 +192,7 @@ impl TestSetup {
             stake_instruction::Entrypoint::vm,
             |_invoke_context| {},
             |_invoke_context| {},
-            self.feature_set.runtime_features(),
+            &self.feature_set.runtime_features(),
         );
     }
 }

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -5,7 +5,7 @@ use {
     solana_account::{create_account_shared_data_for_test, AccountSharedData, WritableAccount},
     solana_clock::{Clock, Epoch},
     solana_instruction::AccountMeta,
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::mock_process_instruction_with_feature_set,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::sysvar::{clock, rent, stake_history},
@@ -124,7 +124,7 @@ impl TestSetup {
             (withdraw_authority_address, AccountSharedData::default()),
         ];
 
-        let accounts = mock_process_instruction(
+        let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             &instruction.data,
@@ -132,10 +132,9 @@ impl TestSetup {
             instruction.accounts.clone(),
             Ok(()),
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::new(self.feature_set.runtime_features()));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            self.feature_set.runtime_features(),
         );
         // update stake account
         self.transaction_accounts[0] = (self.stake_address, accounts[0].clone());
@@ -165,7 +164,7 @@ impl TestSetup {
             ),
         ];
 
-        let accounts = mock_process_instruction(
+        let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             &instruction.data,
@@ -173,10 +172,9 @@ impl TestSetup {
             instruction.accounts.clone(),
             Ok(()),
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::new(self.feature_set.runtime_features()));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            self.feature_set.runtime_features(),
         );
         self.stake_account = accounts[0].clone();
         self.stake_account.set_lamports(ACCOUNT_BALANCE * 2);
@@ -184,7 +182,7 @@ impl TestSetup {
     }
 
     fn run(&self, instruction_data: &[u8]) {
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
             Vec::new(),
             instruction_data,
@@ -192,10 +190,9 @@ impl TestSetup {
             self.instruction_accounts.clone(),
             Ok(()), //expected_result,
             stake_instruction::Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::new(self.feature_set.runtime_features()));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            self.feature_set.runtime_features(),
         );
     }
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -385,7 +385,7 @@ mod tests {
         solana_epoch_rewards::EpochRewards,
         solana_epoch_schedule::EpochSchedule,
         solana_instruction::{AccountMeta, Instruction},
-        solana_program_runtime::invoke_context::mock_process_instruction,
+        solana_program_runtime::invoke_context::mock_process_instruction_with_feature_set,
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_sdk_ids::{
@@ -458,7 +458,7 @@ mod tests {
         instruction_accounts: Vec<AccountMeta>,
         expected_result: Result<(), InstructionError>,
     ) -> Vec<AccountSharedData> {
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &id(),
             Vec::new(),
             instruction_data,
@@ -466,10 +466,9 @@ mod tests {
             instruction_accounts,
             expected_result,
             Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::new(feature_set.runtime_features()))
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            feature_set.runtime_features(),
         )
     }
 
@@ -6973,7 +6972,7 @@ mod tests {
             is_writable: true,
         }];
 
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &id(),
             Vec::new(),
             &instruction_data,
@@ -6981,9 +6980,7 @@ mod tests {
             instruction_accounts,
             Ok(()),
             Entrypoint::vm,
-            |invoke_context| {
-                invoke_context.mock_set_feature_set(Arc::new(feature_set.runtime_features()));
-            },
+            |_invoke_context| {},
             |invoke_context| {
                 let expected_minimum_delegation = crate::get_minimum_delegation(
                     invoke_context.is_stake_raise_minimum_delegation_to_1_sol_active(),
@@ -6993,6 +6990,7 @@ mod tests {
                     invoke_context.transaction_context.get_return_data().1;
                 assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
             },
+            feature_set.runtime_features(),
         );
     }
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -468,7 +468,7 @@ mod tests {
             Entrypoint::vm,
             |_invoke_context| {},
             |_invoke_context| {},
-            feature_set.runtime_features(),
+            &feature_set.runtime_features(),
         )
     }
 
@@ -6990,7 +6990,7 @@ mod tests {
                     invoke_context.transaction_context.get_return_data().1;
                 assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
             },
-            feature_set.runtime_features(),
+            &feature_set.runtime_features(),
         );
     }
 

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -8,7 +8,9 @@ use {
     solana_clock::{Clock, Slot},
     solana_hash::Hash,
     solana_instruction::AccountMeta,
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::{
+        mock_process_instruction, mock_process_instruction_with_feature_set,
+    },
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{SlotHashes, MAX_ENTRIES},
@@ -20,7 +22,6 @@ use {
             MAX_LOCKOUT_HISTORY,
         },
     },
-    std::sync::Arc,
     test::Bencher,
 };
 
@@ -101,8 +102,10 @@ fn bench_process_deprecated_vote_instruction(
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {
+    let mut deprecated_feature_set = FeatureSet::all_enabled();
+    deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
     bencher.iter(|| {
-        mock_process_instruction(
+        mock_process_instruction_with_feature_set(
             &solana_vote_program::id(),
             Vec::new(),
             &instruction_data,
@@ -110,13 +113,9 @@ fn bench_process_deprecated_vote_instruction(
             instruction_account_metas.clone(),
             Ok(()),
             solana_vote_program::vote_processor::Entrypoint::vm,
-            |invoke_context| {
-                let mut deprecated_feature_set = FeatureSet::all_enabled();
-                deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
-                invoke_context
-                    .mock_set_feature_set(Arc::new(deprecated_feature_set.runtime_features()));
-            },
             |_invoke_context| {},
+            |_invoke_context| {},
+            deprecated_feature_set.runtime_features(),
         );
     });
 }

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -115,7 +115,7 @@ fn bench_process_deprecated_vote_instruction(
             solana_vote_program::vote_processor::Entrypoint::vm,
             |_invoke_context| {},
             |_invoke_context| {},
-            deprecated_feature_set.runtime_features(),
+            &deprecated_feature_set.runtime_features(),
         );
     });
 }

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -7,7 +7,9 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta},
-    solana_program_runtime::invoke_context::mock_process_instruction,
+    solana_program_runtime::invoke_context::{
+        mock_process_instruction, mock_process_instruction_with_feature_set,
+    },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk::sysvar,
@@ -23,7 +25,6 @@ use {
             VoteStateUpdate, VoteStateVersions, MAX_LOCKOUT_HISTORY,
         },
     },
-    std::sync::Arc,
 };
 
 fn create_default_rent_account() -> AccountSharedData {
@@ -176,7 +177,9 @@ fn process_deprecated_instruction(
     instruction_accounts: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
 ) -> Vec<AccountSharedData> {
-    mock_process_instruction(
+    let mut deprecated_feature_set = FeatureSet::all_enabled();
+    deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
+    mock_process_instruction_with_feature_set(
         &id(),
         Vec::new(),
         instruction_data,
@@ -184,13 +187,9 @@ fn process_deprecated_instruction(
         instruction_accounts,
         expected_result,
         Entrypoint::vm,
-        |invoke_context| {
-            let mut deprecated_feature_set = FeatureSet::all_enabled();
-            deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
-            invoke_context
-                .mock_set_feature_set(Arc::new(deprecated_feature_set.runtime_features()));
-        },
         |_invoke_context| {},
+        |_invoke_context| {},
+        deprecated_feature_set.runtime_features(),
     )
 }
 

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -189,7 +189,7 @@ fn process_deprecated_instruction(
         Entrypoint::vm,
         |_invoke_context| {},
         |_invoke_context| {},
-        deprecated_feature_set.runtime_features(),
+        &deprecated_feature_set.runtime_features(),
     )
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3437,7 +3437,7 @@ impl Bank {
             blockhash,
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
-            feature_set: Arc::new(self.feature_set.runtime_features()),
+            feature_set: self.feature_set.runtime_features(),
             rent_collector: Some(&rent_collector_with_metrics),
         };
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -23,10 +23,7 @@ use {
     solana_svm_callback::InvokeContextCallback,
     solana_transaction_context::TransactionContext,
     source_buffer::SourceBuffer,
-    std::{
-        cmp::Ordering,
-        sync::{atomic::Ordering::Relaxed, Arc},
-    },
+    std::{cmp::Ordering, sync::atomic::Ordering::Relaxed},
     target_builtin::TargetBuiltin,
     target_core_bpf::TargetCoreBpf,
 };
@@ -164,7 +161,7 @@ impl Bank {
 
             struct MockCallback {}
             impl InvokeContextCallback for MockCallback {}
-
+            let feature_set = self.feature_set.runtime_features();
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
                 &mut program_cache_for_tx_batch,
@@ -172,7 +169,7 @@ impl Bank {
                     Hash::default(),
                     0,
                     &MockCallback {},
-                    Arc::new(self.feature_set.runtime_features()),
+                    &feature_set,
                     &sysvar_cache,
                 ),
                 None,

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -544,7 +544,7 @@ impl JsonRpcRequestProcessor {
             blockhash,
             blockhash_lamports_per_signature: lamports_per_signature,
             epoch_total_stake: 0,
-            feature_set: Arc::new(bank.feature_set.runtime_features()),
+            feature_set: bank.feature_set.runtime_features(),
             rent_collector: None,
         };
 

--- a/svm/examples/paytube/src/lib.rs
+++ b/svm/examples/paytube/src/lib.rs
@@ -149,7 +149,7 @@ impl PayTubeChannel {
             blockhash: Hash::default(),
             blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
             epoch_total_stake: 0,
-            feature_set: Arc::new(feature_set),
+            feature_set,
             rent_collector: Some(&rent_collector),
         };
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -237,11 +237,12 @@ mod tests {
             ]),
         ));
         let sysvar_cache = SysvarCache::default();
+        let feature_set = SVMFeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -295,7 +296,7 @@ mod tests {
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -339,7 +340,7 @@ mod tests {
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -470,11 +471,12 @@ mod tests {
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
         let sysvar_cache = SysvarCache::default();
+        let feature_set = SVMFeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -513,7 +515,7 @@ mod tests {
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -549,7 +551,7 @@ mod tests {
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -670,12 +672,12 @@ mod tests {
                 }
             }
         }
-
+        let feature_set = SVMFeatureSet::all_enabled();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
-            Arc::new(SVMFeatureSet::all_enabled()),
+            &feature_set,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -129,7 +129,7 @@ pub struct TransactionProcessingEnvironment<'a> {
     /// The total stake for the current epoch.
     pub epoch_total_stake: u64,
     /// Runtime feature set to use for the transaction batch.
-    pub feature_set: Arc<SVMFeatureSet>,
+    pub feature_set: SVMFeatureSet,
     /// Rent collector to use for the transaction batch.
     pub rent_collector: Option<&'a dyn SVMRentCollector>,
 }
@@ -373,7 +373,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut account_loader = AccountLoader::new_with_account_cache_capacity(
             config.account_overrides,
             callbacks,
-            environment.feature_set.clone(),
+            &environment.feature_set,
             account_keys_in_batch,
         );
 
@@ -551,7 +551,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let fee_payer_loaded_rent_epoch = loaded_fee_payer.account.rent_epoch();
         loaded_fee_payer.rent_collected = collect_rent_from_account(
-            &account_loader.feature_set,
+            account_loader.feature_set,
             rent_collector,
             fee_payer_address,
             &mut loaded_fee_payer.account,
@@ -852,7 +852,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 environment.blockhash,
                 environment.blockhash_lamports_per_signature,
                 callback,
-                Arc::clone(&environment.feature_set),
+                &environment.feature_set,
                 sysvar_cache,
             ),
             log_collector.clone(),
@@ -1118,6 +1118,7 @@ mod tests {
         #[allow(clippy::type_complexity)]
         inspected_accounts:
             Arc<RwLock<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>>,
+        feature_set: SVMFeatureSet,
     }
 
     impl InvokeContextCallback for MockBankCallback {}
@@ -1195,7 +1196,7 @@ mod tests {
             AccountLoader::new_with_account_cache_capacity(
                 None,
                 callbacks,
-                Arc::<SVMFeatureSet>::default(),
+                &callbacks.feature_set,
                 0,
             )
         }

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -357,7 +357,7 @@ fn execute_fixture_as_instr(
         blockhash,
         lamports_per_signature,
         mock_bank,
-        mock_bank.feature_set.clone(),
+        &mock_bank.feature_set,
         sysvar_cache,
     );
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -115,7 +115,7 @@ impl SvmTestEnvironment<'_> {
 
         let processing_environment = TransactionProcessingEnvironment {
             blockhash: LAST_BLOCKHASH,
-            feature_set: Arc::new(feature_set.runtime_features()),
+            feature_set: feature_set.runtime_features(),
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
             ..TransactionProcessingEnvironment::default()
         };

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -60,7 +60,7 @@ impl ForkGraph for MockForkGraph {
 
 #[derive(Default, Clone)]
 pub struct MockBankCallback {
-    pub feature_set: Arc<SVMFeatureSet>,
+    pub feature_set: SVMFeatureSet,
     pub account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
     #[allow(clippy::type_complexity)]
     pub inspected_accounts:
@@ -129,7 +129,7 @@ impl MockBankCallback {
 
     #[allow(unused)]
     pub fn override_feature_set(&mut self, new_set: SVMFeatureSet) {
-        self.feature_set = Arc::new(new_set)
+        self.feature_set = new_set
     }
 
     pub fn configure_sysvars(&self) {


### PR DESCRIPTION
#### Problem
SVM's `EnvironmentConfig` and `InvokeContext` currently store `Arc<SVMFeatureSet>`. This can be simplified by use of a reference.

#### Summary of Changes

- Use reference of SVMFeatureSet
- Update test macros such that feature-set is not updated after invoke context is already initialized, as feature-set is not mutable for a given instance of `TransactionBatchProcessor` and `InvokeContext`. This test change was necessary to replace `Arc` with the ref.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
