### PR TITLE
Ping latency measurements for Alpenglow

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -4,6 +4,7 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
+    solana_signature::Signature,
     std::{
         cmp::Reverse,
         collections::HashMap,
@@ -703,4 +704,13 @@ where
     for (slot, num_votes) in votes.into_iter().take(NUM_SLOTS) {
         datapoint_trace!(name, ("slot", slot, i64), ("num_votes", num_votes, i64));
     }
+}
+
+/// check if first leading_zeros bits of signature are 0
+#[inline]
+pub(crate) fn should_report_message_signature(signature: &Signature, leading_zeros: u32) -> bool {
+    let Some(Ok(bytes)) = signature.as_ref().get(..8).map(<[u8; 8]>::try_from) else {
+        return false;
+    };
+    u64::from_le_bytes(bytes).trailing_zeros() >= leading_zeros
 }

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -1,4 +1,5 @@
 use {
+    crate::cluster_info_metrics::should_report_message_signature,
     lru::LruCache,
     rand::{CryptoRng, Rng},
     serde_big_array::BigArray,
@@ -19,6 +20,7 @@ use {
 
 const KEY_REFRESH_CADENCE: Duration = Duration::from_secs(60);
 const PING_PONG_HASH_PREFIX: &[u8] = "SOLANA_PING_PONG".as_bytes();
+const PONG_SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 5;
 
 // For backward compatibility we are using a const generic parameter here.
 // N should always be >= 8 and only the first 8 bytes are used. So the new code
@@ -118,6 +120,10 @@ impl Pong {
     pub fn from(&self) -> &Pubkey {
         &self.from
     }
+
+    pub(crate) fn signature(&self) -> &Signature {
+        &self.signature
+    }
 }
 
 impl Sanitize for Pong {
@@ -181,12 +187,17 @@ impl<const N: usize> PingCache<N> {
         };
         self.pongs.put(remote_node, now);
         if let Some(sent_time) = self.ping_times.pop(&socket.ip()) {
-            let rtt = now.saturating_duration_since(sent_time);
-            datapoint_info!(
-                "ping_rtt",
-                ("peer_ip", socket.ip().to_string(), String),
-                ("rtt_us", rtt.as_micros() as i64, i64),
-            );
+            if should_report_message_signature(
+                pong.signature(),
+                PONG_SIGNATURE_SAMPLE_LEADING_ZEROS,
+            ) {
+                let rtt = now.saturating_duration_since(sent_time);
+                datapoint_info!(
+                    "ping_rtt",
+                    ("peer_ip", socket.ip().to_string(), String),
+                    ("rtt_us", rtt.as_micros() as i64, i64),
+                );
+            }
         }
         true
     }


### PR DESCRIPTION
#### Problem
For alpenglow, we need an estimate on roundtrip ping times between validators IP <-> IP

#### Summary of Changes
Add in ping_times member to PingCache so we can track ping/pong round trip. Round trip times are reported to metrics

Note: We could probably get away with making the `ping_times` LruCache less than `GOSSIP_PING_CACHE_CAPACITY` which is 126976.

We also have two `PingCache`s. One for gossip and one for repair. Theoretically, these ping round trips should be the same regardless if it's for repair or gossip. We don't ping/pong if repair request is coming from a quic endpoint.
