### PR TITLE
Stop client gracefully in validator

### DIFF
--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -11,6 +11,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     std::{net::SocketAddr, sync::Arc},
     tokio::runtime::Handle,
+    tokio_util::sync::CancellationToken,
 };
 
 // `maybe_runtime` argument is introduced to be able to use runtime from test
@@ -62,6 +63,7 @@ impl CreateClient for TpuClientNextClient {
             leader_forward_count,
             None,
             bind_socket,
+            CancellationToken::new(),
         )
     }
 }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -246,6 +246,7 @@ impl TpuClientNextClient {
         leader_forward_count: u64,
         identity: Option<&Keypair>,
         bind_socket: UdpSocket,
+        cancel: CancellationToken,
     ) -> Self
     where
         T: TpuInfoWithSendStatic + Clone,
@@ -255,8 +256,6 @@ impl TpuClientNextClient {
         let (sender, receiver) = mpsc::channel(128);
 
         let (update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-
-        let cancel = CancellationToken::new();
 
         let leader_info_provider = CurrentLeaderInfo::new(leader_info);
         let leader_updater: SendTransactionServiceLeaderUpdater<T> =


### PR DESCRIPTION
#### Problem

Currently, tpu-client-next is stopped when the runtime that it is using is stoped but this creates a problem when it is using runtime shared with other services, which happens in TestValidator, because in this case some services will never join.

#### Summary of Changes

Stops tpu-client-next clients in validator gracefully.