### PR TITLE
Replaces process::exit() with panic!() in AppendVec::new()

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -300,13 +300,11 @@ impl AppendVec {
 
         //UNSAFE: Required to create a Mmap
         let mmap = unsafe { MmapMut::map_mut(&data) };
-        let mmap = mmap.unwrap_or_else(|e| {
-            error!(
-                "Failed to map the data file (size: {}): {}.\n
-                    Please increase sysctl vm.max_map_count or equivalent for your platform.",
-                size, e
+        let mmap = mmap.unwrap_or_else(|err| {
+            panic!(
+                "Failed to map the data file (size: {size}): {err}. \
+                 Please increase sysctl vm.max_map_count or equivalent for your platform.",
             );
-            std::process::exit(1);
         });
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
#### Problem

If `AppendVec::new()` fails creating the mmap, it calls `std::process::exit()`. Library crates (like accounts-db) should not call `process::exit()`. Ideally they propagate errors to their callers. Or minimally, they assert invariants or panic when unrecoverable events happen.

The validator has a custom panic handler that sends metrics. So by using `process::exit`, we never get those metrics either.


#### Summary of Changes

Change the `process::exit` to a `panic!`.