### PR TITLE
remove and  disallow `saturating_add_assign!()` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10393,7 +10393,6 @@ dependencies = [
  "solana-pubkey",
  "solana-quic-definitions",
  "solana-runtime",
- "solana-sdk",
  "solana-signature",
  "solana-signer",
  "solana-system-interface",

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,3 +5,7 @@ disallowed-methods = [
     { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
     { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
 ]
+
+disallowed-macros = [
+    { path = "solana_sdk::saturating_add_assign", reason = "Deprecated. Use std::num::Saturating<T> instead." },
+]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -36,6 +36,7 @@ use {
     solana_time_utils::AtomicInterval,
     std::{
         cmp, env,
+        num::Saturating,
         ops::Deref,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -322,20 +323,20 @@ pub struct BatchedTransactionDetails {
 
 #[derive(Debug, Default)]
 pub struct BatchedTransactionCostDetails {
-    pub batched_signature_cost: u64,
-    pub batched_write_lock_cost: u64,
-    pub batched_data_bytes_cost: u64,
-    pub batched_loaded_accounts_data_size_cost: u64,
-    pub batched_programs_execute_cost: u64,
+    pub batched_signature_cost: Saturating<u64>,
+    pub batched_write_lock_cost: Saturating<u64>,
+    pub batched_data_bytes_cost: Saturating<u64>,
+    pub batched_loaded_accounts_data_size_cost: Saturating<u64>,
+    pub batched_programs_execute_cost: Saturating<u64>,
 }
 
 #[derive(Debug, Default)]
 pub struct BatchedTransactionErrorDetails {
-    pub batched_retried_txs_per_block_limit_count: u64,
-    pub batched_retried_txs_per_vote_limit_count: u64,
-    pub batched_retried_txs_per_account_limit_count: u64,
-    pub batched_retried_txs_per_account_data_block_limit_count: u64,
-    pub batched_dropped_txs_per_account_data_total_limit_count: u64,
+    pub batched_retried_txs_per_block_limit_count: Saturating<u64>,
+    pub batched_retried_txs_per_vote_limit_count: Saturating<u64>,
+    pub batched_retried_txs_per_account_limit_count: Saturating<u64>,
+    pub batched_retried_txs_per_account_data_block_limit_count: Saturating<u64>,
+    pub batched_dropped_txs_per_account_data_total_limit_count: Saturating<u64>,
 }
 
 /// Stores the stage's thread handle and output receiver.

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -7,7 +7,6 @@ use {
     },
     solana_clock::Slot,
     solana_poh::poh_recorder::BankStart,
-    solana_sdk::saturating_add_assign,
     solana_svm::transaction_error_metrics::*,
     std::{num::Saturating, time::Instant},
 };
@@ -51,15 +50,15 @@ pub(crate) struct ProcessTransactionsSummary {
 #[derive(Debug, Default, PartialEq)]
 pub struct CommittedTransactionsCounts {
     /// Total number of transactions that were passed as candidates for processing
-    pub attempted_processing_count: u64,
+    pub attempted_processing_count: Saturating<u64>,
     /// Total number of transactions that made it into the block
-    pub committed_transactions_count: u64,
+    pub committed_transactions_count: Saturating<u64>,
     /// Total number of transactions that made it into the block where the transactions
     /// output from processing was success/no error.
-    pub committed_transactions_with_successful_result_count: u64,
+    pub committed_transactions_with_successful_result_count: Saturating<u64>,
     /// All transactions that were processed but then failed record because the
     /// slot ended
-    pub processed_but_failed_commit: u64,
+    pub processed_but_failed_commit: Saturating<u64>,
 }
 
 impl CommittedTransactionsCounts {
@@ -68,24 +67,13 @@ impl CommittedTransactionsCounts {
         transaction_counts: &LeaderProcessedTransactionCounts,
         committed: bool,
     ) {
-        saturating_add_assign!(
-            self.attempted_processing_count,
-            transaction_counts.attempted_processing_count
-        );
+        self.attempted_processing_count += transaction_counts.attempted_processing_count;
         if committed {
-            saturating_add_assign!(
-                self.committed_transactions_count,
-                transaction_counts.processed_count
-            );
-            saturating_add_assign!(
-                self.committed_transactions_with_successful_result_count,
-                transaction_counts.processed_with_successful_result_count
-            );
+            self.committed_transactions_count += transaction_counts.processed_count;
+            self.committed_transactions_with_successful_result_count +=
+                transaction_counts.processed_with_successful_result_count;
         } else {
-            saturating_add_assign!(
-                self.processed_but_failed_commit,
-                transaction_counts.processed_count
-            );
+            self.processed_but_failed_commit += transaction_counts.processed_count;
         }
     }
 }
@@ -128,19 +116,19 @@ struct LeaderSlotPacketCountMetrics {
     // total number of transactions that attempted processing in this slot. Should equal the sum
     // of `committed_transactions_count`, `retryable_errored_transaction_count`, and
     // `nonretryable_errored_transactions_count`.
-    transactions_attempted_processing_count: u64,
+    transactions_attempted_processing_count: Saturating<u64>,
 
     // total number of transactions that were executed and committed into the block
     // on this thread
-    committed_transactions_count: u64,
+    committed_transactions_count: Saturating<u64>,
 
     // total number of transactions that were executed, got a successful execution output/no error,
     // and were then committed into the block
-    committed_transactions_with_successful_result_count: u64,
+    committed_transactions_with_successful_result_count: Saturating<u64>,
 
     // total number of transactions that were not executed or failed commit, BUT were added back to the buffered
     // queue because they were retryable errors
-    retryable_errored_transaction_count: u64,
+    retryable_errored_transaction_count: Saturating<u64>,
 
     // The size of the unprocessed buffer at the end of the slot
     end_of_slot_unprocessed_buffer_len: u64,
@@ -151,27 +139,27 @@ struct LeaderSlotPacketCountMetrics {
 
     // total number of transactions that attempted execution due to some fatal error (too old, duplicate signature, etc.)
     // AND were dropped from the buffered queue
-    nonretryable_errored_transactions_count: u64,
+    nonretryable_errored_transactions_count: Saturating<u64>,
 
     // total number of transactions that were executed, but failed to be committed into the Poh stream because
     // the block ended. Some of these may be already counted in `nonretryable_errored_transactions_count` if they
     // then hit the age limit after failing to be committed.
-    executed_transactions_failed_commit_count: u64,
+    executed_transactions_failed_commit_count: Saturating<u64>,
 
     // total number of transactions that were excluded from the block because there were concurrent write locks active.
     // These transactions are added back to the buffered queue and are already counted in
     // `self.retrayble_errored_transaction_count`.
-    account_lock_throttled_transactions_count: u64,
+    account_lock_throttled_transactions_count: Saturating<u64>,
 
     // total number of transactions that were excluded from the block because their write
     // account locks exceed the limit.
     // These transactions are not retried.
-    account_locks_limit_throttled_transactions_count: u64,
+    account_locks_limit_throttled_transactions_count: Saturating<u64>,
 
     // total number of transactions that were excluded from the block because they were too expensive
     // according to the cost model. These transactions are added back to the buffered queue and are
     // already counted in `self.retrayble_errored_transaction_count`.
-    cost_model_throttled_transactions_count: u64,
+    cost_model_throttled_transactions_count: Saturating<u64>,
 }
 
 impl LeaderSlotPacketCountMetrics {
@@ -180,100 +168,126 @@ impl LeaderSlotPacketCountMetrics {
     }
 
     fn report(&self, slot: Slot) {
+        let &Self {
+            total_new_valid_packets,
+            newly_failed_sigverify_count,
+            failed_sanitization_count,
+            failed_prioritization_count,
+            insufficient_compute_limit_count,
+            excessive_precompile_count,
+            invalid_votes_count,
+            exceeded_buffer_limit_dropped_packets_count,
+            newly_buffered_packets_count,
+            retryable_packets_filtered_count,
+            transactions_attempted_processing_count:
+                Saturating(transactions_attempted_processing_count),
+            committed_transactions_count: Saturating(committed_transactions_count),
+            committed_transactions_with_successful_result_count:
+                Saturating(committed_transactions_with_successful_result_count),
+            retryable_errored_transaction_count: Saturating(retryable_errored_transaction_count),
+            retryable_packets_count,
+            nonretryable_errored_transactions_count:
+                Saturating(nonretryable_errored_transactions_count),
+            executed_transactions_failed_commit_count:
+                Saturating(executed_transactions_failed_commit_count),
+            account_lock_throttled_transactions_count:
+                Saturating(account_lock_throttled_transactions_count),
+            account_locks_limit_throttled_transactions_count:
+                Saturating(account_locks_limit_throttled_transactions_count),
+            cost_model_throttled_transactions_count:
+                Saturating(cost_model_throttled_transactions_count),
+            end_of_slot_unprocessed_buffer_len,
+        } = self;
         datapoint_info!(
             "banking_stage-vote_slot_packet_counts",
             ("slot", slot, i64),
-            ("total_new_valid_packets", self.total_new_valid_packets, i64),
+            ("total_new_valid_packets", total_new_valid_packets, i64),
             (
                 "newly_failed_sigverify_count",
-                self.newly_failed_sigverify_count,
+                newly_failed_sigverify_count,
                 i64
             ),
-            (
-                "failed_sanitization_count",
-                self.failed_sanitization_count,
-                i64
-            ),
+            ("failed_sanitization_count", failed_sanitization_count, i64),
             (
                 "failed_prioritization_count",
-                self.failed_prioritization_count,
+                failed_prioritization_count,
                 i64
             ),
             (
                 "insufficient_compute_limit_count",
-                self.insufficient_compute_limit_count,
+                insufficient_compute_limit_count,
                 i64
             ),
             (
                 "excessive_precompile_count",
-                self.excessive_precompile_count,
+                excessive_precompile_count,
                 i64
             ),
-            ("invalid_votes_count", self.invalid_votes_count, i64),
+            ("invalid_votes_count", invalid_votes_count, i64),
             (
                 "exceeded_buffer_limit_dropped_packets_count",
-                self.exceeded_buffer_limit_dropped_packets_count,
+                exceeded_buffer_limit_dropped_packets_count,
                 i64
             ),
             (
                 "newly_buffered_packets_count",
-                self.newly_buffered_packets_count,
+                newly_buffered_packets_count,
                 i64
             ),
             (
                 "retryable_packets_filtered_count",
-                self.retryable_packets_filtered_count,
+                retryable_packets_filtered_count,
                 i64
             ),
             (
                 "transactions_attempted_processing_count",
-                self.transactions_attempted_processing_count,
+                transactions_attempted_processing_count,
                 i64
             ),
             (
                 "committed_transactions_count",
-                self.committed_transactions_count,
+                committed_transactions_count,
                 i64
             ),
             (
                 "committed_transactions_with_successful_result_count",
-                self.committed_transactions_with_successful_result_count,
+                committed_transactions_with_successful_result_count,
                 i64
             ),
             (
                 "retryable_errored_transaction_count",
-                self.retryable_errored_transaction_count,
+                retryable_errored_transaction_count,
                 i64
             ),
-            ("retryable_packets_count", self.retryable_packets_count, i64),
+            ("retryable_packets_count", retryable_packets_count, i64),
             (
                 "nonretryable_errored_transactions_count",
-                self.nonretryable_errored_transactions_count,
+                nonretryable_errored_transactions_count,
                 i64
             ),
             (
                 "executed_transactions_failed_commit_count",
-                self.executed_transactions_failed_commit_count,
+                executed_transactions_failed_commit_count,
                 i64
             ),
             (
                 "account_lock_throttled_transactions_count",
-                self.account_lock_throttled_transactions_count,
+                account_lock_throttled_transactions_count,
                 i64
             ),
             (
                 "account_locks_limit_throttled_transactions_count",
-                self.account_locks_limit_throttled_transactions_count,
+                account_locks_limit_throttled_transactions_count,
                 i64
             ),
             (
                 "cost_model_throttled_transactions_count",
-                self.cost_model_throttled_transactions_count,
+                cost_model_throttled_transactions_count,
                 i64
             ),
             (
                 "end_of_slot_unprocessed_buffer_len",
-                self.end_of_slot_unprocessed_buffer_len,
+                end_of_slot_unprocessed_buffer_len,
                 i64
             ),
         );
@@ -546,81 +560,67 @@ impl LeaderSlotMetricsTracker {
         process_transactions_summary: &ProcessTransactionsSummary,
     ) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            let ProcessTransactionsSummary {
-                transaction_counts,
+            let &ProcessTransactionsSummary {
+                transaction_counts:
+                    CommittedTransactionsCounts {
+                        attempted_processing_count: Saturating(attempted_processing_count),
+                        committed_transactions_count: Saturating(committed_transactions_count),
+                        committed_transactions_with_successful_result_count:
+                            Saturating(committed_transactions_with_successful_result_count),
+                        processed_but_failed_commit: Saturating(processed_but_failed_commit),
+                    },
                 ref retryable_transaction_indexes,
                 cost_model_throttled_transactions_count,
                 cost_model_us,
                 ref execute_and_commit_timings,
-                error_counters,
+                ref error_counters,
                 ..
             } = process_transactions_summary;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .transactions_attempted_processing_count,
-                transaction_counts.attempted_processing_count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .transactions_attempted_processing_count += attempted_processing_count;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .committed_transactions_count,
-                transaction_counts.committed_transactions_count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .committed_transactions_count += committed_transactions_count;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .committed_transactions_with_successful_result_count,
-                transaction_counts.committed_transactions_with_successful_result_count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .committed_transactions_with_successful_result_count +=
+                committed_transactions_with_successful_result_count;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .executed_transactions_failed_commit_count,
-                transaction_counts.processed_but_failed_commit
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .executed_transactions_failed_commit_count += processed_but_failed_commit;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .retryable_errored_transaction_count,
-                retryable_transaction_indexes.len() as u64
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .retryable_errored_transaction_count += retryable_transaction_indexes.len() as u64;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .nonretryable_errored_transactions_count,
-                transaction_counts
-                    .attempted_processing_count
-                    .saturating_sub(transaction_counts.committed_transactions_count)
-                    .saturating_sub(retryable_transaction_indexes.len() as u64)
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .nonretryable_errored_transactions_count += attempted_processing_count
+                .saturating_sub(committed_transactions_count)
+                .saturating_sub(retryable_transaction_indexes.len() as u64);
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .account_lock_throttled_transactions_count,
-                error_counters.account_in_use.0 as u64
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .account_lock_throttled_transactions_count +=
+                error_counters.account_in_use.0 as u64;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .account_locks_limit_throttled_transactions_count,
-                error_counters.too_many_account_locks.0 as u64
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .account_locks_limit_throttled_transactions_count +=
+                error_counters.too_many_account_locks.0 as u64;
 
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .cost_model_throttled_transactions_count,
-                *cost_model_throttled_transactions_count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .cost_model_throttled_transactions_count += cost_model_throttled_transactions_count;
+
+            leader_slot_metrics
+                .packet_count_metrics
+                .cost_model_throttled_transactions_count += cost_model_throttled_transactions_count;
 
             leader_slot_metrics
                 .timing_metrics
@@ -674,66 +674,45 @@ impl LeaderSlotMetricsTracker {
                 insufficient_compute_limit_count: Saturating(insufficient_compute_limit_count),
             } = stats;
 
-            saturating_add_assign!(metrics.total_new_valid_packets, passed_sigverify_count);
-            saturating_add_assign!(metrics.newly_failed_sigverify_count, failed_sigverify_count);
-            saturating_add_assign!(metrics.invalid_votes_count, invalid_vote_count);
-            saturating_add_assign!(
-                metrics.failed_prioritization_count,
-                failed_prioritization_count
-            );
-            saturating_add_assign!(metrics.failed_sanitization_count, failed_sanitization_count);
-            saturating_add_assign!(
-                metrics.excessive_precompile_count,
-                excessive_precompile_count
-            );
-            saturating_add_assign!(
-                metrics.insufficient_compute_limit_count,
-                insufficient_compute_limit_count
-            );
+            metrics.total_new_valid_packets += passed_sigverify_count;
+            metrics.newly_failed_sigverify_count += failed_sigverify_count;
+            metrics.invalid_votes_count += invalid_vote_count;
+            metrics.failed_prioritization_count += failed_prioritization_count;
+            metrics.failed_sanitization_count += failed_sanitization_count;
+            metrics.excessive_precompile_count += excessive_precompile_count;
+            metrics.insufficient_compute_limit_count += insufficient_compute_limit_count;
         }
     }
 
     pub(crate) fn increment_exceeded_buffer_limit_dropped_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .exceeded_buffer_limit_dropped_packets_count,
-                count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .exceeded_buffer_limit_dropped_packets_count += count;
         }
     }
 
     pub(crate) fn increment_newly_buffered_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .newly_buffered_packets_count,
-                count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .newly_buffered_packets_count += count;
         }
     }
 
     pub(crate) fn increment_retryable_packets_filtered_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .retryable_packets_filtered_count,
-                count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .retryable_packets_filtered_count += count;
         }
     }
 
     pub(crate) fn increment_retryable_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .retryable_packets_count,
-                count
-            );
+            leader_slot_metrics
+                .packet_count_metrics
+                .retryable_packets_count += count;
         }
     }
 
