### PR TITLE
less parallelism in gossip verify

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2129,7 +2129,7 @@ impl ClusterInfo {
                     return None;
                 }
             }
-            protocol.par_verify().then(|| {
+            protocol.verify().then(|| {
                 stats.packets_received_verified_count.add_relaxed(1);
                 (packet.meta().socket_addr(), protocol)
             })

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -90,7 +90,7 @@ impl Protocol {
 
     // Returns true if all signatures verify.
     #[must_use]
-    pub(crate) fn par_verify(&self) -> bool {
+    pub(crate) fn verify(&self) -> bool {
         match self {
             Self::PullRequest(_, caller) => caller.verify(),
             Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -7,7 +7,6 @@ use {
         ping_pong::{self, Pong},
     },
     bincode::serialize,
-    rayon::prelude::*,
     serde::Serialize,
     solana_keypair::signable::Signable,
     solana_perf::packet::PACKET_DATA_SIZE,
@@ -94,8 +93,8 @@ impl Protocol {
     pub(crate) fn par_verify(&self) -> bool {
         match self {
             Self::PullRequest(_, caller) => caller.verify(),
-            Self::PullResponse(_, data) => data.par_iter().all(CrdsValue::verify),
-            Self::PushMessage(_, data) => data.par_iter().all(CrdsValue::verify),
+            Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),
+            Self::PushMessage(_, data) => data.iter().all(CrdsValue::verify),
             Self::PruneMessage(_, data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),


### PR DESCRIPTION
#### Problem

There is excessive parallelism in sigverify of gossip Push and PullResponse packets

#### Summary of Changes

- Switch to sequential processing (verify till first signature failure rather than multithreading within packet)