### PR TITLE
agave-validator: add args tests for run (part 2)

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1768,14 +1768,16 @@ mod tests {
             let logfile = format!("agave-validator-{}.log", identity.pubkey());
             let cuda = false;
             let init_complete_file = None;
-            let no_genesis_fetch = false;
-            let no_snapshot_fetch = false;
             let entrypoints = vec![];
-            let check_vote_account = None;
             let known_validators = None;
             let repair_validators = None;
             let gossip_validators = None;
             let repair_whitelist = None;
+
+            // rpc bootstrap config
+            let no_genesis_fetch = false;
+            let no_snapshot_fetch = false;
+            let check_vote_account = None;
             let only_known_rpc = false;
             let no_incremental_snapshots = false;
             let max_genesis_archive_unpacked_size =
@@ -1808,14 +1810,14 @@ mod tests {
                 logfile: self.logfile.clone(),
                 cuda: self.cuda,
                 init_complete_file: self.init_complete_file.clone(),
-                no_genesis_fetch: self.no_genesis_fetch,
-                no_snapshot_fetch: self.no_snapshot_fetch,
                 entrypoints: self.entrypoints.clone(),
-                check_vote_account: self.check_vote_account.clone(),
                 known_validators: self.known_validators.clone(),
                 repair_validators: self.repair_validators.clone(),
                 gossip_validators: self.gossip_validators.clone(),
                 repair_whitelist: self.repair_whitelist.clone(),
+                no_genesis_fetch: self.no_genesis_fetch,
+                no_snapshot_fetch: self.no_snapshot_fetch,
+                check_vote_account: self.check_vote_account.clone(),
                 only_known_rpc: self.only_known_rpc,
                 no_incremental_snapshots: self.no_incremental_snapshots,
                 max_genesis_archive_unpacked_size: self.max_genesis_archive_unpacked_size,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -35,6 +35,7 @@ const INCLUDE_KEY: &str = "account-index-include-key";
 pub struct RunArgs {
     pub identity: Keypair,
     pub logfile: String,
+    pub cuda: bool,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -49,7 +50,13 @@ impl FromClapArgMatches for RunArgs {
             .map(|s| s.into())
             .unwrap_or_else(|| format!("agave-validator-{}.log", identity.pubkey()));
 
-        Ok(RunArgs { identity, logfile })
+        let cuda = matches.is_present("cuda");
+
+        Ok(RunArgs {
+            identity,
+            logfile,
+            cuda,
+        })
     }
 }
 
@@ -1677,8 +1684,13 @@ mod tests {
         fn default() -> Self {
             let identity = Keypair::new();
             let logfile = format!("agave-validator-{}.log", identity.pubkey());
+            let cuda = false;
 
-            RunArgs { identity, logfile }
+            RunArgs {
+                identity,
+                logfile,
+                cuda,
+            }
         }
     }
 
@@ -1687,6 +1699,7 @@ mod tests {
             RunArgs {
                 identity: self.identity.insecure_clone(),
                 logfile: self.logfile.clone(),
+                cuda: self.cuda,
             }
         }
     }
@@ -1799,5 +1812,15 @@ mod tests {
             default_run_args,
             expected_args,
         );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_cuda_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            cuda: true,
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(vec!["--cuda"], default_run_args, expected_args);
     }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -37,6 +37,9 @@ pub struct RunArgs {
     pub logfile: String,
     pub cuda: bool,
     pub init_complete_file: Option<PathBuf>,
+
+    // rpc bootstrap config
+    pub no_genesis_fetch: bool,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -55,11 +58,14 @@ impl FromClapArgMatches for RunArgs {
 
         let init_complete_file = value_t!(matches, "init_complete_file", PathBuf).ok();
 
+        let no_genesis_fetch = matches.is_present("no_genesis_fetch");
+
         Ok(RunArgs {
             identity,
             logfile,
             cuda,
             init_complete_file,
+            no_genesis_fetch,
         })
     }
 }
