### PR TITLE
Process shred stats

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -84,7 +84,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;
+        let mut receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -84,8 +84,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let mut receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
+        let mut stats = ProcessShredsStats::default();
+        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
@@ -187,7 +187,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             self.next_code_index,
             true, // merkle_variant
             &self.reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
+            &mut stats,
         );
         if let Some(shred) = data_shreds.iter().max_by_key(|shred| shred.index()) {
             self.chained_merkle_root = shred.merkle_root().unwrap();
@@ -207,7 +207,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     self.next_code_index,
                     true, // merkle_variant
                     &self.reed_solomon_cache,
-                    &mut ProcessShredsStats::default(),
+                    &mut stats,
                 );
                 // Don't mark the last shred as last so that validators won't
                 // know that they've gotten all the shreds, and will continue
@@ -221,7 +221,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     self.next_code_index,
                     true, // merkle_variant
                     &self.reed_solomon_cache,
-                    &mut ProcessShredsStats::default(),
+                    &mut stats,
                 );
                 let sigs: Vec<_> = partition_last_data_shred
                     .iter()

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -37,7 +37,8 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
+        let receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
         let bank = receive_results.bank;
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -51,8 +51,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let mut receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
+        let mut stats = ProcessShredsStats::default();
+        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
@@ -106,7 +106,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             self.next_code_index,
             true, // merkle_variant
             &self.reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
+            &mut stats,
         );
 
         if let Some(shred) = data_shreds.iter().max_by_key(|shred| shred.index()) {
@@ -126,7 +126,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
                 self.next_code_index,
                 true, // merkle_variant
                 &self.reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
+                &mut stats,
             );
             // Don't mark the last shred as last so that validators won't know
             // that they've gotten all the shreds, and will continue trying to
@@ -140,7 +140,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
                 self.next_code_index,
                 true, // merkle_variant
                 &self.reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
+                &mut stats,
             );
             assert_eq!(good_last_data_shred.len(), 1);
             self.chained_merkle_root = good_last_data_shred.last().unwrap().merkle_root().unwrap();

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -51,7 +51,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;
+        let mut receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 


### PR DESCRIPTION
#### Problem
The current way we populate `ProcessShredsStats` is pretty clumsy and makes it difficult to expand - which is exactly what I want to do in a future PR 😄.

We essentially do the following:

1. Measure receive and coalesce timings in `fn recv_slot_entries`
2. Return these to the caller in the `ReceiveResults` struct
3. Pass `ReceiveResults` to  `fn process_receive_results`
4. Parse the receive and coalesce fields out of `ReceiveResults`
5. Potentially overwrite them to zero if the slot ended already
6. Push these into a local `ProcessShredsStats` instance
7. Accumulate the local `ProcessShredsStats` instance into a global one

#### Summary of Changes

New flow looks like:
1. Create the local `ProcessShredsStats` instance earlier
2. Pass `ProcessShredsStats` into `fn recv_slot_entries`
3. Push receive and coalesce timings into `ProcessShredsStats` instance
4. Pass `ProcessShredsStats` into `fn process_receive_results`
5. Potentially overwrite receive/coalesce fields to zero if the slot ended already
6. Accumulate the local `ProcessShredsStats` instance into a global one

Now when I want to add some metrics to `fn recv_slot_entries` in the future, I can just add them in step 3 and everything else just works.

Additionally, `time_elapsed` and `time_coalesced` have been dropped from `ReceiveResults` struct. Tests and dummy broadcasters just pass a default `ProcessShredsStats` instance