### PR TITLE
docs: fix link to `solana.rb`

### DIFF
--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -253,7 +253,7 @@ your MacOS or Linux machine.
 
 - Follow instructions at: https://formulae.brew.sh/formula/solana
 
-[Homebrew formulae](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/solana.rb)
+[Homebrew formulae](https://github.com/Homebrew/homebrew-core/blob/master/Formula/s/solana.rb)
 is updated after each `solana` release, however it is possible that the Homebrew
 version is outdated.
 


### PR DESCRIPTION
#### Problem

non working link (404 - page not found)

#### Summary of Changes

updated link so now it works properly


