### PR TITLE
Removing StoredMetaWriteVersion. It is obsolete and the type create an unneeded dependency

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -10,7 +10,6 @@ pub mod test_utils;
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Used by the snapshot code in the runtime crate
-pub use meta::StoredMetaWriteVersion;
 // Some tests/benches use AccountMeta/StoredMeta
 #[cfg(feature = "dev-context-only-utils")]
 pub use meta::{AccountMeta, StoredMeta};

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -9,7 +9,6 @@ pub mod test_utils;
 
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
-// Used by the snapshot code in the runtime crate
 // Some tests/benches use AccountMeta/StoredMeta
 #[cfg(feature = "dev-context-only-utils")]
 pub use meta::{AccountMeta, StoredMeta};

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -6,8 +6,6 @@ use {
     std::{ptr, str},
 };
 
-pub type StoredMetaWriteVersion = u64;
-
 /// Meta contains enough context to recover the index from storage itself
 /// This struct will be backed by mmaped and snapshotted data files.
 /// So the data layout must be stable and consistent across the entire cluster!
@@ -18,7 +16,7 @@ pub struct StoredMeta {
     /// This will be made completely obsolete such that we stop storing it.
     /// We will not support multiple append vecs per slot anymore, so this concept is no longer necessary.
     /// Order of stores of an account to an append vec will determine 'latest' account data per pubkey.
-    pub write_version_obsolete: StoredMetaWriteVersion,
+    pub write_version_obsolete: u64,
     pub data_len: u64,
     /// key for the account
     pub pubkey: Pubkey,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -584,7 +584,7 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
                 },
-                u64::default(),
+                u64::default(), // obsolete, formerly write_version
             )
         }
     }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -516,14 +516,9 @@ mod tests {
     #[cfg(feature = "frozen-abi")]
     mod test_bank_serialize {
         use {
-            super::*,
-            crate::bank::BankHashStats,
-            solana_accounts_db::{
-                accounts_hash::AccountsLtHash, append_vec::StoredMetaWriteVersion,
-            },
-            solana_clock::Slot,
-            solana_frozen_abi::abi_example::AbiExample,
-            solana_lattice_hash::lt_hash::LtHash,
+            super::*, crate::bank::BankHashStats,
+            solana_accounts_db::accounts_hash::AccountsLtHash, solana_clock::Slot,
+            solana_frozen_abi::abi_example::AbiExample, solana_lattice_hash::lt_hash::LtHash,
             std::marker::PhantomData,
         };
 
@@ -589,7 +584,7 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
                 },
-                StoredMetaWriteVersion::default(),
+                u64::default(),
             )
         }
     }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -72,7 +72,7 @@ const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AccountsDbFields<T>(
     HashMap<Slot, Vec<T>>,
-    u64,
+    u64, // obsolete, formerly write_version
     Slot,
     BankHashInfo,
     /// all slots that were roots within the last epoch

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -22,7 +22,6 @@ use {
         accounts_hash::{AccountsDeltaHash, AccountsHash},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::AncestorsForSerialization,
-        append_vec::StoredMetaWriteVersion,
         blockhash_queue::BlockhashQueue,
         epoch_accounts_hash::EpochAccountsHash,
     },
@@ -73,7 +72,7 @@ const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AccountsDbFields<T>(
     HashMap<Slot, Vec<T>>,
-    StoredMetaWriteVersion,
+    u64,
     Slot,
     BankHashInfo,
     /// all slots that were roots within the last epoch
@@ -637,7 +636,7 @@ pub fn serialize_bank_snapshot_into<W>(
     accounts_hash: AccountsHash,
     account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
     extra_fields: ExtraFieldsToSerialize,
-    write_version: StoredMetaWriteVersion,
+    write_version: u64,
 ) -> Result<(), Error>
 where
     W: Write,
@@ -667,7 +666,7 @@ pub fn serialize_bank_snapshot_with<S>(
     accounts_hash: AccountsHash,
     account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
     extra_fields: ExtraFieldsToSerialize,
-    write_version: StoredMetaWriteVersion,
+    write_version: u64,
 ) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -783,7 +782,7 @@ struct SerializableAccountsDb<'a> {
     bank_hash_stats: BankHashStats,
     accounts_delta_hash: AccountsDeltaHash,
     accounts_hash: AccountsHash,
-    write_version: StoredMetaWriteVersion,
+    write_version: u64,
 }
 
 impl Serialize for SerializableAccountsDb<'_> {

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -12,7 +12,6 @@ use {
         accounts_hash::{
             AccountsDeltaHash, AccountsHash, AccountsHashKind, MerkleOrLatticeAccountsHash,
         },
-        append_vec::StoredMetaWriteVersion,
         epoch_accounts_hash::EpochAccountsHash,
     },
     solana_clock::Slot,
@@ -184,7 +183,7 @@ impl AccountsPackage {
                 bank_hash_stats: BankHashStats::default(),
                 accounts_delta_hash: AccountsDeltaHash(Hash::default()),
                 must_include_epoch_accounts_hash: false,
-                write_version: StoredMetaWriteVersion::default(),
+                write_version: u64::default(),
             }),
             enqueued: Instant::now(),
         }
@@ -209,7 +208,7 @@ pub struct SupplementalSnapshotInfo {
     pub bank_hash_stats: BankHashStats,
     pub accounts_delta_hash: AccountsDeltaHash,
     pub must_include_epoch_accounts_hash: bool,
-    pub write_version: StoredMetaWriteVersion,
+    pub write_version: u64,
 }
 
 /// Accounts packages are sent to the Accounts Hash Verifier for processing.  There are multiple
@@ -234,7 +233,7 @@ pub struct SnapshotPackage {
     pub accounts_delta_hash: AccountsDeltaHash,
     pub accounts_hash: AccountsHash,
     pub epoch_accounts_hash: Option<EpochAccountsHash>,
-    pub write_version: StoredMetaWriteVersion,
+    pub write_version: u64,
     pub bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
 
     /// The instant this snapshot package was sent to the queue.
@@ -340,7 +339,7 @@ impl SnapshotPackage {
             accounts_hash: AccountsHash(Hash::default()),
             epoch_accounts_hash: None,
             bank_incremental_snapshot_persistence: None,
-            write_version: StoredMetaWriteVersion::default(),
+            write_version: u64::default(),
             enqueued: Instant::now(),
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -27,7 +27,6 @@ use {
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError, InternalsForArchive, StorageAccess},
         accounts_hash::{AccountsDeltaHash, AccountsHash},
-        append_vec::StoredMetaWriteVersion,
         epoch_accounts_hash::EpochAccountsHash,
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
@@ -881,7 +880,7 @@ fn serialize_snapshot(
     accounts_hash: AccountsHash,
     epoch_accounts_hash: Option<EpochAccountsHash>,
     bank_incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
-    write_version: StoredMetaWriteVersion,
+    write_version: u64,
     should_flush_storages: bool,
 ) -> Result<BankSnapshotInfo> {
     let slot = bank_fields.slot;


### PR DESCRIPTION
#### Problem
StoredMetaWriteVersion is still used as a type in the runtime crate, but the type is unused in the accounts database crate.
Accounts data base stores the data as 
    pub write_version: AtomicU64,

#### Summary of Changes
Remove the type altogether. Just use u64 as that is the source type. The other option considered was moving the type to runtime but brooks recommended this direction. This will allow appendVec to be a private module.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
