### PR TITLE
Modify store-tool to work on files rather than append-vecs

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -17,7 +17,10 @@ pub mod accounts_update_notifier_interface;
 mod active_stats;
 pub mod ancestors;
 mod ancient_append_vecs;
+#[cfg(feature = "dev-context-only-utils")]
 pub mod append_vec;
+#[cfg(not(feature = "dev-context-only-utils"))]
+mod append_vec;
 pub mod blockhash_queue;
 mod bucket_map_holder;
 mod bucket_map_holder_stats;

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -17,10 +17,7 @@ pub mod accounts_update_notifier_interface;
 mod active_stats;
 pub mod ancestors;
 mod ancient_append_vecs;
-#[cfg(feature = "dev-context-only-utils")]
 pub mod append_vec;
-#[cfg(not(feature = "dev-context-only-utils"))]
-mod append_vec;
 pub mod blockhash_queue;
 mod bucket_map_holder;
 mod bucket_map_holder_stats;

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -210,7 +210,7 @@ fn do_search(
         };
         // By default, when the Storage is dropped, the backing file will be removed.
         // We do not want to remove the backing file here in the store-tool, so prevent dropping.
-        let storage = ManuallyDrop::<AccountsFile>::new(storage);
+        let storage = ManuallyDrop::new(storage);
 
         let file_name = Path::new(file.file_name().expect("path is a file"));
         storage.scan_accounts_stored_meta(|account| {

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -208,7 +208,7 @@ fn do_search(
         }) else {
             return;
         };
-        // By default, when the Storage is dropped, the backing file will be removed.
+        // By default, when the storage is dropped, the backing file will be removed.
         // We do not want to remove the backing file here in the store-tool, so prevent dropping.
         let storage = ManuallyDrop::new(storage);
 

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -6,7 +6,7 @@ use {
     },
     rayon::prelude::*,
     solana_account::ReadableAccount,
-    solana_accounts_db::append_vec::AppendVec,
+    solana_accounts_db::accounts_file::{AccountsFile, StorageAccess},
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
@@ -109,13 +109,25 @@ fn cmd_search(
 }
 
 fn do_inspect(file: impl AsRef<Path>, verbose: bool) -> Result<(), String> {
-    let storage = AppendVec::new_for_store_tool(file.as_ref()).map_err(|err| {
-        format!(
-            "failed to open account storage file '{}': {err}",
-            file.as_ref().display(),
-        )
-    })?;
-    // By default, when the AppendVec is dropped, the backing file will be removed.
+    let file_size = fs::metadata(&file)
+        .map_err(|err| {
+            format!(
+                "failed to get file metadata '{}': {err}",
+                file.as_ref().display(),
+            )
+        })?
+        .len() as usize;
+
+    let (storage, _size) =
+        AccountsFile::new_from_file(file.as_ref(), file_size, StorageAccess::default()).map_err(
+            |err| {
+                format!(
+                    "failed to open account storage file '{}': {err}",
+                    file.as_ref().display(),
+                )
+            },
+        )?;
+    // By default, when the storage is dropped, the backing file will be removed.
     // We do not want to remove the backing file here in the store-tool, so prevent dropping.
     let storage = ManuallyDrop::new(storage);
 
@@ -178,7 +190,17 @@ fn do_search(
         )
     })?;
     files.par_iter().for_each(|file| {
-        let Ok(storage) = AppendVec::new_for_store_tool(file).inspect_err(|err| {
+        let file_size = match fs::metadata(file) {
+            Ok(metadata) => metadata.len() as usize,
+            Err(err) => {
+                eprintln!(
+                    "failed to get storage metadata '{}': {err}",
+                    file.display(),
+                );
+                return;
+            }
+        };
+        let Ok((storage, _size)) = AccountsFile::new_from_file(file, file_size, StorageAccess::default()).inspect_err(|err| {
             eprintln!(
                 "failed to open account storage file '{}': {err}",
                 file.display(),
@@ -188,7 +210,7 @@ fn do_search(
         };
         // By default, when the AppendVec is dropped, the backing file will be removed.
         // We do not want to remove the backing file here in the store-tool, so prevent dropping.
-        let storage = ManuallyDrop::new(storage);
+        let storage = ManuallyDrop::<AccountsFile>::new(storage);
 
         let file_name = Path::new(file.file_name().expect("path is a file"));
         storage.scan_accounts_stored_meta(|account| {

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -208,7 +208,7 @@ fn do_search(
         }) else {
             return;
         };
-        // By default, when the AppendVec is dropped, the backing file will be removed.
+        // By default, when the Storage is dropped, the backing file will be removed.
         // We do not want to remove the backing file here in the store-tool, so prevent dropping.
         let storage = ManuallyDrop::<AccountsFile>::new(storage);
 


### PR DESCRIPTION
#### Problem
Append Vecs should be private to the accounts-db but are currently used by the store-tool

#### Summary of Changes
Modified the store-tool to work on files rather than append vecs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
