### PR TITLE
docs: fix docker link

### DIFF
--- a/docker-solana/README.md
+++ b/docker-solana/README.md
@@ -1,17 +1,17 @@
 ## Minimal Solana Docker image
 This image is automatically updated by CI
 
-https://hub.docker.com/r/solanalabs/solana/
+https://hub.docker.com/r/anzaxyz/agave/
 
 ### Usage:
 Run the latest beta image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:beta
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 anzaxyz/agave:beta
 ```
 
 Run the latest edge image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:edge
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 anzaxyz/agave:edge
 ```
 
 Port *8899* is the JSON RPC port, which is used by clients to communicate with the network.

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -44,7 +44,7 @@ Docker's containerization overhead and resultant performance degradation unless
 specially configured.
 
 We use Docker only for development purposes. Docker Hub contains images for all
-releases at [solanalabs/solana](https://hub.docker.com/r/solanalabs/solana).
+releases at [anzaxyz/agave](https://hub.docker.com/r/anzaxyz/agave).
 
 ## Software
 

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -39,7 +39,7 @@ find yourself in need of support.
 ## Docker
 
 Running an Agave validator for live clusters (including mainnet-beta) inside Docker is
-not recommended and generally not supported. This is due to concerns of general
+not recommended and generally not supported. This is due to general concerns of
 Docker's containerization overhead and resultant performance degradation unless
 specially configured. We use Docker only for development purposes.
 

--- a/docs/src/operations/requirements.md
+++ b/docs/src/operations/requirements.md
@@ -41,10 +41,7 @@ find yourself in need of support.
 Running an Agave validator for live clusters (including mainnet-beta) inside Docker is
 not recommended and generally not supported. This is due to concerns of general
 Docker's containerization overhead and resultant performance degradation unless
-specially configured.
-
-We use Docker only for development purposes. Docker Hub contains images for all
-releases at [anzaxyz/agave](https://hub.docker.com/r/anzaxyz/agave).
+specially configured. We use Docker only for development purposes.
 
 ## Software
 


### PR DESCRIPTION
#### Summary of Changes
* Update docker links to agave
* Remove docker link from requirements doc

This re-applies the changes from #6142 
