### PR TITLE
getters should enforce shred version checks. deprecate ones that do not

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2662,7 +2662,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     // Staked nodes entries will not expire until an epoch after. So it
     // is necessary here to filter for recent entries to establish liveness.
     let peers: HashMap<_, _> = cluster_info
-        .tvu_peers(|q| q.clone())
+        .tvu_peers(ContactInfo::clone)
         .into_iter()
         .filter(|node| {
             let age = now.saturating_sub(node.wallclock());

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -305,7 +305,7 @@ fn spy(
             .into_iter()
             .map(|x| x.0)
             .collect::<Vec<_>>();
-        tvu_peers = spy_ref.tvu_peers(|q| q.clone());
+        tvu_peers = spy_ref.tvu_peers(ContactInfo::clone);
 
         let found_nodes_by_pubkey = if let Some(pubkeys) = find_nodes_by_pubkey {
             pubkeys

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -193,12 +193,7 @@ fn get_rpc_peers(
             .unwrap_or_default()
     );
 
-    let mut rpc_peers = cluster_info
-        .all_rpc_peers()
-        .into_iter()
-        .filter(|contact_info| contact_info.shred_version() == shred_version)
-        .collect::<Vec<_>>();
-
+    let mut rpc_peers = cluster_info.rpc_peers();
     if bootstrap_config.only_known_rpc {
         rpc_peers.retain(|rpc_peer| {
             is_known_validator(rpc_peer.pubkey(), &validator_config.known_validators)


### PR DESCRIPTION
WAIT TO MERGE. Should merge with: https://github.com/anza-xyz/agave/pull/5659
#### Problem
We are in the process of removing the special `shred_version == 0` case. our cluster_info getters must check shred version before returning

#### Summary of Changes
deprecate old cluster_info getters that are shred version agnostic. 

Note: we need to wait to merge this until https://github.com/anza-xyz/agave/pull/5659. If we merge this now, while we still accept contactinfo with a different shred version, then messages will sit in our table with the wrong shred version but we will have no way to query them or know they exist.
