### PR TITLE
Speedup index generation for in-memory index: don't throttle in-memory index generation threads

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8698,10 +8698,7 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            if self.accounts_index.is_disk_index_enabled() {
-                                // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
-                                self.maybe_throttle_index_generation();
-                            }
+                            self.maybe_throttle_index_generation();
                             let SlotIndexGenerationInfo {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,
@@ -9025,6 +9022,10 @@ impl AccountsDb {
     /// Startup processes can consume large amounts of memory while inserting accounts into the index as fast as possible.
     /// Calling this can slow down the insertion process to allow flushing to disk to keep pace.
     fn maybe_throttle_index_generation(&self) {
+        // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
+        if !self.accounts_index.is_disk_index_enabled() {
+            return;
+        }
         // This number is chosen to keep the initial ram usage sufficiently small
         // The process of generating the index is goverened entirely by how fast the disk index can be populated.
         // 10M accounts is sufficiently small that it will never have memory usage. It seems sufficiently large that it will provide sufficient performance.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8698,7 +8698,10 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            self.maybe_throttle_index_generation();
+                            if self.accounts_index.is_disk_index_enabled() {
+                                // Only throttle if we are generating on-disk index. Throttling is not needed for in-mem index.
+                                self.maybe_throttle_index_generation();
+                            }
                             let SlotIndexGenerationInfo {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,


### PR DESCRIPTION
#### Problem

At startup, generation in-memory index is very slow compared to disk-based index. We should speed up the index generation for in-memory index.


#### Summary of Changes

Don't throttle in-memory index generation threads.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
