### PR TITLE
Update hashes per batch

### DIFF
--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -27,7 +27,7 @@ pub struct PohService {
 //   contention with the PoH hashing within `tick_producer()`.
 //
 // Can use test_poh_service to calibrate this
-pub const DEFAULT_HASHES_PER_BATCH: u64 = 64;
+pub const DEFAULT_HASHES_PER_BATCH: u64 = 512;
 
 pub const DEFAULT_PINNED_CPU_CORE: usize = 0;
 


### PR DESCRIPTION
hashes per tick has increased 5x since genesis, but the default hashes per batch has not. this has resulted in 5x more locks taken by `PohService` every slot, shittier poh performance, and ultimately higher slot time variance. here we increase the batch size by 8. this gives us ≈122 yield points to check for records (at which point any accumulated records are all included) per tick, or about 7808 yield points per slot. plenty for mainnet traffic.
