### PR TITLE
Do not insert into accounts lt hash cache if freeze has started

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -583,6 +583,7 @@ impl PartialEq for Bank {
             transaction_account_lock_limit: _,
             fee_structure: _,
             cache_for_accounts_lt_hash: _,
+            freeze_started_for_accounts_lt_hash: _,
             stats_for_accounts_lt_hash: _,
             block_id,
             bank_hash_stats: _,
@@ -934,6 +935,12 @@ pub struct Bank {
     /// and not an intermediate state within this slot.
     cache_for_accounts_lt_hash: DashMap<Pubkey, AccountsLtHashCacheValue, ahash::RandomState>,
 
+    /// A flag to indicate when freeze has started, for the accounts lt hash cache
+    ///
+    /// This is similar to `freeze_started`, but needs to be raised *before* any
+    /// deferred changes to account state is started (instead of afterwards).
+    freeze_started_for_accounts_lt_hash: AtomicBool,
+
     /// Stats related to the accounts lt hash
     stats_for_accounts_lt_hash: AccountsLtHashStats,
 
@@ -1140,6 +1147,7 @@ impl Bank {
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash::identity())),
             cache_for_accounts_lt_hash: DashMap::default(),
+            freeze_started_for_accounts_lt_hash: AtomicBool::default(),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1396,6 +1404,7 @@ impl Bank {
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
             cache_for_accounts_lt_hash: DashMap::default(),
+            freeze_started_for_accounts_lt_hash: AtomicBool::new(false),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1873,6 +1882,7 @@ impl Bank {
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash([0xBAD1; LtHash::NUM_ELEMENTS]))),
             cache_for_accounts_lt_hash: DashMap::default(),
+            freeze_started_for_accounts_lt_hash: AtomicBool::new(fields.hash != Hash::default()),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
@@ -2641,6 +2651,8 @@ impl Bank {
         // committed before this write lock can be obtained here.
         let mut hash = self.hash.write().unwrap();
         if *hash == Hash::default() {
+            self.freeze_started_for_accounts_lt_hash
+                .store(true, Ordering::Release);
             // finish up any deferred changes to account state
             self.collect_rent_eagerly();
             self.distribute_transaction_fee_details();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2652,7 +2652,7 @@ impl Bank {
         let mut hash = self.hash.write().unwrap();
         if *hash == Hash::default() {
             self.freeze_started_for_accounts_lt_hash
-                .store(true, Ordering::Release);
+                .store(true, Relaxed);
             // finish up any deferred changes to account state
             self.collect_rent_eagerly();
             self.distribute_transaction_fee_details();


### PR DESCRIPTION
#### Problem

When activating the accounts lt hash feature (SIMD-215) on testnet, there was a bank hash mismatch caused by a bad lt hash.

After investigating with @jstarry[^1], it was concluded this is possible when the leader is still executing transactions after bank freeze has started. This would allow putting an entry into the accounts lt hash cache that was *not* the initial value of the account, and instead the value after bank freeze finishes up any deferred changes to account state. Then, then calculating the lt hash for the slot, we'd compute the wrong final lt hash value, since the initial state of this account was incorrect in the cache.

Here's an example:

1. A bank calls `freeze()` and begins finishing up deferred changes to account state.
2. One of ☝️ is distributing transaction fees, and that stores updates to account `A`.
3. Concurrently, a transaction `T` is executing that includes an instruction that modifies account `A`.
4. `T` loads `A`, and as part of loading `A`, we call `inspect_account()`. The value of `A` that gets loaded is *after* step (2). The modified `A` is added to the accounts lt hash cache.
5. Transaction `T` finished executing and sees it is past the end of the block so it does not commit.
6. When calculating the accounts lt hash, we see that `A` is a modified account in this slot because of step (2). As part of subtracting out the old state of account `A`, we look at the accounts lt hash cache and see there is an entry for `A`. However, this version of `A` is the same as the modified version, and not the old version of `A`. Thus, we calculate the accounts lt hash value.

[^1]: https://discord.com/channels/428295358100013066/838890116386521088/1375339076370300958


#### Summary of Changes

Disallow adding entries to the accounts lt hash cache if freeze has started.

Note, I intend to backport this to v2.2.