### PR TITLE
Assert we never wrap when unref-ing an account index entry

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3247,13 +3247,6 @@ impl AccountsDb {
                 i64
             ),
             (
-                "unref_zero_count",
-                self.accounts_index
-                    .unref_zero_count
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "ancient_account_cleans",
                 ancient_account_cleans.load(Ordering::Relaxed),
                 i64

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1132,10 +1132,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                         };
                         cache = match result {
                             AccountsIndexScanResult::Unref => {
-                                if locked_entry.unref() == 0 {
-                                    info!("scan: refcount of item already at 0: {pubkey}");
-                                    self.unref_zero_count.fetch_add(1, Ordering::Relaxed);
-                                }
+                                locked_entry.unref();
                                 true
                             }
                             AccountsIndexScanResult::UnrefAssert0 => {
@@ -3641,26 +3638,32 @@ pub mod tests {
 
         index.upsert_simple_test(&key, slot1, value);
 
-        let map = index.get_bin(&key);
-        for expected in [false, true] {
-            assert!(map.get_internal_inner(&key, |entry| {
-                // check refcount BEFORE the unref
-                assert_eq!(u64::from(!expected), entry.unwrap().ref_count());
-                // first time, ref count was at 1, we can unref once. Unref should return 1.
-                // second time, ref count was at 0, it is an error to unref. Unref should return 0
-                assert_eq!(u64::from(!expected), entry.unwrap().unref());
-                // check refcount AFTER the unref
-                assert_eq!(
-                    if expected {
-                        (0 as RefCount).wrapping_sub(1)
-                    } else {
-                        0
-                    },
-                    entry.unwrap().ref_count()
-                );
-                (false, true)
-            }));
-        }
+        let entry = index.get_cloned(&key).unwrap();
+        // check refcount BEFORE the unref
+        assert_eq!(entry.ref_count(), 1);
+        // first time, ref count was at 1, we can unref once. Unref should return 1.
+        assert_eq!(entry.unref(), 1);
+        // check refcount AFTER the unref
+        assert_eq!(entry.ref_count(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "decremented ref count when already zero")]
+    fn test_illegal_unref() {
+        let value = true;
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<bool, bool>::default_for_tests();
+        let slot1 = 1;
+
+        index.upsert_simple_test(&key, slot1, value);
+
+        let entry = index.get_cloned(&key).unwrap();
+        // make ref count be zero
+        assert_eq!(entry.unref(), 1);
+        assert_eq!(entry.ref_count(), 0);
+
+        // unref when already at zero should panic
+        entry.unref();
     }
 
     #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -285,8 +285,6 @@ pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub active_scans: AtomicUsize,
     /// # of slots between latest max and latest scan
     pub max_distance_to_min_scan_slot: AtomicU64,
-    // # of unref when the account's ref_count is zero
-    pub unref_zero_count: AtomicU64,
 
     /// populated at generate_index time - accounts that could possibly be rent paying
     pub rent_paying_accounts_by_partition: OnceLock<RentPayingAccountsByPartition>,
@@ -324,7 +322,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             roots_removed: AtomicUsize::default(),
             active_scans: AtomicUsize::default(),
             max_distance_to_min_scan_slot: AtomicU64::default(),
-            unref_zero_count: AtomicU64::default(),
             rent_paying_accounts_by_partition: OnceLock::default(),
         }
     }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -4,7 +4,6 @@ use {
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         is_zero_lamport::IsZeroLamport,
     },
-    log::*,
     solana_clock::Slot,
     std::sync::{
         atomic::{AtomicBool, Ordering},
@@ -50,9 +49,10 @@ impl<T: IndexValue> AccountMapEntry<T> {
     pub fn unref(&self) -> RefCount {
         let previous = self.ref_count.fetch_sub(1, Ordering::Release);
         self.set_dirty(true);
-        if previous == 0 {
-            inc_new_counter_info!("accounts_index-deref_from_0", 1);
-        }
+        assert_ne!(
+            previous, 0,
+            "decremented ref count when already zero: {self:?}"
+        );
         previous
     }
 


### PR DESCRIPTION
#### Problem

Unref-ing an index entry whose ref count is already zero will wrap. This indicates a bug. 

Currently we log and push a metric datapoint, which means we may not notice/be notified if it happens.


#### Summary of Changes

Instead of logging, panic.

A bad ref count can cause accounts to not get cleaned up properly, which can then impact whole storages, and thus snapshots. It is not great to boot/keep using a snapshot with unnecessarily bloated storages.

Additionally, by not panicking immediately, it becomes harder to debug because it requires extra investigation to even know a ref count issue occurred.