### PR TITLE
changelog: Graceful exit is required for fastboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Release channels have their own copy of this changelog:
 * Add `--no-snapshots` to disable generating snapshots.
 * `--block-production-method central-scheduler-greedy` is now the default.
 * The default full snapshot interval is now 50,000 slots.
+* Graceful exit (via `agave-validtor exit`) is required in order to boot from local state. Refer to the help of `--use-snapshot-archives-at-startup` for more information about booting from local state.
 
 #### Deprecations
 * Using `--snapshot-interval-slots 0` to disable generating snapshots is now deprecated.


### PR DESCRIPTION
#### Problem

As of https://github.com/anza-xyz/agave/pull/6202, we now only flush account storages on graceful exit. Therefore, fastboot requires graceful exit to work. This is not noted in the changelog.


#### Summary of Changes

Add it to the changelog.