### PR TITLE
v2.2: SBPF v0.10.1 (backport of #6229)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9459,9 +9459,9 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
+checksum = "8e6aed9fa0b4791538896be288fb5ccb2ab9f558ca0fe1ff28dfd3046fbdb5c5"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,7 +513,7 @@ solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.12" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.12" }
 solana-runtime = { path = "runtime", version = "=2.2.12" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.12" }
-solana-sbpf = "=0.10.0"
+solana-sbpf = "=0.10.1"
 solana-sdk = "2.2.2"
 solana-sdk-ids = "2.2.1"
 solana-sdk-macro = "2.2.1"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7944,9 +7944,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
+checksum = "8e6aed9fa0b4791538896be288fb5ccb2ab9f558ca0fe1ff28dfd3046fbdb5c5"
 dependencies = [
  "byteorder 1.5.0",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -63,7 +63,7 @@ solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version =
 solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.12" }
 solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.12" }
 solana-sdk = "=2.2.2"
-solana-sbpf = "=0.10.0"
+solana-sbpf = "=0.10.1"
 solana-secp256k1-recover = "=2.2.1"
 solana-svm = { path = "../../svm", version = "=2.2.12" }
 solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.12" }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7275,9 +7275,9 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3ce7a0f4d6830124ceb2c263c36d1ee39444ec70146eb49b939e557e72b96"
+checksum = "8e6aed9fa0b4791538896be288fb5ccb2ab9f558ca0fe1ff28dfd3046fbdb5c5"
 dependencies = [
  "byteorder",
  "combine 3.8.1",


### PR DESCRIPTION
SBPF VM [v0.10.1](https://github.com/anza-xyz/sbpf/releases/tag/v0.10.1) was released.