### PR TITLE
chore: Remove last solana-sdk-macro references from cargo lock files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10090,7 +10090,6 @@ dependencies = [
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sdk-ids",
- "solana-sdk-macro",
  "solana-secp256k1-program",
  "solana-seed-derivable",
  "solana-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -532,7 +532,6 @@ solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" 
 solana-sbpf = "=0.11.1"
 solana-sdk = { version = "2.2.2", default-features = false }
 solana-sdk-ids = "2.2.1"
-solana-sdk-macro = "2.2.1"
 solana-secp256k1-program = "2.2.1"
 solana-secp256k1-recover = "2.2.1"
 solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7807,7 +7807,6 @@ dependencies = [
  "solana-reward-info",
  "solana-runtime-transaction",
  "solana-sdk-ids",
- "solana-sdk-macro",
  "solana-secp256k1-program",
  "solana-seed-derivable",
  "solana-serde",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -108,7 +108,6 @@ solana-rent-debits = { workspace = true }
 solana-reward-info = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-sdk-macro = { workspace = true }
 solana-secp256k1-program = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-serde = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7618,7 +7618,6 @@ dependencies = [
  "solana-reward-info",
  "solana-runtime-transaction",
  "solana-sdk-ids",
- "solana-sdk-macro",
  "solana-secp256k1-program",
  "solana-seed-derivable",
  "solana-serde",


### PR DESCRIPTION
The last remaining user of solana-sdk-macro is program-test and will be resolved by #6299. Once it merges, we can completely remove all instances of solana-sdk-macro from all cargo files. 
