### PR TITLE
ci: add more selection rules for filtering Cargo.lock

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -165,13 +165,13 @@ scripts/cargo-for-all-lock-files.sh tree >/dev/null
   mapfile -t lines <filtered-cargo-lock-patch
   i=0
   total=${#lines[@]}
-  while [ $i -lt $total ]; do
+  while [ "$i" -lt "$total" ]; do
     line="${lines[$i]}"
     ((i++))
 
     # filter out orphaned dependency lines
     if [[ "$line" =~ ^@@.*dependencies ]]; then
-      if [ $i -lt $total ]; then
+      if [ "$i" -lt "$total" ]; then
         next_line="${lines[$i]}"
         if [[ "$next_line" =~ ^[+-] ]]; then
           echo "$line" >>"$tmp_file"

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -146,11 +146,43 @@ done
 # Update cargo lock files
 scripts/cargo-for-all-lock-files.sh tree >/dev/null
 
-# Only apply related changes
+# Filter out unrelated changes
+# some other dependencies might change after the tree command (like hashbrown)
+# the workaround is to filter out unrelated changes then apply the patch
 (
   shopt -s globstar
   git diff --unified=0 ./**/Cargo.lock >cargo-lock-patch
-  grep -E '^(diff|index|---|\+\+\+|@@.*@@ name = .*|-version|\+version)' cargo-lock-patch >filtered-cargo-lock-patch
+  grep -E '^(diff|index|---|\+\+\+|@@.*@@ name = .*|-version|\+version|@@.*@@ dependencies.*|- "agave-|\+ "agave-|- "solana-|\+ "solana-)' cargo-lock-patch >filtered-cargo-lock-patch
+
+  # there might some orphaned dependency lines in the filtered file
+  # this is a workaround to filter them out
+  # 1. read the filtered file into an array
+  # 2. iterate over the array
+  # 3. if the line is a dependency line, check the next line to see if it's an orphaned dependency line
+  #     a. if it is, add the current line to the file
+  #     b. if it's not, don't add the current line to the file
+  tmp_file=$(mktemp)
+  mapfile -t lines <filtered-cargo-lock-patch
+  i=0
+  total=${#lines[@]}
+  while [ $i -lt $total ]; do
+    line="${lines[$i]}"
+    ((i++))
+
+    # filter out orphaned dependency lines
+    if [[ "$line" =~ ^@@.*dependencies ]]; then
+      if [ $i -lt $total ]; then
+        next_line="${lines[$i]}"
+        if [[ "$next_line" =~ ^[+-] ]]; then
+          echo "$line" >>"$tmp_file"
+        fi
+      fi
+    else
+      echo "$line" >>"$tmp_file"
+    fi
+  done
+  mv "$tmp_file" filtered-cargo-lock-patch
+
   git checkout ./**/Cargo.lock
   git apply --unidiff-zero filtered-cargo-lock-patch
   rm cargo-lock-patch filtered-cargo-lock-patch


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/910937142182682656/1363189347557310584

we have a filter in `./scripts/increment-cargo-version.sh` that is used to filter Cargo.lock because some dependencies might be bumped during the increment process. since solana-sdk is using a different version of solana-transaction-context, our Cargo.lock patch becomes complicated.

#### Summary of Changes

pick these lines into filtered cargo lock patch

- `@@.*@@ dependencies`
- `- "agave-`
- `+ "agave-`
- `- "solana-`
- `+ "solana-`

then remove the orphaned `@@.*@@ dependencies` lines to ensure the cargo lock diff doesn't break.