### PR TITLE
Fix warning on sdk default-features

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -105,7 +105,7 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sanitize = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
+solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -49,7 +49,7 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sbpf = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
+solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-signer = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -60,7 +60,7 @@ solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
+solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -108,7 +108,7 @@ solana-rent-collector = { workspace = true }
 solana-rent-debits = { workspace = true }
 solana-reward-info = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
+solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }
 solana-secp256k1-program = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -91,7 +91,7 @@ solana-program-runtime = { workspace = true, features = ["dev-context-only-utils
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true }
-solana-sdk = { workspace = true, default-features = false }
+solana-sdk = { workspace = true }
 solana-secp256k1-program = { workspace = true }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-signature = { workspace = true }


### PR DESCRIPTION
#### Problem
- Running clippy I see this warning:
```bash
warning: /Users/apfitzge/Documents/dev/solana/worktrees/development/rpc/Cargo.toml: `default-features` is ignored for solana-sdk, since `default-features` was not specified for `workspace.dependencies.solana-sdk`, this could become a hard error in the future
warning: /Users/apfitzge/Documents/dev/solana/worktrees/development/core/Cargo.toml: `default-features` is ignored for solana-sdk, since `default-features` was not specified for `workspace.dependencies.solana-sdk`, this could become a hard error in the future
warning: /Users/apfitzge/Documents/dev/solana/worktrees/development/runtime/Cargo.toml: `default-features` is ignored for solana-sdk, since `default-features` was not specified for `workspace.dependencies.solana-sdk`, this could become a hard error in the future
warning: /Users/apfitzge/Documents/dev/solana/worktrees/development/svm/Cargo.toml: `default-features` is ignored for solana-sdk, since `default-features` was not specified for `workspace.dependencies.solana-sdk`, this could become a hard error in the future
warning: /Users/apfitzge/Documents/dev/solana/worktrees/development/program-test/Cargo.toml: `default-features` is ignored for solana-sdk, since `default-features` was not specified for `workspace.dependencies.solana-sdk`, this could become a hard error in the future
```

#### Summary of Changes
- Remove the `default-features = false` for `sdk`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
