### PR TITLE
Uses rpc's client_error::Error::kind() in more places

### DIFF
--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -280,7 +280,7 @@ async fn send_transaction_with_rpc_fallback(
             )
             .await
         {
-            match &e.kind {
+            match e.kind() {
                 ErrorKind::Io(_) | ErrorKind::Reqwest(_) => {
                     // fall through on io error, we will retry the transaction
                 }

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -993,7 +993,7 @@ impl RpcClient {
                     code,
                     message,
                     data,
-                }) = &err.kind
+                }) = err.kind()
                 {
                     debug!("{} {}", code, message);
                     if let RpcResponseErrorData::SendTransactionPreflightFailure(

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -570,7 +570,7 @@ fn deserialize_rpc_error() -> ClientResult<()> {
     let err = rpc_client.send_transaction(&tx);
     let err = err.unwrap_err();
 
-    match err.kind {
+    match err.kind() {
         ClientErrorKind::RpcError(RpcError::RpcRequestError { .. }) => {
             // This is what used to happen
             panic!()

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -1006,7 +1006,7 @@ async fn maybe_fetch_cache_info(
 
 fn is_invalid_slot_range_error(client_error: &ClientError) -> bool {
     if let ErrorKind::RpcError(RpcError::RpcResponseError { code, message, .. }) =
-        &client_error.kind
+        client_error.kind()
     {
         return *code == -32602
             && message.contains("Invalid slot range: leader schedule for epoch");

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -278,7 +278,7 @@ fn get_validator_stats(
                     request::RpcResponseErrorData::NodeUnhealthy {
                         num_slots_behind: Some(num_slots_behind),
                     },
-            }) = &err.kind
+            }) = err.kind()
             {
                 format!("{num_slots_behind} slots behind")
             } else {


### PR DESCRIPTION
#### Problem

If/when we change rpc's `client_error::Error::kind` field from `ErrorKind` to `Box<ErrorKind>`, there are miscellaneous uses of `kind` that need to be updated (as expected). It turns out that many uses of `kind` actually want a reference, i.e. `&ErrorKind`. There's also already a function on `client_error::Error` that does just this: `Error::kind()`. So we can/should use that function instead, which means fewer changes later when modifying the underlying `kind` type.

Please see https://github.com/anza-xyz/agave/pull/6290#issuecomment-2902233915 for the full context.


#### Summary of Changes

Use `kind()` in more places.