### PR TITLE
disable retries in solana-perf unittests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,7 +14,7 @@ filter = "package(solana-zk-elgamal-proof-program-tests) & test(/^test_batched_r
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = "package(solana-turbine) | package(solana-gossip)"
+filter = "package(solana-turbine) | package(solana-gossip) | package(solana-perf)"
 retries = 0
 
 [[profile.ci.overrides]]


### PR DESCRIPTION
#### Problem
solana-perf crate does not have flaky tests 

#### Summary of Changes

disable retries