### PR TITLE
Poh: Add TransactionRecorder benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9184,6 +9184,7 @@ dependencies = [
  "assert_matches",
  "bincode",
  "core_affinity",
+ "criterion",
  "crossbeam-channel",
  "log",
  "qualifier_attr",

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 bincode = { workspace = true }
+criterion = { workspace = true }
 rand = { workspace = true }
 solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
@@ -49,6 +50,10 @@ name = "solana_poh"
 
 [[bench]]
 name = "poh"
+
+[[bench]]
+name = "transaction_recorder"
+harness = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -111,15 +111,13 @@ fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
         SanitizedTransaction::from_transaction_for_tests(test_tx()),
     ];
 
+    let txs: Vec<_> = txs.iter().map(|tx| tx.to_versioned_transaction()).collect();
     bencher.iter(|| {
         let _record_result = poh_recorder
             .record(
                 bank.slot(),
                 test::black_box(h1),
-                test::black_box(&txs)
-                    .iter()
-                    .map(|tx| tx.to_versioned_transaction())
-                    .collect(),
+                test::black_box(txs.clone()),
             )
             .unwrap()
             .unwrap();

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -86,7 +86,6 @@ fn bench_record_transactions(c: &mut Criterion) {
     group.throughput(criterion::Throughput::Elements(
         NUM_TRANSACTIONS * NUM_BATCHES,
     ));
-    let mut index = 0;
     group.bench_function("record_transactions", |b| {
         b.iter_custom(|iters| {
             let mut total = Duration::ZERO;
@@ -97,7 +96,7 @@ fn bench_record_transactions(c: &mut Criterion) {
                 bank = Arc::new(Bank::new_from_parent(
                     bank.clone(),
                     &Pubkey::default(),
-                    bank.slot() + 1,
+                    bank.slot().wrapping_add(1),
                 ));
                 poh_recorder.write().unwrap().set_bank(
                     BankWithScheduler::new_without_scheduler(bank.clone()),
@@ -106,7 +105,6 @@ fn bench_record_transactions(c: &mut Criterion) {
 
                 let start = Instant::now();
                 for txs in tx_batches {
-                    index += 1;
                     let summary = transaction_recorder.record_transactions(bank.slot(), txs);
                     assert!(summary.result.is_ok());
                 }

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -27,7 +27,7 @@ fn bench_record_transactions(c: &mut Criterion) {
 
     // Setup the PohService.
     let mut genesis_config_info = create_genesis_config(2);
-    genesis_config_info.genesis_config.ticks_per_slot = 64;
+    genesis_config_info.genesis_config.ticks_per_slot = solana_clock::DEFAULT_TICKS_PER_SLOT;
     genesis_config_info.genesis_config.poh_config = PohConfig {
         target_tick_duration: Duration::from_micros(
             solana_clock::DEFAULT_MS_PER_SLOT * 1_000 / solana_clock::DEFAULT_TICKS_PER_SLOT,
@@ -45,7 +45,7 @@ fn bench_record_transactions(c: &mut Criterion) {
         bank.tick_height(),
         bank.last_blockhash(),
         bank.clone(),
-        Some((0, 0)),
+        None,
         bank.ticks_per_slot(),
         blockstore,
         &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -1,6 +1,5 @@
 use {
     criterion::{criterion_group, criterion_main, Criterion},
-    solana_clock::UPDATED_HASHES_PER_TICK6,
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
@@ -32,7 +31,7 @@ fn bench_record_transactions(c: &mut Criterion) {
     genesis_config_info.genesis_config.poh_config = PohConfig {
         target_tick_duration: Duration::from_millis(400),
         target_tick_count: None,
-        hashes_per_tick: Some(UPDATED_HASHES_PER_TICK6),
+        hashes_per_tick: Some(solana_clock::DEFAULT_HASHES_PER_TICK),
     };
     let exit = Arc::new(AtomicBool::new(false));
     let bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -91,7 +91,7 @@ fn bench_record_transactions(c: &mut Criterion) {
             let mut total = Duration::ZERO;
 
             for _ in 0..iters {
-                let txs: Vec<_> = (0..NUM_BATCHES).map(|_| txs.clone()).collect();
+                let tx_batches: Vec<_> = (0..NUM_BATCHES).map(|_| txs.clone()).collect();
                 poh_recorder.write().unwrap().clear_bank_for_test();
                 poh_recorder.write().unwrap().set_bank(
                     BankWithScheduler::new_without_scheduler(bank.clone()),
@@ -99,7 +99,7 @@ fn bench_record_transactions(c: &mut Criterion) {
                 );
 
                 let start = Instant::now();
-                for txs in txs {
+                for txs in tx_batches {
                     let summary = transaction_recorder.record_transactions(bank.slot(), txs);
                     assert!(summary.result.is_ok());
                 }

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -29,7 +29,9 @@ fn bench_record_transactions(c: &mut Criterion) {
     let mut genesis_config_info = create_genesis_config(2);
     genesis_config_info.genesis_config.ticks_per_slot = 64;
     genesis_config_info.genesis_config.poh_config = PohConfig {
-        target_tick_duration: Duration::from_millis(400),
+        target_tick_duration: Duration::from_micros(
+            solana_clock::DEFAULT_MS_PER_SLOT * 1_000 / solana_clock::DEFAULT_TICKS_PER_SLOT,
+        ),
         target_tick_count: None,
         hashes_per_tick: Some(solana_clock::DEFAULT_HASHES_PER_TICK),
     };

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -22,7 +22,12 @@ use {
 };
 
 fn bench_record_transactions(c: &mut Criterion) {
+    // Relatively small non-zero number of transactions to use for the benchmark.
+    // Ensures we spend some time doing the hash work for entry recording.
     const NUM_TRANSACTIONS: u64 = 16;
+    // Number of batches to process in each benchmark iteration.
+    // Each batch contains NUM_TRANSACTIONS transactions.
+    // This emulates a burst of work coming in from the scheduler.
     const NUM_BATCHES: u64 = 32;
 
     // Setup the PohService.

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -1,0 +1,110 @@
+use {
+    criterion::{criterion_group, criterion_main, Criterion},
+    solana_clock::UPDATED_HASHES_PER_TICK6,
+    solana_hash::Hash,
+    solana_keypair::Keypair,
+    solana_ledger::{
+        blockstore::Blockstore, genesis_utils::create_genesis_config,
+        get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
+    },
+    solana_poh::{
+        poh_recorder::PohRecorder,
+        poh_service::{PohService, DEFAULT_HASHES_PER_BATCH, DEFAULT_PINNED_CPU_CORE},
+        transaction_recorder::TransactionRecorder,
+    },
+    solana_poh_config::PohConfig,
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, installed_scheduler_pool::BankWithScheduler},
+    solana_transaction::versioned::VersionedTransaction,
+    std::{
+        sync::{atomic::AtomicBool, Arc, RwLock},
+        time::{Duration, Instant},
+    },
+};
+
+fn bench_record_transactions(c: &mut Criterion) {
+    const NUM_TRANSACTIONS: u64 = 16;
+
+    // Setup the PohService.
+    let mut genesis_config_info = create_genesis_config(2);
+    genesis_config_info.genesis_config.ticks_per_slot = 64;
+    genesis_config_info.genesis_config.poh_config = PohConfig {
+        target_tick_duration: Duration::from_millis(400),
+        target_tick_count: None,
+        hashes_per_tick: Some(UPDATED_HASHES_PER_TICK6),
+    };
+    let exit = Arc::new(AtomicBool::new(false));
+    let bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Arc::new(
+        Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),
+    );
+    let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+        bank.tick_height(),
+        bank.last_blockhash(),
+        bank.clone(),
+        Some((0, 0)),
+        bank.ticks_per_slot(),
+        blockstore,
+        &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+        &genesis_config_info.genesis_config.poh_config,
+        exit.clone(),
+    );
+    poh_recorder.set_bank(BankWithScheduler::new_without_scheduler(bank.clone()), false);
+
+    let (record_sender, record_receiver) = crossbeam_channel::unbounded();
+    let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
+
+    let txs: Vec<_> = (0..NUM_TRANSACTIONS)
+        .map(|_| {
+            VersionedTransaction::from(solana_system_transaction::transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                1,
+                Hash::new_unique(),
+            ))
+        })
+        .collect();
+
+    let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+    let poh_service = PohService::new(
+        poh_recorder.clone(),
+        &genesis_config_info.genesis_config.poh_config,
+        exit.clone(),
+        bank.ticks_per_slot(),
+        DEFAULT_PINNED_CPU_CORE,
+        DEFAULT_HASHES_PER_BATCH,
+        record_receiver,
+    );
+
+    let mut group = c.benchmark_group("record_transactions");
+    group.throughput(criterion::Throughput::Elements(NUM_TRANSACTIONS));
+    group.bench_function("record_transactions", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+
+            for _ in 0..iters {
+                let txs = txs.clone();
+                poh_recorder.write().unwrap().clear_bank_for_test();
+                poh_recorder
+                    .write()
+                    .unwrap()
+                    .set_bank(BankWithScheduler::new_without_scheduler(bank.clone()), false);
+
+                let start = Instant::now();
+                let summary = transaction_recorder.record_transactions(bank.slot(), txs);
+                assert!(summary.result.is_ok());
+                let elapsed = start.elapsed();
+                total += elapsed;
+            }
+
+            total
+        })
+    });
+
+    exit.store(true, std::sync::atomic::Ordering::Relaxed);
+    poh_service.join().unwrap();
+}
+
+criterion_group!(benches, bench_record_transactions,);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem
- Current benches only test performance of Poh recorder itself.
- Biggest bottleneck in PoH is **not** in performance of poh recorder...it's the communication pattern between the poh service and worker threads.

#### Summary of Changes
- Add a benchmark to have some comparison to evaluate poh changes in performance (from banking worker perspective)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
