### PR TITLE
Bug fix: retry transactions on recording failure

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -370,6 +370,10 @@ impl Consumer {
                 |(index, processing_result)| processing_result.was_processed().then_some(index),
             ));
 
+            // retryable indexes are expected to be sorted - in this case the
+            // `extend` can cause that assumption to be violated.
+            retryable_transaction_indexes.sort_unstable();
+
             return ExecuteAndCommitTransactionsOutput {
                 transaction_counts,
                 retryable_transaction_indexes,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -197,7 +197,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         transactions,
                         max_ages: _,
                     },
-                retryable_indexes,
+                mut retryable_indexes,
             }) => {
                 let num_transactions = ids.len();
                 let num_retryable = retryable_indexes.len();
@@ -206,6 +206,8 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                 self.complete_batch(batch_id, &transactions);
 
                 // Retryable transactions should be inserted back into the container
+                // Need to sort because recording failures lead to out-of-order indexes
+                retryable_indexes.sort_unstable();
                 let mut retryable_iter = retryable_indexes.into_iter().peekable();
                 for (index, (id, transaction)) in izip!(ids, transactions).enumerate() {
                     if let Some(retryable_index) = retryable_iter.peek() {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -208,10 +208,10 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                 // Retryable transactions should be inserted back into the container
                 // Need to sort because recording failures lead to out-of-order indexes
                 retryable_indexes.sort_unstable();
-                let mut retryable_iter = retryable_indexes.into_iter().peekable();
+                let mut retryable_iter = retryable_indexes.iter().peekable();
                 for (index, (id, transaction)) in izip!(ids, transactions).enumerate() {
-                    if let Some(retryable_index) = retryable_iter.peek() {
-                        if *retryable_index == index {
+                    if let Some(&&retryable_index) = retryable_iter.peek() {
+                        if retryable_index == index {
                             container.retry_transaction(id, transaction);
                             retryable_iter.next();
                             continue;
@@ -219,6 +219,11 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                     }
                     container.remove_by_id(id);
                 }
+
+                debug_assert!(
+                    retryable_iter.peek().is_none(),
+                    "retryable indexes were not in order: {retryable_indexes:?}"
+                );
 
                 Ok((num_transactions, num_retryable))
             }


### PR DESCRIPTION
#### Problem
- Split out of #5911
- recording failure **appends** retryable indexes to current retryable index vector
- processing of retryable indexes assumes they are sorted

Example:
- tx errors in batch before recording: `[Ok(()), Err(BlockLimits), Ok(()), Ok(())];`
- recording failure
- `retryable_indexes = [1, 0, 2, 3]`
- only tx `1` will get retried, 0, 2, 3 all get dropped

#### Summary of Changes
- sort indexes before retrying transactions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
