### PR TITLE
use tpu-client-next by default

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -367,7 +367,7 @@ impl Default for ValidatorConfig {
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             tvu_shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             delay_leader_block_for_pending_fork: false,
-            use_tpu_client_next: false,
+            use_tpu_client_next: true,
             retransmit_xdp: None,
         }
     }

--- a/rpc-test/tests/nonblocking.rs
+++ b/rpc-test/tests/nonblocking.rs
@@ -13,7 +13,7 @@ use {
     tokio::time::{sleep, Duration, Instant},
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_send_transaction() {
     let (test_validator, mint_keypair) = TestValidatorGenesis::default().start_async().await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
@@ -47,7 +47,7 @@ async fn test_tpu_send_transaction() {
     tpu_client.shutdown().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_cache_slot_updates() {
     let (test_validator, _) = TestValidatorGenesis::default().start_async().await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1194,7 +1194,7 @@ mod test {
         rpc_client.get_health().expect("health");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn nonblocking_get_health() {
         let (test_validator, _payer) = TestValidatorGenesis::default().start_async().await;
         test_validator.set_startup_verification_complete_for_tests();
@@ -1202,14 +1202,14 @@ mod test {
         rpc_client.get_health().await.expect("health");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[should_panic]
     async fn document_tokio_panic() {
         // `start()` blows up when run within tokio
         let (_test_validator, _payer) = TestValidatorGenesis::default().start();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_deactivate_features() {
         let mut control = FeatureSet::default().inactive().clone();
         let mut deactivate_features = Vec::new();
@@ -1253,7 +1253,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_override_feature_account() {
         let with_deactivate_flag = agave_feature_set::deprecate_rewards_sysvar::id();
         let without_deactivate_flag = agave_feature_set::disable_fees_sysvar::id();
@@ -1291,7 +1291,7 @@ mod test {
         assert!(feature_state.activated_at.is_some());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_core_bpf_programs() {
         let (test_validator, _payer) = TestValidatorGenesis::default()
             .deactivate_features(&[

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1449,6 +1449,7 @@ mod tests {
                     KeyUpdaterType::TpuForwards,
                     KeyUpdaterType::TpuVote,
                     KeyUpdaterType::Forward,
+                    KeyUpdaterType::RpcService
                 ])
             );
             let mut io = MetaIoHandler::default();

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1664,12 +1664,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
     )
     .arg(
-        Arg::with_name("use_tpu_client_next")
-            .long("use-tpu-client-next")
+        Arg::with_name("use_connection_cache")
+            .long("use-connection-cache")
             .takes_value(false)
             .help(
-                "Use tpu-client-next crate to send transactions over TPU ports. If not set,\
-                ConnectionCache is used instead.",
+                "Use connection-cache crate to send transactions over TPU ports. If not set,\
+                tpu-client-next is used by default.",
             ),
     )
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -776,7 +776,7 @@ pub fn execute(
         wen_restart_proto_path: value_t!(matches, "wen_restart", PathBuf).ok(),
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         retransmit_xdp,
-        use_tpu_client_next: matches.is_present("use_tpu_client_next"),
+        use_tpu_client_next: !matches.is_present("use_connection_cache"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

This PR enables tpu-client-next in validator by default.

#### Summary of Changes

