### PR TITLE
Only flushes snapshot storages on graceful exit

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -878,7 +878,10 @@ impl Validator {
             .snapshot_config()
             .should_generate_snapshots()
         {
-            let exit_backpressure = None;
+            let exit_backpressure = config
+                .validator_exit_backpressure
+                .get(SnapshotPackagerService::NAME)
+                .cloned();
             let enable_gossip_push = true;
             let snapshot_packager_service = SnapshotPackagerService::new(
                 pending_snapshot_packages.clone(),

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -22,6 +22,7 @@ use {
     solana_clock::{self as clock, Slot, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SLOT},
     solana_core::{
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
+        snapshot_packager_service::SnapshotPackagerService,
         validator::{is_snapshot_config_valid, ValidatorConfig},
     },
     solana_gossip::gossip_service::discover_validators,
@@ -572,6 +573,11 @@ impl SnapshotValidatorConfig {
         let validator_config = ValidatorConfig {
             snapshot_config,
             account_paths: account_storage_paths,
+            validator_exit_backpressure: [(
+                SnapshotPackagerService::NAME.to_string(),
+                Arc::new(AtomicBool::new(false)),
+            )]
+            .into(),
             ..ValidatorConfig::default_for_test()
         };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -27,6 +27,7 @@ use {
     solana_core::{
         banking_trace::DISABLED_BAKING_TRACE_DIR,
         consensus::tower_storage,
+        snapshot_packager_service::SnapshotPackagerService,
         system_monitor_service::SystemMonitorService,
         tpu::DEFAULT_TPU_COALESCE,
         validator::{
@@ -78,7 +79,7 @@ use {
         path::{Path, PathBuf},
         process::exit,
         str::FromStr,
-        sync::{Arc, RwLock},
+        sync::{atomic::AtomicBool, Arc, RwLock},
         time::Duration,
     },
 };
@@ -1070,6 +1071,13 @@ pub fn execute(
                 .to_string())?;
         }
     }
+
+    let validator_exit_backpressure = [(
+        SnapshotPackagerService::NAME.to_string(),
+        Arc::new(AtomicBool::new(false)),
+    )]
+    .into();
+    validator_config.validator_exit_backpressure = validator_exit_backpressure;
 
     let mut ledger_lock = ledger_lockfile(&ledger_path);
     let _ledger_write_guard = lock_ledger(&ledger_path, &mut ledger_lock);


### PR DESCRIPTION
#### Problem

Flushing files/mmaps is slow and often unnecessary. One of the last places we still do this is flushing the account storage files when taking a snapshot so that it will be safe for fastboot even after a power cycle.

(We'll worry separately about whether we should support the power cycle use case at all.)

However, we don't actually need to flush the storages for every snapshot. Instead, we can flush just once when exiting. We already have a mechanism to gracefully exit, and PR #6041 added a mechanism to apply backpressure when exiting. This would allow us to ensure storages get flushed at graceful exit.


#### Summary of Changes

Hook up SnapshotPackagerService to the exit backpressure mechanism. Now we'll only flush storages when exiting gracefully.


#### Additional Testing

I've run this PR hundreds of times on nodes running against both mainnet-beta and testnet. I've also tested this on a node with snapshots disabled. All of these tests have worked correctly.

From https://github.com/anza-xyz/agave/pull/6041#issuecomment-2872560962, the worst-case time it takes to flush at `exit` has been ~1 second.

Here's the full log:
```
[2025-05-12T13:02:25.807022098Z WARN  agave_validator::admin_rpc_service] validator exit requested
[2025-05-12T13:02:25.807620087Z INFO  agave_validator::admin_rpc_service] Wait for these services to complete: ["SnapshotPackagerService"]
[2025-05-12T13:02:25.984107483Z INFO  solana_core::snapshot_packager_service] Received exit request, tearing down...
[2025-05-12T13:02:26.808071907Z INFO  agave_validator::admin_rpc_service] SnapshotPackagerService's exit backpressure flag is raised
[2025-05-12T13:02:27.119429606Z INFO  solana_core::snapshot_packager_service] Teardown completed in 1.135290763s.
[2025-05-12T13:02:27.119458992Z INFO  solana_core::snapshot_packager_service] SnapshotPackagerService has stopped
[2025-05-12T13:02:27.808191605Z INFO  agave_validator::admin_rpc_service] All services have completed
```