### PR TITLE
Coalesce stats

### DIFF
--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -19,9 +19,16 @@ pub struct ProcessShredsStats {
     pub coding_send_elapsed: u64,
     pub get_leader_schedule_elapsed: u64,
     pub coalesce_elapsed: u64,
+    // The number of times entry coalescing exited because the maximum number of
+    // bytes was hit.
     pub coalesce_exited_hit_max: u64,
+    // The number of times entry coalescing exited because we were tightly
+    // aligned to an erasure batch boundary.
     pub coalesce_exited_tightly_packed: u64,
+    // The number of times entry coalescing exited because the slot ended.
     pub coalesce_exited_slot_ended: u64,
+    // The number of times entry coalescing exited because the maximum coalesce
+    // duration was reached.
     pub coalesce_exited_rcv_timeout: u64,
     // Histogram count of num_data_shreds obtained from serializing entries
     // counted in 5 buckets.

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -19,6 +19,10 @@ pub struct ProcessShredsStats {
     pub coding_send_elapsed: u64,
     pub get_leader_schedule_elapsed: u64,
     pub coalesce_elapsed: u64,
+    pub coalesce_exited_hit_max: u64,
+    pub coalesce_exited_tightly_packed: u64,
+    pub coalesce_exited_slot_ended: u64,
+    pub coalesce_exited_rcv_timeout: u64,
     // Histogram count of num_data_shreds obtained from serializing entries
     // counted in 5 buckets.
     num_data_shreds_hist: [usize; 5],
@@ -104,6 +108,21 @@ impl ProcessShredsStats {
             ("num_data_shreds_63", self.num_data_shreds_hist[3], i64),
             ("num_data_shreds_64", self.num_data_shreds_hist[4], i64),
             ("coalesce_elapsed", self.coalesce_elapsed, i64),
+            (
+                "coalesce_exited_tightly_packed",
+                self.coalesce_exited_tightly_packed,
+                i64
+            ),
+            (
+                "coalesce_exited_slot_ended",
+                self.coalesce_exited_slot_ended,
+                i64
+            ),
+            (
+                "coalesce_exited_rcv_timeout",
+                self.coalesce_exited_rcv_timeout,
+                i64
+            ),
         );
         *self = Self::default();
     }
@@ -178,6 +197,10 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
             coding_send_elapsed,
             get_leader_schedule_elapsed,
             coalesce_elapsed,
+            coalesce_exited_hit_max,
+            coalesce_exited_tightly_packed,
+            coalesce_exited_slot_ended,
+            coalesce_exited_rcv_timeout,
             num_data_shreds_hist,
             num_extant_slots,
             err_unknown_chained_merkle_root,
@@ -194,6 +217,10 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
         self.coding_send_elapsed += coding_send_elapsed;
         self.get_leader_schedule_elapsed += get_leader_schedule_elapsed;
         self.coalesce_elapsed += coalesce_elapsed;
+        self.coalesce_exited_hit_max += coalesce_exited_hit_max;
+        self.coalesce_exited_tightly_packed += coalesce_exited_tightly_packed;
+        self.coalesce_exited_slot_ended += coalesce_exited_slot_ended;
+        self.coalesce_exited_rcv_timeout += coalesce_exited_rcv_timeout;
         self.num_extant_slots += num_extant_slots;
         self.err_unknown_chained_merkle_root += err_unknown_chained_merkle_root;
         self.data_buffer_residual += data_buffer_residual;

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -108,6 +108,7 @@ impl ProcessShredsStats {
             ("num_data_shreds_63", self.num_data_shreds_hist[3], i64),
             ("num_data_shreds_64", self.num_data_shreds_hist[4], i64),
             ("coalesce_elapsed", self.coalesce_elapsed, i64),
+            ("coalesce_exited_hit_max", self.coalesce_exited_hit_max, i64),
             (
                 "coalesce_exited_tightly_packed",
                 self.coalesce_exited_tightly_packed,

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -29,7 +29,7 @@ fn data_shred_bytes_per_batch() -> u64 {
 }
 
 static TARGET_BATCH_BYTES_DEFAULT: OnceLock<u64> = OnceLock::new();
-pub fn get_target_batch_bytes_default() -> &'static u64 {
+fn get_target_batch_bytes_default() -> &'static u64 {
     TARGET_BATCH_BYTES_DEFAULT.get_or_init(|| {
         // Empirically discovered to be a good balance between avoiding padding and
         // not delaying broadcast.
@@ -38,10 +38,10 @@ pub fn get_target_batch_bytes_default() -> &'static u64 {
 }
 
 static TARGET_BATCH_PAD_BYTES: OnceLock<u64> = OnceLock::new();
-pub fn get_target_batch_pad_bytes() -> &'static u64 {
+fn get_target_batch_pad_bytes() -> &'static u64 {
     TARGET_BATCH_PAD_BYTES.get_or_init(|| {
         // Less than 5% padding is acceptable overhead. Let's not push our luck.
-        (data_shred_bytes_per_batch() as f32 * 0.05) as u64
+        data_shred_bytes_per_batch() / 20
     })
 }
 

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -11,7 +11,7 @@ use {
     solana_runtime::bank::Bank,
     solana_sdk::{clock::Slot, hash::Hash},
     std::{
-        sync::Arc,
+        sync::{Arc, OnceLock},
         time::{Duration, Instant},
     },
 };
@@ -28,15 +28,21 @@ fn data_shred_bytes_per_batch() -> u64 {
     *get_data_shred_bytes_per_batch_typical()
 }
 
-fn target_batch_bytes_default() -> u64 {
-    // Empirically discovered to be a good balance between avoiding padding and
-    // not delaying broadcast.
-    3 * data_shred_bytes_per_batch()
+static TARGET_BATCH_BYTES_DEFAULT: OnceLock<u64> = OnceLock::new();
+pub fn get_target_batch_bytes_default() -> &'static u64 {
+    TARGET_BATCH_BYTES_DEFAULT.get_or_init(|| {
+        // Empirically discovered to be a good balance between avoiding padding and
+        // not delaying broadcast.
+        3 * data_shred_bytes_per_batch()
+    })
 }
 
-fn target_batch_pad_bytes() -> f64 {
-    // Less than 5% padding is acceptable overhead. Let's not push our luck.
-    data_shred_bytes_per_batch() as f64 * 0.05
+static TARGET_BATCH_PAD_BYTES: OnceLock<u64> = OnceLock::new();
+pub fn get_target_batch_pad_bytes() -> &'static u64 {
+    TARGET_BATCH_PAD_BYTES.get_or_init(|| {
+        // Less than 5% padding is acceptable overhead. Let's not push our luck.
+        (data_shred_bytes_per_batch() as f64 * 0.05) as u64
+    })
 }
 
 fn keep_coalescing_entries(
@@ -57,7 +63,7 @@ fn keep_coalescing_entries(
     }
     let bytes_to_fill_erasure_batch =
         data_shred_bytes_per_batch() - (serialized_batch_byte_count % data_shred_bytes_per_batch());
-    if (bytes_to_fill_erasure_batch as f64) < target_batch_pad_bytes() {
+    if bytes_to_fill_erasure_batch < *get_target_batch_pad_bytes() {
         // We're close enough to tightly packing erasure batches. Just send it.
         process_stats.coalesce_exited_tightly_packed += 1;
         return false;
@@ -113,7 +119,7 @@ pub(super) fn recv_slot_entries(
     let next_full_batch_byte_count = serialized_batch_byte_count
         .div_ceil(data_shred_bytes_per_batch())
         .saturating_mul(data_shred_bytes_per_batch());
-    let max_batch_byte_count = next_full_batch_byte_count.max(target_batch_bytes_default());
+    let max_batch_byte_count = next_full_batch_byte_count.max(*get_target_batch_bytes_default());
 
     // Coalesce entries until one of the following conditions are hit:
     // 1. We ticked through the entire slot.

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -41,7 +41,7 @@ static TARGET_BATCH_PAD_BYTES: OnceLock<u64> = OnceLock::new();
 pub fn get_target_batch_pad_bytes() -> &'static u64 {
     TARGET_BATCH_PAD_BYTES.get_or_init(|| {
         // Less than 5% padding is acceptable overhead. Let's not push our luck.
-        (data_shred_bytes_per_batch() as f64 * 0.05) as u64
+        (data_shred_bytes_per_batch() as f32 * 0.05) as u64
     })
 }
 


### PR DESCRIPTION
#### Problem
There is limited observability into how well we are coalescing entries.

#### Summary of Changes
Add per slot stats (for leader only) to understand why we exited coalesce using 4 bucket categories:

- `coalesce_exited_hit_max` --> about to exceed max batch size
- `coalesce_exited_tightly_packed` --> tightly aligned to a multiple of batch size
- `coalesce_exited_slot_ended` --> the slot has ended
- `coalesce_exited_rcv_timeout` --> we've timed out waiting for entries to coalesce