### PR TITLE
bump stable rust to 1.86.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"


### PR DESCRIPTION
#### Problem

https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/

#### Summary of Changes

bump it