### PR TITLE
ledger: Use `BytesPacket` instead of `Packet` in tests

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -87,14 +87,14 @@ mod test {
         packet.meta_mut().flags |= PacketFlags::REPAIR;
 
         let leader_slots = HashMap::from([(slot, keypair.pubkey())]);
-        assert!(verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(verify_shred_cpu(&packet, &leader_slots, &cache));
 
         let wrong_keypair = Keypair::new();
         let leader_slots = HashMap::from([(slot, wrong_keypair.pubkey())]);
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
 
         let leader_slots = HashMap::new();
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu(&packet, &leader_slots, &cache));
     }
 
     #[test]

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -50,7 +50,11 @@ impl BytesPacket {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn from_bytes(dest: Option<&SocketAddr>, buffer: Bytes) -> Self {
+    pub fn from_bytes<B>(dest: Option<&SocketAddr>, buffer: B) -> Self
+    where
+        B: Into<Bytes>,
+    {
+        let buffer = buffer.into();
         let mut meta = Meta {
             size: buffer.len(),
             ..Default::default()


### PR DESCRIPTION
#### Problem

`BytesPacket` is a new type of packet introduced in anza-xyz/agave#5646 which uses `bytes::Bytes` to allow cheap clones without making an actual copy of the data.

#### Summary of Changes

Use the new type in ledger tests.