### PR TITLE
Feature - Remove loader v4 instruction deploy from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9668,6 +9668,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-lattice-hash",
  "solana-loader-v3-interface",
+ "solana-loader-v4-interface",
  "solana-logger",
  "solana-measure",
  "solana-metrics",

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -752,19 +752,33 @@ pub fn process_deploy_program(
         .verify::<RequisiteVerifier>()
         .map_err(|err| format!("ELF error: {err}"))?;
 
-    // Create and add retract message
+    // Create and add retract and set_program_length instructions
     let mut initial_instructions = Vec::default();
-    let mut retract_instruction = None;
     if let Some(program_account) = program_account.as_ref() {
-        retract_instruction =
-            build_retract_instruction(program_account, program_address, &authority_pubkey)?;
+        if let Some(retract_instruction) =
+            build_retract_instruction(program_account, program_address, &authority_pubkey)?
+        {
+            initial_instructions.insert(0, retract_instruction);
+        }
+        let (mut set_program_length_instructions, _lamports_required) =
+            build_set_program_length_instructions(
+                rpc_client.clone(),
+                config,
+                auth_signer_index,
+                program_account,
+                program_address,
+                program_data.len() as u32,
+            )?;
+        if !set_program_length_instructions.is_empty() {
+            initial_instructions.append(&mut set_program_length_instructions);
+        }
     }
 
     let upload_address = buffer_address.unwrap_or(program_address);
-    let upload_account = if buffer_address.is_some() {
-        buffer_account
+    let (upload_account, upload_account_length) = if buffer_address.is_some() {
+        (buffer_account, upload_range.len())
     } else {
-        program_account
+        (program_account, program_data.len())
     };
     let existing_lamports = upload_account
         .as_ref()
@@ -779,7 +793,7 @@ pub fn process_deploy_program(
                 instruction::set_program_length(
                     upload_address,
                     &authority_pubkey,
-                    program_data.len() as u32,
+                    upload_account_length as u32,
                     &payer_pubkey,
                 ),
             ]);
@@ -790,11 +804,12 @@ pub fn process_deploy_program(
             upload_address,
             lamports_required,
             &authority_pubkey,
-            program_data.len() as u32,
+            upload_account_length as u32,
             &payer_pubkey,
         ));
     }
 
