### PR TITLE
scrub use of `ConfigState` from config program client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7690,9 +7690,8 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program-client"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+version = "1.0.0"
+source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
 dependencies = [
  "bincode",
  "borsh 0.10.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "serde_yaml 0.9.34+deprecated",
  "solana-clap-utils",
+ "solana-config-interface",
  "solana-config-program-client",
  "solana-hash",
  "solana-keypair",
@@ -7360,6 +7361,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-compute-budget-interface",
+ "solana-config-interface",
  "solana-config-program-client",
  "solana-connection-cache",
  "solana-decode-error",
@@ -7689,14 +7691,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-program-client"
+name = "solana-config-interface"
 version = "1.0.0"
-source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbdbcfedb467322ac9686ca61da0a1fdede2fd99a01fb2ed52b49452abd22e0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-config-program-client"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9867b9ffae6e48a97ce6349e7796fcb34084298e909a8fa1fe427f41b52fd4"
 dependencies = [
  "bincode",
  "borsh 0.10.3",
  "kaigan",
  "serde",
+ "solana-config-interface",
  "solana-program",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,7 +416,7 @@ solana-compute-budget = { path = "compute-budget", version = "=2.3.0" }
 solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.0" }
 solana-compute-budget-interface = "2.2.2"
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.0" }
-solana-config-program-client = "0.0.2"
+solana-config-program-client = { git = "https://github.com/solana-program/config.git", branch = "drop-config-state" }
 solana-connection-cache = { path = "connection-cache", version = "=2.3.0", default-features = false }
 solana-core = { path = "core", version = "=2.3.0" }
 solana-cost-model = { path = "cost-model", version = "=2.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,7 +416,8 @@ solana-compute-budget = { path = "compute-budget", version = "=2.3.0" }
 solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.0" }
 solana-compute-budget-interface = "2.2.2"
 solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.0" }
-solana-config-program-client = { git = "https://github.com/solana-program/config.git", branch = "drop-config-state" }
+solana-config-interface = "1.0.0"
+solana-config-program-client = "1.1.0"
 solana-connection-cache = { path = "connection-cache", version = "=2.3.0", default-features = false }
 solana-core = { path = "core", version = "=2.3.0" }
 solana-cost-model = { path = "cost-model", version = "=2.3.0" }

--- a/account-decoder/src/validator_info.rs
+++ b/account-decoder/src/validator_info.rs
@@ -1,5 +1,6 @@
 pub const MAX_SHORT_FIELD_LENGTH: usize = 80;
 pub const MAX_LONG_FIELD_LENGTH: usize = 300;
+/// Maximum size of validator configuration data (`ValidatorInfo`).
 pub const MAX_VALIDATOR_INFO: u64 = 576;
 
 solana_pubkey::declare_id!("Va1idator1nfo111111111111111111111111111111");

--- a/account-decoder/src/validator_info.rs
+++ b/account-decoder/src/validator_info.rs
@@ -1,5 +1,3 @@
-use solana_config_program_client::instructions_bincode::ConfigState;
-
 pub const MAX_SHORT_FIELD_LENGTH: usize = 80;
 pub const MAX_LONG_FIELD_LENGTH: usize = 300;
 pub const MAX_VALIDATOR_INFO: u64 = 576;
@@ -9,10 +7,4 @@ solana_pubkey::declare_id!("Va1idator1nfo111111111111111111111111111111");
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Default)]
 pub struct ValidatorInfo {
     pub info: String,
-}
-
-impl ConfigState for ValidatorInfo {
-    fn max_space() -> u64 {
-        MAX_VALIDATOR_INFO
-    }
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,6 +42,7 @@ solana-clock = "=2.2.2"
 solana-cluster-type = "=2.2.1"
 solana-commitment-config = "=2.2.1"
 solana-compute-budget-interface = { version = "=2.2.2", features = ["borsh"] }
+solana-config-interface = { workspace = true }
 solana-config-program-client = { workspace = true, features = ["serde"] }
 solana-connection-cache = { workspace = true }
 solana-decode-error = "=2.2.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-clock = "=2.2.2"
 solana-cluster-type = "=2.2.1"
 solana-commitment-config = "=2.2.1"
 solana-compute-budget-interface = { version = "=2.2.2", features = ["borsh"] }
-solana-config-interface = { workspace = true }
+solana-config-interface = "=1.0.0"
 solana-config-program-client = { workspace = true, features = ["serde"] }
 solana-connection-cache = { workspace = true }
 solana-decode-error = "=2.2.1"

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -20,11 +20,8 @@ use {
         keypair::DefaultSigner,
     },
     solana_cli_output::{CliValidatorInfo, CliValidatorInfoVec},
-    solana_config_program_client::{
-        get_config_data,
-        instructions_bincode::{self as config_instruction},
-        ConfigKeys,
-    },
+    solana_config_interface::instruction::{self as config_instruction},
+    solana_config_program_client::{get_config_data, ConfigKeys},
     solana_keypair::Keypair,
     solana_message::Message,
     solana_pubkey::Pubkey,
@@ -360,17 +357,18 @@ pub fn process_set_validator_info(
                 "Publishing info for Validator {:?}",
                 config.signers[0].pubkey()
             );
-            let mut instructions = config_instruction::create_account::<ValidatorInfo>(
-                &config.signers[0].pubkey(),
-                &info_pubkey,
-                lamports,
-                MAX_VALIDATOR_INFO,
-                keys.clone(),
-            )
-            .with_compute_unit_config(&ComputeUnitConfig {
-                compute_unit_price,
-                compute_unit_limit,
-            });
+            let mut instructions =
+                config_instruction::create_account_with_max_config_space::<ValidatorInfo>(
+                    &config.signers[0].pubkey(),
+                    &info_pubkey,
+                    lamports,
+                    MAX_VALIDATOR_INFO,
+                    keys.clone(),
+                )
+                .with_compute_unit_config(&ComputeUnitConfig {
+                    compute_unit_price,
+                    compute_unit_limit,
+                });
             instructions.extend_from_slice(&[config_instruction::store(
                 &info_pubkey,
                 true,

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -10,7 +10,7 @@ use {
     serde_json::{Map, Value},
     solana_account::Account,
     solana_account_decoder::validator_info::{
-        self, ValidatorInfo, MAX_LONG_FIELD_LENGTH, MAX_SHORT_FIELD_LENGTH,
+        self, ValidatorInfo, MAX_LONG_FIELD_LENGTH, MAX_SHORT_FIELD_LENGTH, MAX_VALIDATOR_INFO,
     },
     solana_clap_utils::{
         compute_budget::{compute_unit_price_arg, ComputeUnitLimit, COMPUTE_UNIT_PRICE_ARG},
@@ -22,7 +22,7 @@ use {
     solana_cli_output::{CliValidatorInfo, CliValidatorInfoVec},
     solana_config_program_client::{
         get_config_data,
-        instructions_bincode::{self as config_instruction, ConfigState},
+        instructions_bincode::{self as config_instruction},
         ConfigKeys,
     },
     solana_keypair::Keypair,
@@ -48,7 +48,7 @@ pub fn check_details_length(string: String) -> Result<(), String> {
 
 pub fn check_total_length(info: &ValidatorInfo) -> Result<(), String> {
     let size = serialized_size(&info).unwrap();
-    let limit = ValidatorInfo::max_space();
+    let limit = MAX_VALIDATOR_INFO;
 
     if size > limit {
         Err(format!(
@@ -337,7 +337,7 @@ pub fn process_set_validator_info(
         (validator_info::id(), false),
         (config.signers[0].pubkey(), true),
     ];
-    let data_len = ValidatorInfo::max_space()
+    let data_len = MAX_VALIDATOR_INFO
         .checked_add(serialized_size(&ConfigKeys { keys: keys.clone() }).unwrap())
         .expect("ValidatorInfo and two keys fit into a u64");
     let lamports = rpc_client.get_minimum_balance_for_rent_exemption(data_len as usize)?;
@@ -364,6 +364,7 @@ pub fn process_set_validator_info(
                 &config.signers[0].pubkey(),
                 &info_pubkey,
                 lamports,
+                MAX_VALIDATOR_INFO,
                 keys.clone(),
             )
             .with_compute_unit_config(&ComputeUnitConfig {
@@ -661,7 +662,7 @@ mod tests {
 
         assert_eq!(
             serialized_size(&validator_info).unwrap(),
-            ValidatorInfo::max_space()
+            MAX_VALIDATOR_INFO
         );
     }
 }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -29,6 +29,7 @@ serde_derive = { workspace = true }
 serde_yaml = { workspace = true }
 serde_yaml_08 = { package = "serde_yaml", version = "0.8.26" }
 solana-clap-utils = { workspace = true }
+solana-config-interface = { workspace = true }
 solana-config-program-client = { workspace = true, features = ["serde"] }
 solana-hash = "=2.3.0"
 solana-keypair = "=2.2.1"

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -29,8 +29,8 @@ serde_derive = { workspace = true }
 serde_yaml = { workspace = true }
 serde_yaml_08 = { package = "serde_yaml", version = "0.8.26" }
 solana-clap-utils = { workspace = true }
-solana-config-interface = { workspace = true }
-solana-config-program-client = { workspace = true, features = ["serde"] }
+solana-config-interface = "=1.0.0"
+solana-config-program-client = { version = "=1.1.0", features = ["serde"] }
 solana-hash = "=2.3.0"
 solana-keypair = "=2.2.1"
 solana-logger = "=2.3.1"

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -11,7 +11,7 @@ use {
     serde_derive::{Deserialize, Serialize},
     solana_config_program_client::{
         get_config_data,
-        instructions_bincode::{self as config_instruction, ConfigState},
+        instructions_bincode::{self as config_instruction},
     },
     solana_hash::Hash,
     solana_keypair::{read_keypair_file, signable::Signable, Keypair},
@@ -229,12 +229,13 @@ fn new_update_manifest(
         let recent_blockhash = rpc_client.get_latest_blockhash()?;
 
         let lamports = rpc_client
-            .get_minimum_balance_for_rent_exemption(SignedUpdateManifest::max_space() as usize)?;
+            .get_minimum_balance_for_rent_exemption(SignedUpdateManifest::MAX_SPACE as usize)?;
 
         let instructions = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
             &update_manifest_keypair.pubkey(),
             lamports,
+            SignedUpdateManifest::MAX_SPACE,
             vec![], // additional keys
         );
         let message = Message::new(&instructions, Some(&from_keypair.pubkey()));

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -9,10 +9,8 @@ use {
     crossbeam_channel::unbounded,
     indicatif::{ProgressBar, ProgressStyle},
     serde_derive::{Deserialize, Serialize},
-    solana_config_program_client::{
-        get_config_data,
-        instructions_bincode::{self as config_instruction},
-    },
+    solana_config_interface::instruction::{self as config_instruction},
+    solana_config_program_client::get_config_data,
     solana_hash::Hash,
     solana_keypair::{read_keypair_file, signable::Signable, Keypair},
     solana_message::Message,
@@ -231,13 +229,14 @@ fn new_update_manifest(
         let lamports = rpc_client
             .get_minimum_balance_for_rent_exemption(SignedUpdateManifest::MAX_SPACE as usize)?;
 
-        let instructions = config_instruction::create_account::<SignedUpdateManifest>(
-            &from_keypair.pubkey(),
-            &update_manifest_keypair.pubkey(),
-            lamports,
-            SignedUpdateManifest::MAX_SPACE,
-            vec![], // additional keys
-        );
+        let instructions =
+            config_instruction::create_account_with_max_config_space::<SignedUpdateManifest>(
+                &from_keypair.pubkey(),
+                &update_manifest_keypair.pubkey(),
+                lamports,
+                SignedUpdateManifest::MAX_SPACE,
+                vec![], // additional keys
+            );
         let message = Message::new(&instructions, Some(&from_keypair.pubkey()));
         let signers = [from_keypair, update_manifest_keypair];
         let transaction = Transaction::new(&signers, message, recent_blockhash);

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -1,6 +1,5 @@
 use {
     serde_derive::{Deserialize, Serialize},
-    solana_config_program_client::instructions_bincode::ConfigState,
     solana_hash::Hash,
     solana_keypair::signable::Signable,
     solana_pubkey::Pubkey,
@@ -42,6 +41,8 @@ impl Signable for SignedUpdateManifest {
 }
 
 impl SignedUpdateManifest {
+    pub const MAX_SPACE: u64 = 256; // Enough space for a fully populated SignedUpdateManifest
+
     pub fn deserialize(
         account_pubkey: &Pubkey,
         input: &[u8],
@@ -53,11 +54,5 @@ impl SignedUpdateManifest {
         } else {
             Ok(manifest)
         }
-    }
-}
-
-impl ConfigState for SignedUpdateManifest {
-    fn max_space() -> u64 {
-        256 // Enough space for a fully populated SignedUpdateManifest
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5956,9 +5956,8 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program-client"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+version = "1.0.0"
+source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
 dependencies = [
  "bincode",
  "borsh 0.10.3",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5955,14 +5955,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-program-client"
+name = "solana-config-interface"
 version = "1.0.0"
-source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbdbcfedb467322ac9686ca61da0a1fdede2fd99a01fb2ed52b49452abd22e0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-config-program-client"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9867b9ffae6e48a97ce6349e7796fcb34084298e909a8fa1fe427f41b52fd4"
 dependencies = [
  "bincode",
  "borsh 0.10.3",
  "kaigan",
  "serde",
+ "solana-config-interface",
  "solana-program",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5802,14 +5802,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-program-client"
+name = "solana-config-interface"
 version = "1.0.0"
-source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbdbcfedb467322ac9686ca61da0a1fdede2fd99a01fb2ed52b49452abd22e0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-config-program-client"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9867b9ffae6e48a97ce6349e7796fcb34084298e909a8fa1fe427f41b52fd4"
 dependencies = [
  "bincode",
  "borsh 0.10.4",
  "kaigan",
  "serde",
+ "solana-config-interface",
  "solana-program",
 ]
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5803,9 +5803,8 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program-client"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+version = "1.0.0"
+source = "git+https://github.com/solana-program/config.git?branch=drop-config-state#adace9caa7c0302225d94d9564e7a637f8339fa7"
 dependencies = [
  "bincode",
  "borsh 0.10.4",


### PR DESCRIPTION
#### Problem
We're trying to get rid of the `ConfigState` trait, since it's not super useful. It's also not necessary in Agave at all.

#### Summary of Changes
Scrub all use of `ConfigState`, and use the helpers from the config client that only require `serde::Serialize`.
Note this depends on the linked branch for now, so it's to remain a draft until that lands.