### PR TITLE
deprecate discover_cluster which automatically uses shred_version 0

### DIFF
--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -164,6 +164,27 @@ pub fn discover_cluster(
     Ok(validators)
 }
 
+pub fn discover_cluster_with_shred_version(
+    entrypoint: &SocketAddr,
+    num_nodes: usize,
+    my_shred_version: u16,
+    socket_addr_space: SocketAddrSpace,
+) -> std::io::Result<Vec<ContactInfo>> {
+    const DISCOVER_CLUSTER_TIMEOUT: Duration = Duration::from_secs(120);
+    let (_all_peers, validators) = discover(
+        None, // keypair
+        Some(entrypoint),
+        Some(num_nodes),
+        DISCOVER_CLUSTER_TIMEOUT,
+        None,             // find_nodes_by_pubkey
+        None,             // find_node_by_gossip_addr
+        None,             // my_gossip_addr
+        my_shred_version, // my_shred_version
+        socket_addr_space,
+    )?;
+    Ok(validators)
+}
+
 pub fn discover(
     keypair: Option<Keypair>,
     entrypoint: Option<&SocketAddr>,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -143,7 +143,7 @@ impl GossipService {
 }
 
 /// Discover Validators in a cluster
-#[deprecated(since = "3.0.0", note = "use `discover` instead")]
+#[deprecated(since = "3.0.0", note = "use `discover_validators` instead")]
 pub fn discover_cluster(
     entrypoint: &SocketAddr,
     num_nodes: usize,
@@ -164,7 +164,7 @@ pub fn discover_cluster(
     Ok(validators)
 }
 
-pub fn discover_cluster_with_shred_version(
+pub fn discover_validators(
     entrypoint: &SocketAddr,
     num_nodes: usize,
     my_shred_version: u16,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -149,19 +149,7 @@ pub fn discover_cluster(
     num_nodes: usize,
     socket_addr_space: SocketAddrSpace,
 ) -> std::io::Result<Vec<ContactInfo>> {
-    const DISCOVER_CLUSTER_TIMEOUT: Duration = Duration::from_secs(120);
-    let (_all_peers, validators) = discover(
-        None, // keypair
-        Some(entrypoint),
-        Some(num_nodes),
-        DISCOVER_CLUSTER_TIMEOUT,
-        None, // find_nodes_by_pubkey
-        None, // find_node_by_gossip_addr
-        None, // my_gossip_addr
-        0,    // my_shred_version
-        socket_addr_space,
-    )?;
-    Ok(validators)
+    discover_validators(entrypoint, num_nodes, 0, socket_addr_space)
 }
 
 pub fn discover_validators(

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -143,6 +143,7 @@ impl GossipService {
 }
 
 /// Discover Validators in a cluster
+#[deprecated(since = "3.0.0", note = "use `discover` instead")]
 pub fn discover_cluster(
     entrypoint: &SocketAddr,
     num_nodes: usize,

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -16,7 +16,7 @@ use {
         crds_data::{self, CrdsData},
         crds_value::{CrdsValue, CrdsValueLabel},
         gossip_error::GossipError,
-        gossip_service::{self, discover_cluster, GossipService},
+        gossip_service::{self, discover, GossipService},
     },
     solana_ledger::blockstore::Blockstore,
     solana_rpc_client::rpc_client::RpcClient,
@@ -67,9 +67,15 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
     socket_addr_space: SocketAddrSpace,
     connection_cache: &Arc<ConnectionCache>,
 ) {
-    let cluster_nodes = discover_cluster(
-        &entry_point_info.gossip().unwrap(),
-        nodes,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&entry_point_info.gossip().unwrap()),
+        Some(nodes),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         socket_addr_space,
     )
     .unwrap();
@@ -234,9 +240,15 @@ pub fn kill_entry_and_spend_and_verify_rest(
     info!("kill_entry_and_spend_and_verify_rest...");
 
     // Ensure all nodes have spun up and are funded.
-    let cluster_nodes = discover_cluster(
-        &entry_point_info.gossip().unwrap(),
-        nodes,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&entry_point_info.gossip().unwrap()),
+        Some(nodes),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         socket_addr_space,
     )
     .unwrap();

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -16,7 +16,7 @@ use {
         crds_data::{self, CrdsData},
         crds_value::{CrdsValue, CrdsValueLabel},
         gossip_error::GossipError,
-        gossip_service::{self, discover, GossipService},
+        gossip_service::{self, discover_cluster_with_shred_version, GossipService},
     },
     solana_ledger::blockstore::Blockstore,
     solana_rpc_client::rpc_client::RpcClient,
@@ -67,14 +67,9 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
     socket_addr_space: SocketAddrSpace,
     connection_cache: &Arc<ConnectionCache>,
 ) {
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&entry_point_info.gossip().unwrap()),
-        Some(nodes),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &entry_point_info.gossip().unwrap(),
+        nodes,
         0, /* shred_version */
         socket_addr_space,
     )
@@ -240,14 +235,9 @@ pub fn kill_entry_and_spend_and_verify_rest(
     info!("kill_entry_and_spend_and_verify_rest...");
 
     // Ensure all nodes have spun up and are funded.
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&entry_point_info.gossip().unwrap()),
-        Some(nodes),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &entry_point_info.gossip().unwrap(),
+        nodes,
         0, /* shred_version */
         socket_addr_space,
     )

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -16,7 +16,7 @@ use {
         crds_data::{self, CrdsData},
         crds_value::{CrdsValue, CrdsValueLabel},
         gossip_error::GossipError,
-        gossip_service::{self, discover_cluster_with_shred_version, GossipService},
+        gossip_service::{self, discover_validators, GossipService},
     },
     solana_ledger::blockstore::Blockstore,
     solana_rpc_client::rpc_client::RpcClient,
@@ -67,10 +67,10 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
     socket_addr_space: SocketAddrSpace,
     connection_cache: &Arc<ConnectionCache>,
 ) {
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &entry_point_info.gossip().unwrap(),
         nodes,
-        0, /* shred_version */
+        entry_point_info.shred_version(),
         socket_addr_space,
     )
     .unwrap();
@@ -235,10 +235,10 @@ pub fn kill_entry_and_spend_and_verify_rest(
     info!("kill_entry_and_spend_and_verify_rest...");
 
     // Ensure all nodes have spun up and are funded.
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &entry_point_info.gossip().unwrap(),
         nodes,
-        0, /* shred_version */
+        entry_point_info.shred_version(),
         socket_addr_space,
     )
     .unwrap();

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -22,7 +22,7 @@ use {
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
         validator::{is_snapshot_config_valid, ValidatorConfig},
     },
-    solana_gossip::gossip_service::discover_cluster,
+    solana_gossip::gossip_service::discover,
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{Blockstore, PurgeType},
@@ -386,9 +386,15 @@ pub fn run_cluster_partition<C>(
         &cluster.connection_cache,
     );
 
-    let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip().unwrap(),
-        num_nodes,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&cluster.entry_point_info.gossip().unwrap()),
+        Some(num_nodes),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )
     .unwrap();

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -22,7 +22,7 @@ use {
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
         validator::{is_snapshot_config_valid, ValidatorConfig},
     },
