### PR TITLE
include existing zero lamport in duplicates

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1474,8 +1474,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             .insert_new_entry_if_missing_with_lock(pubkey, new_entry)
                         {
                             InsertNewEntryResults::DidNotExist => {}
-                            InsertNewEntryResults::ExistedNewEntryZeroLamports => {}
-                            InsertNewEntryResults::ExistedNewEntryNonZeroLamports(other_slot) => {
+                            InsertNewEntryResults::ExistedNewEntryZeroLamports(other_slot)
+                            | InsertNewEntryResults::ExistedNewEntryNonZeroLamports(other_slot) => {
                                 if let Some(other_slot) = other_slot {
                                     duplicates_from_in_memory.push((other_slot, pubkey));
                                 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -143,7 +143,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for InMemAccoun
 
 pub enum InsertNewEntryResults {
     DidNotExist,
-    ExistedNewEntryZeroLamports,
+    ExistedNewEntryZeroLamports(Option<Slot>),
     ExistedNewEntryNonZeroLamports(Option<Slot>),
 }
 
@@ -876,7 +876,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         if !already_existed {
             InsertNewEntryResults::DidNotExist
         } else if new_entry_zero_lamports {
-            InsertNewEntryResults::ExistedNewEntryZeroLamports
+            InsertNewEntryResults::ExistedNewEntryZeroLamports(other_slot)
         } else {
             InsertNewEntryResults::ExistedNewEntryNonZeroLamports(other_slot)
         }


### PR DESCRIPTION
#### Problem

Include exising zero accounts in `duplicates` list so that lthash get the correct set of accounts to mixout when verifying at startup. 


#### Summary of Changes


Fixes #6153
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
