### PR TITLE
Batch retransmit channel reads

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -219,6 +219,9 @@ enum RetransmitSocket<'a> {
     Xdp(&'a XdpSender),
 }
 
+/// The number of shreds to pull from the retransmit_receiver at a time.
+const RETRANSMIT_BATCH_SIZE: usize = 4096;
+
 // pull the shreds from the shreds_receiver until empty, then retransmit them.
 // uses a thread_pool to parallelize work if there are enough shreds to justify that
 #[allow(clippy::too_many_arguments)]
@@ -238,12 +241,15 @@ fn retransmit(
     max_slots: &MaxSlots,
     rpc_subscriptions: Option<&RpcSubscriptions>,
     slot_status_notifier: Option<&SlotStatusNotifier>,
+    shred_buf: &mut Vec<shred::Payload>,
 ) -> Result<(), RecvError> {
     // Try to receive shreds from the channel without blocking. If the channel
     // is empty precompute turbine trees speculatively. If no cache updates are
     // made then block on the channel until some shreds are received.
-    let mut shreds = match retransmit_receiver.try_recv() {
-        Ok(shreds) => shreds,
+    match retransmit_receiver.try_recv() {
+        Ok(shreds) => {
+            shred_buf.extend(shreds);
+        }
         Err(TryRecvError::Disconnected) => return Err(RecvError),
         Err(TryRecvError::Empty) => {
             if cache_retransmit_addrs(
@@ -256,14 +262,20 @@ fn retransmit(
             ) {
                 return Ok(());
             }
-            retransmit_receiver.recv()?
+            shred_buf.extend(retransmit_receiver.recv()?);
         }
     };
     // now the batch has started
     let mut timer_start = Measure::start("retransmit");
-    // drain the channel until it is empty to form a batch
-    shreds.extend(retransmit_receiver.try_iter().flatten());
-    stats.num_shreds += shreds.len();
+    // Create a RETRANSMIT_BATCH_SIZE sized batch from the channel
+    shred_buf.extend(
+        retransmit_receiver
+            .try_iter()
+            // We already pulled 1 batch
+            .take(RETRANSMIT_BATCH_SIZE - 1)
+            .flatten(),
+    );
+    stats.num_shreds += shred_buf.len();
     stats.total_batches += 1;
 
     let mut epoch_fetch = Measure::start("retransmit_epoch_fetch");
@@ -283,7 +295,7 @@ fn retransmit(
     epoch_cache_update.stop();
     stats.epoch_cache_update += epoch_cache_update.as_us();
     // Lookup slot leader and cluster nodes for each slot.
-    let cache: HashMap<Slot, _> = shreds
+    let cache: HashMap<Slot, _> = shred_buf
         .iter()
         .filter_map(|shred| shred::layout::get_slot(shred))
         .collect::<HashSet<Slot>>()
@@ -297,7 +309,7 @@ fn retransmit(
             // skip the shred.
             let Some(slot_leader) = leader_schedule_cache.slot_leader_at(slot, Some(&working_bank))
             else {
-                stats.unknown_shred_slot_leader += shreds.len();
+                stats.unknown_shred_slot_leader += shred_buf.len();
                 return None;
             };
             let cluster_nodes =
@@ -333,17 +345,17 @@ fn retransmit(
         socket
     };
 
-    let slot_stats = if shreds.len() < PAR_ITER_MIN_NUM_SHREDS {
+    let slot_stats = if shred_buf.len() < PAR_ITER_MIN_NUM_SHREDS {
         stats.num_small_batches += 1;
-        shreds
-            .into_iter()
+        shred_buf
+            .drain(..)
             .enumerate()
             .filter_map(|(index, shred)| retransmit_shred(shred, retransmit_socket(index), stats))
             .fold(HashMap::new(), record)
     } else {
         thread_pool.install(|| {
-            shreds
-                .into_par_iter()
+            shred_buf
+                .par_drain(..)
                 .filter_map(|shred| {
                     retransmit_shred(
                         shred,
@@ -604,6 +616,7 @@ impl RetransmitStage {
             .name("solRetransmittr".to_string())
             .spawn({
                 move || {
+                    let mut shred_buf = Vec::with_capacity(RETRANSMIT_BATCH_SIZE);
                     while retransmit(
                         &thread_pool,
                         &bank_forks,
@@ -620,6 +633,7 @@ impl RetransmitStage {
                         &max_slots,
                         rpc_subscriptions.as_deref(),
                         slot_status_notifier.as_ref(),
+                        &mut shred_buf,
                     )
                     .is_ok()
                     {}


### PR DESCRIPTION
#### Problem
Similar to https://github.com/anza-xyz/agave/pull/5177, `retransmit` uses `receiver.try_iter()` to drain the retransmit channel, which under high load, can trigger a ton of allocations and may hang the thread for an extended period of time.

#### Summary of Changes

This PR updates `retransmit` to pull off a fixed number of shred batches per iteration and re-uses a buffer for those shred batches on each iteration. This removes all the unnecessary allocation on every loop iteration, making memory usage predictable, and avoids hanging the retransmit thread on high load.

The channel in question here is already bounded with `EvictingSender`, so we do not risk blocking sends in sigverify. We also do not seem to be dropping any shreds generally.
![image](https://github.com/user-attachments/assets/e3bad593-b1ec-4ff4-b18d-516b9ba53ce5)


