### PR TITLE
Coalesce carryover entry

### DIFF
--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -38,6 +38,7 @@ pub(super) struct BroadcastDuplicatesRun {
     config: BroadcastDuplicatesConfig,
     current_slot: Slot,
     chained_merkle_root: Hash,
+    carryover_entry: Option<WorkingBankEntry>,
     next_shred_index: u32,
     next_code_index: u32,
     shred_version: u16,
@@ -59,6 +60,7 @@ impl BroadcastDuplicatesRun {
         Self {
             config,
             chained_merkle_root: Hash::default(),
+            carryover_entry: None,
             next_shred_index: u32::MAX,
             next_code_index: 0,
             shred_version,
@@ -86,7 +88,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         // 1) Pull entries from banking stage
         let mut stats = ProcessShredsStats::default();
         let mut receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
+            broadcast_utils::recv_slot_entries(receiver, &mut self.carryover_entry, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -85,7 +85,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut stats = ProcessShredsStats::default();
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut stats)?;
+        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -85,7 +85,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut stats = ProcessShredsStats::default();
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
+        let mut receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -9,6 +9,7 @@ use {
 #[derive(Clone)]
 pub(super) struct BroadcastFakeShredsRun {
     last_blockhash: Hash,
+    carryover_entry: Option<WorkingBankEntry>,
     partition: usize,
     shred_version: u16,
     next_code_index: u32,
@@ -19,6 +20,7 @@ impl BroadcastFakeShredsRun {
     pub(super) fn new(partition: usize, shred_version: u16) -> Self {
         Self {
             last_blockhash: Hash::default(),
+            carryover_entry: None,
             partition,
             shred_version,
             next_code_index: 0,
@@ -39,7 +41,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(
             receiver,
-            &mut None,
+            &mut self.carryover_entry,
             &mut ProcessShredsStats::default(),
         )?;
         let bank = receive_results.bank;

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -37,7 +37,11 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut ProcessShredsStats::default())?;
+        let receive_results = broadcast_utils::recv_slot_entries(
+            receiver,
+            &mut None,
+            &mut ProcessShredsStats::default(),
+        )?;
         let bank = receive_results.bank;
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -37,8 +37,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut ProcessShredsStats::default())?;
+        let receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut ProcessShredsStats::default())?;
         let bank = receive_results.bank;
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -38,13 +38,18 @@ fn keep_coalescing_entries(
 
 pub(super) fn recv_slot_entries(
     receiver: &Receiver<WorkingBankEntry>,
+    carryover_entry: &mut Option<WorkingBankEntry>,
     process_stats: &mut ProcessShredsStats,
 ) -> Result<ReceiveResults> {
-    let timer = Duration::new(1, 0);
     let recv_start = Instant::now();
-    let (mut bank, (entry, mut last_tick_height)) = receiver.recv_timeout(timer)?;
-    let mut entries = vec![entry];
+
+    // If there is a carryover entry, use it. Else, see if there is a new entry.
+    let (mut bank, (entry, mut last_tick_height)) = match carryover_entry.take() {
+        Some((bank, (entry, tick_height))) => (bank, (entry, tick_height)),
+        None => receiver.recv_timeout(Duration::new(1, 0))?,
+    };
     assert!(last_tick_height <= bank.max_tick_height());
+    let mut entries = vec![entry];
 
     // Drain the channel of entries.
     while last_tick_height != bank.max_tick_height() {
@@ -90,11 +95,18 @@ pub(super) fn recv_slot_entries(
             warn!("Broadcast for slot: {} interrupted", bank.slot());
             entries.clear();
             serialized_batch_byte_count = 8; // Vec len
-            bank = try_bank;
+            bank = try_bank.clone();
             coalesce_start = Instant::now();
         }
         last_tick_height = tick_height;
+
         let entry_bytes = serialized_size(&entry)?;
+        if serialized_batch_byte_count + entry_bytes > target_serialized_batch_byte_count {
+            // This entry will push us over the batch byte limit. Save it for
+            // the next batch.
+            *carryover_entry = Some((try_bank, (entry, tick_height)));
+            break;
+        }
 
         // Add the entry to the batch.
         serialized_batch_byte_count += entry_bytes;
@@ -187,7 +199,7 @@ mod tests {
 
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut ProcessShredsStats::default()) {
+        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default()) {
             assert_eq!(result.bank.slot(), bank1.slot());
             last_tick_height = result.last_tick_height;
             res_entries.extend(result.entries);
@@ -229,7 +241,7 @@ mod tests {
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
         let mut bank_slot = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut ProcessShredsStats::default()) {
+        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default()) {
             bank_slot = result.bank.slot();
             last_tick_height = result.last_tick_height;
             res_entries = result.entries;

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -199,7 +199,8 @@ mod tests {
 
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default()) {
+        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default())
+        {
             assert_eq!(result.bank.slot(), bank1.slot());
             last_tick_height = result.last_tick_height;
             res_entries.extend(result.entries);
@@ -241,7 +242,8 @@ mod tests {
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
         let mut bank_slot = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default()) {
+        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default())
+        {
             bank_slot = result.bank.slot();
             last_tick_height = result.last_tick_height;
             res_entries = result.entries;

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -16,6 +16,7 @@ pub(super) struct FailEntryVerificationBroadcastRun {
     good_shreds: Vec<Shred>,
     current_slot: Slot,
     chained_merkle_root: Hash,
+    carryover_entry: Option<WorkingBankEntry>,
     next_shred_index: u32,
     next_code_index: u32,
     cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
@@ -33,6 +34,7 @@ impl FailEntryVerificationBroadcastRun {
             good_shreds: vec![],
             current_slot: 0,
             chained_merkle_root: Hash::default(),
+            carryover_entry: None,
             next_shred_index: 0,
             next_code_index: 0,
             cluster_nodes_cache,
@@ -53,7 +55,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         // 1) Pull entries from banking stage
         let mut stats = ProcessShredsStats::default();
         let mut receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
+            broadcast_utils::recv_slot_entries(receiver, &mut self.carryover_entry, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -51,8 +51,9 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-let mut stats = ProcessShredsStats::default();
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
+        let mut stats = ProcessShredsStats::default();
+        let mut receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -51,8 +51,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
-        let mut stats = ProcessShredsStats::default();
-        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut stats)?;
+let mut stats = ProcessShredsStats::default();
+        let mut receive_results = broadcast_utils::recv_slot_entries(receiver, &mut None, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -440,8 +440,11 @@ impl BroadcastRun for StandardBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         let mut process_stats = ProcessShredsStats::default();
-        let receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut self.carryover_entry, &mut process_stats)?;
+        let receive_results = broadcast_utils::recv_slot_entries(
+            receiver,
+            &mut self.carryover_entry,
+            &mut process_stats,
+        )?;
         // TODO: Confirm that last chunk of coding shreds
         // will not be lost or delayed for too long.
         self.process_receive_results(

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -21,6 +21,7 @@ pub struct StandardBroadcastRun {
     slot: Slot,
     parent: Slot,
     chained_merkle_root: Hash,
+    carryover_entry: Option<WorkingBankEntry>,
     next_shred_index: u32,
     next_code_index: u32,
     // If last_tick_height has reached bank.max_tick_height() for this slot
@@ -52,6 +53,7 @@ impl StandardBroadcastRun {
             slot: Slot::MAX,
             parent: Slot::MAX,
             chained_merkle_root: Hash::default(),
+            carryover_entry: None,
             next_shred_index: 0,
             next_code_index: 0,
             completed: true,
@@ -438,7 +440,8 @@ impl BroadcastRun for StandardBroadcastRun {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         let mut process_stats = ProcessShredsStats::default();
-        let receive_results = broadcast_utils::recv_slot_entries(receiver, &mut process_stats)?;
+        let receive_results =
+            broadcast_utils::recv_slot_entries(receiver, &mut self.carryover_entry, &mut process_stats)?;
         // TODO: Confirm that last chunk of coding shreds
         // will not be lost or delayed for too long.
         self.process_receive_results(


### PR DESCRIPTION
#### Problem
We currently keep popping entries until we exceed the target. It would be better to keep popping until we're about to exceed the target.

#### Summary of Changes
Check if the latest entry will push us over the target and if it will, just stash it for the next iteration.