### PR TITLE
chore: update quinn-proto in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ protobuf-src = "1.1.0"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.8"
-quinn-proto = "0.11.11"
+quinn-proto = "0.11.12"
 quote = "1.0"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }


### PR DESCRIPTION
#### Problem

we bumped quinn-proto to 0.11.12 in https://github.com/anza-xyz/agave/pull/6170. however, we're still referencing the old version of quinn-proto in Cargo.toml

#### Summary of Changes

correct it to eliminate confusion