### PR TITLE
increase stake threshold for gossip pings

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -19,7 +19,7 @@ use {
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, SnapshotHashes, Vote, MAX_VOTES},
-        crds_filter::{should_retain_crds_value, GossipFilterDirection, MIN_STAKE_FOR_GOSSIP},
+        crds_filter::{should_retain_crds_value, GossipFilterDirection, MIN_STAKE_TO_SKIP_PING},
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
@@ -2961,7 +2961,7 @@ fn verify_gossip_addr<R: Rng + CryptoRng>(
         _ => return true, // If not a contact-info, nothing to verify.
     };
     // For (sufficiently) staked nodes, don't bother with ping/pong.
-    if stakes.get(pubkey).copied() >= Some(MIN_STAKE_FOR_GOSSIP) {
+    if stakes.get(pubkey).copied() >= Some(MIN_STAKE_TO_SKIP_PING) {
         return true;
     }
     // Invalid addresses are not verifiable.

--- a/gossip/src/crds_filter.rs
+++ b/gossip/src/crds_filter.rs
@@ -16,6 +16,8 @@ const MIN_NUM_STAKED_NODES: usize = 500;
 /// Minimum stake that a node should have so that all its CRDS values are
 /// propagated through gossip (below this only subset of CRDS is propagated).
 pub(crate) const MIN_STAKE_FOR_GOSSIP: u64 = solana_native_token::LAMPORTS_PER_SOL;
+/// Minimum stake required for a node to bypass the initial ping check when joining gossip.
+pub(crate) const MIN_STAKE_TO_SKIP_PING: u64 = 1000 * solana_native_token::LAMPORTS_PER_SOL;
 
 /// Returns false if the CRDS value should be discarded.
 /// `direction` controls whether we are looking at


### PR DESCRIPTION
#### Problem
to avoid getting pinged when joining gossip, you need 1 SOL stake. it's too low

#### Summary of Changes
Increase minimum stake threshold  to 1000 SOL to avoid ping when initially joining gossip

shoutout @alexpyattaev for the discussion/thoughts on this