### PR TITLE
clippy: Raises result_large_err to squelch lint

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,10 @@
 too-many-arguments-threshold = 9
 
+# Set the result_large_err lint threshold based on the current sizes as of May 21 2025.
+# solana_rpc_client_api::client_error::Error is 256 bytes
+# solana_tps_client::TpsClientError uses the ClientError (above) and is 264 bytes
+large-error-threshold = 265
+
 # Disallow specific methods from being used
 disallowed-methods = [
     { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },


### PR DESCRIPTION
#### Problem

Upgrading Rust to 1.87.0[^1] is blocked on a new clippy lint[^2], `result_large_err`[^3].

[^1]: https://github.com/anza-xyz/agave/issues/6279
[^2]: https://github.com/anza-xyz/agave/issues/6278
[^3]: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err


#### Summary of Changes

Raise the threshold for the lint to 265, since the largest size today is 264 bytes.

A subsequent PR can fix the underlying Error type to box the large variant, and remove the custom threshold. 

By raising the threshold here, we unblock upgrading Rust, and we don't change any behavior.

Note that annotating the Error enums with `#[allow(clippy::result_large_err)]` does *not* squelch the lint unfortunately.

Fixes #6278 