### PR TITLE
ci: add clippy rules back to cli call

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 //! The `net_utils` module assists with networking
 mod ip_echo_client;
 mod ip_echo_server;

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -24,4 +24,9 @@ source "$here/../ci/rust-version.sh" nightly
 #   ref: https://github.com/rust-lang/rust/issues/66287
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
-  --workspace --all-targets --features dummy-for-ci-check,frozen-abi
+  --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
+  --deny=warnings \
+  --deny=clippy::default_trait_access \
+  --deny=clippy::arithmetic_side_effects \
+  --deny=clippy::manual_let_else \
+  --deny=clippy::used_underscore_binding


### PR DESCRIPTION
### Problem

we moved the clippy rules from the cli call to `clippy.toml` in #5673, then moved the rule again to the workspace (Cargo.toml) in #5710. however, it caused some issues:

#### 1. worksapce lints don't apply to all crates by default

we will need to add something like

```
[lints]
workspace = true
```

to get crates follow the clippy rule. unfortunately, we already had something sneak into master. you can check the build from the first commit in this PR: https://buildkite.com/anza/agave/builds/22874#0196663a-0a7b-4a56-801a-b0b624917fed. 


#### 2. multiple workspaces in agave

for now, we have several different workspaces in Agave. if we want all of them to follow the same rules as before, we’ll need to copy the rules into each one. maintaining consistency will likely become an issue in the future.


### Summary of Changes

- add the rules back to cli call to ensure the protection is still working
- add an issue to track the newly added code that doesn’t follow the Clippy rule.

---

note: part of #5952