### PR TITLE
chore: Remove the last solana-sdk references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-unified-scheduler-pool",
@@ -6747,7 +6747,7 @@ dependencies = [
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-program",
  "spl-generic-token",
@@ -6840,7 +6840,7 @@ dependencies = [
  "solana-signer",
  "solana-system-interface",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
  "thiserror 2.0.12",
@@ -6862,7 +6862,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
 ]
@@ -7125,7 +7125,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "static_assertions",
  "test-case",
@@ -7454,7 +7454,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote-program",
@@ -8744,7 +8744,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote",
@@ -8844,7 +8844,7 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -9453,7 +9453,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "test-case",
  "thiserror 2.0.12",
@@ -9504,7 +9504,6 @@ dependencies = [
  "solana-rent",
  "solana-runtime",
  "solana-sbpf",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-signer",
  "solana-stable-layout",
@@ -9516,7 +9515,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-program",
  "spl-generic-token",
@@ -9698,18 +9697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-reserved-account-keys"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
-dependencies = [
- "lazy_static",
- "solana-feature-set",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-reward-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9805,7 +9792,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tpu-client",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-validator-exit",
@@ -10112,7 +10099,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
@@ -10186,53 +10173,6 @@ dependencies = [
  "shuttle",
  "thiserror 2.0.12",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8af90d2ce445440e0548fa4a5f96fe8b265c22041a68c942012ffadd029667d"
-dependencies = [
- "bincode",
- "bs58",
- "getrandom 0.1.16",
- "js-sys",
- "serde",
- "solana-account",
- "solana-bn254",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-feature-set",
- "solana-fee-structure",
- "solana-inflation",
- "solana-instruction",
- "solana-message",
- "solana-native-token",
- "solana-nonce-account",
- "solana-packet",
- "solana-poh-config",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent-debits",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-time-utils",
- "solana-transaction-context 2.2.1",
- "solana-validator-exit",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -10569,7 +10509,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
  "solana-vote-program",
@@ -10634,7 +10574,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.12",
@@ -10661,7 +10601,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -10790,7 +10730,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "spl-generic-token",
@@ -10832,7 +10772,7 @@ dependencies = [
  "solana-rent",
  "solana-rent-collector",
  "solana-sdk-ids",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
 ]
 
@@ -10898,7 +10838,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -11236,21 +11176,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.3.0"
 dependencies = [
  "bincode",
@@ -11265,7 +11190,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-system-interface",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "static_assertions",
 ]
 
@@ -11398,7 +11323,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.12",
 ]
@@ -11724,7 +11649,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,7 +530,6 @@ solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2
 solana-runtime = { path = "runtime", version = "=2.3.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" }
 solana-sbpf = "=0.11.1"
-solana-sdk = { version = "2.2.2", default-features = false }
 solana-sdk-ids = "2.2.1"
 solana-secp256k1-program = "2.2.1"
 solana-secp256k1-recover = "2.2.1"

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -49,7 +49,6 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sbpf = { workspace = true }
-solana-sdk = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }
 solana-stable-layout = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5447,7 +5447,7 @@ dependencies = [
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "spl-generic-token",
  "static_assertions",
@@ -5495,7 +5495,7 @@ dependencies = [
  "solana-program",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
  "thiserror 2.0.12",
@@ -5517,7 +5517,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
 ]
@@ -5662,7 +5662,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.12",
 ]
@@ -6758,7 +6758,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote",
@@ -6852,7 +6852,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -7283,7 +7283,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.12",
 ]
@@ -7332,7 +7332,6 @@ dependencies = [
  "solana-rent",
  "solana-runtime",
  "solana-sbpf",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-signer",
  "solana-stable-layout",
@@ -7343,7 +7342,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-program",
  "spl-generic-token",
@@ -7510,18 +7509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-reserved-account-keys"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
-dependencies = [
- "lazy_static",
- "solana-feature-set",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-reward-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7599,7 +7586,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tpu-client",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-validator-exit",
@@ -7829,7 +7816,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
@@ -7935,7 +7922,7 @@ dependencies = [
  "solana-sysvar",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-type-overrides",
@@ -8419,53 +8406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sdk"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8af90d2ce445440e0548fa4a5f96fe8b265c22041a68c942012ffadd029667d"
-dependencies = [
- "bincode",
- "bs58",
- "getrandom 0.1.14",
- "js-sys",
- "serde",
- "solana-account",
- "solana-bn254",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-feature-set",
- "solana-fee-structure",
- "solana-inflation",
- "solana-instruction",
- "solana-message",
- "solana-native-token",
- "solana-nonce-account",
- "solana-packet",
- "solana-poh-config",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent-debits",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-time-utils",
- "solana-transaction-context 2.2.1",
- "solana-validator-exit",
- "thiserror 2.0.12",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "solana-sdk-ids"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8740,7 +8680,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
@@ -8802,7 +8742,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -8894,7 +8834,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "spl-generic-token",
@@ -8924,7 +8864,7 @@ dependencies = [
  "solana-rent",
  "solana-rent-collector",
  "solana-sdk-ids",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
 ]
 
@@ -8977,7 +8917,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -9227,21 +9167,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.3.0"
 dependencies = [
  "bincode",
@@ -9340,7 +9265,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.12",
 ]
@@ -9568,7 +9493,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.12",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -2892,7 +2892,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-validator-exit",
@@ -5293,7 +5293,7 @@ dependencies = [
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "spl-generic-token",
  "static_assertions",
@@ -5341,7 +5341,7 @@ dependencies = [
  "solana-program",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
  "thiserror 2.0.12",
@@ -5363,7 +5363,7 @@ dependencies = [
  "solana-pubkey",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "tarpc",
 ]
@@ -5508,7 +5508,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.12",
 ]
@@ -6569,7 +6569,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote",
@@ -6663,7 +6663,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -7094,7 +7094,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.12",
 ]
@@ -7143,7 +7143,6 @@ dependencies = [
  "solana-rent",
  "solana-runtime",
  "solana-sbpf",
- "solana-sdk",
  "solana-sdk-ids",
  "solana-signer",
  "solana-stable-layout",
@@ -7154,7 +7153,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-program",
  "spl-generic-token",
@@ -7321,18 +7320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-reserved-account-keys"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
-dependencies = [
- "lazy_static",
- "solana-feature-set",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-reward-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7410,7 +7397,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tpu-client",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-validator-exit",
@@ -7639,7 +7626,7 @@ dependencies = [
  "solana-time-utils",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
@@ -7698,53 +7685,6 @@ dependencies = [
  "rustc-demangle",
  "thiserror 2.0.12",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8af90d2ce445440e0548fa4a5f96fe8b265c22041a68c942012ffadd029667d"
-dependencies = [
- "bincode",
- "bs58",
- "getrandom 0.1.16",
- "js-sys",
- "serde",
- "solana-account",
- "solana-bn254",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-feature-set",
- "solana-fee-structure",
- "solana-inflation",
- "solana-instruction",
- "solana-message",
- "solana-native-token",
- "solana-nonce-account",
- "solana-packet",
- "solana-poh-config",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent-debits",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-time-utils",
- "solana-transaction-context 2.2.1",
- "solana-validator-exit",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -8022,7 +7962,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
@@ -8084,7 +8024,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -8175,7 +8115,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "spl-generic-token",
@@ -8241,7 +8181,7 @@ dependencies = [
  "solana-rent",
  "solana-rent-collector",
  "solana-sdk-ids",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
 ]
 
@@ -8294,7 +8234,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -8544,21 +8484,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.3.0"
 dependencies = [
  "bincode",
@@ -8657,7 +8582,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.12",
 ]
@@ -8882,7 +8807,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.3.0",
+ "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.12",
 ]


### PR DESCRIPTION
The last remaining users of solana-sdk are program-test and and solana-sdk-macro. The former will be resolved by https://github.com/anza-xyz/agave/pull/6299. The latter will be resolved by #6333. Once they merge, we can completely remove all instances of solana-sdk from all cargo files.

Once we remove solana-sdk, we don't need to keep older pinned versions of 'solana-transaction-context' and 'solana-reserved-account-keys'. For crates that were using the latest version of ''solana-transaction-context' we don't need to explicitly specify 2.3.0.
