### PR TITLE
bump rust nightly to 2025-03-31

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2024-11-22
+  nightly_version=2025-03-31
 fi
 
 


### PR DESCRIPTION
#### Problem

we haven’t upgraded the nightly version in a while. it seems we don’t have a rule for which version to use, so I’ll just stick with this one:

```
1.86.0-aarch64-apple-darwin unchanged - rustc 1.86.0 (05f9846f8 2025-03-31)
```

#### Summary of Changes

bump it