### PR TITLE
Introduce `new_with_client` contructur to TPU

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -135,7 +135,7 @@ pub(crate) fn spawn_forwarding_stage(
     match client {
         ForwardingClientOption::ConnectionCache(connection_cache) => {
             let non_vote_client =
-                ConnectionCacheClient::new(connection_cache, forward_address_getter);
+                ConnectionCacheClient::new(connection_cache.clone(), forward_address_getter);
             let forwarding_stage = ForwardingStage::new(
                 receiver,
                 vote_client,
@@ -148,7 +148,7 @@ pub(crate) fn spawn_forwarding_stage(
                     .name("solFwdStage".to_string())
                     .spawn(move || forwarding_stage.run())
                     .unwrap(),
-                client_updater: Arc::new(non_vote_client) as Arc<dyn NotifyKeyUpdate + Send + Sync>,
+                client_updater: connection_cache as Arc<dyn NotifyKeyUpdate + Send + Sync>,
             }
         }
         ForwardingClientOption::TpuClientNext((
@@ -528,12 +528,6 @@ impl ForwardingClient for ConnectionCacheClient {
         let conn = self.connection_cache.get_connection(&current_address);
         conn.send_data_batch_async(wire_transactions)?;
         Ok(())
-    }
-}
-
-impl NotifyKeyUpdate for ConnectionCacheClient {
-    fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        self.connection_cache.update_key(identity)
     }
 }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -17,7 +17,9 @@ use {
             VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
-        forwarding_stage::{spawn_forwarding_stage, ForwardAddressGetter},
+        forwarding_stage::{
+            spawn_forwarding_stage, ForwardAddressGetter, SpawnForwardingStageResult,
+        },
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
@@ -134,6 +136,92 @@ impl Tpu {
         tpu_coalesce: Duration,
         duplicate_confirmed_slot_sender: DuplicateConfirmedSlotsSender,
         connection_cache: &Arc<ConnectionCache>,
+        turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
+        keypair: &Keypair,
+        log_messages_bytes_limit: Option<usize>,
+        staked_nodes: &Arc<RwLock<StakedNodes>>,
+        shared_staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
+        banking_tracer_channels: Channels,
+        tracer_thread_hdl: TracerThread,
+        tpu_enable_udp: bool,
+        tpu_quic_server_config: QuicServerParams,
+        tpu_fwd_quic_server_config: QuicServerParams,
+        vote_quic_server_config: QuicServerParams,
+        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        block_production_method: BlockProductionMethod,
+        transaction_struct: TransactionStructure,
+        enable_block_production_forwarding: bool,
+        generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */
+    ) -> (Self, Vec<Arc<dyn NotifyKeyUpdate + Sync + Send>>) {
+        let client = ForwardingClientOption::ConnectionCache(connection_cache.clone());
+        Self::new_with_client(
+            cluster_info,
+            poh_recorder,
+            transaction_recorder,
+            entry_receiver,
+            retransmit_slots_receiver,
+            sockets,
+            subscriptions,
+            transaction_status_sender,
+            entry_notification_sender,
+            blockstore,
+            broadcast_type,
+            exit,
+            shred_version,
+            vote_tracker,
+            bank_forks,
+            verified_vote_sender,
+            gossip_verified_vote_hash_sender,
+            replay_vote_receiver,
+            replay_vote_sender,
+            bank_notification_sender,
+            tpu_coalesce,
+            duplicate_confirmed_slot_sender,
+            client,
+            turbine_quic_endpoint_sender,
+            keypair,
+            log_messages_bytes_limit,
+            staked_nodes,
+            shared_staked_nodes_overrides,
+            banking_tracer_channels,
+            tracer_thread_hdl,
+            tpu_enable_udp,
+            tpu_quic_server_config,
+            tpu_fwd_quic_server_config,
+            vote_quic_server_config,
+            prioritization_fee_cache,
+            block_production_method,
+            transaction_struct,
+            enable_block_production_forwarding,
+            generator_config,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_client(
+        cluster_info: &Arc<ClusterInfo>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
+        transaction_recorder: TransactionRecorder,
+        entry_receiver: Receiver<WorkingBankEntry>,
+        retransmit_slots_receiver: Receiver<Slot>,
+        sockets: TpuSockets,
+        subscriptions: &Arc<RpcSubscriptions>,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        entry_notification_sender: Option<EntryNotifierSender>,
+        blockstore: Arc<Blockstore>,
+        broadcast_type: &BroadcastStageType,
+        exit: Arc<AtomicBool>,
+        shred_version: u16,
+        vote_tracker: Arc<VoteTracker>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        verified_vote_sender: VerifiedVoteSender,
+        gossip_verified_vote_hash_sender: GossipVerifiedVoteHashSender,
+        replay_vote_receiver: ReplayVoteReceiver,
+        replay_vote_sender: ReplayVoteSender,
+        bank_notification_sender: Option<BankNotificationSender>,
+        tpu_coalesce: Duration,
+        duplicate_confirmed_slot_sender: DuplicateConfirmedSlotsSender,
+        client: ForwardingClientOption,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
         keypair: &Keypair,
         log_messages_bytes_limit: Option<usize>,
@@ -329,9 +417,10 @@ impl Tpu {
             prioritization_fee_cache,
         );
 
-        let client = ForwardingClientOption::ConnectionCache(connection_cache.clone());
-
-        let forwarding_stage = spawn_forwarding_stage(
+        let SpawnForwardingStageResult {
+            join_handle: forwarding_stage,
+            client_updater,
+        } = spawn_forwarding_stage(
             forward_stage_receiver,
             client,
             vote_forwards_client_socket,
@@ -374,6 +463,7 @@ impl Tpu {
             key_updaters.push(forwards_key_updater);
         }
         key_updaters.push(vote_streamer_key_updater);
+        key_updaters.push(client_updater);
         (
             Self {
                 fetch_stage,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1657,9 +1657,9 @@ impl Validator {
             if let Some(json_rpc_service) = &json_rpc_service {
                 key_notifies.push(json_rpc_service.get_client_key_updater())
             }
+            // note, that we don't need to add ConnectionClient to key_notifiers
+            // because it is added inside Tpu.
         }
-        // add connection_cache because it is still used in Forwarder.
-        key_notifies.push(connection_cache);
 
         *admin_rpc_service_post_init.write().unwrap() = Some(AdminRpcRequestMetadataPostInit {
             bank_forks: bank_forks.clone(),


### PR DESCRIPTION
#### Problem

TPU is currently hardwired to use ConnectionCache as QUIC client implementation

#### Summary of Changes

This PR allows to construct TPU with alternative QUIC client implementations.
It also changes the place where ConnectionCache is added to the vector of keypair updaters from validator.rs to tpu.rs
