### PR TITLE
Renames to IndexLimitMb::Minimal

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -58,7 +58,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Unlimited,
+    index_limit_mb: IndexLimitMb::Minimal,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -66,7 +66,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: IndexLimitMb::Unlimited,
+    index_limit_mb: IndexLimitMb::Minimal,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -201,10 +201,9 @@ enum ScanTypes<R: RangeBounds<Pubkey>> {
 /// specification of how much memory in-mem portion of account index can use
 #[derive(Debug, Copy, Clone, Default)]
 pub enum IndexLimitMb {
-    /// use disk index while allowing to use as much memory as available for
-    /// in-memory index.
+    /// use disk index while keeping a minimal amount in-mem
     #[default]
-    Unlimited,
+    Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
 }
@@ -2201,7 +2200,7 @@ pub mod tests {
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
         config.index_limit_mb = if use_disk {
-            IndexLimitMb::Unlimited
+            IndexLimitMb::Minimal
         } else {
             IndexLimitMb::InMemOnly // in-mem only
         };

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -218,7 +218,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             .unwrap_or_default()
         {
             IndexLimitMb::InMemOnly => None,
-            IndexLimitMb::Unlimited => Some(BucketMap::new(bucket_config)),
+            IndexLimitMb::Minimal => Some(BucketMap::new(bucket_config)),
         };
 
         Self {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -291,7 +291,7 @@ pub fn get_accounts_db_config(
     let accounts_index_index_limit_mb = if arg_matches.is_present("disable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {
-        IndexLimitMb::Unlimited
+        IndexLimitMb::Minimal
     };
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -408,7 +408,7 @@ pub fn execute(
     accounts_index_config.index_limit_mb = if matches.is_present("disable_accounts_disk_index") {
         IndexLimitMb::InMemOnly
     } else {
-        IndexLimitMb::Unlimited
+        IndexLimitMb::Minimal
     };
 
     {


### PR DESCRIPTION
#### Problem

The enum variant for setting the memory limit for the in-mem accounts index is misleadingly named. Currently `IndexLimitMb::Unlimited` does *in theory* allow unlimited mem usage, but it also quite aggressively flush entries to disk, so even though there's no limit to how much mem the index can use, in practice it is quite minimal. Additionally, one might assume/infer that `IndexLimitMb::Unlimited` and `IndexLimitMb::InMemOnly` are synonyms and do the same thing, but they don't. Only `IndexMemLimitMb::InMemOnly` actually keeps the whole index in mem.

Furthermore, we'd eventually like a middle ground between these two options, where it would be possible to set a size value and the index will not flush entries to disk until that size is exceeded. To do that, we'll likely add another variant to this enum, which would make the `Unlimited` name even more confusing.


#### Summary of Changes

Rename the variant to `Minimal`.