@@ -1690,12 +1696,14 @@ mod tests {
             let logfile = format!("agave-validator-{}.log", identity.pubkey());
             let cuda = false;
             let init_complete_file = None;
+            let no_genesis_fetch = false;
 
             RunArgs {
                 identity,
                 logfile,
                 cuda,
                 init_complete_file,
+                no_genesis_fetch,
             }
         }
     }
@@ -1707,6 +1715,7 @@ mod tests {
                 logfile: self.logfile.clone(),
                 cuda: self.cuda,
                 init_complete_file: self.init_complete_file.clone(),
+                no_genesis_fetch: self.no_genesis_fetch,
             }
         }
     }
@@ -1840,6 +1849,20 @@ mod tests {
         };
         test_run_command_with_identity_setup(
             vec!["--init-complete-file", "init_complete"],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_genesis_fetch_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            no_genesis_fetch: true,
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec!["--no-genesis-fetch"],
             default_run_args,
             expected_args,
         );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -40,6 +40,7 @@ pub struct RunArgs {
 
     // rpc bootstrap config
     pub no_genesis_fetch: bool,
+    pub no_snapshot_fetch: bool,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -59,6 +60,7 @@ impl FromClapArgMatches for RunArgs {
         let init_complete_file = value_t!(matches, "init_complete_file", PathBuf).ok();
 
         let no_genesis_fetch = matches.is_present("no_genesis_fetch");
+        let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
 
         Ok(RunArgs {
             identity,
@@ -66,6 +68,7 @@ impl FromClapArgMatches for RunArgs {
             cuda,
             init_complete_file,
             no_genesis_fetch,
+            no_snapshot_fetch,
         })
     }
 }
@@ -1697,6 +1700,7 @@ mod tests {
             let cuda = false;
             let init_complete_file = None;
             let no_genesis_fetch = false;
+            let no_snapshot_fetch = false;
 
             RunArgs {
                 identity,
@@ -1704,6 +1708,7 @@ mod tests {
                 cuda,
                 init_complete_file,
                 no_genesis_fetch,
+                no_snapshot_fetch,
             }
         }
     }
@@ -1716,6 +1721,7 @@ mod tests {
                 cuda: self.cuda,
                 init_complete_file: self.init_complete_file.clone(),
                 no_genesis_fetch: self.no_genesis_fetch,
+                no_snapshot_fetch: self.no_snapshot_fetch,
             }
         }
     }
@@ -1863,6 +1869,20 @@ mod tests {
         };
         test_run_command_with_identity_setup(
             vec!["--no-genesis-fetch"],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_snapshot_fetch_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            no_snapshot_fetch: true,
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec!["--no-snapshot-fetch"],
             default_run_args,
             expected_args,
         );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -3,7 +3,7 @@ use {
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
     },
