### PR TITLE
validator: Add --wait-for-exit flag to exit subcommand

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpc-core = { workspace = true }
 jsonrpc-core-client = { workspace = true, features = ["ipc"] }
 jsonrpc-derive = { workspace = true }
 jsonrpc-ipc-server = { workspace = true }
+libc = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -152,7 +152,8 @@ pub trait AdminRpc {
     type Metadata;
 
     #[rpc(meta, name = "exit")]
-    fn exit(&self, meta: Self::Metadata) -> Result<()>;
+    /// Initiates validator exit and returns the PID
+    fn exit(&self, meta: Self::Metadata) -> Result<u32>;
 
     #[rpc(meta, name = "reloadPlugin")]
     fn reload_plugin(
@@ -256,7 +257,7 @@ pub struct AdminRpcImpl;
 impl AdminRpc for AdminRpcImpl {
     type Metadata = AdminRpcRequestMetadata;
 
-    fn exit(&self, meta: Self::Metadata) -> Result<()> {
+     fn exit(&self, meta: Self::Metadata) -> Result<u32> {
         debug!("exit admin rpc request received");
 
         thread::Builder::new()
@@ -266,7 +267,7 @@ impl AdminRpc for AdminRpcImpl {
                 // receive a confusing error as the validator shuts down before a response is sent back.
                 thread::sleep(Duration::from_millis(100));
 
-                warn!("validator exit requested");
+                info!("validator exit requested");
                 meta.validator_exit.write().unwrap().exit();
 
                 if !meta.validator_exit_backpressure.is_empty() {
@@ -308,7 +309,7 @@ impl AdminRpc for AdminRpcImpl {
             })
             .unwrap();
 
-        Ok(())
+        Ok(std::process::id())
     }
 
     fn reload_plugin(
@@ -1510,9 +1511,13 @@ mod tests {
             expected_validator_id.pubkey().to_string()
         );
 
-        let contact_info_request =
-            r#"{"jsonrpc":"2.0","id":1,"method":"exit","params":[]}"#.to_string();
-        let exit_response = test_validator.handle_request(&contact_info_request);
+        let expected_parsed_response: Value = serde_json::from_str(&format!(
+            r#"{{"id": 1, "jsonrpc": "2.0", "result": {} }}"#,
+            std::process::id()
+        ))
+        .unwrap();
+        let exit_request = r#"{"jsonrpc":"2.0","id":1,"method":"exit","params":[]}"#.to_string();
+        let exit_response = test_validator.handle_request(&exit_request);
         let actual_parsed_response: Value =
             serde_json::from_str(&exit_response.expect("actual response"))
                 .expect("actual response deserialization");

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -257,7 +257,7 @@ pub struct AdminRpcImpl;
 impl AdminRpc for AdminRpcImpl {
     type Metadata = AdminRpcRequestMetadata;
 
-     fn exit(&self, meta: Self::Metadata) -> Result<u32> {
+    fn exit(&self, meta: Self::Metadata) -> Result<u32> {
         debug!("exit admin rpc request received");
 
         thread::Builder::new()

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -134,16 +134,14 @@ fn poll_until_pid_terminates(pid: u32) -> Result<()> {
             libc::kill(pid, /*sig:*/ 0)
         };
         if result >= 0 {
-            Err(Error::Dynamic(
-                "unexpected result for kill({pid}, 0)".into(),
-            ))?;
+            println!("Waiting for {pid} to terminate ...");
         } else {
             let errno = io::Error::last_os_error()
                 .raw_os_error()
                 .ok_or(Error::Dynamic("unable to read raw os error".into()))?;
             match errno {
                 libc::ESRCH => {
-                    // The process doesn't exist, we're done
+                    println!("Process {pid} has terminated");
                     break;
                 }
                 libc::EINVAL => {

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -102,7 +102,9 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     }
 
     let admin_client = admin_rpc_service::connect(ledger_path);
-    admin_rpc_service::runtime().block_on(async move { admin_client.await?.exit().await })?;
+    let _validator_pid =
+        admin_rpc_service::runtime().block_on(async move { admin_client.await?.exit().await })?;
+
     println!("Exit request sent");
 
     if exit_args.monitor {

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    TryFromInt(#[from] std::num::TryFromIntError),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
#### Problem
Currently, `agave-validator exit` will return immediately when the `AdminRpc` function call returns, even though the actual validator process might still be running. This isn't ideal if someone is trying to do something like:
```bash
agave-validator exit && ./restart_validator_script.sh
```

#### Summary of Changes
- Make the running validator return its' PID from the `AdminRpc` function
- Add a new `--wait-for-exit` flag to enable a loop that spins until the returned PID is no longer active

#### Testing
Tested this out:
```
$ ./src/agave/target/release/agave-validator exit --wait-for-exit
...
Maximum permitted delinquency: 5%
Ready to restart
Exit request sent
Waiting for agave-validator process 3379207 to terminate
Done, agave-validator process 3379207 has terminated
```
Immediately after, `./restart` was able to proceed immediately whereas it would previously "stall" for a couple second while previous process was still alive:
```
$ ./restart 
+ sudo systemctl daemon-reload
+ sudo systemctl restart sol
```