### PR TITLE
Refactors DCOU in ReadOnlyAccountsCache::evict()

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -380,12 +380,11 @@ impl ReadOnlyAccountsCache {
             }
 
             let key = key_to_evict.expect("eviction sample should not be empty");
-            #[cfg(not(feature = "dev-context-only-utils"))]
-            Self::do_remove(&key, cache, data_size);
+            let _entry = Self::do_remove(&key, cache, data_size);
             #[cfg(feature = "dev-context-only-utils")]
             {
-                let entry = Self::do_remove(&key, cache, data_size);
-                callback(&key, entry.unwrap());
+                #[allow(clippy::used_underscore_binding)]
+                callback(&key, _entry.unwrap());
             }
             num_evicts = num_evicts.saturating_add(1);
         }


### PR DESCRIPTION
#### Problem

There is code duplication in `ReadOnlyAccountsCache::evict()` between the DCOU and non-DCOU blocks. They both call `do_remove()`, and then only DCOU calls `callback`. This can be simplified.


#### Summary of Changes

Refactor to remove code duplication.