### PR TITLE
reduce vote tx batch size

### DIFF
--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -36,8 +36,10 @@ use {
     },
 };
 
-// Step-size set to be 64, equal to the maximum batch/entry size.
-pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 64;
+// This vote batch size was selected to balance the following two things:
+// 1. Amortize execution overhead (Larger is better)
+// 2. Constrain max entry size for FEC set packing (Smaller is better)
+pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 16;
 
 pub struct VoteWorker {
     decision_maker: DecisionMaker,


### PR DESCRIPTION
#### Problem
Batch size of 64 can result in large entries (64*350B = 22.4kB) for packing into erasure batches (~31kB of data). Especially with the move to fixed size FEC sets, this can result in excessive padding.

#### Summary of Changes
Reduce the maximum vote batch size from 64 to 16.

This was observed to have negligible impact on execution overhead amortization on mainnet:
![image](https://github.com/user-attachments/assets/215d6fe6-7394-4c3d-b274-082a4c806c72)
We average ~30us before (left of sample 170) and after (right of sample 170).
The spikes are only when we fail to pack a decent number of votes in the slot.
The rate of occurrence where we didn't pack many votes (<500 votes) is the same in each case (~3%)

The average number of votes packed per slot is essentially the same pre and post change:
1250 votes per slot before change, 1288 votes per slot after change