### PR TITLE
Make BankForks::frozen_banks() return an iterator

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -180,8 +180,12 @@ impl ClusterSlotsService {
         // TODO: Should probably incorporate slots that were replayed on startup,
         // and maybe some that were frozen < snapshot root in case validators restart
         // from newer snapshots and lose history.
-        let frozen_banks = bank_forks.read().unwrap().frozen_banks();
-        let mut frozen_bank_slots: Vec<Slot> = frozen_banks.keys().cloned().collect();
+        let mut frozen_bank_slots: Vec<_> = bank_forks
+            .read()
+            .unwrap()
+            .frozen_banks()
+            .map(|(slot, _bank)| slot)
+            .collect();
         frozen_bank_slots.sort_unstable();
 
         if !frozen_bank_slots.is_empty() {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -362,10 +362,14 @@ impl Tower {
         vote_account: &Pubkey,
     ) -> Self {
         let root_bank = bank_forks.root_bank();
+        let frozen_banks: Vec<_> = bank_forks
+            .frozen_banks()
+            .map(|(_slot, bank)| bank)
+            .collect();
         let (_progress, heaviest_subtree_fork_choice) =
             crate::replay_stage::ReplayStage::initialize_progress_and_fork_choice(
                 root_bank.deref(),
-                bank_forks.frozen_banks().values().cloned().collect(),
+                frozen_banks,
                 node_pubkey,
                 vote_account,
                 vec![],

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -175,8 +175,7 @@ impl VoteSimulator {
             .read()
             .unwrap()
             .frozen_banks()
-            .values()
-            .cloned()
+            .map(|(_slot, bank)| bank)
             .collect();
 
         let _ = ReplayStage::compute_bank_stats(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -202,7 +202,10 @@ struct GraphConfig {
 #[allow(clippy::cognitive_complexity)]
 fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
     let frozen_banks = bank_forks.frozen_banks();
-    let mut fork_slots: HashSet<_> = frozen_banks.keys().cloned().collect();
+    let mut fork_slots: HashSet<_> = bank_forks
+        .frozen_banks()
+        .map(|(slot, _bank)| slot)
+        .collect();
     for (_, bank) in frozen_banks {
         for parent in bank.parents() {
             fork_slots.remove(&parent.slot());


### PR DESCRIPTION
#### Problem
There are a handful of callers of this function that want different things. 

#### Summary of Changes
To avoid wasted allocations, return an iterator and allow the caller collect into whichever data structure they need

