### PR TITLE
Cleanup - Removes use of `VmValue::VmAddress` which defers the address translation

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -48,35 +48,6 @@ fn check_account_info_pointer(
     Ok(())
 }
 
-enum VmValue<'a, T> {
-    VmAddress { vm_addr: u64, check_aligned: bool },
-    // Once direct mapping is activated, this variant can be removed and the
-    // enum can be made a struct.
-    Translated(&'a mut T),
-}
-
-impl<T> VmValue<'_, T> {
-    fn get(&self, memory_mapping: &MemoryMapping) -> Result<&T, Error> {
-        match self {
-            VmValue::VmAddress {
-                vm_addr,
-                check_aligned,
-            } => translate_type(memory_mapping, *vm_addr, *check_aligned),
-            VmValue::Translated(addr) => Ok(*addr),
-        }
-    }
-
-    fn get_mut(&mut self, memory_mapping: &MemoryMapping) -> Result<&mut T, Error> {
-        match self {
-            VmValue::VmAddress {
-                vm_addr,
-                check_aligned,
-            } => translate_type_mut(memory_mapping, *vm_addr, *check_aligned),
-            VmValue::Translated(addr) => Ok(*addr),
-        }
-    }
-}
-
 /// Host side representation of AccountInfo or SolAccountInfo passed to the CPI syscall.
 ///
 /// At the start of a CPI, this can be different from the data stored in the
@@ -99,7 +70,7 @@ struct CallerAccount<'a> {
     // Given the corresponding input AccountInfo::data, vm_data_addr points to
     // the pointer field and ref_to_len_in_vm points to the length field.
     vm_data_addr: u64,
