### PR TITLE
fix: unwrap() to return a reference instead of cloning

### DIFF
--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -31,10 +31,10 @@ pub enum BanksClientError {
 }
 
 impl BanksClientError {
-    pub fn unwrap(&self) -> TransactionError {
+    pub fn unwrap(&self) -> &TransactionError {
         match self {
             BanksClientError::TransactionError(err)
-            | BanksClientError::SimulationError { err, .. } => err.clone(),
+            | BanksClientError::SimulationError { err, .. } => err,
             _ => panic!("unexpected transport error"),
         }
     }


### PR DESCRIPTION
#### Problem  
`unwrap(&self)` was returning a `TransactionError` by value, which led to an unnecessary `.clone()`.

#### Summary of Changes  
changed return type to `&TransactionError` so we return a reference instead. removed the `.clone()` call—simpler and more efficient.