### PR TITLE
Test SBPFv3 in downstream programs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -165,3 +165,11 @@ jobs:
           cd "${{ matrix.programs }}"
           rm -rf target/deploy target/sbpf*
           $CARGO_TEST_SBF --arch v2 --manifest-path program/Cargo.toml
+
+      - name: Test SBPFv3
+        shell: bash
+        run: |
+          source ci/downstream-projects/common.sh
+          cd "${{ matrix.programs }}"
+          rm -rf target/deploy target/sbpf*
+          $CARGO_TEST_SBF --arch v3 --manifest-path program/Cargo.toml


### PR DESCRIPTION
#### Problem

The platform-tools already supports the SBPFv3 architecture, and we want to enable it on main net at some point in the future. Meanwhile, the downstream programs should also be tested with it, to ensure there are no unexpected incompatibilities when we finally enable it.

#### Summary of Changes

Add another task in the yaml file to test the v3 architecture.