### PR TITLE
Removes is_ancient()

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6766,7 +6766,6 @@ fn test_shrink_ancient_overflow_with_min_size() {
         .storage
         .get_slot_storage_entry(max_slot_inclusive - 1)
         .unwrap();
-    assert!(is_ancient(&ancient2.accounts));
     assert!(ancient2.capacity() > ideal_av_size); // min_size kicked in, which cause the appendvec to be larger than the ideal_av_size
 
     // Combine normal append vec(s) into existing ancient append vec this
@@ -6785,21 +6784,18 @@ fn test_shrink_ancient_overflow_with_min_size() {
     // Nothing should be combined because the append vec are oversized.
     // min_size kicked in, which cause the appendvecs to be larger than the ideal_av_size.
     let ancient = db.storage.get_slot_storage_entry(ancient_slot).unwrap();
-    assert!(is_ancient(&ancient.accounts));
     assert!(ancient.capacity() > ideal_av_size);
 
     let ancient2 = db
         .storage
         .get_slot_storage_entry(max_slot_inclusive - 1)
         .unwrap();
-    assert!(is_ancient(&ancient2.accounts));
     assert!(ancient2.capacity() > ideal_av_size);
 
     let ancient3 = db
         .storage
         .get_slot_storage_entry(max_slot_inclusive)
         .unwrap();
-    assert!(is_ancient(&ancient3.accounts));
     assert!(ancient3.capacity() > ideal_av_size);
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6,7 +6,7 @@ use {
         accounts_file::AccountsFileProvider,
         accounts_hash::MERKLE_FANOUT,
         accounts_index::{tests::*, AccountIndex, AccountSecondaryIndexesIncludeExclude},
-        ancient_append_vecs::{self, is_ancient},
+        ancient_append_vecs,
         append_vec::{
             aligned_stored_size, test_utils::TempFile, AccountMeta, AppendVec, StoredAccountMeta,
             StoredMeta,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2492,21 +2492,6 @@ pub mod tests {
         assert_eq!(get_ancient_append_vec_capacity(), 128 * 1024 * 1024);
     }
 
-    #[test]
-    fn test_is_ancient() {
-        for (size, expected_ancient) in [
-            (get_ancient_append_vec_capacity() + 1, true),
-            (get_ancient_append_vec_capacity(), true),
-            (get_ancient_append_vec_capacity() - 1, false),
-        ] {
-            let tf = crate::append_vec::test_utils::get_append_vec_path("test_is_ancient");
-            let (_temp_dirs, _paths) = get_temp_accounts_paths(1).unwrap();
-            let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, size as usize));
-
-            assert_eq!(expected_ancient, is_ancient(&av));
-        }
-    }
-
     fn get_one_packed_ancient_append_vec_and_others(
         alive: bool,
         num_normal_slots: usize,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -4,8 +4,6 @@
 //! 2. multiple 'slots' squashed into a single older (ie. ancient) slot for convenience and performance
 //!
 //! Otherwise, an ancient append vec is the same as any other append vec
-#[cfg(test)]
-use crate::accounts_file::AccountsFile;
 use {
     crate::{
         account_storage::ShrinkInProgress,
@@ -1188,14 +1186,6 @@ pub const fn get_ancient_append_vec_capacity() -> u64 {
     RESULT
 }
 
-/// is this a max-size append vec designed to be used as an ancient append vec?
-//
-// NOTE: Only used by ancient append vecs "append" method, which is test-only now.
-#[cfg(test)]
-pub fn is_ancient(storage: &AccountsFile) -> bool {
-    storage.capacity() >= get_ancient_append_vec_capacity()
-}
-
 #[cfg(test)]
 pub mod tests {
     use {
@@ -1203,7 +1193,6 @@ pub mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                get_temp_accounts_paths,
                 tests::{
                     append_single_account_with_default_hash, compare_all_accounts,
                     create_db_with_storages_and_index, create_storages_and_update_index,
@@ -1215,9 +1204,7 @@ pub mod tests {
             accounts_file::StorageAccess,
             accounts_hash::AccountHash,
             accounts_index::{AccountsIndexScanResult, ScanFilter, UpsertReclaim},
-            append_vec::{
-                aligned_stored_size, AccountMeta, AppendVec, StoredAccountMeta, StoredMeta,
-            },
+            append_vec::{aligned_stored_size, AccountMeta, StoredAccountMeta, StoredMeta},
             storable_accounts::{tests::build_accounts_from_storage, StorableAccountsBySlot},
         },
         rand::seq::SliceRandom as _,


### PR DESCRIPTION
#### Problem

The "append" method for squashing ancient storages is no longer supported, yet remains in the code. This is tech debt.

The fn, `is_ancient()`, is only used by tests. We can remove the tests, and then the fn.


#### Summary of Changes

Remove 'em.