### PR TITLE
Refactor - Enable resizing in `TransactionAccounts`

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -395,10 +395,7 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?;
                 // The redundant check helps to avoid the expensive data comparison if we can
-                match borrowed_account
-                    .can_data_be_resized(data.len())
-                    .and_then(|_| borrowed_account.can_data_be_changed())
-                {
+                match borrowed_account.can_data_be_resized(data.len()) {
                     Ok(()) => borrowed_account.set_data_from_slice(data)?,
                     Err(err) if borrowed_account.get_data() != data => return Err(err),
                     _ => {}
@@ -562,10 +559,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
                 let data = buffer
                     .get(start..start + post_len)
                     .ok_or(InstructionError::InvalidArgument)?;
-                match borrowed_account
-                    .can_data_be_resized(post_len)
-                    .and_then(|_| borrowed_account.can_data_be_changed())
-                {
+                match borrowed_account.can_data_be_resized(post_len) {
                     Ok(()) => borrowed_account.set_data_from_slice(data)?,
                     Err(err) if borrowed_account.get_data() != data => return Err(err),
                     _ => {}
@@ -578,10 +572,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
                 let data = buffer
                     .get(start..start + MAX_PERMITTED_DATA_INCREASE)
                     .ok_or(InstructionError::InvalidArgument)?;
-                match borrowed_account
-                    .can_data_be_resized(post_len)
-                    .and_then(|_| borrowed_account.can_data_be_changed())
-                {
+                match borrowed_account.can_data_be_resized(post_len) {
                     Ok(()) => {
                         borrowed_account.set_data_length(post_len)?;
                         let allocated_bytes = post_len.saturating_sub(pre_len);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -186,7 +186,6 @@ pub fn invoke_builtin_function(
                 if borrowed_account
                     .can_data_be_resized(account_info.data_len())
                     .is_ok()
-                    && borrowed_account.can_data_be_changed().is_ok()
                 {
                     borrowed_account.set_data_from_slice(&account_info.data.borrow())?;
                 }
@@ -307,10 +306,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             }
             let account_info_data = account_info.try_borrow_data().unwrap();
             // The redundant check helps to avoid the expensive data comparison if we can
-            match borrowed_account
-                .can_data_be_resized(account_info_data.len())
-                .and_then(|_| borrowed_account.can_data_be_changed())
-            {
+            match borrowed_account.can_data_be_resized(account_info_data.len()) {
                 Ok(()) => borrowed_account
                     .set_data_from_slice(&account_info_data)
                     .unwrap(),

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1189,10 +1189,7 @@ fn update_callee_account(
     if direct_mapping {
         let prev_len = callee_account.get_data().len();
         let post_len = *caller_account.ref_to_len_in_vm.get(memory_mapping)? as usize;
-        match callee_account
-            .can_data_be_resized(post_len)
-            .and_then(|_| callee_account.can_data_be_changed())
-        {
+        match callee_account.can_data_be_resized(post_len) {
             Ok(()) => {
                 let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
                 // bpf_loader_deprecated programs don't have a realloc region
@@ -1227,10 +1224,7 @@ fn update_callee_account(
         }
     } else {
         // The redundant check helps to avoid the expensive data comparison if we can
-        match callee_account
-            .can_data_be_resized(caller_account.serialized_data.len())
-            .and_then(|_| callee_account.can_data_be_changed())
-        {
+        match callee_account.can_data_be_resized(caller_account.serialized_data.len()) {
             Ok(()) => callee_account.set_data_from_slice(caller_account.serialized_data)?,
             Err(err) if callee_account.get_data() != caller_account.serialized_data => {
                 return Err(Box::new(err));

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -962,7 +962,6 @@ impl BorrowedAccount<'_> {
     ))]
     pub fn set_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;
-        self.can_data_be_changed()?;
         self.touch()?;
 
         self.update_accounts_resize_delta(data.len())?;
@@ -977,7 +976,6 @@ impl BorrowedAccount<'_> {
     #[cfg(not(target_os = "solana"))]
     pub fn set_data_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;
-        self.can_data_be_changed()?;
         self.touch()?;
         self.update_accounts_resize_delta(data.len())?;
         // Note that we intentionally don't call self.make_data_mut() here.  make_data_mut() will
@@ -995,7 +993,6 @@ impl BorrowedAccount<'_> {
     #[cfg(not(target_os = "solana"))]
     pub fn set_data_length(&mut self, new_length: usize) -> Result<(), InstructionError> {
         self.can_data_be_resized(new_length)?;
-        self.can_data_be_changed()?;
         // don't touch the account if the length does not change
         if self.get_data().len() == new_length {
             return Ok(());
@@ -1011,7 +1008,6 @@ impl BorrowedAccount<'_> {
     pub fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         let new_len = self.get_data().len().saturating_add(data.len());
         self.can_data_be_resized(new_len)?;
-        self.can_data_be_changed()?;
 
         if data.is_empty() {
             return Ok(());
@@ -1223,7 +1219,8 @@ impl BorrowedAccount<'_> {
         }
         self.transaction_context
             .accounts
-            .can_data_be_resized(old_len, new_len)
+            .can_data_be_resized(old_len, new_len)?;
+        self.can_data_be_changed()
     }
 
     #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Problem
The account data write access handler can currently not change an accounts data length.

#### Summary of Changes

So this shuffles code around to make account resizing available to the global `TransactionContext` and `TransactionAccounts`, not just the `InstructionContext` and `BorrowedAccount`.

- Removes `TransactionAccounts::touched_count()` and `TransactionAccounts::into_accounts()`.
- Moves `TransactionContext::accounts_resize_delta` into `TransactionAccounts::resize_delta`.
- Adds `TransactionAccounts::update_accounts_resize_delta()` and `TransactionAccounts::can_data_be_resized()`.
- Makes `BorrowedAccount::can_data_be_resized()` imply `BorrowedAccount::can_data_be_changed()`.