### PR TITLE
SIMD-0186: Loaded Transaction Data Sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ check-cfg = [
 ]
 
 [workspace.lints.rust]
-warnings = "deny"
+# XXX HANA warnings = "deny"
 
 # Clippy lint configuration that can not be applied in clippy.toml
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ check-cfg = [
 ]
 
 [workspace.lints.rust]
-# XXX HANA warnings = "deny"
+warnings = "deny"
 
 # Clippy lint configuration that can not be applied in clippy.toml
 [workspace.lints.clippy]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -153,6 +153,8 @@ impl FeatureSet {
             increase_tx_account_lock_limit: self.is_active(&increase_tx_account_lock_limit::id()),
             disable_rent_fees_collection: self.is_active(&disable_rent_fees_collection::id()),
             enable_extend_program_checked: self.is_active(&enable_extend_program_checked::id()),
+            formalize_loaded_transaction_data_size: self
+                .is_active(&formalize_loaded_transaction_data_size::id()),
         }
     }
 }
@@ -1095,6 +1097,10 @@ pub mod enable_extend_program_checked {
     solana_pubkey::declare_id!("97QCmR4QtfeQsAti9srfHFk5uMRFP95CvXG8EGr615HM");
 }
 
+pub mod formalize_loaded_transaction_data_size {
+    solana_pubkey::declare_id!("DeS7sR48ZcFTUmt5FFEVDr1v1bh73aAbZiZq3SYr8Eh8");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1330,6 +1336,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (mask_out_rent_epoch_in_vm_serialization::id(), "SIMD-0267: Sets rent_epoch to a constant in the VM"),
         (enshrine_slashing_program::id(), "SIMD-0204: Slashable event verification"),
         (enable_extend_program_checked::id(), "Enable ExtendProgramChecked instruction"),
+        (formalize_loaded_transaction_data_size::id(), "SIMD-0186: Loaded transaction data size specification"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8400,6 +8400,7 @@ fn test_program_is_native_loader() {
     );
 }
 
+// HANA this breaks, expects UnsupportedProgramId but we produce InvalidProgramForExecution
 #[test]
 fn test_invoke_non_program_account_owned_by_a_builtin() {
     let (genesis_config, mint_keypair) = create_genesis_config(10000000);
@@ -13383,6 +13384,7 @@ fn test_deploy_last_epoch_slot() {
     assert_eq!(result_with_feature_enabled, Ok(()));
 }
 
+// HANA this breaks, expects UnsupportedProgramId but we produce InvalidProgramForExecution
 #[test]
 fn test_loader_v3_to_v4_migration() {
     solana_logger::setup();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8403,7 +8403,7 @@ fn test_program_is_native_loader(formalize_loaded_transaction_data_size: bool) {
 
     let err = bank.process_transaction(&tx).unwrap_err();
     if formalize_loaded_transaction_data_size {
-        assert_eq!(err, TransactionError::InvalidProgramForExecution,);
+        assert_eq!(err, TransactionError::ProgramAccountNotFound);
     } else {
         assert_eq!(
             err,
@@ -10598,7 +10598,7 @@ fn test_an_empty_instruction_without_program(formalize_loaded_transaction_data_s
 
     let err = bank.process_transaction(&tx).unwrap_err();
     if formalize_loaded_transaction_data_size {
-        assert_eq!(err, TransactionError::InvalidProgramForExecution,);
+        assert_eq!(err, TransactionError::ProgramAccountNotFound);
     } else {
         assert_eq!(
             err,

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -36,6 +36,7 @@ pub struct SVMFeatureSet {
     pub increase_tx_account_lock_limit: bool,
     pub disable_rent_fees_collection: bool,
     pub enable_extend_program_checked: bool,
+    pub formalize_loaded_transaction_data_size: bool,
 }
 
 impl SVMFeatureSet {
@@ -77,6 +78,7 @@ impl SVMFeatureSet {
             increase_tx_account_lock_limit: true,
             disable_rent_fees_collection: true,
             enable_extend_program_checked: true,
+            formalize_loaded_transaction_data_size: true,
         }
     }
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -39,7 +39,7 @@ use {
 
 // Per SIMD-0186, all accounts are assigned a base size of 64 bytes to cover
 // the storage cost of metadata.
-const TRANSACTION_ACCOUNT_BASE_SIZE: usize = 64;
+pub(crate) const TRANSACTION_ACCOUNT_BASE_SIZE: usize = 64;
 
 // Per SIMD-0186, resolved address lookup tables are assigned a base size of 8248
 // bytes: 8192 bytes for the maximum table size plus 56 bytes for metadata.

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -3060,6 +3060,13 @@ mod tests {
         }
 
         let mut all_accounts = mock_bank.accounts_map.keys().copied().collect::<Vec<_>>();
+
+        // append some to-be-created accounts
+        // this is to test that their size is 0 rather than 64
+        for _ in 0..32 {
+            all_accounts.push(Pubkey::new_unique());
+        }
+
         let mut account_loader = (&mock_bank).into();
 
         // now generate arbitrary transactions using this accounts
@@ -3112,8 +3119,9 @@ mod tests {
                 .collect::<AHashSet<_>>();
 
             for pubkey in transaction.account_keys().iter() {
-                let account = mock_bank.accounts_map.get(pubkey).unwrap();
-                expected_size += TRANSACTION_ACCOUNT_BASE_SIZE + account.data().len();
+                if let Some(account) = mock_bank.accounts_map.get(pubkey) {
+                    expected_size += TRANSACTION_ACCOUNT_BASE_SIZE + account.data().len();
+                };
 
                 if let Some((programdata_address, programdata_size)) =
                     programdata_tracker.get(pubkey)

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1099,7 +1099,10 @@ mod tests {
     use {
         super::*,
         crate::{
-            account_loader::{LoadedTransactionAccount, ValidatedTransactionDetails},
+            account_loader::{
+                LoadedTransactionAccount, ValidatedTransactionDetails,
+                TRANSACTION_ACCOUNT_BASE_SIZE,
+            },
             nonce_info::NonceInfo,
             rollback_accounts::RollbackAccounts,
         },
@@ -1147,14 +1150,23 @@ mod tests {
         }
     }
 
-    // HANA enable all by default
-    #[derive(Default, Clone)]
+    #[derive(Clone)]
     struct MockBankCallback {
         account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
         #[allow(clippy::type_complexity)]
         inspected_accounts:
             Arc<RwLock<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>>,
         feature_set: SVMFeatureSet,
+    }
+
+    impl Default for MockBankCallback {
+        fn default() -> Self {
+            Self {
+                account_shared_data: Arc::default(),
+                inspected_accounts: Arc::default(),
+                feature_set: SVMFeatureSet::all_enabled(),
+            }
+        }
     }
 
     impl InvokeContextCallback for MockBankCallback {}
@@ -2037,9 +2049,11 @@ mod tests {
         assert_eq!(entry, Arc::new(program));
     }
 
-    // HANA fails with feature
-    #[test]
-    fn test_validate_transaction_fee_payer_exact_balance() {
+    #[test_case(false; "informal_loaded_size")]
+    #[test_case(true; "simd186_loaded_size")]
+    fn test_validate_transaction_fee_payer_exact_balance(
+        formalize_loaded_transaction_data_size: bool,
+    ) {
         let lamports_per_signature = 5000;
         let message = new_unchecked_sanitized_message(Message::new_with_blockhash(
             &[
@@ -2077,10 +2091,12 @@ mod tests {
         );
         let mut mock_accounts = HashMap::new();
         mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
-        let mock_bank = MockBankCallback {
+        let mut mock_bank = MockBankCallback {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        mock_bank.feature_set.formalize_loaded_transaction_data_size =
+            formalize_loaded_transaction_data_size;
         let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
@@ -2109,6 +2125,12 @@ mod tests {
             account
         };
 
+        let base_account_size = if formalize_loaded_transaction_data_size {
+            TRANSACTION_ACCOUNT_BASE_SIZE
+        } else {
+            0
+        };
+
         assert_eq!(
             result,
             Ok(ValidatedTransactionDetails {
@@ -2124,7 +2146,7 @@ mod tests {
                     .loaded_accounts_data_size_limit,
                 fee_details: FeeDetails::new(transaction_fee, priority_fee),
                 loaded_fee_payer_account: LoadedTransactionAccount {
-                    loaded_size: fee_payer_account.data().len(),
+                    loaded_size: base_account_size + fee_payer_account.data().len(),
                     account: post_validation_fee_payer_account,
                     rent_collected: fee_payer_rent_debit,
                 },
@@ -2132,9 +2154,11 @@ mod tests {
         );
     }
 
-    // HANA fails with feature
-    #[test]
-    fn test_validate_transaction_fee_payer_rent_paying() {
+    #[test_case(false; "informal_loaded_size")]
+    #[test_case(true; "simd186_loaded_size")]
+    fn test_validate_transaction_fee_payer_rent_paying(
+        formalize_loaded_transaction_data_size: bool,
+    ) {
         let lamports_per_signature = 5000;
         let message = new_unchecked_sanitized_message(Message::new_with_blockhash(
             &[],
@@ -2159,10 +2183,13 @@ mod tests {
 
         let mut mock_accounts = HashMap::new();
         mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
-        let mock_bank = MockBankCallback {
+        let mut mock_bank = MockBankCallback {
             account_shared_data: Arc::new(RwLock::new(mock_accounts)),
             ..Default::default()
         };
+        mock_bank.feature_set.formalize_loaded_transaction_data_size =
+            formalize_loaded_transaction_data_size;
+        mock_bank.feature_set.disable_rent_fees_collection = false;
         let mut account_loader = (&mock_bank).into();
 
         let mut error_counters = TransactionErrorMetrics::default();
@@ -2186,6 +2213,12 @@ mod tests {
             account
         };
 
+        let base_account_size = if formalize_loaded_transaction_data_size {
+            TRANSACTION_ACCOUNT_BASE_SIZE
+        } else {
+            0
+        };
+
         assert_eq!(
             result,
             Ok(ValidatedTransactionDetails {
@@ -2201,7 +2234,7 @@ mod tests {
                     .loaded_accounts_data_size_limit,
                 fee_details: FeeDetails::new(transaction_fee, 0),
                 loaded_fee_payer_account: LoadedTransactionAccount {
-                    loaded_size: fee_payer_account.data().len(),
+                    loaded_size: base_account_size + fee_payer_account.data().len(),
                     account: post_validation_fee_payer_account,
                     rent_collected: fee_payer_rent_debit,
                 }
@@ -2384,9 +2417,9 @@ mod tests {
         assert_eq!(result, Err(TransactionError::DuplicateInstruction(1u8)));
     }
 
-    // HANA fails with feature
-    #[test]
-    fn test_validate_transaction_fee_payer_is_nonce() {
+    #[test_case(false; "informal_loaded_size")]
+    #[test_case(true; "simd186_loaded_size")]
+    fn test_validate_transaction_fee_payer_is_nonce(formalize_loaded_transaction_data_size: bool) {
         let lamports_per_signature = 5000;
         let rent_collector = RentCollector::default();
         let compute_unit_limit = 1000u64;
@@ -2425,10 +2458,12 @@ mod tests {
 
             let mut mock_accounts = HashMap::new();
             mock_accounts.insert(*fee_payer_address, fee_payer_account.clone());
-            let mock_bank = MockBankCallback {
+            let mut mock_bank = MockBankCallback {
                 account_shared_data: Arc::new(RwLock::new(mock_accounts)),
                 ..Default::default()
             };
+            mock_bank.feature_set.formalize_loaded_transaction_data_size =
+                formalize_loaded_transaction_data_size;
             let mut account_loader = (&mock_bank).into();
 
             let mut error_counters = TransactionErrorMetrics::default();
@@ -2461,6 +2496,12 @@ mod tests {
                 account
             };
 
+            let base_account_size = if formalize_loaded_transaction_data_size {
+                TRANSACTION_ACCOUNT_BASE_SIZE
+            } else {
+                0
+            };
+
             assert_eq!(
                 result,
                 Ok(ValidatedTransactionDetails {
@@ -2476,7 +2517,7 @@ mod tests {
                         .loaded_accounts_data_size_limit,
                     fee_details: FeeDetails::new(transaction_fee, priority_fee),
                     loaded_fee_payer_account: LoadedTransactionAccount {
-                        loaded_size: fee_payer_account.data().len(),
+                        loaded_size: base_account_size + fee_payer_account.data().len(),
                         account: post_validation_fee_payer_account,
                         rent_collected: 0,
                     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1147,6 +1147,7 @@ mod tests {
         }
     }
 
+    // HANA enable all by default
     #[derive(Default, Clone)]
     struct MockBankCallback {
         account_shared_data: Arc<RwLock<HashMap<Pubkey, AccountSharedData>>>,
@@ -2036,6 +2037,7 @@ mod tests {
         assert_eq!(entry, Arc::new(program));
     }
 
+    // HANA fails with feature
     #[test]
     fn test_validate_transaction_fee_payer_exact_balance() {
         let lamports_per_signature = 5000;
@@ -2130,6 +2132,7 @@ mod tests {
         );
     }
 
+    // HANA fails with feature
     #[test]
     fn test_validate_transaction_fee_payer_rent_paying() {
         let lamports_per_signature = 5000;
@@ -2381,6 +2384,7 @@ mod tests {
         assert_eq!(result, Err(TransactionError::DuplicateInstruction(1u8)));
     }
 
+    // HANA fails with feature
     #[test]
     fn test_validate_transaction_fee_payer_is_nonce() {
         let lamports_per_signature = 5000;


### PR DESCRIPTION
#### Problem
[simd186](https://github.com/solana-foundation/solana-improvement-documents/pull/186) declaratively defines a new transaction data size algorithm that replaces the existing ad hoc but consensus-relevant one. the current algorithm is difficult for new validators to implement correctlt because of certain surprising behaviors, and also routinely undercounts the true size of loaderv3 programs by a substantial margin

#### Summary of Changes
implement simd186. we do this by changing the existing `load_transaction_accounts()` to simply branch on the feature gate to the two functions `load_transaction_accounts_simd186()` or `load_transaction_accounts_old()`. the former is brand new, the latter is the existing impl unchanged. this entails some code duplication until the feature is activated, but the new function is substantially changed in a way that would be quite difficult to follow if we branched on the feature inline. namely:
* we use the `LoadedTransactionAccounts` struct as an accumulator rather than defining a ton of variables and passing ownership to the struct at the end
* we define a new function on the aforementioned struct `increase_calculated_data_size()` which replaces `accumulate_and_check_loaded_account_data_size()`
* we instantiate `program_indices` with its proper capacity rather than mapping to it
* the accumulation of `program_indicies` is _substantially_ simplified:
    - because we no longer need to count loaders against transaction size, a lot of confusing logic is simply deleted. this was worse when simd186 was initially drafted (loaders were kicked onto `account_keys` and it was very hard to see that this short-circuited them being counted for every program id) but its behavior still rather unintuitive
    - instead of loading the program owner and checking if its owner is owned by `NativeLoader`, we simply check if the program is owned by `PROGRAM_OWNERS` and abort if it is not. because `enable_transaction_loading_failure_fees` is now active plus a fix made by alexander to `InvokeContext`, the behavior is actually identical and this is strictly an optimization

we also change all `transaction_processor.rs` and `account_loader.rs` unit tests to enable all features by default as https://github.com/anza-xyz/agave/pull/6043 did for integration tests. this is substantially safer for implementing new svm features

Feature Gate Issue: https://github.com/anza-xyz/feature-gate-tracker/issues/88