### PR TITLE
When Mergify warns people to update the JS RPC client, it now calls it `@solana/kit` instead of `@solana/web3.js`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -193,7 +193,7 @@ pull_request_rules:
           If this PR represents a change to the public RPC API:
 
           1. Make sure it includes a complementary update to `rpc-client/` ([example](https://github.com/solana-labs/solana/pull/29558/files))
-          2. Open a follow-up PR to update the JavaScript client `@solana/web3.js` ([example](https://github.com/solana-labs/solana-web3.js/pull/2868/files))
+          2. Open a follow-up PR to update the JavaScript client `@solana/kit` ([example](https://github.com/solana-labs/solana-web3.js/pull/2868/files))
 
           Thank you for keeping the RPC clients in sync with the server API @{{author}}.
   - name: Reminder to add Firedancer team to changes in `programs/`


### PR DESCRIPTION
#### Problem

We're using the old name ([example](https://github.com/anza-xyz/agave/pull/5894#issuecomment-2817325570)).

#### Summary of Changes

* Change the name to `@solana/kit`
* Do _not_ change the URL, because the old web3.js example is still, in principle, relevant.