### PR TITLE
add a new metrics transaction_dropped

### DIFF
--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -1,9 +1,9 @@
 use {
-    solana_poh::poh_recorder::{BankStart, PohRecorder},
     solana_clock::{
         DEFAULT_TICKS_PER_SLOT, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
         HOLD_TRANSACTIONS_SLOT_OFFSET,
     },
+    solana_poh::poh_recorder::{BankStart, PohRecorder},
     solana_pubkey::Pubkey,
     std::{
         sync::{Arc, RwLock},
@@ -139,10 +139,10 @@ mod tests {
     use {
         super::*,
         core::panic,
+        solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         solana_ledger::{blockstore::Blockstore, genesis_utils::create_genesis_config},
         solana_poh::poh_recorder::create_test_recorder,
         solana_runtime::bank::Bank,
-        solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         std::{
             env::temp_dir,
             sync::{atomic::Ordering, Arc},

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -17,7 +17,7 @@ use {
     solana_keypair::Keypair,
     std::{
         net::{SocketAddr, UdpSocket},
-        sync::Arc,
+        sync::{atomic::Ordering, Arc},
     },
     thiserror::Error,
     tokio::sync::{mpsc, watch},
@@ -138,17 +138,18 @@ impl From<StakeIdentity> for QuicClientCertificate {
 /// accordingly.
 #[async_trait]
 pub trait WorkersBroadcaster {
-    /// Sends a `transaction_batch` to workers associated with the given
+    /// Sends a `transaction_batch` to the workers associated with the given
     /// `leaders` addresses.
     ///
-    /// Returns error if a critical issue occurs, e.g. the implementation
-    /// encounters an unrecoverable error. In this case, it will trigger
-    /// stopping the scheduler and cleaning all the data.
+    /// On success, returns the number of leaders that received the batch.
+    /// Returns an error only in the case of a critical issue, such as an
+    /// unrecoverable failure. In such cases, the scheduler will stop and
+    /// all data will be cleaned up.
     async fn send_to_workers(
         workers: &mut WorkersCache,
         leaders: &[SocketAddr],
         transaction_batch: TransactionBatch,
-    ) -> Result<(), ConnectionWorkersSchedulerError>;
+    ) -> Result<usize, ConnectionWorkersSchedulerError>;
 }
 
 impl ConnectionWorkersScheduler {
@@ -283,11 +284,20 @@ impl ConnectionWorkersScheduler {
                 }
             }
 
-            if let Err(error) =
-                Broadcaster::send_to_workers(&mut workers, &send_leaders, transaction_batch).await
+            let batch_size = transaction_batch.len() as u64;
+            match Broadcaster::send_to_workers(&mut workers, &send_leaders, transaction_batch).await
             {
-                last_error = Some(error);
-                break;
+                Ok(num_workers_received_batch) => {
+                    if num_workers_received_batch == 0 {
+                        stats
+                            .transaction_dropped
+                            .fetch_add(batch_size, Ordering::Relaxed);
+                    }
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                    break;
+                }
             }
         }
 
@@ -331,7 +341,8 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
         workers: &mut WorkersCache,
         leaders: &[SocketAddr],
         transaction_batch: TransactionBatch,
-    ) -> Result<(), ConnectionWorkersSchedulerError> {
+    ) -> Result<usize, ConnectionWorkersSchedulerError> {
+        let mut num_sent = 0;
         for new_leader in leaders {
             if !workers.contains(new_leader) {
                 warn!("No existing worker for {new_leader:?}, skip sending to this leader.");
@@ -356,8 +367,9 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
                     // If we have failed to send batch, it will be dropped.
                 }
             }
+            num_sent += 1;
         }
-        Ok(())
+        Ok(num_sent)
     }
 }
 

--- a/tpu-client-next/src/metrics.rs
+++ b/tpu-client-next/src/metrics.rs
@@ -41,9 +41,10 @@ impl SendTransactionStats {
 
                     datapoint_info!(
                         name,
+                        ("successfully_sent", view.successfully_sent, i64),
+                        ("transaction_dropped", view.transaction_dropped, i64),
                         ("connect_error", connect_error, i64),
                         ("connection_error", connection_error, i64),
-                        ("successfully_sent", view.successfully_sent, i64),
                         ("write_error", write_error, i64),
                     );
                 }

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -16,6 +16,8 @@ use {
 #[derive(Debug, Default)]
 pub struct SendTransactionStats {
     pub successfully_sent: AtomicU64,
+    /// Number of dropped transactions batches due to full worker queue.
+    pub transaction_dropped: AtomicU64,
     pub connect_error_cids_exhausted: AtomicU64,
     pub connect_error_invalid_remote_address: AtomicU64,
     pub connect_error_other: AtomicU64,
@@ -141,6 +143,7 @@ impl fmt::Display for SendTransactionStats {
             self,
             f,
             successfully_sent,
+            transaction_dropped,
             connect_error_cids_exhausted,
             connect_error_invalid_remote_address,
             connect_error_other,
@@ -193,6 +196,7 @@ define_non_atomic_struct_for!(
     SendTransactionStats,
     {
         successfully_sent,
+        transaction_dropped,
         connect_error_cids_exhausted,
         connect_error_invalid_remote_address,
         connect_error_other,

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -36,6 +36,11 @@ impl TransactionBatch {
             timestamp: timestamp(),
         }
     }
+
+    pub fn len(&self) -> usize {
+        self.wired_transactions.len()
+    }
+
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }


### PR DESCRIPTION
#### Problem

This PR introduces a new metric to tpu-client-next showing how many txs has not been delivered to any host.

#### Summary of Changes


