### PR TITLE
cleanup: Use .default_value() for several CLAP args

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -31,7 +31,6 @@ use {
     },
     anyhow::{anyhow, Context, Result},
     crossbeam_channel::{bounded, unbounded, Receiver},
-    lazy_static::lazy_static,
     quinn::Endpoint,
     solana_accounts_db::{
         accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
@@ -174,14 +173,7 @@ impl BlockVerificationMethod {
     }
 
     pub fn cli_message() -> &'static str {
-        lazy_static! {
-            static ref MESSAGE: String = format!(
-                "Switch transaction scheduling method for verifying ledger entries [default: {}]",
-                BlockVerificationMethod::default()
-            );
-        };
-
-        &MESSAGE
+        "Switch transaction scheduling method for verifying ledger entries"
     }
 }
 
@@ -199,14 +191,7 @@ impl BlockProductionMethod {
     }
 
     pub fn cli_message() -> &'static str {
-        lazy_static! {
-            static ref MESSAGE: String = format!(
-                "Switch transaction scheduling method for producing ledger entries [default: {}]",
-                BlockProductionMethod::default()
-            );
-        };
-
-        &MESSAGE
+        "Switch transaction scheduling method for producing ledger entries"
     }
 }
 
@@ -224,14 +209,7 @@ impl TransactionStructure {
     }
 
     pub fn cli_message() -> &'static str {
-        lazy_static! {
-            static ref MESSAGE: String = format!(
-                "Switch internal transaction structure/representation [default: {}]",
-                TransactionStructure::default()
-            );
-        };
-
-        &MESSAGE
+        "Switch internal transaction structure/representation"
     }
 }
 

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -359,12 +359,11 @@ pub fn load_and_process_ledger(
             exit.clone(),
         )
         .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
-    let block_verification_method = value_t!(
+    let block_verification_method = value_t_or_exit!(
         arg_matches,
         "block_verification_method",
         BlockVerificationMethod
-    )
-    .unwrap_or_default();
+    );
     info!(
         "Using: block-verification-method: {}",
         block_verification_method,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -982,6 +982,7 @@ fn main() {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockVerificationMethod::cli_names())
+                .default_value(BlockVerificationMethod::default().into())
                 .global(true)
                 .help(BlockVerificationMethod::cli_message()),
         )
@@ -1484,6 +1485,7 @@ fn main() {
                         .value_name("METHOD")
                         .takes_value(true)
                         .possible_values(BlockProductionMethod::cli_names())
+                        .default_value(BlockProductionMethod::default().into())
                         .help(BlockProductionMethod::cli_message()),
                 )
                 .arg(
@@ -2548,12 +2550,11 @@ fn main() {
                             None, // transaction status sender
                         );
 
-                    let block_production_method = value_t!(
+                    let block_production_method = value_t_or_exit!(
                         arg_matches,
                         "block_production_method",
                         BlockProductionMethod
-                    )
-                    .unwrap_or_default();
+                    );
                     let transaction_struct =
                         value_t!(arg_matches, "transaction_struct", TransactionStructure)
                             .unwrap_or_default();

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1560,6 +1560,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(BlockVerificationMethod::cli_names())
+            .default_value(BlockVerificationMethod::default().into())
             .help(BlockVerificationMethod::cli_message()),
     )
     .arg(
@@ -1568,6 +1569,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(BlockProductionMethod::cli_names())
+            .default_value(BlockProductionMethod::default().into())
             .help(BlockProductionMethod::cli_message()),
     )
     .arg(
@@ -1576,6 +1578,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("STRUCT")
             .takes_value(true)
             .possible_values(TransactionStructure::cli_names())
+            .default_value(TransactionStructure::default().into())
             .help(TransactionStructure::cli_message()),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1035,24 +1035,21 @@ pub fn execute(
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, matches);
-    validator_config.block_verification_method = value_t!(
+    validator_config.block_verification_method = value_t_or_exit!(
         matches,
         "block_verification_method",
         BlockVerificationMethod
-    )
-    .unwrap_or_default();
-    validator_config.block_production_method = value_t!(
+    );
+    validator_config.block_production_method = value_t_or_exit!(
         matches, // comment to align formatting...
         "block_production_method",
         BlockProductionMethod
-    )
-    .unwrap_or_default();
-    validator_config.transaction_struct = value_t!(
+    );
+    validator_config.transaction_struct = value_t_or_exit!(
         matches, // comment to align formatting...
         "transaction_struct",
         TransactionStructure
-    )
-    .unwrap_or_default();
+    );
     validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();
     validator_config.unified_scheduler_handler_threads =
         value_t!(matches, "unified_scheduler_handler_threads", usize).ok();


### PR DESCRIPTION
#### Problem
These args previously used lazy_static to construct a help message that includes a default value. We can simplify by using the `.default_value()` function on the CLAP `Argument`. The default will still be shown in help message and we can now avoid `.unwrap_or_default()` & the `lazy_static`
