### PR TITLE
Use 2 threads in tests with async TestValidator

### DIFF
--- a/rpc-test/tests/nonblocking.rs
+++ b/rpc-test/tests/nonblocking.rs
@@ -13,7 +13,7 @@ use {
     tokio::time::{sleep, Duration, Instant},
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_send_transaction() {
     let (test_validator, mint_keypair) = TestValidatorGenesis::default().start_async().await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
@@ -47,7 +47,7 @@ async fn test_tpu_send_transaction() {
     tpu_client.shutdown().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_cache_slot_updates() {
     let (test_validator, _) = TestValidatorGenesis::default().start_async().await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1194,7 +1194,7 @@ mod test {
         rpc_client.get_health().expect("health");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn nonblocking_get_health() {
         let (test_validator, _payer) = TestValidatorGenesis::default().start_async().await;
         test_validator.set_startup_verification_complete_for_tests();
@@ -1202,14 +1202,14 @@ mod test {
         rpc_client.get_health().await.expect("health");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[should_panic]
     async fn document_tokio_panic() {
         // `start()` blows up when run within tokio
         let (_test_validator, _payer) = TestValidatorGenesis::default().start();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_deactivate_features() {
         let mut control = FeatureSet::default().inactive().clone();
         let mut deactivate_features = Vec::new();
@@ -1253,7 +1253,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_override_feature_account() {
         let with_deactivate_flag = agave_feature_set::deprecate_rewards_sysvar::id();
         let without_deactivate_flag = agave_feature_set::disable_fees_sysvar::id();
@@ -1291,7 +1291,7 @@ mod test {
         assert!(feature_state.activated_at.is_some());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_core_bpf_programs() {
         let (test_validator, _payer) = TestValidatorGenesis::default()
             .deactivate_features(&[


### PR DESCRIPTION
#### Problem

These tests create a validator instance inside an async function. This results in the blocking Drop logic being executed within the async task itself.

This design leads to busy waiting when the validator contains async tasks—such as the tpu-client-next service. Since the Tokio runtime is blocked by the synchronous Drop, it can no longer schedule other tasks, including those necessary for shutdown. In particular, if a tpu-client-next instance is running (an async-based service), it will never complete, causing the system to hang.

For example, when attempting to drop the Turbine broadcaster, we end up busy-looping inside BroadcastStage::run, effectively blocking the single-threaded runtime. This issue has been confirmed using tokio-console:

```
11 ▶              32s    32s    0ns  188µs 1     blocking <cargo>/tokio-1.45.1/src/runtime/scheduler/multi_thread/worker|
```

The root cause is that BroadcastStage will only exit when its slot sender is dropped. That sender lives in the PohRecorder, which is part of the mechanism for determining the next leader for the tpu-client. However, since tpu-client-next is an async service, it requires the runtime to remain responsive. The runtime being blocked by Drop prevents this, creating a deadlock.


#### Summary of Changes


Use multithreaded runtime for these tests.