+    // Create and add write messages
     let mut write_messages = vec![];
     if upload_signer_index.is_none() {
         if upload_account.is_none() {
@@ -808,24 +823,6 @@ pub fn process_deploy_program(
         if upload_range.is_empty() {
             return Err(format!("Attempting to upload empty range {:?}", upload_range).into());
         }
-
-        // Create and add set_program_length message
-        if let Some(upload_account) = upload_account.as_ref() {
-            let (mut set_program_length_instructions, _lamports_required) =
-                build_set_program_length_instructions(
-                    rpc_client.clone(),
-                    config,
-                    auth_signer_index,
-                    upload_account,
-                    upload_address,
-                    program_data.len() as u32,
-                )?;
-            if !set_program_length_instructions.is_empty() {
-                initial_instructions.append(&mut set_program_length_instructions);
-            }
-        }
-
-        // Create and add write messages
         let first_write_message = Message::new(
             &[instruction::write(
                 upload_address,
@@ -849,39 +846,27 @@ pub fn process_deploy_program(
         }
     }
 
-    // Create and add deploy messages
-    let mut final_instructions = Vec::default();
-    if buffer_address == Some(program_address) {
+    let final_instructions = if buffer_address == Some(program_address) {
         // Upload to buffer only and skip actual deployment
-    } else if buffer_address.is_some() {
-        // Redeploy with a buffer account
-        if let Some(retract_instruction) = retract_instruction {
-            final_instructions.push(retract_instruction);
-        }
-        final_instructions.push(instruction::deploy_from_source(
-            program_address,
-            &authority_pubkey,
-            upload_address,
-        ));
-        let mut lamports_to_retrive = upload_account
-            .as_ref()
-            .map(|account| account.lamports)
-            .unwrap_or(0);
-        if upload_signer_index.is_some() {
-            lamports_to_retrive = lamports_to_retrive.saturating_add(lamports_required);
-        }
-        final_instructions.push(system_instruction::transfer(
-            upload_address,
-            &payer_pubkey,
-            lamports_to_retrive,
-        ));
+        Vec::default()
+    } else if let Some(buffer_address) = buffer_address {
+        // Redeployment with a buffer
+        vec![
+            instruction::copy(
+                program_address,
+                &authority_pubkey,
+                buffer_address,
+                upload_range.start as u32,
+                0,
+                upload_range.len() as u32,
+            ),
+            instruction::deploy(program_address, &authority_pubkey),
+            instruction::set_program_length(buffer_address, &authority_pubkey, 0, &payer_pubkey),
+        ]
     } else {
-        // Deploy new program or redeploy without a buffer account
-        if let Some(retract_instruction) = retract_instruction {
-            initial_instructions.insert(0, retract_instruction);
-        }
-        final_instructions.push(instruction::deploy(program_address, &authority_pubkey));
-    }
+        // Initial deployment or redeployment without a buffer
+        vec![instruction::deploy(program_address, &authority_pubkey)]
+    };
 
     send_messages(
         rpc_client,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -819,7 +819,7 @@ pub mod remaining_compute_units_syscall_enabled {
 }
 
 pub mod enable_loader_v4 {
-    solana_pubkey::declare_id!("8Cb77yHjPWe9wuWUfXeh6iszFGCDGNCoFk3tprViYHNm");
+    solana_pubkey::declare_id!("G8yMNsNUd4p3VB22ycrPEB1qRgepCFeFpAqD2Lr66s36");
 }
 
 pub mod require_rent_exempt_split_destination {

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -1271,49 +1271,6 @@ mod tests {
         );
         assert_eq!(accounts[0].lamports(), transaction_accounts[0].1.lamports());
 
-        // Error: Source program is not writable
-        process_instruction(
-            vec![],
-            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
-            transaction_accounts.clone(),
-            &[(0, false, true), (1, true, false), (2, false, false)],
-            Err(InstructionError::InvalidArgument),
-        );
-
-        // Error: Source program is not retracted
-        process_instruction(
-            vec![],
-            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
-            transaction_accounts.clone(),
-            &[(2, false, true), (1, true, false), (0, false, true)],
-            Err(InstructionError::InvalidArgument),
-        );
-
-        // Redeploy: Retract, then replace data by other source
-        let accounts = process_instruction(
-            vec![],
-            &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
-            transaction_accounts.clone(),
-            &[(0, false, true), (1, true, false)],
-            Ok(()),
-        );
-        transaction_accounts[0].1 = accounts[0].clone();
-        let accounts = process_instruction(
-            vec![],
-            &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
-            transaction_accounts.clone(),
-            &[(0, false, true), (1, true, false), (2, false, true)],
-            Ok(()),
-        );
-        assert_eq!(
-            accounts[0].data().len(),
-            transaction_accounts[2].1.data().len(),
-        );
-        assert_eq!(accounts[2].data().len(), 0,);
-        assert_eq!(accounts[0].lamports(), transaction_accounts[2].1.lamports());
-        assert_eq!(accounts[2].lamports(), transaction_accounts[0].1.lamports());
-        transaction_accounts[0].1 = accounts[0].clone();
-
         // Error: Program was deployed recently, cooldown still in effect
         process_instruction(
             vec![],

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7523,6 +7523,7 @@ dependencies = [
  "solana-cost-model",
  "solana-fee",
  "solana-lattice-hash",
+ "solana-loader-v4-interface",
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1754,7 +1754,8 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
             Some(&program_id),
         );
     let undeployment_instruction = loader_v4::retract(&program_id, &authority_keypair.pubkey());
-    let deployment_instruction = deployment_instructions.pop().unwrap();
+    let redeployment_instructions =
+        deployment_instructions.split_off(deployment_instructions.len() - 3);
     let signers: &[&[&Keypair]] = &[
         &[&mint_keypair, &source_program_keypair],
         &[&mint_keypair, &authority_keypair],
@@ -1797,7 +1798,7 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
         ),
         (
             indirect_invoke_instruction,
-            TransactionError::InstructionError(2, InstructionError::UnsupportedProgramId),
+            TransactionError::InstructionError(4, InstructionError::UnsupportedProgramId),
         ),
     ] {
         // Call upgradeable program
@@ -1809,7 +1810,9 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
         let message = Message::new(
             &[
                 undeployment_instruction.clone(),
-                deployment_instruction.clone(),
+                redeployment_instructions[0].clone(),
+                redeployment_instructions[1].clone(),
+                redeployment_instructions[2].clone(),
                 invoke_instruction,
             ],
             Some(&mint_keypair.pubkey()),
@@ -2076,7 +2079,7 @@ fn test_program_sbf_upgrade() {
             Some(&program_id),
         );
     deployment_instructions.insert(
-        deployment_instructions.len() - 1,
+        deployment_instructions.len() - 3,
         loader_v4::retract(&program_id, &new_authority_keypair.pubkey()),
     );
     let signers: &[&[&Keypair]] = &[
@@ -2182,7 +2185,7 @@ fn test_program_sbf_upgrade_via_cpi() {
             Some(&program_id),
         );
     deployment_instructions.insert(
-        deployment_instructions.len() - 1,
+        deployment_instructions.len() - 3,
         loader_v4::retract(&program_id, &new_authority_keypair.pubkey()),
     );
     let mut upgrade_instruction = deployment_instructions.pop().unwrap();
@@ -2202,13 +2205,9 @@ fn test_program_sbf_upgrade_via_cpi() {
         .accounts
         .insert(0, AccountMeta::new(loader_v4::id(), false));
     let message = Message::new(&[upgrade_instruction], Some(&mint_keypair.pubkey()));
-    let result =
-        bank_client.send_and_confirm_message(&[&mint_keypair, &new_authority_keypair], message);
-    // This fails for now because of the `callee_account.is_executable()` check in CPI `translate_and_update_accounts()`
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
-    );
+    bank_client
+        .send_and_confirm_message(&[&mint_keypair, &new_authority_keypair], message)
+        .unwrap();
     bank_client
         .advance_slot(1, &bank_forks, &Pubkey::default())
         .expect("Failed to advance the slot");
@@ -2218,7 +2217,7 @@ fn test_program_sbf_upgrade_via_cpi() {
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
-        TransactionError::InstructionError(0, InstructionError::UnsupportedProgramId)
+        TransactionError::InstructionError(0, InstructionError::Custom(43))
     );
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -66,6 +66,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-lattice-hash = { workspace = true }
+solana-loader-v4-interface = { workspace = true, features = ["serde"] }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -2,6 +2,7 @@
 use {
     crate::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     serde::Serialize,
+    solana_loader_v4_interface::instruction,
     solana_sdk::{
         account::{AccountSharedData, WritableAccount},
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
@@ -279,7 +280,8 @@ pub fn instructions_to_load_program_of_loader_v4<T: Client>(
             &program_keypair.pubkey(),
             bank_client
                 .get_minimum_balance_for_rent_exemption(
-                    loader_v4::LoaderV4State::program_data_offset().saturating_add(program.len()),
+                    solana_loader_v4_interface::state::LoaderV4State::program_data_offset()
+                        .saturating_add(program.len()),
                 )
                 .unwrap(),
             0,
@@ -287,7 +289,7 @@ pub fn instructions_to_load_program_of_loader_v4<T: Client>(
         ));
         program_keypair
     });
-    instructions.push(loader_v4::set_program_length(
+    instructions.push(instruction::set_program_length(
         &program_keypair.pubkey(),
         &authority_keypair.pubkey(),
         program.len() as u32,
@@ -296,7 +298,7 @@ pub fn instructions_to_load_program_of_loader_v4<T: Client>(
     let chunk_size = CHUNK_SIZE;
     let mut offset = 0;
     for chunk in program.chunks(chunk_size) {
-        instructions.push(loader_v4::write(
+        instructions.push(instruction::write(
             &program_keypair.pubkey(),
             &authority_keypair.pubkey(),
             offset,
@@ -304,15 +306,31 @@ pub fn instructions_to_load_program_of_loader_v4<T: Client>(
         ));
         offset += chunk_size as u32;
     }
-    instructions.push(if let Some(target_program_id) = target_program_id {
-        loader_v4::deploy_from_source(
+    if let Some(target_program_id) = target_program_id {
+        instructions.push(instruction::set_program_length(
+            target_program_id,
+            &authority_keypair.pubkey(),
+            program.len() as u32,
+            &payer_keypair.pubkey(),
+        ));
+        instructions.push(instruction::copy(
             target_program_id,
             &authority_keypair.pubkey(),
             &program_keypair.pubkey(),
-        )
+            0,
+            0,
+            program.len() as u32,
+        ));
+        instructions.push(instruction::deploy(
+            target_program_id,
+            &authority_keypair.pubkey(),
+        ));
     } else {
-        loader_v4::deploy(&program_keypair.pubkey(), &authority_keypair.pubkey())
-    });
+        instructions.push(instruction::deploy(
+            &program_keypair.pubkey(),
+            &authority_keypair.pubkey(),
+        ));
+    }
     (program_keypair, instructions)
 }
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7347,6 +7347,7 @@ dependencies = [
  "solana-cost-model",
  "solana-fee",
  "solana-lattice-hash",
+ "solana-loader-v4-interface",
  "solana-measure",
  "solana-metrics",
  "solana-nohash-hasher",


### PR DESCRIPTION
#### Problem

The deploy from source instruction is unnecessary as its use case is covered by the copy instruction.

#### Summary of Changes

The CLI now sends the sequence:
- Either create or retract program account
- Set length of program account
- Copy from buffer account
- Deploy program account
- Set length of buffer account to zero, effectively closing it and retrieving its funds

Feature Gate Issue: [#78](https://github.com/anza-xyz/feature-gate-tracker/issues/78)