### PR TITLE
Remove direct access to SO_REUSEPORT

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
     let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
-        SocketConfig::default().reuseport(true),
+        SocketConfig::default(),
         num_sockets,
     )
     .unwrap();

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
         let mut read_channels = Vec::new();
         let mut read_threads = Vec::new();
         let recycler = PacketBatchRecycler::default();
-        let config = SocketConfig::default().reuseport(true);
+        let config = SocketConfig::default();
         let (port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
             ip_addr,
             (port, port + num_sockets as u16),

--- a/docs/src/validator/tvu.md
+++ b/docs/src/validator/tvu.md
@@ -23,13 +23,13 @@ Internally, TVU is actually bound with multiple sockets to improve kernel's hand
 
 > **NOTE:** TPU sockets use similar logic
 
-A node advertises one external ip/port for TVU while binding multiple sockets to that same port using SO_REUSEPORT:
+A node advertises one external ip/port for TVU while binding multiple sockets to that same port:
 
 ```rust
 let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
     bind_ip_addr,
     port_range,
-    socket_config_reuseport,
+    socket_config,
     num_tvu_sockets.get(),
 )
 .expect("tvu multi_bind");

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2368,7 +2368,7 @@ impl Node {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = localhost_port_range_for_tests();
         let udp_config = SocketConfig::default();
-        let quic_config = SocketConfig::default().reuseport(true);
+        let quic_config = SocketConfig::default();
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
@@ -2520,6 +2520,7 @@ impl Node {
             bind_gossip_port_in_range(gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
+        #[allow(deprecated)] // will be cleaned in a separate PR
         let socket_config_reuseport = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
@@ -2674,7 +2675,7 @@ impl Node {
             bind_gossip_port_in_range(&gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        let socket_config_reuseport = SocketConfig::default().reuseport(true);
+        let socket_config_reuseport = SocketConfig::default();
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2520,8 +2520,6 @@ impl Node {
             bind_gossip_port_in_range(gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        #[allow(deprecated)] // will be cleaned in a separate PR
-        let socket_config_reuseport = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
@@ -2531,12 +2529,11 @@ impl Node {
                 port_range,
                 QUIC_PORT_OFFSET,
                 socket_config,
-                socket_config_reuseport,
+                socket_config,
             )
             .unwrap();
         let tpu_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, socket_config_reuseport)
-                .unwrap();
+            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, socket_config).unwrap();
 
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
@@ -2544,26 +2541,19 @@ impl Node {
                 port_range,
                 QUIC_PORT_OFFSET,
                 socket_config,
-                socket_config_reuseport,
+                socket_config,
             )
             .unwrap();
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, DEFAULT_QUIC_ENDPOINTS, socket_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
-        let tpu_vote_quic: Vec<UdpSocket> = bind_more_with_config(
-            tpu_vote_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_vote_quic: Vec<UdpSocket> =
+            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, socket_config).unwrap();
 
         let (_, retransmit_socket) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
@@ -2675,12 +2665,11 @@ impl Node {
             bind_gossip_port_in_range(&gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        let socket_config_reuseport = SocketConfig::default();
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport,
+            socket_config,
             num_tvu_receive_sockets.get(),
         )
         .expect("tvu multi_bind");
@@ -2689,20 +2678,19 @@ impl Node {
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (tpu_port, tpu_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 32)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 32)
                 .expect("tpu multi_bind");
 
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            socket_config_reuseport,
+            socket_config,
         );
         let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config_reuseport)
-                .unwrap();
+            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config).unwrap();
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 8)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 8)
                 .expect("tpu_forwards multi_bind");
 
         let (_tpu_forwards_port_quic, tpu_forwards_quic) = Self::bind_with_config(
@@ -2711,33 +2699,26 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            socket_config_reuseport,
+            socket_config,
         );
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), socket_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 1)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 1)
                 .expect("tpu_vote multi_bind");
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let tpu_vote_quic = bind_more_with_config(
-            tpu_vote_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_vote_quic =
+            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), socket_config).unwrap();
 
         let (_, retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport,
+            socket_config,
             num_tvu_retransmit_sockets.get(),
         )
         .expect("retransmit multi_bind");
@@ -2751,7 +2732,7 @@ impl Node {
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (_, broadcast) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 4)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 4)
                 .expect("broadcast multi_bind");
 
         let (_, ancestor_hashes_requests) =
@@ -2790,6 +2771,23 @@ impl Node {
         info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
             .unwrap();
 
+        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
+            multi_bind_in_range_with_config(
+                vortexor_receiver_addr.ip(),
+                (
+                    vortexor_receiver_addr.port(),
+                    vortexor_receiver_addr.port() + 1,
+                ),
+                socket_config,
+                32,
+            )
+            .unwrap_or_else(|_| {
+                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
+            })
+            .1
+        });
+
+        info!("vortexor_receivers is {vortexor_receivers:?}");
         trace!("new ContactInfo: {:?}", info);
         let sockets = Sockets {
             gossip,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2771,23 +2771,6 @@ impl Node {
         info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
             .unwrap();
 
-        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
-            multi_bind_in_range_with_config(
-                vortexor_receiver_addr.ip(),
-                (
-                    vortexor_receiver_addr.port(),
-                    vortexor_receiver_addr.port() + 1,
-                ),
-                socket_config,
-                32,
-            )
-            .unwrap_or_else(|_| {
-                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
-            })
-            .1
-        });
-
-        info!("vortexor_receivers is {vortexor_receivers:?}");
         trace!("new ContactInfo: {:?}", info);
         let sockets = Sockets {
             gossip,

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -393,7 +393,6 @@ pub fn multi_bind_in_range(
     multi_bind_in_range_with_config(ip_addr, range, config, num)
 }
 
-//#[deprecated(since = "2.3.0", note = "use `bind_to_with_config` instead")]
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
     let config = SocketConfig {
         reuseport,
@@ -423,7 +422,12 @@ pub fn bind_to_localhost() -> io::Result<UdpSocket> {
 
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
-    bind_to_async(IpAddr::V4(Ipv4Addr::LOCALHOST), /*port:*/ 0, false).await
+    bind_to_async(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        /*port:*/ 0,
+        /*reuseport:*/ false,
+    )
+    .await
 }
 
 pub fn bind_to_unspecified() -> io::Result<UdpSocket> {

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -404,22 +404,6 @@ pub fn multi_bind_in_range_with_config(
     Ok((port, sockets))
 }
 
-// binds many sockets to the same port in a range
-// Note: The `mut` modifier for `num` is unused but kept for compatibility with the public API.
-#[deprecated(
-    since = "2.2.0",
-    note = "use `multi_bind_in_range_with_config` instead"
-)]
-#[allow(unused_mut)]
-pub fn multi_bind_in_range(
-    ip_addr: IpAddr,
-    range: PortRange,
-    mut num: usize,
-) -> io::Result<(u16, Vec<UdpSocket>)> {
-    let config = SocketConfig::default();
-    multi_bind_in_range_with_config(ip_addr, range, config, num)
-}
-
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
     let config = SocketConfig {
         reuseport,

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -96,7 +96,7 @@ pub fn create_quic_server_sockets() -> Vec<UdpSocket> {
     multi_bind_in_range_with_config(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         port_range,
-        SocketConfig::default().reuseport(true),
+        SocketConfig::default(),
         num,
     )
     .expect("bind operation for quic server sockets should succeed")

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -79,9 +79,13 @@ mod tests {
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
-        let reader = bind_to_async(addr.ip(), /*port*/ addr.port())
-            .await
-            .expect("bind");
+        let reader = bind_to_async(
+            addr.ip(),
+            /*port*/ addr.port(),
+            /*reuseport:*/ false,
+        )
+        .await
+        .expect("bind");
         check_send_one(&connection, &reader).await;
         check_send_batch(&connection, &reader).await;
     }

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -79,13 +79,9 @@ mod tests {
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
-        let reader = bind_to_async(
-            addr.ip(),
-            /*port*/ addr.port(),
-            /*reuseport:*/ false,
-        )
-        .await
-        .expect("bind");
+        let reader = bind_to_async(addr.ip(), /*port*/ addr.port())
+            .await
+            .expect("bind");
         check_send_one(&connection, &reader).await;
         check_send_batch(&connection, &reader).await;
     }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -100,7 +100,7 @@ pub fn main() {
     )
     .unwrap();
 
-    let config = SocketConfig::default().reuseport(false);
+    let config = SocketConfig::default();
 
     let sender_socket =
         bind_in_range_with_config(*bind_address, dynamic_port_range, config).unwrap();

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -61,7 +61,7 @@ impl Vortexor {
         tpu_forward_address: Option<SocketAddr>,
         num_quic_endpoints: usize,
     ) -> TpuSockets {
-        let quic_config = SocketConfig::default().reuseport(true);
+        let quic_config = SocketConfig::default();
 
         let tpu_quic = bind_sockets(
             bind_address,


### PR DESCRIPTION
#### Problem

- SO_REUSEPORT flag is tricky to use correctly
- API in net-utils encouraged incorrect usage of the flag
- Multiple devs tripped this particular trap, API needs to improve

This is a split-off from https://github.com/anza-xyz/agave/pull/5832

#### Summary of Changes

- Remove the need to explicitly manage SO_REUSEPORT in SocketConfig, thus removing the burden of thinking about it from the caller side (which, as practice shows, was super easy to get wrong).
- Manage SO_REUSEPORT for sockets from high-level API, preventing misuse
- Extra tests to make sure it works correctly.
