### PR TITLE
Removing unnecessary clones 

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3433,12 +3433,10 @@ impl AccountsDb {
             let mut curr = 1;
 
             while curr < accounts.len() {
-                if accounts[curr].pubkey() == accounts[last].pubkey() {
-                    accounts[last] = accounts[curr];
-                } else {
+                if accounts[curr].pubkey() != accounts[last].pubkey() {
                     last += 1;
-                    accounts[last] = accounts[curr];
                 }
+                accounts[last] = accounts[curr];
                 curr += 1;
             }
             accounts.truncate(last + 1);

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -2274,24 +2274,25 @@ mod tests {
     fn test_hashing(hashes: Vec<Hash>, fanout: usize) -> Hash {
         let temp: Vec<_> = hashes.iter().map(|h| (Pubkey::default(), *h)).collect();
         let result = AccountsHasher::compute_merkle_root(temp, fanout);
-        let reduced: Vec<_> = hashes.clone();
+        let len = hashes.len();
+        let reduced: Vec<_> = hashes;
         let result2 = AccountsHasher::compute_merkle_root_from_slices(
-            hashes.len(),
+            len,
             fanout,
             None,
             |start| &reduced[start..],
             None,
         );
-        assert_eq!(result, result2.0, "len: {}", hashes.len());
+        assert_eq!(result, result2.0, "len: {}", len);
 
         let result2 = AccountsHasher::compute_merkle_root_from_slices(
-            hashes.len(),
+            len,
             fanout,
             Some(1),
             |start| &reduced[start..],
             None,
         );
-        assert_eq!(result, result2.0, "len: {}", hashes.len());
+        assert_eq!(result, result2.0, "len: {}", len);
 
         let max = std::cmp::min(reduced.len(), fanout * 2);
         for left in 0..max {

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -2275,7 +2275,7 @@ mod tests {
         let temp: Vec<_> = hashes.iter().map(|h| (Pubkey::default(), *h)).collect();
         let result = AccountsHasher::compute_merkle_root(temp, fanout);
         let len = hashes.len();
-        let reduced: Vec<_> = hashes;
+        let reduced = hashes;
         let result2 = AccountsHasher::compute_merkle_root_from_slices(
             len,
             fanout,

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -567,7 +567,7 @@ mod tests {
         let slot = MAX_ENTRIES as Slot;
         let pubkey = Pubkey::new_unique();
         let account = AccountSharedData::new(42, ACCOUNT_DATA_SIZE, &Pubkey::default());
-        cache.store(pubkey, slot, account.clone());
+        cache.store(pubkey, slot, account);
 
         // wait for the evictor to run...
         let timer = Instant::now();


### PR DESCRIPTION
#### Problem
I would like to run unnecessary clone linter locally, but Test code has unnecessary clones that are caught by clippy

#### Summary of Changes
Fix the unnecessary clones in tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
