### PR TITLE
streamer: Use `BytesPacket` instead of `Packet`

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -8,7 +8,7 @@ use {
         sockets::{SocketConfiguration, multi_bind_in_range_with_config},
     },
     solana_streamer::{
-        packet::{PACKET_DATA_SIZE, Packet, PacketBatchRecycler, RecycledPacketBatch},
+        packet::{PACKET_DATA_SIZE, Packet, RecycledPacketBatch},
         sendmmsg::batch_send,
         streamer::{PacketBatchReceiver, StreamerReceiveStats, receiver},
     },
@@ -122,7 +122,6 @@ fn main() -> Result<()> {
     .unwrap();
 
     let mut addr = SocketAddr::new(ip_addr, 0);
-    let recycler = PacketBatchRecycler::default();
     let exit = Arc::new(AtomicBool::new(false));
     let stats = Arc::new(StreamerReceiveStats::new("bench-streamer-test"));
 
@@ -140,10 +139,8 @@ fn main() -> Result<()> {
                 Arc::new(read_socket),
                 exit.clone(),
                 packet_sender,
-                recycler.clone(),
                 stats.clone(),
                 None, // coalesce
-                true,
                 false,
             );
 

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -6,10 +6,7 @@ use {
     solana_clock::{DEFAULT_TICKS_PER_SLOT, HOLD_TRANSACTIONS_SLOT_OFFSET},
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
     solana_packet::PacketFlags,
-    solana_perf::{
-        packet::{PacketBatchRecycler, PacketRefMut},
-        recycler::Recycler,
-    },
+    solana_perf::packet::PacketRefMut,
     solana_poh::poh_recorder::PohRecorder,
     solana_streamer::streamer::{
         self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats,
@@ -137,8 +134,6 @@ impl FetchStage {
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce: Option<Duration>,
     ) -> Self {
-        let recycler: PacketBatchRecycler = Recycler::warmed(1000, 1024);
-
         let tpu_vote_stats = Arc::new(StreamerReceiveStats::new("tpu_vote_receiver"));
         let tpu_vote_threads: Vec<_> = tpu_vote_sockets
             .into_iter()
@@ -149,10 +144,8 @@ impl FetchStage {
                     socket,
                     exit.clone(),
                     vote_sender.clone(),
-                    recycler.clone(),
                     tpu_vote_stats.clone(),
                     coalesce,
-                    true,
                     true, // only staked connections should be voting
                 )
             })

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -24,10 +24,7 @@ use {
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol, ping_pong::Pong},
     solana_keypair::{Keypair, Signer, signable::Signable},
     solana_ledger::blockstore::Blockstore,
-    solana_perf::{
-        packet::{PacketBatch, PacketFlags, PacketRef, deserialize_from_with_limit},
-        recycler::Recycler,
-    },
+    solana_perf::packet::{PacketBatch, PacketFlags, PacketRef, deserialize_from_with_limit},
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::streamer::{self, PacketBatchReceiver, StreamerReceiveStats},
@@ -165,12 +162,10 @@ impl AncestorHashesService {
             ancestor_hashes_request_socket.clone(),
             exit.clone(),
             response_sender.clone(),
-            Recycler::default(),
             Arc::new(StreamerReceiveStats::new(
                 "ancestor_hashes_response_receiver",
             )),
             Some(Duration::from_millis(1)), // coalesce
-            false,                          // use_pinned_memory
             false,                          // is_staked_service
         );
 
@@ -1313,10 +1308,8 @@ mod test {
                 Arc::new(responder_node.sockets.serve_repair),
                 exit.clone(),
                 requests_sender,
-                Recycler::default(),
                 Arc::new(StreamerReceiveStats::new("repair_request_receiver")),
                 Some(Duration::from_millis(1)), // coalesce
-                false,
                 false,
             );
             let (remote_request_sender, remote_request_receiver) = unbounded();

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1244,6 +1244,7 @@ mod test {
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
         solana_runtime::bank::Bank,
         solana_signer::Signer,
+        solana_streamer::packet::BytesPacketBatch,
         solana_time_utils::timestamp,
         std::collections::HashSet,
     };
@@ -1278,8 +1279,8 @@ mod test {
         );
 
         // Receive and translate repair packet
-        let mut packets = vec![solana_packet::Packet::default(); 1];
-        let _recv_count = solana_streamer::recvmmsg::recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(1);
+        let _recv_count = solana_streamer::recvmmsg::recv_mmsg(&reader, &mut packets).unwrap();
         let packet = &packets[0];
         let Some(bytes) = packet.data(..).map(Vec::from) else {
             panic!("packet data not found");

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -3,7 +3,7 @@ use {
     bytes::Bytes,
     crossbeam_channel::{Receiver, Sender, unbounded},
     solana_net_utils::SocketAddrSpace,
-    solana_perf::{packet::PacketBatch, recycler::Recycler},
+    solana_perf::packet::PacketBatch,
     solana_streamer::streamer::{self, StreamerReceiveStats},
     std::{
         net::{SocketAddr, UdpSocket},
@@ -36,10 +36,8 @@ impl ServeRepairService {
             serve_repair_socket.clone(),
             exit.clone(),
             request_sender,
-            Recycler::default(),
             Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
             Some(Duration::from_millis(1)), // coalesce
-            false,                          // use_pinned_memory
             false,                          // is_staked_service
         );
         let t_packet_adapter = Builder::new()

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -12,9 +12,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::shred::{self, ShredFetchStats, should_discard_shred},
     solana_packet::{Meta, PACKET_DATA_SIZE},
-    solana_perf::packet::{
-        BytesPacket, BytesPacketBatch, PacketBatch, PacketBatchRecycler, PacketFlags, PacketRef,
-    },
+    solana_perf::packet::{BytesPacket, BytesPacketBatch, PacketBatch, PacketFlags, PacketRef},
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::{
@@ -185,7 +183,6 @@ impl ShredFetchStage {
         sockets: Vec<Arc<UdpSocket>>,
         exit: Arc<AtomicBool>,
         sender: EvictingSender<PacketBatch>,
-        recycler: PacketBatchRecycler,
         bank_forks: Arc<RwLock<BankForks>>,
         shred_version: u16,
         name: &'static str,
@@ -207,10 +204,8 @@ impl ShredFetchStage {
                     socket,
                     exit.clone(),
                     packet_sender.clone(),
-                    recycler.clone(),
                     receiver_stats.clone(),
                     Some(Duration::from_millis(5)), // coalesce
-                    true,                           // use_pinned_memory
                     false,                          // is_staked_service
                 )
             })
@@ -247,7 +242,6 @@ impl ShredFetchStage {
         turbine_disabled: Arc<AtomicBool>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let recycler = PacketBatchRecycler::warmed(100, 1024);
         let repair_context = RepairContext {
             repair_socket: repair_socket.clone(),
             cluster_info,
@@ -260,7 +254,6 @@ impl ShredFetchStage {
             sockets,
             exit.clone(),
             sender.clone(),
-            recycler.clone(),
             bank_forks.clone(),
             shred_version,
             "shred_fetch",
@@ -276,7 +269,6 @@ impl ShredFetchStage {
             vec![repair_socket],
             exit.clone(),
             sender.clone(),
-            recycler,
             bank_forks.clone(),
             shred_version,
             "shred_fetch_repair",

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -10,7 +10,6 @@ use {
     crossbeam_channel::Sender,
     solana_keypair::Keypair,
     solana_net_utils::{DEFAULT_IP_ECHO_SERVER_THREADS, SocketAddrSpace},
-    solana_perf::recycler::Recycler,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     solana_signer::Signer,
@@ -63,10 +62,8 @@ impl GossipService {
             cluster_info.bind_ip_addrs(),
             exit.clone(),
             request_sender,
-            Recycler::default(),
             gossip_receiver_stats.clone(),
             Some(Duration::from_millis(1)), // coalesce
-            false,
             false,
         );
         let (consume_sender, listen_receiver) =

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -20,8 +20,8 @@ use {
 pub use {
     solana_packet::{Meta, PACKET_DATA_SIZE, Packet},
     solana_perf::packet::{
-        NUM_PACKETS, PACKETS_PER_BATCH, PacketBatch, PacketBatchRecycler, PacketRef, PacketRefMut,
-        RecycledPacketBatch,
+        BytesPacket, BytesPacketBatch, NUM_PACKETS, PACKETS_PER_BATCH, PacketBatch,
+        PacketBatchRecycler, PacketRef, PacketRefMut, RecycledPacketBatch,
     },
 };
 
@@ -35,14 +35,14 @@ This is a wrapper around recvmmsg(7) call.
 */
 #[cfg(not(unix))]
 pub(crate) fn recv_from(
-    batch: &mut RecycledPacketBatch,
+    batch: &mut BytesPacketBatch,
     socket: &UdpSocket,
     // If max_wait is None, reads from the socket until either:
     //   * 64 packets are read (PACKETS_PER_BATCH == 64), or
     //   * There are no more data available to read from the socket.
     max_wait: Option<Duration>,
 ) -> Result<usize> {
-    let mut i = 0;
+    batch.clear();
     //DOCUMENTED SIDE-EFFECT
     //Performance out of the IO without poll
     //  * block on the socket until it's readable
@@ -54,9 +54,8 @@ pub(crate) fn recv_from(
     let should_wait = max_wait.is_some();
     let start = should_wait.then(Instant::now);
     loop {
-        batch.resize(PACKETS_PER_BATCH, Packet::default());
-        match recv_mmsg(socket, &mut batch[i..]) {
-            Err(err) if i > 0 => {
+        match recv_mmsg(socket, batch) {
+            Err(err) if !batch.is_empty() => {
                 if !should_wait && err.kind() == ErrorKind::WouldBlock {
                     break;
                 }
@@ -66,14 +65,13 @@ pub(crate) fn recv_from(
                 return Err(e);
             }
             Ok(npkts) => {
-                if i == 0 {
+                if batch.is_empty() {
                     socket.set_nonblocking(true)?;
                 }
                 trace!("got {npkts} packets");
-                i += npkts;
                 // Try to batch into big enough buffers
                 // will cause less re-shuffling later on.
-                if i >= PACKETS_PER_BATCH {
+                if batch.len() >= PACKETS_PER_BATCH {
                     break;
                 }
             }
@@ -82,15 +80,14 @@ pub(crate) fn recv_from(
             break;
         }
     }
-    batch.truncate(i);
-    Ok(i)
+    Ok(batch.len())
 }
 
 /// Receive multiple messages from `sock` into buffer provided in `batch`.
 /// This is a wrapper around recvmmsg(7) call.
 #[cfg(unix)]
 pub(crate) fn recv_from(
-    batch: &mut RecycledPacketBatch,
+    batch: &mut BytesPacketBatch,
     socket: &UdpSocket,
     // If max_wait is None, reads from the socket until either:
     //   * 64 packets are read (PACKETS_PER_BATCH == 64), or
@@ -133,7 +130,7 @@ pub(crate) fn recv_from(
     /// - If any packets were read, the function will exit.
     /// - If no packets were read, the function will return an error.
     fn recv_from_once(
-        batch: &mut RecycledPacketBatch,
+        batch: &mut BytesPacketBatch,
         socket: &UdpSocket,
         poll_fd: &mut [PollFd],
     ) -> Result<usize> {
@@ -141,7 +138,7 @@ pub(crate) fn recv_from(
         let mut did_poll = false;
 
         loop {
-            match recv_mmsg(socket, &mut batch[i..]) {
+            match recv_mmsg(socket, batch) {
                 Ok(npkts) => {
                     i += npkts;
                     if i >= PACKETS_PER_BATCH {
@@ -178,7 +175,7 @@ pub(crate) fn recv_from(
     /// On subsequent iterations, when [`ErrorKind::WouldBlock`] is encountered, poll for the
     /// saturating duration since the start of the loop.
     fn recv_from_coalesce(
-        batch: &mut RecycledPacketBatch,
+        batch: &mut BytesPacketBatch,
         socket: &UdpSocket,
         max_wait: Duration,
         poll_fd: &mut [PollFd],
@@ -199,12 +196,11 @@ pub(crate) fn recv_from(
         // `ppoll` is not supported on non-linuxish platforms, so we use `poll`, which only
         // supports millisecond precision.
         const MIN_POLL_DURATION: Duration = Duration::from_millis(1);
-
         let mut i = 0;
         let deadline = Instant::now() + max_wait;
 
         loop {
-            match recv_mmsg(socket, &mut batch[i..]) {
+            match recv_mmsg(socket, batch) {
                 Ok(npkts) => {
                     i += npkts;
                     if i >= PACKETS_PER_BATCH {
@@ -269,12 +265,11 @@ pub(crate) fn recv_from(
 
     trace!("receiving on {}", socket.local_addr().unwrap());
 
+    batch.clear();
     let i = match max_wait {
         Some(max_wait) => recv_from_coalesce(batch, socket, max_wait, poll_fd),
         None => recv_from_once(batch, socket, poll_fd),
     }?;
-
-    batch.truncate(i);
 
     Ok(i)
 }
@@ -316,7 +311,7 @@ mod tests {
     }
 
     fn recv_from(
-        batch: &mut RecycledPacketBatch,
+        batch: &mut BytesPacketBatch,
         socket: &UdpSocket,
         max_wait: Option<Duration>,
     ) -> Result<usize> {
@@ -350,9 +345,7 @@ mod tests {
         }
         send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
 
-        batch
-            .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+        let mut batch = BytesPacketBatch::with_capacity(PACKETS_PER_BATCH);
         let recvd = recv_from(
             &mut batch,
             &recv_socket,
@@ -396,8 +389,6 @@ mod tests {
         let recv_socket = bind_to_localhost_unique().expect("should bind - receiver");
         let addr = recv_socket.local_addr().unwrap();
         let send_socket = bind_to_localhost_unique().expect("should bind - sender");
-        let mut batch = RecycledPacketBatch::with_capacity(PACKETS_PER_BATCH);
-        batch.resize(PACKETS_PER_BATCH, Packet::default());
 
         // Should only get PACKETS_PER_BATCH packets per iteration even
         // if a lot more were sent, and regardless of packet size
@@ -411,6 +402,7 @@ mod tests {
             }
             send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
         }
+        let mut batch = BytesPacketBatch::with_capacity(PACKETS_PER_BATCH);
         let recvd = recv_from(
             &mut batch,
             &recv_socket,

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -13,18 +13,27 @@ use {
     },
 };
 use {
-    crate::packet::{Meta, Packet},
+    crate::packet::{BytesPacketBatch, Meta, PACKET_DATA_SIZE},
+    bytes::BytesMut,
+    solana_perf::packet::BytesPacket,
     std::{cmp, io, net::UdpSocket},
 };
 
 #[cfg(not(target_os = "linux"))]
-pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num packets:*/ usize> {
-    debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
+pub fn recv_mmsg(
+    socket: &UdpSocket,
+    packets: &mut BytesPacketBatch,
+) -> io::Result</*num packets:*/ usize> {
     let mut i = 0;
-    let count = cmp::min(PACKETS_PER_BATCH, packets.len());
-    for p in packets.iter_mut().take(count) {
-        p.meta_mut().size = 0;
-        match socket.recv_from(p.buffer_mut()) {
+    let remaining_capacity = packets.capacity().saturating_sub(packets.len());
+    let count = cmp::min(PACKETS_PER_BATCH, remaining_capacity);
+    for _ in 0..count {
+        let mut buffer = BytesMut::with_capacity(PACKET_DATA_SIZE);
+        // SAFETY: `buffer` has capacity for `PACKET_DATA_SIZE` bytes,
+        // and the OS immediately writes exactly the bytes reported by `nrecv`.
+        let recv_slice =
+            unsafe { std::slice::from_raw_parts_mut(buffer.as_mut_ptr(), PACKET_DATA_SIZE) };
+        match socket.recv_from(recv_slice) {
             Err(_) if i > 0 => {
                 break;
             }
@@ -32,11 +41,12 @@ pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num
                 return Err(e);
             }
             Ok((nrecv, from)) => {
-                p.meta_mut().size = nrecv;
-                p.meta_mut().set_socket_addr(&from);
-                if i == 0 {
-                    socket.set_nonblocking(true)?;
-                }
+                // SAFETY: The OS wrote `nrecv` initialized bytes into `recv_slice`.
+                unsafe { buffer.set_len(nrecv) };
+                let mut meta = Meta::default();
+                meta.size = nrecv;
+                meta.set_socket_addr(&from);
+                packets.push(BytesPacket::new(buffer.freeze(), meta));
             }
         }
         i += 1;
@@ -91,14 +101,16 @@ this function
  prior to calling this function if you require this to actually time out after 1 second.
 */
 #[cfg(target_os = "linux")]
-pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num packets:*/ usize> {
-    // Should never hit this, but bail if the caller didn't provide any Packets
-    // to receive into
-    if packets.is_empty() {
+pub fn recv_mmsg(
+    sock: &UdpSocket,
+    packets: &mut BytesPacketBatch,
+) -> io::Result</*num packets:*/ usize> {
+    let remaining_capacity = packets.capacity().saturating_sub(packets.len());
+    // Should never hit this, but bail if the batch provided by the caller does
+    // not have any remaining capacity
+    if remaining_capacity == 0 {
         return Ok(0);
     }
-    // Assert that there are no leftovers in packets.
-    debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
     const SOCKADDR_STORAGE_SIZE: socklen_t = mem::size_of::<sockaddr_storage>() as socklen_t;
 
     let mut iovs = [MaybeUninit::uninit(); PACKETS_PER_BATCH];
@@ -106,15 +118,15 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
     let mut hdrs = [MaybeUninit::uninit(); PACKETS_PER_BATCH];
 
     let sock_fd = sock.as_raw_fd();
-    let count = cmp::min(iovs.len(), packets.len());
+    let count = cmp::min(PACKETS_PER_BATCH, remaining_capacity);
 
-    for (packet, hdr, iov, addr) in
-        izip!(packets.iter_mut(), &mut hdrs, &mut iovs, &mut addrs).take(count)
-    {
-        let buffer = packet.buffer_mut();
+    let mut buffers = Vec::with_capacity(count);
+
+    for (hdr, iov, addr) in izip!(&mut hdrs, &mut iovs, &mut addrs).take(count) {
+        let mut buffer = BytesMut::with_capacity(PACKET_DATA_SIZE);
         iov.write(iovec {
             iov_base: buffer.as_mut_ptr() as *mut libc::c_void,
-            iov_len: buffer.len(),
+            iov_len: PACKET_DATA_SIZE,
         });
 
         let msg_hdr = create_msghdr(addr, SOCKADDR_STORAGE_SIZE, iov);
@@ -123,6 +135,7 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
             msg_len: 0,
             msg_hdr,
         });
+        buffers.push(buffer);
     }
 
     let mut ts = libc::timespec {
@@ -145,7 +158,7 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
     } else {
         usize::try_from(nrecv).unwrap()
     };
-    for (addr, hdr, pkt) in izip!(addrs, hdrs, packets.iter_mut()).take(nrecv) {
+    for (addr, hdr, mut buffer) in izip!(addrs, hdrs, buffers).take(nrecv) {
         // SAFETY: We initialized `count` elements of `hdrs` above. `count` is
         // passed to recvmmsg() as the limit of messages that can be read. So,
         // `nrevc <= count` which means we initialized this `hdr` and
@@ -154,10 +167,17 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
         // SAFETY: Similar to above, we initialized this `addr` and recvmmsg()
         // will have populated it
         let addr_ref = unsafe { addr.assume_init_ref() };
-        pkt.meta_mut().size = hdr_ref.msg_len as usize;
+        // let mut buffer = BytesMut::new();
+        // std::mem::swap(&mut buffer, &mut buffers[i]);
+        let msg_len = hdr_ref.msg_len as usize;
+        // SAFETY: `recvmmsg` wrote `msg_len` initialized bytes into the buffer.
+        unsafe { buffer.set_len(msg_len) };
+        let mut meta = Meta::default();
+        meta.size = msg_len;
         if let Some(addr) = cast_socket_addr(addr_ref, hdr_ref) {
-            pkt.meta_mut().set_socket_addr(&addr);
+            meta.set_socket_addr(&addr);
         }
+        packets.push(BytesPacket::new(buffer.freeze(), meta));
     }
 
     for (iov, addr, hdr) in izip!(&mut iovs, &mut addrs, &mut hdrs).take(count) {
@@ -181,7 +201,10 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
 #[cfg(test)]
 mod tests {
     use {
-        crate::{packet::PACKET_DATA_SIZE, recvmmsg::*},
+        crate::{
+            packet::{BytesPacketBatch, PACKET_DATA_SIZE},
+            recvmmsg::*,
+        },
         solana_net_utils::sockets::{
             SocketConfiguration as SocketConfig, bind_in_range_with_config,
             localhost_port_range_for_tests, unique_port_range_for_tests,
@@ -223,8 +246,8 @@ mod tests {
                 sender.send_to(&data[..], addr).unwrap();
             }
 
-            let mut packets = vec![Packet::default(); TEST_NUM_MSGS];
-            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            let mut packets = BytesPacketBatch::with_capacity(TEST_NUM_MSGS);
+            let recv = recv_mmsg(&reader, &mut packets).unwrap();
             assert_eq!(sent, recv);
             for packet in packets.iter().take(recv) {
                 assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
@@ -249,18 +272,16 @@ mod tests {
                 sender.send_to(&data[..], addr).unwrap();
             }
 
-            let mut packets = vec![Packet::default(); TEST_NUM_MSGS];
-            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            let mut packets = BytesPacketBatch::with_capacity(TEST_NUM_MSGS);
+            let recv = recv_mmsg(&reader, &mut packets).unwrap();
             assert_eq!(TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
                 assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
                 assert_eq!(packet.meta().socket_addr(), saddr);
             }
 
-            packets
-                .iter_mut()
-                .for_each(|pkt| *pkt.meta_mut() = Meta::default());
-            let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+            packets.clear();
+            let recv = recv_mmsg(&reader, &mut packets).unwrap();
             assert_eq!(sent - TEST_NUM_MSGS, recv);
             for packet in packets.iter().take(recv) {
                 assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
@@ -289,8 +310,8 @@ mod tests {
         }
 
         let start = Instant::now();
-        let mut packets = vec![Packet::default(); TEST_NUM_MSGS];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(TEST_NUM_MSGS);
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
             assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
@@ -298,10 +319,8 @@ mod tests {
         }
         reader.set_nonblocking(true).unwrap();
 
-        packets
-            .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
-        let _recv = recv_mmsg(&reader, &mut packets[..]);
+        packets.clear();
+        let _recv = recv_mmsg(&reader, &mut packets);
         assert!(start.elapsed().as_secs() < 5);
     }
 
@@ -334,24 +353,21 @@ mod tests {
             let data = [0; PACKET_DATA_SIZE];
             sender2.send_to(&data[..], reader_addr).unwrap();
         }
+        let mut packets = BytesPacketBatch::with_capacity(TEST_NUM_MSGS);
 
-        let mut packets = vec![Packet::default(); TEST_NUM_MSGS];
-
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(sent1) {
             assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), sender1_addr);
         }
-        for packet in packets.iter().skip(sent1).take(recv - sent1) {
+        for packet in packets.iter().skip(sent1) {
             assert_eq!(packet.meta().size, PACKET_DATA_SIZE);
             assert_eq!(packet.meta().socket_addr(), sender_addr);
         }
 
-        packets
-            .iter_mut()
-            .for_each(|pkt| *pkt.meta_mut() = Meta::default());
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        packets.clear();
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(sent1 + sent2 - TEST_NUM_MSGS, recv);
         for packet in packets.iter().take(recv) {
             assert_eq!(packet.meta().size, PACKET_DATA_SIZE);

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -242,7 +242,7 @@ where
 mod tests {
     use {
         crate::{
-            packet::Packet,
+            packet::{BytesPacketBatch, Packet},
             recvmmsg::recv_mmsg,
             sendmmsg::{SendPktsError, batch_send, multi_target_send},
         },
@@ -267,8 +267,8 @@ mod tests {
         let sent = batch_send(&sender, packet_refs).ok();
         assert_eq!(sent, Some(()));
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(32, recv);
     }
 
@@ -298,12 +298,12 @@ mod tests {
         let sent = batch_send(&sender, packet_refs).ok();
         assert_eq!(sent, Some(()));
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(16, recv);
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader2, &mut packets).unwrap();
         assert_eq!(16, recv);
     }
 
@@ -333,20 +333,20 @@ mod tests {
         .ok();
         assert_eq!(sent, Some(()));
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         assert_eq!(1, recv);
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader2, &mut packets).unwrap();
         assert_eq!(1, recv);
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader3, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader3, &mut packets).unwrap();
         assert_eq!(1, recv);
 
-        let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader4, &mut packets[..]).unwrap();
+        let mut packets = BytesPacketBatch::with_capacity(32);
+        let recv = recv_mmsg(&reader4, &mut packets).unwrap();
         assert_eq!(1, recv);
     }
 

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -3,10 +3,7 @@
 
 use {
     crate::{
-        packet::{
-            self, PACKETS_PER_BATCH, Packet, PacketBatch, PacketBatchRecycler, PacketRef,
-            RecycledPacketBatch,
-        },
+        packet::{self, BytesPacketBatch, PACKETS_PER_BATCH, PacketBatch, PacketRef},
         sendmmsg::{SendPktsError, batch_send},
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
@@ -161,10 +158,8 @@ fn recv_loop<P: SocketProvider>(
     provider: &mut P,
     exit: &AtomicBool,
     packet_batch_sender: &impl ChannelSend<PacketBatch>,
-    recycler: &PacketBatchRecycler,
     stats: &StreamerReceiveStats,
     coalesce: Option<Duration>,
-    use_pinned_memory: bool,
     is_staked_service: bool,
 ) -> Result<()> {
     fn setup_socket(socket: &UdpSocket) -> Result<()> {
@@ -185,12 +180,7 @@ fn recv_loop<P: SocketProvider>(
     let mut poll_fd = [PollFd::new(socket.as_fd(), PollFlags::POLLIN)];
 
     loop {
-        let mut packet_batch = if use_pinned_memory {
-            RecycledPacketBatch::new_with_recycler(recycler, PACKETS_PER_BATCH, stats.name)
-        } else {
-            RecycledPacketBatch::with_capacity(PACKETS_PER_BATCH)
-        };
-        packet_batch.resize(PACKETS_PER_BATCH, Packet::default());
+        let mut packet_batch = BytesPacketBatch::with_capacity(PACKETS_PER_BATCH);
 
         loop {
             // Check for exit signal, even if socket is busy
@@ -223,7 +213,8 @@ fn recv_loop<P: SocketProvider>(
                     packet_batch
                         .iter_mut()
                         .for_each(|p| p.meta_mut().set_from_staked_node(is_staked_service));
-                    match packet_batch_sender.try_send(packet_batch.into()) {
+                    let batch = PacketBatch::from(packet_batch);
+                    match packet_batch_sender.try_send(batch) {
                         Ok(_) => {}
                         Err(TrySendError::Full(_)) => {
                             stats.num_packets_dropped.fetch_add(len, Ordering::Relaxed);
@@ -255,10 +246,8 @@ pub fn receiver(
     socket: Arc<UdpSocket>,
     exit: Arc<AtomicBool>,
     packet_batch_sender: impl ChannelSend<PacketBatch>,
-    recycler: PacketBatchRecycler,
     stats: Arc<StreamerReceiveStats>,
     coalesce: Option<Duration>,
-    use_pinned_memory: bool,
     is_staked_service: bool,
 ) -> JoinHandle<()> {
     Builder::new()
@@ -269,10 +258,8 @@ pub fn receiver(
                 &mut provider,
                 &exit,
                 &packet_batch_sender,
-                &recycler,
                 &stats,
                 coalesce,
-                use_pinned_memory,
                 is_staked_service,
             );
         })
@@ -286,10 +273,8 @@ pub fn receiver_atomic(
     bind_ip_addrs: Arc<BindIpAddrs>,
     exit: Arc<AtomicBool>,
     packet_batch_sender: impl ChannelSend<PacketBatch>,
-    recycler: PacketBatchRecycler,
     stats: Arc<StreamerReceiveStats>,
     coalesce: Option<Duration>,
-    use_pinned_memory: bool,
     is_staked_service: bool,
 ) -> JoinHandle<()> {
     Builder::new()
@@ -300,10 +285,8 @@ pub fn receiver_atomic(
                 &mut provider,
                 &exit,
                 &packet_batch_sender,
-                &recycler,
                 &stats,
                 coalesce,
-                use_pinned_memory,
                 is_staked_service,
             );
         })
@@ -603,7 +586,6 @@ mod test {
         },
         crossbeam_channel::unbounded,
         solana_net_utils::sockets::bind_to_localhost_unique,
-        solana_perf::recycler::Recycler,
         std::{
             io::{self, Write},
             sync::{
@@ -648,10 +630,8 @@ mod test {
             Arc::new(read),
             exit.clone(),
             s_reader,
-            Recycler::default(),
             stats.clone(),
             Some(Duration::from_millis(1)), // coalesce
-            true,
             false,
         );
         const NUM_PACKETS: usize = 5;

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -3,7 +3,7 @@
 use {
     solana_net_utils::sockets::bind_to_localhost_unique,
     solana_streamer::{
-        packet::{Meta, PACKET_DATA_SIZE, Packet},
+        packet::{BytesPacketBatch, PACKET_DATA_SIZE},
         recvmmsg::*,
     },
     std::time::Instant,
@@ -25,13 +25,14 @@ pub fn test_recv_mmsg_batch_size() {
             let data = [0; PACKET_DATA_SIZE];
             sender.send_to(&data[..], addr).unwrap();
         }
-        let mut packets = vec![Packet::default(); TEST_BATCH_SIZE];
+        let mut packets = BytesPacketBatch::with_capacity(TEST_BATCH_SIZE);
         let now = Instant::now();
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
+        let recv = recv_mmsg(&reader, &mut packets).unwrap();
         elapsed_in_max_batch += now.elapsed().as_nanos();
         if recv == TEST_BATCH_SIZE {
             num_max_batches += 1;
         }
+        packets.clear();
     });
     assert!(num_max_batches > 990);
 
@@ -41,17 +42,15 @@ pub fn test_recv_mmsg_batch_size() {
             let data = [0; PACKET_DATA_SIZE];
             sender.send_to(&data[..], addr).unwrap();
         }
-        let mut packets = vec![Packet::default(); 4];
+        let mut packets = BytesPacketBatch::with_capacity(4);
         let mut recv = 0;
         let now = Instant::now();
-        while let Ok(num) = recv_mmsg(&reader, &mut packets[..]) {
+        while let Ok(num) = recv_mmsg(&reader, &mut packets) {
             recv += num;
             if recv >= TEST_BATCH_SIZE {
                 break;
             }
-            packets
-                .iter_mut()
-                .for_each(|pkt| *pkt.meta_mut() = Meta::default());
+            packets.clear();
         }
         elapsed_in_small_batch += now.elapsed().as_nanos();
         assert_eq!(TEST_BATCH_SIZE, recv);


### PR DESCRIPTION
#### Problem

The `Packet` struct stores the payload in a byte array. Using that struct often involves moving and cloning it, which then results in large memory copies.

#### Summary of Changes

`BytesPacket` is the new type of packet (introduced in anza-xyz/agave#5646) which uses `bytes::Bytes` and therefore doesn't make an actual copy of the underlying data. We use it in QUIC servers already.

Use it in the UDP streamer as well, to let the other components of Agave (gossip, turbine etc.) benefit from the zero-copy capabilities.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
