### PR TITLE
Removing extra timing information from bucket_create_key

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -287,7 +287,6 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         random: u64,
         is_resizing: bool,
     ) -> Result<u64, BucketMapError> {
-        let mut m = Measure::start("bucket_create_key");
         let ix = Self::bucket_index_ix(key, random) % index.capacity();
         for i in ix..ix + index.max_search() {
             let ii = i % index.capacity();
@@ -298,19 +297,8 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
             // These fields will be overwritten after allocation by callers.
             // Since this part of the mmapped file could have previously been used by someone else, there can be garbage here.
             IndexEntryPlaceInBucket::new(ii).init(index, key);
-            //debug!(                "INDEX ALLOC {:?} {} {} {}",                key, ii, index.capacity, elem_uid            );
-            m.stop();
-            index
-                .stats
-                .find_index_entry_mut_us
-                .fetch_add(m.as_us(), Ordering::Relaxed);
             return Ok(ii);
         }
-        m.stop();
-        index
-            .stats
-            .find_index_entry_mut_us
-            .fetch_add(m.as_us(), Ordering::Relaxed);
         Err(BucketMapError::IndexNoSpace(index.contents.capacity()))
     }
 


### PR DESCRIPTION
#### Problem
Bucket Create Key measures each key allocation, but the overall measurement is already captured in the calling function grow_index. The measurement and atomic access takes ~50% of the total function time. 

#### Summary of Changes
Removed measurement of bucket_create_key. It is redundant. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
