### PR TITLE
Clean up InsertNewEntryResults enum

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1474,8 +1474,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                             .insert_new_entry_if_missing_with_lock(pubkey, new_entry)
                         {
                             InsertNewEntryResults::DidNotExist => {}
-                            InsertNewEntryResults::ExistedNewEntryZeroLamports(other_slot)
-                            | InsertNewEntryResults::ExistedNewEntryNonZeroLamports(other_slot) => {
+                            InsertNewEntryResults::Existed(other_slot) => {
                                 if let Some(other_slot) = other_slot {
                                     duplicates_from_in_memory.push((other_slot, pubkey));
                                 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -865,15 +865,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         drop(map);
         self.update_entry_stats(m, found_in_mem);
         let stats = self.stats();
-        if !already_existed {
-            stats.inc_insert();
-        } else {
+        if already_existed {
             Self::update_stat(&stats.updates_in_mem, 1);
-        }
-        if !already_existed {
-            InsertNewEntryResults::DidNotExist
-        } else {
             InsertNewEntryResults::Existed(other_slot)
+        } else {
+            stats.inc_insert();
+            InsertNewEntryResults::DidNotExist
         }
     }
 


### PR DESCRIPTION
#### Problem

There is no longer a need to differentiate between Zero duplicates and non-zero duplicates in InsertNewEntryResults when building index. 

#### Summary of Changes

- merge zero and non-zero variants in InsertNewEntryResults
- a small refactor if checks



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
