### PR TITLE
Fix misfiring 'solana-sdk disallowed' check

### DIFF
--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -73,7 +73,7 @@ fi
 
 # Disallow (re)introduction of solana sdk dependencies
 (
-  if git diff "$target" | grep -v '+++' | grep '^+.*solana[-_]sdk[: =]'; then
+  if git diff "$target" -- . ':(exclude)clippy.toml' | grep -v '+++' | grep '^+.*solana[-_]sdk[: =]'; then
     cat <<'EOF' 1>&2
 
 Error: solana sdk crate dependencies (re)introduced.


### PR DESCRIPTION
#### Problem
During upstream sync CI run in invalidator, 'ci/sanity-test.sh' is misfiring on a solana-sdk reference from the disallowed macros in 'clippy.toml'.

#### Summary of Changes
Exclude 'clippy.toml' from the solana-sdk disallowed check.



