### PR TITLE
blockstore: Adjust rocksdb threadpool config

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1160,24 +1160,18 @@ fn get_db_options(blockstore_options: &BlockstoreOptions) -> Options {
     // pool is used for compactions whereas the high priority pool is used for
     // memtable flushes. Separate pools are created so that compactions are
     // unable to stall memtable flushes (which could stall memtable writes).
-    let mut env = rocksdb::Env::new().unwrap();
-    env.set_low_priority_background_threads(
-        blockstore_options.num_rocksdb_compaction_threads.get() as i32,
-    );
-    env.set_high_priority_background_threads(
-        blockstore_options.num_rocksdb_flush_threads.get() as i32
-    );
-    options.set_env(&env);
-    // rocksdb will try to scale threadpool sizes automatically based on the
-    // value set for max_background_jobs. The automatic scaling can increase,
-    // but not decrease the number of threads in each pool. But, we already
-    // set desired threadpool sizes with set_low_priority_background_threads()
-    // and set_high_priority_background_threads(). So, set max_background_jobs
-    // to a small number (2) so that rocksdb will leave the previously
-    // configured threadpool sizes as-is. The value (2) would result in one
-    // low priority and one high priority thread which is the minimum for each.
-    options.set_max_background_jobs(2);
-
+    //
+    // For now, use the deprecated methods to configure the exact amount of
+    // threads for each pool. The new method, set_max_background_jobs(N),
+    // configures N/4 low priority threads and 3N/4 high priority threads.
+    #[allow(deprecated)]
+    {
+        options.set_max_background_compactions(
+            blockstore_options.num_rocksdb_compaction_threads.get() as i32,
+        );
+        options
+            .set_max_background_flushes(blockstore_options.num_rocksdb_flush_threads.get() as i32);
+    }
     // Set max total wal size to 4G.
     options.set_max_total_wal_size(4 * 1024 * 1024 * 1024);
 


### PR DESCRIPTION
#### Problem
A previous change wired up the ability to configure rocksdb threadpool sizes through BlockstoreOptions. That change kept the threadpool sizes the same, but unintentionally limited how many concurrent flushes and compactions could be scheduled in each pool. The result was reduced parallelism with mostly idle threadpools. The previous change is https://github.com/anza-xyz/agave/pull/4214

#### Summary of Changes
This change restores the previous level of allowed parallelism in the compact and flush threadpools

#### Who is Effected
With current MNB load, I believe the node had to have the following in order to experience a noticeable issue:
1) Running with `--enable-rpc-transaction-history`
2) Running with larger than default `--limit-ledger-size`
3) Potentially getting actual RPC load on Blockstore methods; these increase reads which compete with compaction

Item 1. introduces two extra columns that increase our total amount of data written to the Blockstore by 2-3x. Item 2. opens up to some elevated I/O to clean those two extra columns (see https://github.com/anza-xyz/agave/issues/6017 for more details).

#### Testing
With the current tip of master, I put a breakpoint [here](https://github.com/facebook/rocksdb/blob/main/db/db_impl/db_impl_compaction_flush.cc#L2941-L2962), and observed the following (noting that the pool sizes scale with N threads):
```
// v2.1
(gdb) print res
$1 = {max_flushes = 8, max_compactions = 24}

// tip of master & v2.2
(gdb) print res
$1 = {max_flushes = 1, max_compactions = 1}

// this PR
(gdb) print res
$1 = {max_flushes = 8, max_compactions = 32}
```
You may notice that `max_compaction` changes in this PR vs. `v2.1`. In rocks, the size of the threadpool and the number of jobs that can be scheduled in parallel are separate numbers:
- In `<= v2.1` on this box, we'd create 32 threads for compaction but only allow up to 24 jobs to be run in parallel
    - More details on why in https://github.com/anza-xyz/agave/pull/4214
- This PR allows all 32 created threads to be utilized at once
    - I'd argue this makes the configuration more intuitive, and we can reduce the threadpool size subsequently
