### PR TITLE
alpenglow: add feature gate

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1101,6 +1101,10 @@ pub mod formalize_loaded_transaction_data_size {
     solana_pubkey::declare_id!("DeS7sR48ZcFTUmt5FFEVDr1v1bh73aAbZiZq3SYr8Eh8");
 }
 
+pub mod alpenglow {
+    solana_pubkey::declare_id!("mustRekeyVm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1337,6 +1341,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (enshrine_slashing_program::id(), "SIMD-0204: Slashable event verification"),
         (enable_extend_program_checked::id(), "Enable ExtendProgramChecked instruction"),
         (formalize_loaded_transaction_data_size::id(), "SIMD-0186: Loaded transaction data size specification"),
+        (alpenglow::id(), "Enable Alpenglow"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -227,7 +227,7 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     do_activate_all_features::<false>(genesis_config);
 }
 
-pub fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
+fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
         if IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id() {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -219,10 +219,20 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
     }
 }
 
+pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
+    do_activate_all_features::<true>(genesis_config);
+}
+
 pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
+    do_activate_all_features::<false>(genesis_config);
+}
+
+pub fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
-        activate_feature(genesis_config, *feature_id);
+        if IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id() {
+            activate_feature(genesis_config, *feature_id);
+        }
     }
 }
 


### PR DESCRIPTION
Add new feature gate for alpenglow with a dummy key.

Once alpenglow stabilizes and is ready for activation, this will be rekeyed to a proper one.