@@ -748,32 +727,24 @@ impl LeaderSlotMetricsTracker {
     // Outermost banking thread's loop timing metrics
     pub(crate) fn increment_process_buffered_packets_us(&mut self, us: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .timing_metrics
-                    .outer_loop_timings
-                    .process_buffered_packets_us,
-                us
-            );
+            leader_slot_metrics
+                .timing_metrics
+                .outer_loop_timings
+                .process_buffered_packets_us += us;
         }
     }
 
     pub(crate) fn increment_receive_and_buffer_packets_us(&mut self, us: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .timing_metrics
-                    .outer_loop_timings
-                    .receive_and_buffer_packets_us,
-                us
-            );
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .timing_metrics
-                    .outer_loop_timings
-                    .receive_and_buffer_packets_invoked_count,
-                1
-            );
+            leader_slot_metrics
+                .timing_metrics
+                .outer_loop_timings
+                .receive_and_buffer_packets_us += us;
+
+            leader_slot_metrics
+                .timing_metrics
+                .outer_loop_timings
+                .receive_and_buffer_packets_invoked_count += 1;
         }
     }
 
@@ -835,23 +806,17 @@ impl LeaderSlotMetricsTracker {
 
     pub(crate) fn increment_dropped_gossip_vote_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .vote_packet_count_metrics
-                    .dropped_gossip_votes,
-                count
-            );
+            leader_slot_metrics
+                .vote_packet_count_metrics
+                .dropped_gossip_votes += count;
         }
     }
 
     pub(crate) fn increment_dropped_tpu_vote_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .vote_packet_count_metrics
