### PR TITLE
ledger-tool: Wire up transaction_struct Argument

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1489,6 +1489,15 @@ fn main() {
                         .help(BlockProductionMethod::cli_message()),
                 )
                 .arg(
+                    Arg::with_name("transaction_struct")
+                        .long("transaction-structure")
+                        .value_name("STRUCT")
+                        .takes_value(true)
+                        .possible_values(TransactionStructure::cli_names())
+                        .default_value(TransactionStructure::default().into())
+                        .help(TransactionStructure::cli_message()),
+                )
+                .arg(
                     Arg::with_name("first_simulated_slot")
                         .long("first-simulated-slot")
                         .value_name("SLOT")
@@ -2556,8 +2565,7 @@ fn main() {
                         BlockProductionMethod
                     );
                     let transaction_struct =
-                        value_t!(arg_matches, "transaction_struct", TransactionStructure)
-                            .unwrap_or_default();
+                        value_t_or_exit!(arg_matches, "transaction_struct", TransactionStructure);
 
                     info!("Using: block-production-method: {block_production_method} transaction-structure: {transaction_struct}");
 


### PR DESCRIPTION
~~On top of https://github.com/anza-xyz/agave/pull/6123, that should merge first~~ (DONE)

#### Problem
The argument is currently parsed in the simulate-block-production
command, but the argument is not instantiated. Thus, there is no way to
toggle which mode is used right now

Looks like this was just an oversight from https://github.com/anza-xyz/agave/pull/3820
