### PR TITLE
Only hard link snapshot storages on graceful exit

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -18,7 +18,7 @@ use {
             Arc, Mutex,
         },
         thread::{self, Builder, JoinHandle},
-        time::Duration,
+        time::{Duration, Instant},
     },
 };
 
@@ -173,6 +173,8 @@ impl SnapshotPackagerService {
 
     /// Performs final operations before gracefully shutting down
     fn teardown(state: &TeardownState, snapshot_config: &SnapshotConfig) {
+        info!("Flushing account storages...");
+        let start = Instant::now();
         for storage in &state.snapshot_storages {
             let result = storage.flush();
             if let Err(err) = result {
@@ -185,11 +187,31 @@ impl SnapshotPackagerService {
                 return;
             }
         }
+        info!("Flushing account storages... Done in {:?}", start.elapsed());
 
         let bank_snapshot_dir = snapshot_utils::get_bank_snapshot_dir(
             &snapshot_config.bank_snapshots_dir,
             state.snapshot_slot,
         );
+
+        info!("Hard linking account storages...");
+        let start = Instant::now();
+        let result = snapshot_utils::hard_link_storages_to_snapshot(
+            &bank_snapshot_dir,
+            state.snapshot_slot,
+            &state.snapshot_storages,
+        );
+        if let Err(err) = result {
+            warn!("Failed to hard link account storages: {err}");
+            // If hard linking the storages failed, we do *NOT* want to write
+            // the "storages flushed" file, so return early.
+            return;
+        }
+        info!(
+            "Hard linking account storages... Done in {:?}",
+            start.elapsed(),
+        );
+
         let result = snapshot_utils::write_storages_flushed_file(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark snapshot storages 'flushed': {err}");


### PR DESCRIPTION
#### Problem

Hard linking the account storage files when taking a snapshot is quite expensive. We do this for fastboot, and that means we have to hard link *all* the storages. For an incremental snapshot, this ends up being the single longest running task, taking about 50% of the time.

Here's the canaries over 24 hours. This is the total time when creating the bank snapshot. So around 12 seconds total.
<img width="721" alt="total" src="https://github.com/user-attachments/assets/a6c58fdc-10bc-404b-a585-6a8ddb311d47" />

Of that 12 seconds, around 8 seconds (!!) is just the hard linking of storages. This PR makes this go entirely to 0.
<img width="719" alt="hard link" src="https://github.com/user-attachments/assets/e8f75492-15b0-4114-b105-f28f805b1f3c" />


#### Summary of Changes

We've already made it so that graceful exit is required for fastboot, so we can make hard linking the storages happen only on graceful exit too.

Note, this means graceful exit will take a bit longer. I've been seeing times ~2 seconds to hard link all the storages. This feels like a fine trade off to me.


#### Additional Testing

I've run this PR against testnet with both graceful and non-graceful exit multiple times. Every time the node restarted successfully and in the expected way.

Edit: I ran this PR against mainnet with my single NVME dev box and hard linking took ~6 seconds.