### PR TITLE
Use TypedColumn::deserialize for column de/serialization

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -26,7 +26,6 @@ use {
     agave_feature_set::FeatureSet,
     agave_snapshots::unpack_genesis_archive,
     assert_matches::debug_assert_matches,
-    bincode::{deserialize, serialize},
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     dashmap::DashSet,
     itertools::Itertools,
@@ -635,7 +634,7 @@ impl Blockstore {
         let candidate_fec_set_index = u32::try_from(candidate_fec_set_index)
             .expect("fec_set_index from a previously inserted shred should fit in u32");
         let candidate_erasure_set = ErasureSetId::new(slot, candidate_fec_set_index);
-        let candidate_erasure_meta: ErasureMeta = deserialize(candidate_erasure_meta.as_ref())?;
+        let candidate_erasure_meta = cf::ErasureMeta::deserialize(candidate_erasure_meta.as_ref())?;
 
         // Check if this is actually the consecutive erasure set
         let Some(next_fec_set_index) = candidate_erasure_meta.next_fec_set_index() else {
@@ -754,7 +753,7 @@ impl Blockstore {
     ) -> Result<impl Iterator<Item = (Slot, Hash, UnixTimestamp)> + '_> {
         let iter = self.optimistic_slots_cf.iter(IteratorMode::End)?;
         Ok(iter.map(|(slot, bytes)| {
-            let meta: OptimisticSlotMetaVersioned = deserialize(&bytes).unwrap();
+            let meta = cf::OptimisticSlots::deserialize(&bytes).unwrap();
             (slot, meta.hash(), meta.timestamp())
         }))
     }
@@ -2892,7 +2891,7 @@ impl Blockstore {
         let iterator = self.transaction_status_index_cf.iter(IteratorMode::Start)?;
         let mut highest_primary_index_slot = None;
         for (_, data) in iterator {
-            let meta: TransactionStatusIndexMeta = deserialize(&data).unwrap();
+            let meta = cf::TransactionStatusIndex::deserialize(&data).unwrap();
             if highest_primary_index_slot.is_none()
                 || highest_primary_index_slot.is_some_and(|slot| slot < meta.max_slot)
             {
@@ -3534,22 +3533,19 @@ impl Blockstore {
         // or `PerfSampleV2` encoding.  We expect `PerfSampleV1` to be a prefix of the
         // `PerfSampleV2` encoding (see [`perf_sample_v1_is_prefix_of_perf_sample_v2`]), so we try
         // them in order.
-        let samples =
-            self.perf_samples_cf
-                .iter(IteratorMode::End)?
-                .take(num)
-                .map(|(slot, data)| {
-                    deserialize::<PerfSample>(&data)
-                        .map(|sample| (slot, sample))
-                        .map_err(Into::into)
-                });
+        let samples = self
+            .perf_samples_cf
+            .iter(IteratorMode::End)?
+            .take(num)
+            .map(|(slot, data)| cf::PerfSamples::deserialize(&data).map(|sample| (slot, sample)));
 
         samples.collect()
     }
 
     pub fn write_perf_sample(&self, index: Slot, perf_sample: &PerfSample) -> Result<()> {
         // Always write as the current version.
-        let bytes = serialize(&perf_sample).expect("`PerfSample` can be serialized with `bincode`");
+        let bytes =
+            cf::PerfSamples::serialize(perf_sample).expect("`PerfSample` can be serialized");
         self.perf_samples_cf.put_bytes(index, &bytes)
     }
 
@@ -4117,8 +4113,9 @@ impl Blockstore {
             .duplicate_slots_cf
             .iter(IteratorMode::From(0, IteratorDirection::Forward))
             .unwrap();
-        iter.next()
-            .map(|(slot, proof_bytes)| (slot, deserialize(&proof_bytes).unwrap()))
+        iter.next().map(|(slot, proof_bytes)| {
+            (slot, cf::DuplicateSlots::deserialize(&proof_bytes).unwrap())
+        })
     }
 
     pub fn store_duplicate_slot<S, T>(&self, slot: Slot, shred1: S, shred2: T) -> Result<()>

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -2,7 +2,7 @@
 use {
     crate::{
         blockstore::error::Result,
-        blockstore_meta::{self},
+        blockstore_meta::{self, PerfSample},
     },
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
@@ -592,6 +592,10 @@ impl TypedColumn for columns::Blocktime {
 impl SlotColumn for columns::PerfSamples {}
 impl ColumnName for columns::PerfSamples {
     const NAME: &'static str = "perf_samples";
+}
+
+impl TypedColumn for columns::PerfSamples {
+    type Type = PerfSample;
 }
 
 impl SlotColumn for columns::BlockHeight {}


### PR DESCRIPTION
#### Problem

Many of the functions in `blockstore.rs` use `bincode::serialize` /  `bincode::deserialize` directly rather than the underlying column's `serialize` / `deserialize` methods. Using the column's respective methods ensure column setters and getters respect any custom de/serialization logic defined therein.

#### Summary of Changes

Updates remaining usage of `bincode::serialize` /  `bincode::deserialize` in `blockstore.rs` to use the column's `TypedColumn::deserialize` / `serialize` methods.

~`PerfSample` had its own deserialization logic defined inline in `get_recent_perf_samples`. I have moved this into a `TypedColumn` definition in accordance with this new pattern.~ edit: solved via https://github.com/anza-xyz/agave/pull/11043