### PR TITLE
clippy: allow large_enum_variant in token command error and svm example

### DIFF
--- a/svm/examples/json-rpc/client/src/utils.rs
+++ b/svm/examples/json-rpc/client/src/utils.rs
@@ -8,6 +8,7 @@ use {
     yaml_rust::YamlLoader,
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("failed to read solana config file: ({0})")]

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -104,6 +104,7 @@ impl From<Vec<FundingSource>> for FundingSources {
 
 type StakeExtras = Vec<(Keypair, Option<DateTime<Utc>>)>;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("I/O error")]


### PR DESCRIPTION
#### Problem

part of nightly rust bumping https://github.com/anza-xyz/agave/pull/5952

https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant

![Screenshot 2025-04-24 at 14 32 28](https://github.com/user-attachments/assets/4087db80-25b8-46ef-971e-8f433856cb02)

since they are not a validator related thing. I guess we might be okay to just allow them 🤔 

#### Summary of Changes

allow it