### PR TITLE
Adds IsLoadable trait

### DIFF
--- a/accounts-db/src/is_loadable.rs
+++ b/accounts-db/src/is_loadable.rs
@@ -1,0 +1,15 @@
+use crate::is_zero_lamport::IsZeroLamport;
+
+/// A trait to see if an account is loadable or not.
+pub trait IsLoadable {
+    /// Is this account loadable?
+    fn is_loadable(&self) -> bool;
+}
+
+impl<T: IsZeroLamport> IsLoadable for T {
+    fn is_loadable(&self) -> bool {
+        // Don't ever load zero lamport accounts into runtime because
+        // the existence of zero-lamport accounts are never deterministic!!
+        !self.is_zero_lamport()
+    }
+}

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -30,6 +30,7 @@ pub mod contains;
 pub mod epoch_accounts_hash;
 mod file_io;
 pub mod hardened_unpack;
+pub mod is_loadable;
 mod is_zero_lamport;
 pub mod partitioned_rewards;
 pub mod pubkey_bins;

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -9,7 +9,10 @@ use {
     serde::ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     serde_derive::{Deserialize, Serialize},
     solana_account_decoder::{encode_ui_account, UiAccountData, UiAccountEncoding},
-    solana_accounts_db::accounts_index::{ScanConfig, ScanOrder},
+    solana_accounts_db::{
+        accounts_index::{ScanConfig, ScanOrder},
+        is_loadable::IsLoadable as _,
+    },
     solana_cli_output::{
         display::writeln_transaction, CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay,
         VerboseDisplay,
@@ -831,7 +834,7 @@ struct AccountsScanner {
 impl AccountsScanner {
     /// Returns true if this account should be included in the output
     fn should_process_account(&self, account: &AccountSharedData) -> bool {
-        solana_accounts_db::accounts::Accounts::is_loadable(account.lamports())
+        account.is_loadable()
             && (self.config.include_sysvars || !solana_sdk::sysvar::check_id(account.owner()))
     }
 


### PR DESCRIPTION
#### Problem

`Accounts` has a static method to determine if an account is loadable or not. It takes in the lamports as the parameter, and returns a bool if greater than zero or not. This feels a little out of place. We already have a trait for saying if an account has zero lamports or not. And it also feels strange to have the user call this function by passing in the lamports and not the account itself (iow, why doesn't the user just hardcode `accounts.lamports() > 0` themselves?). 


#### Summary of Changes

Add a new trait, `IsLoadable`, for accounts, and auto impl for anything that also impls `IsZeroLamport`. Now we can call `.is_loadable()` on any account that implements `.is_zero_lamport()`.

This is purely a cosmetic/quality-of-life change; no behavior has been modified.