### PR TITLE
alpenglow: adjust tick verification for alpenglow blocks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4202,6 +4202,7 @@ impl ReplayStage {
                     slot_status_notifier,
                     NewBankOptions::default(),
                 );
+                blockstore_processor::set_alpenglow_ticks(&child_bank);
                 let empty: Vec<Pubkey> = vec![];
                 Self::update_fork_propagated_threshold_from_votes(
                     progress,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1095,6 +1095,9 @@ fn verify_ticks(
             return Ok(());
         }
 
+        // If the bank is in the alpenglow epoch, but the parent is from an epoch
+        // where the feature flag is not active, we must verify ticks that correspond
+        // to the epoch in which poh is active.
         if bank.slot() >= first_alpenglow_slot && next_bank_tick_height == max_bank_tick_height {
             if entries.is_empty() {
                 // This shouldn't happen, but good to double check

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1056,7 +1056,7 @@ pub fn process_blockstore_from_root(
 /// Verify that a segment of entries has the correct number of ticks and hashes
 fn verify_ticks(
     bank: &Bank,
-    entries: &[Entry],
+    mut entries: &[Entry],
     slot_full: bool,
     tick_hash_count: &mut u64,
 ) -> std::result::Result<(), BlockError> {
@@ -1083,6 +1083,29 @@ fn verify_ticks(
         if !slot_full {
             warn!("Slot: {} was not marked full", bank.slot());
             return Err(BlockError::InvalidLastTick);
+        }
+    }
+
+    if let Some(first_alpenglow_slot) = bank
+        .feature_set
+        .activated_slot(&agave_feature_set::alpenglow::id())
+    {
+        if bank.parent_slot() >= first_alpenglow_slot {
+            // If fully in an alpenglow epoch, no tick verification is needed
+            return Ok(());
+        }
+
+        if bank.slot() >= first_alpenglow_slot && next_bank_tick_height == max_bank_tick_height {
+            if entries.is_empty() {
+                // This shouldn't happen, but good to double check
+                error!("Processing empty entries in verify_ticks()");
+                return Ok(());
+            }
+            // last entry must be a tick, as verified by the `has_trailing_entry`
+            // check above. Because in Alpenglow the last tick does not have any
+            // hashing guarantees, we pass everything but that last tick to the
+            // entry verification.
+            entries = &entries[..entries.len() - 1];
         }
     }
 
@@ -1786,6 +1809,7 @@ fn process_next_slots(
                     .unwrap(),
                 *next_slot,
             );
+            set_alpenglow_ticks(&next_bank);
             trace!(
                 "New bank for slot {}, parent slot is {}",
                 next_slot,
@@ -1798,6 +1822,60 @@ fn process_next_slots(
     // Reverse sort by slot, so the next slot to be processed can be popped
     pending_slots.sort_by(|a, b| b.1.slot().cmp(&a.1.slot()));
     Ok(())
+}
+
+/// Set alpenglow bank tick height.
+///
+/// For alpenglow banks this tick height is `max_tick_height` - 1, for a bank on the epoch boundary
+/// of feature activation, we need ticks_per_slot for each slot between the parent and epoch boundary
+/// and one extra tick for the alpenglow bank
+pub fn set_alpenglow_ticks(bank: &Bank) {
+    let Some(first_alpenglow_slot) = bank
+        .feature_set
+        .activated_slot(&agave_feature_set::alpenglow::id())
+    else {
+        return;
+    };
+
+    let Some(alpenglow_ticks) = calculate_alpenglow_ticks(
+        bank.slot(),
+        first_alpenglow_slot,
+        bank.parent_slot(),
+        bank.ticks_per_slot(),
+    ) else {
+        return;
+    };
+
+    info!(
+        "Alpenglow: Setting tick height for slot {} to {}",
+        bank.slot(),
+        bank.max_tick_height() - alpenglow_ticks
+    );
+    bank.set_tick_height(bank.max_tick_height() - alpenglow_ticks);
+}
+
+fn calculate_alpenglow_ticks(
+    slot: Slot,
+    first_alpenglow_slot: Slot,
+    parent_slot: Slot,
+    ticks_per_slot: u64,
+) -> Option<u64> {
+    // Slots before alpenglow shouldn't have alpenglow ticks
+    if slot < first_alpenglow_slot {
+        return None;
+    }
+
+    let alpenglow_ticks = if parent_slot < first_alpenglow_slot && slot >= first_alpenglow_slot {
+        // 1. All slots between the parent and the first alpenglow slot need to
+        // have `ticks_per_slot` ticks
+        // 2. One extra tick for the actual alpenglow slot
+        // 3. There are no ticks for any skipped alpenglow slots
+        (first_alpenglow_slot - parent_slot - 1) * ticks_per_slot + 1
+    } else {
+        1
+    };
+
+    Some(alpenglow_ticks)
 }
 
 /// Starting with the root slot corresponding to `start_slot_meta`, iteratively
@@ -5351,5 +5429,61 @@ pub mod tests {
         );
         // Adding another None will noop (even though the block is already full)
         assert!(check_block_cost_limits(&bank, &tx_costs[0..1]).is_ok());
+    }
+
+    #[test]
+    fn test_calculate_alpenglow_ticks() {
+        let first_alpenglow_slot = 10;
+        let ticks_per_slot = 2;
+
+        // Slots before alpenglow don't have alpenglow ticks
+        let slot = 9;
+        let parent_slot = 8;
+        assert!(
+            calculate_alpenglow_ticks(slot, first_alpenglow_slot, parent_slot, ticks_per_slot)
+                .is_none()
+        );
+
+        // First alpenglow slot should only have 1 tick
+        let slot = first_alpenglow_slot;
+        let parent_slot = first_alpenglow_slot - 1;
+        assert_eq!(
+            calculate_alpenglow_ticks(slot, first_alpenglow_slot, parent_slot, ticks_per_slot)
+                .unwrap(),
+            1
+        );
+
+        // First alpenglow slot with skipped non-alpenglow slots
+        // need to have `ticks_per_slot` ticks per skipped slot and
+        // then one additional tick for the first alpenglow slot
+        let slot = first_alpenglow_slot;
+        let num_skipped_slots = 3;
+        let parent_slot = first_alpenglow_slot - num_skipped_slots - 1;
+        assert_eq!(
+            calculate_alpenglow_ticks(slot, first_alpenglow_slot, parent_slot, ticks_per_slot)
+                .unwrap(),
+            num_skipped_slots * ticks_per_slot + 1
+        );
+
+        // Skipped alpenglow slots don't need any additional ticks
+        let slot = first_alpenglow_slot + 2;
+        let parent_slot = first_alpenglow_slot;
+        assert_eq!(
+            calculate_alpenglow_ticks(slot, first_alpenglow_slot, parent_slot, ticks_per_slot)
+                .unwrap(),
+            1
+        );
+
+        // Skipped alpenglow slots along skipped non-alpenglow slots
+        // need to have `ticks_per_slot` ticks per skipped non-alpenglow
+        // slot only and then one additional tick for the alpenglow slot
+        let slot = first_alpenglow_slot + 2;
+        let num_skipped_non_alpenglow_slots = 4;
+        let parent_slot = first_alpenglow_slot - num_skipped_non_alpenglow_slots - 1;
+        assert_eq!(
+            calculate_alpenglow_ticks(slot, first_alpenglow_slot, parent_slot, ticks_per_slot)
+                .unwrap(),
+            num_skipped_non_alpenglow_slots * ticks_per_slot + 1
+        );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4139,6 +4139,10 @@ impl Bank {
             );
     }
 
+    pub fn set_tick_height(&self, tick_height: u64) {
+        self.tick_height.store(tick_height, Relaxed)
+    }
+
     pub fn set_inflation(&self, inflation: Inflation) {
         *self.inflation.write().unwrap() = inflation;
     }


### PR DESCRIPTION
#### Problem
Alpenglow blocks do not have the required ticks per block. Instead for v1 they will only have 1 tick at the end of the block, as it is convenient to use max tick height as a signal for bank completion. In the future we can revisit the format to remove ticks from block serialization entirely.

#### Summary of Changes
When generating a new bank in replay, or when loading banks from blockstore on startup, we artificially increase the tick height:
- For banks where the parent was created after the alpenglow feature gate was enabled, we set the tick height to `max_tick_height - 1`, 
- For banks that straddle the epoch boundary of the feature flag activation, we require `ticks_per_slot` for each slot between the parent and the boundary, and 1 tick for the alpenglow bank, so the tick height is set to `max_tick_height - (first_alpenglow_slot - parent_slot - 1) * ticks_per_slot - 1`

When verifying ticks:
- For blocks where the parent was created after the alpenglow feature gate was enabled, we skip the tick hash count verification entirely
- For blocks that straddle the epoch boundary of the feature flag activation, we only verify tick hash count for the ticks corresponding to the poh blocks by ignoring the last entry (which must be the 1 alpenglow tick)

A future PR will modify the leader logic to also create banks with the correct amount of ticks when the flag is active.