### PR TITLE
Set units_consumed by simulated transaction by executed_units

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3297,48 +3297,43 @@ impl Bank {
             },
         );
 
-        let units_consumed =
-            timings
-                .details
-                .per_program_timings
-                .iter()
-                .fold(0, |acc: u64, (_, program_timing)| {
-                    (std::num::Saturating(acc)
-                        + program_timing.accumulated_units
-                        + program_timing.total_errored_units)
-                        .0
-                });
-
         debug!("simulate_transaction: {:?}", timings);
 
         let processing_result = processing_results
             .pop()
             .unwrap_or(Err(TransactionError::InvalidProgramForExecution));
-        let (post_simulation_accounts, result, logs, return_data, inner_instructions) =
-            match processing_result {
-                Ok(processed_tx) => match processed_tx {
-                    ProcessedTransaction::Executed(executed_tx) => {
-                        let details = executed_tx.execution_details;
-                        let post_simulation_accounts = executed_tx
-                            .loaded_transaction
-                            .accounts
-                            .into_iter()
-                            .take(number_of_accounts)
-                            .collect::<Vec<_>>();
-                        (
-                            post_simulation_accounts,
-                            details.status,
-                            details.log_messages,
-                            details.return_data,
-                            details.inner_instructions,
-                        )
-                    }
-                    ProcessedTransaction::FeesOnly(fees_only_tx) => {
-                        (vec![], Err(fees_only_tx.load_error), None, None, None)
-                    }
-                },
-                Err(error) => (vec![], Err(error), None, None, None),
-            };
+        let (
+            post_simulation_accounts,
+            result,
+            logs,
+            return_data,
+            inner_instructions,
+            units_consumed,
+        ) = match processing_result {
+            Ok(processed_tx) => match processed_tx {
+                ProcessedTransaction::Executed(executed_tx) => {
+                    let details = executed_tx.execution_details;
+                    let post_simulation_accounts = executed_tx
+                        .loaded_transaction
+                        .accounts
+                        .into_iter()
+                        .take(number_of_accounts)
+                        .collect::<Vec<_>>();
+                    (
+                        post_simulation_accounts,
+                        details.status,
+                        details.log_messages,
+                        details.return_data,
+                        details.inner_instructions,
+                        details.executed_units,
+                    )
+                }
+                ProcessedTransaction::FeesOnly(fees_only_tx) => {
+                    (vec![], Err(fees_only_tx.load_error), None, None, None, 0)
+                }
+            },
+            Err(error) => (vec![], Err(error), None, None, None, 0),
+        };
         let logs = logs.unwrap_or_default();
 
         TransactionSimulationResult {


### PR DESCRIPTION
#### Problem

`TransactionExecutionDetails.executed_units` should be the single source of truth for how many Compute Units consumed after executing a transaction. It is currently used at:
- bank to create commit result (https://github.com/anza-xyz/agave/blob/master/runtime/src/bank.rs#L3827), which is used by leader to track block limits.
- `transaction_status_meta.compute_units-consumed` (https://github.com/anza-xyz/agave/blob/master/rpc/src/transaction_status_service.rs#L181), which is later stored to blockstore

`simulate_transaction` should not need to iterate through `pre_program_timings` to accumulate executed units. In fact, `per_program_timings` that collected here (https://github.com/anza-xyz/agave/blob/master/svm/src/message_processor.rs#L73-L78), then accumulated at bank.simulate_transaction is the same value as `executed_units`

#### Summary of Changes
- remove iterating per_program_timings to collect unites consumed, 
- read directly from ProcessedTransaction.executed_units.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
