### PR TITLE
Add AppendVec::new_from_reader

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -445,10 +445,10 @@ impl AppendVec {
     }
 
     /// Used to open append vec from a stream of bytes
-    pub fn new_from_reader<R: Read>(reader: &mut R, current_len: usize) -> Self {
-        let mut mmap = MmapMut::map_anon(current_len).unwrap();
-        copy(&mut reader.take(current_len as u64), &mut mmap.as_mut()).unwrap();
-        AppendVec {
+    pub fn new_from_reader<R: Read>(reader: &mut R, current_len: usize) -> Result<Self> {
+        let mut mmap = MmapMut::map_anon(current_len)?;
+        copy(&mut reader.take(current_len as u64), &mut mmap.as_mut())?;
+        Ok(AppendVec {
             path: PathBuf::default(),
             backing: AppendVecFileBacking::Mmap(mmap),
             append_lock: Mutex::new(()),
@@ -456,7 +456,7 @@ impl AppendVec {
             file_size: current_len as u64,
             remove_file_on_drop: AtomicBool::new(false),
             is_dirty: AtomicBool::new(false),
-        }
+        })
     }
 
     /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -7,6 +7,7 @@
 mod meta;
 pub mod test_utils;
 
+use std::io::copy;
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
@@ -40,7 +41,7 @@ use {
         self,
         convert::TryFrom,
         fs::{remove_file, File, OpenOptions},
-        io::{Seek, SeekFrom, Write},
+        io::{Seek, SeekFrom, Write, Read},
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,
@@ -441,6 +442,21 @@ impl AppendVec {
         }
 
         Ok((new, num_accounts))
+    }
+
+    /// Used to open append vec from a stream of bytes
+    pub fn new_from_reader<R: Read>(reader: &mut R, current_len: usize) -> Self {
+        let mut mmap = MmapMut::map_anon(current_len).unwrap();
+        copy(&mut reader.take(current_len as u64), &mut mmap.as_mut()).unwrap();
+        AppendVec {
+            path: PathBuf::default(),
+            backing: AppendVecFileBacking::Mmap(mmap),
+            append_lock: Mutex::new(()),
+            current_len: AtomicUsize::new(current_len),
+            file_size: current_len as u64,
+            remove_file_on_drop: AtomicBool::new(false),
+            is_dirty: AtomicBool::new(false),
+        }
     }
 
     /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -7,7 +7,6 @@
 mod meta;
 pub mod test_utils;
 
-use std::io::copy;
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
@@ -41,7 +40,7 @@ use {
         self,
         convert::TryFrom,
         fs::{remove_file, File, OpenOptions},
-        io::{Seek, SeekFrom, Write, Read},
+        io::{copy, Read, Seek, SeekFrom, Write},
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,


### PR DESCRIPTION
#### Problem
I am trying to revive [solana-snapshot-etl](https://github.com/riptl/solana-snapshot-etl/tree/main), but it has locally copied many fields and methods instead of importing them from Agave libraries. I have a WIP revived version [here](https://github.com/riptl/solana-snapshot-etl/compare/main...jito-labs:solana-snapshot-etl:lb/revive?expand=1) that uses new_from_reader locally.

#### Summary of Changes
Add `AppendVec::new_from_reader` method, which lets one open an AppendVec from a stream of bytes (a compressed file) to iterate over the appendvec fast.

#### Note to maintainers
Unfortunately I am not familiar with this code, so if a maintainer can leave comments of tests and other checks that need to be performed I would be more than happy to add them.