### PR TITLE
chore(xdp): Prepare for Rust 2024 migration

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -364,31 +364,38 @@ pub(crate) unsafe fn mmap_ring<T>(
     ring_type: u64,
 ) -> Result<RingMmap<T>, io::Error> {
     let map_size = (offsets.desc as usize).saturating_add(size);
-    let map_addr = mmap(
-        ptr::null_mut(),
-        map_size,
-        libc::PROT_READ | libc::PROT_WRITE,
-        libc::MAP_SHARED | libc::MAP_POPULATE,
-        fd,
-        ring_type as i64,
-    );
+    // Safety: just a libc wrapper. We pass a valid size and file descriptor.
+    let map_addr = unsafe {
+        mmap(
+            ptr::null_mut(),
+            map_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED | libc::MAP_POPULATE,
+            fd,
+            ring_type as i64,
+        )
+    };
     if map_addr == libc::MAP_FAILED {
         return Err(io::Error::last_os_error());
     }
-    let producer = map_addr.add(offsets.producer as usize) as *mut AtomicU32;
-    let consumer = map_addr.add(offsets.consumer as usize) as *mut AtomicU32;
-    let desc = map_addr.add(offsets.desc as usize) as *mut T;
-    let flags = map_addr.add(offsets.flags as usize) as *mut AtomicU32;
-    // V1
-    // let flags = map_addr.add(offsets.consumer as usize + mem::size_of::<u32>()) as *mut AtomicU32;
-    Ok(RingMmap {
-        mmap: map_addr as *const u8,
-        mmap_len: map_size,
-        producer,
-        consumer,
-        desc,
-        flags,
-    })
+    // Safety: manual pointer arithmetic. We are sure that the given offsets
+    // don't exceed the bounds.
+    unsafe {
+        let producer = map_addr.add(offsets.producer as usize) as *mut AtomicU32;
+        let consumer = map_addr.add(offsets.consumer as usize) as *mut AtomicU32;
+        let desc = map_addr.add(offsets.desc as usize) as *mut T;
+        let flags = map_addr.add(offsets.flags as usize) as *mut AtomicU32;
+        // V1
+        // let flags = map_addr.add(offsets.consumer as usize + mem::size_of::<u32>()) as *mut AtomicU32;
+        Ok(RingMmap {
+            mmap: map_addr as *const u8,
+            mmap_len: map_size,
+            producer,
+            consumer,
+            desc,
+            flags,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -1,3 +1,13 @@
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
+
 #[cfg(target_os = "linux")]
 pub mod device;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
#### Problem

In Rust 2021, unsafe calls done in bodies of unsafe functions don't need an unsafe block. That changed in Rust 2024, which always requires unsafe calls to be done in unsafe blocks.

https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html

#### Summary of Changes

To make the crate ready for migration, add missing unsafe blocks and enable lints required by the new edition.

Ref: #6203
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
