### PR TITLE
tpu-client-next: add worker cache tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10807,6 +10807,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
  "solana-pubkey",
  "solana-quic-definitions",
  "solana-rpc-client",

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -34,10 +34,10 @@ crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-commitment-config = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
-solana-net-utils = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -37,6 +37,7 @@ solana-commitment-config = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+solana-net-utils = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -200,7 +200,7 @@ impl ConnectionWorker {
     ///
     /// If an error occurs, the state may transition to `Retry` or `Closing`,
     /// depending on the nature of the error.
-    async fn create_connection(&mut self, max_retries_attempt: usize) {
+    async fn create_connection(&mut self, retries_attempt: usize) {
         let connecting = self.endpoint.connect(self.peer, "connect");
         match connecting {
             Ok(connecting) => {
@@ -219,8 +219,7 @@ impl ConnectionWorker {
                     Err(err) => {
                         warn!("Connection error {}: {}", self.peer, err);
                         record_error(err.into(), &self.send_txs_stats);
-                        self.connection =
-                            ConnectionState::Retry(max_retries_attempt.saturating_add(1));
+                        self.connection = ConnectionState::Retry(retries_attempt.saturating_add(1));
                     }
                 }
             }


### PR DESCRIPTION
#### Problem

Adds 3 tests and moves one private function from scheduler to workers_cache for the sake of test. Changes are split by commits.

#### Summary of Changes

