### PR TITLE
Revert "Enables experimental accumulator hash by default (#6071)"

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -112,9 +112,9 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .possible_values(&["mmap", "file"])
             .help("Access account storages using this method"),
-        Arg::with_name("no_accounts_db_experimental_accumulator_hash")
-            .long("no-accounts-db-experimental-accumulator-hash")
-            .help("Disables the experimental accumulator hash")
+        Arg::with_name("accounts_db_experimental_accumulator_hash")
+            .long("accounts-db-experimental-accumulator-hash")
+            .help("Enables the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_verify_experimental_accumulator_hash")
             .long("accounts-db-verify-experimental-accumulator-hash")
@@ -360,8 +360,8 @@ pub fn get_accounts_db_config(
         test_skip_rewrites_but_include_in_bank_hash: false,
         storage_access,
         scan_filter_for_shrinking,
-        enable_experimental_accumulator_hash: !arg_matches
-            .is_present("no_accounts_db_experimental_accumulator_hash"),
+        enable_experimental_accumulator_hash: arg_matches
+            .is_present("accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: arg_matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
         snapshots_use_experimental_accumulator_hash: arg_matches

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1415,9 +1415,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
-        Arg::with_name("no_accounts_db_experimental_accumulator_hash")
-            .long("no-accounts-db-experimental-accumulator-hash")
-            .help("Disables the experimental accumulator hash")
+        Arg::with_name("accounts_db_experimental_accumulator_hash")
+            .long("accounts-db-experimental-accumulator-hash")
+            .help("Enables the experimental accumulator hash")
             .hidden(hidden_unless_forced()),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -524,8 +524,8 @@ pub fn execute(
         test_skip_rewrites_but_include_in_bank_hash: false,
         storage_access,
         scan_filter_for_shrinking,
-        enable_experimental_accumulator_hash: !matches
-            .is_present("no_accounts_db_experimental_accumulator_hash"),
+        enable_experimental_accumulator_hash: matches
+            .is_present("accounts_db_experimental_accumulator_hash"),
         verify_experimental_accumulator_hash: matches
             .is_present("accounts_db_verify_experimental_accumulator_hash"),
         snapshots_use_experimental_accumulator_hash: matches


### PR DESCRIPTION
#### Problem

With the lt hash enabled, accounts verification at startup fails if the disk index is disabled. See https://github.com/anza-xyz/agave/issues/6153 for more information.


#### Summary of Changes

Revert #6071 while we work on a fix for the underlying issue.