### PR TITLE
Removes the total_unique_writes_size accounts write cache datapoint

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -168,17 +168,6 @@ impl AccountsCache {
             is_frozen: AtomicBool::default(),
         })
     }
-    fn unique_account_writes_size(&self) -> u64 {
-        self.cache
-            .iter()
-            .map(|item| {
-                let slot_cache = item.value();
-                slot_cache
-                    .unique_account_writes_size
-                    .load(Ordering::Relaxed)
-            })
-            .sum()
-    }
     pub fn size(&self) -> u64 {
         self.total_size.load(Ordering::Relaxed)
     }
@@ -191,11 +180,6 @@ impl AccountsCache {
                 i64
             ),
             ("num_slots", self.cache.len(), i64),
-            (
-                "total_unique_writes_size",
-                self.unique_account_writes_size(),
-                i64
-            ),
             ("total_size", self.size(), i64),
         );
     }


### PR DESCRIPTION
#### Problem

The `total_unique_writes_size` accounts write cache datapoint is slow to compute. This is because it does a DashMap iteration across all the slots in the write cache. The DashMap iter has to take a read lock on every shard it accesses, which isn't great. This is done every time submitting metrics for the write cache, which is every one second.

Ideally there are only around 100 slots in the write cache, so it could be suggested this is fine/fast enough. However, when the write cache is not flushed, it can grow to 2,000+ slots, which then makes computing this datapoint take that much longer.

I see that this datapoint was added back when the write cache itself was first added (https://github.com/solana-labs/solana/pull/13140). Nowadays, my understanding and experience is that no one uses this datapoint. So instead of changing the impl for the datapoint it should be safe to remove it entirely. Note that we have the total size of the cache, which is more useful. Additionally, we still have the _per slot_ datapoint in the write cache for the `unique_account_write_size`.


#### Summary of Changes

Remove it.