### PR TITLE
Removes AccountsDb::get_oldest_non_ancient_slot()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6874,20 +6874,6 @@ impl AccountsDb {
         }
     }
 
-    /// `oldest_non_ancient_slot` is only applicable when `Append` is used for ancient append vec packing.
-    /// If `Pack` is used for ancient append vec packing, return None.
-    /// Otherwise, return a slot 'max_slot_inclusive' - (slots_per_epoch - `self.ancient_append_vec_offset`)
-    /// If ancient append vecs are not enabled, return 0.
-    fn get_oldest_non_ancient_slot_for_hash_calc_scan(
-        &self,
-        _max_slot_inclusive: Slot,
-        _config: &CalcAccountsHashConfig<'_>,
-    ) -> Option<Slot> {
-        // oldest_non_ancient_slot is only applicable when ancient storages are created with `Append`. When ancient storages are created with `Pack`, ancient storages
-        // can be created in between non-ancient storages. Return None, because oldest_non_ancient_slot is not applicable here.
-        None
-    }
-
     /// hash info about 'storage' into 'hasher'
     /// return true iff storage is valid for loading from cache
     fn hash_storage_info(

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -186,11 +186,7 @@ impl AccountsDb {
     where
         S: AppendVecScan,
     {
-        let oldest_non_ancient_slot_for_split = self
-            .get_oldest_non_ancient_slot_for_hash_calc_scan(
-                snapshot_storages.max_slot_inclusive(),
-                config,
-            );
+        let oldest_non_ancient_slot_for_split = None;
         let splitter =
             SplitAncientStorages::new(oldest_non_ancient_slot_for_split, snapshot_storages);
         let oldest_non_ancient_slot_for_identification = self

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6057,37 +6057,6 @@ define_accounts_db_test!(test_many_unrefs, |db| {
     assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
 });
 
-#[test]
-fn test_get_oldest_non_ancient_slot_for_hash_calc_scan() {
-    let mut db = AccountsDb::new_single_for_tests();
-
-    let config = CalcAccountsHashConfig::default();
-    let slot = config.epoch_schedule.slots_per_epoch;
-    let slots_per_epoch = config.epoch_schedule.slots_per_epoch;
-    assert_ne!(slot, 0);
-    let offset = 10;
-    assert_eq!(
-        db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-        None,
-    );
-    // ancient append vecs enabled (but at 0 offset), so can be non-zero
-    db.ancient_append_vec_offset = Some(0);
-    // 0..=(slots_per_epoch - 1) are all non-ancient
-    assert_eq!(
-        db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch - 1, &config),
-        None,
-    );
-    // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
-    assert_eq!(
-        db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
-        None,
-    );
-    assert_eq!(
-        db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-        None,
-    );
-}
-
 define_accounts_db_test!(test_mark_dirty_dead_stores_empty, |db| {
     let slot = 0;
     for add_dirty_stores in [false, true] {


### PR DESCRIPTION
#### Problem

Follow up from https://github.com/anza-xyz/agave/pull/6126#discussion_r2075650234. `AccountsDb::get_oldest_non_ancient_slot()` now always returns None, so we can fix up its callers.


#### Summary of Changes

Removes AccountsDb::get_oldest_non_ancient_slot()