### PR TITLE
Fix - Loader-v3 to v4 migration of closed programs

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -819,7 +819,7 @@ pub mod remaining_compute_units_syscall_enabled {
 }
 
 pub mod enable_loader_v4 {
-    solana_pubkey::declare_id!("G8yMNsNUd4p3VB22ycrPEB1qRgepCFeFpAqD2Lr66s36");
+    solana_pubkey::declare_id!("2aQJYqER2aKyb3cZw22v4SL2xMX7vwXBRWfvS4pTrtED");
 }
 
 pub mod require_rent_exempt_split_destination {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -39,7 +39,6 @@ use {
     },
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
-        system_program,
     },
     solana_system_interface::{instruction as system_instruction, MAX_PERMITTED_DATA_LENGTH},
     solana_transaction_context::{IndexOfAccount, InstructionContext, TransactionContext},
@@ -1400,11 +1399,7 @@ fn process_loader_upgradeable_instruction(
             }
             program.set_data_from_slice(&[])?;
             program.checked_add_lamports(programdata_funds)?;
-            if program_len == 0 {
-                program.set_owner(&system_program::id().to_bytes())?;
-            } else {
-                program.set_owner(&loader_v4::id().to_bytes())?;
-            }
+            program.set_owner(&loader_v4::id().to_bytes())?;
             drop(program);
 
             let mut programdata =
@@ -1412,7 +1407,18 @@ fn process_loader_upgradeable_instruction(
             programdata.set_lamports(0)?;
             drop(programdata);
 
-            if program_len > 0 {
+            if program_len == 0 {
+                invoke_context
+                    .program_cache_for_tx_batch
+                    .store_modified_entry(
+                        program_address,
+                        Arc::new(ProgramCacheEntry::new_tombstone(
+                            clock_slot,
+                            ProgramCacheEntryOwner::LoaderV4,
+                            ProgramCacheEntryType::Closed,
+                        )),
+                    );
+            } else {
                 invoke_context.native_invoke(
                     solana_loader_v4_interface::instruction::set_program_length(
                         &program_address,
@@ -1474,7 +1480,6 @@ fn process_loader_upgradeable_instruction(
             let mut programdata =
                 instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
             programdata.set_data_from_slice(&[])?;
-            programdata.set_owner(&system_program::id().to_bytes())?;
             drop(programdata);
 
             ic_logger_msg!(log_collector, "Migrated program {:?}", &program_address);
@@ -1813,7 +1818,7 @@ mod tests {
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
-        solana_sdk_ids::sysvar,
+        solana_sdk_ids::{system_program, sysvar},
         solana_svm_feature_set::SVMFeatureSet,
         std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
     };


### PR DESCRIPTION
#### Problem
#5968 but with the migration instruction instead of redeployment with a source buffer.

#### Summary of Changes

- Rekeys the feature
- Have closed programs be deleted by the rent collector instead of assigning them to the system program.
- Allows uninitialized program accounts to be closed via `SetProgramLength` to zero.

Feature gate issue: https://github.com/anza-xyz/feature-gate-tracker/issues/78