### PR TITLE
Refactor - Reorder `translate_mut()` in syscalls

### DIFF
--- a/programs/bpf_loader/src/syscalls/mem_ops.rs
+++ b/programs/bpf_loader/src/syscalls/mem_ops.rs
@@ -108,11 +108,6 @@ declare_builtin_function!(
                 n,
                 invoke_context.get_check_aligned(),
             )?;
-            let cmp_result = translate_type_mut::<i32>(
-                memory_mapping,
-                cmp_result_addr,
-                invoke_context.get_check_aligned(),
-            )?;
 
             debug_assert_eq!(s1.len(), n as usize);
             debug_assert_eq!(s2.len(), n as usize);
@@ -120,7 +115,13 @@ declare_builtin_function!(
             // memcmp is marked unsafe since it assumes that the inputs are at least
             // `n` bytes long. `s1` and `s2` are guaranteed to be exactly `n` bytes
             // long because `translate_slice` would have failed otherwise.
-            *cmp_result = unsafe { memcmp(s1, s2, n as usize) };
+            let result = unsafe { memcmp(s1, s2, n as usize) };
+
+            *translate_type_mut::<i32>(
+                memory_mapping,
+                cmp_result_addr,
+                invoke_context.get_check_aligned(),
+            )? = result;
         }
 
         Ok(0)

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -919,6 +919,12 @@ declare_builtin_function!(
         let cost = invoke_context.get_execution_cost().secp256k1_recover_cost;
         consume_compute_meter(invoke_context, cost)?;
 
+        let secp256k1_recover_result = translate_slice_mut::<u8>(
+            memory_mapping,
+            result_addr,
+            SECP256K1_PUBLIC_KEY_LENGTH as u64,
+            invoke_context.get_check_aligned(),
+        )?;
         let hash = translate_slice::<u8>(
             memory_mapping,
             hash_addr,
@@ -929,12 +935,6 @@ declare_builtin_function!(
             memory_mapping,
             signature_addr,
             SECP256K1_SIGNATURE_LENGTH as u64,
-            invoke_context.get_check_aligned(),
-        )?;
-        let secp256k1_recover_result = translate_slice_mut::<u8>(
-            memory_mapping,
-            result_addr,
-            SECP256K1_PUBLIC_KEY_LENGTH as u64,
             invoke_context.get_check_aligned(),
         )?;
 
@@ -1432,6 +1432,11 @@ declare_builtin_function!(
                 length,
                 invoke_context.get_check_aligned(),
             )?;
+            let program_id_result = translate_type_mut::<Pubkey>(
+                memory_mapping,
+                program_id_addr,
+                invoke_context.get_check_aligned(),
+            )?;
 
             let to_slice = return_data_result;
             let from_slice = return_data
@@ -1441,12 +1446,6 @@ declare_builtin_function!(
                 return Err(SyscallError::InvalidLength.into());
             }
             to_slice.copy_from_slice(from_slice);
-
-            let program_id_result = translate_type_mut::<Pubkey>(
-                memory_mapping,
-                program_id_addr,
-                invoke_context.get_check_aligned(),
-            )?;
 
             if !is_nonoverlapping(
                 to_slice.as_ptr() as usize,
@@ -1669,17 +1668,16 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, cost)?;
 
-        let input = translate_slice::<u8>(
-            memory_mapping,
-            input_addr,
-            input_size,
-            invoke_context.get_check_aligned(),
-        )?;
-
         let call_result = translate_slice_mut::<u8>(
             memory_mapping,
             result_addr,
             output as u64,
+            invoke_context.get_check_aligned(),
+        )?;
+        let input = translate_slice::<u8>(
+            memory_mapping,
+            input_addr,
+            input_size,
             invoke_context.get_check_aligned(),
         )?;
 
@@ -1935,17 +1933,16 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, cost)?;
 
-        let input = translate_slice::<u8>(
-            memory_mapping,
-            input_addr,
-            input_size,
-            invoke_context.get_check_aligned(),
-        )?;
-
         let call_result = translate_slice_mut::<u8>(
             memory_mapping,
             result_addr,
             output as u64,
+            invoke_context.get_check_aligned(),
+        )?;
+        let input = translate_slice::<u8>(
+            memory_mapping,
+            input_addr,
+            input_size,
             invoke_context.get_check_aligned(),
         )?;
 

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -196,11 +196,11 @@ declare_builtin_function!(
                 .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost)),
         )?;
 
-        // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
-        let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;
-
         // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
         let var = translate_slice_mut::<u8>(memory_mapping, var_addr, length, check_aligned)?;
+
+        // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
+        let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;
 
         // Abort: "`offset + length` is not in `[0, 2^64)`."
         let offset_length = offset


### PR DESCRIPTION
#### Problem

The `MemoryCowCallback` can be triggered by a `translate_mut()` which in turn calls `MemoryMapping::map()` with `AccessType::Store`. Meaning a `MemoryRegion` can get a new host address during a syscall (other than CPI because that forbids control structures inside accounts). Thus, any live references from other `translate()` calls can become invalid (using an outdated host address).

#### Summary of Changes

Reorders all `translate_mut()` to happen either before any `translate()` or after all others (depending on what is easier in terms of code motion). This way there should not be any other live references to become invalid when `translate_mut()` is called.