### PR TITLE
Allow disabling jemalloc via Cargo features

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -181,9 +181,10 @@ test-case = { workspace = true }
 sysctl = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
+jemallocator = { workspace = true, optional = true }
 
 [features]
+default = ["jemallocator"]
 dev-context-only-utils = [
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -1,5 +1,3 @@
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
-use jemallocator::Jemalloc;
 #[path = "receive_and_buffer_utils.rs"]
 mod utils;
 use {
@@ -24,9 +22,12 @@ use {
     std::time::{Duration, Instant},
 };
 
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[cfg(all(
+    not(any(target_env = "msvc", target_os = "freebsd")),
+    feature = "jemallocator"
+))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 // a bench consumer worker that quickly drain work channel, then send a OK back via completed-work
 // channel
 // NOTE: Avoid creating PingPong within bench iter since joining threads at its eol would

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -84,12 +84,13 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
+jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
 
 [features]
+default = ["jemallocator"]
 dev-context-only-utils = []
 
 [target."cfg(unix)".dependencies]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -797,12 +797,12 @@ fn record_transactions(
     }
 }
 
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
-use jemallocator::Jemalloc;
-
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[cfg(all(
+    not(any(target_env = "msvc", target_os = "freebsd")),
+    feature = "jemallocator"
+))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -10,6 +10,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+default = ["jemallocator"]
+
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
@@ -82,7 +85,7 @@ spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tempfile = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
+jemallocator = { workspace = true, optional = true }
 
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::arithmetic_side_effects)]
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
-use jemallocator::Jemalloc;
 use {
     agave_validator::{
         cli::{app, warn_for_deprecated_arguments, DefaultArgs},
@@ -11,9 +9,12 @@ use {
     std::{path::PathBuf, process::exit},
 };
 
-#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[cfg(all(
+    not(any(target_env = "msvc", target_os = "freebsd")),
+    feature = "jemallocator"
+))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub fn main() {
     let default_args = DefaultArgs::new();


### PR DESCRIPTION
#### Problem

The agave-validator does not compile with LLVM security tools like AddressSanitizer and MemorySanitizer because those tools are incompatible with jemalloc.

#### Summary of Changes

Makes jemalloc a default-enabled optional feature.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
