### PR TITLE
Adds information to the last_cleaned_block_height assert message

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -600,13 +600,25 @@ impl AccountsBackgroundService {
                             last_snapshot_end_time = Some(Instant::now());
                             match snapshot_handle_result {
                                 Ok(snapshot_block_height) => {
-                                    assert!(last_cleaned_block_height <= snapshot_block_height);
+                                    assert!(
+                                        last_cleaned_block_height <= snapshot_block_height,
+                                        "last cleaned block height: {last_cleaned_block_height}, \
+                                         snapshot request block height: {snapshot_block_height}, \
+                                         is startup verification complete: {}, \
+                                         enqueued snapshot requests: {:?}",
+                                        bank.is_startup_verification_complete(),
+                                        request_handlers
+                                            .snapshot_request_handler
+                                            .snapshot_request_receiver
+                                            .try_iter()
+                                            .collect::<Vec<_>>(),
+                                    );
                                     last_cleaned_block_height = snapshot_block_height;
                                 }
                                 Err(err) => {
                                     error!(
                                         "Stopping AccountsBackgroundService! \
-                                        Fatal error while handling snapshot requests: {err}",
+                                         Fatal error while handling snapshot requests: {err}",
                                     );
                                     exit.store(true, Ordering::Relaxed);
                                     break;


### PR DESCRIPTION
#### Problem

When AccountsBackgroundService asserts from https://github.com/anza-xyz/agave/issues/6295, we don't get much information about the state of ABS, which could help corroborate current working theories.


#### Summary of Changes

When the assert fails, dump out more information about the state of ABS.

Note, I intend to backport this to v2.2.