### PR TITLE
Report leader blocks cost-tracker-stats to metrics w tag

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3171,7 +3171,8 @@ impl ReplayStage {
                     }
                 }
 
-                let block_id = if bank.collector_id() != my_pubkey {
+                let is_leader_block = bank.collector_id() == my_pubkey;
+                let block_id = if !is_leader_block {
                     // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK correctly retransmitted
                     // shreds in the last FEC set, mark it dead. No reason to perform this check on our leader block.
                     match blockstore.check_last_fec_set_and_get_block_id(
@@ -3230,6 +3231,7 @@ impl ReplayStage {
                 cost_update_sender
                     .send(CostUpdate::FrozenBank {
                         bank: bank.clone_without_scheduler(),
+                        is_leader_block,
                     })
                     .unwrap_or_else(|err| {
                         warn!("cost_update_sender failed sending bank stats: {:?}", err)

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -216,7 +216,7 @@ impl CostTracker {
         self.transaction_count.0
     }
 
-    pub fn report_stats(&self, bank_slot: solana_clock::Slot) {
+    pub fn report_stats(&self, bank_slot: solana_clock::Slot, is_leader: bool) {
         // skip reporting if block is empty
         if self.transaction_count.0 == 0 {
             return;
@@ -226,6 +226,7 @@ impl CostTracker {
 
         datapoint_info!(
             "cost_tracker_stats",
+            "is_leader" => is_leader.to_string(),
             ("bank_slot", bank_slot as i64, i64),
             ("block_cost", self.block_cost as i64, i64),
             ("vote_cost", self.vote_cost as i64, i64),


### PR DESCRIPTION
#### Problem

All (metrics-reporting) nodes are submitting cost-tracker stats, making query leader produced stats harder.

#### Summary of Changes
- add a `is_leader` tag to metrics to simplify query leader's cost-tracker-stats


Fixes #5756 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
