### PR TITLE
Remove redundant BufReaders for decompressing tar archives

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -16,7 +16,7 @@ use {
             RebuiltSnapshotStorage, SnapshotStorageRebuilder,
         },
     },
-    bzip2::bufread::BzDecoder,
+    bzip2::read::BzDecoder,
     crossbeam_channel::Sender,
     flate2::read::GzDecoder,
     log::*,
@@ -2315,7 +2315,7 @@ fn untar_snapshot_create_shared_buffer(
     };
     // Apply buffered reader for decoders that do not buffer internally.
     match archive_format {
-        ArchiveFormat::TarBzip2 => SharedBuffer::new(BzDecoder::new(BufReader::new(open_file()))),
+        ArchiveFormat::TarBzip2 => SharedBuffer::new(BzDecoder::new(open_file())),
         ArchiveFormat::TarGzip => SharedBuffer::new(GzDecoder::new(open_file())),
         ArchiveFormat::TarZstd { .. } => {
             SharedBuffer::new(zstd::stream::read::Decoder::new(open_file()).unwrap())

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2313,14 +2313,15 @@ fn untar_snapshot_create_shared_buffer(
             })
             .unwrap()
     };
+    // Apply buffered reader for decoders that do not buffer internally.
     match archive_format {
         ArchiveFormat::TarBzip2 => SharedBuffer::new(BzDecoder::new(BufReader::new(open_file()))),
-        ArchiveFormat::TarGzip => SharedBuffer::new(GzDecoder::new(BufReader::new(open_file()))),
+        ArchiveFormat::TarGzip => SharedBuffer::new(GzDecoder::new(open_file())),
         ArchiveFormat::TarZstd { .. } => SharedBuffer::new(
-            zstd::stream::read::Decoder::new(BufReader::new(open_file())).unwrap(),
+            zstd::stream::read::Decoder::new(open_file()).unwrap(),
         ),
         ArchiveFormat::TarLz4 => {
-            SharedBuffer::new(lz4::Decoder::new(BufReader::new(open_file())).unwrap())
+            SharedBuffer::new(lz4::Decoder::new(open_file()).unwrap())
         }
         ArchiveFormat::Tar => SharedBuffer::new(BufReader::new(open_file())),
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2317,12 +2317,10 @@ fn untar_snapshot_create_shared_buffer(
     match archive_format {
         ArchiveFormat::TarBzip2 => SharedBuffer::new(BzDecoder::new(BufReader::new(open_file()))),
         ArchiveFormat::TarGzip => SharedBuffer::new(GzDecoder::new(open_file())),
-        ArchiveFormat::TarZstd { .. } => SharedBuffer::new(
-            zstd::stream::read::Decoder::new(open_file()).unwrap(),
-        ),
-        ArchiveFormat::TarLz4 => {
-            SharedBuffer::new(lz4::Decoder::new(open_file()).unwrap())
+        ArchiveFormat::TarZstd { .. } => {
+            SharedBuffer::new(zstd::stream::read::Decoder::new(open_file()).unwrap())
         }
+        ArchiveFormat::TarLz4 => SharedBuffer::new(lz4::Decoder::new(open_file()).unwrap()),
         ArchiveFormat::Tar => SharedBuffer::new(BufReader::new(open_file())),
     }
 }


### PR DESCRIPTION
#### Problem
ZSTD `Decoder::new` creates buf reader with tuned size already, other decoders handle buffering too:
* `BzDecoder` https://docs.rs/bzip2/latest/src/bzip2/read.rs.html#87-91
* `GzDecoder` https://docs.rs/flate2/latest/src/flate2/gz/read.rs.html#143-147
* `lz4::Decoder` https://docs.rs/lz4/1.28.1/src/lz4/decoder.rs.html#33-43 (it uses a vec buffer directly)
* `zstd::Decoder` https://github.com/gyscos/zstd-rs/blob/229054099aa73f7e861762f687d7e07cac1d9b3b/src/stream/read/mod.rs#L29

In those cases wrapping reader with `BufReader` is counter-productive or unnecessary (bzip2 provides both `bufread` and `read` decoders) 

#### Summary of Changes
Remove redundant BufReaders for decompressing tar archives when underlying decompressor is already doing buffering.
