### PR TITLE
add methods to deconstruct RuntimeTransaction, ResolvedTransactionView, TransactionView

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -35,6 +35,12 @@ pub struct RuntimeTransaction<T> {
     meta: TransactionMeta,
 }
 
+impl<T> RuntimeTransaction<T> {
+    pub fn into_inner_transaction(self) -> T {
+        self.transaction
+    }
+}
+
 impl<T> StaticMeta for RuntimeTransaction<T> {
     fn message_hash(&self) -> &Hash {
         &self.meta.message_hash

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -149,6 +149,10 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
     pub fn loaded_addresses(&self) -> Option<&LoadedAddresses> {
         self.resolved_addresses.as_ref()
     }
+
+    pub fn into_view(self) -> TransactionView<true, D> {
+        self.view
+    }
 }
 
 impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -166,6 +166,11 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
     pub fn message_data(&self) -> &[u8] {
         &self.data()[usize::from(self.frame.message_offset())..]
     }
+
+    #[inline]
+    pub fn into_inner_data(self) -> D {
+        self.data
+    }
 }
 
 // Implementation that relies on sanitization checks having been run.


### PR DESCRIPTION
#### Problem
I have a `RuntimeTransaction` that uses an `Arc<Vec<u8>>` (bls impl for Vec<u8> in some other PR), and i'd like to get back the data when i'm done

#### Summary of Changes
deconstruct `RuntimeTransaction` into a `ResolvedTransactionView` into a `TransactionView` into inner `D`
