### PR TITLE
rpc: Remove unused solana-sdk dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9809,7 +9809,6 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",
- "solana-sdk",
  "solana-send-transaction-service",
  "solana-sha256-hasher",
  "solana-signature",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7607,7 +7607,6 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",
- "solana-sdk",
  "solana-send-transaction-service",
  "solana-signature",
  "solana-signer",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -60,7 +60,6 @@ solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7419,7 +7419,6 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",
- "solana-sdk",
  "solana-send-transaction-service",
  "solana-signature",
  "solana-signer",


### PR DESCRIPTION
#### Problem
@t-nelson already did all of the actual work in removing use of `solana-sdk` usage from `solana-rpc`, this just removes `solana-sdk` from the dependency list in `Cargo.toml`
