### PR TITLE
Passes AccountsIndexConfig by reference

### DIFF
--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -27,7 +27,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
 
     let mut reclaims = vec![];
     let index = AccountsIndex::<AccountInfo, AccountInfo>::new(
-        Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
+        &ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         Arc::default(),
     );
     for f in 0..NUM_FORKS {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1938,7 +1938,8 @@ impl AccountsDb {
         exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts_db_config = accounts_db_config.unwrap_or_default();
-        let accounts_index = AccountsIndex::new(accounts_db_config.index.clone(), exit);
+        let accounts_index_config = accounts_db_config.index.unwrap_or_default();
+        let accounts_index = AccountsIndex::new(&accounts_index_config, exit);
 
         let base_working_path = accounts_db_config.base_working_path.clone();
         let (base_working_path, base_working_temp_dir) =

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1636,7 +1636,7 @@ mod tests {
     fn new_for_test<T: IndexValue>() -> InMemAccountsIndex<T, T> {
         let holder = Arc::new(BucketMapHolder::new(
             BINS_FOR_TESTING,
-            &Some(AccountsIndexConfig::default()),
+            &AccountsIndexConfig::default(),
             1,
         ));
         let bin = 0;
@@ -1646,7 +1646,7 @@ mod tests {
     fn new_disk_buckets_for_test<T: IndexValue>() -> InMemAccountsIndex<T, T> {
         let holder = Arc::new(BucketMapHolder::new(
             BINS_FOR_TESTING,
-            &Some(AccountsIndexConfig::default()),
+            &AccountsIndexConfig::default(),
             1,
         ));
         let bin = 0;

--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -153,10 +153,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndexStorage<
     }
 
     /// allocate BucketMapHolder and InMemAccountsIndex[]
-    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>, exit: Arc<AtomicBool>) -> Self {
+    pub fn new(bins: usize, config: &AccountsIndexConfig, exit: Arc<AtomicBool>) -> Self {
         let num_flush_threads = config
-            .as_ref()
-            .and_then(|config| config.num_flush_threads)
+            .num_flush_threads
             .unwrap_or_else(accounts_index::default_num_flush_threads);
 
         let storage = Arc::new(BucketMapHolder::new(bins, config, num_flush_threads.get()));

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -195,28 +195,21 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         }
     }
 
-    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>, threads: usize) -> Self {
+    pub fn new(bins: usize, config: &AccountsIndexConfig, threads: usize) -> Self {
         const DEFAULT_AGE_TO_STAY_IN_CACHE: Age = 5;
         let ages_to_stay_in_cache = config
-            .as_ref()
-            .and_then(|config| config.ages_to_stay_in_cache)
+            .ages_to_stay_in_cache
             .unwrap_or(DEFAULT_AGE_TO_STAY_IN_CACHE);
 
         let mut bucket_config = BucketMapConfig::new(bins);
-        bucket_config.drives = config.as_ref().and_then(|config| {
-            bucket_config.restart_config_file = config.drives.as_ref().and_then(|drives| {
-                drives
-                    .first()
-                    .map(|drive| drive.join("accounts_index_restart"))
-            });
-            config.drives.clone()
-        });
-
-        let disk = match config
+        bucket_config.drives = config.drives.as_ref().cloned();
+        bucket_config.restart_config_file = bucket_config
+            .drives
             .as_ref()
-            .map(|config| config.index_limit_mb)
-            .unwrap_or(AccountsIndexConfig::default().index_limit_mb)
-        {
+            .and_then(|drives| drives.first())
+            .map(|drive| drive.join("accounts_index_restart"));
+
+        let disk = match config.index_limit_mb {
             IndexLimitMb::InMemOnly => None,
             IndexLimitMb::Minimal => Some(BucketMap::new(bucket_config)),
         };
@@ -392,7 +385,7 @@ pub mod tests {
     fn test_next_bucket_to_flush() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let visited = (0..bins)
             .map(|_| AtomicUsize::default())
             .collect::<Vec<_>>();
@@ -415,7 +408,7 @@ pub mod tests {
     fn test_ages() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(0, test.current_age());
         assert_eq!(test.ages_to_stay_in_cache, test.future_age_to_flush(false));
         assert_eq!(Age::MAX, test.future_age_to_flush(true));
@@ -435,7 +428,7 @@ pub mod tests {
     fn test_age_increment() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         for age in 0..513 {
             assert_eq!(test.current_age(), (age % 256) as Age);
 
@@ -456,7 +449,7 @@ pub mod tests {
     fn test_throttle() {
         solana_logger::setup();
         let bins = 128;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let bins = test.bins as u64;
         let interval_ms = test.age_interval_ms();
         // 90% of time elapsed, all but 1 bins flushed, should not wait since we'll end up right on time
@@ -485,7 +478,7 @@ pub mod tests {
     fn test_disk_index_enabled() {
         let bins = 1;
         let config = AccountsIndexConfig::default();
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(config), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
         assert!(test.is_disk_index_enabled());
     }
 
@@ -493,7 +486,7 @@ pub mod tests {
     fn test_age_time() {
         solana_logger::setup();
         let bins = 1;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let threads = 2;
         let time = AGE_MS * 8 / 3;
         let expected = (time / AGE_MS) as Age;
@@ -525,7 +518,7 @@ pub mod tests {
     fn test_age_broad() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64, u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
+        let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(test.current_age(), 0);
         for _ in 0..bins {
             assert!(!test.all_buckets_flushed_at_current_age());


### PR DESCRIPTION
#### Problem

The AccountsIndexConfig is passed around as a `&Option<AccountsIndexConfig>`, which is not very ergonomic. Also, we should always have an AccountsIndexConfig; its fields can be optional, but the whole config itself shall always be present.


#### Summary of Changes

Pass the config as `&AccountsIndexConfig`.