### PR TITLE
Update LocalCluster to discover cluster using correct shred version

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2250,6 +2250,10 @@ fn test_hard_fork_invalidates_tower() {
         &cluster.lock().unwrap().genesis_config.hash(),
         Some(&hard_forks),
     );
+    cluster
+        .lock()
+        .unwrap()
+        .set_shred_version(expected_shred_version);
 
     validator_a_info
         .config


### PR DESCRIPTION
#### Problem
LocalCluster was always trying to discover nodes with shred version 0. But the validators running in that cluster are not on shred version 0. We are removing support for shred version 0. So we need to make sure that LocalCluster is properly discovering nodes before we remove support.

#### Summary of Changes
Make LocalCluster discover nodes using the correct shred version
