### PR TITLE
cleanup: Deprecate program ID wrapper functions

### DIFF
--- a/transaction-status/benches/extract_memos.rs
+++ b/transaction-status/benches/extract_memos.rs
@@ -5,15 +5,15 @@ extern crate test;
 use {
     solana_message::{compiled_instruction::CompiledInstruction, Message},
     solana_pubkey::Pubkey,
-    solana_transaction_status::extract_memos::{spl_memo_id_v1, spl_memo_id_v3, ExtractMemos},
+    solana_transaction_status::extract_memos::ExtractMemos,
     test::Bencher,
 };
 
 #[bench]
 fn bench_extract_memos(b: &mut Bencher) {
     let mut account_keys: Vec<Pubkey> = (0..64).map(|_| Pubkey::new_unique()).collect();
-    account_keys[62] = spl_memo_id_v1();
-    account_keys[63] = spl_memo_id_v3();
+    account_keys[62] = spl_memo::v1::id();
+    account_keys[63] = spl_memo::id();
     let memo = "Test memo";
 
     let instructions: Vec<_> = (0..20)

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -8,19 +8,16 @@ use {
 
 // A helper function to convert spl_memo::v1::id() as spl_sdk::pubkey::Pubkey to
 // solana_pubkey::Pubkey
+#[deprecated(since = "2.3.0", note = "Use `spl_memo::v1::id()` instead")]
 pub fn spl_memo_id_v1() -> Pubkey {
-    *MEMO_PROGRAM_ID_V1
+    spl_memo::v1::id()
 }
 
 // A helper function to convert spl_memo::id() as spl_sdk::pubkey::Pubkey to
 // solana_pubkey::Pubkey
+#[deprecated(since = "2.3.0", note = "Use `spl_memo::id()` instead")]
 pub fn spl_memo_id_v3() -> Pubkey {
-    *MEMO_PROGRAM_ID_V3
-}
-
-lazy_static! {
-    static ref MEMO_PROGRAM_ID_V1: Pubkey = Pubkey::new_from_array(spl_memo::v1::id().to_bytes());
-    static ref MEMO_PROGRAM_ID_V3: Pubkey = Pubkey::new_from_array(spl_memo::id().to_bytes());
+    spl_memo::id()
 }
 
 pub fn extract_and_fmt_memos<T: ExtractMemos>(message: &T) -> Option<String> {
@@ -86,7 +83,7 @@ fn extract_memos_inner(
                 KeyType::MemoProgram => Some(&ix.data),
                 KeyType::OtherProgram => None,
                 KeyType::Unknown(program_id) => {
-                    if **program_id == *MEMO_PROGRAM_ID_V1 || **program_id == *MEMO_PROGRAM_ID_V3 {
+                    if **program_id == spl_memo::v1::id() || **program_id == spl_memo::id() {
                         account_keys[index] = KeyType::MemoProgram;
                         Some(&ix.data)
                     } else {
@@ -133,9 +130,9 @@ mod test {
         ];
         let static_keys = vec![
             fee_payer,
-            spl_memo_id_v1(),
+            spl_memo::v1::id(),
             another_program_id,
-            spl_memo_id_v3(),
+            spl_memo::id(),
         ];
         let account_keys = AccountKeys::new(&static_keys, None);
 

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -11,8 +11,12 @@ use {
 
 // A helper function to convert spl_associated_token_account::id() as spl_sdk::pubkey::Pubkey
 // to solana_pubkey::Pubkey
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `spl_associated_token_account::id()` instead"
+)]
 pub fn spl_associated_token_id() -> Pubkey {
-    Pubkey::new_from_array(spl_associated_token_account::id().to_bytes())
+    spl_associated_token_account::id()
 }
 
 pub fn parse_associated_token(

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -13,7 +13,7 @@ use {
 // to solana_pubkey::Pubkey
 #[deprecated(
     since = "2.3.0",
-    note = "Use `spl_associated_token_account::id()` instead"
+    note = "Use `spl_associated_token_account_client::program::id()` instead"
 )]
 pub fn spl_associated_token_id() -> Pubkey {
     spl_associated_token_account::id()

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -1,9 +1,8 @@
 pub use solana_transaction_status_client_types::ParsedInstruction;
 use {
     crate::{
-        extract_memos::{spl_memo_id_v1, spl_memo_id_v3},
         parse_address_lookup_table::parse_address_lookup_table,
-        parse_associated_token::{parse_associated_token, spl_associated_token_id},
+        parse_associated_token::parse_associated_token,
         parse_bpf_loader::{parse_bpf_loader, parse_bpf_upgradeable_loader},
         parse_stake::parse_stake,
         parse_system::parse_system,
@@ -25,12 +24,12 @@ use {
 
 lazy_static! {
     static ref ADDRESS_LOOKUP_PROGRAM_ID: Pubkey = address_lookup_table::id();
-    static ref ASSOCIATED_TOKEN_PROGRAM_ID: Pubkey = spl_associated_token_id();
+    static ref ASSOCIATED_TOKEN_PROGRAM_ID: Pubkey = spl_associated_token_account::id();
     static ref BPF_LOADER_PROGRAM_ID: Pubkey = solana_sdk_ids::bpf_loader::id();
     static ref BPF_UPGRADEABLE_LOADER_PROGRAM_ID: Pubkey =
         solana_sdk_ids::bpf_loader_upgradeable::id();
-    static ref MEMO_V1_PROGRAM_ID: Pubkey = spl_memo_id_v1();
-    static ref MEMO_V3_PROGRAM_ID: Pubkey = spl_memo_id_v3();
+    static ref MEMO_V1_PROGRAM_ID: Pubkey = spl_memo::v1::id();
+    static ref MEMO_V3_PROGRAM_ID: Pubkey = spl_memo::id();
     static ref STAKE_PROGRAM_ID: Pubkey = stake::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref VOTE_PROGRAM_ID: Pubkey = vote::id();


### PR DESCRIPTION
#### Problem
We have some dated helper functions that are no longer needed. The `id()` method is now `const` so the lazy creation (at runtime) + helper methods are no longer needed and can be deprecated

This codes dates back quite a while; see f4ae450f3488cba949744d5fea9f7d214c63108a and 35a5dd9c457. Note the function signature from `spl_memo` for when this code was introduced (3.0.1) vs now.
- https://docs.rs/spl-memo/3.0.1/spl_memo/fn.id.html
- https://docs.rs/spl-memo/latest/spl_memo/fn.id.html