### PR TITLE
clippy: useless_nonzero_new_unchecked

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3099,7 +3099,7 @@ mod tests {
         },
     };
     const DEFAULT_NUM_QUIC_ENDPOINTS: NonZeroUsize =
-        unsafe { NonZeroUsize::new_unchecked(DEFAULT_QUIC_ENDPOINTS) };
+        NonZeroUsize::new(DEFAULT_QUIC_ENDPOINTS).unwrap();
 
     impl ClusterInfo {
         // Wrapper for ClusterInfo.new_pull_requests replicating old return


### PR DESCRIPTION
#### Problem

part of nightly rust bumping https://github.com/anza-xyz/agave/pull/5952

https://rust-lang.github.io/rust-clippy/master/index.html#useless_nonzero_new_unchecked

![Screenshot 2025-04-24 at 14 15 48](https://github.com/user-attachments/assets/cabd6cbf-9272-4015-bf39-718bb9bd2dc2)

#### Summary of Changes

fix it