### PR TITLE
Conditionally sets num threads for index's BgThreads if disk index is enabled or not

### DIFF
--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -63,10 +63,18 @@ impl BgThreads {
         can_advance_age: bool,
         exit: Arc<AtomicBool>,
     ) -> Self {
+        let is_disk_index_enabled = storage.is_disk_index_enabled();
+        let num_threads = if is_disk_index_enabled {
+            threads.get()
+        } else {
+            // no disk index, so only need 1 thread to report stats
+            1
+        };
+
         // stop signal used for THIS batch of bg threads
         let local_exit = Arc::new(AtomicBool::default());
         let handles = Some(
-            (0..threads.get())
+            (0..num_threads)
                 .map(|idx| {
                     // the first thread we start is special
                     let can_advance_age = can_advance_age && idx == 0;

--- a/accounts-db/src/bucket_map_holder_stats.rs
+++ b/accounts-db/src/bucket_map_holder_stats.rs
@@ -225,7 +225,7 @@ impl BucketMapHolderStats {
 
         // sum of elapsed time in each thread
         let mut thread_time_elapsed_ms = elapsed_ms * storage.threads as u64;
-        if disk.is_some() {
+        if storage.is_disk_index_enabled() {
             if was_startup {
                 // these stats only apply at startup
                 datapoint_info!(


### PR DESCRIPTION
#### Problem

If the accounts disk index is disabled, we still spin up all the threads for flushing the disk index. This is unnecessary.


#### Summary of Changes

Conditionally sets number of threads used by BgThreads based on if the disk index is enabled or not.

Alternatively, we could (should?) not instantiate BgThreads at all, if the disk index is disabled. Since we use BgThreads to report metrics, we'd need to move metrics reporting elsewhere. That's a bit larger of a change, so this PR is meant to be smaller and get much of the benefit.