### PR TITLE
Always do startup accounts verification with fastboot if lt hash feature is not active

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -381,7 +381,7 @@ pub fn bank_from_snapshot_dir(
         storage,
         next_append_vec_id,
     };
-    let ((bank, _info), measure_rebuild_bank) = measure_time!(
+    let ((bank, info), measure_rebuild_bank) = measure_time!(
         rebuild_bank_from_snapshot(
             bank_snapshot,
             account_paths,
@@ -400,9 +400,27 @@ pub fn bank_from_snapshot_dir(
     );
     info!("{}", measure_rebuild_bank);
 
-    // Skip bank.verify_snapshot_bank.  Subsequent snapshot requests/accounts hash verification requests
-    // will calculate and check the accounts hash, so we will still have safety/correctness there.
-    bank.set_initial_accounts_hash_verification_completed();
+    if bank
+        .feature_set
+        .is_active(&feature_set::accounts_lt_hash::id())
+    {
+        // Skip bank.verify_snapshot_bank.  Subsequent snapshot requests/accounts hash verification requests
+        // will calculate and check the accounts hash, so we will still have safety/correctness there.
+        bank.set_initial_accounts_hash_verification_completed();
+    } else {
+        // Until the accounts lattice hash feature is enabled, always do accounts verification
+        if !bank.verify_snapshot_bank(
+            false,     // do not test hash calculation
+            true,      // do not shrink
+            false,     // do not clean
+            Slot::MIN, // doesn't matter, only used for calling clean (which we are skipping)
+            None,      // not used for lt hash
+            info.duplicates_lt_hash,
+        ) && limit_load_slot_count_from_snapshot.is_none()
+        {
+            panic!("Snapshot bank for slot {} failed to verify", bank.slot());
+        }
+    }
 
     let timings = BankFromDirTimings {
         rebuild_storages_us: measure_rebuild_storages.as_us(),


### PR DESCRIPTION
#### Problem

We are now computing the accounts lattice hash by default, even though the *feature* is only active on testnet.  This is done so that when we do activate the feature, nodes do not have to perform the initial accounts lattice hash calculation at the epoch boundary (which will be a few minutes on mainnet-beta).

At startup, we do accounts verification -- if we loaded from a snapshot *archive*.  If we fastbooted, then we skip this verification.

And therein lies the problem.

If the accounts lattice hash feature is *not* active, and we always fastboot, then the actual accounts lattice hash value is never verified.  This means a node could have an incorrect value and not find out until the feature is activated, which would result in the node crashing[^1].

We want to catch any incorrect accounts lattice hash values well before feature activation.

[^1]: See https://github.com/anza-xyz/agave/pull/6307 for an example of this problem happening on testnet.


#### Summary of Changes

If the accounts lattice hash feature is not active, and we're fastbooting, then always do the startup accounts verification.

Note, I intend to backport this to v2.2.


#### Additional Testing

I ran this on a mainnet-beta node and confirmed with fastboot that startup accounts verification was indeed done.  I then ran this on a testnet node and confirmed with fastboot that startup accounts verification was *not* done (since the accounts lattice hash feature is active there).