### PR TITLE
do not accept requests with shred version 0. must match our shred version

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2910,8 +2910,7 @@ fn check_pull_request_shred_version(self_shred_version: u16, caller: &CrdsValue)
         CrdsData::LegacyContactInfo(node) => node.shred_version(),
         _ => return false,
     };
-    // Allow spy nodes with shred-verion == 0 to pull from other nodes.
-    shred_version == 0u16 || shred_version == self_shred_version
+    shred_version == self_shred_version
 }
 
 // Discards CrdsValues in PushMessages and PullResponses from nodes with

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -319,8 +319,7 @@ pub(crate) fn get_gossip_nodes<R: Rng>(
     now: u64,
     pubkey: &Pubkey, // This node.
     // By default, should only push to or pull from gossip nodes with the same
-    // shred-version. Except for spy nodes (shred_version == 0u16) which can
-    // pull from any node.
+    // shred-version.
     verify_shred_version: impl Fn(/*shred_version:*/ u16) -> bool,
     crds: &RwLock<Crds>,
     gossip_validators: Option<&HashSet<Pubkey>>,

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -254,7 +254,7 @@ impl CrdsGossipPull {
             &self_keypair.pubkey(),
             // Pull from nodes with the same shred version, unless this is a
             // spy node which then can pull from any node.
-            |shred_version| self_shred_version == 0u16 || shred_version == self_shred_version,
+            |shred_version| shred_version == self_shred_version,
             crds,
             gossip_validators,
             stakes,


### PR DESCRIPTION
#### Problem
nodes will always respond to pull requests if they are sent with shred version == 0. We are in the process of removing the special `shred_version == 0` case so we need to only respond when sender shred version matches our own.

#### Summary of Changes
don't respond to pull requests with different shred version

PR https://github.com/anza-xyz/agave/pull/6033 must be merged before this one