### PR TITLE
fixed fec

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -52,7 +52,7 @@
 #[cfg(test)]
 pub(crate) use self::shred_code::MAX_CODE_SHREDS_PER_SLOT;
 pub(crate) use self::{
-    merkle_tree::{PROOF_NUM_ENTRIES_TYPICAL, SIZE_OF_MERKLE_ROOT},
+    merkle_tree::{PROOF_ENTRIES_FOR_32_32_BATCH, SIZE_OF_MERKLE_ROOT},
     payload::serde_bytes_payload,
 };
 pub use {
@@ -128,7 +128,7 @@ pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHRED
 static DATA_SHRED_BYTES_PER_BATCH_TYPICAL: OnceLock<u64> = OnceLock::new();
 pub fn get_data_shred_bytes_per_batch_typical() -> &'static u64 {
     DATA_SHRED_BYTES_PER_BATCH_TYPICAL.get_or_init(|| {
-        let capacity = ShredData::capacity(Some((PROOF_NUM_ENTRIES_TYPICAL, true, false)))
+        let capacity = ShredData::capacity(Some((PROOF_ENTRIES_FOR_32_32_BATCH, true, false)))
             .expect("Failed to get shred capacity");
         (DATA_SHREDS_PER_FEC_BLOCK * capacity) as u64
     })

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -115,6 +115,8 @@ const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 // each erasure batch depends on the number of shreds obtained from serializing
 // a &[Entry].
 pub const DATA_SHREDS_PER_FEC_BLOCK: usize = 32;
+pub const CODING_SHREDS_PER_FEC_BLOCK: usize = 32;
+pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHREDS_PER_FEC_BLOCK;
 
 // Statically compute the typical data batch size assuming:
 // 1. 32:32 erasure coding batch

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -51,7 +51,10 @@
 
 #[cfg(test)]
 pub(crate) use self::shred_code::MAX_CODE_SHREDS_PER_SLOT;
-pub(crate) use self::{merkle_tree::SIZE_OF_MERKLE_ROOT, payload::serde_bytes_payload};
+pub(crate) use self::{
+    merkle_tree::{PROOF_NUM_ENTRIES_TYPICAL, SIZE_OF_MERKLE_ROOT},
+    payload::serde_bytes_payload,
+};
 pub use {
     self::{
         payload::Payload,
@@ -125,8 +128,7 @@ pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHRED
 static DATA_SHRED_BYTES_PER_BATCH_TYPICAL: OnceLock<u64> = OnceLock::new();
 pub fn get_data_shred_bytes_per_batch_typical() -> &'static u64 {
     DATA_SHRED_BYTES_PER_BATCH_TYPICAL.get_or_init(|| {
-        let proof_size = merkle::get_proof_size(DATA_SHREDS_PER_FEC_BLOCK * 2);
-        let capacity = ShredData::capacity(Some((proof_size, true, false)))
+        let capacity = ShredData::capacity(Some((PROOF_NUM_ENTRIES_TYPICAL, true, false)))
             .expect("Failed to get shred capacity");
         (DATA_SHREDS_PER_FEC_BLOCK * capacity) as u64
     })

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -13,8 +13,8 @@ use {
                 Shred as ShredTrait, ShredCode as ShredCodeTrait, ShredData as ShredDataTrait,
             },
             CodingShredHeader, DataShredHeader, Error, ProcessShredsStats, ShredCommonHeader,
-            ShredFlags, ShredVariant, DATA_SHREDS_PER_FEC_BLOCK, SIZE_OF_CODING_SHRED_HEADERS,
-            SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_SIGNATURE,
+            ShredFlags, ShredVariant, DATA_SHREDS_PER_FEC_BLOCK, SHREDS_PER_FEC_BLOCK,
+            SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_SIGNATURE,
         },
         shredder::{self, ReedSolomonCache},
     },
@@ -1032,11 +1032,10 @@ pub(super) fn make_shreds_from_data(
     let now = Instant::now();
     let chained = chained_merkle_root.is_some();
     let resigned = chained && is_last_in_slot;
-    let erasure_batch_size =
-        shredder::get_erasure_batch_size(DATA_SHREDS_PER_FEC_BLOCK, is_last_in_slot);
-    let proof_size = get_proof_size(erasure_batch_size);
-    let data_buffer_size = ShredData::capacity(proof_size, chained, resigned)?;
-    let chunk_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_size;
+    let proof_size = PROOF_NUM_ENTRIES;
+    let data_buffer_per_shred_size = ShredData::capacity(proof_size, chained, resigned)?;
+    let data_buffer_total_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size;
+
     // Common header for the data shreds.
     let mut common_header_data = ShredCommonHeader {
         signature: Signature::default(),
@@ -1050,6 +1049,7 @@ pub(super) fn make_shreds_from_data(
         version: shred_version,
         fec_set_index: next_shred_index,
     };
+
     // Common header for the coding shreds.
     let mut common_header_code = ShredCommonHeader {
         shred_variant: ShredVariant::MerkleCode {
@@ -1060,6 +1060,8 @@ pub(super) fn make_shreds_from_data(
         index: next_code_index,
         ..common_header_data
     };
+
+    // Data header for the data shreds.
     let data_header = {
         let parent_offset = slot
             .checked_sub(parent_slot)
@@ -1072,22 +1074,30 @@ pub(super) fn make_shreds_from_data(
             size: 0u16,
         }
     };
+
+    // Pre-allocate shreds to avoid reallocations.
     let mut shreds = {
-        let capacity = 2 * DATA_SHREDS_PER_FEC_BLOCK * data.len().div_ceil(chunk_size);
-        Vec::<Shred>::with_capacity(capacity)
+        let number_of_batches = data.len().div_ceil(data_buffer_total_size);
+        let total_num_shreds = SHREDS_PER_FEC_BLOCK * number_of_batches;
+        Vec::<Shred>::with_capacity(total_num_shreds)
     };
-    // Split the data into erasure batches and initialize
-    // data and coding shreds for each batch.
-    while data.len() >= 2 * chunk_size || data.len() == chunk_size {
-        let (chunk, rest) = data.split_at(chunk_size);
-        debug_assert_eq!(chunk.len(), DATA_SHREDS_PER_FEC_BLOCK * data_buffer_size);
+    stats.data_bytes += data.len();
+
+    // Split the data into full erasure batches and initialize data and coding
+    // shreds for each batch.
+    while data.len() >= data_buffer_total_size {
+        let (current_batch_data_chunk, rest) = data.split_at(data_buffer_total_size);
+        debug_assert_eq!(
+            current_batch_data_chunk.len(),
+            DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size
+        );
         common_header_data.fec_set_index = common_header_data.index;
         common_header_code.fec_set_index = common_header_data.fec_set_index;
         shreds.extend(
             make_shreds_data(
                 &mut common_header_data,
                 data_header,
-                chunk.chunks(data_buffer_size),
+                current_batch_data_chunk.chunks(data_buffer_per_shred_size),
             )
             .map(Shred::ShredData),
         );
@@ -1101,34 +1111,16 @@ pub(super) fn make_shreds_from_data(
         );
         data = rest;
     }
-    // If shreds.is_empty() then the data argument was empty. In that case we
-    // want to generate one data shred with empty data.
+
+    // Two possibilities for taking this conditional:
+    //
+    // 1.) We have leftover data which is less than a full erasure batch.
+    // AND/OR
+    // 2.) Shreds is_empty, which only happens when we entered w/ zero data.
+    //
+    // In either case, we want to generate empty data shreds.
     if !data.is_empty() || shreds.is_empty() {
-        // Should generate at least one data shred (which may have no data).
-        // Last erasure batch should also be padded with empty data shreds to
-        // make >= 32 data shreds. This guarantees that the batch cannot be
-        // recovered unless 32+ shreds are received from turbine or repair.
-        let min_num_data_shreds = if is_last_in_slot {
-            DATA_SHREDS_PER_FEC_BLOCK
-        } else {
-            1
-        };
-        // Find the Merkle proof_size and data_buffer_size
-        // which can embed the remaining data.
-        let (proof_size, data_buffer_size, num_data_shreds) = (1u8..32)
-            .find_map(|proof_size| {
-                let data_buffer_size = ShredData::capacity(proof_size, chained, resigned).ok()?;
-                let num_data_shreds = data.len().div_ceil(data_buffer_size);
-                let num_data_shreds = num_data_shreds.max(min_num_data_shreds);
-                let erasure_batch_size =
-                    shredder::get_erasure_batch_size(num_data_shreds, is_last_in_slot);
-                (proof_size == get_proof_size(erasure_batch_size)).then_some((
-                    proof_size,
-                    data_buffer_size,
-                    num_data_shreds,
-                ))
-            })
-            .ok_or(Error::UnknownProofSize)?;
+        stats.padding_bytes += data_buffer_total_size - data.len();
         common_header_data.shred_variant = ShredVariant::MerkleData {
             proof_size,
             chained,
@@ -1142,35 +1134,23 @@ pub(super) fn make_shreds_from_data(
         common_header_data.fec_set_index = common_header_data.index;
         common_header_code.fec_set_index = common_header_data.fec_set_index;
         shreds.extend({
+            // Create data chunks out of remaining data + padding.
             let chunks = data
-                .chunks(data_buffer_size)
+                .chunks(data_buffer_per_shred_size)
                 .chain(std::iter::repeat(&[][..])) // possible padding
-                .take(num_data_shreds);
+                .take(DATA_SHREDS_PER_FEC_BLOCK);
             make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
         });
-        if let Some(Shred::ShredData(shred)) = shreds.last() {
-            stats.data_buffer_residual += data_buffer_size - shred.data()?.len();
-        }
         shreds.extend(
-            make_shreds_code(&mut common_header_code, num_data_shreds, is_last_in_slot)
-                .map(Shred::ShredCode),
+            make_shreds_code(
+                &mut common_header_code,
+                DATA_SHREDS_PER_FEC_BLOCK,
+                is_last_in_slot,
+            )
+            .map(Shred::ShredCode),
         );
     }
-    // Only the trailing data shreds may have residual data buffer.
-    debug_assert!(shreds
-        .iter()
-        .rev()
-        .filter_map(|shred| match shred {
-            Shred::ShredCode(_) => None,
-            Shred::ShredData(shred) => Some(shred),
-        })
-        .skip_while(|shred| is_last_in_slot && shred.data().unwrap().is_empty())
-        .skip(1)
-        .all(|shred| {
-            let proof_size = shred.proof_size().unwrap();
-            let capacity = ShredData::capacity(proof_size, chained, resigned).unwrap();
-            shred.data().unwrap().len() == capacity
-        }));
+
     // Adjust flags for the very last data shred.
     if let Some(Shred::ShredData(shred)) = shreds
         .iter_mut()
@@ -1182,10 +1162,14 @@ pub(super) fn make_shreds_from_data(
         } else {
             ShredFlags::DATA_COMPLETE_SHRED
         };
+
+        // Record metrics for number data shreds generated.
         let num_data_shreds = shred.common_header.index - next_shred_index;
         stats.record_num_data_shreds(num_data_shreds as usize);
     }
     stats.gen_data_elapsed += now.elapsed().as_micros() as u64;
+
+    // Generate Merkle for all erasure batches.
     let now = Instant::now();
     // Group shreds by their respective erasure-batch.
     let batches: Vec<&mut [Shred]> = shreds

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1021,7 +1021,7 @@ pub(super) fn make_shreds_from_data(
     let now = Instant::now();
     let chained = chained_merkle_root.is_some();
     let resigned = chained && is_last_in_slot;
-    let proof_size = PROOF_NUM_ENTRIES_TYPICAL;
+    let proof_size = PROOF_ENTRIES_FOR_32_32_BATCH;
     let data_buffer_per_shred_size = ShredData::capacity(proof_size, chained, resigned)?;
     let data_buffer_total_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size;
 

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -9,6 +9,7 @@ pub(crate) const SIZE_OF_MERKLE_ROOT: usize = std::mem::size_of::<Hash>();
 const_assert_eq!(SIZE_OF_MERKLE_ROOT, 32);
 const_assert_eq!(SIZE_OF_MERKLE_PROOF_ENTRY, 20);
 pub(crate) const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
+pub(crate) const PROOF_NUM_ENTRIES: u8 = 6;
 
 // Defense against second preimage attack:
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -9,7 +9,8 @@ pub(crate) const SIZE_OF_MERKLE_ROOT: usize = std::mem::size_of::<Hash>();
 const_assert_eq!(SIZE_OF_MERKLE_ROOT, 32);
 const_assert_eq!(SIZE_OF_MERKLE_PROOF_ENTRY, 20);
 pub(crate) const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
-pub(crate) const PROOF_NUM_ENTRIES: u8 = 6;
+// Number of proof entries for the standard 64 shred batch.
+pub(crate) const PROOF_NUM_ENTRIES_TYPICAL: u8 = 6;
 
 // Defense against second preimage attack:
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -10,7 +10,7 @@ const_assert_eq!(SIZE_OF_MERKLE_ROOT, 32);
 const_assert_eq!(SIZE_OF_MERKLE_PROOF_ENTRY, 20);
 pub(crate) const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
 // Number of proof entries for the standard 64 shred batch.
-pub(crate) const PROOF_NUM_ENTRIES_TYPICAL: u8 = 6;
+pub(crate) const PROOF_ENTRIES_FOR_32_32_BATCH: u8 = 6;
 
 // Defense against second preimage attack:
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -37,7 +37,8 @@ pub struct ProcessShredsStats {
     pub num_extant_slots: u64,
     // When looking up chained merkle root from parent slot fails.
     pub err_unknown_chained_merkle_root: u64,
-    pub(crate) data_buffer_residual: usize,
+    pub(crate) padding_bytes: usize,
+    pub(crate) data_bytes: usize,
     num_merkle_data_shreds: usize,
     num_merkle_coding_shreds: usize,
 }
@@ -108,7 +109,8 @@ impl ProcessShredsStats {
                 self.err_unknown_chained_merkle_root,
                 i64
             ),
-            ("data_buffer_residual", self.data_buffer_residual, i64),
+            ("padding_bytes", self.padding_bytes, i64),
+            ("data_bytes", self.data_bytes, i64),
             ("num_data_shreds_07", self.num_data_shreds_hist[0], i64),
             ("num_data_shreds_15", self.num_data_shreds_hist[1], i64),
             ("num_data_shreds_31", self.num_data_shreds_hist[2], i64),
@@ -212,7 +214,8 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
             num_data_shreds_hist,
             num_extant_slots,
             err_unknown_chained_merkle_root,
-            data_buffer_residual,
+            padding_bytes,
+            data_bytes,
             num_merkle_data_shreds,
             num_merkle_coding_shreds,
         } = rhs;
@@ -231,7 +234,8 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
         self.coalesce_exited_rcv_timeout += coalesce_exited_rcv_timeout;
         self.num_extant_slots += num_extant_slots;
         self.err_unknown_chained_merkle_root += err_unknown_chained_merkle_root;
-        self.data_buffer_residual += data_buffer_residual;
+        self.padding_bytes += padding_bytes;
+        self.data_bytes += data_bytes;
         self.num_merkle_data_shreds += num_merkle_data_shreds;
         self.num_merkle_coding_shreds += num_merkle_coding_shreds;
         for (i, bucket) in self.num_data_shreds_hist.iter_mut().enumerate() {


### PR DESCRIPTION
#### Problem
Current variable sized FEC sets can be hard to reason about. Fixed FEC sets should be less likely to result in bugs and provide an easier path to some performance optimizations. The only downside is the potential for padding to align to 32 data shred boundaries.

Expectation is that padding is under control after all of the entry coalescing changes made as part of:

- #5908
- #5918
- #5919
- #5920
- #5921

#### Summary of Changes

1. Always create 32:32 FEC sets
2. Fix a bunch of unit tests that assume variable sized FEC sets
3. Add constants `CODING_SHREDS_PER_FEC_BLOCK`, `SHREDS_PER_FEC_BLOCK`, and `PROOF_NUM_ENTRIES_TYPICAL` for convenience
4. `fn get_proof_size` is only used by tests and thus moves into that section
5. Rework ProcessShredsStats to make sense with this new shredding strategy: drop `data_buffer_residual` and add `pad_bytes` and `data_bytes`