### PR TITLE
remove max-threads as it does not do anything

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,9 +5,6 @@ dir = "target/nextest"
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
 retries = { backoff = "fixed", count = 3, delay = "1s" }
-# Prevent nextest from using > 64 processes at once
-# setting this higher may break port allocation logic in net-utils
-max-threads = 64
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
#### Problem
max-threads can not be provided as default parameters in nextest. Neither can it be provided for all tests at once. Intention was to prevent CI from using > 64 cores at once thus possibly breaking port assignment logic, but apparently nextest can not handle that for us.

#### Summary of Changes
- Remove the max-threads constraint

