### PR TITLE
better API for find_available_ports_in_range

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2447,9 +2447,10 @@ impl Node {
 
         let repair = bind_to_localhost().unwrap();
         let repair_quic = bind_to_localhost().unwrap();
-        let rpc_ports = find_available_ports_in_range(localhost_ip_addr, port_range, 2).unwrap();
-        let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[0]);
-        let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_ports[1]);
+        let [rpc_port, rpc_pubsub_port] =
+            find_available_ports_in_range(localhost_ip_addr, port_range).unwrap();
+        let rpc_addr = SocketAddr::new(localhost_ip_addr, rpc_port);
+        let rpc_pubsub_addr = SocketAddr::new(localhost_ip_addr, rpc_pubsub_port);
         let broadcast = vec![bind_to_unspecified().unwrap()];
         let retransmit_socket = bind_to_unspecified().unwrap();
         let serve_repair = bind_to_localhost().unwrap();
@@ -2623,9 +2624,8 @@ impl Node {
         let (_, ancestor_hashes_requests_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let rpc_ports = find_available_ports_in_range(bind_ip_addr, port_range, 2).unwrap();
-        let rpc_port = rpc_ports[0];
-        let rpc_pubsub_port = rpc_ports[1];
+        let [rpc_port, rpc_pubsub_port] =
+            find_available_ports_in_range(bind_ip_addr, port_range).unwrap();
 
         // These are client sockets, so the port is set to be 0 because it must be ephimeral.
         let tpu_vote_forwards_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();


### PR DESCRIPTION
#### Problem
Recently added function could have a better API as suggested in https://github.com/anza-xyz/agave/pull/5865#discussion_r2060965703

This technically breaks API of a pub fn, but we have not had any releases since it was added.

#### Summary of Changes

- Implement the better API
- Add missing test for the same function