-    ref_to_len_in_vm: VmValue<'a, u64>,
+    ref_to_len_in_vm: &'a mut u64,
 }
 
 impl<'a> CallerAccount<'a> {
@@ -187,29 +158,18 @@ impl<'a> CallerAccount<'a> {
                     .unwrap_or(u64::MAX),
             )?;
 
-            let ref_to_len_in_vm = if direct_mapping {
-                let vm_addr = (account_info.data.as_ptr() as *const u64 as u64)
-                    .saturating_add(size_of::<u64>() as u64);
+            let vm_len_addr = (account_info.data.as_ptr() as *const u64 as u64)
+                .saturating_add(size_of::<u64>() as u64);
+            if direct_mapping {
                 // In the same vein as the other check_account_info_pointer() checks, we don't lock
                 // this pointer to a specific address but we don't want it to be inside accounts, or
                 // callees might be able to write to the pointed memory.
-                if vm_addr >= ebpf::MM_INPUT_START {
+                if vm_len_addr >= ebpf::MM_INPUT_START {
                     return Err(SyscallError::InvalidPointer.into());
                 }
-                VmValue::VmAddress {
-                    vm_addr,
-                    check_aligned: invoke_context.get_check_aligned(),
-                }
-            } else {
-                let translated = translate(
-                    memory_mapping,
-                    AccessType::Store,
-                    (account_info.data.as_ptr() as *const u64 as u64)
-                        .saturating_add(size_of::<u64>() as u64),
-                    8,
-                )? as *mut u64;
-                VmValue::Translated(unsafe { &mut *translated })
-            };
+            }
+            let host_len_addr =
+                translate(memory_mapping, AccessType::Store, vm_len_addr, 8)? as *mut u64;
             let vm_data_addr = data.as_ptr() as u64;
 
             let serialized_data = if direct_mapping {
@@ -234,7 +194,9 @@ impl<'a> CallerAccount<'a> {
                     invoke_context.get_check_aligned(),
                 )?
             };
-            (serialized_data, vm_data_addr, ref_to_len_in_vm)
+            (serialized_data, vm_data_addr, unsafe {
+                &mut *host_len_addr
+            })
         };
 
         Ok(CallerAccount {
@@ -326,24 +288,15 @@ impl<'a> CallerAccount<'a> {
         // The account info might be read only in the vm though, so we translate
         // to ensure we can write. This is tested by programs/sbf/rust/ro_modify
         // which puts SolAccountInfo in rodata.
-        let data_len_vm_addr = vm_addr
+        let vm_len_addr = vm_addr
             .saturating_add(&account_info.data_len as *const u64 as u64)
             .saturating_sub(account_info as *const _ as *const u64 as u64);
-
-        let ref_to_len_in_vm = if direct_mapping {
-            VmValue::VmAddress {
-                vm_addr: data_len_vm_addr,
-                check_aligned: invoke_context.get_check_aligned(),
-            }
-        } else {
-            let data_len_addr = translate(
-                memory_mapping,
-                AccessType::Store,
-                data_len_vm_addr,
-                size_of::<u64>() as u64,
-            )?;
-            VmValue::Translated(unsafe { &mut *(data_len_addr as *mut u64) })
-        };
+        let host_len_addr = translate(
+            memory_mapping,
+            AccessType::Store,
+            vm_len_addr,
+            size_of::<u64>() as u64,
+        )?;
 
         Ok(CallerAccount {
             lamports,
@@ -351,7 +304,7 @@ impl<'a> CallerAccount<'a> {
             original_data_len: account_metadata.original_data_len,
             serialized_data,
             vm_data_addr: account_info.data_addr,
-            ref_to_len_in_vm,
+            ref_to_len_in_vm: unsafe { &mut *(host_len_addr as *mut u64) },
         })
     }
 
@@ -1188,7 +1141,7 @@ fn update_callee_account(
 
     if direct_mapping {
         let prev_len = callee_account.get_data().len();
-        let post_len = *caller_account.ref_to_len_in_vm.get(memory_mapping)? as usize;
+        let post_len = *caller_account.ref_to_len_in_vm as usize;
         match callee_account.can_data_be_resized(post_len) {
             Ok(()) => {
                 let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
@@ -1375,7 +1328,7 @@ fn update_caller_account(
         }
     }
 
-    let prev_len = *caller_account.ref_to_len_in_vm.get(memory_mapping)? as usize;
+    let prev_len = *caller_account.ref_to_len_in_vm as usize;
     let post_len = callee_account.get_data().len();
     if prev_len != post_len {
         let max_increase = if direct_mapping && !invoke_context.get_check_aligned() {
@@ -1471,7 +1424,7 @@ fn update_caller_account(
             )?;
         }
         // this is the len field in the AccountInfo::data slice
-        *caller_account.ref_to_len_in_vm.get_mut(memory_mapping)? = post_len as u64;
+        *caller_account.ref_to_len_in_vm = post_len as u64;
 
         // this is the len field in the serialized parameters
         let serialized_len_ptr = translate_type_mut::<u64>(
@@ -1819,10 +1772,7 @@ mod tests {
         assert_eq!(caller_account.owner, account.owner());
         assert_eq!(caller_account.original_data_len, account.data().len());
         assert_eq!(
-            *caller_account
-                .ref_to_len_in_vm
-                .get(&memory_mapping)
-                .unwrap() as usize,
+            *caller_account.ref_to_len_in_vm as usize,
             account.data().len()
         );
         assert_eq!(caller_account.serialized_data, account.data());
@@ -1948,13 +1898,7 @@ mod tests {
             .unwrap();
 
             let data_len = callee_account.get_data().len();
-            assert_eq!(
-                data_len,
-                *caller_account
-                    .ref_to_len_in_vm
-                    .get(&memory_mapping)
-                    .unwrap() as usize
-            );
+            assert_eq!(data_len, *caller_account.ref_to_len_in_vm as usize);
             assert_eq!(data_len, serialized_len());
             assert_eq!(data_len, caller_account.serialized_data.len());
             assert_eq!(
@@ -2093,13 +2037,7 @@ mod tests {
 
                 let data_len = callee_account.get_data().len();
                 // the account info length must get updated
-                assert_eq!(
-                    data_len,
-                    *caller_account
-                        .ref_to_len_in_vm
-                        .get(&memory_mapping)
-                        .unwrap() as usize
-                );
+                assert_eq!(data_len, *caller_account.ref_to_len_in_vm as usize);
                 // the length slot in the serialization parameters must be updated
                 assert_eq!(data_len, serialized_len());
 
@@ -2377,10 +2315,7 @@ mod tests {
         // close the account
         let mut data = Vec::new();
         caller_account.serialized_data = &mut data;
-        *caller_account
-            .ref_to_len_in_vm
-            .get_mut(&memory_mapping)
-            .unwrap() = 0;
+        *caller_account.ref_to_len_in_vm = 0;
         let mut owner = system_program::id();
         caller_account.owner = &mut owner;
         update_callee_account(
@@ -2449,10 +2384,7 @@ mod tests {
 
         // without direct mapping
         let mut data = b"foobarbaz".to_vec();
-        *caller_account
-            .ref_to_len_in_vm
-            .get_mut(&memory_mapping)
-            .unwrap() = data.len() as u64;
+        *caller_account.ref_to_len_in_vm = data.len() as u64;
         caller_account.serialized_data = &mut data;
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2470,10 +2402,7 @@ mod tests {
 
         // with direct mapping
         let mut data = b"baz".to_vec();
-        *caller_account
-            .ref_to_len_in_vm
-            .get_mut(&memory_mapping)
-            .unwrap() = 9;
+        *caller_account.ref_to_len_in_vm = 9;
         caller_account.serialized_data = &mut data;
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -2549,10 +2478,7 @@ mod tests {
             (6, b"foobar".to_vec()),    // == original_data_len, truncates
             (3, b"foo".to_vec()),       // < original_data_len, truncates
         ] {
-            *caller_account
-                .ref_to_len_in_vm
-                .get_mut(&memory_mapping)
-                .unwrap() = len as u64;
+            *caller_account.ref_to_len_in_vm = len as u64;
             update_callee_account(
                 &invoke_context,
                 &memory_mapping,
@@ -2569,10 +2495,7 @@ mod tests {
         // close the account
         let mut data = Vec::new();
         caller_account.serialized_data = &mut data;
-        *caller_account
-            .ref_to_len_in_vm
-            .get_mut(&memory_mapping)
-            .unwrap() = 0;
+        *caller_account.ref_to_len_in_vm = 0;
         let mut owner = system_program::id();
         caller_account.owner = &mut owner;
         update_callee_account(
@@ -2743,7 +2666,7 @@ mod tests {
                 original_data_len: self.len as usize,
                 serialized_data: data,
                 vm_data_addr: self.vm_addr + mem::size_of::<u64>() as u64,
-                ref_to_len_in_vm: VmValue::Translated(&mut self.len),
+                ref_to_len_in_vm: &mut self.len,
             }
         }
     }


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/32649 [introduced](https://github.com/solana-labs/solana/pull/32649/commits/dd2a9b3f610b1a0e65aa80e17c3673312bdff279) `VmValue::VmAddress` which defers the address translation of the length field in the `AccountInfo` (`ref_to_len_in_vm`) because its permissions might change throughout the CPI call. However, [a later commit](https://github.com/solana-labs/solana/pull/32649/commits/863f0210408a40e44d4827a771faf3158a76bb98) in the same PR also forbids the `AccountInfo` to be placed inside an account, which means it can not change throughout a CPI call. Thus, this deferring of the address translation (and hence the permission checks too) is no longer necessary.

Now, in general we should stop using raw pointers and switch to references wherever we could. But, I feel this is best done after direct mapping is cleaned up in order to reduce the feature gate complexity.

#### Summary of Changes

- Replaces use of `VmValue::VmAddress` with `VmValue::Translated`
- Removes `VmValue` entirely