### PR TITLE
solana-client tests to use dedicated port ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,7 +7450,6 @@ name = "solana-client-test"
 version = "2.3.0"
 dependencies = [
  "futures-util",
- "rand 0.8.5",
  "serde_json",
  "solana-client",
  "solana-clock",
@@ -7462,6 +7461,7 @@ dependencies = [
  "solana-merkle-tree",
  "solana-message",
  "solana-native-token",
+ "solana-net-utils",
  "solana-perf",
  "solana-pubkey",
  "solana-pubsub-client",

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 
 [dependencies]
 futures-util = { workspace = true }
-rand = { workspace = true }
 serde_json = { workspace = true }
 solana-client = { workspace = true }
 solana-clock = { workspace = true }
@@ -44,6 +43,7 @@ tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -1,6 +1,5 @@
 use {
     futures_util::StreamExt,
-    rand::Rng,
     serde_json::{json, Value},
     solana_clock::Slot,
     solana_commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -52,10 +51,8 @@ use {
 };
 
 fn pubsub_addr() -> SocketAddr {
-    SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        rand::thread_rng().gen_range(1024..65535),
-    )
+    let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

Tests for solana-client kept using random ports to ensure maximal CI pain

#### Summary of Changes

Port to dedicated port ranges.