-    clap::{value_t, App, Arg, ArgMatches},
+    clap::{value_t, values_t, App, Arg, ArgMatches},
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::keypair_of,
@@ -25,7 +25,7 @@ use {
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_unified_scheduler_pool::DefaultSchedulerPool,
-    std::{path::PathBuf, str::FromStr},
+    std::{collections::HashSet, net::SocketAddr, path::PathBuf, str::FromStr},
 };
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
@@ -37,6 +37,7 @@ pub struct RunArgs {
     pub logfile: String,
     pub cuda: bool,
     pub init_complete_file: Option<PathBuf>,
+    pub entrypoints: Vec<SocketAddr>,
 
     // rpc bootstrap config
     pub no_genesis_fetch: bool,
@@ -62,11 +63,24 @@ impl FromClapArgMatches for RunArgs {
         let no_genesis_fetch = matches.is_present("no_genesis_fetch");
         let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
 
+        let entrypoints = values_t!(matches, "entrypoint", String).unwrap_or_default();
+        let mut parsed_entrypoints = HashSet::new();
+        for entrypoint in entrypoints {
+            let parsed = solana_net_utils::parse_host_port(&entrypoint).map_err(|err| {
+                Box::<dyn std::error::Error>::from(format!(
+                    "failed to parse entrypoint address: {err}"
+                ))
+            })?;
+            parsed_entrypoints.insert(parsed);
+        }
+        let entrypoints = parsed_entrypoints.into_iter().collect();
+
         Ok(RunArgs {
             identity,
             logfile,
             cuda,
             init_complete_file,
+            entrypoints,
             no_genesis_fetch,
             no_snapshot_fetch,
         })
@@ -1691,7 +1705,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        std::net::{IpAddr, Ipv4Addr},
+    };
 
     impl Default for RunArgs {
         fn default() -> Self {
@@ -1701,6 +1718,7 @@ mod tests {
             let init_complete_file = None;
             let no_genesis_fetch = false;
             let no_snapshot_fetch = false;
+            let entrypoints = vec![];
 
             RunArgs {
                 identity,
@@ -1709,6 +1727,7 @@ mod tests {
                 init_complete_file,
                 no_genesis_fetch,
                 no_snapshot_fetch,
+                entrypoints,
             }
         }
     }
@@ -1722,6 +1741,7 @@ mod tests {
                 init_complete_file: self.init_complete_file.clone(),
                 no_genesis_fetch: self.no_genesis_fetch,
                 no_snapshot_fetch: self.no_snapshot_fetch,
+                entrypoints: self.entrypoints.clone(),
             }
         }
     }
@@ -1797,7 +1817,11 @@ mod tests {
 
         let args = [&["--identity", file.to_str().unwrap()], &args[..]].concat();
         let matches = get_run_command_matches(&default_args, args);
-        let args = RunArgs::from_clap_arg_match(&matches).unwrap();
+        let mut args = RunArgs::from_clap_arg_match(&matches).unwrap();
+
+        // clap doesn't ensure elements order, sort them
+        args.entrypoints.sort();
+
         assert_eq!(args, expected_args);
     }
 
@@ -1883,6 +1907,67 @@ mod tests {
         };
         test_run_command_with_identity_setup(
             vec!["--no-snapshot-fetch"],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_entrypoint_long_arg_single_address() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            entrypoints: vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                8000,
+            )],
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec!["--entrypoint", "127.0.0.1:8000"],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_entrypoint_long_arg_multiple_addresses() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            entrypoints: vec![
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8001),
+            ],
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec![
+                "--entrypoint",
+                "127.0.0.1:8000",
+                "--entrypoint",
+                "127.0.0.1:8001",
+            ],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_entrypoint_long_arg_duplicate_address() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            entrypoints: vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                8000,
+            )],
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec![
+                "--entrypoint",
+                "127.0.0.1:8000",
+                "--entrypoint",
+                "127.0.0.1:8000",
+            ],
             default_run_args,
             expected_args,
         );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -51,6 +51,7 @@ pub struct RunArgs {
     pub no_snapshot_fetch: bool,
     pub check_vote_account: Option<String>,
     pub only_known_rpc: bool,
+    pub no_incremental_snapshots: bool,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -106,6 +107,8 @@ impl FromClapArgMatches for RunArgs {
 
         let only_known_rpc = matches.is_present("only_known_rpc");
 
+        let no_incremental_snapshots = matches.is_present("no_incremental_snapshots");
+
         Ok(RunArgs {
             identity,
             logfile,
@@ -120,6 +123,7 @@ impl FromClapArgMatches for RunArgs {
             gossip_validators,
             repair_whitelist,
             only_known_rpc,
+            no_incremental_snapshots,
         })
     }
 }
@@ -1762,6 +1766,7 @@ mod tests {
             let gossip_validators = None;
             let repair_whitelist = None;
             let only_known_rpc = false;
+            let no_incremental_snapshots = false;
 
             RunArgs {
                 identity,
@@ -1777,6 +1782,7 @@ mod tests {
                 gossip_validators,
                 repair_whitelist,
                 only_known_rpc,
+                no_incremental_snapshots,
             }
         }
     }
@@ -1797,6 +1803,7 @@ mod tests {
                 gossip_validators: self.gossip_validators.clone(),
                 repair_whitelist: self.repair_whitelist.clone(),
                 only_known_rpc: self.only_known_rpc,
+                no_incremental_snapshots: self.no_incremental_snapshots,
             }
         }
     }
