### PR TITLE
Add SOCKET_TAG_ALPENGLOW so we can cache Alpenglow port later.

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -286,6 +286,7 @@ impl ContactInfo {
     );
     get_socket!(tpu_vote, SOCKET_TAG_TPU_VOTE, SOCKET_TAG_TPU_VOTE_QUIC);
     get_socket!(tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
+    get_socket!(alpenglow, SOCKET_TAG_ALPENGLOW);
 
     set_socket!(set_gossip, SOCKET_TAG_GOSSIP);
     set_socket!(set_rpc, SOCKET_TAG_RPC);
@@ -299,6 +300,7 @@ impl ContactInfo {
     set_socket!(@multi set_serve_repair, SOCKET_TAG_SERVE_REPAIR, SOCKET_TAG_SERVE_REPAIR_QUIC);
     set_socket!(@multi set_tpu_vote, SOCKET_TAG_TPU_VOTE, SOCKET_TAG_TPU_VOTE_QUIC);
     set_socket!(@multi set_tvu, SOCKET_TAG_TVU, SOCKET_TAG_TVU_QUIC);
+    set_socket!(set_alpenglow, SOCKET_TAG_ALPENGLOW);
 
     remove_socket!(
         remove_serve_repair,
@@ -755,6 +757,7 @@ mod tests {
         assert_matches!(ci.tpu_vote(Protocol::QUIC), None);
         assert_matches!(ci.tvu(Protocol::QUIC), None);
         assert_matches!(ci.tvu(Protocol::UDP), None);
+        assert_matches!(ci.alpenglow(), None);
     }
 
     #[test]
@@ -882,6 +885,10 @@ mod tests {
             }
             assert_eq!(node.gossip().as_ref(), sockets.get(&SOCKET_TAG_GOSSIP));
             assert_eq!(node.rpc().as_ref(), sockets.get(&SOCKET_TAG_RPC));
+            assert_eq!(
+                node.alpenglow().as_ref(),
+                sockets.get(&SOCKET_TAG_ALPENGLOW)
+            );
             assert_eq!(
                 node.rpc_pubsub().as_ref(),
                 sockets.get(&SOCKET_TAG_RPC_PUBSUB)

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -44,8 +44,9 @@ const SOCKET_TAG_TPU_VOTE: u8 = 9;
 const SOCKET_TAG_TPU_VOTE_QUIC: u8 = 12;
 const SOCKET_TAG_TVU: u8 = 10;
 const SOCKET_TAG_TVU_QUIC: u8 = 11;
-const_assert_eq!(SOCKET_CACHE_SIZE, 13);
-const SOCKET_CACHE_SIZE: usize = SOCKET_TAG_TPU_VOTE_QUIC as usize + 1usize;
+const SOCKET_TAG_ALPENGLOW: u8 = 13;
+const_assert_eq!(SOCKET_CACHE_SIZE, 14);
+const SOCKET_CACHE_SIZE: usize = SOCKET_TAG_ALPENGLOW as usize + 1usize;
 
 // An alias for a function that reads data from a ContactInfo entry stored in
 // the gossip CRDS table.


### PR DESCRIPTION
Add SOCKET_TAG_ALPENGLOW so later we can put alpenglow socket into cache.
