### PR TITLE
shredder bench: finalize changes started in #5985

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -143,9 +143,9 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
             &entries,
             true, // is_last_in_slot
             merkle_root,
-            0,     // next_shred_index
-            0,     // next_code_index
-            false, // merkle_variant
+            0,    // next_shred_index
+            0,    // next_code_index
+            true, // merkle_variant
             &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
@@ -164,9 +164,9 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
         &entries,
         true, // is_last_in_slot
         merkle_root,
-        0,     // next_shred_index
-        0,     // next_code_index
-        false, // merkle_variant
+        0,    // next_shred_index
+        0,    // next_code_index
+        true, // merkle_variant
         &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -7,8 +7,9 @@ use {
     rand::Rng,
     solana_entry::entry::{create_ticks, Entry},
     solana_ledger::shred::{
-        max_entries_per_n_shred, max_ticks_per_n_shreds, ProcessShredsStats, ReedSolomonCache,
-        Shred, ShredFlags, Shredder, LEGACY_SHRED_DATA_CAPACITY,
+        get_data_shred_bytes_per_batch_typical, max_entries_per_n_shred, max_ticks_per_n_shreds,
+        ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder,
+        DATA_SHREDS_PER_FEC_BLOCK,
     },
     solana_perf::test_tx,
     solana_sdk::{hash::Hash, signature::Keypair},
@@ -27,14 +28,18 @@ fn make_large_unchained_entries(txs_per_entry: u64, num_entries: u64) -> Vec<Ent
         .map(|_| make_test_entry(txs_per_entry))
         .collect()
 }
+const SHRED_SIZE_TYPICAL: usize = {
+    let batch_payload = get_data_shred_bytes_per_batch_typical() as usize;
+    batch_payload / DATA_SHREDS_PER_FEC_BLOCK
+};
 
 #[bench]
 fn bench_shredder_ticks(bencher: &mut Bencher) {
     let kp = Keypair::new();
-    let shred_size = LEGACY_SHRED_DATA_CAPACITY;
-    let num_shreds = 1_000_000_usize.div_ceil(shred_size);
+
+    let num_shreds = 1_000_000_usize.div_ceil(SHRED_SIZE_TYPICAL);
     // ~1Mb
-    let num_ticks = max_ticks_per_n_shreds(1, Some(LEGACY_SHRED_DATA_CAPACITY)) * num_shreds as u64;
+    let num_ticks = max_ticks_per_n_shreds(1, Some(SHRED_SIZE_TYPICAL)) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
     let reed_solomon_cache = ReedSolomonCache::default();
     let chained_merkle_root = Some(Hash::new_from_array(rand::thread_rng().gen()));
@@ -57,7 +62,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
 #[bench]
 fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let kp = Keypair::new();
-    let shred_size = LEGACY_SHRED_DATA_CAPACITY;
+    let shred_size = SHRED_SIZE_TYPICAL;
     let num_shreds = 1_000_000_usize.div_ceil(shred_size);
     let txs_per_entry = 128;
     let num_entries = max_entries_per_n_shred(
@@ -88,7 +93,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
 #[bench]
 fn bench_deshredder(bencher: &mut Bencher) {
     let kp = Keypair::new();
-    let shred_size = LEGACY_SHRED_DATA_CAPACITY;
+    let shred_size = SHRED_SIZE_TYPICAL;
     // ~10Mb
     let num_shreds = 10_000_000_usize.div_ceil(shred_size);
     let num_ticks = max_ticks_per_n_shreds(1, Some(shred_size)) * num_shreds as u64;
@@ -115,7 +120,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
-    let data = vec![0; LEGACY_SHRED_DATA_CAPACITY];
+    let data = vec![0; SHRED_SIZE_TYPICAL];
 
     let shred = Shred::new_from_data(2, 1, 1, &data, ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 1);
 
@@ -138,17 +143,18 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
     let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Some(Hash::new_from_array(rand::thread_rng().gen()));
     bencher.iter(|| {
-        let result = shredder.entries_to_shreds(
-            &Keypair::new(),
-            &entries,
-            true, // is_last_in_slot
-            merkle_root,
-            0,    // next_shred_index
-            0,    // next_code_index
-            true, // merkle_variant
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
+        let result: Vec<_> = shredder
+            .make_merkle_shreds_from_entries(
+                &Keypair::new(),
+                &entries,
+                true, // is_last_in_slot
+                merkle_root,
+                0, // next_shred_index
+                0, // next_code_index
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .collect();
         black_box(result);
     })
 }
@@ -159,17 +165,18 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
     let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Some(Hash::new_from_array(rand::thread_rng().gen()));
-    let (_data_shreds, coding_shreds) = shredder.entries_to_shreds(
-        &Keypair::new(),
-        &entries,
-        true, // is_last_in_slot
-        merkle_root,
-        0,    // next_shred_index
-        0,    // next_code_index
-        true, // merkle_variant
-        &reed_solomon_cache,
-        &mut ProcessShredsStats::default(),
-    );
+    let (_data_shreds, coding_shreds): (Vec<_>, Vec<_>) = shredder
+        .make_merkle_shreds_from_entries(
+            &Keypair::new(),
+            &entries,
+            true, // is_last_in_slot
+            merkle_root,
+            0, // next_shred_index
+            0, // next_code_index
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        )
+        .partition(Shred::is_data);
 
     bencher.iter(|| {
         let result = Shredder::try_recovery(coding_shreds.clone(), &reed_solomon_cache).unwrap();


### PR DESCRIPTION
#### Problem
Legacy shreds need to go https://github.com/anza-xyz/agave/issues/5982

https://github.com/anza-xyz/agave/pull/5985/ did not completely eradicate legacy shreds from shredder bench.

#### Summary of Changes

- Switch to other API that can not make legacy shreds
- Stop using constant tied to legacy shreds


