### PR TITLE
Expands test_verify_accounts_lt_hash_at_startup() to test with and without the disk index

### DIFF
--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -410,8 +410,11 @@ mod tests {
             snapshot_utils,
         },
         solana_account::{ReadableAccount as _, WritableAccount as _},
-        solana_accounts_db::accounts_db::{
-            AccountsDbConfig, DuplicatesLtHash, ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        solana_accounts_db::{
+            accounts_db::{AccountsDbConfig, DuplicatesLtHash, ACCOUNTS_DB_CONFIG_FOR_TESTING},
+            accounts_index::{
+                AccountsIndexConfig, IndexLimitMb, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+            },
         },
         solana_feature_gate_interface::{self as feature, Feature},
         solana_fee_calculator::FeeRateGovernor,
@@ -420,7 +423,7 @@ mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::{self as pubkey, Pubkey},
         solana_signer::Signer as _,
-        std::{cmp, collections::HashMap, ops::RangeFull, str::FromStr as _, sync::Arc},
+        std::{cmp, collections::HashMap, iter, ops::RangeFull, str::FromStr as _, sync::Arc},
         tempfile::TempDir,
         test_case::{test_case, test_matrix},
     };
@@ -921,10 +924,17 @@ mod tests {
 
     #[test_matrix(
         [Features::None, Features::All],
-        [Cli::Off, Cli::On]
+        [Cli::Off, Cli::On],
+        [IndexLimitMb::Minimal, IndexLimitMb::InMemOnly]
     )]
-    fn test_verify_accounts_lt_hash_at_startup(features: Features, verify_cli: Cli) {
-        let (genesis_config, mint_keypair) = genesis_config_with(features);
+    fn test_verify_accounts_lt_hash_at_startup(
+        features: Features,
+        verify_cli: Cli,
+        accounts_index_limit: IndexLimitMb,
+    ) {
+        let (mut genesis_config, mint_keypair) = genesis_config_with(features);
+        // This test requires zero fees so that we can easily transfer an account's entire balance.
+        genesis_config.fee_rate_governor = FeeRateGovernor::new(0, 0);
         let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank.rc
             .accounts
@@ -963,6 +973,41 @@ mod tests {
             bank.force_flush_accounts_cache();
         }
 
+        // Create a few more storages to exercise the zero lamport duplicates handling during
+        // generate_index(), which is used for the lattice-based accounts verification.
+        // There needs to be accounts that only have a single duplicate (i.e. there are only two
+        // versions of the accounts), and toggle between non-zero and zero lamports.
+        // One account will go zero -> non-zero, and the other will go non-zero -> zero.
+        let num_accounts = 2;
+        let accounts: Vec<_> = iter::repeat_with(Keypair::new).take(num_accounts).collect();
+        for i in 0..num_accounts {
+            let slot = bank.slot() + 1;
+            bank =
+                new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
+            bank.register_unique_recent_blockhash_for_test();
+
+            // transfer into the accounts so they start with a non-zero balance
+            for account in &accounts {
+                bank.transfer(amount, &mint_keypair, &account.pubkey())
+                    .unwrap();
+                assert_ne!(bank.get_balance(&account.pubkey()), 0);
+            }
+
+            // then transfer *out* all the lamports from one of 'em
+            bank.transfer(
+                bank.get_balance(&accounts[i].pubkey()),
+                &accounts[i],
+                &pubkey::new_rand(),
+            )
+            .unwrap();
+            assert_eq!(bank.get_balance(&accounts[i].pubkey()), 0);
+
+            // flush the write cache to disk to ensure the storages match the accounts written here
+            bank.fill_bank_with_ticks_for_tests();
+            bank.squash();
+            bank.force_flush_accounts_cache();
+        }
+
         // verification happens at startup, so mimic the behavior by loading from a snapshot
         let snapshot_config = SnapshotConfig::default();
         let bank_snapshots_dir = TempDir::new().unwrap();
@@ -977,11 +1022,16 @@ mod tests {
         )
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
+        let accounts_index_config = AccountsIndexConfig {
+            index_limit_mb: accounts_index_limit,
+            ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
+        };
         let accounts_db_config = AccountsDbConfig {
             enable_experimental_accumulator_hash: match verify_cli {
                 Cli::Off => false,
                 Cli::On => true,
             },
+            index: Some(accounts_index_config),
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         };
         let (roundtrip_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(


### PR DESCRIPTION
#### Problem

#6153 identified a testing gap: lattice-based accounts verification at startup relies on `generate_index()` to produce complete information about duplicates.


#### Summary of Changes

Expand `test_verify_accounts_lt_hash_at_startup()` to test with both the disk index enabled and disabled.


#### Additional Testing

I rebased this PR on the commit *before* #6158 to ensure the updated test failed when disabling the disk index. It did. And then when I rebased back on master (on top of #6158), the test passed.