### PR TITLE
fix geyser plugin manager always setting is_vote = false on non-legacy transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8437,7 +8437,6 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-signature",
- "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
  "solana-vote-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8435,9 +8435,12 @@ dependencies = [
  "solana-pubkey",
  "solana-rpc",
  "solana-runtime",
+ "solana-sdk",
  "solana-signature",
+ "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
+ "solana-vote-program",
  "thiserror 2.0.12",
  "tokio",
 ]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -29,7 +29,6 @@ solana-pubkey = { workspace = true }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true }
 solana-signature = { workspace = true }
-solana-system-program = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -29,10 +29,15 @@ solana-pubkey = { workspace = true }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true }
 solana-signature = { workspace = true }
+solana-system-program = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
+solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+solana-sdk = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -97,9 +97,11 @@ impl TransactionNotifierImpl {
         ReplicaTransactionInfoV2 {
             index,
             signature,
-            is_vote: account_keys[instructions[0].program_id_index as usize]
-                == solana_vote_program::id()
-                || transaction.is_simple_vote_transaction(),
+            is_vote: if account_keys.len() > 0 && instructions.len() > 0 {
+                account_keys[instructions[0].program_id_index as usize] == solana_vote_program::id()
+            } else {
+                false
+            },
             transaction,
             transaction_status_meta,
         }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -97,7 +97,7 @@ impl TransactionNotifierImpl {
         ReplicaTransactionInfoV2 {
             index,
             signature,
-            is_vote: if account_keys.len() > 0 && instructions.len() > 0 {
+            is_vote: if !account_keys.is_empty() && !instructions.is_empty() {
                 account_keys[instructions[0].program_id_index as usize] == solana_vote_program::id()
             } else {
                 false

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -8,6 +8,7 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_metrics::*,
+    solana_pubkey::Pubkey,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
     solana_signature::Signature,
     solana_transaction::sanitized::SanitizedTransaction,
@@ -90,12 +91,89 @@ impl TransactionNotifierImpl {
         transaction_status_meta: &'a TransactionStatusMeta,
         transaction: &'a SanitizedTransaction,
     ) -> ReplicaTransactionInfoV2<'a> {
+        let msg = transaction.message();
+        let instructions = msg.instructions();
+
+        // Detect the two-instruction durable-nonce advance + vote pattern
+        let durable_nonce_and_vote = instructions.len() == 2 && {
+            // we need the full account_keys slice here so that
+            // .program_id(&keys) won't index out of bounds
+            let keys: Vec<Pubkey> = msg.account_keys().iter().copied().collect();
+            instructions[0].program_id(&keys) == &solana_system_program::id()
+                && instructions[1].program_id(&keys) == &solana_vote_program::id()
+        };
+
         ReplicaTransactionInfoV2 {
             index,
             signature,
-            is_vote: transaction.is_simple_vote_transaction(),
+            is_vote: durable_nonce_and_vote || transaction.is_simple_vote_transaction(),
             transaction,
             transaction_status_meta,
         }
+    }
+}
+
+#[cfg(test)]
+mod transaction_notifier_tests {
+    use {
+        super::TransactionNotifierImpl,
+        solana_pubkey::Pubkey,
+        solana_sdk::{
+            hash::Hash,
+            signature::{Keypair, Signer},
+            system_instruction,
+            transaction::Transaction as LegacyTransaction,
+        },
+        solana_transaction::sanitized::SanitizedTransaction,
+        solana_transaction_status::TransactionStatusMeta,
+        solana_vote_program::{vote_instruction::vote as vote_instruction, vote_state::Vote},
+    };
+
+    #[test]
+    fn test_build_replica_transaction_info_vote_detection() {
+        // 1) set up keypairs and a unique vote account
+        let fee_payer = Keypair::new();
+        let recipient = Keypair::new();
+        let vote_authority = Keypair::new();
+        let vote_pubkey = Pubkey::new_unique();
+        let recent_blockhash = Hash::new_unique();
+
+        // 2) build exactly two instructions:
+        //    a transfer (system program) then a vote
+        let ix1 = system_instruction::transfer(
+            &fee_payer.pubkey(),
+            &recipient.pubkey(),
+            1, // lamports
+        );
+        // vote data
+        let vote = Vote {
+            slots: vec![0],
+            hash: recent_blockhash,
+            timestamp: Some(0),
+        };
+        // make the vote instruction
+        let ix2 = vote_instruction(&vote_pubkey, &vote_authority.pubkey(), vote);
+
+        // 3) assemble & sign a legacy transaction
+        let mut legacy_tx =
+            LegacyTransaction::new_with_payer(&[ix1, ix2], Some(&fee_payer.pubkey()));
+        // fee_payer signs the transfer, vote_authority signs the vote
+        legacy_tx.sign(&[&fee_payer, &vote_authority], recent_blockhash);
+
+        // 4) convert into a SanitizedTransaction for the notifier
+        let tx: SanitizedTransaction = SanitizedTransaction::from_transaction_for_tests(legacy_tx);
+
+        // 5) grab its first signature
+        let signature = &tx.signatures()[0];
+
+        // 6) default‐initialize a dummy TransactionStatusMeta
+        let meta = TransactionStatusMeta::default();
+
+        // 7) run your patched vote‐detection
+        let info =
+            TransactionNotifierImpl::build_replica_transaction_info(0, signature, &meta, &tx);
+
+        // 8) ensure we classified this 2‐instruction pattern as a vote
+        assert!(info.is_vote, "system+vote should be classified as vote");
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6486,7 +6486,6 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-signature",
- "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
  "solana-vote-program",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6486,8 +6486,10 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-signature",
+ "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
+ "solana-vote-program",
  "thiserror 2.0.12",
  "tokio",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6297,7 +6297,6 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-signature",
- "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
  "solana-vote-program",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6297,8 +6297,10 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-signature",
+ "solana-system-program",
  "solana-transaction",
  "solana-transaction-status",
+ "solana-vote-program",
  "thiserror 2.0.12",
  "tokio",
 ]


### PR DESCRIPTION
#### Problem
Currently the geyser plugin manager uses `is_simple_vote_transaction()` to determine if a transaction is or is not a vote. Before versioned transactions this worked fine, however for newer transactions it will simply always return false. The result is all transactions these days come into geyser with `is_vote = false` which can be confusing / misleading for geyser plugin authors

#### Summary of Changes
We make a tiny change to `build_replica_transaction_info` to detect votes and set `is_vote` correctly in the case of newer transaction formats.

