### PR TITLE
Adding obsolete account support to serialize

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -798,7 +798,7 @@ impl Serialize for SerializableAccountsDb<'_> {
                 x.first().unwrap().slot(),
                 utils::serialize_iter_as_seq(
                     x.iter()
-                        .map(|x| SerializableAccountStorageEntry::from(x.as_ref())),
+                        .map(|x| SerializableAccountStorageEntry::from((x.as_ref(), self.slot))),
                 ),
             )
         }));

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -798,7 +798,7 @@ impl Serialize for SerializableAccountsDb<'_> {
                 x.first().unwrap().slot(),
                 utils::serialize_iter_as_seq(
                     x.iter()
-                        .map(|x| SerializableAccountStorageEntry::from((x.as_ref(), self.slot))),
+                        .map(|x| SerializableAccountStorageEntry::new(x.as_ref(), self.slot)),
                 ),
             )
         }));

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -1,6 +1,7 @@
 use {
     serde::{Deserialize, Serialize},
     solana_accounts_db::accounts_db::AccountStorageEntry,
+    solana_clock::Slot,
 };
 
 /// The serialized AccountsFileId type is fixed as usize
@@ -32,6 +33,20 @@ impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
         Self {
             id: rhs.id() as SerializedAccountsFileId,
             accounts_current_len: rhs.accounts.len(),
+        }
+    }
+}
+
+/// When obsolete accounts are enabled, the saved size is decreased by the
+/// amount of obsolete bytes in the storage. The number of obsolete bytes is
+/// determined by the snapshot slot, as an entry's obsolescence is dependant
+/// on the slot that marked it as such.
+impl From<(&AccountStorageEntry, Slot)> for SerializableAccountStorageEntry {
+    fn from(value: (&AccountStorageEntry, Slot)) -> Self {
+        Self {
+            id: value.0.id() as SerializedAccountsFileId,
+            accounts_current_len: value.0.accounts.len()
+                - value.0.get_obsolete_bytes(Some(value.1)),
         }
     }
 }

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -19,18 +19,9 @@ pub(super) trait SerializableStorage {
     fn current_len(&self) -> usize;
 }
 
-impl SerializableStorage for SerializableAccountStorageEntry {
-    fn id(&self) -> SerializedAccountsFileId {
-        self.id
-    }
-    fn current_len(&self) -> usize {
-        self.accounts_current_len
-    }
-}
-
 impl SerializableAccountStorageEntry {
-    /// Creates a new `SerializableAccountStorageEntry` from the current
-    /// `AccountStorageEntry` and a given snapshot slot. When obsolete accounts
+    /// Creates a new SerializableAccountStorageEntry from the current
+    /// AccountStorageEntry and a given snapshot slot. When obsolete accounts
     /// are enabled, the saved size is decreased by the amount of obsolete bytes
     /// in the storage. The number of obsolete bytes is determined by the snapshot
     /// slot, as an entry's obsolescence is dependent on the slot that marked it
@@ -44,6 +35,15 @@ impl SerializableAccountStorageEntry {
             accounts_current_len: accounts.accounts.len()
                 - accounts.get_obsolete_bytes(Some(snapshot_slot)),
         }
+    }
+}
+
+impl SerializableStorage for SerializableAccountStorageEntry {
+    fn id(&self) -> SerializedAccountsFileId {
+        self.id
+    }
+    fn current_len(&self) -> usize {
+        self.accounts_current_len
     }
 }
 

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -14,11 +14,6 @@ pub struct SerializableAccountStorageEntry {
     accounts_current_len: usize,
 }
 
-pub(super) trait SerializableStorage {
-    fn id(&self) -> SerializedAccountsFileId;
-    fn current_len(&self) -> usize;
-}
-
 impl SerializableAccountStorageEntry {
     /// Creates a new SerializableAccountStorageEntry from the current
     /// AccountStorageEntry and a given snapshot slot. When obsolete accounts
@@ -36,6 +31,11 @@ impl SerializableAccountStorageEntry {
                 - accounts.get_obsolete_bytes(Some(snapshot_slot)),
         }
     }
+}
+
+pub(super) trait SerializableStorage {
+    fn id(&self) -> SerializedAccountsFileId;
+    fn current_len(&self) -> usize;
 }
 
 impl SerializableStorage for SerializableAccountStorageEntry {

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -28,25 +28,21 @@ impl SerializableStorage for SerializableAccountStorageEntry {
     }
 }
 
-impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
-    fn from(rhs: &AccountStorageEntry) -> Self {
-        Self {
-            id: rhs.id() as SerializedAccountsFileId,
-            accounts_current_len: rhs.accounts.len(),
-        }
-    }
-}
-
-/// When obsolete accounts are enabled, the saved size is decreased by the
-/// amount of obsolete bytes in the storage. The number of obsolete bytes is
-/// determined by the snapshot slot, as an entry's obsolescence is dependant
-/// on the slot that marked it as such.
-impl From<(&AccountStorageEntry, Slot)> for SerializableAccountStorageEntry {
-    fn from(value: (&AccountStorageEntry, Slot)) -> Self {
-        Self {
-            id: value.0.id() as SerializedAccountsFileId,
-            accounts_current_len: value.0.accounts.len()
-                - value.0.get_obsolete_bytes(Some(value.1)),
+impl SerializableAccountStorageEntry {
+    /// Creates a new `SerializableAccountStorageEntry` from the current
+    /// `AccountStorageEntry` and a given snapshot slot. When obsolete accounts
+    /// are enabled, the saved size is decreased by the amount of obsolete bytes
+    /// in the storage. The number of obsolete bytes is determined by the snapshot
+    /// slot, as an entry's obsolescence is dependent on the slot that marked it
+    /// as such.
+    pub fn new(
+        accounts: &AccountStorageEntry,
+        snapshot_slot: Slot,
+    ) -> SerializableAccountStorageEntry {
+        SerializableAccountStorageEntry {
+            id: accounts.id() as SerializedAccountsFileId,
+            accounts_current_len: accounts.accounts.len()
+                - accounts.get_obsolete_bytes(Some(snapshot_slot)),
         }
     }
 }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1275,9 +1275,7 @@ mod tests {
         bank0
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         // Force flush the bank to create the account storage entry
         bank0.squash();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1319,16 +1319,15 @@ mod tests {
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
-        let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             bank_snapshots_dir.path(),
             &bank1,
             None,
-            full_snapshot_archives_dir.path(),
-            incremental_snapshot_archives_dir.path(),
+            snapshot_archives_dir.path(),
+            snapshot_archives_dir.path(),
             snapshot_archive_format,
         )
         .unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1311,18 +1311,11 @@ mod tests {
         bank1
             .transfer(sol_to_lamports(1.), &key3, &key1.pubkey())
             .unwrap();
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+
+        bank1.fill_bank_with_ticks_for_tests();
 
         // Mark the entry for pubkey1 as obsolete in slot0
-        bank1
-            .accounts()
-            .accounts_db
-            .storage
-            .get_slot_storage_entry(target_slot)
-            .unwrap()
-            .mark_account_obsolete(offset, 0, slot);
+        account_storage_entry.mark_account_obsolete(offset, 0, slot);
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1254,6 +1254,117 @@ mod tests {
         assert_eq!(original_bank, roundtrip_bank);
     }
 
+    /// This tests handling of obsolete accounts during a full snapshot with obsolete accounts
+    /// marked in the accounts database. This test injects them directly
+    #[test]
+    fn test_roundtrip_bank_to_and_from_full_snapshot_with_obsolete_account() {
+        let collector = Pubkey::new_unique();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+
+        // Create a few accounts
+        let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1_000_000.));
+        let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        bank0
+            .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
+            .unwrap();
+        bank0
+            .transfer(sol_to_lamports(2.), &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank0
+            .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
+            .unwrap();
+        while !bank0.is_complete() {
+            bank0.register_unique_tick();
+        }
+
+        // Force flush the bank to create the account storage entry
+        bank0.squash();
+        bank0.force_flush_accounts_cache();
+
+        // Find the account storage entry for slot 0
+        let target_slot = 0;
+        let account_storage_entry = bank0
+            .accounts()
+            .accounts_db
+            .storage
+            .get_slot_storage_entry(target_slot)
+            .unwrap();
+
+        // Find all the accounts in slot 0
+        let accounts = bank0
+            .accounts()
+            .accounts_db
+            .get_unique_accounts_from_storage(&account_storage_entry);
+
+        // Find the offset of pubkey `key1` in the accounts db slot0 and save the offset.
+        let offset = accounts
+            .stored_accounts
+            .iter()
+            .find(|account| key1.pubkey() == *account.pubkey())
+            .map(|account| account.index_info.offset())
+            .expect("Pubkey1 is present in Slot0");
+
+        // Create a new slot, and invalidate the account for key1 in slot0
+        let slot = 1;
+        let bank1 =
+            new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
+        bank1
+            .transfer(sol_to_lamports(1.), &key3, &key1.pubkey())
+            .unwrap();
+        while !bank1.is_complete() {
+            bank1.register_unique_tick();
+        }
+
+        // Mark the entry for pubkey1 as obsolete in slot0
+        bank1
+            .accounts()
+            .accounts_db
+            .storage
+            .get_slot_storage_entry(target_slot)
+            .unwrap()
+            .mark_account_obsolete(offset, 0, slot);
+
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let snapshot_archive_format = SnapshotConfig::default().archive_format;
+
+        let full_snapshot_archive_info = bank_to_full_snapshot_archive(
+            bank_snapshots_dir.path(),
+            &bank1,
+            None,
+            full_snapshot_archives_dir.path(),
+            incremental_snapshot_archives_dir.path(),
+            snapshot_archive_format,
+        )
+        .unwrap();
+
+        let (roundtrip_bank, _) = bank_from_snapshot_archives(
+            &[accounts_dir],
+            bank_snapshots_dir.path(),
+            &full_snapshot_archive_info,
+            None,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            None,
+            false,
+            false,
+            false,
+            false,
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+        roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
+        assert_eq!(*bank1, roundtrip_bank);
+    }
+
     /// Test roundtrip of bank to a full snapshot, then back again.  This test is more involved
     /// than the simple version above; creating multiple banks over multiple slots and doing
     /// multiple transfers.  So this full snapshot should contain more data.


### PR DESCRIPTION
#### Problem
When saving a snapshot, the size of an account storage entry is stored in two places: the serialized account storage entry and also as the actual size of data that is archived. The size stored in the serialized account storage entry is verified during account storage entry sanitize. With obsolete accounts, the size is reduced by size of obsolete accounts

#### Summary of Changes
When storing the size of the account storage entry, subtract the size of obsolete accounts. 
Added a test for this, as existing tests will not exercise this behaviour until obsolete accounts is fully implemented. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
