### PR TITLE
[docs] Fix link in zk-elgamal-proof.md

### DIFF
--- a/docs/src/runtime/zk-elgamal-proof.md
+++ b/docs/src/runtime/zk-elgamal-proof.md
@@ -41,7 +41,7 @@ treatment of Pedersen commitment and the (twisted) ElGamal encryption schemes.
 - [Notes](https://github.com/solana-labs/solana/blob/master/docs/src/runtime/zk-docs/twisted_elgamal.pdf)
   on the twisted ElGamal encryption
 - A technical
-  [overview](https://github.com/solana-labs/solana-program-library/blob/master/token/zk-token-protocol-paper/part1.pdf)
+  [overview](https://github.com/solana-program/token-2022/blob/main/zk-token-protocol-paper/part1.pdf)
   of the SPL Token 2022 confidential extension
 - Pretty Good Confidentiality [research paper](https://eprint.iacr.org/2019/319)
 


### PR DESCRIPTION
#### Problem
The Solana Program Library repository has been broken up into separate repos. The link to SPL ZK-Tokens Protocol Overvew was broken.

#### Summary of Changes
Fixed the link.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
