### PR TITLE
Removing register unique ticks as it is only used to fill bank.

### DIFF
--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -142,9 +142,8 @@ impl VoteSimulator {
                         .any(|lockout| lockout.slot() == parent));
                 }
             }
-            while new_bank.tick_height() < new_bank.max_tick_height() {
-                new_bank.register_unique_tick();
-            }
+
+            new_bank.fill_bank_with_ticks_for_tests();
             if !visit.node().has_no_child() || is_frozen {
                 new_bank.set_block_id(Some(Hash::new_unique()));
                 new_bank.freeze();
@@ -398,9 +397,7 @@ pub fn initialize_state(
         bank0.transfer(10_000, &mint_keypair, pubkey).unwrap();
     }
 
-    while bank0.tick_height() < bank0.max_tick_height() {
-        bank0.register_unique_tick();
-    }
+    bank0.fill_bank_with_ticks_for_tests();
     bank0.freeze();
     let mut progress = ProgressMap::default();
     progress.insert(

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -496,9 +496,7 @@ fn test_bank_forks_incremental_snapshot(
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
-            while !bank.is_complete() {
-                bank.register_unique_tick();
-            }
+            bank.fill_bank_with_ticks_for_tests();
 
             bank_scheduler
         };
@@ -783,9 +781,7 @@ fn test_snapshots_with_background_services(
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
-            while !bank.is_complete() {
-                bank.register_unique_tick();
-            }
+            bank.fill_bank_with_ticks_for_tests();
         }
 
         // Call `BankForks::set_root()` to cause snapshots to be taken

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2331,9 +2331,7 @@ fn main() {
                     }
 
                     if child_bank_required {
-                        while !bank.is_complete() {
-                            bank.register_unique_tick();
-                        }
+                        bank.fill_bank_with_ticks_for_tests();
                     }
 
                     let pre_capitalization = bank.capitalization();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3127,11 +3127,6 @@ impl Bank {
         self.register_tick_for_test(&Hash::default())
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn register_unique_tick(&self) {
-        self.register_tick_for_test(&Hash::new_unique())
-    }
-
     pub fn is_complete(&self) -> bool {
         self.tick_height() == self.max_tick_height()
     }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1211,9 +1211,7 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let original_bank = Bank::new_for_tests(&genesis_config);
 
-        while !original_bank.is_complete() {
-            original_bank.register_unique_tick();
-        }
+        original_bank.fill_bank_with_ticks_for_tests();
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1277,9 +1275,7 @@ mod tests {
         bank0
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
         let bank1 =
@@ -1293,9 +1289,7 @@ mod tests {
         bank1
             .transfer(sol_to_lamports(5.), &mint_keypair, &key5.pubkey())
             .unwrap();
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+        bank1.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank2 =
@@ -1303,9 +1297,7 @@ mod tests {
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank2.is_complete() {
-            bank2.register_unique_tick();
-        }
+        bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank3 =
@@ -1313,9 +1305,7 @@ mod tests {
         bank3
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank3.is_complete() {
-            bank3.register_unique_tick();
-        }
+        bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank4 =
@@ -1323,9 +1313,7 @@ mod tests {
         bank4
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank4.is_complete() {
-            bank4.register_unique_tick();
-        }
+        bank4.fill_bank_with_ticks_for_tests();
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1395,9 +1383,7 @@ mod tests {
         bank0
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
         let bank1 =
@@ -1411,9 +1397,7 @@ mod tests {
         bank1
             .transfer(sol_to_lamports(5.), &mint_keypair, &key5.pubkey())
             .unwrap();
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+        bank1.fill_bank_with_ticks_for_tests();
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1438,9 +1422,7 @@ mod tests {
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank2.is_complete() {
-            bank2.register_unique_tick();
-        }
+        bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank3 =
@@ -1448,9 +1430,7 @@ mod tests {
         bank3
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank3.is_complete() {
-            bank3.register_unique_tick();
-        }
+        bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank4 =
@@ -1458,9 +1438,7 @@ mod tests {
         bank4
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank4.is_complete() {
-            bank4.register_unique_tick();
-        }
+        bank4.fill_bank_with_ticks_for_tests();
 
         let incremental_snapshot_archive_info = bank_to_incremental_snapshot_archive(
             bank_snapshots_dir.path(),
@@ -1515,9 +1493,7 @@ mod tests {
         bank0
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
         let bank1 =
@@ -1531,9 +1507,7 @@ mod tests {
         bank1
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+        bank1.fill_bank_with_ticks_for_tests();
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1558,9 +1532,7 @@ mod tests {
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank2.is_complete() {
-            bank2.register_unique_tick();
-        }
+        bank2.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank3 =
@@ -1568,9 +1540,7 @@ mod tests {
         bank3
             .transfer(sol_to_lamports(2.), &mint_keypair, &key2.pubkey())
             .unwrap();
-        while !bank3.is_complete() {
-            bank3.register_unique_tick();
-        }
+        bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank4 =
@@ -1578,9 +1548,7 @@ mod tests {
         bank4
             .transfer(sol_to_lamports(3.), &mint_keypair, &key3.pubkey())
             .unwrap();
-        while !bank4.is_complete() {
-            bank4.register_unique_tick();
-        }
+        bank4.fill_bank_with_ticks_for_tests();
 
         bank_to_incremental_snapshot_archive(
             &bank_snapshots_dir,
@@ -1665,9 +1633,7 @@ mod tests {
         bank0
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
             .unwrap();
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
         let bank1 =
@@ -1675,9 +1641,7 @@ mod tests {
         bank1
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+        bank1.fill_bank_with_ticks_for_tests();
 
         let full_snapshot_slot = slot;
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
@@ -1713,9 +1677,7 @@ mod tests {
             0,
             "Ensure Account1's balance is zero"
         );
-        while !bank2.is_complete() {
-            bank2.register_unique_tick();
-        }
+        bank2.fill_bank_with_ticks_for_tests();
 
         // Take an incremental snapshot and then do a roundtrip on the bank and ensure it
         // deserializes correctly.
@@ -1761,16 +1723,12 @@ mod tests {
         bank3
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
             .unwrap();
-        while !bank3.is_complete() {
-            bank3.register_unique_tick();
-        }
+        bank3.fill_bank_with_ticks_for_tests();
 
         let slot = slot + 1;
         let bank4 =
             new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank3, &collector, slot);
-        while !bank4.is_complete() {
-            bank4.register_unique_tick();
-        }
+        bank4.fill_bank_with_ticks_for_tests();
 
         // Ensure account1 has been cleaned/purged from everywhere
         bank4.squash();
@@ -1833,16 +1791,12 @@ mod tests {
 
         let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1_000_000.));
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        while !bank0.is_complete() {
-            bank0.register_unique_tick();
-        }
+        bank0.fill_bank_with_ticks_for_tests();
 
         let slot = 1;
         let bank1 =
             new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, slot);
-        while !bank1.is_complete() {
-            bank1.register_unique_tick();
-        }
+        bank1.fill_bank_with_ticks_for_tests();
 
         let all_snapshots_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
@@ -1864,9 +1818,7 @@ mod tests {
         bank2
             .transfer(sol_to_lamports(1.), &mint_keypair, &key1.pubkey())
             .unwrap();
-        while !bank2.is_complete() {
-            bank2.register_unique_tick();
-        }
+        bank2.fill_bank_with_ticks_for_tests();
 
         bank_to_incremental_snapshot_archive(
             &all_snapshots_dir,


### PR DESCRIPTION
#### Problem
All use cases of register unique ticks are used to fill the entire bank. There is already an API to fill the entire bank that should be used instead.

#### Summary of Changes
Replace all uses of register unique ticks with fill_bank_with_ticks_for_tests
Remove register unique ticks

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
