### PR TITLE
Removes CreateAncientStorage enum

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -150,13 +150,6 @@ const SHRINK_COLLECT_CHUNK_SIZE: usize = 50;
 /// candidates for shrinking.
 const SHRINK_INSERT_ANCIENT_THRESHOLD: usize = 10;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum CreateAncientStorage {
-    /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats
-    #[default]
-    Pack,
-}
-
 #[derive(Debug)]
 enum StoreTo<'a> {
     /// write to cache

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6057,12 +6057,8 @@ define_accounts_db_test!(test_many_unrefs, |db| {
     assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
 });
 
-#[test_case(CreateAncientStorage::Pack; "pack")]
-fn test_get_oldest_non_ancient_slot_for_hash_calc_scan(
-    _create_ancient_storage: CreateAncientStorage,
-) {
-    let expected = |_v| None;
-
+#[test]
+fn test_get_oldest_non_ancient_slot_for_hash_calc_scan() {
     let mut db = AccountsDb::new_single_for_tests();
 
     let config = CalcAccountsHashConfig::default();
@@ -6072,23 +6068,23 @@ fn test_get_oldest_non_ancient_slot_for_hash_calc_scan(
     let offset = 10;
     assert_eq!(
         db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-        expected(db.ancient_append_vec_offset.unwrap() as u64 + offset + 1)
+        None,
     );
     // ancient append vecs enabled (but at 0 offset), so can be non-zero
     db.ancient_append_vec_offset = Some(0);
     // 0..=(slots_per_epoch - 1) are all non-ancient
     assert_eq!(
         db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch - 1, &config),
-        expected(0)
+        None,
     );
     // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
     assert_eq!(
         db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
-        expected(1)
+        None,
     );
     assert_eq!(
         db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-        expected(offset + 1)
+        None,
     );
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6,7 +6,7 @@ use {
         accounts_file::AccountsFileProvider,
         accounts_hash::MERKLE_FANOUT,
         accounts_index::{tests::*, AccountIndex, AccountSecondaryIndexesIncludeExclude},
-        ancient_append_vecs,
+        ancient_append_vecs::{self, is_ancient},
         append_vec::{
             aligned_stored_size, test_utils::TempFile, AccountMeta, AppendVec, StoredAccountMeta,
             StoredMeta,
@@ -6057,21 +6057,13 @@ define_accounts_db_test!(test_many_unrefs, |db| {
     assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
 });
 
-#[test_case(CreateAncientStorage::Append; "append")]
 #[test_case(CreateAncientStorage::Pack; "pack")]
 fn test_get_oldest_non_ancient_slot_for_hash_calc_scan(
-    create_ancient_storage: CreateAncientStorage,
+    _create_ancient_storage: CreateAncientStorage,
 ) {
-    let expected = |v| {
-        if create_ancient_storage == CreateAncientStorage::Append {
-            Some(v)
-        } else {
-            None
-        }
-    };
+    let expected = |_v| None;
 
     let mut db = AccountsDb::new_single_for_tests();
-    db.create_ancient_storage = create_ancient_storage;
 
     let config = CalcAccountsHashConfig::default();
     let slot = config.epoch_schedule.slots_per_epoch;

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -28,7 +28,8 @@ pub const ALIGN_BOUNDARY_OFFSET: usize = mem::size_of::<u64>();
 #[macro_export]
 macro_rules! u64_align {
     ($addr: expr) => {
-        ($addr + (ALIGN_BOUNDARY_OFFSET - 1)) & !(ALIGN_BOUNDARY_OFFSET - 1)
+        ($addr + ($crate::accounts_file::ALIGN_BOUNDARY_OFFSET - 1))
+            & !($crate::accounts_file::ALIGN_BOUNDARY_OFFSET - 1)
     };
 }
 
@@ -88,6 +89,9 @@ impl AccountsFile {
     }
 
     /// true if this storage can possibly be appended to (independent of capacity check)
+    //
+    // NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+    #[cfg(test)]
     pub(crate) fn can_append(&self) -> bool {
         match self {
             Self::AppendVec(av) => av.can_append(),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -4,6 +4,8 @@
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
 //!
 //! Otherwise, an ancient append vec is the same as any other append vec
+#[cfg(test)]
+use crate::accounts_file::AccountsFile;
 use {
     crate::{
         account_storage::ShrinkInProgress,
@@ -12,7 +14,6 @@ use {
             AccountFromStorage, AccountStorageEntry, AccountsDb, AliveAccounts,
             GetUniqueAccountsResult, ShrinkCollect, ShrinkCollectAliveSeparatedByRefs,
         },
-        accounts_file::AccountsFile,
         active_stats::ActiveStatItem,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
     },
@@ -1073,6 +1074,9 @@ impl<'a> PackedAncientStorage<'a> {
 
 /// a set of accounts need to be stored.
 /// If there are too many to fit in 'Primary', the rest are put in 'Overflow'
+//
+// NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+#[cfg(test)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StorageSelector {
     Primary,
@@ -1084,6 +1088,9 @@ pub enum StorageSelector {
 /// The 'store' functions need data stored in a slice of specific type.
 /// We need 1-2 of these slices constructed based on available bytes and individual account sizes.
 /// The slice arithmetic across both hashes and account data gets messy. So, this struct abstracts that.
+//
+// NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+#[cfg(test)]
 pub struct AccountsToStore<'a> {
     accounts: &'a [&'a AccountFromStorage],
     /// if 'accounts' contains more items than can be contained in the primary storage, then we have to split these accounts.
@@ -1096,6 +1103,8 @@ pub struct AccountsToStore<'a> {
     bytes_overflow: usize,
 }
 
+// NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+#[cfg(test)]
 impl<'a> AccountsToStore<'a> {
     /// break 'stored_accounts' into primary and overflow
     /// available_bytes: how many bytes remain in the primary storage. Excess accounts will be directed to an overflow storage
@@ -1187,6 +1196,9 @@ pub const fn get_ancient_append_vec_capacity() -> u64 {
 }
 
 /// is this a max-size append vec designed to be used as an ancient append vec?
+//
+// NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+#[cfg(test)]
 pub fn is_ancient(storage: &AccountsFile) -> bool {
     storage.capacity() >= get_ancient_append_vec_capacity()
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -21,7 +21,7 @@ use {
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_file::{
             AccountsFileError, InternalsForArchive, MatchAccountOwnerError, Result, StorageAccess,
-            StoredAccountsInfo, ALIGN_BOUNDARY_OFFSET,
+            StoredAccountsInfo,
         },
         accounts_hash::AccountHash,
         buffered_reader::{BufferedReader, BufferedReaderStatus, Stack},
@@ -1312,6 +1312,8 @@ impl AppendVec {
         })
     }
 
+    // NOTE: Only used by ancient append vecs "append" method, which is test-only now.
+    #[cfg(test)]
     pub(crate) fn can_append(&self) -> bool {
         match &self.backing {
             AppendVecFileBacking::File(_file) => false,

--- a/accounts-db/src/tiered_storage/mmap_utils.rs
+++ b/accounts-db/src/tiered_storage/mmap_utils.rs
@@ -1,9 +1,4 @@
-use {
-    crate::{accounts_file::ALIGN_BOUNDARY_OFFSET, u64_align},
-    log::*,
-    memmap2::Mmap,
-    std::io::Result as IoResult,
-};
+use {crate::u64_align, log::*, memmap2::Mmap, std::io::Result as IoResult};
 
 /// Borrows a value of type `T` from `mmap`
 ///

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -2,7 +2,7 @@ use {
     crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
     solana_accounts_db::{
-        accounts_db::{AccountsDb, AccountsDbConfig, CreateAncientStorage},
+        accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_file::StorageAccess,
         accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanFilter},
         utils::create_and_canonicalize_directories,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -358,7 +358,6 @@ pub fn get_accounts_db_config(
         exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         test_skip_rewrites_but_include_in_bank_hash: false,
-        create_ancient_storage: CreateAncientStorage::Pack,
         storage_access,
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: !arg_matches

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -10,7 +10,7 @@ use {
     log::*,
     rand::{seq::SliceRandom, thread_rng},
     solana_accounts_db::{
-        accounts_db::{AccountShrinkThreshold, AccountsDb, AccountsDbConfig, CreateAncientStorage},
+        accounts_db::{AccountShrinkThreshold, AccountsDb, AccountsDbConfig},
         accounts_file::StorageAccess,
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -521,7 +521,6 @@ pub fn execute(
         )
         .ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
-        create_ancient_storage: CreateAncientStorage::Pack,
         test_skip_rewrites_but_include_in_bank_hash: false,
         storage_access,
         scan_filter_for_shrinking,


### PR DESCRIPTION
#### Problem

The "append" method for squashing ancient storages is no longer supported, yet remains in the code. This is tech debt.


#### Summary of Changes

Remove the `CreateAncientStorage` enum, and the `AccountsDb::create_ancient_storage` field.

And then fix up all the places that were using them.

I may be useful to walk through the PR commit-by-commit. Also, subsequent PRs will clean this up more. I tried to keep the refactoring as close to zero as possible.