-                    .dropped_tpu_votes,
-                count
-            );
+            leader_slot_metrics
+                .vote_packet_count_metrics
+                .dropped_tpu_votes += count;
         }
     }
 }

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -9,7 +9,7 @@ use {
     solana_poh::poh_recorder::BankStart,
     solana_sdk::saturating_add_assign,
     solana_svm::transaction_error_metrics::*,
-    std::time::Instant,
+    std::{num::Saturating, time::Instant},
 };
 
 /// A summary of what happened to transactions passed to the processing pipeline.
@@ -665,13 +665,13 @@ impl LeaderSlotMetricsTracker {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             let metrics = &mut leader_slot_metrics.packet_count_metrics;
             let PacketReceiverStats {
-                passed_sigverify_count,
-                failed_sigverify_count,
-                invalid_vote_count,
-                failed_prioritization_count,
-                failed_sanitization_count,
-                excessive_precompile_count,
-                insufficient_compute_limit_count,
+                passed_sigverify_count: Saturating(passed_sigverify_count),
+                failed_sigverify_count: Saturating(failed_sigverify_count),
+                invalid_vote_count: Saturating(invalid_vote_count),
+                failed_prioritization_count: Saturating(failed_prioritization_count),
+                failed_sanitization_count: Saturating(failed_sanitization_count),
+                excessive_precompile_count: Saturating(excessive_precompile_count),
+                insufficient_compute_limit_count: Saturating(insufficient_compute_limit_count),
             } = stats;
 
             saturating_add_assign!(metrics.total_new_valid_packets, passed_sigverify_count);

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -8,8 +8,7 @@ use {
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     crossbeam_channel::RecvTimeoutError,
     solana_perf::packet::PacketBatch,
-    solana_sdk::saturating_add_assign,
-    std::time::{Duration, Instant},
+    std::{num::Saturating, time::{Duration, Instant}},
 };
 
 /// Results from deserializing packet batches.
@@ -29,19 +28,19 @@ pub struct PacketDeserializer {
 #[derive(Default, Debug, PartialEq)]
 pub struct PacketReceiverStats {
     /// Number of packets passing sigverify
-    pub passed_sigverify_count: u64,
+    pub passed_sigverify_count: Saturating<u64>,
     /// Number of packets failing sigverify
-    pub failed_sigverify_count: u64,
+    pub failed_sigverify_count: Saturating<u64>,
     /// Number of packets dropped due to sanitization error
-    pub failed_sanitization_count: u64,
+    pub failed_sanitization_count: Saturating<u64>,
     /// Number of packets dropped due to prioritization error
-    pub failed_prioritization_count: u64,
+    pub failed_prioritization_count: Saturating<u64>,
     /// Number of vote packets dropped
-    pub invalid_vote_count: u64,
+    pub invalid_vote_count: Saturating<u64>,
     /// Number of packets dropped due to excessive precompiles
-    pub excessive_precompile_count: u64,
+    pub excessive_precompile_count: Saturating<u64>,
     /// Number of packets dropped due to insufficient compute limit
-    pub insufficient_compute_limit_count: u64,
+    pub insufficient_compute_limit_count: Saturating<u64>,
 }
 
 impl PacketReceiverStats {
@@ -51,21 +50,21 @@ impl PacketReceiverStats {
             | DeserializedPacketError::DeserializationError(..)
             | DeserializedPacketError::SignatureOverflowed(..)
             | DeserializedPacketError::SanitizeError(..) => {
-                saturating_add_assign!(self.failed_sanitization_count, 1);
+                self.failed_sanitization_count += 1;
             }
             DeserializedPacketError::PrioritizationFailure => {
-                saturating_add_assign!(self.failed_prioritization_count, 1);
+                self.failed_prioritization_count += 1;
             }
             DeserializedPacketError::VoteTransactionError => {
-                saturating_add_assign!(self.invalid_vote_count, 1);
+                self.invalid_vote_count += 1;
             }
             DeserializedPacketError::FailedFilter(PacketFilterFailure::ExcessivePrecompiles) => {
-                saturating_add_assign!(self.excessive_precompile_count, 1);
+                self.excessive_precompile_count += 1;
             }
             DeserializedPacketError::FailedFilter(
                 PacketFilterFailure::InsufficientComputeLimit,
             ) => {
-                saturating_add_assign!(self.insufficient_compute_limit_count, 1);
+                self.insufficient_compute_limit_count += 1;
             }
         }
     }
@@ -106,7 +105,7 @@ impl PacketDeserializer {
         ) -> Result<ImmutableDeserializedPacket, PacketFilterFailure>,
     ) -> ReceivePacketResults {
         let mut packet_stats = PacketReceiverStats::default();
-        let mut errors = 0_usize;
+        let mut errors = Saturating::<usize>(0);
         let deserialized_packets: Vec<_> = banking_batches
             .iter()
             .flat_map(|banking_batch| banking_batch.iter())
@@ -118,23 +117,18 @@ impl PacketDeserializer {
                 {
                     Ok(pkt) => Some(pkt),
                     Err(err) => {
-                        saturating_add_assign!(errors, 1);
+                        errors += 1;
                         packet_stats.increment_error_count(&err);
                         None
                     }
                 }
             })
             .collect();
-        saturating_add_assign!(
-            packet_stats.passed_sigverify_count,
-            deserialized_packets.len().saturating_add(errors) as u64
-        );
-        saturating_add_assign!(
-            packet_stats.failed_sigverify_count,
-            packet_count
-                .saturating_sub(deserialized_packets.len())
-                .saturating_sub(errors) as u64
-        );
+        let Saturating(errors) = errors;
+        packet_stats.passed_sigverify_count += errors.saturating_add(deserialized_packets.len()) as u64;
+        packet_stats.failed_sigverify_count += packet_count
+            .saturating_sub(deserialized_packets.len())
+            .saturating_sub(errors) as u64;
 
         ReceivePacketResults {
             deserialized_packets,
@@ -207,8 +201,8 @@ mod tests {
     fn test_deserialize_and_collect_packets_empty() {
         let results = PacketDeserializer::deserialize_and_collect_packets(0, &[], Ok);
         assert_eq!(results.deserialized_packets.len(), 0);
-        assert_eq!(results.packet_stats.passed_sigverify_count, 0);
-        assert_eq!(results.packet_stats.failed_sigverify_count, 0);
+        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(0));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(0));
     }
 
     #[test]
@@ -224,8 +218,8 @@ mod tests {
             Ok,
         );
         assert_eq!(results.deserialized_packets.len(), 2);
-        assert_eq!(results.packet_stats.passed_sigverify_count, 2);
-        assert_eq!(results.packet_stats.failed_sigverify_count, 0);
+        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(2));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(0));
     }
 
     #[test]