-    solana_gossip::gossip_service::discover_cluster_with_shred_version,
+    solana_gossip::gossip_service::discover_validators,
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{Blockstore, PurgeType},
@@ -386,10 +386,10 @@ pub fn run_cluster_partition<C>(
         &cluster.connection_cache,
     );
 
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &cluster.entry_point_info.gossip().unwrap(),
         num_nodes,
-        0, /* shred_version */
+        cluster.entry_point_info.shred_version(),
         SocketAddrSpace::Unspecified,
     )
     .unwrap();

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -22,7 +22,7 @@ use {
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
         validator::{is_snapshot_config_valid, ValidatorConfig},
     },
-    solana_gossip::gossip_service::discover,
+    solana_gossip::gossip_service::discover_cluster_with_shred_version,
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{Blockstore, PurgeType},
@@ -386,14 +386,9 @@ pub fn run_cluster_partition<C>(
         &cluster.connection_cache,
     );
 
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&cluster.entry_point_info.gossip().unwrap()),
-        Some(num_nodes),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &cluster.entry_point_info.gossip().unwrap(),
+        num_nodes,
         0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -16,7 +16,7 @@ use {
     solana_gossip::{
         cluster_info::Node,
         contact_info::{ContactInfo, Protocol},
-        gossip_service::{discover, discover_cluster},
+        gossip_service::discover,
     },
     solana_ledger::{create_new_tmp_ledger_with_size, shred::Shred},
     solana_net_utils::bind_to_unspecified,
@@ -616,9 +616,15 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let cluster_nodes = discover_cluster(
-            &alive_node_contact_infos[0].gossip().unwrap(),
-            alive_node_contact_infos.len(),
+        let (_, cluster_nodes) = discover(
+            None,
+            Some(&alive_node_contact_infos[0].gossip().unwrap()),
+            Some(alive_node_contact_infos.len()),
+            Duration::from_secs(120),
+            None,
+            None,
+            None,
+            0, /* shred_version */
             socket_addr_space,
         )
         .unwrap();
@@ -676,9 +682,15 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let cluster_nodes = discover_cluster(
-            &alive_node_contact_infos[0].gossip().unwrap(),
-            alive_node_contact_infos.len(),
+        let (_, cluster_nodes) = discover(
+            None,
+            Some(&alive_node_contact_infos[0].gossip().unwrap()),
+            Some(alive_node_contact_infos.len()),
+            Duration::from_secs(120),
+            None,
+            None,
+            None,
+            0, /* shred_version */
             socket_addr_space,
         )
         .unwrap();

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -16,7 +16,7 @@ use {
     solana_gossip::{
         cluster_info::Node,
         contact_info::{ContactInfo, Protocol},
-        gossip_service::discover,
+        gossip_service::{discover, discover_cluster_with_shred_version},
     },
     solana_ledger::{create_new_tmp_ledger_with_size, shred::Shred},
     solana_net_utils::bind_to_unspecified,
@@ -616,14 +616,9 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let (_, cluster_nodes) = discover(
-            None,
-            Some(&alive_node_contact_infos[0].gossip().unwrap()),
-            Some(alive_node_contact_infos.len()),
-            Duration::from_secs(120),
-            None,
-            None,
-            None,
+        let cluster_nodes = discover_cluster_with_shred_version(
+            &alive_node_contact_infos[0].gossip().unwrap(),
+            alive_node_contact_infos.len(),
             0, /* shred_version */
             socket_addr_space,
         )
@@ -682,14 +677,9 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let (_, cluster_nodes) = discover(
-            None,
-            Some(&alive_node_contact_infos[0].gossip().unwrap()),
-            Some(alive_node_contact_infos.len()),
-            Duration::from_secs(120),
-            None,
-            None,
-            None,
+        let cluster_nodes = discover_cluster_with_shred_version(
+            &alive_node_contact_infos[0].gossip().unwrap(),
+            alive_node_contact_infos.len(),
             0, /* shred_version */
             socket_addr_space,
         )

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -16,7 +16,7 @@ use {
     solana_gossip::{
         cluster_info::Node,
         contact_info::{ContactInfo, Protocol},
-        gossip_service::{discover, discover_cluster_with_shred_version},
+        gossip_service::{discover, discover_validators},
     },
     solana_ledger::{create_new_tmp_ledger_with_size, shred::Shred},
     solana_net_utils::bind_to_unspecified,
@@ -616,10 +616,10 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let cluster_nodes = discover_cluster_with_shred_version(
+        let cluster_nodes = discover_validators(
             &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
-            0, /* shred_version */
+            alive_node_contact_infos[0].shred_version(),
             socket_addr_space,
         )
         .unwrap();
@@ -677,10 +677,10 @@ impl LocalCluster {
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
         info!("{} discovering nodes", test_name);
-        let cluster_nodes = discover_cluster_with_shred_version(
+        let cluster_nodes = discover_validators(
             &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
-            0, /* shred_version */
+            alive_node_contact_infos[0].shred_version(),
             socket_addr_space,
         )
         .unwrap();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_download_utils::download_snapshot_archive,
     solana_entry::entry::create_ticks,
-    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover},
+    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover_cluster_with_shred_version},
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
@@ -337,16 +337,10 @@ fn test_forwarding() {
     };
 
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&cluster.entry_point_info.gossip().unwrap()),
-        Some(2),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
-        0, /* shred_version */
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &cluster.entry_point_info.gossip().unwrap(),
+        2,
+        0,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -427,15 +421,10 @@ fn test_mainnet_beta_cluster_type() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&cluster.entry_point_info.gossip().unwrap()),
-        Some(1),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
-        0, /* shred_version */
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &cluster.entry_point_info.gossip().unwrap(),
+        1,
+        0,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -1351,15 +1340,10 @@ fn test_snapshots_blockstore_floor() {
     let slot_floor = archive_info.slot();
 
     // Start up a new node from a snapshot
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&cluster.entry_point_info.gossip().unwrap()),
-        Some(1),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
-        0, /* shred_version */
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &cluster.entry_point_info.gossip().unwrap(),
+        1,
+        0,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -4352,15 +4336,10 @@ fn test_listener_startup() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let (_, cluster_nodes) = discover(
-        None,
-        Some(&cluster.entry_point_info.gossip().unwrap()),
-        Some(4),
-        Duration::from_secs(120),
-        None,
-        None,
-        None,
-        0, /* shred_version */
+    let cluster_nodes = discover_cluster_with_shred_version(
+        &cluster.entry_point_info.gossip().unwrap(),
+        4,
+        0,
         SocketAddrSpace::Unspecified,
     )
     .unwrap();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_download_utils::download_snapshot_archive,
     solana_entry::entry::create_ticks,
-    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover_cluster_with_shred_version},
+    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover_validators},
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
@@ -337,10 +337,10 @@ fn test_forwarding() {
     };
 
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &cluster.entry_point_info.gossip().unwrap(),
         2,
-        0,
+        cluster.entry_point_info.shred_version(),
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -421,10 +421,10 @@ fn test_mainnet_beta_cluster_type() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &cluster.entry_point_info.gossip().unwrap(),
         1,
-        0,
+        cluster.entry_point_info.shred_version(),
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -1340,10 +1340,10 @@ fn test_snapshots_blockstore_floor() {
     let slot_floor = archive_info.slot();
 
     // Start up a new node from a snapshot
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &cluster.entry_point_info.gossip().unwrap(),
         1,
-        0,
+        cluster.entry_point_info.shred_version(),
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -4336,10 +4336,10 @@ fn test_listener_startup() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let cluster_nodes = discover_cluster_with_shred_version(
+    let cluster_nodes = discover_validators(
         &cluster.entry_point_info.gossip().unwrap(),
         4,
-        0,
+        cluster.entry_point_info.shred_version(),
         SocketAddrSpace::Unspecified,
     )
     .unwrap();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_download_utils::download_snapshot_archive,
     solana_entry::entry::create_ticks,
-    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover_cluster},
+    solana_gossip::{crds_data::MAX_VOTES, gossip_service::discover},
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
@@ -338,9 +338,15 @@ fn test_forwarding() {
 
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
-    let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip().unwrap(),
-        2,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&cluster.entry_point_info.gossip().unwrap()),
+        Some(2),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -421,9 +427,15 @@ fn test_mainnet_beta_cluster_type() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip().unwrap(),
-        1,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&cluster.entry_point_info.gossip().unwrap()),
+        Some(1),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -1339,9 +1351,15 @@ fn test_snapshots_blockstore_floor() {
     let slot_floor = archive_info.slot();
 
     // Start up a new node from a snapshot
-    let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip().unwrap(),
-        1,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&cluster.entry_point_info.gossip().unwrap()),
+        Some(1),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )
     .unwrap();
@@ -4334,9 +4352,15 @@ fn test_listener_startup() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    let cluster_nodes = discover_cluster(
-        &cluster.entry_point_info.gossip().unwrap(),
-        4,
+    let (_, cluster_nodes) = discover(
+        None,
+        Some(&cluster.entry_point_info.gossip().unwrap()),
+        Some(4),
+        Duration::from_secs(120),
+        None,
+        None,
+        None,
+        0, /* shred_version */
         SocketAddrSpace::Unspecified,
     )
     .unwrap();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -22,7 +22,7 @@ use {
     solana_gossip::{
         cluster_info::{ClusterInfo, Node},
         contact_info::Protocol,
-        gossip_service::discover,
+        gossip_service::discover_cluster_with_shred_version,
         socketaddr,
     },
     solana_ledger::{
@@ -1051,18 +1051,8 @@ impl TestValidator {
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of
         // test validators concurrently...
-        discover(
-            None,
-            Some(&gossip),
-            Some(1),
-            Duration::from_secs(120),
-            None,
-            None,
-            None,
-            /* shred_version */ 0,
-            socket_addr_space,
-        )
-        .map_err(|err| format!("TestValidator startup failed: {err:?}"))?;
+        discover_cluster_with_shred_version(&gossip, 1, 0, socket_addr_space)
+            .map_err(|err| format!("TestValidator startup failed: {err:?}"))?;
 
         let test_validator = TestValidator {
             ledger_path,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -22,7 +22,6 @@ use {
     solana_gossip::{
         cluster_info::{ClusterInfo, Node},
         contact_info::Protocol,
-        gossip_service::discover_validators,
         socketaddr,
     },
     solana_ledger::{
@@ -1033,7 +1032,7 @@ impl TestValidator {
             validator_config.tower_storage = tower_storage.clone();
         }
 
-        let validator = Validator::new(
+        let validator = Some(Validator::new(
             node,
             Arc::new(validator_identity),
             &ledger_path,
@@ -1047,17 +1046,7 @@ impl TestValidator {
             socket_addr_space,
             ValidatorTpuConfig::new_for_tests(config.tpu_enable_udp),
             config.admin_rpc_service_post_init.clone(),
-        )?;
-
-        // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of
-        // test validators concurrently...
-        discover_validators(
-            &gossip,
-            1,
-            validator.cluster_info.my_shred_version(),
-            socket_addr_space,
-        )
-        .map_err(|err| format!("TestValidator startup failed: {err:?}"))?;
+        )?);
 
         let test_validator = TestValidator {
             ledger_path,
@@ -1066,7 +1055,7 @@ impl TestValidator {
             rpc_url,
             tpu,
             gossip,
-            validator: Some(validator),
+            validator,
             vote_account_address,
         };
         Ok(test_validator)

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -22,7 +22,7 @@ use {
     solana_gossip::{
         cluster_info::{ClusterInfo, Node},
         contact_info::Protocol,
-        gossip_service::discover_cluster,
+        gossip_service::discover,
         socketaddr,
     },
     solana_ledger::{
@@ -1051,8 +1051,18 @@ impl TestValidator {
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of
         // test validators concurrently...
-        discover_cluster(&gossip, 1, socket_addr_space)
-            .map_err(|err| format!("TestValidator startup failed: {err:?}"))?;
+        discover(
+            None,
+            Some(&gossip),
+            Some(1),
+            Duration::from_secs(120),
+            None,
+            None,
+            None,
+            /* shred_version */ 0,
+            socket_addr_space,
+        )
+        .map_err(|err| format!("TestValidator startup failed: {err:?}"))?;
 
         let test_validator = TestValidator {
             ledger_path,


### PR DESCRIPTION
#### Problem
we are removing the special case of shred_version == 0. `discover_cluster()` always sets shred version to 0.

#### Summary of Changes
deprecate `discover_cluster()` and replace with `discover_cluster_with_shred_version()` so people pay attention to the shred_version they are using.
