### PR TITLE
Bump platform tools to v1.48

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -23,7 +23,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.47";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.48";
 
 #[derive(Debug)]
 pub struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.47"
+tools-version = "v1.48"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -27,4 +27,4 @@ check-cfg = [
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.47"
+tools-version = "v1.48"

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.47
+version=v1.48
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -11,7 +11,8 @@ edition = "2021"
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
-    'cfg(feature, values("custom-panic", "custom-heap"))'
+    'cfg(feature, values("custom-panic", "custom-heap"))',
+    'cfg(target_feature, values("dynamic-frames"))'
 ]
 
 [workspace.dependencies]

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -34,7 +34,7 @@ rust-v0:
 	cp -r target/sbpf-solana-solana/release/* target/deploy
 
 rust-new:
-	RUSTFLAGS="-C instrument-coverage=no" cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace --features dynamic-frames ; \
+	RUSTFLAGS="-C instrument-coverage=no" cargo +solana build --release --target sbpf$(VER)-solana-solana --workspace ; \
 	cp -r target/sbpf$(VER)-solana-solana/release/* target/deploy
 
 .PHONY: test-v3

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -19,6 +19,3 @@ crate-type = ["cdylib"]
 
 [lints]
 workspace = true
-
-[features]
-dynamic-frames = []

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(unreachable_code)]
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg(feature = "dynamic-frames")]
+#[cfg(target_feature = "dynamic-frames")]
 use solana_program::program_memory::sol_memcmp;
 use {
     solana_program::{
@@ -1465,7 +1465,7 @@ fn process_instruction<'a>(
                 )
             };
 
-            #[cfg(not(feature = "dynamic-frames"))]
+            #[cfg(not(target_feature = "dynamic-frames"))]
             // We don't know in which frame we are now, so we skip a few (10) frames at the start
             // which might have been used by the current call stack. We check that the memory for
             // the 10..MAX_CALL_DEPTH frames is zeroed. Then we write a sentinel value, and in the
@@ -1479,7 +1479,7 @@ fn process_instruction<'a>(
                 stack.fill(42);
             }
 
-            #[cfg(feature = "dynamic-frames")]
+            #[cfg(target_feature = "dynamic-frames")]
             // When we have dynamic frames, the stack grows from the higher addresses, so we
             // compare from zero until the beginning of a function frame.
             {


### PR DESCRIPTION
#### Problem

The Rust default sorting algorithm is drift sort, [which allocates 4096 byes on the stack to avoid heap allocations](https://github.com/anza-xyz/rust/blob/89fb68fd3298a1c6998337b891f975eb60b8a4e4/library/core/src/slice/sort/stable/mod.rs#L105-L107). This allocation causes a stack overflow in SBF.

The problem has been fixed in https://github.com/anza-xyz/rust/pull/127.

#### Summary of Changes

1. Bump platform tools to version v1.48
2. The `dynamic-frames` is now a native target feature, so I exchanged the existing crate feature by the new target feature for cleaner commands.
