### PR TITLE
core: migrate shredder and sigverify_stage benchmarks to stable bencher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8100,6 +8100,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.22.1",
+ "bencher",
  "bincode",
  "bs58",
  "bytemuck",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -219,6 +219,7 @@ solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
+bencher = { workspace = true }
 
 [[bench]]
 name = "banking_stage"
@@ -228,6 +229,11 @@ name = "gen_keys"
 
 [[bench]]
 name = "sigverify_stage"
+harness = false
+
+[[bench]]
+name = "shredder"
+harness = false
 
 [[bench]]
 name = "receive_and_buffer"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -190,6 +190,7 @@ sysctl = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
+bencher = { workspace = true }
 criterion = { workspace = true }
 fs_extra = { workspace = true }
 serde_json = { workspace = true }
@@ -219,7 +220,6 @@ solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
-bencher = { workspace = true }
 
 [[bench]]
 name = "banking_stage"

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![feature(test)]
-
-extern crate test;
 
 use {
+    bencher::{benchmark_group, benchmark_main, Bencher},
     rand::Rng,
     solana_entry::entry::{create_ticks, Entry},
     solana_hash::Hash,
@@ -14,7 +12,7 @@ use {
         CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK,
     },
     solana_perf::test_tx,
-    test::{black_box, Bencher},
+    std::hint::black_box,
 };
 
 fn make_test_entry(txs_per_entry: u64) -> Entry {
@@ -34,7 +32,6 @@ const SHRED_SIZE_TYPICAL: usize = {
     batch_payload / DATA_SHREDS_PER_FEC_BLOCK
 };
 
-#[bench]
 fn bench_shredder_ticks(bencher: &mut Bencher) {
     let kp = Keypair::new();
 
@@ -59,7 +56,6 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 fn bench_shredder_large_entries(bencher: &mut Bencher) {
     let kp = Keypair::new();
     let shred_size = SHRED_SIZE_TYPICAL;
@@ -89,7 +85,6 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 fn bench_deshredder(bencher: &mut Bencher) {
     let kp = Keypair::new();
     let shred_size = SHRED_SIZE_TYPICAL;
@@ -116,7 +111,6 @@ fn bench_deshredder(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
     let keypair = Keypair::new();
     let shredder = Shredder::new(2, 1, 0, 0).unwrap();
@@ -150,7 +144,6 @@ fn make_entries() -> Vec<Entry> {
     make_large_unchained_entries(txs_per_entry, num_entries)
 }
 
-#[bench]
 fn bench_shredder_coding(bencher: &mut Bencher) {
     let entries = make_entries();
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
@@ -173,7 +166,6 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 fn bench_shredder_decoding(bencher: &mut Bencher) {
     let entries = make_entries();
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
@@ -199,3 +191,14 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
         }
     })
 }
+
+benchmark_group!(
+    benches,
+    bench_shredder_ticks,
+    bench_shredder_large_entries,
+    bench_deshredder,
+    bench_deserialize_hdr,
+    bench_shredder_coding,
+    bench_shredder_decoding
+);
+benchmark_main!(benches);

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -314,9 +314,9 @@ fn benches() -> Vec<TestDescAndFn> {
         .enumerate()
         .for_each(|(i, &discard_factor)| {
             let name = format!(
-                "{:?}-bench_shrink_sigverify_stage_core - discard_factor: {:?}",
-                i, discard_factor
+                "{i:?}-bench_shrink_sigverify_stage_core - discard_factor: {discard_factor:?}"
             );
+
             benches.push(TestDescAndFn {
                 desc: TestDesc {
                     name: Cow::from(name),


### PR DESCRIPTION
#### Problem
#5931

#### Summary of Changes
Move shredder and sigverify_stage benchmarks to bencher 0.1.5.

[sigverify-before.log](https://github.com/user-attachments/files/21898353/sigverify-before.log)
[shredder-before.log](https://github.com/user-attachments/files/21898354/shredder-before.log)
[sigverify-after.log](https://github.com/user-attachments/files/21898355/sigverify-after.log)
[shredder-after.log](https://github.com/user-attachments/files/21910429/shredder-after.log)
[sigverify-after-no-macro.log](https://github.com/user-attachments/files/21919059/sigverify-after-no-macro.log)


