### PR TITLE
4x faster HashMap<Pubkey, stake>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10972,6 +10972,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "solana-tls-utils",
+ "solana-vote",
  "static_assertions",
  "test-case",
  "thiserror 2.0.12",

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -100,13 +100,13 @@ fn create_connection_cache(
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
     info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let stakes = HashMap::from([
+    let stakes = HashMap::from_iter([
         (client_node_id.pubkey(), stake),
         (Pubkey::new_unique(), total_stake - stake),
     ]);
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
         Arc::new(stakes),
-        HashMap::<Pubkey, u64>::default(), // overrides
+        HashMap::default(), // overrides
     )));
     ConnectionCache::new_with_client_options(
         "bench-tps-connection_cache_quic",

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -164,7 +164,7 @@ fn main() -> Result<()> {
         let stake: u64 = 1024;
         let total_stake: u64 = 1024;
 
-        let stakes = HashMap::from([
+        let stakes = HashMap::from_iter([
             (identity_keypair.pubkey(), stake),
             (Pubkey::new_unique(), total_stake.saturating_sub(stake)),
         ]);

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -49,9 +49,10 @@ use {
         socket::SocketAddrSpace,
         streamer::PacketBatchSender,
     },
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
         cmp::Reverse,
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -523,7 +524,7 @@ impl ServeRepair {
 
     fn decode_request(
         remote_request: RemoteRequest,
-        epoch_staked_nodes: &Option<Arc<HashMap<Pubkey, u64>>>,
+        epoch_staked_nodes: &Option<Arc<StakedNodesHashMap>>,
         whitelist: &HashSet<Pubkey>,
         my_id: &Pubkey,
         socket_addr_space: &SocketAddrSpace,
@@ -595,7 +596,7 @@ impl ServeRepair {
 
     fn decode_requests(
         requests: Vec<RemoteRequest>,
-        epoch_staked_nodes: &Option<Arc<HashMap<Pubkey, u64>>>,
+        epoch_staked_nodes: &Option<Arc<StakedNodesHashMap>>,
         whitelist: &HashSet<Pubkey>,
         my_id: &Pubkey,
         socket_addr_space: &SocketAddrSpace,

--- a/gossip/benches/crds.rs
+++ b/gossip/benches/crds.rs
@@ -24,7 +24,7 @@ fn bench_find_old_labels(bencher: &mut Bencher) {
     std::iter::repeat_with(|| (CrdsValue::new_rand(&mut rng, None), rng.gen_range(0..now)))
         .take(50_000)
         .for_each(|(v, ts)| assert!(crds.insert(v, ts, GossipRoute::LocalMessage).is_ok()));
-    let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+    let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
     let timeouts = CrdsTimeouts::new(
         Pubkey::new_unique(),
         CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -77,7 +77,7 @@ use {
     },
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
-    solana_vote::vote_parser,
+    solana_vote::{vote_account::StakedNodesHashMap, vote_parser},
     std::{
         borrow::Borrow,
         collections::{HashMap, HashSet},
@@ -179,7 +179,7 @@ pub struct ClusterInfo {
 #[must_use]
 fn should_retain_crds_value(
     value: &CrdsValue,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesHashMap,
     drop_unstaked_node_instance: bool,
 ) -> bool {
     match value.data() {
@@ -252,7 +252,7 @@ impl ClusterInfo {
     fn refresh_push_active_set(
         &self,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         gossip_validators: Option<&HashSet<Pubkey>>,
         sender: &impl ChannelSend<PacketBatch>,
     ) {
@@ -1223,7 +1223,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let now = timestamp();
         let self_info = CrdsValue::new(CrdsData::from(self.my_contact_info()), &self.keypair());
@@ -1271,7 +1271,7 @@ impl ClusterInfo {
     }
     fn new_push_requests(
         &self,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let self_id = self.id();
         let (entries, push_messages, num_pushes) = {
@@ -1323,7 +1323,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         generate_pull_requests: bool,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         self.trim_crds_table(CRDS_UNIQUE_PUBKEY_CAPACITY, stakes);
@@ -1346,7 +1346,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         gossip_validators: Option<&HashSet<Pubkey>>,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         sender: &impl ChannelSend<PacketBatch>,
         generate_pull_requests: bool,
     ) -> Result<(), GossipError> {
@@ -1400,7 +1400,7 @@ impl ClusterInfo {
         &self,
         thread_pool: &ThreadPool,
         epoch_duration: Duration,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) {
         let self_pubkey = self.id();
         let timeouts = self
@@ -1416,7 +1416,7 @@ impl ClusterInfo {
 
     // Trims the CRDS table by dropping all values associated with the pubkeys
     // with the lowest stake, so that the number of unique pubkeys are bounded.
-    fn trim_crds_table(&self, cap: usize, stakes: &HashMap<Pubkey, u64>) {
+    fn trim_crds_table(&self, cap: usize, stakes: &StakedNodesHashMap) {
         if !self.gossip.crds.read().unwrap().should_trim(cap) {
             return;
         }
@@ -1531,7 +1531,7 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    fn handle_batch_prune_messages(&self, messages: Vec<PruneData>, stakes: &HashMap<Pubkey, u64>) {
+    fn handle_batch_prune_messages(&self, messages: Vec<PruneData>, stakes: &StakedNodesHashMap) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_prune_messages_time);
         if messages.is_empty() {
             return;
@@ -1582,7 +1582,7 @@ impl ClusterInfo {
         requests: Vec<PullRequest>,
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         response_sender: &impl ChannelSend<PacketBatch>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_requests_time);
@@ -1660,7 +1660,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
         mut requests: Vec<PullRequest>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> PacketBatch {
         const DEFAULT_EPOCH_DURATION_MS: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT;
         let output_size_limit =
@@ -1757,7 +1757,7 @@ impl ClusterInfo {
     fn handle_batch_pull_responses(
         &self,
         responses: Vec<CrdsValue>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         epoch_duration: Duration,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_responses_time);
@@ -1849,7 +1849,7 @@ impl ClusterInfo {
         messages: Vec<(Pubkey, Vec<CrdsValue>)>,
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         response_sender: &impl ChannelSend<PacketBatch>,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_push_messages_time);
@@ -1882,7 +1882,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         // Unique origin pubkeys of upserted CRDS values from push messages.
         origins: impl IntoIterator<Item = Pubkey>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> Vec<(SocketAddr, Protocol /*::PruneMessage*/)> {
         let _st = ScopedTimer::from(&self.stats.generate_prune_messages);
         let self_pubkey = self.id();
@@ -1947,7 +1947,7 @@ impl ClusterInfo {
         thread_pool: &ThreadPool,
         recycler: &PacketBatchRecycler,
         response_sender: &impl ChannelSend<PacketBatch>,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         epoch_duration: Duration,
         should_check_duplicate_instance: bool,
     ) -> Result<(), GossipError> {
@@ -2111,7 +2111,7 @@ impl ClusterInfo {
             .add_relaxed(num_packets as u64);
         fn verify_packet(
             packet: &Packet,
-            stakes: &HashMap<Pubkey, u64>,
+            stakes: &StakedNodesHashMap,
             stats: &GossipStats,
         ) -> Option<(SocketAddr, Protocol)> {
             let mut protocol: Protocol =
@@ -2978,7 +2978,7 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
     rng: &mut R,
     keypair: &Keypair,
     value: &CrdsValue,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesHashMap,
     socket_addr_space: &SocketAddrSpace,
     ping_cache: &Mutex<PingCache>,
     pings: &mut Vec<(SocketAddr, Ping)>,
@@ -3090,7 +3090,7 @@ mod tests {
             &self,
             thread_pool: &ThreadPool,
             gossip_validators: Option<&HashSet<Pubkey>>,
-            stakes: &HashMap<Pubkey, u64>,
+            stakes: &StakedNodesHashMap,
         ) -> (
             Vec<(SocketAddr, Ping)>,     // Ping packets
             Vec<(SocketAddr, Protocol)>, // Pull requests
@@ -3132,7 +3132,7 @@ mod tests {
         });
         let entrypoint_pubkey = solana_pubkey::new_rand();
         let data = test_crds_values(entrypoint_pubkey);
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
             CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout
@@ -3270,17 +3270,17 @@ mod tests {
         cluster_info.gossip.refresh_push_active_set(
             &cluster_info.keypair(),
             cluster_info.my_shred_version(),
-            &HashMap::new(), // stakes
-            None,            // gossip validators
+            &HashMap::default(), // stakes
+            None,                // gossip validators
             &cluster_info.ping_cache,
             &mut Vec::new(), // pings
             &SocketAddrSpace::Unspecified,
         );
         let mut reqs = cluster_info.generate_new_gossip_requests(
             &thread_pool,
-            None,            // gossip_validators
-            &HashMap::new(), // stakes
-            true,            // generate_pull_requests
+            None,                // gossip_validators
+            &HashMap::default(), // stakes
+            true,                // generate_pull_requests
         );
         //assert none of the addrs are invalid.
         assert!(reqs.all(|(addr, _)| {
@@ -3399,7 +3399,7 @@ mod tests {
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
         );
-        let stakes = HashMap::<Pubkey, u64>::default();
+        let stakes = HashMap::default();
         cluster_info.ping_cache.lock().unwrap().mock_pong(
             *peer.pubkey(),
             peer.gossip().unwrap(),
@@ -3445,7 +3445,7 @@ mod tests {
                 cluster_info.my_shred_version(),
                 timestamp(),
                 None,
-                &HashMap::new(),
+                &HashMap::default(),
                 992, // max_bloom_filter_bytes
                 &cluster_info.ping_cache,
                 &mut pings,
@@ -3774,7 +3774,8 @@ mod tests {
         let entrypoint_pubkey = solana_pubkey::new_rand();
         let entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
         cluster_info.set_entrypoint(entrypoint.clone());
-        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &HashMap::new());
+        let (pings, pulls) =
+            cluster_info.old_pull_requests(&thread_pool, None, &HashMap::default());
         assert!(pings.is_empty());
         assert_eq!(pulls.len(), MIN_NUM_BLOOM_FILTERS);
         for (addr, msg) in pulls {
@@ -3790,14 +3791,15 @@ mod tests {
         // now add this message back to the table and make sure after the next pull, the entrypoint is unset
         let entrypoint_crdsvalue = CrdsValue::new_unsigned(CrdsData::from(&entrypoint));
         let cluster_info = Arc::new(cluster_info);
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = cluster_info.gossip.make_timeouts(
             cluster_info.id(),
             &stakes,
             Duration::from_millis(cluster_info.gossip.pull.crds_timeout),
         );
         cluster_info.handle_pull_response(vec![entrypoint_crdsvalue], &timeouts);
-        let (pings, pulls) = cluster_info.old_pull_requests(&thread_pool, None, &HashMap::new());
+        let (pings, pulls) =
+            cluster_info.old_pull_requests(&thread_pool, None, &HashMap::default());
         assert_eq!(pings.len(), 1);
         assert_eq!(pulls.len(), MIN_NUM_BLOOM_FILTERS);
         assert_eq!(*cluster_info.entrypoints.read().unwrap(), vec![entrypoint]);
@@ -3808,7 +3810,6 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let d = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
         let cluster_info = ClusterInfo::new(d.clone(), keypair, SocketAddrSpace::Unspecified);
-        let mut stakes = HashMap::new();
 
         // no stake
         let id = Pubkey::from([1u8; 32]);
@@ -3819,7 +3820,6 @@ mod tests {
         let id2 = Pubkey::from([2u8; 32]);
         let mut contact_info = ContactInfo::new_localhost(&id2, timestamp());
         cluster_info.insert_info(contact_info.clone());
-        stakes.insert(id2, 10);
 
         // duplicate
         contact_info.set_wallclock(timestamp() + 1);
@@ -3830,7 +3830,6 @@ mod tests {
         let mut contact_info = ContactInfo::new_localhost(&id3, timestamp());
         contact_info.remove_tvu();
         cluster_info.insert_info(contact_info);
-        stakes.insert(id3, 10);
 
         // normal but with different shred version
         let id4 = Pubkey::from([4u8; 32]);
@@ -3838,7 +3837,6 @@ mod tests {
         contact_info.set_shred_version(1);
         assert_ne!(contact_info.shred_version(), d.shred_version());
         cluster_info.insert_info(contact_info);
-        stakes.insert(id4, 10);
     }
 
     #[test]
@@ -3857,7 +3855,7 @@ mod tests {
             .unwrap();
         cluster_info.set_entrypoint(entrypoint.clone());
 
-        let mut stakes = HashMap::new();
+        let mut stakes = HashMap::default();
 
         let other_node_pubkey = solana_pubkey::new_rand();
         let other_node = ContactInfo::new_localhost(&other_node_pubkey, timestamp());
@@ -4024,7 +4022,7 @@ mod tests {
         })
         .take(NO_ENTRIES)
         .collect();
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
             CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS * 4, // default_timeout

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -3,7 +3,7 @@ use {
     itertools::Itertools,
     solana_clock::Slot,
     solana_measure::measure::Measure,
-    solana_pubkey::Pubkey,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
         cmp::Reverse,
         collections::HashMap,
@@ -206,7 +206,7 @@ impl GossipStats {
 pub(crate) fn submit_gossip_stats(
     stats: &GossipStats,
     gossip: &CrdsGossip,
-    stakes: &HashMap<Pubkey, u64>,
+    stakes: &StakedNodesHashMap,
 ) {
     let (crds_stats, table_size, num_nodes, num_pubkeys, purged_values_size, failed_inserts_size) = {
         let gossip_crds = gossip.crds.read().unwrap();

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -45,6 +45,7 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
         cmp::Ordering,
         collections::{hash_map, BTreeMap, HashMap, VecDeque},
@@ -639,7 +640,7 @@ impl Crds {
         // Set of pubkeys to never drop.
         // e.g. known validators, self pubkey, ...
         keep: &[Pubkey],
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         now: u64,
     ) -> Result</*num purged:*/ usize, CrdsError> {
         if self.should_trim(cap) {
@@ -655,7 +656,7 @@ impl Crds {
         &mut self,
         size: usize,
         keep: &[Pubkey],
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
         now: u64,
     ) -> Result</*num purged:*/ usize, CrdsError> {
         if stakes.values().all(|&stake| stake == 0) {
@@ -956,7 +957,7 @@ mod tests {
             Ok(())
         );
         let pubkey = Pubkey::new_unique();
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let epoch_duration = Duration::from_secs(48 * 3600);
         let timeouts = CrdsTimeouts::new(
             pubkey,
@@ -992,7 +993,7 @@ mod tests {
         let mut rng = thread_rng();
         let mut crds = Crds::default();
         let val = CrdsValue::new_rand(&mut rng, None);
-        let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             3,                              // default_timeout
@@ -1051,7 +1052,7 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
         );
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                              // default_timeout
@@ -1077,7 +1078,7 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(())
         );
-        let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let mut stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             0,                              // default_timeout
@@ -1465,7 +1466,7 @@ mod tests {
             crds.insert(val.clone(), 1, GossipRoute::LocalMessage),
             Ok(_)
         );
-        let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
+        let stakes = HashMap::from_iter([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                        // default_timeout

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -9,6 +9,7 @@ use {
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
         cmp::Reverse,
         collections::HashMap,
@@ -41,7 +42,7 @@ pub struct DuplicateShredHandler {
     bank_forks: Arc<RwLock<BankForks>>,
     // Cache information from root bank so we could function correctly without reading roots.
     cached_on_epoch: Epoch,
-    cached_staked_nodes: Arc<HashMap<Pubkey, u64>>,
+    cached_staked_nodes: Arc<StakedNodesHashMap>,
     cached_slots_in_epoch: u64,
     // Used to notify duplicate consensus state machine
     duplicate_slots_sender: Sender<Slot>,
@@ -79,7 +80,7 @@ impl DuplicateShredHandler {
             consumed: HashMap::<Slot, bool>::default(),
             last_root: 0,
             cached_on_epoch: 0,
-            cached_staked_nodes: Arc::new(HashMap::new()),
+            cached_staked_nodes: Arc::new(HashMap::default()),
             cached_slots_in_epoch: 0,
             blockstore,
             leader_schedule_cache,

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -1,13 +1,12 @@
 use {
     solana_clock::{Epoch, DEFAULT_MS_PER_SLOT},
     solana_epoch_schedule::EpochSchedule,
-    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
         bank_forks::{BankForks, ReadOnlyAtomicSlot},
     },
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
-        collections::HashMap,
         sync::{Arc, RwLock},
         time::Duration,
     },
@@ -20,13 +19,13 @@ pub struct EpochSpecs {
     epoch_schedule: EpochSchedule,
     root: ReadOnlyAtomicSlot, // updated by bank-forks.
     bank_forks: Arc<RwLock<BankForks>>,
-    current_epoch_staked_nodes: Arc<HashMap<Pubkey, /*stake:*/ u64>>,
+    current_epoch_staked_nodes: Arc<StakedNodesHashMap>,
     epoch_duration: Duration,
 }
 
 impl EpochSpecs {
     #[inline]
-    pub fn current_epoch_staked_nodes(&mut self) -> &Arc<HashMap<Pubkey, /*stake:*/ u64>> {
+    pub fn current_epoch_staked_nodes(&mut self) -> &Arc<StakedNodesHashMap> {
         self.maybe_refresh();
         &self.current_epoch_staked_nodes
     }
@@ -81,6 +80,7 @@ mod tests {
     use {
         super::*,
         solana_clock::Slot,
+        solana_pubkey::Pubkey,
         solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
 

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -2,6 +2,7 @@ use {
     itertools::Itertools,
     lru::LruCache,
     solana_pubkey::Pubkey,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{cmp::Reverse, collections::HashMap},
 };
 
@@ -40,7 +41,7 @@ impl ReceivedCache {
         origin: Pubkey,  // CRDS value owner.
         stake_threshold: f64,
         min_ingress_nodes: usize,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> impl Iterator<Item = Pubkey> {
         match self.0.peek_mut(&origin) {
             None => None,
@@ -96,7 +97,7 @@ impl ReceivedCacheEntry {
         origin: &Pubkey, // CRDS value owner.
         stake_threshold: f64,
         min_ingress_nodes: usize,
-        stakes: &HashMap<Pubkey, u64>,
+        stakes: &StakedNodesHashMap,
     ) -> impl Iterator<Item = Pubkey> {
         debug_assert!((0.0..=1.0).contains(&stake_threshold));
         debug_assert!(self.num_upserts >= ReceivedCache::MIN_NUM_UPSERTS);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -25,6 +25,7 @@ use {
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
     solana_time_utils::timestamp,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{
         collections::{HashMap, HashSet},
         net::{Ipv4Addr, SocketAddr},
@@ -91,8 +92,8 @@ impl Deref for Network {
     }
 }
 
-fn stakes(network: &Network) -> HashMap<Pubkey, u64> {
-    let mut stakes = HashMap::new();
+fn stakes(network: &Network) -> StakedNodesHashMap {
+    let mut stakes = HashMap::default();
     for (key, Node { stake, .. }) in network.iter() {
         stakes.insert(*key, *stake);
     }
@@ -295,9 +296,9 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     network_values.par_iter().for_each(|node| {
         node.gossip.refresh_push_active_set(
             &node.keypair,
-            0,               // shred version
-            &HashMap::new(), // stakes
-            None,            // gossip validators
+            0,                   // shred version
+            &HashMap::default(), // stakes
+            None,                // gossip validators
             &node.ping_cache,
             &mut Vec::new(), // pings
             &SocketAddrSpace::Unspecified,
@@ -475,9 +476,9 @@ fn network_run_push(
             network_values.par_iter().for_each(|node| {
                 node.gossip.refresh_push_active_set(
                     &node.keypair,
-                    0,               // shred version
-                    &HashMap::new(), // stakes
-                    None,            // gossip validators
+                    0,                   // shred version
+                    &HashMap::default(), // stakes
+                    None,                // gossip validators
                     &node.ping_cache,
                     &mut Vec::new(), // pings
                     &SocketAddrSpace::Unspecified,
@@ -554,7 +555,7 @@ fn network_run_pull(
                             0, // shred version.
                             now,
                             None,
-                            &HashMap::new(),
+                            &HashMap::default(),
                             992, // max_bloom_filter_bytes
                             from.ping_cache.deref(),
                             &mut pings,
@@ -816,15 +817,15 @@ fn test_prune_errors() {
     let ping_cache = new_ping_cache();
     crds_gossip.refresh_push_active_set(
         &keypair,
-        0,               // shred version
-        &HashMap::new(), // stakes
-        None,            // gossip validators
+        0,                   // shred version
+        &HashMap::default(), // stakes
+        None,                // gossip validators
         &ping_cache,
         &mut Vec::new(), // pings
         &SocketAddrSpace::Unspecified,
     );
     let now = timestamp();
-    let stakes = HashMap::<Pubkey, u64>::default();
+    let stakes = HashMap::default();
     //incorrect dest
     let mut res = crds_gossip.process_prune_msg(
         &id,                                      // self_pubkey

--- a/ledger/src/leader_schedule/identity_keyed.rs
+++ b/ledger/src/leader_schedule/identity_keyed.rs
@@ -3,6 +3,7 @@ use {
     itertools::Itertools,
     solana_pubkey::Pubkey,
     solana_sdk::clock::Epoch,
+    solana_vote::vote_account::StakedNodesHashMap,
     std::{collections::HashMap, ops::Index, sync::Arc},
 };
 
@@ -16,7 +17,7 @@ pub struct LeaderSchedule {
 impl LeaderSchedule {
     // Note: passing in zero stakers will cause a panic.
     pub fn new(
-        epoch_staked_nodes: &HashMap<Pubkey, u64>,
+        epoch_staked_nodes: &StakedNodesHashMap,
         epoch: Epoch,
         len: u64,
         repeat: u64,
@@ -86,7 +87,7 @@ mod tests {
     #[test]
     fn test_leader_schedule_basic() {
         let num_keys = 10;
-        let stakes: HashMap<_, _> = (0..num_keys)
+        let stakes = (0..num_keys)
             .map(|i| (solana_pubkey::new_rand(), i))
             .collect();
 
@@ -102,7 +103,7 @@ mod tests {
     #[test]
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
-        let stakes: HashMap<_, _> = (0..num_keys)
+        let stakes = (0..num_keys)
             .map(|i| (solana_pubkey::new_rand(), i))
             .collect();
 
@@ -125,7 +126,7 @@ mod tests {
     fn test_repeated_leader_schedule_specific() {
         let alice_pubkey = solana_pubkey::new_rand();
         let bob_pubkey = solana_pubkey::new_rand();
-        let stakes: HashMap<_, _> = [(alice_pubkey, 2), (bob_pubkey, 1)].into_iter().collect();
+        let stakes = [(alice_pubkey, 2), (bob_pubkey, 1)].into_iter().collect();
 
         let epoch = 0;
         let len = 8;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -209,7 +209,7 @@ impl LocalCluster {
             }
 
             let total_stake = config.node_stakes.iter().sum::<u64>();
-            let stakes = HashMap::from([
+            let stakes = HashMap::from_iter([
                 (client_keypair.pubkey(), stake),
                 (Pubkey::new_unique(), total_stake.saturating_sub(stake)),
             ]);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9073,6 +9073,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "solana-tls-utils",
+ "solana-vote",
  "static_assertions",
  "thiserror 2.0.12",
  "tokio",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -176,7 +176,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_timings::{ExecuteTimingType, ExecuteTimings},
     solana_transaction_context::{TransactionAccount, TransactionReturnData},
-    solana_vote::vote_account::{VoteAccount, VoteAccountsHashMap},
+    solana_vote::vote_account::{StakedNodesHashMap, VoteAccount, VoteAccountsHashMap},
     std::{
         collections::{HashMap, HashSet},
         fmt,
@@ -6248,11 +6248,11 @@ impl Bank {
     }
 
     /// Get the staked nodes map for the current Bank::epoch
-    pub fn current_epoch_staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub fn current_epoch_staked_nodes(&self) -> Arc<StakedNodesHashMap> {
         self.current_epoch_stakes().stakes().staked_nodes()
     }
 
-    pub fn epoch_staked_nodes(&self, epoch: Epoch) -> Option<Arc<HashMap<Pubkey, u64>>> {
+    pub fn epoch_staked_nodes(&self, epoch: Epoch) -> Option<Arc<StakedNodesHashMap>> {
         Some(self.epoch_stakes.get(&epoch)?.stakes().staked_nodes())
     }
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -14,7 +14,7 @@ use {
         vote::state::VoteStateVersions,
     },
     solana_stake_program::stake_state::Stake,
-    solana_vote::vote_account::{VoteAccount, VoteAccounts},
+    solana_vote::vote_account::{StakedNodesHashMap, VoteAccount, VoteAccounts},
     std::{
         collections::HashMap,
         ops::Add,
@@ -196,7 +196,7 @@ impl<T: Clone> Stakes<T> {
         &self.vote_accounts
     }
 
-    pub(crate) fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub(crate) fn staked_nodes(&self) -> Arc<StakedNodesHashMap> {
         self.vote_accounts.staked_nodes()
     }
 }
@@ -434,7 +434,7 @@ impl StakesEnum {
         }
     }
 
-    pub(crate) fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
+    pub(crate) fn staked_nodes(&self) -> Arc<StakedNodesHashMap> {
         match self {
             StakesEnum::Accounts(stakes) => stakes.staked_nodes(),
             StakesEnum::Delegations(stakes) => stakes.staked_nodes(),

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -37,7 +37,7 @@ solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-quic-definitions = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1883,7 +1883,7 @@ pub mod test {
         solana_logger::setup();
 
         let client_keypair = Keypair::new();
-        let stakes = HashMap::from([(client_keypair.pubkey(), 100_000)]);
+        let stakes = HashMap::from_iter([(client_keypair.pubkey(), 100_000)]);
         let staked_nodes = StakedNodes::new(
             Arc::new(stakes),
             HashMap::<Pubkey, u64>::default(), // overrides
@@ -1915,7 +1915,7 @@ pub mod test {
         solana_logger::setup();
 
         let client_keypair = Keypair::new();
-        let stakes = HashMap::from([(client_keypair.pubkey(), 0)]);
+        let stakes = HashMap::from_iter([(client_keypair.pubkey(), 0)]);
         let staked_nodes = StakedNodes::new(
             Arc::new(stakes),
             HashMap::<Pubkey, u64>::default(), // overrides

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -11,7 +11,7 @@ use {
     histogram::Histogram,
     itertools::Itertools,
     solana_packet::Packet,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_time_utils::timestamp,
     std::{
         cmp::Reverse,
@@ -65,7 +65,7 @@ where
 // Total stake and nodes => stake map
 #[derive(Default)]
 pub struct StakedNodes {
-    stakes: Arc<HashMap<Pubkey, u64>>,
+    stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
     overrides: HashMap<Pubkey, u64>,
     total_stake: u64,
     max_stake: u64,
@@ -356,7 +356,7 @@ impl StreamerSendStats {
 impl StakedNodes {
     /// Calculate the stake stats: return the new (total_stake, min_stake and max_stake) tuple
     fn calculate_stake_stats(
-        stakes: &Arc<HashMap<Pubkey, u64>>,
+        stakes: &Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
         overrides: &HashMap<Pubkey, u64>,
     ) -> (u64, u64, u64) {
         let values = stakes
@@ -370,7 +370,10 @@ impl StakedNodes {
         (total_stake, min_stake, max_stake)
     }
 
-    pub fn new(stakes: Arc<HashMap<Pubkey, u64>>, overrides: HashMap<Pubkey, u64>) -> Self {
+    pub fn new(
+        stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>,
+        overrides: HashMap<Pubkey, u64>,
+    ) -> Self {
         let (total_stake, min_stake, max_stake) = Self::calculate_stake_stats(&stakes, &overrides);
         Self {
             stakes,
@@ -405,7 +408,7 @@ impl StakedNodes {
     }
 
     // Update the stake map given a new stakes map
-    pub fn update_stake_map(&mut self, stakes: Arc<HashMap<Pubkey, u64>>) {
+    pub fn update_stake_map(&mut self, stakes: Arc<HashMap<Pubkey, u64, PubkeyHasherBuilder>>) {
         let (total_stake, min_stake, max_stake) =
             Self::calculate_stake_stats(&stakes, &self.overrides);
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8414,6 +8414,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "solana-tls-utils",
+ "solana-vote",
  "static_assertions",
  "thiserror 2.0.12",
  "tokio",

--- a/tps-client/src/utils.rs
+++ b/tps-client/src/utils.rs
@@ -73,7 +73,7 @@ pub fn create_connection_cache(
     let (stake, total_stake) =
         find_node_activated_stake(rpc_client, client_node_id.pubkey()).unwrap_or_default();
     info!("Stake for specified client_node_id: {stake}, total stake: {total_stake}");
-    let stakes = HashMap::from([
+    let stakes = HashMap::from_iter([
         (client_node_id.pubkey(), stake),
         (
             Pubkey::new_unique(),

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -386,7 +386,7 @@ async fn test_connection_pruned_and_reopened() {
 #[tokio::test]
 async fn test_staked_connection() {
     let stake_identity = Keypair::new();
-    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let stakes = HashMap::from_iter([(stake_identity.pubkey(), 100_000)]);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -40,6 +40,7 @@ solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-streamer = { workspace = true }
 solana-tls-utils = { workspace = true }
+solana-vote = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -132,7 +132,7 @@ pub fn main() {
     let sigverify_stage = Vortexor::create_sigverify_stage(tpu_receiver, non_vote_sender);
 
     // To be linked with StakedNodes service.
-    let stake_map = Arc::new(HashMap::new());
+    let stake_map = Arc::new(HashMap::default());
     let staked_nodes_overrides = HashMap::new();
 
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -85,7 +85,7 @@ impl StakeUpdater {
                             vote_account.activated_stake,
                         ))
                     })
-                    .collect::<HashMap<Pubkey, u64>>(),
+                    .collect::<HashMap<Pubkey, u64, _>>(),
             );
 
             *last_refresh = Some(Instant::now());

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -55,7 +55,7 @@ async fn test_vortexor() {
     let tpu_address = tpu_sockets.tpu_quic[0].local_addr().unwrap();
     let tpu_fwd_address = tpu_sockets.tpu_quic_fwd[0].local_addr().unwrap();
 
-    let stakes = HashMap::from([(keypair.pubkey(), 10000)]);
+    let stakes = HashMap::from_iter([(keypair.pubkey(), 10000)]);
     let staked_nodes = Arc::new(RwLock::new(StakedNodes::new(
         Arc::new(stakes),
         HashMap::<Pubkey, u64>::default(), // overrides


### PR DESCRIPTION
#### Problem
Do we deserve 4x faster hashmaps in all contexts where key is a Pubkey of a staked node thanks to https://github.com/anza-xyz/solana-sdk/pull/96? We happen to have a lot of them in the hot paths of gossip and turbine. 

**This breaks a massive amounts of public APIs** and fails CI in spectacular ways on most non-linux platforms!

 Need to figure out a way to **measure impact** and, if it is worth it, figure out how to merge it.

#### Summary of Changes

- Switch to the new custom Hasher