### PR TITLE
Epoch Rewards Cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1408,10 +1408,7 @@ impl Bank {
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
-            epoch_reward_calculation_results: Arc::new(Mutex::new(HashMap::<
-                Epoch,
-                HashMap<Slot, PartitionedRewardsCalculation>,
-            >::default())),
+            epoch_reward_calculation_results: parent.epoch_reward_calculation_results.clone(),
         };
 
         let (_, ancestors_time_us) = measure_us!({

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -584,7 +584,7 @@ impl PartialEq for Bank {
             stats_for_accounts_lt_hash: _,
             block_id,
             bank_hash_stats: _,
-            epoch_reward_calculation_results: _,
+            epoch_rewards_calculation_cache: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -947,7 +947,7 @@ pub struct Bank {
     /// The cache of epoch rewards calculation results
     /// This is used to avoid recalculating the same epoch rewards at epoch boundary.
     /// The outer hashmap is keyed by current epoch, and the inner hashmap is keyed by the parent slot in previous epoch.
-    epoch_reward_calculation_results:
+    epoch_rewards_calculation_cache:
         Arc<Mutex<HashMap<Epoch, HashMap<Slot, PartitionedRewardsCalculation>>>>,
 }
 
@@ -1148,10 +1148,7 @@ impl Bank {
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
-            epoch_reward_calculation_results: Arc::new(Mutex::new(HashMap::<
-                Epoch,
-                HashMap<Slot, PartitionedRewardsCalculation>,
-            >::default())),
+            epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
         };
 
         bank.transaction_processor =
@@ -1408,7 +1405,7 @@ impl Bank {
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
-            epoch_reward_calculation_results: parent.epoch_reward_calculation_results.clone(),
+            epoch_rewards_calculation_cache: parent.epoch_rewards_calculation_cache.clone(),
         };
 
         let (_, ancestors_time_us) = measure_us!({
@@ -1886,10 +1883,7 @@ impl Bank {
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
-            epoch_reward_calculation_results: Arc::new(Mutex::new(HashMap::<
-                Epoch,
-                HashMap<Slot, PartitionedRewardsCalculation>,
-            >::default())),
+            epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
         };
 
         bank.transaction_processor =

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -946,9 +946,8 @@ pub struct Bank {
 
     /// The cache of epoch rewards calculation results
     /// This is used to avoid recalculating the same epoch rewards at epoch boundary.
-    /// The outer hashmap is keyed by current epoch, and the inner hashmap is keyed by the parent slot in previous epoch.
-    epoch_rewards_calculation_cache:
-        Arc<Mutex<HashMap<Epoch, HashMap<Slot, PartitionedRewardsCalculation>>>>,
+    /// The hashmap is keyed by parent_hash.
+    epoch_rewards_calculation_cache: Arc<Mutex<HashMap<Hash, PartitionedRewardsCalculation>>>,
 }
 
 #[derive(Debug)]
@@ -6891,6 +6890,10 @@ impl Bank {
 
     pub fn get_bank_hash_stats(&self) -> BankHashStats {
         self.bank_hash_stats.load()
+    }
+
+    pub fn clear_epoch_rewards_cache(&self) {
+        self.epoch_rewards_calculation_cache.lock().unwrap().clear();
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2519,12 +2519,14 @@ impl Bank {
     fn update_reward_history(
         &self,
         stake_rewards: StakeRewards,
-        mut vote_rewards: Vec<(Pubkey, RewardInfo)>,
+        vote_rewards: &[(Pubkey, RewardInfo)],
     ) {
         let additional_reserve = stake_rewards.len() + vote_rewards.len();
         let mut rewards = self.rewards.write().unwrap();
         rewards.reserve(additional_reserve);
-        rewards.append(&mut vote_rewards);
+        vote_rewards.iter().for_each(|(vote_pubkey, vote_reward)| {
+            rewards.push((vote_pubkey.clone(), vote_reward.clone()));
+        });
         stake_rewards
             .into_iter()
             .filter(|x| x.get_stake_reward() > 0)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2545,7 +2545,7 @@ impl Bank {
         let mut rewards = self.rewards.write().unwrap();
         rewards.reserve(additional_reserve);
         vote_rewards.iter().for_each(|(vote_pubkey, vote_reward)| {
-            rewards.push((vote_pubkey.clone(), vote_reward.clone()));
+            rewards.push((*vote_pubkey, *vote_reward));
         });
         stake_rewards
             .into_iter()

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -28,7 +28,6 @@ use {
     solana_clock::{Epoch, Slot},
     solana_measure::measure_us,
     solana_pubkey::Pubkey,
-    solana_reward_info::RewardInfo,
     solana_stake_interface::state::Delegation,
     solana_sysvar::epoch_rewards::EpochRewards,
     solana_vote::vote_account::VoteAccount,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -96,16 +96,17 @@ impl Bank {
     ) -> CalculateRewardsAndDistributeVoteRewardsResult {
         // We hold the lock here for the epoch rewards calculation cache to prevent
         // rewards computation across multiple forks simultaneously. This aligns with
-        // how bank replay currently operates—all banks are replayed sequentially.
-        // As such, this lock does not actually block fork replays under the current model.
+        // how banks are currently created- all banks are created sequentially.
+        // As such, this lock does not actually introduce contention because bank
+        // creation (and therefore reward calculation) is always done sequentially.
         //
-        // However, if we plan to support parallel bank replays in the future, this logic
+        // However, if we plan to support creating banks in parallel in the future, this logic
         // would need to change to allow rewards computation on multiple forks concurrently.
         // That said, there's still a compelling reason to keep this lock even in a parallel
-        // replay model: we want to avoid calculating rewards multiple times for the same
+        // bank creation model: we want to avoid calculating rewards multiple times for the same
         // parent bank hash. This lock ensures that.
         //
-        // Processing forks in parallel would also introduce contention for compute resources,
+        // Creating bank for multiple forks in parallel would also introduce contention for compute resources,
         // potentially slowing down the performance of both forks. This, in turn, could delay
         // vote propagation and consensus for the leading fork—the one most likely to become rooted.
         //

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -94,6 +94,24 @@ impl Bank {
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> CalculateRewardsAndDistributeVoteRewardsResult {
+        // We hold the lock here for the epoch rewards calculation cache to prevent
+        // rewards computation across multiple forks simultaneously. This aligns with
+        // how bank replay currently operates—all banks are replayed sequentially.
+        // As such, this lock does not actually block fork replays under the current model.
+        //
+        // However, if we plan to support parallel bank replays in the future, this logic
+        // would need to change to allow rewards computation on multiple forks concurrently.
+        // That said, there's still a compelling reason to keep this lock even in a parallel
+        // replay model: we want to avoid calculating rewards multiple times for the same
+        // parent bank hash. This lock ensures that.
+        //
+        // Processing forks in parallel would also introduce contention for compute resources,
+        // potentially slowing down the performance of both forks. This, in turn, could delay
+        // vote propagation and consensus for the leading fork—the one most likely to become rooted.
+        //
+        // Therefore, it seems beneficial to continue processing forks sequentially at epoch
+        // boundaries: acquire the lock for the first fork, compute rewards, and let other forks
+        // wait until the computation is complete.
         let mut epoch_rewards_calculation_cache =
             self.epoch_rewards_calculation_cache.lock().unwrap();
         let rewards_calculation = epoch_rewards_calculation_cache

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -100,9 +100,8 @@ impl Bank {
             .lock()
             .unwrap()
             .get(&self.epoch)
-            .map(|m| m.get(&self.parent_slot))
-            .flatten()
-            .map(|m| m.clone());
+            .and_then(|m| m.get(&self.parent_slot))
+            .cloned();
 
         if reward_calculation.is_none() {
             let calculation = self.calculate_rewards_for_partitioning(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -122,7 +122,7 @@ impl Bank {
             prev_epoch_duration_in_years,
             capitalization,
             point_value,
-        } = rewards_calculation.unwrap();
+        } = rewards_calculation;
 
         let total_vote_rewards = vote_account_rewards.total_vote_rewards_lamports;
         self.store_vote_accounts_partitioned(&vote_account_rewards, metrics);

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -10,7 +10,7 @@ use {
         },
         stake_account::StakeAccount,
     },
-    log::error,
+    log::{error, info},
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
     solana_accounts_db::stake_rewards::StakeReward,
     solana_measure::measure_us,
@@ -129,6 +129,16 @@ impl Bank {
                 EpochRewardStatus::Active(EpochRewardPhase::Distribution(_))
             ));
             self.epoch_reward_status = EpochRewardStatus::Inactive;
+
+            self.epoch_reward_calculation_results
+                .lock()
+                .unwrap()
+                .remove(&self.epoch);
+            info!(
+                "remove epoch reward calculation result for epoch {}",
+                self.epoch
+            );
+
             self.set_epoch_rewards_sysvar_to_inactive();
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -10,7 +10,7 @@ use {
         },
         stake_account::StakeAccount,
     },
-    log::{error, info},
+    log::error,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
     solana_accounts_db::stake_rewards::StakeReward,
     solana_measure::measure_us,
@@ -129,16 +129,6 @@ impl Bank {
                 EpochRewardStatus::Active(EpochRewardPhase::Distribution(_))
             ));
             self.epoch_reward_status = EpochRewardStatus::Inactive;
-
-            self.epoch_rewards_calculation_cache
-                .lock()
-                .unwrap()
-                .remove(&self.epoch);
-            info!(
-                "removed epoch rewards calculation result for epoch {}",
-                self.epoch
-            );
-
             self.set_epoch_rewards_sysvar_to_inactive();
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -130,12 +130,12 @@ impl Bank {
             ));
             self.epoch_reward_status = EpochRewardStatus::Inactive;
 
-            self.epoch_reward_calculation_results
+            self.epoch_rewards_calculation_cache
                 .lock()
                 .unwrap()
                 .remove(&self.epoch);
             info!(
-                "remove epoch reward calculation result for epoch {}",
+                "removed epoch rewards calculation result for epoch {}",
                 self.epoch
             );
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -693,7 +693,6 @@ mod tests {
                     curr_bank.get_balance(&solana_sysvar::epoch_rewards::id());
                 assert!(epoch_rewards_lamports > 0);
             }
-            // previous_bank = Arc::new(curr_bank);
             previous_bank = curr_bank;
         }
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -374,7 +374,7 @@ mod tests {
                 .cloned()
         }
 
-        fn get_epoch_rewards_cache_size(&self) -> usize {
+        fn get_epoch_rewards_cache_len(&self) -> usize {
             self.epoch_rewards_calculation_cache.lock().unwrap().len()
         }
     }
@@ -656,7 +656,7 @@ mod tests {
                 // Make a root the bank, which is the first bank in the epoch.
                 // This will clear the cache.
                 let _ = bank_forks.write().unwrap().set_root(slot, None, None);
-                assert_eq!(curr_bank.get_epoch_rewards_cache_size(), 0);
+                assert_eq!(curr_bank.get_epoch_rewards_cache_len(), 0);
             } else if slot == SLOTS_PER_EPOCH + 1 {
                 // 1. when curr_slot == SLOTS_PER_EPOCH + 1, the 2nd block of
                 // epoch 1, reward distribution should happen in this block.
@@ -745,7 +745,7 @@ mod tests {
                 assert!(curr_bank
                     .get_epoch_rewards_from_cache(&curr_bank.parent_hash)
                     .is_some());
-                assert_eq!(curr_bank.get_epoch_rewards_cache_size(), 1);
+                assert_eq!(curr_bank.get_epoch_rewards_cache_len(), 1);
 
                 // cap should increase because of new epoch rewards
                 assert!(post_cap > pre_cap);
@@ -764,7 +764,7 @@ mod tests {
                 assert!(curr_bank
                     .get_epoch_rewards_from_cache(&starting_hash.unwrap())
                     .is_some());
-                assert_eq!(curr_bank.get_epoch_rewards_cache_size(), 1);
+                assert_eq!(curr_bank.get_epoch_rewards_cache_len(), 1);
 
                 // 1st reward distribution block, state should be partitioned.
                 assert!(curr_bank.is_partitioned());
@@ -782,7 +782,7 @@ mod tests {
                 // Now make a root the  first bank in the epoch.
                 // This should clear the cache.
                 let _ = bank_forks.write().unwrap().set_root(slot - 1, None, None);
-                assert_eq!(curr_bank.get_epoch_rewards_cache_size(), 0);
+                assert_eq!(curr_bank.get_epoch_rewards_cache_len(), 0);
             } else if slot == SLOTS_PER_EPOCH + 2 {
                 // When curr_slot == SLOTS_PER_EPOCH + 2, the 3nd block of
                 // epoch 1, reward distribution should happen in this block.

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -372,9 +372,8 @@ mod tests {
                 .lock()
                 .unwrap()
                 .get(&epoch)
-                .map(|m| m.get(&parent_slot))
-                .flatten()
-                .map(|m| m.clone())
+                .and_then(|m| m.get(&parent_slot))
+                .cloned()
         }
 
         fn get_epoch_rewards_cache_size(&self) -> usize {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -744,6 +744,11 @@ mod tests {
                     RewardInterval::InsideInterval
                 );
 
+                assert!(curr_bank
+                    .get_epoch_rewards_from_cache(curr_bank.epoch, starting_slot)
+                    .is_some());
+                assert_eq!(curr_bank.get_epoch_rewards_cache_size(), 1);
+
                 // 1st reward distribution block, state should be partitioned.
                 assert!(curr_bank.is_partitioned());
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -368,7 +368,7 @@ mod tests {
             epoch: Epoch,
             parent_slot: Slot,
         ) -> Option<PartitionedRewardsCalculation> {
-            self.epoch_reward_calculation_results
+            self.epoch_rewards_calculation_cache
                 .lock()
                 .unwrap()
                 .get(&epoch)
@@ -377,7 +377,7 @@ mod tests {
         }
 
         fn get_epoch_rewards_cache_size(&self) -> usize {
-            self.epoch_reward_calculation_results.lock().unwrap().len()
+            self.epoch_rewards_calculation_cache.lock().unwrap().len()
         }
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -646,13 +646,8 @@ mod tests {
                 assert!(curr_bank
                     .get_epoch_rewards_from_cache(&curr_bank.parent_hash)
                     .is_some());
+                assert_eq!(post_cap, pre_cap);
 
-                if slot == SLOTS_PER_EPOCH {
-                    // cap should increase because of new epoch rewards
-                    assert!(post_cap > pre_cap);
-                } else {
-                    assert_eq!(post_cap, pre_cap);
-                }
                 // Make a root the bank, which is the first bank in the epoch.
                 // This will clear the cache.
                 let _ = bank_forks.write().unwrap().set_root(slot, None, None);
@@ -746,9 +741,6 @@ mod tests {
                     .get_epoch_rewards_from_cache(&curr_bank.parent_hash)
                     .is_some());
                 assert_eq!(curr_bank.get_epoch_rewards_cache_len(), 1);
-
-                // cap should increase because of new epoch rewards
-                assert!(post_cap > pre_cap);
                 starting_hash = Some(curr_bank.parent_hash);
             } else if slot == SLOTS_PER_EPOCH + 1 {
                 // When curr_slot == SLOTS_PER_EPOCH + 1, the 2nd block of

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -94,7 +94,7 @@ pub(super) struct VoteRewardsAccounts {
 /// result of calculating the stake rewards at end of epoch
 pub(super) struct StakeRewardCalculation {
     /// each individual stake account to reward
-    stake_rewards: PartitionedStakeRewards,
+    stake_rewards: Arc<PartitionedStakeRewards>,
     /// total lamports across all `stake_rewards`
     total_stake_rewards_lamports: u64,
 }
@@ -130,7 +130,7 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 /// This struct exists so we can have a function which does all the calculation with no
 /// side effects.
 pub(super) struct PartitionedRewardsCalculation {
-    pub(super) vote_account_rewards: VoteRewardsAccounts,
+    pub(super) vote_account_rewards: Arc<VoteRewardsAccounts>,
     pub(super) stake_rewards: StakeRewardCalculation,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
@@ -148,7 +148,7 @@ pub(super) struct CalculateRewardsAndDistributeVoteRewardsResult {
     /// vote accounts
     pub(super) point_value: PointValue,
     /// stake rewards that still need to be distributed
-    pub(super) stake_rewards: Vec<PartitionedStakeReward>,
+    pub(super) stake_rewards: Arc<Vec<PartitionedStakeReward>>,
 }
 
 pub(crate) type StakeRewards = Vec<StakeReward>;
@@ -186,12 +186,12 @@ impl Bank {
     pub(crate) fn set_epoch_reward_status_calculation(
         &mut self,
         distribution_starting_block_height: u64,
-        stake_rewards: Vec<PartitionedStakeReward>,
+        stake_rewards: Arc<Vec<PartitionedStakeReward>>,
     ) {
         self.epoch_reward_status =
             EpochRewardStatus::Active(EpochRewardPhase::Calculation(StartBlockHeightAndRewards {
                 distribution_starting_block_height,
-                all_stake_rewards: Arc::new(stake_rewards),
+                all_stake_rewards: Arc::clone(&stake_rewards),
             }));
     }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -362,6 +362,12 @@ impl BankForks {
                     .unwrap()
                     .node_id_to_vote_accounts()
             );
+            // Now we have rooted a bank in a new epoch, there are no needs to
+            // keep the epoch rewards cache for current epoch any longer.
+            info!(
+                "Clearing epoch rewards cache for epoch {old_epoch} after setting root to slot {root}"
+            );
+            root_bank.clear_epoch_rewards_cache();
         }
         let root_tx_count = root_bank
             .parents()


### PR DESCRIPTION
#### Problem

Calculating epoch rewards is expensive. And recalculating epoch rewards for
every fork at epoch boundary make it even more expensive. And for case when
the multiple forks, which share the same parent node in previous epoch, we can
reuse the reward calculation results. 

In this PR, we introduce a epoch reward cache to allow reuse previous
calculated epoch rewards results.


##### Testing Result from mainnet

The following is the log for my node running against mainnet for epoch 787
with the cache. As we can see in the log, there are two forks across the epoch
boundary 787:

```
339983999 -- 339984000 (A)
   \
    \
     339984004 (B)
```

The first epoch reward computation A takes 522ms, i.e.
`update_rewards_with_thread_pool_us=522453i`. While the second epoch reward
computation (B) reuse the result from the cache by A. B only takes 1.4ms (~500X speedup)
(update_rewards_with_thread_pool_us=1419i). And almost all of B's time is to store
vote rewards (store_vote_accounts_us=1327i), computation takes almost no time!


```
agave-validator.log.1:[2025-05-14T15:07:08.675862037Z INFO  solana_runtime::bank::partitioned_epoch_rewards::calculation] calculated rewards for epoch 787 and parent_slot 339983999
agave-validator.log.1:[2025-05-14T15:07:09.432065486Z INFO  solana_runtime::bank::partitioned_epoch_rewards::calculation] rewards calculation already exists for epoch 787 and parent_slot 339983999
agave-validator.log.1:[2025-05-14T15:07:10.500016995Z INFO  solana_metrics::metrics] datapoint: bank-new_from_parent-new_epoch_timings epoch=787i slot=339984000i parent_slot=339983999i thread_pool_creation_us=4879i apply_feature_activations=924i activate_epoch_us=265292i update_epoch_stakes_us=1488i update_rewards_with_thread_pool_us=522453i calculate_points_us=49257i redeem_rewards_us=238431i store_stake_accounts_us=0i store_vote_accounts_us=2142i
agave-validator.log.1:[2025-05-14T15:07:10.500263202Z INFO  solana_metrics::metrics] datapoint: bank-new_from_parent-new_epoch_timings epoch=787i slot=339984004i parent_slot=339983999i thread_pool_creation_us=7419i apply_feature_activations=226i activate_epoch_us=259870i update_epoch_stakes_us=1347i update_rewards_with_thread_pool_us=1419i calculate_points_us=0i redeem_rewards_us=0i store_stake_accounts_us=0i store_vote_accounts_us=1327i

```

#### Summary of Changes

- Introduce epoch reward cache to reuse epoch reward computation results 




Fixes #

<!-- Don't forget to add the "feature-gate" label -->
~

