### PR TITLE
move get_gossip_port, rename it appropriately

### DIFF
--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -38,7 +38,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
     (start, start + 20)
 }
 
-pub fn get_gossip_port(
+pub fn bind_gossip_port_in_range(
     gossip_addr: &SocketAddr,
     port_range: PortRange,
     bind_ip_addr: IpAddr,


### PR DESCRIPTION
#### Problem
cluster_info is too big, moving functions away from it
split-off from https://github.com/anza-xyz/agave/pull/5832

#### Summary of Changes

- move get_gossip_port to net_utils