### PR TITLE
docs: fix dead link in src/cli/install.md

### DIFF
--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -20,7 +20,7 @@ on your preferred workflow:
 - Open your favorite Terminal application
 
 - Install the Agave release
-  [LATEST_AGAVE_RELEASE_VERSION](https://github.com/anza-xyz/agave/releases/tag/LATEST_AGAVE_RELEASE_VERSION)
+  [LATEST_AGAVE_RELEASE_VERSION](https://github.com/anza-xyz/agave/releases)
   on your machine by running:
 
 ```bash


### PR DESCRIPTION
#### Problem
There was a dead link https://github.com/anza-xyz/agave/releases/tag/LATEST_AGAVE_RELEASE_VERSION 
i replaced that link with a working one https://github.com/anza-xyz/agave/releases
no need to point at "Last agave realese.." cause the last realese on the beginning of the link https://github.com/anza-xyz/agave/releases

