### PR TITLE
Boxes rpc client_error::Error's ErrorKind field

### DIFF
--- a/rpc-client-api/src/client_error.rs
+++ b/rpc-client-api/src/client_error.rs
@@ -77,14 +77,14 @@ pub struct Error {
     pub request: Option<request::RpcRequest>,
 
     #[source]
-    pub kind: ErrorKind,
+    pub kind: Box<ErrorKind>,
 }
 
 impl Error {
     pub fn new_with_request(kind: ErrorKind, request: request::RpcRequest) -> Self {
         Self {
             request: Some(request),
-            kind,
+            kind: Box::new(kind),
         }
     }
 
@@ -100,7 +100,7 @@ impl Error {
     }
 
     pub fn kind(&self) -> &ErrorKind {
-        &self.kind
+        self.kind.as_ref()
     }
 
     pub fn get_transaction_error(&self) -> Option<TransactionError> {
@@ -112,7 +112,7 @@ impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
         Self {
             request: None,
-            kind,
+            kind: Box::new(kind),
         }
     }
 }
@@ -121,14 +121,14 @@ impl From<TransportError> for Error {
     fn from(err: TransportError) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
 
 impl From<Error> for TransportError {
     fn from(client_error: Error) -> Self {
-        client_error.kind.into()
+        (*client_error.kind).into()
     }
 }
 
@@ -136,7 +136,7 @@ impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
@@ -145,7 +145,7 @@ impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
@@ -158,7 +158,7 @@ impl From<reqwest_middleware::Error> for Error {
         };
         Self {
             request: None,
-            kind,
+            kind: Box::new(kind),
         }
     }
 }
@@ -167,7 +167,7 @@ impl From<request::RpcError> for Error {
     fn from(err: request::RpcError) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
@@ -176,7 +176,7 @@ impl From<serde_json::error::Error> for Error {
     fn from(err: serde_json::error::Error) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
@@ -185,7 +185,7 @@ impl From<SignerError> for Error {
     fn from(err: SignerError) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }
@@ -194,7 +194,7 @@ impl From<TransactionError> for Error {
     fn from(err: TransactionError) -> Self {
         Self {
             request: None,
-            kind: err.into(),
+            kind: Box::new(err.into()),
         }
     }
 }


### PR DESCRIPTION
#### Problem

Issue #6278: The rpc `client_error::Error` struct triggers the `result_large_err` clippy lint. This is because the `kind` field is of type `ErrorKind`, which is 232 bytes. To fix this, and since this is only needed in the error case, we can box the `ErrorKind`.

Please see https://github.com/anza-xyz/agave/pull/6290#issuecomment-2902233915 for the full context.


#### Summary of Changes

Boxes solana_rpc_client_api::client_error::Error's ErrorKind field, `kind`.

> [!IMPORTANT]
> Since the ErrorKind field is public and exported[^1], this is an **API-BREAKING CHANGE**. As such, the earliest it can be merged is in v3.0.
    
[^1]: https://docs.rs/solana-rpc-client-api/2.2.7/solana_rpc_client_api/client_error/struct.Error.html