### PR TITLE
SnapshotPackagerService can flush storages on graceful exit only

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -895,11 +895,13 @@ impl Validator {
             .snapshot_config()
             .should_generate_snapshots()
         {
+            let exit_backpressure = None;
             let enable_gossip_push = true;
             let snapshot_packager_service = SnapshotPackagerService::new(
                 pending_snapshot_packages.clone(),
                 starting_snapshot_hashes,
                 exit.clone(),
+                exit_backpressure,
                 cluster_info.clone(),
                 snapshot_controller.clone(),
                 enable_gossip_push,

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -187,6 +187,7 @@ impl BackgroundServices {
             pending_snapshot_packages.clone(),
             None,
             exit.clone(),
+            None,
             cluster_info.clone(),
             snapshot_controller.clone(),
             false,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -737,6 +737,7 @@ fn test_snapshots_with_background_services(
         pending_snapshot_packages.clone(),
         None,
         exit.clone(),
+        None,
         cluster_info.clone(),
         snapshot_controller.clone(),
         false,


### PR DESCRIPTION
#### Problem

Flushing files/mmaps is slow and often unnecessary. One of the last places we still do this is flushing the account storage files when taking a snapshot so that it will be safe for fastboot even after a power cycle.

(We'll worry separately about whether we should support the power cycle use case at all.)

Now when SnapshotPackagerService takes a snapshot, it could flush or not. However, if SPS opt-ed out, then there would be no way to actually flush if we did want to (e.g. only flush storages when exiting gracefully).


#### Summary of Changes

Continuing on from #6031, plumb the ability for SPS to know if there's a graceful exit or not. This way we can opt into only flushing on graceful exit, or keeping the current behavior and flush every snapshot.


#### Other Testing

I've got this hooked up with graceful exit support, and have passed unit/local cluster tests, *plus* run it against testnet with ~100 iterations of graceful (or ungraceful) exits to observe expected behavior.