### PR TITLE
switch to workspace deps in net-utils

### DIFF
--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -26,7 +26,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 socket2 = { workspace = true }
-solana-serde = "=2.2.1"
+solana-serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 


### PR DESCRIPTION
#### Problem

net-utils no longer needs to pin version of solana-serde

#### Summary of Changes

switch to workspace version
