### PR TITLE
Removing Unnecessary Clone

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7307,7 +7307,7 @@ impl AccountsDb {
                 if offsets.len() == store.count() {
                     // all remaining alive accounts in the storage are being removed, so the entire storage/slot is dead
                     store.remove_accounts(store.alive_bytes(), reset_accounts, offsets.len());
-                    self.dirty_stores.insert(*slot, store.clone());
+                    self.dirty_stores.insert(*slot, store);
                     dead_slots.insert(*slot);
                 } else {
                     // not all accounts are being removed, so figure out sizes of accounts we are removing and update the alive bytes and alive account count


### PR DESCRIPTION
#### Problem
Unnecessary clone of AccountStorageEntry as it is dropped right after

#### Summary of Changes
Remove the unnecessary clone. 
Found using nursery lint: redundant_clone

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
