### PR TITLE
Removes StoredAccountMeta from tiered storage

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -384,20 +384,20 @@ mod tests {
         let mut max_pubkey = MIN_PUBKEY;
 
         reader
-            .scan_accounts_stored_meta(|stored_account_meta| {
-                if let Some(account) = expected_accounts_map.get(stored_account_meta.pubkey()) {
+            .scan_accounts(|stored_account| {
+                if let Some(account) = expected_accounts_map.get(stored_account.pubkey()) {
                     verify_test_account_with_footer(
-                        &stored_account_meta,
+                        &stored_account,
                         account,
-                        stored_account_meta.pubkey(),
+                        stored_account.pubkey(),
                         footer,
                     );
-                    verified_accounts.insert(*stored_account_meta.pubkey());
-                    if min_pubkey > *stored_account_meta.pubkey() {
-                        min_pubkey = *stored_account_meta.pubkey();
+                    verified_accounts.insert(*stored_account.pubkey());
+                    if min_pubkey > *stored_account.pubkey() {
+                        min_pubkey = *stored_account.pubkey();
                     }
-                    if max_pubkey < *stored_account_meta.pubkey() {
-                        max_pubkey = *stored_account_meta.pubkey();
+                    if max_pubkey < *stored_account.pubkey() {
+                        max_pubkey = *stored_account.pubkey();
                     }
                 }
             })

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use crate::account_storage::meta::StoredAccountMeta;
 use {
     crate::{
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
@@ -101,21 +99,6 @@ impl TieredStorageReader {
         }
     }
 
-    /// calls `callback` with the account located at the specified index offset.
-    ///
-    /// Prefer get_stored_account_callback() when possible, as it does not contain file format
-    /// implementation details, and thus potentially can read less and be faster.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_stored_account_meta_callback<Ret>(
-        &self,
-        index_offset: IndexOffset,
-        callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
-    ) -> TieredStorageResult<Option<Ret>> {
-        match self {
-            Self::Hot(hot) => hot.get_stored_account_meta_callback(index_offset, callback),
-        }
-    }
-
     /// Returns Ok(index_of_matching_owner) if the account owner at
     /// `account_offset` is one of the pubkeys in `owners`.
     ///
@@ -185,20 +168,6 @@ impl TieredStorageReader {
     ) -> TieredStorageResult<()> {
         match self {
             Self::Hot(hot) => hot.scan_accounts(callback),
-        }
-    }
-
-    /// Iterate over all accounts and call `callback` with each account.
-    ///
-    /// Prefer scan_accounts() when possible, as it does not contain file format
-    /// implementation details, and thus potentially can read less and be faster.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub(crate) fn scan_accounts_stored_meta(
-        &self,
-        callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
-    ) -> TieredStorageResult<()> {
-        match self {
-            Self::Hot(hot) => hot.scan_accounts_stored_meta(callback),
         }
     }
 

--- a/accounts-db/src/tiered_storage/test_utils.rs
+++ b/accounts-db/src/tiered_storage/test_utils.rs
@@ -2,12 +2,8 @@
 //! Helper functions for TieredStorage tests
 use {
     super::footer::TieredStorageFooter,
-    crate::{
-        account_storage::meta::{StoredAccountMeta, StoredMeta},
-        accounts_hash::AccountHash,
-    },
+    crate::account_storage::{meta::StoredMeta, stored_account_info::StoredAccountInfo},
     solana_account::{Account, AccountSharedData, ReadableAccount},
-    solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_rent_collector::RENT_EXEMPT_RENT_EPOCH,
 };
@@ -43,29 +39,28 @@ pub(super) fn create_test_account(seed: u64) -> (StoredMeta, AccountSharedData) 
 }
 
 pub(super) fn verify_test_account(
-    stored_meta: &StoredAccountMeta<'_>,
+    stored_account: &StoredAccountInfo<'_>,
     acc: &impl ReadableAccount,
     address: &Pubkey,
 ) {
     let (lamports, owner, data, executable) =
         (acc.lamports(), acc.owner(), acc.data(), acc.executable());
 
-    assert_eq!(stored_meta.lamports(), lamports);
-    assert_eq!(stored_meta.data().len(), data.len());
-    assert_eq!(stored_meta.data(), data);
-    assert_eq!(stored_meta.executable(), executable);
-    assert_eq!(stored_meta.owner(), owner);
-    assert_eq!(stored_meta.pubkey(), address);
-    assert_eq!(*stored_meta.hash(), AccountHash(Hash::default()));
+    assert_eq!(stored_account.lamports(), lamports);
+    assert_eq!(stored_account.data().len(), data.len());
+    assert_eq!(stored_account.data(), data);
+    assert_eq!(stored_account.executable(), executable);
+    assert_eq!(stored_account.owner(), owner);
+    assert_eq!(stored_account.pubkey(), address);
 }
 
 pub(super) fn verify_test_account_with_footer(
-    stored_meta: &StoredAccountMeta<'_>,
+    stored_account: &StoredAccountInfo<'_>,
     account: &impl ReadableAccount,
     address: &Pubkey,
     footer: &TieredStorageFooter,
 ) {
-    verify_test_account(stored_meta, account, address);
+    verify_test_account(stored_account, account, address);
     assert!(footer.min_account_address <= *address);
     assert!(footer.max_account_address >= *address);
 }


### PR DESCRIPTION
#### Problem

StoredAccountMeta should not be used outside of where AppendVec internals are needed.  Currently, Tiered Storage has methods that use/return StoredAccountMeta, even though it doesn't really fit in the TS impl.


#### Summary of Changes

Removes StoredAccountMeta from Tiered Storage.