### PR TITLE
Enables experimental accumulator hash by default

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -126,9 +126,9 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .possible_values(&["mmap", "file"])
             .help("Access account storages using this method"),
-        Arg::with_name("accounts_db_experimental_accumulator_hash")
-            .long("accounts-db-experimental-accumulator-hash")
-            .help("Enables the experimental accumulator hash")
+        Arg::with_name("no_accounts_db_experimental_accumulator_hash")
+            .long("no-accounts-db-experimental-accumulator-hash")
+            .help("Disables the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_verify_experimental_accumulator_hash")
             .long("accounts-db-verify-experimental-accumulator-hash")
@@ -387,8 +387,8 @@ pub fn get_accounts_db_config(
         create_ancient_storage,
         storage_access,
         scan_filter_for_shrinking,
-        enable_experimental_accumulator_hash: arg_matches
-            .is_present("accounts_db_experimental_accumulator_hash"),
+        enable_experimental_accumulator_hash: !arg_matches
+            .is_present("no_accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: arg_matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
         snapshots_use_experimental_accumulator_hash: arg_matches

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1433,9 +1433,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
-        Arg::with_name("accounts_db_experimental_accumulator_hash")
-            .long("accounts-db-experimental-accumulator-hash")
-            .help("Enables the experimental accumulator hash")
+        Arg::with_name("no_accounts_db_experimental_accumulator_hash")
+            .long("no-accounts-db-experimental-accumulator-hash")
+            .help("Disables the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -537,8 +537,8 @@ pub fn execute(
             .is_present("accounts_db_test_skip_rewrites"),
         storage_access,
         scan_filter_for_shrinking,
-        enable_experimental_accumulator_hash: matches
-            .is_present("accounts_db_experimental_accumulator_hash"),
+        enable_experimental_accumulator_hash: !matches
+            .is_present("no_accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
         snapshots_use_experimental_accumulator_hash: matches


### PR DESCRIPTION
#### Problem

Operationally, rolling out the activation of SIMD-215 (accounts lattice hash) is tricky. We want the super majority of stake to already be calculating the accounts lt hash *before* feature activation. Otherwise, at feature activation time nodes would need to pause and perform the initial accounts lt hash calculation. Enabling the accounts lt hash calculation prior to feature activation is possible, but *opt in*.

See additional discussion on Discord here: https://discord.com/channels/428295358100013066/910937142182682656/1367497417401958510


#### Summary of Changes

Turn on calculating the accounts lt hash by default.


#### Additional Testing

I ran this on node and confirmed (1) without the `--no-xxx` flag that the initial lt hash *is* calculated at startup, and (2) that with the `--no-xxx` flag that the lt hashes are *not* calculated.


Note, I intend to backport to v2.2, since that's the version we'll activate the lt hash on.