### PR TITLE
svm: Remove solana-sdk dependency from examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10817,7 +10817,6 @@ dependencies = [
  "solana-rent-collector",
  "solana-rent-debits",
  "solana-sbpf",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-secp256k1-program",
  "solana-secp256r1-program",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -90,7 +90,6 @@ solana-program-runtime = { workspace = true, features = ["dev-context-only-utils
 solana-pubkey = { workspace = true, features = [ "rand" ] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true }
-solana-sdk = { workspace = true }
 solana-secp256k1-program = { workspace = true }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-signature = { workspace = true, features = [ "rand" ] }
@@ -115,7 +114,6 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-program-runtime/frozen-abi",
-    "solana-sdk/frozen-abi",
 ]
 shuttle-test = [
     "solana-type-overrides/shuttle-test",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -2883,7 +2883,6 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-rpc-client-api",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-signature",
  "solana-svm",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -37,7 +37,6 @@ solana-logger = "=2.3.1"
 solana-perf = { path = "../../perf" }
 solana-program-runtime = { path = "../../program-runtime" }
 solana-rpc-client-api = { path = "../../rpc-client-api" }
-solana-sdk = { version = "=2.2.2", default-features = false }
 solana-svm = { path = "../" }
 solana-svm-callback = { path = "../../svm-callback" }
 solana-svm-feature-set = { path = "../../svm-feature-set" }

--- a/svm/examples/json-rpc/server/Cargo.toml
+++ b/svm/examples/json-rpc/server/Cargo.toml
@@ -35,7 +35,6 @@ solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm = { workspace = true }


### PR DESCRIPTION
This rips out the dependency on `solana-sdk`; however, I'm not sure that the examples are currently building in CI. Running `cargo build` in `<REPO_ROOT>/svm/examples` yields this error on the tip of master (this goes away if you enable the `blake3` feature):

<details>
<summary>cargo build output</summary>

```
error[E0599]: no function or associated item named `try_create` found for struct `SanitizedTransaction` in the current scope
   --> json-rpc/server/src/rpc_process.rs:911:27
    |
911 |     SanitizedTransaction::try_create(
    |                           ^^^^^^^^^^ function or associated item not found in `SanitizedTransaction`
    |
note: if you're trying to build a new `SanitizedTransaction` consider using one of the following associated functions:
      SanitizedTransaction::try_new
      SanitizedTransaction::try_new_from_fields
   --> /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-transaction-2.2.2/src/sanitized.rs:58:5
    |
58  | /     pub fn try_new(
59  | |         tx: SanitizedVersionedTransaction,
60  | |         message_hash: Hash,
61  | |         is_simple_vote_tx: bool,
62  | |         address_loader: impl AddressLoader,
63  | |         reserved_account_keys: &HashSet<Pubkey>,
64  | |     ) -> Result<Self> {
    | |_____________________^
...
148 | /     pub fn try_new_from_fields(
149 | |         message: SanitizedMessage,
150 | |         message_hash: Hash,
151 | |         is_simple_vote_tx: bool,
152 | |         signatures: Vec<Signature>,
153 | |     ) -> Result<Self> {
    | |_____________________^

error[E0599]: no function or associated item named `try_from_legacy_transaction` found for struct `SanitizedTransaction` in the current scope
   --> paytube/src/transaction.rs:65:37
    |
65  |         SolanaSanitizedTransaction::try_from_legacy_transaction(
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `SanitizedTransaction`
    |
note: if you're trying to build a new `SanitizedTransaction` consider using one of the following associated functions:
      SanitizedTransaction::try_new
      SanitizedTransaction::try_new_from_fields
   --> /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-transaction-2.2.2/src/sanitized.rs:58:5
    |
58  | /     pub fn try_new(
59  | |         tx: SanitizedVersionedTransaction,
60  | |         message_hash: Hash,
61  | |         is_simple_vote_tx: bool,
62  | |         address_loader: impl AddressLoader,
63  | |         reserved_account_keys: &HashSet<Pubkey>,
64  | |     ) -> Result<Self> {
    | |_____________________^
...
148 | /     pub fn try_new_from_fields(
149 | |         message: SanitizedMessage,
150 | |         message_hash: Hash,
151 | |         is_simple_vote_tx: bool,
152 | |         signatures: Vec<Signature>,
153 | |     ) -> Result<Self> {
    | |_____________________^
```

</details>

Moreso, this is an invalid dependency path given that `sdk` is no longer in the monorepo:
https://github.com/anza-xyz/agave/blob/ae8fe771a6622c6511bc010532d6064a8c842b76/svm/examples/json-rpc/program/Cargo.toml#L13

This is because `json-rpc-example-program` is not listed in the `members`:
https://github.com/anza-xyz/agave/blob/ae8fe771a6622c6511bc010532d6064a8c842b76/svm/examples/Cargo.toml#L1-L2

For the sake of progressing removal of `solana-sdk`, I propose we push these changes as is (assuming CI is happy) and then tackle further cleanup later
