### PR TITLE
Revert "docs: fix docker link (#6142)"

### DIFF
--- a/docker-solana/README.md
+++ b/docker-solana/README.md
@@ -1,17 +1,17 @@
 ## Minimal Solana Docker image
 This image is automatically updated by CI
 
-https://hub.docker.com/r/anzaxyz/agave/
+https://hub.docker.com/r/solanalabs/solana/
 
 ### Usage:
 Run the latest beta image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 agavexyz/agave:beta
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:beta
 ```
 
 Run the latest edge image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 agavexyz/agave:edge
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:edge
 ```
 
 Port *8899* is the JSON RPC port, which is used by clients to communicate with the network.

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -44,7 +44,7 @@ Docker's containerization overhead and resultant performance degradation unless
 specially configured.
 
 We use Docker only for development purposes. Docker Hub contains images for all
-releases at [agavexyz/agave](https://hub.docker.com/r/agavexyz/agave).
+releases at [solanalabs/solana](https://hub.docker.com/r/solanalabs/solana).
 
 ## Software
 


### PR DESCRIPTION
This reverts commit 428c6b8326e4ca5ccd0b9d4bf9bae92333c454f9.

#### Problem
#6142 contained `agavexyz` in some places instead of `anzaxyz`. We want to backport this change, but the backport hasn't landed yet. Let's revert this from master and open another PR that we can backport cleanly.

