### PR TITLE
genesis: create EpochRewards at epoch 0

### DIFF
--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -45,9 +45,9 @@ pub fn create_account(lamports: u64, config: &Config) -> AccountSharedData {
 #[allow(deprecated)]
 pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
     let mut account = create_config_account(vec![], &Config::default(), 0);
-    let lamports = genesis_config.rent.minimum_balance(account.data().len());
+    let lamports = std::cmp::max(genesis_config.rent.minimum_balance(account.data().len()), 1);
 
-    account.set_lamports(lamports.max(1));
+    account.set_lamports(lamports);
 
     genesis_config.add_account(solana_stake_interface::config::id(), account);
 

--- a/programs/stake/src/epoch_rewards.rs
+++ b/programs/stake/src/epoch_rewards.rs
@@ -1,0 +1,21 @@
+//! Creates the initial empty EpochRewards sysvar
+use {
+    solana_account::{AccountSharedData, WritableAccount},
+    solana_genesis_config::GenesisConfig,
+    solana_sdk_ids::sysvar,
+    solana_sysvar::{
+        epoch_rewards::{self, EpochRewards},
+        Sysvar,
+    },
+};
+
+pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
+    let data = vec![0; EpochRewards::size_of()];
+    let lamports = genesis_config.rent.minimum_balance(data.len());
+
+    let account = AccountSharedData::create(lamports, data, sysvar::id(), false, u64::MAX);
+
+    genesis_config.add_account(epoch_rewards::id(), account);
+
+    lamports
+}

--- a/programs/stake/src/epoch_rewards.rs
+++ b/programs/stake/src/epoch_rewards.rs
@@ -11,7 +11,7 @@ use {
 
 pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
     let data = vec![0; EpochRewards::size_of()];
-    let lamports = genesis_config.rent.minimum_balance(data.len());
+    let lamports = std::cmp::max(genesis_config.rent.minimum_balance(data.len()), 1);
 
     let account = AccountSharedData::create(lamports, data, sysvar::id(), false, u64::MAX);
 

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -8,13 +8,16 @@ pub use solana_sdk_ids::stake::{check_id, id};
 use {solana_genesis_config::GenesisConfig, solana_native_token::LAMPORTS_PER_SOL};
 
 pub mod config;
+pub mod epoch_rewards;
 #[deprecated(since = "2.2.0")]
 pub mod points;
 pub mod stake_instruction;
 pub mod stake_state;
 
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
-    config::add_genesis_account(genesis_config)
+    let config_lamports = config::add_genesis_account(genesis_config);
+    let rewards_lamports = epoch_rewards::add_genesis_account(genesis_config);
+    config_lamports.saturating_add(rewards_lamports)
 }
 
 /// The minimum stake amount that can be delegated, in lamports.

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -265,13 +265,12 @@ mod tests {
             runtime_config::RuntimeConfig,
         },
         assert_matches::assert_matches,
-        solana_account::{state_traits::StateMut, Account, WritableAccount},
+        solana_account::{state_traits::StateMut, Account},
         solana_accounts_db::accounts_db::{AccountsDbConfig, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_reward_info::RewardType,
-        solana_sdk_ids::sysvar::epoch_rewards,
         solana_signer::Signer,
         solana_stake_interface::{error::StakeError, state::StakeStateV2},
         solana_system_transaction as system_transaction,
@@ -406,11 +405,6 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
-        genesis_config
-            .accounts
-            .get_mut(&epoch_rewards::id())
-            .unwrap()
-            .set_lamports(1);
 
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING.clone();
         accounts_db_config.partitioned_epoch_rewards_config =


### PR DESCRIPTION
#### Problem
the bpf stake program depends on the existence of `EpochRewards` to function, but this account does not exist until epoch 1. this means:
1) all stake operations fail on `solana-test-validator` in the first epoch
2) all stake operations would fail on a brand new cluster in the first epoch

#### Summary of Changes
create a blank `SysvarEpochRewards1111111111111111111111111` account at genesis

closes #4928 