### PR TITLE
ledger-tool: Cleanup accounts subcommand output

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,7 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
-    solana_account_decoder::UiAccountEncoding,
+    solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_file::StorageAccess,
@@ -13,6 +13,7 @@ use {
         input_parsers::pubkeys_of,
         input_validators::{is_parsable, is_pow2, is_within_range},
     },
+    solana_cli_output::CliAccountNewConfig,
     solana_clock::Slot,
     solana_ledger::{
         blockstore_processor::ProcessOptions,
@@ -378,6 +379,28 @@ pub(crate) fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncodi
         Some("base64") => UiAccountEncoding::Base64,
         Some("base64+zstd") => UiAccountEncoding::Base64Zstd,
         _ => UiAccountEncoding::Base64,
+    }
+}
+
+pub(crate) fn parse_account_output_config(matches: &ArgMatches<'_>) -> CliAccountNewConfig {
+    let data_encoding = parse_encoding_format(matches);
+    let output_account_data = !matches.is_present("no_account_data");
+    let data_slice_config = if output_account_data {
+        // None yields the entire account in the slice
+        None
+    } else {
+        // usize::MAX is a sentinel that will yield an
+        // empty data slice. Because of this, length is
+        // ignored so any value will do
+        let offset = usize::MAX;
+        let length = 0;
+        Some(UiDataSliceConfig { offset, length })
+    };
+
+    CliAccountNewConfig {
+        data_encoding,
+        data_slice_config,
+        ..CliAccountNewConfig::default()
     }
 }
 

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,6 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     clap::{value_t, value_t_or_exit, values_t, values_t_or_exit, Arg, ArgMatches},
+    solana_account_decoder::UiAccountEncoding,
     solana_accounts_db::{
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_file::StorageAccess,
@@ -368,6 +369,15 @@ pub fn get_accounts_db_config(
             .is_present("accounts_db_snapshots_use_experimental_accumulator_hash"),
         num_hash_threads,
         ..AccountsDbConfig::default()
+    }
+}
+
+pub(crate) fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncoding {
+    match matches.value_of("encoding") {
+        Some("jsonParsed") => UiAccountEncoding::JsonParsed,
+        Some("base64") => UiAccountEncoding::Base64,
+        Some("base64+zstd") => UiAccountEncoding::Base64Zstd,
+        _ => UiAccountEncoding::Base64,
     }
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2575,9 +2575,12 @@ fn main() {
                     let bank = bank_forks.read().unwrap().working_bank();
 
                     let include_sysvars = arg_matches.is_present("include_sysvars");
-                    let include_account_contents = !arg_matches.is_present("no_account_contents");
-                    let include_account_data = !arg_matches.is_present("no_account_data");
-                    let account_data_encoding = parse_encoding_format(arg_matches);
+                    let output_config = if arg_matches.is_present("no_account_contents") {
+                        None
+                    } else {
+                        Some(parse_account_output_config(arg_matches))
+                    };
+
                     let mode = if let Some(pubkeys) = pubkeys_of(arg_matches, "account") {
                         info!("Scanning individual accounts: {pubkeys:?}");
                         AccountsOutputMode::Individual(pubkeys)
@@ -2590,10 +2593,8 @@ fn main() {
                     };
                     let config = AccountsOutputConfig {
                         mode,
+                        output_config,
                         include_sysvars,
-                        include_account_contents,
-                        include_account_data,
-                        account_data_encoding,
                     };
                     let output_format =
                         OutputFormat::from_matches(arg_matches, "output_format", false);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -22,7 +22,7 @@ use {
     log::*,
     serde_derive::Serialize,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
-    solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
+    solana_account_decoder::UiDataSliceConfig,
     solana_accounts_db::{
         accounts_db::CalcAccountsHashDataSource,
         accounts_index::{ScanConfig, ScanOrder},
@@ -111,15 +111,6 @@ mod ledger_path;
 mod ledger_utils;
 mod output;
 mod program;
-
-fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncoding {
-    match matches.value_of("encoding") {
-        Some("jsonParsed") => UiAccountEncoding::JsonParsed,
-        Some("base64") => UiAccountEncoding::Base64,
-        Some("base64+zstd") => UiAccountEncoding::Base64Zstd,
-        _ => UiAccountEncoding::Base64,
-    }
-}
 
 fn render_dot(dot: String, output_file: &str, output_format: &str) -> io::Result<()> {
     let mut child = Command::new("dot")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -22,7 +22,6 @@ use {
     log::*,
     serde_derive::Serialize,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
-    solana_account_decoder::UiDataSliceConfig,
     solana_accounts_db::{
         accounts_db::CalcAccountsHashDataSource,
         accounts_index::{ScanConfig, ScanOrder},
@@ -35,7 +34,7 @@ use {
             is_within_range,
         },
     },
-    solana_cli_output::{CliAccount, CliAccountNewConfig, OutputFormat},
+    solana_cli_output::{CliAccount, OutputFormat},
     solana_clock::{Epoch, Slot},
     solana_core::{
         banking_simulation::{BankingSimulator, BankingTraceEvents},
@@ -1678,24 +1677,7 @@ fn main() {
                     let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
 
                     if output_accounts {
-                        let data_encoding = parse_encoding_format(arg_matches);
-                        let output_account_data = !arg_matches.is_present("no_account_data");
-                        let data_slice_config = if output_account_data {
-                            // None yields the entire account in the slice
-                            None
-                        } else {
-                            // usize::MAX is a sentinel that will yield an
-                            // empty data slice. Because of this, length is
-                            // ignored so any value will do
-                            let offset = usize::MAX;
-                            let length = 0;
-                            Some(UiDataSliceConfig { offset, length })
-                        };
-                        let cli_account_config = CliAccountNewConfig {
-                            data_encoding,
-                            data_slice_config,
-                            ..CliAccountNewConfig::default()
-                        };
+                        let output_config = parse_account_output_config(arg_matches);
 
                         let accounts: Vec<_> = genesis_config
                             .accounts
@@ -1704,7 +1686,7 @@ fn main() {
                                 CliAccount::new_with_config(
                                     &pubkey,
                                     &AccountSharedData::from(account),
-                                    &cli_account_config,
+                                    &output_config,
                                 )
                             })
                             .collect();

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -769,10 +769,8 @@ pub enum AccountsOutputMode {
 
 pub struct AccountsOutputConfig {
     pub mode: AccountsOutputMode,
+    pub output_config: Option<CliAccountNewConfig>,
     pub include_sysvars: bool,
-    pub include_account_contents: bool,
-    pub include_account_data: bool,
-    pub account_data_encoding: UiAccountEncoding,
 }
 
 impl AccountsOutputStreamer {
@@ -841,24 +839,26 @@ impl AccountsScanner {
         seq_serializer: &mut Option<S>,
         pubkey: &Pubkey,
         account: &AccountSharedData,
-        slot: Option<Slot>,
-        cli_account_new_config: &CliAccountNewConfig,
     ) where
         S: SerializeSeq,
     {
-        if self.config.include_account_contents {
+        if let Some(output_config) = &self.config.output_config {
+            let cli_account = CliAccount::new_with_config(pubkey, account, output_config);
+
             if let Some(serializer) = seq_serializer {
-                let cli_account =
-                    CliAccount::new_with_config(pubkey, account, cli_account_new_config);
                 serializer.serialize_element(&cli_account).unwrap();
             } else {
-                output_account(
-                    pubkey,
-                    account,
-                    slot,
-                    self.config.include_account_data,
-                    self.config.account_data_encoding,
-                );
+                print!("{}", &cli_account);
+                // CliAccount doesn't print the account data payload so handle
+                // that separately. If --no-account-data was specified,
+                // output_config.data_slice_config will have been created to
+                // yield an empty slice which will make data.empty() below true
+                let account_data = cli_account.keyed_account.account.data.decode();
+                if let Some(data) = account_data {
+                    if !data.is_empty() {
+                        println!("{:?}", data.hex_dump());
+                    }
+                }
             }
         }
     }
@@ -870,23 +870,12 @@ impl AccountsScanner {
         let mut total_accounts_stats = self.total_accounts_stats.borrow_mut();
         let rent_collector = self.bank.rent_collector();
 
-        let cli_account_new_config = CliAccountNewConfig {
-            data_encoding: self.config.account_data_encoding,
-            ..CliAccountNewConfig::default()
-        };
-
         let scan_func = |account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
-            if let Some((pubkey, account, slot)) =
+            if let Some((pubkey, account, _slot)) =
                 account_tuple.filter(|(_, account, _)| self.should_process_account(account))
             {
                 total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
-                self.maybe_output_account(
-                    seq_serializer,
-                    pubkey,
-                    &account,
-                    Some(slot),
-                    &cli_account_new_config,
-                );
+                self.maybe_output_account(seq_serializer, pubkey, &account);
             }
         };
 
@@ -895,19 +884,13 @@ impl AccountsScanner {
                 self.bank.scan_all_accounts(scan_func, true).unwrap();
             }
             AccountsOutputMode::Individual(pubkeys) => pubkeys.iter().for_each(|pubkey| {
-                if let Some((account, slot)) = self
+                if let Some((account, _slot)) = self
                     .bank
                     .get_account_modified_slot_with_fixed_root(pubkey)
                     .filter(|(account, _)| self.should_process_account(account))
                 {
                     total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
-                    self.maybe_output_account(
-                        seq_serializer,
-                        pubkey,
-                        &account,
-                        Some(slot),
-                        &cli_account_new_config,
-                    );
+                    self.maybe_output_account(seq_serializer, pubkey, &account);
                 }
             }),
             AccountsOutputMode::Program(program_pubkey) => self
@@ -918,13 +901,7 @@ impl AccountsScanner {
                 .filter(|(_, account)| self.should_process_account(account))
                 .for_each(|(pubkey, account)| {
                     total_accounts_stats.accumulate_account(pubkey, account, rent_collector);
-                    self.maybe_output_account(
-                        seq_serializer,
-                        pubkey,
-                        account,
-                        None,
-                        &cli_account_new_config,
-                    );
+                    self.maybe_output_account(seq_serializer, pubkey, account);
                 }),
         }
     }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -9,7 +9,6 @@ use {
     serde::ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     serde_derive::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_account_decoder::{encode_ui_account, UiAccountData, UiAccountEncoding},
     solana_accounts_db::{
         accounts_index::{ScanConfig, ScanOrder},
         is_loadable::IsLoadable as _,
@@ -939,41 +938,3 @@ impl fmt::Display for CliAccounts {
 }
 impl QuietDisplay for CliAccounts {}
 impl VerboseDisplay for CliAccounts {}
-
-pub fn output_account(
-    pubkey: &Pubkey,
-    account: &AccountSharedData,
-    modified_slot: Option<Slot>,
-    print_account_data: bool,
-    encoding: UiAccountEncoding,
-) {
-    println!("{pubkey}:");
-    println!("  balance: {} SOL", lamports_to_sol(account.lamports()));
-    println!("  owner: '{}'", account.owner());
-    println!("  executable: {}", account.executable());
-    if let Some(slot) = modified_slot {
-        println!("  slot: {slot}");
-    }
-    println!("  rent_epoch: {}", account.rent_epoch());
-    println!("  data_len: {}", account.data().len());
-    if print_account_data {
-        let account_data = encode_ui_account(pubkey, account, encoding, None, None).data;
-        match account_data {
-            UiAccountData::Binary(data, data_encoding) => {
-                println!("  data: '{data}'");
-                println!(
-                    "  encoding: {}",
-                    serde_json::to_string(&data_encoding).unwrap()
-                );
-            }
-            UiAccountData::Json(account_data) => {
-                println!(
-                    "  data: '{}'",
-                    serde_json::to_string(&account_data).unwrap()
-                );
-                println!("  encoding: \"jsonParsed\"");
-            }
-            UiAccountData::LegacyBinary(_) => {}
-        };
-    }
-}


### PR DESCRIPTION
#### Problem
Two problems:
1. `agave-ledger-tool accounts --no-account-data --output json` would still output the data
2. `agave-ledger-tool` uses a custom function to output accounts when there is a "standard" function

#### Summary of Changes
1. Use the same solution from https://github.com/anza-xyz/agave/pull/5528 to actually honor the `--no-account-data` flag
2. Shift the "standard" output function to use the shared function; output will match `solana account`

#### Testing
<details>
<summary>Some sample output with the new branch</summary>

With `--no-account-data`:
```
$ cargo run -- accounts --ledger ../validator/test-ledger --halt-at-slot 0 --account H253PPA38ecQvnpSvfWgqBfMuVgZ656CEXLgTHwZQHfs --no-account-data
...
Public Key: H253PPA38ecQvnpSvfWgqBfMuVgZ656CEXLgTHwZQHfs
Balance: 0.50917272 SOL
Owner: BPFLoaderUpgradeab1e11111111111111111111111
Executable: false
Rent Epoch: 0

TotalAccountsStats {
    ...
}
```

Without `--no-account-data`:
```
Public Key: H253PPA38ecQvnpSvfWgqBfMuVgZ656CEXLgTHwZQHfs
Balance: 0.50917272 SOL
Owner: BPFLoaderUpgradeab1e11111111111111111111111
Executable: false
Rent Epoch: 0

Length: 73029 (0x11d45) bytes
0000:   03 00 00 00  00 00 00 00  00 00 00 00  01 00 00 00   ................
0010:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................

TotalAccountsStats {
    ...
}
```

</details>

One side effect here is that we no longer honor `--encoding` in the print (ie not json) case. Doing the hex dump matches what `solana account` does, so I could see an argument for each direction. Will let this sit a little and think about it more