@@ -2317,6 +2324,20 @@ mod tests {
                 &known_validators_pubkey.to_string(),
                 "--only-known-rpc",
             ],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_incremental_snapshot_fetch_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            no_incremental_snapshots: true,
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec!["--no-incremental-snapshots"],
             default_run_args,
             expected_args,
         );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -42,6 +42,7 @@ pub struct RunArgs {
     // rpc bootstrap config
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
+    pub check_vote_account: Option<String>,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -75,6 +76,10 @@ impl FromClapArgMatches for RunArgs {
         }
         let entrypoints = parsed_entrypoints.into_iter().collect();
 
+        let check_vote_account = matches
+            .value_of("check_vote_account")
+            .map(|url| url.to_string());
+
         Ok(RunArgs {
             identity,
             logfile,
@@ -83,6 +88,7 @@ impl FromClapArgMatches for RunArgs {
             entrypoints,
             no_genesis_fetch,
             no_snapshot_fetch,
+            check_vote_account,
         })
     }
 }
@@ -1719,6 +1725,7 @@ mod tests {
             let no_genesis_fetch = false;
             let no_snapshot_fetch = false;
             let entrypoints = vec![];
+            let check_vote_account = None;
 
             RunArgs {
                 identity,
@@ -1728,6 +1735,7 @@ mod tests {
                 no_genesis_fetch,
                 no_snapshot_fetch,
                 entrypoints,
+                check_vote_account,
             }
         }
     }
@@ -1742,6 +1750,7 @@ mod tests {
                 no_genesis_fetch: self.no_genesis_fetch,
                 no_snapshot_fetch: self.no_snapshot_fetch,
                 entrypoints: self.entrypoints.clone(),
+                check_vote_account: self.check_vote_account.clone(),
             }
         }
     }
