### PR TITLE
update our contactinfo wallclock when sending pull request

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1229,7 +1229,10 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let now = timestamp();
-        let self_info = CrdsValue::new(CrdsData::from(self.my_contact_info()), &self.keypair());
+        let self_info = CrdsValue::new(
+            CrdsData::from(self.my_contact_info_with_current_wallclock(now)),
+            &self.keypair(),
+        );
         let max_bloom_filter_bytes = get_max_bloom_filter_bytes(&self_info);
         let mut pings = Vec::new();
         let pulls = {
@@ -2344,6 +2347,13 @@ impl ClusterInfo {
             shred_version,
         );
         (contact_info, gossip_socket, None)
+    }
+
+    #[inline]
+    fn my_contact_info_with_current_wallclock(&self, wallclock: u64) -> ContactInfo {
+        let mut contact_info = self.my_contact_info();
+        contact_info.set_wallclock(wallclock);
+        contact_info
     }
 }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1229,10 +1229,9 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> {
         let now = timestamp();
-        let self_info = CrdsValue::new(
-            CrdsData::from(self.my_contact_info_with_current_wallclock(now)),
-            &self.keypair(),
-        );
+        let mut contact_info = self.my_contact_info();
+        contact_info.set_wallclock(now);
+        let self_info = CrdsValue::new(CrdsData::from(contact_info), &self.keypair());
         let max_bloom_filter_bytes = get_max_bloom_filter_bytes(&self_info);
         let mut pings = Vec::new();
         let pulls = {
@@ -2347,13 +2346,6 @@ impl ClusterInfo {
             shred_version,
         );
         (contact_info, gossip_socket, None)
-    }
-
-    #[inline]
-    fn my_contact_info_with_current_wallclock(&self, wallclock: u64) -> ContactInfo {
-        let mut contact_info = self.my_contact_info();
-        contact_info.set_wallclock(wallclock);
-        contact_info
     }
 }
 


### PR DESCRIPTION
#### Problem
Nodes with an out of sync wallclock tend to have a significantly depleted crds table. This results in peer nodes sending back a significant number of PullResponses to the out of sync node. Peer nodes currently have no way to know if the PullRequest they are receiving is from an in sync or out of sync node.

We need to:
1) Update ContactInfo wallclock on sent pull requests (This PR)
2) Wait for everyone to adopt this code
3) Drop all PullRequests with a wallclock outside some time window (https://github.com/anza-xyz/agave/pull/6366)

#### Summary of Changes
When sending a PullRequest, send your ContactInfo with an updated timestamp in the PullRequest. Note that this updated timestamp in ContactInfo doesn't reflect the true time the node actually sends the PullRequest. However, the difference in creation time to send time is on the order of 10s of ms which should be fine comparing clock drift on the PullRequest receiver end. 

Note: we aren't adding much overhead here except for creating a new contact info and updating its wallclock. No additional message signing is added.