### PR TITLE
Fix unused import warning: move import to test module

### DIFF
--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -14,10 +14,7 @@ use {
 };
 use {
     crate::packet::{Meta, Packet},
-    std::{
-        cmp, io,
-        net::{Ipv4Addr, Ipv6Addr, UdpSocket},
-    },
+    std::{cmp, io, net::UdpSocket},
 };
 
 #[cfg(not(target_os = "linux"))]
@@ -177,7 +174,7 @@ mod tests {
             bind_in_range_with_config, sockets::localhost_port_range_for_tests, SocketConfig,
         },
         std::{
-            net::{IpAddr, SocketAddr, UdpSocket},
+            net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
             time::{Duration, Instant},
         },
     };

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -55,7 +55,7 @@ fn cast_socket_addr(addr: &sockaddr_storage, hdr: &mmsghdr) -> Option<SocketAddr
         // ref: https://github.com/rust-lang/socket2/blob/65085d9dff270e588c0fbdd7217ec0b392b05ef2/src/sockaddr.rs#L167-L172
         let addr = unsafe { &*(addr as *const _ as *const sockaddr_in) };
         return Some(SocketAddr::V4(SocketAddrV4::new(
-            Ipv4Addr::from(addr.sin_addr.s_addr.to_ne_bytes()),
+            std::net::Ipv4Addr::from(addr.sin_addr.s_addr.to_ne_bytes()),
             u16::from_be(addr.sin_port),
         )));
     }
@@ -65,7 +65,7 @@ fn cast_socket_addr(addr: &sockaddr_storage, hdr: &mmsghdr) -> Option<SocketAddr
         // ref: https://github.com/rust-lang/socket2/blob/65085d9dff270e588c0fbdd7217ec0b392b05ef2/src/sockaddr.rs#L174-L189
         let addr = unsafe { &*(addr as *const _ as *const sockaddr_in6) };
         return Some(SocketAddr::V6(SocketAddrV6::new(
-            Ipv6Addr::from(addr.sin6_addr.s6_addr),
+            std::net::Ipv6Addr::from(addr.sin6_addr.s6_addr),
             u16::from_be(addr.sin6_port),
             addr.sin6_flowinfo,
             addr.sin6_scope_id,


### PR DESCRIPTION
#### Problem
- #5964 introduced these imports but they are only used in tests
- running `./cargo nightly clippy --all-targets` throws warnings that bother me 

#### Summary of Changes
- Remove unused imports
- Add necessary imports to tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
