### PR TITLE
rename data fec

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3173,7 +3173,7 @@ impl ReplayStage {
 
                 let is_leader_block = bank.collector_id() == my_pubkey;
                 let block_id = if !is_leader_block {
-                    // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK correctly retransmitted
+                    // If the block does not have at least DATA_SHRED_PER_FEC_SET correctly retransmitted
                     // shreds in the last FEC set, mark it dead. No reason to perform this check on our leader block.
                     match blockstore.check_last_fec_set_and_get_block_id(
                         bank.slot(),

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -118,8 +118,8 @@ const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 // each erasure batch depends on the number of shreds obtained from serializing
 // a &[Entry].
 pub const DATA_SHRED_PER_FEC_SET: usize = 32;
-pub const CODING_SHREDS_PER_FEC_BLOCK: usize = 32;
-pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHRED_PER_FEC_SET + CODING_SHREDS_PER_FEC_BLOCK;
+pub const CODING_SHREDS_PER_FEC_SET: usize = 32;
+pub const SHREDS_PER_FEC_SET: usize = DATA_SHRED_PER_FEC_SET + CODING_SHREDS_PER_FEC_SET;
 
 // Statically compute the typical data batch size assuming:
 // 1. 32:32 erasure coding batch

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -117,9 +117,9 @@ const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 // data shreds per each batch as below. The actual number of data shreds in
 // each erasure batch depends on the number of shreds obtained from serializing
 // a &[Entry].
-pub const DATA_SHREDS_PER_FEC_BLOCK: usize = 32;
+pub const DATA_SHRED_PER_FEC_SET: usize = 32;
 pub const CODING_SHREDS_PER_FEC_BLOCK: usize = 32;
-pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHREDS_PER_FEC_BLOCK;
+pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHRED_PER_FEC_SET + CODING_SHREDS_PER_FEC_BLOCK;
 
 // Statically compute the typical data batch size assuming:
 // 1. 32:32 erasure coding batch
@@ -130,7 +130,7 @@ pub fn get_data_shred_bytes_per_batch_typical() -> &'static u64 {
     DATA_SHRED_BYTES_PER_BATCH_TYPICAL.get_or_init(|| {
         let capacity = ShredData::capacity(Some((PROOF_ENTRIES_FOR_32_32_BATCH, true, false)))
             .expect("Failed to get shred capacity");
-        (DATA_SHREDS_PER_FEC_BLOCK * capacity) as u64
+        (DATA_SHRED_PER_FEC_SET * capacity) as u64
     })
 }
 

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -13,7 +13,7 @@ use {
                 Shred as ShredTrait, ShredCode as ShredCodeTrait, ShredData as ShredDataTrait,
             },
             CodingShredHeader, DataShredHeader, Error, ProcessShredsStats, ShredCommonHeader,
-            ShredFlags, ShredVariant, DATA_SHREDS_PER_FEC_BLOCK, SHREDS_PER_FEC_BLOCK,
+            ShredFlags, ShredVariant, DATA_SHRED_PER_FEC_SET, SHREDS_PER_FEC_BLOCK,
             SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_SIGNATURE,
         },
         shredder::{self, ReedSolomonCache},
@@ -1023,7 +1023,7 @@ pub(super) fn make_shreds_from_data(
     let resigned = chained && is_last_in_slot;
     let proof_size = PROOF_ENTRIES_FOR_32_32_BATCH;
     let data_buffer_per_shred_size = ShredData::capacity(proof_size, chained, resigned)?;
-    let data_buffer_total_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size;
+    let data_buffer_total_size = DATA_SHRED_PER_FEC_SET * data_buffer_per_shred_size;
 
     // Common header for the data shreds.
     let mut common_header_data = ShredCommonHeader {
@@ -1078,7 +1078,7 @@ pub(super) fn make_shreds_from_data(
         let (current_batch_data_chunk, rest) = data.split_at(data_buffer_total_size);
         debug_assert_eq!(
             current_batch_data_chunk.len(),
-            DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size
+            DATA_SHRED_PER_FEC_SET * data_buffer_per_shred_size
         );
         common_header_data.fec_set_index = common_header_data.index;
         common_header_code.fec_set_index = common_header_data.fec_set_index;
@@ -1093,7 +1093,7 @@ pub(super) fn make_shreds_from_data(
         shreds.extend(
             make_shreds_code(
                 &mut common_header_code,
-                DATA_SHREDS_PER_FEC_BLOCK,          // num_data_shreds
+                DATA_SHRED_PER_FEC_SET,             // num_data_shreds
                 is_last_in_slot && rest.is_empty(), // is_last_in_slot
             )
             .map(Shred::ShredCode),
@@ -1127,13 +1127,13 @@ pub(super) fn make_shreds_from_data(
             let chunks = data
                 .chunks(data_buffer_per_shred_size)
                 .chain(std::iter::repeat(&[][..])) // possible padding
-                .take(DATA_SHREDS_PER_FEC_BLOCK);
+                .take(DATA_SHRED_PER_FEC_SET);
             make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
         });
         shreds.extend(
             make_shreds_code(
                 &mut common_header_code,
-                DATA_SHREDS_PER_FEC_BLOCK,
+                DATA_SHRED_PER_FEC_SET,
                 is_last_in_slot,
             )
             .map(Shred::ShredCode),

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -13,7 +13,7 @@ use {
                 Shred as ShredTrait, ShredCode as ShredCodeTrait, ShredData as ShredDataTrait,
             },
             CodingShredHeader, DataShredHeader, Error, ProcessShredsStats, ShredCommonHeader,
-            ShredFlags, ShredVariant, DATA_SHRED_PER_FEC_SET, SHREDS_PER_FEC_BLOCK,
+            ShredFlags, ShredVariant, DATA_SHRED_PER_FEC_SET, SHREDS_PER_FEC_SET,
             SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_SIGNATURE,
         },
         shredder::{self, ReedSolomonCache},
@@ -1067,7 +1067,7 @@ pub(super) fn make_shreds_from_data(
     // Pre-allocate shreds to avoid reallocations.
     let mut shreds = {
         let number_of_batches = data.len().div_ceil(data_buffer_total_size);
-        let total_num_shreds = SHREDS_PER_FEC_BLOCK * number_of_batches;
+        let total_num_shreds = SHREDS_PER_FEC_SET * number_of_batches;
         Vec::<Shred>::with_capacity(total_num_shreds)
     };
     stats.data_bytes += data.len();

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -4,8 +4,8 @@ use {
         legacy, merkle,
         payload::Payload,
         traits::{Shred, ShredCode as ShredCodeTrait},
-        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
-        DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData, DATA_SHRED_PER_FEC_SET,
+        MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
     solana_sdk::{clock::Slot, hash::Hash, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
@@ -168,7 +168,7 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
         ));
     }
     let num_coding_shreds = usize::from(coding_header.num_coding_shreds);
-    if num_coding_shreds > 8 * DATA_SHREDS_PER_FEC_BLOCK {
+    if num_coding_shreds > 8 * DATA_SHRED_PER_FEC_SET {
         return Err(Error::InvalidNumCodingShreds(
             coding_header.num_coding_shreds,
         ));

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -1,6 +1,6 @@
 use {
     crate::shred::{
-        self, Error, ProcessShredsStats, Shred, ShredData, ShredFlags, DATA_SHREDS_PER_FEC_BLOCK,
+        self, Error, ProcessShredsStats, Shred, ShredData, ShredFlags, DATA_SHRED_PER_FEC_SET,
     },
     itertools::Itertools,
     lazy_lru::LruCache,
@@ -194,7 +194,7 @@ impl Shredder {
         };
         let shreds: Vec<&[u8]> = serialized_shreds.chunks(data_buffer_size).collect();
         let fec_set_offsets: Vec<usize> =
-            get_fec_set_offsets(shreds.len(), DATA_SHREDS_PER_FEC_BLOCK).collect();
+            get_fec_set_offsets(shreds.len(), DATA_SHRED_PER_FEC_SET).collect();
         assert_eq!(shreds.len(), fec_set_offsets.len());
         let shreds: Vec<Shred> = PAR_THREAD_POOL.install(|| {
             shreds
@@ -467,7 +467,7 @@ impl Shredder {
 }
 
 impl ReedSolomonCache {
-    const CAPACITY: usize = 4 * DATA_SHREDS_PER_FEC_BLOCK;
+    const CAPACITY: usize = 4 * DATA_SHRED_PER_FEC_SET;
 
     pub(crate) fn get(
         &self,
@@ -506,7 +506,7 @@ pub(crate) fn get_erasure_batch_size(num_data_shreds: usize, is_last_in_slot: bo
         .copied()
         .unwrap_or(2 * num_data_shreds);
     if is_last_in_slot {
-        erasure_batch_size.max(2 * DATA_SHREDS_PER_FEC_BLOCK)
+        erasure_batch_size.max(2 * DATA_SHRED_PER_FEC_SET)
     } else {
         erasure_batch_size
     }
@@ -589,7 +589,7 @@ mod tests {
             })
             .collect();
 
-        let num_expected_data_shreds = DATA_SHREDS_PER_FEC_BLOCK;
+        let num_expected_data_shreds = DATA_SHRED_PER_FEC_SET;
         let num_expected_coding_shreds = CODING_SHREDS_PER_FEC_BLOCK;
         let start_index = 0;
         let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
@@ -1236,7 +1236,7 @@ mod tests {
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
-        const MIN_CHUNK_SIZE: usize = DATA_SHREDS_PER_FEC_BLOCK;
+        const MIN_CHUNK_SIZE: usize = DATA_SHRED_PER_FEC_SET;
         let chunks: Vec<_> = data_shreds
             .iter()
             .group_by(|shred| shred.fec_set_index())

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -540,7 +540,7 @@ mod tests {
             blockstore::MAX_DATA_SHREDS_PER_SLOT,
             shred::{
                 self, max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred,
-                ShredType, CODING_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT,
+                ShredType, CODING_SHREDS_PER_FEC_SET, MAX_CODE_SHREDS_PER_SLOT,
             },
         },
         assert_matches::assert_matches,
@@ -590,7 +590,7 @@ mod tests {
             .collect();
 
         let num_expected_data_shreds = DATA_SHRED_PER_FEC_SET;
-        let num_expected_coding_shreds = CODING_SHREDS_PER_FEC_BLOCK;
+        let num_expected_coding_shreds = CODING_SHREDS_PER_FEC_SET;
         let start_index = 0;
         let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
             &keypair,

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -3,7 +3,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::shred::{
         max_entries_per_n_shred, verify_test_data_shred, ProcessShredsStats, ReedSolomonCache,
-        Shred, Shredder, DATA_SHREDS_PER_FEC_BLOCK, LEGACY_SHRED_DATA_CAPACITY,
+        Shred, Shredder, DATA_SHRED_PER_FEC_SET, LEGACY_SHRED_DATA_CAPACITY,
     },
     solana_sdk::{
         clock::Slot,
@@ -28,7 +28,7 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
     let slot = 0x1234_5678_9abc_def0;
     let shredder = Shredder::new(slot, slot - 5, 0, 0).unwrap();
     let num_fec_sets = 100;
-    let num_data_shreds = DATA_SHREDS_PER_FEC_BLOCK * num_fec_sets;
+    let num_data_shreds = DATA_SHRED_PER_FEC_SET * num_fec_sets;
     let keypair0 = Keypair::new();
     let keypair1 = Keypair::new();
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
@@ -73,8 +73,8 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
 
     let mut all_shreds = vec![];
     for i in 0..num_fec_sets {
-        let shred_start_index = DATA_SHREDS_PER_FEC_BLOCK * i;
-        let end_index = shred_start_index + DATA_SHREDS_PER_FEC_BLOCK - 1;
+        let shred_start_index = DATA_SHRED_PER_FEC_SET * i;
+        let end_index = shred_start_index + DATA_SHRED_PER_FEC_SET - 1;
         let fec_set_shreds = data_shreds[shred_start_index..=end_index]
             .iter()
             .cloned()
@@ -106,7 +106,7 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
             shred_info.insert(i * 2, recovered_shred);
         }
 
-        all_shreds.extend(shred_info.into_iter().take(DATA_SHREDS_PER_FEC_BLOCK));
+        all_shreds.extend(shred_info.into_iter().take(DATA_SHRED_PER_FEC_SET));
     }
 
     let result = {
@@ -196,11 +196,11 @@ fn setup_different_sized_fec_blocks(
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
     let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
 
-    // Make enough entries for `DATA_SHREDS_PER_FEC_BLOCK + 2` shreds so one
-    // fec set will have `DATA_SHREDS_PER_FEC_BLOCK` shreds and the next
+    // Make enough entries for `DATA_SHRED_PER_FEC_SET + 2` shreds so one
+    // fec set will have `DATA_SHRED_PER_FEC_SET` shreds and the next
     // will have 2 shreds.
-    assert!(DATA_SHREDS_PER_FEC_BLOCK > 2);
-    let num_shreds_per_iter = DATA_SHREDS_PER_FEC_BLOCK + 2;
+    assert!(DATA_SHRED_PER_FEC_SET > 2);
+    let num_shreds_per_iter = DATA_SHRED_PER_FEC_SET + 2;
     let num_entries = max_entries_per_n_shred(
         &entry,
         num_shreds_per_iter as u64,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -492,7 +492,7 @@ mod test {
             blockstore::Blockstore,
             genesis_utils::create_genesis_config,
             get_tmp_ledger_path,
-            shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
+            shred::{max_ticks_per_n_shreds, DATA_SHRED_PER_FEC_SET},
         },
         solana_net_utils::bind_to_unspecified,
         solana_runtime::bank::Bank,
@@ -588,7 +588,7 @@ mod test {
     #[test]
     fn test_slot_interrupt() {
         // Setup
-        let num_shreds_per_slot = DATA_SHREDS_PER_FEC_BLOCK as u64;
+        let num_shreds_per_slot = DATA_SHRED_PER_FEC_SET as u64;
         let (blockstore, genesis_config, cluster_info, bank0, leader_keypair, socket, bank_forks) =
             setup(num_shreds_per_slot);
         let (quic_endpoint_sender, _quic_endpoint_receiver) =
@@ -687,7 +687,7 @@ mod test {
         // index < the previous shred index for slot 0
         assert_eq!(
             standard_broadcast_run.next_shred_index as usize,
-            DATA_SHREDS_PER_FEC_BLOCK
+            DATA_SHRED_PER_FEC_SET
         );
         assert_eq!(standard_broadcast_run.slot, 2);
         assert_eq!(standard_broadcast_run.parent, 0);
@@ -756,7 +756,7 @@ mod test {
             shreds.extend(recv_shreds.deref().clone());
         }
         // At least as many coding shreds as data shreds.
-        assert!(shreds.len() >= DATA_SHREDS_PER_FEC_BLOCK * 2);
+        assert!(shreds.len() >= DATA_SHRED_PER_FEC_SET * 2);
         assert_eq!(
             shreds.iter().filter(|shred| shred.is_data()).count(),
             shreds.len() / 2
@@ -765,7 +765,7 @@ mod test {
         while let Ok((recv_shreds, _)) = brecv.recv_timeout(Duration::from_secs(1)) {
             shreds.extend(recv_shreds.deref().clone());
         }
-        assert!(shreds.len() >= DATA_SHREDS_PER_FEC_BLOCK * 2);
+        assert!(shreds.len() >= DATA_SHRED_PER_FEC_SET * 2);
         assert_eq!(
             shreds.iter().filter(|shred| shred.is_data()).count(),
             shreds.len() / 2


### PR DESCRIPTION
Breaks public API - Do not merge

#### Problem
Renaming to align on `*FEC_SET` terminology

#### Summary of Changes
Rename the following:
`DATA_SHREDS_PER_FEC_BLOCK` --> `DATA_SHREDS_PER_FEC_SET`
`CODING_SHREDS_PER_FEC_BLOCK` --> `CODING_SHREDS_PER_FEC_SET`
`SHREDS_PER_FEC_BLOCK` --> `SHREDS_PER_FEC_SET`