### PR TITLE
Optimize dashmap for reward calculation - preallocate dashmap

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -313,7 +313,8 @@ impl Bank {
         };
 
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
-        let vote_account_rewards: VoteRewards = DashMap::new();
+        let estimated_num_vote_accounts = cached_vote_accounts.len();
+        let vote_account_rewards: VoteRewards = DashMap::with_capacity(estimated_num_vote_accounts);
         let total_stake_rewards = AtomicU64::default();
         let (stake_rewards, measure_stake_rewards_us) = measure_us!(thread_pool.install(|| {
             stake_delegations


### PR DESCRIPTION
#### Problem

Split from #5853 

The default `dashmap` for storing vote rewards in reward calculation can be optimized. 

We can preallocate dashmap with the number of vote accounts to save extra allocations. 

Here we use the number of vote_accounts in the cache as the estimated capacity for the dashmap, i.e. estimated_num_vote_accounts . The `estimated_num_vote_accounts` should be the upper-bound for the dashmap. Among those vote accounts in the cache, there could be some vote accounts that don't receive any vote rewards. Those acccounts won't be inserted into the dashmap. So we may overallocate a bit. But that's not much compared to the saving of reallocation.



#### Summary of Changes

Preallocate dashmap for reward calculation


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
