### PR TITLE
rpc: remove intermediate allocations in getInflationReward

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -674,14 +674,13 @@ impl JsonRpcRequestProcessor {
         slot: Slot,
         addresses: &'a [String],
         reward_type_filter: &'a F,
-    ) -> HashMap<String, (Reward, Slot)>
+    ) -> impl Iterator<Item = (String, (Reward, Slot))> + use<'a, F>
     where
         F: Fn(RewardType) -> bool,
     {
         Self::filter_rewards(rewards, reward_type_filter)
             .filter(|reward| addresses.contains(&reward.pubkey))
-            .map(|reward| (reward.pubkey.clone(), (reward.clone(), slot)))
-            .collect()
+            .map(move |reward| (reward.pubkey.clone(), (reward.clone(), slot)))
     }
 
     fn filter_rewards<'a, F>(
@@ -789,6 +788,7 @@ impl JsonRpcRequestProcessor {
                         || (!epoch_has_partitioned_rewards && reward_type == RewardType::Staking)
                 },
             )
+            .collect()
         };
 
         // Append stake account rewards from partitions if partitions epoch

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -670,7 +670,7 @@ impl JsonRpcRequestProcessor {
     }
 
     fn filter_map_rewards<'a, F>(
-        rewards: &'a Option<Rewards>,
+        rewards: Option<Rewards>,
         slot: Slot,
         addresses: &'a [String],
         reward_type_filter: &'a F,
@@ -680,18 +680,18 @@ impl JsonRpcRequestProcessor {
     {
         Self::filter_rewards(rewards, reward_type_filter)
             .filter(|reward| addresses.contains(&reward.pubkey))
-            .map(move |reward| (reward.pubkey.clone(), (reward.clone(), slot)))
+            .map(move |reward| (reward.pubkey.clone(), (reward, slot)))
     }
 
     fn filter_rewards<'a, F>(
-        rewards: &'a Option<Rewards>,
+        rewards: Option<Rewards>,
         reward_type_filter: &'a F,
-    ) -> impl Iterator<Item = &'a Reward>
+    ) -> impl Iterator<Item = Reward> + use<'a, F>
     where
         F: Fn(RewardType) -> bool,
     {
         rewards
-            .iter()
+            .into_iter()
             .flatten()
             .filter(move |reward| reward.reward_type.is_some_and(reward_type_filter))
     }
@@ -780,7 +780,7 @@ impl JsonRpcRequestProcessor {
             let addresses: Vec<String> =
                 addresses.iter().map(|pubkey| pubkey.to_string()).collect();
             Self::filter_map_rewards(
-                &epoch_boundary_block.rewards,
+                epoch_boundary_block.rewards,
                 first_confirmed_block_in_epoch,
                 &addresses,
                 &|reward_type| -> bool {
@@ -862,7 +862,7 @@ impl JsonRpcRequestProcessor {
                 };
 
                 let index_reward_map = Self::filter_map_rewards(
-                    &block.rewards,
+                    block.rewards,
                     slot,
                     addresses,
                     &|reward_type| -> bool { reward_type == RewardType::Staking },

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -683,10 +683,10 @@ impl JsonRpcRequestProcessor {
             .map(move |reward| (reward.pubkey.clone(), (reward, slot)))
     }
 
-    fn filter_rewards<'a, F>(
+    fn filter_rewards<F>(
         rewards: Option<Rewards>,
-        reward_type_filter: &'a F,
-    ) -> impl Iterator<Item = Reward> + use<'a, F>
+        reward_type_filter: &F,
+    ) -> impl Iterator<Item = Reward> + use<'_, F>
     where
         F: Fn(RewardType) -> bool,
     {


### PR DESCRIPTION
#### Summary of Changes

- Intermediate `HashMap` for `index_reward_map` removed (this item was immediately iterated over to extend a different `HashMap`
- `Reward` clone removed as we can take ownership from the block instead of borrowing