### PR TITLE
switch to rpc-client-types in pubsub-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9520,7 +9520,7 @@ dependencies = [
  "solana-clock",
  "solana-commitment-config",
  "solana-pubkey",
- "solana-rpc-client-api",
+ "solana-rpc-client-types",
  "solana-signature",
  "thiserror 2.0.12",
  "tokio",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7358,7 +7358,7 @@ dependencies = [
  "solana-account-decoder-client-types",
  "solana-clock",
  "solana-pubkey",
- "solana-rpc-client-api",
+ "solana-rpc-client-types",
  "solana-signature",
  "thiserror 2.0.12",
  "tokio",

--- a/pubsub-client/Cargo.toml
+++ b/pubsub-client/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-clock = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+solana-rpc-client-types = { workspace = true }
 solana-signature = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/pubsub-client/src/nonblocking/pubsub_client.rs
+++ b/pubsub-client/src/nonblocking/pubsub_client.rs
@@ -178,7 +178,7 @@ use {
     solana_account_decoder_client_types::UiAccount,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
-    solana_rpc_client_api::{
+    solana_rpc_client_types::{
         config::{
             RpcAccountInfoConfig, RpcBlockSubscribeConfig, RpcBlockSubscribeFilter,
             RpcProgramAccountsConfig, RpcSignatureSubscribeConfig, RpcTransactionLogsConfig,

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -49,7 +49,7 @@
 //! use solana_commitment_config::CommitmentConfig;
 //! use solana_pubkey::Pubkey;
 //! use solana_pubsub_client::pubsub_client::PubsubClient;
-//! use solana_rpc_client_api::config::RpcAccountInfoConfig;
+//! use solana_rpc_client_types::config::RpcAccountInfoConfig;
 //! use std::thread;
 //!
 //! fn get_account_updates(account_pubkey: Pubkey) -> Result<()> {
@@ -99,7 +99,7 @@ use {
     solana_account_decoder_client_types::UiAccount,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
-    solana_rpc_client_api::{
+    solana_rpc_client_types::{
         config::{
             RpcAccountInfoConfig, RpcBlockSubscribeConfig, RpcBlockSubscribeFilter,
             RpcProgramAccountsConfig, RpcSignatureSubscribeConfig, RpcTransactionLogsConfig,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7160,7 +7160,7 @@ dependencies = [
  "solana-account-decoder-client-types",
  "solana-clock",
  "solana-pubkey",
- "solana-rpc-client-api",
+ "solana-rpc-client-types",
  "solana-signature",
  "thiserror 2.0.12",
  "tokio",


### PR DESCRIPTION
#### Problem
This only needs solana-rpc-client-types, not solana-rpc-client-api which is heavier
