### PR TITLE
Implementing an Account Storage Reader to stream Account Storages during snapshots and testing

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -205,7 +205,7 @@ mod tests {
         // Offsets may be None if the storage is empty
         if let Some(offsets) = offsets {
             offsets.offsets.iter().enumerate().for_each(|(i, offset)| {
-                // Remove the specified percentage of accounts
+                // Remove the specified number of accounts
                 if (number_of_accounts_to_remove != 0)
                     && (i % (total_accounts / number_of_accounts_to_remove)) == 0
                 {
@@ -217,6 +217,19 @@ mod tests {
         let storage = storage
             .reopen_as_readonly(storage_access)
             .unwrap_or(storage);
+
+        // Assert that storage.accounts was reopened with the specified access type
+        match storage_access {
+            StorageAccess::File => assert!(matches!(
+                storage.accounts.internals_for_archive(),
+                InternalsForArchive::FileIo(_)
+            )),
+            StorageAccess::Mmap => assert!(matches!(
+                storage.accounts.internals_for_archive(),
+                InternalsForArchive::Mmap(_)
+            )),
+        }
+
         assert_eq!(dead_account_offset.len(), number_of_accounts_to_remove);
 
         // Mark the dead accounts in storage

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -41,9 +41,11 @@ impl<'a> AccountStorageReader<'a> {
         }
 
         // Convert the length to the size
-        sorted_obsolete_accounts.iter_mut().for_each(|(_offset, len)| {
-            *len = storage.accounts.calculate_stored_size(*len);
-        });
+        sorted_obsolete_accounts
+            .iter_mut()
+            .for_each(|(_offset, len)| {
+                *len = storage.accounts.calculate_stored_size(*len);
+            });
 
         sorted_obsolete_accounts
             .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -390,7 +390,7 @@ mod tests {
                 storage.accounts.len() - storage.get_obsolete_bytes(Some(snapshot_slot));
             assert_eq!(reader.len(), current_len);
 
-            // Create a temporary file to write the reader's output. It will get dropped and deleted every
+            // Create a file to write the reader's output. It will get deleted by AccountsFile::drop() every
             // iteration so it does not need a unique name
             let temp_file_path = temp_dir.path().join("output_file");
             let mut output_file = File::create(&temp_file_path).unwrap();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -30,11 +30,11 @@ impl<'a> AccountStorageReader<'a> {
 
         let mut sorted_dead_accounts = storage.get_dead_accounts(snapshot_slot);
         sorted_dead_accounts
-            .sort_unstable_by(|&(a_offset, _), &(b_offset, _)| b_offset.cmp(&a_offset));
+            .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
 
         let file = match internals {
             InternalsForArchive::Mmap(_internals) => None,
-            InternalsForArchive::FileIo(_internals) => Some(File::open(storage.accounts.path())?),
+            InternalsForArchive::FileIo(path) => Some(File::open(path)?),
         };
 
         Ok(Self {
@@ -86,15 +86,15 @@ impl Read for AccountStorageReader<'_> {
             let read_size = match self.internals {
                 InternalsForArchive::Mmap(data) => (&data
                     [self.current_offset..self.current_offset + bytes_to_read])
-                    .read(&mut buf[total_read..total_read + bytes_to_read])?,
+                    .read(&mut buf[total_read..][..bytes_to_read])?,
 
                 InternalsForArchive::FileIo(_) => {
-                    if let Some(file) = &mut self.file {
-                        file.seek(SeekFrom::Start(self.current_offset as u64))?;
-                        file.read(&mut buf[total_read..total_read + bytes_to_read])?
-                    } else {
-                        0
-                    }
+                    let file = &mut self
+                        .file
+                        .as_mut()
+                        .expect("File is opened during initialization");
+                    file.seek(SeekFrom::Start(self.current_offset as u64))?;
+                    file.read(&mut buf[total_read..][..bytes_to_read])?
                 }
             };
 
@@ -120,84 +120,96 @@ mod tests {
         },
         solana_account::AccountSharedData,
         solana_pubkey::Pubkey,
+        std::iter,
         test_case::test_case,
     };
 
-    fn create_storage_for_storage_reader(slot: Slot) -> AccountStorageEntry {
+    fn create_storage_for_storage_reader(
+        slot: Slot,
+        provider: AccountsFileProvider,
+    ) -> (AccountStorageEntry, Vec<tempfile::TempDir>) {
         let id = 0;
-        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let (temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let file_size = 1024 * 1024;
-        AccountStorageEntry::new(
-            &paths[0],
-            slot,
-            id,
-            file_size,
-            AccountsFileProvider::AppendVec,
+        (
+            AccountStorageEntry::new(&paths[0], slot, id, file_size, provider),
+            temp_dirs,
         )
     }
 
-    #[test]
-    fn test_account_storage_reader_no_dead_accounts() {
-        let storage = create_storage_for_storage_reader(0);
+    #[test_case(AccountsFileProvider::AppendVec)]
+    #[test_case(AccountsFileProvider::HotStorage)]
+    fn test_account_storage_reader_no_dead_accounts(provider: AccountsFileProvider) {
+        let (storage, _temp_dirs) = create_storage_for_storage_reader(0, provider);
 
         let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
         let account2 = AccountSharedData::new(1, 10, &Pubkey::new_unique());
         let shared_key = solana_pubkey::new_rand();
         let slot = 0;
 
-        storage
-            .accounts
-            .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
+        let accounts = [(&shared_key, &account), (&shared_key, &account2)];
 
-        storage
-            .accounts
-            .append_accounts(&(slot, &[(&shared_key, &account2)][..]), 0);
+        storage.accounts.append_accounts(&(slot, &accounts[..]), 0);
 
         let reader = AccountStorageReader::new(&storage, None).unwrap();
         assert_eq!(reader.len(), storage.accounts.len());
     }
 
-    #[test_case(0, 0)]
-    #[test_case(1, 0)]
-    #[test_case(1, 1)]
-    #[test_case(100, 0)]
-    #[test_case(100, 10)]
-    #[test_case(100, 100)]
-    fn test_account_storage_read_with_dead_accounts(
+    #[test_case(0, 0, StorageAccess::File)]
+    #[test_case(1, 0, StorageAccess::File)]
+    #[test_case(1, 1, StorageAccess::File)]
+    #[test_case(100, 0, StorageAccess::File)]
+    #[test_case(100, 10, StorageAccess::File)]
+    #[test_case(100, 100, StorageAccess::File)]
+    #[test_case(0, 0, StorageAccess::Mmap)]
+    #[test_case(1, 0, StorageAccess::Mmap)]
+    #[test_case(1, 1, StorageAccess::Mmap)]
+    #[test_case(100, 0, StorageAccess::Mmap)]
+    #[test_case(100, 10, StorageAccess::Mmap)]
+    #[test_case(100, 100, StorageAccess::Mmap)]
+    fn test_account_storage_reader_with_dead_accounts(
         total_accounts: usize,
         number_of_accounts_to_remove: usize,
+        storage_access: StorageAccess,
     ) {
-        let storage = create_storage_for_storage_reader(0);
+        let (storage, _temp_dirs) =
+            create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec);
 
         let shared_key = solana_pubkey::new_rand();
         let slot = 0;
 
         // Create a bunch of accounts and add them to the storage
-        let mut offsets = Vec::new();
-        for _ in 0..total_accounts {
-            // Get the current length of storage rounded up to the nearest multiple of 8 before adding each account
-            // This will be an offset that can be used later to mark the account as dead
-            let len = storage.accounts.len();
-            let rounded_len = (len + 7) & !7; // Round up to the nearest multiple of 8
-            offsets.push(rounded_len);
+        let accounts: Vec<_> =
+            iter::repeat_with(|| AccountSharedData::new(1, 10, &Pubkey::new_unique()))
+                .take(total_accounts)
+                .collect();
 
-            // Add a new account
-            let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
-            storage
-                .accounts
-                .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
-        }
+        let accounts_to_append: Vec<_> = accounts
+            .iter()
+            .map(|account| (&shared_key, account))
+            .collect();
+
+        let offsets = storage
+            .accounts
+            .append_accounts(&(slot, &accounts_to_append[..]), 0);
 
         // Select some accounts to mark as dead.
         let mut dead_account_offset = Vec::new();
-        offsets.iter().enumerate().for_each(|(i, offset)| {
-            // Remove the specified percentage of accounts
-            if (number_of_accounts_to_remove != 0)
-                && (i % (total_accounts / number_of_accounts_to_remove)) == 0
-            {
-                dead_account_offset.push(*offset);
-            }
-        });
+
+        // Offsets may be None if the storage is empty
+        if let Some(offsets) = offsets {
+            offsets.offsets.iter().enumerate().for_each(|(i, offset)| {
+                // Remove the specified percentage of accounts
+                if (number_of_accounts_to_remove != 0)
+                    && (i % (total_accounts / number_of_accounts_to_remove)) == 0
+                {
+                    dead_account_offset.push(*offset);
+                }
+            })
+        };
+
+        // Reopen the storage as the specified access type
+        storage.reopen_as_readonly_test_hook(storage_access);
 
         assert_eq!(dead_account_offset.len(), number_of_accounts_to_remove);
 
@@ -210,7 +222,7 @@ mod tests {
         // Create the reader and check the length
         let mut reader = AccountStorageReader::new(&storage, None).unwrap();
         let current_len = storage.accounts.len() - storage.get_dead_account_bytes(None);
-        assert_eq!(reader.len() as usize, current_len as usize,);
+        assert_eq!(reader.len(), current_len);
 
         // Create a temporary directory and a file within it
         let temp_dir = tempfile::tempdir().unwrap();
@@ -246,36 +258,42 @@ mod tests {
     }
 
     #[test]
-    fn test_account_storage_read_filter_by_slot() {
-        let storage = create_storage_for_storage_reader(10);
+    fn test_account_storage_reader_filter_by_slot() {
+        let (storage, _temp_dirs) =
+            create_storage_for_storage_reader(10, AccountsFileProvider::AppendVec);
 
         let shared_key = solana_pubkey::new_rand();
         let slot = 10;
 
         // Create a bunch of accounts and add them to the storage
-        let mut offsets = Vec::new();
-        for _ in 0..30 {
-            // Get the current length of storage rounded up to the nearest multiple of 8 before adding each account
-            // This will be an offset that can be used later to mark the account as dead
-            let len = storage.accounts.len();
-            let rounded_len = (len + 7) & !7; // Round up to the nearest multiple of 8
-            offsets.push(rounded_len);
+        let accounts: Vec<_> =
+            iter::repeat_with(|| AccountSharedData::new(1, 10, &Pubkey::new_unique()))
+                .take(30)
+                .collect();
 
-            // Add a new account
-            let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
-            storage
-                .accounts
-                .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
-        }
+        let accounts_to_append: Vec<_> = accounts
+            .iter()
+            .map(|account| (&shared_key, account))
+            .collect();
+
+        let offsets = storage
+            .accounts
+            .append_accounts(&(slot, &accounts_to_append[..]), 0);
 
         // Select some accounts to mark as dead. Need to find the starting offset of the account to mark them
         let mut dead_account_offset = Vec::new();
-        offsets.iter().enumerate().for_each(|(i, offset)| {
-            // Mark half the accounts as dead
-            if i % 2 == 0 {
-                dead_account_offset.push(*offset);
-            }
-        });
+
+        offsets
+            .unwrap()
+            .offsets
+            .iter()
+            .enumerate()
+            .for_each(|(i, offset)| {
+                // Mark half the accounts as dead
+                if i % 2 == 0 {
+                    dead_account_offset.push(*offset);
+                }
+            });
 
         // Mark the dead accounts in storage
         let mut slot = 0;
@@ -290,7 +308,7 @@ mod tests {
         for slot in 1..=10 {
             let mut reader = AccountStorageReader::new(&storage, Some(slot)).unwrap();
             let current_len = storage.accounts.len() - storage.get_dead_account_bytes(Some(slot));
-            assert_eq!(reader.len() as usize, current_len as usize);
+            assert_eq!(reader.len(), current_len);
 
             // Create a temporary directory and a file within it
             let temp_dir = tempfile::tempdir().unwrap();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -29,6 +29,12 @@ impl<'a> AccountStorageReader<'a> {
         let num_alive_bytes = num_total_bytes - storage.get_dead_account_bytes(snapshot_slot);
 
         let mut sorted_dead_accounts = storage.get_dead_accounts(snapshot_slot);
+
+        // Conver the length to the size
+        sorted_dead_accounts.iter_mut().for_each(|(_offset, len)| {
+            *len = storage.accounts.calculate_stored_size(*len);
+        });
+
         sorted_dead_accounts
             .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
 
@@ -65,7 +71,7 @@ impl Read for AccountStorageReader<'_> {
             let next_dead_account = self.sorted_dead_accounts.last();
             if let Some(&(dead_start, dead_size)) = next_dead_account {
                 if self.current_offset == dead_start {
-                    self.current_offset += dead_size;
+                    self.current_offset += dead_size.min(self.num_total_bytes - dead_start);
                     self.sorted_dead_accounts.pop();
                     continue;
                 }
@@ -215,7 +221,7 @@ mod tests {
 
         // Mark the dead accounts in storage
         dead_account_offset.into_iter().for_each(|offset| {
-            let mut size = storage.accounts.get_account_sizes(&[offset]);
+            let mut size = storage.accounts.get_account_data_lens(&[offset]);
             storage.add_dead_account(offset, size.pop().unwrap(), 0);
         });
 
@@ -298,7 +304,7 @@ mod tests {
         // Mark the dead accounts in storage
         let mut slot = 0;
         dead_account_offset.into_iter().for_each(|offset| {
-            let mut size = storage.accounts.get_account_sizes(&[offset]);
+            let mut size = storage.accounts.get_account_data_lens(&[offset]);
             storage.add_dead_account(offset, size.pop().unwrap(), slot);
             slot += 1;
         });

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -115,8 +115,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            accounts_db::get_temp_accounts_paths,
-            accounts_db::AccountStorageEntry,
+            accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
             accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
         },
         solana_account::AccountSharedData,

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -333,8 +333,6 @@ mod tests {
                 .take(total_accounts)
                 .collect();
 
-
-
         let accounts_to_append: Vec<_> = accounts
             .into_iter()
             .map(|account| (Pubkey::new_unique(), account))

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -175,8 +175,7 @@ mod tests {
         let mut size = storage.accounts.get_account_data_lens(&[0]);
         storage.mark_account_obsolete(offset, size.pop().unwrap(), 0);
 
-        let reader = AccountStorageReader::new(&storage, None).unwrap();
-        assert_eq!(reader.len(), storage.accounts.len());
+        _ = AccountStorageReader::new(&storage, None).unwrap();
     }
 
     #[test_case(AccountsFileProvider::AppendVec)]

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,0 +1,107 @@
+use {
+    crate::{accounts_db::AccountStorageEntry, accounts_file::InternalsForArchive},
+    std::{
+        fs::File,
+        io::{self, Read, Seek, SeekFrom},
+        sync::Arc,
+    },
+};
+
+/// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
+/// This type skips over the data in the sorted dead accounts structure.
+pub struct AccountStorageReader<'a> {
+    sorted_dead_accounts: Vec<(usize, usize, u64)>,
+    current_offset: usize,
+    file: Option<File>,
+    internals: InternalsForArchive<'a>,
+    length: usize,
+}
+
+impl<'a> AccountStorageReader<'a> {
+    /// Creates a new `AccountStorageReader` from an `AccountStorageEntry`.
+    /// The dead accounts structure is sorted during initialization.
+    pub fn new(
+        storage: &'a Arc<AccountStorageEntry>,
+        snapshot_slot: Option<u64>,
+    ) -> io::Result<Self> {
+        let sorted_dead_accounts = {
+            let mut dead_accounts = storage.get_sorted_dead_accounts();
+            dead_accounts.reverse();
+            dead_accounts
+                .into_iter()
+                .filter(|&(_, _, slot)| {
+                    snapshot_slot.is_none_or(|snapshot_slot| slot <= snapshot_slot)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let length = storage.accounts.len() - storage.get_dead_account_bytes(snapshot_slot);
+
+        let file = match storage.accounts.internals_for_archive() {
+            InternalsForArchive::Mmap(_internals) => None,
+            InternalsForArchive::FileIo(_internals) => {
+                Some(File::open(storage.accounts.path()).unwrap())
+            }
+        };
+
+        Ok(Self {
+            sorted_dead_accounts,
+            current_offset: 0,
+            file,
+            internals: storage.accounts.internals_for_archive(),
+            length,
+        })
+    }
+
+    pub fn get_length(&self) -> usize {
+        self.length
+    }
+}
+
+impl Read for AccountStorageReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut total_read = 0;
+        let buf_len = buf.len();
+
+        while total_read < buf_len {
+            let next_dead_account = self.sorted_dead_accounts.last();
+
+            // Check if the current offset is within a dead account range
+            if let Some(&(dead_start, dead_size, _)) = next_dead_account {
+                if self.current_offset == dead_start {
+                    // Skip the dead account range
+                    self.current_offset += dead_size;
+                    if let Some(file) = &mut self.file {
+                        file.seek(SeekFrom::Start(self.current_offset as u64))?;
+                    }
+                    self.sorted_dead_accounts.pop();
+                    continue;
+                }
+            }
+
+            let remaining = if let Some(&(dead_start, _, _)) = next_dead_account {
+                (dead_start as isize - self.current_offset as isize).max(0) as usize
+            } else {
+                buf_len - total_read
+            };
+
+            let read_size = if let Some(file) = &mut self.file {
+                file.read(&mut buf[total_read..total_read + remaining.min(buf_len - total_read)])?
+            } else if let InternalsForArchive::Mmap(data) = &self.internals {
+                (&data[self.current_offset..])
+                    .read(&mut buf[total_read..total_read + remaining.min(buf_len - total_read)])?
+            } else {
+                0
+            };
+
+            if read_size == 0 {
+                break; // EOF
+            }
+
+            self.current_offset += read_size;
+            total_read += read_size;
+        }
+
+        Ok(total_read)
+    }
+}

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,60 +1,58 @@
 use {
-    crate::{accounts_db::AccountStorageEntry, accounts_file::InternalsForArchive},
+    crate::{
+        account_info::Offset, accounts_db::AccountStorageEntry, accounts_file::InternalsForArchive,
+    },
+    solana_clock::Slot,
     std::{
         fs::File,
         io::{self, Read, Seek, SeekFrom},
-        sync::Arc,
     },
 };
 
 /// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
 /// This type skips over the data in the sorted dead accounts structure.
 pub struct AccountStorageReader<'a> {
-    sorted_dead_accounts: Vec<(usize, usize, u64)>,
+    sorted_dead_accounts: Vec<(Offset, usize)>,
     current_offset: usize,
     file: Option<File>,
     internals: InternalsForArchive<'a>,
-    length: usize,
+    num_alive_bytes: usize,
+    num_total_bytes: usize,
 }
 
 impl<'a> AccountStorageReader<'a> {
     /// Creates a new `AccountStorageReader` from an `AccountStorageEntry`.
     /// The dead accounts structure is sorted during initialization.
-    pub fn new(
-        storage: &'a Arc<AccountStorageEntry>,
-        snapshot_slot: Option<u64>,
-    ) -> io::Result<Self> {
-        let sorted_dead_accounts = {
-            let mut dead_accounts = storage.get_sorted_dead_accounts();
-            dead_accounts.reverse();
-            dead_accounts
-                .into_iter()
-                .filter(|&(_, _, slot)| {
-                    snapshot_slot.is_none_or(|snapshot_slot| slot <= snapshot_slot)
-                })
-                .collect::<Vec<_>>()
-        };
+    pub fn new(storage: &'a AccountStorageEntry, snapshot_slot: Option<Slot>) -> io::Result<Self> {
+        let internals = storage.accounts.internals_for_archive();
+        let num_total_bytes = storage.accounts.len();
+        let num_alive_bytes = num_total_bytes - storage.get_dead_account_bytes(snapshot_slot);
 
-        let length = storage.accounts.len() - storage.get_dead_account_bytes(snapshot_slot);
+        let mut sorted_dead_accounts = storage.get_dead_accounts(snapshot_slot);
+        sorted_dead_accounts
+            .sort_unstable_by(|&(a_offset, _), &(b_offset, _)| b_offset.cmp(&a_offset));
 
-        let file = match storage.accounts.internals_for_archive() {
+        let file = match internals {
             InternalsForArchive::Mmap(_internals) => None,
-            InternalsForArchive::FileIo(_internals) => {
-                Some(File::open(storage.accounts.path()).unwrap())
-            }
+            InternalsForArchive::FileIo(_internals) => Some(File::open(storage.accounts.path())?),
         };
 
         Ok(Self {
             sorted_dead_accounts,
             current_offset: 0,
             file,
-            internals: storage.accounts.internals_for_archive(),
-            length,
+            internals,
+            num_alive_bytes,
+            num_total_bytes,
         })
     }
 
-    pub fn get_length(&self) -> usize {
-        self.length
+    pub fn len(&self) -> usize {
+        self.num_alive_bytes
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_alive_bytes == 0
     }
 }
 
@@ -65,38 +63,35 @@ impl Read for AccountStorageReader<'_> {
 
         while total_read < buf_len {
             let next_dead_account = self.sorted_dead_accounts.last();
-
-            // Check if the current offset is within a dead account range
-            if let Some(&(dead_start, dead_size, _)) = next_dead_account {
+            if let Some(&(dead_start, dead_size)) = next_dead_account {
                 if self.current_offset == dead_start {
-                    // Skip the dead account range
                     self.current_offset += dead_size;
-                    if let Some(file) = &mut self.file {
-                        file.seek(SeekFrom::Start(self.current_offset as u64))?;
-                    }
                     self.sorted_dead_accounts.pop();
                     continue;
                 }
             }
 
-            // Determine how much data to read
-            let remaining = {
-                let max_readable = self.length - self.current_offset;
-                if let Some(&(dead_start, _, _)) = next_dead_account {
-                    (dead_start - self.current_offset).min(max_readable)
-                } else {
-                    (buf_len - total_read).min(max_readable)
-                }
+            // Cannot read beyond the end of the buffer
+            let bytes_left_in_buffer = buf_len.saturating_sub(total_read);
+
+            // Cannot read beyond the next dead account or the end of the file
+            let bytes_to_read_from_file = if let Some(&(dead_start, _)) = next_dead_account {
+                dead_start.saturating_sub(self.current_offset)
+            } else {
+                self.num_total_bytes.saturating_sub(self.current_offset)
             };
 
-            // Perform the read operation
+            let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
+
             let read_size = match self.internals {
                 InternalsForArchive::Mmap(data) => (&data
-                    [self.current_offset..self.current_offset + remaining])
-                    .read(&mut buf[total_read..total_read + remaining])?,
+                    [self.current_offset..self.current_offset + bytes_to_read])
+                    .read(&mut buf[total_read..total_read + bytes_to_read])?,
+
                 InternalsForArchive::FileIo(_) => {
                     if let Some(file) = &mut self.file {
-                        file.read(&mut buf[total_read..total_read + remaining])?
+                        file.seek(SeekFrom::Start(self.current_offset as u64))?;
+                        file.read(&mut buf[total_read..total_read + bytes_to_read])?
                     } else {
                         0
                     }
@@ -112,5 +107,213 @@ impl Read for AccountStorageReader<'_> {
         }
 
         Ok(total_read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            accounts_db::get_temp_accounts_paths,
+            accounts_db::AccountStorageEntry,
+            accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
+        },
+        solana_account::AccountSharedData,
+        solana_pubkey::Pubkey,
+        test_case::test_case,
+    };
+
+    fn create_storage_for_storage_reader(slot: Slot) -> AccountStorageEntry {
+        let id = 0;
+        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let file_size = 1024 * 1024;
+        AccountStorageEntry::new(
+            &paths[0],
+            slot,
+            id,
+            file_size,
+            AccountsFileProvider::AppendVec,
+        )
+    }
+
+    #[test]
+    fn test_account_storage_reader_no_dead_accounts() {
+        let storage = create_storage_for_storage_reader(0);
+
+        let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
+        let account2 = AccountSharedData::new(1, 10, &Pubkey::new_unique());
+        let shared_key = solana_pubkey::new_rand();
+        let slot = 0;
+
+        storage
+            .accounts
+            .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
+
+        storage
+            .accounts
+            .append_accounts(&(slot, &[(&shared_key, &account2)][..]), 0);
+
+        let reader = AccountStorageReader::new(&storage, None).unwrap();
+        assert_eq!(reader.len(), storage.accounts.len());
+    }
+
+    #[test_case(0, 0)]
+    #[test_case(1, 0)]
+    #[test_case(1, 1)]
+    #[test_case(100, 0)]
+    #[test_case(100, 10)]
+    #[test_case(100, 100)]
+    fn test_account_storage_read_with_dead_accounts(
+        total_accounts: usize,
+        number_of_accounts_to_remove: usize,
+    ) {
+        let storage = create_storage_for_storage_reader(0);
+
+        let shared_key = solana_pubkey::new_rand();
+        let slot = 0;
+
+        // Create a bunch of accounts and add them to the storage
+        let mut offsets = Vec::new();
+        for _ in 0..total_accounts {
+            // Get the current length of storage rounded up to the nearest multiple of 8 before adding each account
+            // This will be an offset that can be used later to mark the account as dead
+            let len = storage.accounts.len();
+            let rounded_len = (len + 7) & !7; // Round up to the nearest multiple of 8
+            offsets.push(rounded_len);
+
+            // Add a new account
+            let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
+            storage
+                .accounts
+                .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
+        }
+
+        // Select some accounts to mark as dead.
+        let mut dead_account_offset = Vec::new();
+        offsets.iter().enumerate().for_each(|(i, offset)| {
+            // Remove the specified percentage of accounts
+            if (number_of_accounts_to_remove != 0)
+                && (i % (total_accounts / number_of_accounts_to_remove)) == 0
+            {
+                dead_account_offset.push(*offset);
+            }
+        });
+
+        assert_eq!(dead_account_offset.len(), number_of_accounts_to_remove);
+
+        // Mark the dead accounts in storage
+        dead_account_offset.into_iter().for_each(|offset| {
+            let mut size = storage.accounts.get_account_sizes(&[offset]);
+            storage.add_dead_account(offset, size.pop().unwrap(), 0);
+        });
+
+        // Create the reader and check the length
+        let mut reader = AccountStorageReader::new(&storage, None).unwrap();
+        let current_len = storage.accounts.len() - storage.get_dead_account_bytes(None);
+        assert_eq!(reader.len() as usize, current_len as usize,);
+
+        // Create a temporary directory and a file within it
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_file_path = temp_dir.path().join("output_file");
+        let mut output_file = File::create(&temp_file_path).unwrap();
+
+        let bytes_written = std::io::copy(&mut reader, &mut output_file).unwrap();
+        assert_eq!(bytes_written as usize, reader.len());
+
+        // Close the file
+        drop(output_file);
+
+        // If the number of accounts left is not zero, create a new AccountsFile from the output file
+        // and verify that the number of accounts in the new file is correct
+        if (total_accounts - number_of_accounts_to_remove) != 0 {
+            let (accounts_file, num_accounts) =
+                AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
+                    .unwrap();
+
+            // Verify that the correct numbe rof accounts were found in the file
+            assert_eq!(
+                num_accounts,
+                (total_accounts - number_of_accounts_to_remove)
+            );
+
+            // Create a new AccountStorageEntry from the output file
+            let new_storage =
+                AccountStorageEntry::new_existing(slot, 0, accounts_file, num_accounts);
+
+            // Verify that the new storage has the same length as the reader
+            assert_eq!(new_storage.accounts.len(), reader.len());
+        }
+    }
+
+    #[test]
+    fn test_account_storage_read_filter_by_slot() {
+        let storage = create_storage_for_storage_reader(10);
+
+        let shared_key = solana_pubkey::new_rand();
+        let slot = 10;
+
+        // Create a bunch of accounts and add them to the storage
+        let mut offsets = Vec::new();
+        for _ in 0..30 {
+            // Get the current length of storage rounded up to the nearest multiple of 8 before adding each account
+            // This will be an offset that can be used later to mark the account as dead
+            let len = storage.accounts.len();
+            let rounded_len = (len + 7) & !7; // Round up to the nearest multiple of 8
+            offsets.push(rounded_len);
+
+            // Add a new account
+            let account = AccountSharedData::new(1, 10, &Pubkey::new_unique());
+            storage
+                .accounts
+                .append_accounts(&(slot, &[(&shared_key, &account)][..]), 0);
+        }
+
+        // Select some accounts to mark as dead. Need to find the starting offset of the account to mark them
+        let mut dead_account_offset = Vec::new();
+        offsets.iter().enumerate().for_each(|(i, offset)| {
+            // Mark half the accounts as dead
+            if i % 2 == 0 {
+                dead_account_offset.push(*offset);
+            }
+        });
+
+        // Mark the dead accounts in storage
+        let mut slot = 0;
+        dead_account_offset.into_iter().for_each(|offset| {
+            let mut size = storage.accounts.get_account_sizes(&[offset]);
+            storage.add_dead_account(offset, size.pop().unwrap(), slot);
+            slot += 1;
+        });
+
+        // Create the reader and check the length
+        // Now iterate through all the slots and verify correctness
+        for slot in 1..=10 {
+            let mut reader = AccountStorageReader::new(&storage, Some(slot)).unwrap();
+            let current_len = storage.accounts.len() - storage.get_dead_account_bytes(Some(slot));
+            assert_eq!(reader.len() as usize, current_len as usize);
+
+            // Create a temporary directory and a file within it
+            let temp_dir = tempfile::tempdir().unwrap();
+            let temp_file_path = temp_dir.path().join("output_file");
+            let mut output_file = File::create(&temp_file_path).unwrap();
+
+            let bytes_written = std::io::copy(&mut reader, &mut output_file).unwrap();
+            assert_eq!(bytes_written as usize, reader.len());
+
+            // Close the file
+            drop(output_file);
+
+            let (accounts_file, num_accounts) =
+                AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
+                    .unwrap();
+
+            // Create a new AccountStorageEntry from the output file
+            let new_storage =
+                AccountStorageEntry::new_existing(slot, 0, accounts_file, num_accounts);
+
+            // Verify that the new storage has the same length as the reader
+            assert_eq!(new_storage.accounts.len(), reader.len());
+        }
     }
 }

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -58,7 +58,7 @@ impl<'a> AccountStorageReader<'a> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.num_alive_bytes == 0
+        self.len() == 0
     }
 }
 
@@ -81,7 +81,7 @@ impl Read for AccountStorageReader<'_> {
             let bytes_left_in_buffer = buf_len.saturating_sub(total_read);
 
             // Cannot read beyond the next dead account or the end of the file
-            let bytes_to_read_from_file = if let Some(&(dead_start, _)) = next_dead_account {
+            let bytes_to_read_from_file = if let Some((dead_start, _)) = next_dead_account {
                 dead_start.saturating_sub(self.current_offset)
             } else {
                 self.num_total_bytes.saturating_sub(self.current_offset)
@@ -214,9 +214,9 @@ mod tests {
             })
         };
 
-        // Reopen the storage as the specified access type
-        storage.reopen_as_readonly_test_hook(storage_access);
-
+        let storage = storage
+            .reopen_as_readonly(storage_access)
+            .unwrap_or(storage);
         assert_eq!(dead_account_offset.len(), number_of_accounts_to_remove);
 
         // Mark the dead accounts in storage

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -232,8 +232,8 @@ mod tests {
                 .collect();
 
         let accounts_to_append: Vec<_> = accounts
-            .iter()
-            .map(|account| (Pubkey::new_unique(), (*account).clone()))
+            .into_iter()
+            .map(|account| (Pubkey::new_unique(), account))
             .collect();
 
         let offsets = storage
@@ -333,9 +333,11 @@ mod tests {
                 .take(total_accounts)
                 .collect();
 
+
+
         let accounts_to_append: Vec<_> = accounts
-            .iter()
-            .map(|account| (Pubkey::new_unique(), (*account).clone()))
+            .into_iter()
+            .map(|account| (Pubkey::new_unique(), account))
             .collect();
 
         let offsets = storage

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -283,7 +283,7 @@ mod tests {
         let temp_file_path = temp_dir.path().join("output_file");
         let mut output_file = File::create(&temp_file_path).unwrap();
 
-        let bytes_written = std::io::copy(&mut reader, &mut output_file).unwrap();
+        let bytes_written = io::copy(&mut reader, &mut output_file).unwrap();
         assert_eq!(bytes_written as usize, reader.len());
 
         // Close the file
@@ -369,7 +369,7 @@ mod tests {
             let temp_file_path = temp_dir.path().join("output_file");
             let mut output_file = File::create(&temp_file_path).unwrap();
 
-            let bytes_written = std::io::copy(&mut reader, &mut output_file).unwrap();
+            let bytes_written = io::copy(&mut reader, &mut output_file).unwrap();
             assert_eq!(bytes_written as usize, reader.len());
 
             // Close the file

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1074,16 +1074,15 @@ pub struct AccountStorageEntry {
     /// shrink more likely to visit this storage.
     zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
 
-    /// Dead Accounts. These are accounts that are still present in the storage
+    /// Obsolete Accounts. These are accounts that are still present in the storage
     /// but should be ignored during rebuild. They have been removed
     /// from the accounts index, so they will not be picked up by scan.
-    /// Slot is the slot that the account was rewritten to a newer
-    /// Slot and invalidated from this storage.
-    /// Two scenarios cause an account entry to be marked dead
+    /// Slot is the slot at which the account is no longer needed.
+    /// Two scenarios cause an account entry to be marked obsolete
     /// 1. The account was rewritten to a newer slot
     /// 2. The account was set to zero lamports and is older than the last
-    ///    full snapshot
-    dead_account_offsets: RwLock<Vec<(Offset, usize, Slot)>>,
+    ///    full snapshot. In this case, slot is set to the snapshot slot
+    obsolete_accounts: RwLock<Vec<(Offset, usize, Slot)>>,
 }
 
 impl AccountStorageEntry {
@@ -1105,7 +1104,7 @@ impl AccountStorageEntry {
             count_and_status: SeqLock::new((0, AccountStorageStatus::Available)),
             alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
-            dead_account_offsets: RwLock::default(),
+            obsolete_accounts: RwLock::default(),
         }
     }
 
@@ -1125,7 +1124,7 @@ impl AccountStorageEntry {
             alive_bytes: AtomicUsize::new(self.alive_bytes()),
             accounts,
             zero_lamport_single_ref_offsets: RwLock::default(),
-            dead_account_offsets: RwLock::new(self.dead_account_offsets.read().unwrap().clone()),
+            obsolete_accounts: RwLock::new(self.obsolete_accounts.read().unwrap().clone()),
         })
     }
 
@@ -1142,7 +1141,7 @@ impl AccountStorageEntry {
             count_and_status: SeqLock::new((0, AccountStorageStatus::Available)),
             alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
-            dead_account_offsets: RwLock::default(),
+            obsolete_accounts: RwLock::default(),
         }
     }
 
@@ -1179,42 +1178,42 @@ impl AccountStorageEntry {
         self.alive_bytes.load(Ordering::Acquire)
     }
 
-    /// Adds passed in offset to the dead account vector
-    pub fn add_dead_account(&self, offset: Offset, data_len: usize, slot: Slot) {
-        self.dead_account_offsets
+    /// Marks the account at the given offset as obsolete
+    pub fn mark_account_obsolete(&self, offset: Offset, data_len: usize, slot: Slot) {
+        self.obsolete_accounts
             .write()
             .unwrap()
             .push((offset, data_len, slot));
     }
 
-    /// Returns the dead accounts that were dead as of Slot or older
-    /// If slot is None then it will be assumed to be the max root
-    /// and all dead accounts will be returned
-    pub fn get_dead_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)> {
-        self.dead_account_offsets
+    /// Returns the accounts that were marked obsolete as of the passed in slot
+    /// or earlier. If slot is None, then slot will be assumed to be the max root
+    /// and all obsolete accounts will be returned.
+    pub fn get_obsolete_accounts(&self, slot: Option<Slot>) -> Vec<(Offset, usize)> {
+        self.obsolete_accounts
             .read()
             .unwrap()
             .iter()
-            .filter(|(_, _, dead_slot)| slot.is_none_or(|s| *dead_slot <= s))
+            .filter(|(_, _, obsolete_slot)| slot.is_none_or(|s| *obsolete_slot <= s))
             .map(|(offset, data_len, _)| (*offset, *data_len))
             .collect()
     }
 
-    /// Returns the number of dead bytes in the storage as of a given slot
-    /// If slot is None then it will be assumed to be the max root
-    /// and all dead bytes will be returned
-    pub fn get_dead_account_bytes(&self, slot: Option<Slot>) -> usize {
-        let dead_accounts = self.dead_account_offsets.read().unwrap();
-        let dead_bytes = dead_accounts
+    /// Returns the number of bytes that were marked obsolete as of the passed
+    /// in slot or earlier. If slot is None, then slot will be assumed to be the
+    /// max root, and all obsolete bytes will be returned.
+    pub fn get_obsolete_bytes(&self, slot: Option<Slot>) -> usize {
+        let obsolete_accounts = self.obsolete_accounts.read().unwrap();
+        let obsolete_bytes = obsolete_accounts
             .iter()
-            .filter(|(_, _, dead_slot)| slot.is_none_or(|s| *dead_slot <= s))
+            .filter(|(_, _, obsolete_slot)| slot.is_none_or(|s| *obsolete_slot <= s))
             .map(|(offset, data_len, _)| {
                 self.accounts
                     .calculate_stored_size(*data_len)
                     .min(self.accounts.len() - offset)
             })
             .sum();
-        dead_bytes
+        obsolete_bytes
     }
 
     /// Return true if offset is "new" and inserted successfully. Otherwise,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1125,7 +1125,7 @@ impl AccountStorageEntry {
             alive_bytes: AtomicUsize::new(self.alive_bytes()),
             accounts,
             zero_lamport_single_ref_offsets: RwLock::default(),
-            dead_account_offsets: RwLock::default(),
+            dead_account_offsets: RwLock::new(self.dead_account_offsets.read().unwrap().clone()),
         })
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1164,6 +1164,17 @@ impl AccountStorageEntry {
         self.alive_bytes.load(Ordering::Acquire)
     }
 
+    // Returns the dead accounts sorted as a vector
+    pub fn get_sorted_dead_accounts(&self) -> Vec<(Offset, usize, Slot)> {
+        Vec::new()
+    }
+
+    // Returns the number of dead bytes in the storage as of a given slot
+    // If slot is None, it returns all dead bytes
+    pub fn get_dead_account_bytes(&self, _slot: Option<Slot>) -> usize {
+        0
+    }
+
     /// Return true if offset is "new" and inserted successfully. Otherwise,
     /// return false if the offset exists already.
     fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1260,6 +1260,13 @@ impl AccountStorageEntry {
         self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    /// This is a test hook to allow us to reopen the storage as readonly
+    /// This is only used in tests, and should not be used in production code
+    pub fn reopen_as_readonly_test_hook(&self, storage_access: StorageAccess) -> Option<Self> {
+        self.reopen_as_readonly(storage_access)
+    }
+
     // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
     // So also mark this function as DCOU to squelch an "unused function" clippy warning.
     #[cfg(feature = "dev-context-only-utils")]

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -7,6 +7,7 @@ extern crate lazy_static;
 pub mod account_info;
 pub mod account_locks;
 pub mod account_storage;
+pub mod account_storage_reader;
 pub mod accounts;
 mod accounts_cache;
 pub mod accounts_db;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -34,7 +34,8 @@ mod serde_snapshot_tests {
         solana_rent_collector::RentCollector,
         std::{
             fs::File,
-            io::{copy, BufReader, Cursor, Read, Write},
+            io,
+            io::{BufReader, Cursor, Read, Write},
             ops::RangeFull,
             path::{Path, PathBuf},
             sync::{
@@ -144,11 +145,11 @@ mod serde_snapshot_tests {
             let output_path = output_dir.as_ref().join(file_name);
             let mut reader = AccountStorageReader::new(&storage_entry, None).unwrap();
             let mut writer = File::create(&output_path)?;
-            copy(&mut reader, &mut writer)?;
+            io::copy(&mut reader, &mut writer)?;
 
             // Read new file into append-vec and build new entry
             let (accounts_file, num_accounts) =
-                AccountsFile::new_from_file(output_path, reader.get_length(), storage_access)?;
+                AccountsFile::new_from_file(output_path, reader.len(), storage_access)?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.id(),

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -34,8 +34,7 @@ mod serde_snapshot_tests {
         solana_rent_collector::RentCollector,
         std::{
             fs::File,
-            io,
-            io::{BufReader, Cursor, Read, Write},
+            io::{self, BufReader, Cursor, Read, Write},
             ops::RangeFull,
             path::{Path, PathBuf},
             sync::{

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -15,6 +15,7 @@ mod serde_snapshot_tests {
         solana_account::{AccountSharedData, ReadableAccount},
         solana_accounts_db::{
             account_storage::AccountStorageMap,
+            account_storage_reader::AccountStorageReader,
             accounts::Accounts,
             accounts_db::{
                 get_temp_accounts_paths, test_utils::create_test_accounts, AccountStorageEntry,
@@ -33,7 +34,7 @@ mod serde_snapshot_tests {
         solana_rent_collector::RentCollector,
         std::{
             fs::File,
-            io::{BufReader, Cursor, Read, Write},
+            io::{copy, BufReader, Cursor, Read, Write},
             ops::RangeFull,
             path::{Path, PathBuf},
             sync::{
@@ -139,17 +140,15 @@ mod serde_snapshot_tests {
         let mut next_append_vec_id = 0;
         for storage_entry in storage_entries.into_iter() {
             // Copy file to new directory
-            let storage_path = storage_entry.path();
             let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());
             let output_path = output_dir.as_ref().join(file_name);
-            std::fs::copy(storage_path, &output_path)?;
+            let mut reader = AccountStorageReader::new(&storage_entry, None).unwrap();
+            let mut writer = File::create(&output_path)?;
+            copy(&mut reader, &mut writer)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, num_accounts) = AccountsFile::new_from_file(
-                output_path,
-                storage_entry.accounts.len(),
-                storage_access,
-            )?;
+            let (accounts_file, num_accounts) =
+                AccountsFile::new_from_file(output_path, reader.get_length(), storage_access)?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.id(),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -519,6 +519,9 @@ pub enum ArchiveSnapshotPackageError {
 
     #[error("failed to move archive from '{1}' to '{2}': {0}")]
     MoveArchive(#[source] IoError, PathBuf, PathBuf),
+
+    #[error("failed to create account storage reader '{1}': {0}")]
+    AccountStorageReaderError(#[source] IoError, PathBuf),
 }
 
 /// Errors that can happen in `hard_link_storages_to_snapshot()`
@@ -1115,12 +1118,15 @@ fn archive_snapshot(
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 
-                let reader = AccountStorageReader::new(storage, Some(snapshot_slot)).unwrap();
+                let reader =
+                    AccountStorageReader::new(storage, Some(snapshot_slot)).map_err(|err| {
+                        E::AccountStorageReaderError(err, storage.path().to_path_buf())
+                    })?;
                 let mut header = tar::Header::new_gnu();
                 header.set_path(path_in_archive).map_err(|err| {
                     E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
                 })?;
-                header.set_size(reader.get_length() as u64);
+                header.set_size(reader.len() as u64);
                 header.set_cksum();
                 archive.append(&header, reader).map_err(|err| {
                     E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -24,8 +24,9 @@ use {
     regex::Regex,
     solana_accounts_db::{
         account_storage::AccountStorageMap,
+        account_storage_reader::AccountStorageReader,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
-        accounts_file::{AccountsFile, AccountsFileError, InternalsForArchive, StorageAccess},
+        accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         accounts_hash::{AccountsDeltaHash, AccountsHash},
         append_vec::StoredMetaWriteVersion,
         epoch_accounts_hash::EpochAccountsHash,
@@ -1113,21 +1114,17 @@ fn archive_snapshot(
             for storage in snapshot_storages {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
-                match storage.accounts.internals_for_archive() {
-                    InternalsForArchive::Mmap(data) => {
-                        let mut header = tar::Header::new_gnu();
-                        header.set_path(path_in_archive).map_err(|err| {
-                            E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                        })?;
-                        header.set_size(storage.capacity());
-                        header.set_cksum();
-                        archive.append(&header, data)
-                    }
-                    InternalsForArchive::FileIo(path) => {
-                        archive.append_path_with_name(path, path_in_archive)
-                    }
-                }
-                .map_err(|err| E::ArchiveAccountStorageFile(err, storage.path().to_path_buf()))?;
+
+                let reader = AccountStorageReader::new(storage, Some(snapshot_slot)).unwrap();
+                let mut header = tar::Header::new_gnu();
+                header.set_path(path_in_archive).map_err(|err| {
+                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                })?;
+                header.set_size(reader.get_length() as u64);
+                header.set_cksum();
+                archive.append(&header, reader).map_err(|err| {
+                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                })?;
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;


### PR DESCRIPTION
#### Problem
Account archive internals are exposed to the runtime library
Dead accounts need to be filtered when being written to storage during snapshot.

#### Summary of Changes
Implemented an account storage reader to convert an account storage into a class that supports the trait read.
Modified paths that stream account storages to use the new type. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
