### PR TITLE
Revert "switch net-utils cargo dep versions to workspace (#5998)"

### DIFF
--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -24,8 +24,8 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 socket2 = { workspace = true }
-solana-logger = { workspace = true, optional = true }
-solana-serde = { workspace = true }
+solana-logger = { version = "=2.3.1", optional = true }
+solana-serde = "=2.2.1"
 solana-version = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }


### PR DESCRIPTION
This reverts commit 94c85c4e7288bd0d92ad5deae96969dc5d55c236.

#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1366427553232846990

the deps are pined intentionally

#### Summary of Changes

revert it