### PR TITLE
Optimize dashmap for reward calculation - use ahasher

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -61,7 +61,7 @@ use {
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
-    ahash::AHashSet,
+    ahash::{AHashSet, RandomState},
     dashmap::{DashMap, DashSet},
     log::*,
     rayon::{
@@ -954,7 +954,7 @@ struct VoteReward {
     vote_rewards: u64,
 }
 
-type VoteRewards = DashMap<Pubkey, VoteReward>;
+type VoteRewards = DashMap<Pubkey, VoteReward, RandomState>;
 
 #[derive(Debug, Default)]
 pub struct NewBankOptions {
@@ -2483,9 +2483,7 @@ impl Bank {
     /// - we want this fn to have no side effects (such as actually storing vote accounts) so that we
     ///   can compare the expected results with the current code path
     /// - we want to be able to batch store the vote accounts later for improved performance/cache updating
-    fn calc_vote_accounts_to_store(
-        vote_account_rewards: DashMap<Pubkey, VoteReward>,
-    ) -> VoteRewardsAccounts {
+    fn calc_vote_accounts_to_store(vote_account_rewards: VoteRewards) -> VoteRewardsAccounts {
         let len = vote_account_rewards.len();
         let mut result = VoteRewardsAccounts {
             rewards: Vec::with_capacity(len),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -17,6 +17,7 @@ use {
         stake_account::StakeAccount,
         stakes::Stakes,
     },
+    ahash::random_state::RandomState as AHashRandomState,
     dashmap::DashMap,
     log::{debug, info},
     rayon::{
@@ -314,7 +315,10 @@ impl Bank {
 
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let estimated_num_vote_accounts = cached_vote_accounts.len();
-        let vote_account_rewards: VoteRewards = DashMap::with_capacity(estimated_num_vote_accounts);
+        let vote_account_rewards: VoteRewards = DashMap::with_capacity_and_hasher(
+            estimated_num_vote_accounts,
+            AHashRandomState::default(),
+        );
         let total_stake_rewards = AtomicU64::default();
         let (stake_rewards, measure_stake_rewards_us) = measure_us!(thread_pool.install(|| {
             stake_delegations


### PR DESCRIPTION

#### Problem

Split from https://github.com/anza-xyz/agave/pull/5853

The default `dashmap` for storing vote rewards in reward calculation can be optimized. 

We can use a cheaper `ahash`  as the hasher instead of the default hasher.



#### Summary of Changes

Use ahash for dashmap

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
