### PR TITLE
Default account's db scan_filter to OnlyAbnormal

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -87,11 +87,11 @@ pub(crate) struct GenerateIndexResult<T: IndexValue> {
 /// which accounts `scan` should load from disk
 pub enum ScanFilter {
     /// Scan both in-memory and on-disk index
-    #[default]
     All,
 
     /// abnormal = ref_count != 1 or slot list.len() != 1
     /// Scan only in-memory index and skip on-disk index
+    #[default]
     OnlyAbnormal,
 
     /// Similar to `OnlyAbnormal but also check on-disk index to verify the


### PR DESCRIPTION
#### Problem

When performing accounts index scan, if we are only interested in "abnormal" index entries, then we can skip looking at the on-disk entries. This is because on-disk entry will always be "normal".  Here, "normal" means ref_count = 1 and slot_list.len() = 1. "abnormal" means ref_count!=1 or slot_list.len()!=1. 

Clean,ing shrinking and zero_lamport tracking, in which we are only interested in scanning "abnormal" index entries, can get the benefit from using "OnlyAbnormal" Scanfilter. 

In https://github.com/anza-xyz/agave/pull/2689, we introduced a CLI to toggle "ScanFilter" type to experiment and test this optimization. After testing and running with ScanFilter to "OnlyAbnormal" for months without issue, it is time to turn this optimization on by default. 


#### Summary of Changes

In this PR, we change the default value of ScanFilter to OnlyAbnormal.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
