### PR TITLE
deps: bump solana-feature-gate-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,9 +8211,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
+checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,7 +437,7 @@ solana-epoch-schedule = "2.2.1"
 solana-example-mocks = "2.2.1"
 solana-faucet = { path = "faucet", version = "=2.3.0" }
 solana-feature-gate-client = "0.0.2"
-solana-feature-gate-interface = "2.2.1"
+solana-feature-gate-interface = "2.2.2"
 solana-fee-calculator = "2.2.1"
 solana-fee = { path = "fee", version = "=2.3.0" }
 solana-fee-structure = "2.2.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,7 +46,7 @@ solana-connection-cache = { workspace = true }
 solana-decode-error = "=2.2.1"
 solana-epoch-schedule = "=2.2.1"
 solana-feature-gate-client = "=0.0.2"
-solana-feature-gate-interface = "=2.2.1"
+solana-feature-gate-interface = "=2.2.2"
 solana-fee-calculator = "=2.2.1"
 solana-fee-structure = "=2.2.1"
 solana-hash = "=2.2.1"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -26,7 +26,7 @@ solana-clock = "=2.2.1"
 solana-commitment-config = "=2.2.1"
 solana-entry = { workspace = true }
 solana-epoch-schedule = "=2.2.1"
-solana-feature-gate-interface = "=2.2.1"
+solana-feature-gate-interface = "=2.2.2"
 solana-fee-calculator = "=2.2.1"
 solana-genesis-config = "=2.2.1"
 solana-inflation = "=2.2.1"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6345,9 +6345,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
+checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
 dependencies = [
  "bincode",
  "serde",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6180,9 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
+checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
 dependencies = [
  "bincode",
  "serde",


### PR DESCRIPTION
#### Problem
A nice fix went into `solana-feature-gate-interface` over in SDK land, and Agave should be using it.
https://github.com/anza-xyz/solana-sdk/pull/168

#### Summary of Changes
Bump the dependency to the newer version with the fix.