### PR TITLE
Add completed_data_indexes migration scaffolding

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -63,8 +63,8 @@ use {
         cell::RefCell,
         cmp,
         collections::{
-            btree_map::Entry as BTreeMapEntry, hash_map::Entry as HashMapEntry, BTreeMap, BTreeSet,
-            HashMap, HashSet, VecDeque,
+            btree_map::Entry as BTreeMapEntry, hash_map::Entry as HashMapEntry, BTreeMap, HashMap,
+            HashSet, VecDeque,
         },
         convert::TryInto,
         fmt::Write,
@@ -3678,7 +3678,7 @@ impl Blockstore {
     // Get the range of indexes [start_index, end_index] of every completed data block
     fn get_completed_data_ranges(
         start_index: u32,
-        completed_data_indexes: &BTreeSet<u32>,
+        completed_data_indexes: &CompletedDataIndexes,
         consumed: u32,
     ) -> CompletedRanges {
         // `consumed` is the next missing shred index, but shred `i` existing in
@@ -3686,7 +3686,7 @@ impl Blockstore {
         assert!(!completed_data_indexes.contains(&consumed));
         completed_data_indexes
             .range(start_index..consumed)
-            .scan(start_index, |start, &index| {
+            .scan(start_index, |start, index| {
                 let out = *start..index + 1;
                 *start = index + 1;
                 Some(out)
@@ -4691,8 +4691,13 @@ fn update_completed_data_indexes<'a>(
     new_shred_index: u32,
     received_data_shreds: &'a ShredIndex,
     // Shreds indices which are marked data complete.
-    completed_data_indexes: &mut BTreeSet<u32>,
+    completed_data_indexes: &mut CompletedDataIndexes,
 ) -> impl Iterator<Item = Range<u32>> + 'a {
+    // new_shred_index is data complete, so need to insert here into
+    // the completed_data_indexes.
+    if is_last_in_data {
+        completed_data_indexes.insert(new_shred_index);
+    }
     // Consecutive entries i, j, k in this array represent potential ranges
     // [i, j), [j, k) that could be completed data ranges
     [
@@ -4701,12 +4706,7 @@ fn update_completed_data_indexes<'a>(
             .next_back()
             .map(|index| index + 1)
             .or(Some(0u32)),
-        is_last_in_data.then(|| {
-            // new_shred_index is data complete, so need to insert here into
-            // the completed_data_indexes.
-            completed_data_indexes.insert(new_shred_index);
-            new_shred_index + 1
-        }),
+        is_last_in_data.then(|| new_shred_index + 1),
         completed_data_indexes
             .range(new_shred_index + 1..)
             .next()
@@ -10472,7 +10472,7 @@ pub mod tests {
 
     #[test]
     fn test_update_completed_data_indexes() {
-        let mut completed_data_indexes = BTreeSet::default();
+        let mut completed_data_indexes = CompletedDataIndexes::default();
         let mut shred_index = ShredIndex::default();
 
         for i in 0..10 {
@@ -10484,13 +10484,13 @@ pub mod tests {
                 &mut completed_data_indexes
             )
             .eq(std::iter::once(i..i + 1)));
-            assert!(completed_data_indexes.iter().copied().eq(0..=i));
+            assert!(completed_data_indexes.clone().into_iter().eq(0..=i));
         }
     }
 
     #[test]
     fn test_update_completed_data_indexes_out_of_order() {
-        let mut completed_data_indexes = BTreeSet::default();
+        let mut completed_data_indexes = CompletedDataIndexes::default();
         let mut shred_index = ShredIndex::default();
 
         shred_index.insert(4);
@@ -10512,7 +10512,7 @@ pub mod tests {
             update_completed_data_indexes(true, 3, &shred_index, &mut completed_data_indexes)
                 .eq([])
         );
-        assert!(completed_data_indexes.iter().eq([3].iter()));
+        assert!(completed_data_indexes.clone().into_iter().eq([3]));
 
         // Inserting data complete shred 1 now confirms the range of shreds [2, 3]
         // is part of the same data set
@@ -10521,7 +10521,7 @@ pub mod tests {
             update_completed_data_indexes(true, 1, &shred_index, &mut completed_data_indexes)
                 .eq(std::iter::once(2..4))
         );
-        assert!(completed_data_indexes.iter().eq([1, 3].iter()));
+        assert!(completed_data_indexes.clone().into_iter().eq([1, 3]));
 
         // Inserting data complete shred 0 now confirms the range of shreds [0]
         // is part of the same data set
@@ -10530,7 +10530,7 @@ pub mod tests {
             update_completed_data_indexes(true, 0, &shred_index, &mut completed_data_indexes)
                 .eq([0..1, 1..2])
         );
-        assert!(completed_data_indexes.iter().eq([0, 1, 3].iter()));
+        assert!(completed_data_indexes.clone().into_iter().eq([0, 1, 3]));
     }
 
     #[test]

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -123,11 +123,7 @@ impl Blockstore {
                     slot,
                     from_slot..=to_slot
                 );
-                self.put_meta_bytes(
-                    slot,
-                    &bincode::serialize(&meta).expect("couldn't update meta"),
-                )
-                .expect("couldn't update meta");
+                self.put_meta(slot, &meta).expect("couldn't update meta");
             }
             time.stop();
             total_retain_us += time.as_us();

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -73,6 +73,10 @@ impl CompletedDataIndexesV2 {
         self.index.iter_ones().map(|i| i as u32)
     }
 
+    /// Only needed for V1 / V2 test compatibility.
+    ///
+    /// TODO: Remove once the migration is complete.
+    #[cfg(test)]
     #[inline]
     pub fn into_iter(&self) -> impl DoubleEndedIterator<Item = u32> + '_ {
         self.iter()
@@ -113,7 +117,7 @@ impl FromIterator<u32> for CompletedDataIndexesV2 {
 
 impl From<CompletedDataIndexesV2> for CompletedDataIndexesV1 {
     fn from(value: CompletedDataIndexesV2) -> Self {
-        value.into_iter().collect()
+        value.iter().collect()
     }
 }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -51,14 +51,13 @@ impl Default for ConnectedFlags {
     }
 }
 
-/// Now deprecated format for completed data indexes.
+/// Legacy completed data indexes type; de/serialization is inefficient for a BTreeSet.
 ///
 /// Replaced by [`CompletedDataIndexesV2`].
 pub type CompletedDataIndexesV1 = BTreeSet<u32>;
-/// New format for completed data indexes.
+/// A fixed size BitVec offers fast lookup and fast de/serialization.
 ///
-/// `BTreeSet` is inefficient for de/serialization. We
-/// are migrating to a bitvec to improve that.
+/// Supersedes [`CompletedDataIndexesV1`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct CompletedDataIndexesV2 {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -951,7 +951,6 @@ pub fn create_test_recorder_with_index_tracking(
 mod tests {
     use {
         super::*,
-        bincode::serialize,
         crossbeam_channel::bounded,
         solana_clock::DEFAULT_TICKS_PER_SLOT,
         solana_ledger::{
@@ -1916,10 +1915,7 @@ mod tests {
             received: 1,
             ..SlotMeta::default()
         };
-        poh_recorder
-            .blockstore
-            .put_meta_bytes(0, &serialize(&parent_meta).unwrap())
-            .unwrap();
+        poh_recorder.blockstore.put_meta(0, &parent_meta).unwrap();
 
         // Use a key that's different from the previous leader so that grace
         // ticks are enforced.


### PR DESCRIPTION
#### Problem

Follow up of #5994, this sets up the start of the migration process for backing `completed_data_indexes` with a bitvec.

#### Summary of Changes

Following the same pattern as #3900, this sets up two formats for the `SlotMeta` column: `SlotMetaV1` (current) and `SlotMetaV2` (incoming).

Reiterating the strategy:
1. Release 1: Add ability to read new format as fallback, keep writing old format
2. Release 2: Switch to writing new format, keep reading old format as fallback
3. Release 3: Remove old format support once stable

This allows safe downgrade to Release 1 since it can read both formats