@@ -246,7 +240,7 @@ mod tests {
             Ok,
         );
         assert_eq!(results.deserialized_packets.len(), 1);
-        assert_eq!(results.packet_stats.passed_sigverify_count, 1);
-        assert_eq!(results.packet_stats.failed_sigverify_count, 1);
+        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(1));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(1));
     }
 }

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -132,7 +132,7 @@ impl PacketReceiver {
         vote_storage: &mut VoteStorage,
         vote_source: VoteSource,
         deserialized_packets: Vec<ImmutableDeserializedPacket>,
-        dropped_packets_count: &mut usize,
+        dropped_packets_count: &mut Saturating<usize>,
         newly_buffered_packets_count: &mut usize,
         newly_buffered_forwarded_packets_count: &mut usize,
         banking_stage_stats: &mut BankingStageStats,

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -10,8 +10,7 @@ use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
-    solana_sdk::saturating_add_assign,
-    std::{sync::atomic::Ordering, time::Duration},
+    std::{num::Saturating, sync::atomic::Ordering, time::Duration},
 };
 
 pub struct PacketReceiver {
@@ -93,7 +92,7 @@ impl PacketReceiver {
 
         slot_metrics_tracker.increment_received_packet_counts(packet_stats);
 
-        let mut dropped_packets_count = 0;
+        let mut dropped_packets_count = Saturating(0);
         let mut newly_buffered_packets_count = 0;
         let mut newly_buffered_forwarded_packets_count = 0;
         Self::push_unprocessed(
@@ -115,9 +114,12 @@ impl PacketReceiver {
         vote_source_counts
             .receive_and_buffer_packets_count
             .fetch_add(packet_count, Ordering::Relaxed);
-        vote_source_counts
-            .dropped_packets_count
-            .fetch_add(dropped_packets_count, Ordering::Relaxed);
+        {
+            let Saturating(dropped_packets_count) = dropped_packets_count;
+            vote_source_counts
+                .dropped_packets_count
+                .fetch_add(dropped_packets_count, Ordering::Relaxed);
+        }
         vote_source_counts
             .newly_buffered_packets_count
             .fetch_add(newly_buffered_packets_count, Ordering::Relaxed);
@@ -153,10 +155,7 @@ impl PacketReceiver {
                 vote_storage.insert_batch(vote_source, deserialized_packets.into_iter());
             slot_metrics_tracker
                 .accumulate_vote_batch_insertion_metrics(&vote_batch_insertion_metrics);
-            saturating_add_assign!(
-                *dropped_packets_count,
-                vote_batch_insertion_metrics.total_dropped_packets()
-            );
+            *dropped_packets_count += vote_batch_insertion_metrics.total_dropped_packets();
         }
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -6,7 +6,7 @@ use {
         transaction_state::TransactionState, transaction_state_container::StateContainer,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    solana_sdk::saturating_add_assign,
+    std::num::Saturating,
 };
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -27,8 +27,8 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut impl StateContainer<Tx>,
     ) -> Result<(usize, usize), SchedulerError> {
-        let mut total_num_transactions: usize = 0;
-        let mut total_num_retryable: usize = 0;
+        let mut total_num_transactions = Saturating::<usize>(0);
+        let mut total_num_retryable = Saturating::<usize>(0);
         loop {
             let (num_transactions, num_retryable) = self
                 .scheduling_common_mut()
@@ -36,9 +36,11 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
             if num_transactions == 0 {
                 break;
             }
-            saturating_add_assign!(total_num_transactions, num_transactions);
-            saturating_add_assign!(total_num_retryable, num_retryable);
+            total_num_transactions += num_transactions;
+            total_num_retryable += num_retryable;
         }
+        let Saturating(total_num_transactions) = total_num_transactions;
+        let Saturating(total_num_retryable) = total_num_retryable;
         Ok((total_num_transactions, total_num_retryable))
     }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -4,7 +4,7 @@ use {
     solana_poh::poh_recorder::BankStart,
     solana_clock::Slot,
     solana_time_utils::AtomicInterval,
-    std::time::{Duration, Instant},
+    std::{num::Saturating, time::{Duration, Instant}},
 };
 
 #[derive(Default)]
@@ -47,38 +47,37 @@ struct SlotSchedulerCountMetrics {
 #[derive(Default)]
 pub struct SchedulerCountMetricsInner {
     /// Number of packets received.
-    pub num_received: usize,
+    pub num_received: Saturating<usize>,
     /// Number of packets buffered.
-    pub num_buffered: usize,
-
+    pub num_buffered: Saturating<usize>,
     /// Number of transactions scheduled.
-    pub num_scheduled: usize,
+    pub num_scheduled: Saturating<usize>,
     /// Number of transactions that were unschedulable due to multiple conflicts.
-    pub num_unschedulable_conflicts: usize,
+    pub num_unschedulable_conflicts: Saturating<usize>,
     /// Number of transactions that were unschedulable due to thread capacity.
-    pub num_unschedulable_threads: usize,
+    pub num_unschedulable_threads: Saturating<usize>,
     /// Number of transactions that were filtered out during scheduling.
-    pub num_schedule_filtered_out: usize,
+    pub num_schedule_filtered_out: Saturating<usize>,
     /// Number of completed transactions received from workers.
-    pub num_finished: usize,
+    pub num_finished: Saturating<usize>,
     /// Number of transactions that were retryable.
-    pub num_retryable: usize,
+    pub num_retryable: Saturating<usize>,
 
     /// Number of transactions that were immediately dropped on receive.
-    pub num_dropped_on_receive: usize,
+    pub num_dropped_on_receive: Saturating<usize>,
     /// Number of transactions that were dropped due to sanitization failure.
-    pub num_dropped_on_sanitization: usize,
+    pub num_dropped_on_sanitization: Saturating<usize>,
     /// Number of transactions that were dropped due to failed lock validation.
-    pub num_dropped_on_validate_locks: usize,
+    pub num_dropped_on_validate_locks: Saturating<usize>,
     /// Number of transactions that were dropped due to failed transaction
     /// checks during receive.
-    pub num_dropped_on_receive_transaction_checks: usize,
+    pub num_dropped_on_receive_transaction_checks: Saturating<usize>,
     /// Number of transactions that were dropped due to clearing.
-    pub num_dropped_on_clear: usize,
+    pub num_dropped_on_clear: Saturating<usize>,
     /// Number of transactions that were dropped due to age and status checks.
-    pub num_dropped_on_age_and_status: usize,
+    pub num_dropped_on_age_and_status: Saturating<usize>,
     /// Number of transactions that were dropped due to exceeded capacity.
-    pub num_dropped_on_capacity: usize,
+    pub num_dropped_on_capacity: Saturating<usize>,
     /// Min prioritization fees in the transaction container
     pub min_prioritization_fees: u64,
     /// Max prioritization fees in the transaction container
@@ -113,43 +112,64 @@ impl SlotSchedulerCountMetrics {
 
 impl SchedulerCountMetricsInner {
     fn report(&self, name: &'static str, slot: Option<Slot>) {
+        let &Self {
+            num_received: Saturating(num_received),
+            num_buffered: Saturating(num_buffered),
+            num_scheduled: Saturating(num_scheduled),
+            num_unschedulable_conflicts: Saturating(num_unschedulable_conflicts),
+            num_unschedulable_threads: Saturating(num_unschedulable_threads),
+            num_schedule_filtered_out: Saturating(num_schedule_filtered_out),
+            num_finished: Saturating(num_finished),
+            num_retryable: Saturating(num_retryable),
+            num_dropped_on_receive: Saturating(num_dropped_on_receive),
+            num_dropped_on_sanitization: Saturating(num_dropped_on_sanitization),
+            num_dropped_on_validate_locks: Saturating(num_dropped_on_validate_locks),
+            num_dropped_on_receive_transaction_checks: Saturating(
+                num_dropped_on_receive_transaction_checks,
+            ),
+            num_dropped_on_clear: Saturating(num_dropped_on_clear),
+            num_dropped_on_age_and_status: Saturating(num_dropped_on_age_and_status),
+            num_dropped_on_capacity: Saturating(num_dropped_on_capacity),
+            min_prioritization_fees: _min_prioritization_fees,
+            max_prioritization_fees: _max_prioritization_fees,
+        } = self;
         let mut datapoint = create_datapoint!(
             @point name,
-            ("num_received", self.num_received, i64),
-            ("num_buffered", self.num_buffered, i64),
-            ("num_scheduled", self.num_scheduled, i64),
-            ("num_unschedulable_conflicts", self.num_unschedulable_conflicts, i64),
-            ("num_unschedulable_threads", self.num_unschedulable_threads, i64),
+            ("num_received", num_received, i64),
+            ("num_buffered", num_buffered, i64),
+            ("num_scheduled", num_scheduled, i64),
+            ("num_unschedulable_conflicts", num_unschedulable_conflicts, i64),
+            ("num_unschedulable_threads", num_unschedulable_threads, i64),
             (
                 "num_schedule_filtered_out",
-                self.num_schedule_filtered_out,
+                num_schedule_filtered_out,
                 i64
             ),
-            ("num_finished", self.num_finished, i64),
-            ("num_retryable", self.num_retryable, i64),
-            ("num_dropped_on_receive", self.num_dropped_on_receive, i64),
+            ("num_finished", num_finished, i64),
+            ("num_retryable", num_retryable, i64),
+            ("num_dropped_on_receive", num_dropped_on_receive, i64),
             (
                 "num_dropped_on_sanitization",
-                self.num_dropped_on_sanitization,
+                num_dropped_on_sanitization,
                 i64
             ),
             (
                 "num_dropped_on_validate_locks",
-                self.num_dropped_on_validate_locks,
+                num_dropped_on_validate_locks,
                 i64
             ),
             (
                 "num_dropped_on_receive_transaction_checks",
-                self.num_dropped_on_receive_transaction_checks,
+                num_dropped_on_receive_transaction_checks,
                 i64
             ),
-            ("num_dropped_on_clear", self.num_dropped_on_clear, i64),
+            ("num_dropped_on_clear", num_dropped_on_clear, i64),
             (
                 "num_dropped_on_age_and_status",
-                self.num_dropped_on_age_and_status,
+                num_dropped_on_age_and_status,
                 i64
             ),
-            ("num_dropped_on_capacity", self.num_dropped_on_capacity, i64),
+            ("num_dropped_on_capacity", num_dropped_on_capacity, i64),
             ("min_priority", self.get_min_priority(), i64),
             ("max_priority", self.get_max_priority(), i64)
         );
@@ -160,39 +180,39 @@ impl SchedulerCountMetricsInner {
     }
 
     fn has_data(&self) -> bool {
-        self.num_received != 0
-            || self.num_buffered != 0
-            || self.num_scheduled != 0
-            || self.num_unschedulable_conflicts != 0
-            || self.num_unschedulable_threads != 0
-            || self.num_schedule_filtered_out != 0
-            || self.num_finished != 0
-            || self.num_retryable != 0
-            || self.num_dropped_on_receive != 0
-            || self.num_dropped_on_sanitization != 0
-            || self.num_dropped_on_validate_locks != 0
-            || self.num_dropped_on_receive_transaction_checks != 0
-            || self.num_dropped_on_clear != 0
-            || self.num_dropped_on_age_and_status != 0
-            || self.num_dropped_on_capacity != 0
+        self.num_received != Saturating(0)
+            || self.num_buffered != Saturating(0)
+            || self.num_scheduled != Saturating(0)
+            || self.num_unschedulable_conflicts != Saturating(0)
+            || self.num_unschedulable_threads != Saturating(0)
+            || self.num_schedule_filtered_out != Saturating(0)
+            || self.num_finished != Saturating(0)
+            || self.num_retryable != Saturating(0)
+            || self.num_dropped_on_receive != Saturating(0)
+            || self.num_dropped_on_sanitization != Saturating(0)
+            || self.num_dropped_on_validate_locks != Saturating(0)
+            || self.num_dropped_on_receive_transaction_checks != Saturating(0)
+            || self.num_dropped_on_clear != Saturating(0)
+            || self.num_dropped_on_age_and_status != Saturating(0)
+            || self.num_dropped_on_capacity != Saturating(0)
     }
 
     fn reset(&mut self) {
-        self.num_received = 0;
-        self.num_buffered = 0;
-        self.num_scheduled = 0;
-        self.num_unschedulable_conflicts = 0;
-        self.num_unschedulable_threads = 0;
-        self.num_schedule_filtered_out = 0;
-        self.num_finished = 0;
-        self.num_retryable = 0;
-        self.num_dropped_on_receive = 0;
-        self.num_dropped_on_sanitization = 0;
-        self.num_dropped_on_validate_locks = 0;
-        self.num_dropped_on_receive_transaction_checks = 0;
-        self.num_dropped_on_clear = 0;
-        self.num_dropped_on_age_and_status = 0;
-        self.num_dropped_on_capacity = 0;
+        self.num_received = Saturating(0);
+        self.num_buffered = Saturating(0);
+        self.num_scheduled = Saturating(0);
+        self.num_unschedulable_conflicts = Saturating(0);
+        self.num_unschedulable_threads = Saturating(0);
+        self.num_schedule_filtered_out = Saturating(0);
+        self.num_finished = Saturating(0);
+        self.num_retryable = Saturating(0);
+        self.num_dropped_on_receive = Saturating(0);
+        self.num_dropped_on_sanitization = Saturating(0);
+        self.num_dropped_on_validate_locks = Saturating(0);
+        self.num_dropped_on_receive_transaction_checks = Saturating(0);
+        self.num_dropped_on_clear = Saturating(0);
+        self.num_dropped_on_age_and_status = Saturating(0);
+        self.num_dropped_on_capacity = Saturating(0);
         self.min_prioritization_fees = u64::MAX;
         self.max_prioritization_fees = 0;
     }
@@ -264,21 +284,21 @@ struct SlotSchedulerTimingMetrics {
 #[derive(Default)]
 pub struct SchedulerTimingMetricsInner {
     /// Time spent making processing decisions.
-    pub decision_time_us: u64,
+    pub decision_time_us: Saturating<u64>,
     /// Time spent receiving packets.
-    pub receive_time_us: u64,
+    pub receive_time_us: Saturating<u64>,
     /// Time spent buffering packets.
-    pub buffer_time_us: u64,
+    pub buffer_time_us: Saturating<u64>,
     /// Time spent filtering transactions during scheduling.
-    pub schedule_filter_time_us: u64,
+    pub schedule_filter_time_us: Saturating<u64>,
     /// Time spent scheduling transactions.
-    pub schedule_time_us: u64,
+    pub schedule_time_us: Saturating<u64>,
     /// Time spent clearing transactions from the container.
-    pub clear_time_us: u64,
+    pub clear_time_us: Saturating<u64>,
     /// Time spent cleaning expired or processed transactions from the container.
-    pub clean_time_us: u64,
+    pub clean_time_us: Saturating<u64>,
     /// Time spent receiving completed transactions.
-    pub receive_completed_time_us: u64,
+    pub receive_completed_time_us: Saturating<u64>,
 }
 
 impl IntervalSchedulerTimingMetrics {
@@ -309,18 +329,28 @@ impl SlotSchedulerTimingMetrics {
 
 impl SchedulerTimingMetricsInner {
     fn report(&self, name: &'static str, slot: Option<Slot>) {
+        let &Self {
+            decision_time_us: Saturating(decision_time_us),
+            receive_time_us: Saturating(receive_time_us),
+            buffer_time_us: Saturating(buffer_time_us),
+            schedule_filter_time_us: Saturating(schedule_filter_time_us),
+            schedule_time_us: Saturating(schedule_time_us),
+            clear_time_us: Saturating(clear_time_us),
+            clean_time_us: Saturating(clean_time_us),
+            receive_completed_time_us: Saturating(receive_completed_time_us),
+        } = self;
         let mut datapoint = create_datapoint!(
             @point name,
-            ("decision_time_us", self.decision_time_us, i64),
-            ("receive_time_us", self.receive_time_us, i64),
-            ("buffer_time_us", self.buffer_time_us, i64),
-            ("schedule_filter_time_us", self.schedule_filter_time_us, i64),
-            ("schedule_time_us", self.schedule_time_us, i64),
-            ("clear_time_us", self.clear_time_us, i64),
-            ("clean_time_us", self.clean_time_us, i64),
+            ("decision_time_us", decision_time_us, i64),
+            ("receive_time_us", receive_time_us, i64),
+            ("buffer_time_us", buffer_time_us, i64),
+            ("schedule_filter_time_us", schedule_filter_time_us, i64),
+            ("schedule_time_us", schedule_time_us, i64),
+            ("clear_time_us", clear_time_us, i64),
+            ("clean_time_us", clean_time_us, i64),
             (
                 "receive_completed_time_us",
-                self.receive_completed_time_us,
+                receive_completed_time_us,
                 i64
             )
         );
@@ -331,14 +361,14 @@ impl SchedulerTimingMetricsInner {
     }
 
     fn reset(&mut self) {
-        self.decision_time_us = 0;
-        self.receive_time_us = 0;
-        self.buffer_time_us = 0;
-        self.schedule_filter_time_us = 0;
-        self.schedule_time_us = 0;
-        self.clear_time_us = 0;
-        self.clean_time_us = 0;
-        self.receive_completed_time_us = 0;
+        self.decision_time_us = Saturating(0);
+        self.receive_time_us = Saturating(0);
+        self.buffer_time_us = Saturating(0);
+        self.schedule_filter_time_us = Saturating(0);
+        self.schedule_time_us = Saturating(0);
+        self.clear_time_us = Saturating(0);
+        self.clean_time_us = Saturating(0);
+        self.receive_completed_time_us = Saturating(0);
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8615,7 +8615,6 @@ dependencies = [
  "solana-pubkey",
  "solana-quic-definitions",
  "solana-runtime",
- "solana-sdk",
  "solana-signature",
  "solana-time-utils",
  "solana-tpu-client-next",

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -26,7 +26,6 @@ solana-nonce-account = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-quic-definitions = { workspace = true }
 solana-runtime = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
 solana-signature = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tpu-client-next = { workspace = true, features = ["metrics"] }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7898,7 +7898,6 @@ dependencies = [
  "solana-pubkey",
  "solana-quic-definitions",
  "solana-runtime",
- "solana-sdk",
  "solana-signature",
  "solana-time-utils",
  "solana-tpu-client-next",


### PR DESCRIPTION
#### Problem
the `saturating_add_assign!()` macro in the `solana-sdk` crate is deprecated as it's functionality has now been stabilized as `std::num::Saturating<T>`

#### Summary of Changes
* replace all instances of `solana_sdk::saturating_add_assign!()` with equivalent `std::num::Saturating<T>` logic.
* add clippy lint to disallow new additions of the macro

Fixes https://github.com/anza-xyz/agave/issues/502