### PR TITLE
core: Remove solana-sdk dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -104,7 +104,6 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sanitize = { workspace = true }
-solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -2,10 +2,11 @@
 use solana_perf::packet::PacketRef;
 use {
     super::immutable_deserialized_packet::{DeserializedPacketError, ImmutableDeserializedPacket},
+    solana_bincode::limited_deserialize,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
-    solana_sdk::program_utils::limited_deserialize,
     solana_vote_program::vote_instruction::VoteInstruction,
     std::sync::Arc,
 };
@@ -50,7 +51,7 @@ impl LatestValidatorVotePacket {
             }
         };
 
-        match limited_deserialize::<VoteInstruction>(&instruction.data) {
+        match limited_deserialize::<VoteInstruction>(&instruction.data, PACKET_DATA_SIZE as u64) {
             Ok(vote_state_update_instruction)
                 if instruction_filter(&vote_state_update_instruction) =>
             {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6069,7 +6069,6 @@ dependencies = [
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sanitize",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-sha256-hasher",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5916,7 +5916,6 @@ dependencies = [
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sanitize",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-sha256-hasher",


### PR DESCRIPTION
#### Problem
The current code uses `limited_deserialize()` from `solana-sdk`:
https://github.com/anza-xyz/solana-sdk/blob/1276772ee61fbd1f8a60cfec7cd553aa4f6a55f3/sdk/src/program_utils.rs#L13-L21
This function doesn't have a `limit` parameter, and instead hardcodes `PACKET_DATA_SIZE` as the limit. However, the implementation is actually just a re-export of `solana-bincode` as shown below:
https://github.com/anza-xyz/solana-sdk/blob/master/program/src/program_utils.rs
So, just update to `solana-bincode` directly with `PACKET_DATA_SIZE` set as the limit to maintain existing behavior