### PR TITLE
Do not clean in ABS if startup verification is ongoing and there are pending snapshot requests

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -622,11 +622,11 @@ impl AccountsBackgroundService {
                                 // once startup verification completed, this old snapshot request
                                 // would be handled, and we'd break the invariant above that
                                 // last_cleaned_block_height must be <= snapshot_block_height.
-                                !request_handlers
-                                    .snapshot_request_handler
-                                    .snapshot_request_receiver
-                                    .is_empty()
-                                    && !bank.is_startup_verification_complete()
+                                bank.is_startup_verification_complete()
+                                    || request_handlers
+                                        .snapshot_request_handler
+                                        .snapshot_request_receiver
+                                        .is_empty()
                             )
                         {
                             // Note that the flush will do an internal clean of the


### PR DESCRIPTION
#### Problem

Please see #6295.


#### Summary of Changes

Do not clean in ABS if startup verification is ongoing and there are pending snapshot requests.

Fixes #6295