### PR TITLE
Add ingress_filter

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -171,6 +171,7 @@ pub struct ClusterInfo {
     contact_save_interval: u64,  // milliseconds, 0 = disabled
     contact_info_path: PathBuf,
     socket_addr_space: SocketAddrSpace,
+    ingress_filter: Arc<RwLock<Arc<dyn Fn(&CrdsData) -> bool + Send + Sync + 'static>>>,
 }
 
 // Returns false if the CRDS value should be discarded.
@@ -235,9 +236,18 @@ impl ClusterInfo {
             contact_info_path: PathBuf::default(),
             contact_save_interval: 0, // disabled
             socket_addr_space,
+            ingress_filter: Arc::new(RwLock::new(Arc::new(|_: &CrdsData| true))),
         };
         me.refresh_my_gossip_contact_info();
         me
+    }
+
+    pub fn set_ingress_filter(
+        &self,
+        filter: Arc<dyn Fn(&CrdsData) -> bool + Send + Sync + 'static>,
+    ) {
+        let mut guard = self.ingress_filter.write().unwrap();
+        *guard = filter;
     }
 
     pub fn set_contact_debug_interval(&mut self, new: u64) {
@@ -1972,6 +1982,12 @@ impl ClusterInfo {
                 })
             }
         }
+
+        // Read the filter ONCE
+        let filter_lock = self.ingress_filter.read().unwrap();
+        let filter_fn = filter_lock.clone();
+        drop(filter_lock);
+
         // Check if there is a duplicate instance of
         // this node with more recent timestamp.
         let check_duplicate_instance = {
@@ -2043,7 +2059,15 @@ impl ClusterInfo {
                     if should_check_duplicate_instance {
                         check_duplicate_instance(&data)?;
                     }
-                    data.retain(&mut verify_gossip_addr);
+                    // Apply filter first, then shadowing closure (1-arg) within retain
+                    data.retain(|value| {
+                        let passes_filter = filter_fn(value.data());
+                        if !passes_filter {
+                            self.stats.ingress_filtered_count.add_relaxed(1);
+                            return false;
+                        }
+                        verify_gossip_addr(value) // Calls 1-arg shadowing closure
+                    });
                     if !data.is_empty() {
                         self.stats
                             .push_message_value_count

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -165,6 +165,7 @@ pub struct GossipStats {
     pub(crate) tvu_peers: Counter,
     pub(crate) verify_gossip_packets_time: Counter,
     pub(crate) window_request_loopback: Counter,
+    pub(crate) ingress_filtered_count: Counter,
 }
 
 impl GossipStats {
@@ -582,6 +583,11 @@ pub(crate) fn submit_gossip_stats(
         (
             "trim_crds_table_purged_values_count",
             stats.trim_crds_table_purged_values_count.clear(),
+            i64
+        ),
+        (
+            "ingress_filtered_count",
+            stats.ingress_filtered_count.clear(),
             i64
         ),
     );


### PR DESCRIPTION
#### Problem

High volume of gossip traffic can lead to unnecessary processing of irrelevant messages (e.g., votes on RPC nodes), consuming resources.

#### Summary of Changes

Introduces a configurable ingress filter (`ClusterInfo::set_ingress_filter`) applied early within `process_packets`. Initially enabled only for `PushMessage` content, this filter drops unwanted `CrdsData` *before* address verification to reduce processing load. Adds `ingress_filtered_count` metric.

Motivation details here: https://github.com/Blockdaemon/agave-snapshot-gossip-client/blob/main/docs/light-gossip-mode-proposal.md