@@ -1967,6 +1976,30 @@ mod tests {
                 "127.0.0.1:8000",
                 "--entrypoint",
                 "127.0.0.1:8000",
+            ],
+            default_run_args,
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_check_vote_account_long_arg() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            entrypoints: vec![SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                8000,
+            )],
+            check_vote_account: Some("https://api.mainnet-beta.solana.com".to_string()),
+            ..default_run_args.clone()
+        };
+        test_run_command_with_identity_setup(
+            vec![
+                // entrypoint is required for check-vote-account
+                "--entrypoint",
+                "127.0.0.1:8000",
+                "--check-vote-account",
+                "https://api.mainnet-beta.solana.com",
             ],
             default_run_args,
             expected_args,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -165,9 +165,7 @@ pub fn execute(
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: run_args.no_genesis_fetch,
         no_snapshot_fetch: run_args.no_snapshot_fetch,
-        check_vote_account: matches
-            .value_of("check_vote_account")
-            .map(|url| url.to_string()),
+        check_vote_account: run_args.check_vote_account,
         only_known_rpc: matches.is_present("only_known_rpc"),
         max_genesis_archive_unpacked_size: value_t_or_exit!(
             matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -160,7 +160,7 @@ pub fn execute(
         .staked_map_id,
     ));
 
-    let init_complete_file = matches.value_of("init_complete_file");
+    let init_complete_file = run_args.init_complete_file;
 
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: matches.is_present("no_genesis_fetch"),
@@ -1314,7 +1314,8 @@ pub fn execute(
     }?;
 
     if let Some(filename) = init_complete_file {
-        File::create(filename).map_err(|err| format!("unable to create {filename}: {err}"))?;
+        File::create(&filename)
+            .map_err(|err| format!("unable to create {}: {err}", filename.display()))?;
     }
     info!("Validator initialized");
     validator.join();

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -331,16 +331,7 @@ pub fn execute(
     } else {
         AccountShrinkThreshold::IndividualStore { shrink_ratio }
     };
-    let entrypoint_addrs = values_t!(matches, "entrypoint", String)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|entrypoint| {
-            solana_net_utils::parse_host_port(&entrypoint)
-                .map_err(|err| format!("failed to parse entrypoint address: {err}"))
-        })
-        .collect::<Result<HashSet<_>, _>>()?
-        .into_iter()
-        .collect::<Vec<_>>();
+    let entrypoint_addrs = run_args.entrypoints;
     for addr in &entrypoint_addrs {
         if !socket_addr_space.check(addr) {
             Err(format!("invalid entrypoint address: {addr}"))?;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -129,7 +129,7 @@ pub fn execute(
     info!("{} {}", crate_name!(), solana_version);
     info!("Starting validator with: {:#?}", std::env::args_os());
 
-    let cuda = matches.is_present("cuda");
+    let cuda = run_args.cuda;
     if cuda {
         solana_perf::perf_libs::init_cuda();
         enable_recycler_warming();

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -167,11 +167,7 @@ pub fn execute(
         no_snapshot_fetch: run_args.no_snapshot_fetch,
         check_vote_account: run_args.check_vote_account,
         only_known_rpc: run_args.only_known_rpc,
-        max_genesis_archive_unpacked_size: value_t_or_exit!(
-            matches,
-            "max_genesis_archive_unpacked_size",
-            u64
-        ),
+        max_genesis_archive_unpacked_size: run_args.max_genesis_archive_unpacked_size,
         incremental_snapshot_fetch: !run_args.no_incremental_snapshots,
     };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -164,7 +164,7 @@ pub fn execute(
 
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: run_args.no_genesis_fetch,
-        no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
+        no_snapshot_fetch: run_args.no_snapshot_fetch,
         check_vote_account: matches
             .value_of("check_vote_account")
             .map(|url| url.to_string()),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -163,7 +163,7 @@ pub fn execute(
     let init_complete_file = run_args.init_complete_file;
 
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
-        no_genesis_fetch: matches.is_present("no_genesis_fetch"),
+        no_genesis_fetch: run_args.no_genesis_fetch,
         no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
         check_vote_account: matches
             .value_of("check_vote_account")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -166,7 +166,7 @@ pub fn execute(
         no_genesis_fetch: run_args.no_genesis_fetch,
         no_snapshot_fetch: run_args.no_snapshot_fetch,
         check_vote_account: run_args.check_vote_account,
-        only_known_rpc: matches.is_present("only_known_rpc"),
+        only_known_rpc: run_args.only_known_rpc,
         max_genesis_archive_unpacked_size: value_t_or_exit!(
             matches,
             "max_genesis_archive_unpacked_size",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -172,7 +172,7 @@ pub fn execute(
             "max_genesis_archive_unpacked_size",
             u64
         ),
-        incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
+        incremental_snapshot_fetch: !run_args.no_incremental_snapshots,
     };
 
     let private_rpc = matches.is_present("private_rpc");


### PR DESCRIPTION
### Problem

https://github.com/anza-xyz/agave/issues/4082

### Summary of Changes

#### cuda

nothing to highlight

#### init-complete-file

convert to `Option<PathBuf>`

#### no-genesis-fetch

nothing to highlight

#### no-snapshot-fetch

nothing to highlight

#### entrypoint(s)

slightly refactor the parsing logic and move it out of the execute func

#### check-vote-account

nothing to highlight

#### known-validator, repair-validator, gossip-validator, repair-whitelist

(move them together since they share the same patterns and validation function)

I extracted the arg parsing logic out of the verification function. also added tests for the verification function

#### only-known-rpc

nothing to highlight

#### no-incremental-snapshots

nothing to highlight

#### max-genesis-archive-unpacked-size

replace `value_t_or_exit!` with `value_t!` + Box error