### PR TITLE
Adds tiered storage impl for scan_accounts()

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -625,7 +625,7 @@ impl HotStorageReader {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
-    pub(crate) fn scan_accounts(
+    pub(crate) fn scan_accounts_stored_meta(
         &self,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> TieredStorageResult<()> {
@@ -1646,7 +1646,7 @@ mod tests {
         // verify everything
         let mut i = 0;
         hot_storage
-            .scan_accounts(|stored_meta| {
+            .scan_accounts_stored_meta(|stored_meta| {
                 storable_accounts.account_default_if_zero_lamport(i, |account| {
                     verify_test_account(
                         &stored_meta,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -625,6 +625,20 @@ impl HotStorageReader {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
+    pub fn scan_accounts(
+        &self,
+        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>),
+    ) -> TieredStorageResult<()> {
+        for i in 0..self.footer.account_entry_count {
+            self.get_stored_account_callback(IndexOffset(i), &mut callback)?;
+        }
+        Ok(())
+    }
+
+    /// Iterate over all accounts and call `callback` with each account.
+    ///
+    /// Prefer scan_accounts() when possible, as it does not contain file format
+    /// implementation details, and thus potentially can read less and be faster.
     pub(crate) fn scan_accounts_stored_meta(
         &self,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -639,6 +639,7 @@ impl HotStorageReader {
     ///
     /// Prefer scan_accounts() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
+    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn scan_accounts_stored_meta(
         &self,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -213,7 +213,7 @@ impl TieredStorageReader {
         callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> TieredStorageResult<()> {
         match self {
-            Self::Hot(hot) => hot.scan_accounts(callback),
+            Self::Hot(hot) => hot.scan_accounts_stored_meta(callback),
         }
     }
 

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -189,19 +189,11 @@ impl TieredStorageReader {
     /// as it can potentially read less and be faster.
     pub fn scan_accounts(
         &self,
-        mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>),
+        callback: impl for<'local> FnMut(StoredAccountInfo<'local>),
     ) -> TieredStorageResult<()> {
-        self.scan_accounts_stored_meta(|stored_account_meta| {
-            let account = StoredAccountInfo {
-                pubkey: stored_account_meta.pubkey(),
-                lamports: stored_account_meta.lamports(),
-                owner: stored_account_meta.owner(),
-                data: stored_account_meta.data(),
-                executable: stored_account_meta.executable(),
-                rent_epoch: stored_account_meta.rent_epoch(),
-            };
-            callback(account);
-        })
+        match self {
+            Self::Hot(hot) => hot.scan_accounts(callback),
+        }
     }
 
     /// Iterate over all accounts and call `callback` with each account.

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -200,6 +200,7 @@ impl TieredStorageReader {
     ///
     /// Prefer scan_accounts() when possible, as it does not contain file format
     /// implementation details, and thus potentially can read less and be faster.
+    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn scan_accounts_stored_meta(
         &self,
         callback: impl for<'local> FnMut(StoredAccountMeta<'local>),


### PR DESCRIPTION
#### Problem

StoredAccountMeta should not be used outside of where AppendVec internals are needed.  Currently, Tiered Storage has methods that use/return StoredAccountMeta, even though it doesn't really fit in the TS impl.


#### Summary of Changes

- renames hot::scan_accounts to scan_accounts_stored_meta
- adds tiered storage impl for scan_accounts()
- marks scan_accounts_stored_meta() as dcou