### PR TITLE
Adds scaffolding for not flushing storages when taking snapshots

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -71,6 +71,7 @@ impl SnapshotPackagerService {
                         measure_us!(snapshot_utils::serialize_and_archive_snapshot_package(
                             snapshot_package,
                             snapshot_config,
+                            true, // always flush the storages to enable fastboot
                         ));
                     if let Err(err) = archive_result {
                         error!(


### PR DESCRIPTION
#### Problem

Flushing files/mmaps is slow and often unnecessary. One of the last places we still do this is flushing the account storage files when taking a snapshot so that it will be safe for fastboot even after a power cycle.

(We'll worry separately about whether we should support the power cycle use case at all.)

Right now we don't have any way to opt out of this flushing.


#### Summary of Changes

Add the necessary plumbing into the snapshot code to *not* flush the account storage files when taking a snapshot.

Other notable changes:

At startup, we want to know if a snapshot is fastboot-able or not. Since this depends on if the storages were flushed or not, this PR adds a new file to the bank snapshot to indicate this. Note, this file doesn't go into the snapshot archive, it is entirely local and used exclusively for fastboot.

The intention with this PR is to not change any current behavior; just lay the ground work. Subsequent PRs will make behavioral changes, and will be much smaller by doing this work separately.