### PR TITLE
net-utils: remove clippy::arithmetic_side_effects from prod code

### DIFF
--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -10,6 +10,9 @@ license = { workspace = true }
 edition = { workspace = true }
 rust-version = "1.83.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::arithmetic_side_effects)]
-
 //! The `net_utils` module assists with networking
 mod ip_echo_client;
 mod ip_echo_server;

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -19,6 +19,7 @@ const SLICE_PER_PROCESS: u16 = (u16::MAX - BASE_PORT) / 64;
 ///
 /// When running without nextest, this will only bump an atomic and eventually
 /// panic when it runs out of port numbers to assign.
+#[allow(clippy::arithmetic_side_effects)]
 pub fn localhost_port_range_for_tests() -> (u16, u16) {
     static SLICE: AtomicU16 = AtomicU16::new(0);
     let offset = SLICE.fetch_add(20, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
allow(clippy::arithmetic_side_effects) was applied too broadly

#### Summary of Changes
Apply to the one function that needs it
