### PR TITLE
Refactor - Preparation to have `translate_mut()` variants require `&mut MemoryMapping`

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -459,7 +459,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     ) -> Result<Vec<Pubkey>, Error> {
         let mut signers = Vec::new();
         if signers_seeds_len > 0 {
-            let signers_seeds = translate_slice_of_slices::<VmSlice<u8>>(
+            let signers_seeds = translate_slice::<VmSlice<VmSlice<u8>>>(
                 memory_mapping,
                 signers_seeds_addr,
                 signers_seeds_len,
@@ -469,7 +469,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                 return Err(Box::new(SyscallError::TooManySigners));
             }
             for signer_seeds in signers_seeds.iter() {
-                let untranslated_seeds = translate_slice_of_slices::<u8>(
+                let untranslated_seeds = translate_slice::<VmSlice<u8>>(
                     memory_mapping,
                     signer_seeds.ptr(),
                     signer_seeds.len(),

--- a/programs/bpf_loader/src/syscalls/logging.rs
+++ b/programs/bpf_loader/src/syscalls/logging.rs
@@ -120,7 +120,7 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
 
-        let untranslated_fields = translate_slice_of_slices::<u8>(
+        let untranslated_fields = translate_slice::<VmSlice<u8>>(
             memory_mapping,
             addr,
             len,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -586,83 +586,93 @@ fn address_is_aligned<T>(address: u64) -> bool {
         .expect("T to be non-zero aligned")
 }
 
-fn translate(
-    memory_mapping: &MemoryMapping,
-    access_type: AccessType,
-    vm_addr: u64,
-    len: u64,
-) -> Result<u64, Error> {
-    memory_mapping
-        .map(access_type, vm_addr, len)
-        .map_err(|err| err.into())
-        .into()
+macro_rules! translate_inner {
+    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $len:expr $(,)?) => {
+        Result::<u64, Error>::from(
+            $memory_mapping
+                .map($access_type, $vm_addr, $len)
+                .map_err(|err| err.into()),
+        )
+    };
+}
+macro_rules! translate_type_inner {
+    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+        let host_addr = translate_inner!(
+            $memory_mapping,
+            $access_type,
+            $vm_addr,
+            size_of::<$T>() as u64
+        )?;
+        if !$check_aligned {
+            Ok(unsafe { std::mem::transmute::<u64, &mut $T>(host_addr) })
+        } else if !address_is_aligned::<$T>(host_addr) {
+            Err(SyscallError::UnalignedPointer.into())
+        } else {
+            Ok(unsafe { &mut *(host_addr as *mut $T) })
+        }
+    }};
+}
+macro_rules! translate_slice_inner {
+    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+        if $len == 0 {
+            return Ok(&mut []);
+        }
+        let total_size = $len.saturating_mul(size_of::<$T>() as u64);
+        if isize::try_from(total_size).is_err() {
+            return Err(SyscallError::InvalidLength.into());
+        }
+        let host_addr = translate_inner!($memory_mapping, $access_type, $vm_addr, total_size)?;
+        if $check_aligned && !address_is_aligned::<$T>(host_addr) {
+            return Err(SyscallError::UnalignedPointer.into());
+        }
+        Ok(unsafe { from_raw_parts_mut(host_addr as *mut $T, $len as usize) })
+    }};
+}
+macro_rules! translate_slice_of_slices_inner {
+    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+        if $len == 0 {
+            return Ok(&mut []);
+        }
+        let total_size = $len.saturating_mul(size_of::<VmSlice<$T>>() as u64);
+        if isize::try_from(total_size).is_err() {
+            return Err(SyscallError::InvalidLength.into());
+        }
+        let host_addr = translate_inner!($memory_mapping, $access_type, $vm_addr, total_size)?;
+        if $check_aligned && !address_is_aligned::<VmSlice<$T>>(host_addr) {
+            return Err(SyscallError::UnalignedPointer.into());
+        }
+        Ok(unsafe { from_raw_parts_mut(host_addr as *mut VmSlice<$T>, $len as usize) })
+    }};
 }
 
-fn translate_type_inner<'a, T>(
-    memory_mapping: &MemoryMapping,
-    access_type: AccessType,
-    vm_addr: u64,
-    check_aligned: bool,
-) -> Result<&'a mut T, Error> {
-    let host_addr = translate(memory_mapping, access_type, vm_addr, size_of::<T>() as u64)?;
-    if !check_aligned {
-        Ok(unsafe { std::mem::transmute::<u64, &mut T>(host_addr) })
-    } else if !address_is_aligned::<T>(host_addr) {
-        Err(SyscallError::UnalignedPointer.into())
-    } else {
-        Ok(unsafe { &mut *(host_addr as *mut T) })
-    }
-}
 fn translate_type_mut<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,
     check_aligned: bool,
 ) -> Result<&'a mut T, Error> {
-    translate_type_inner::<T>(memory_mapping, AccessType::Store, vm_addr, check_aligned)
+    translate_type_inner!(memory_mapping, AccessType::Store, vm_addr, T, check_aligned)
 }
 fn translate_type<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,
     check_aligned: bool,
 ) -> Result<&'a T, Error> {
-    translate_type_inner::<T>(memory_mapping, AccessType::Load, vm_addr, check_aligned)
+    translate_type_inner!(memory_mapping, AccessType::Load, vm_addr, T, check_aligned)
         .map(|value| &*value)
 }
 
-fn translate_slice_inner<'a, T>(
-    memory_mapping: &MemoryMapping,
-    access_type: AccessType,
-    vm_addr: u64,
-    len: u64,
-    check_aligned: bool,
-) -> Result<&'a mut [T], Error> {
-    if len == 0 {
-        return Ok(&mut []);
-    }
-
-    let total_size = len.saturating_mul(size_of::<T>() as u64);
-    if isize::try_from(total_size).is_err() {
-        return Err(SyscallError::InvalidLength.into());
-    }
-
-    let host_addr = translate(memory_mapping, access_type, vm_addr, total_size)?;
-
-    if check_aligned && !address_is_aligned::<T>(host_addr) {
-        return Err(SyscallError::UnalignedPointer.into());
-    }
-    Ok(unsafe { from_raw_parts_mut(host_addr as *mut T, len as usize) })
-}
 fn translate_slice_mut<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,
     len: u64,
     check_aligned: bool,
 ) -> Result<&'a mut [T], Error> {
-    translate_slice_inner::<T>(
+    translate_slice_inner!(
         memory_mapping,
         AccessType::Store,
         vm_addr,
         len,
+        T,
         check_aligned,
     )
 }
@@ -672,38 +682,15 @@ fn translate_slice<'a, T>(
     len: u64,
     check_aligned: bool,
 ) -> Result<&'a [T], Error> {
-    translate_slice_inner::<T>(
+    translate_slice_inner!(
         memory_mapping,
         AccessType::Load,
         vm_addr,
         len,
+        T,
         check_aligned,
     )
     .map(|value| &*value)
-}
-
-fn translate_slice_of_slices_inner<'a, T>(
-    memory_mapping: &MemoryMapping,
-    access_type: AccessType,
-    vm_addr: u64,
-    len: u64,
-    check_aligned: bool,
-) -> Result<&'a mut [VmSlice<T>], Error> {
-    if len == 0 {
-        return Ok(&mut []);
-    }
-
-    let total_size = len.saturating_mul(size_of::<VmSlice<T>>() as u64);
-    if isize::try_from(total_size).is_err() {
-        return Err(SyscallError::InvalidLength.into());
-    }
-
-    let host_addr = translate(memory_mapping, access_type, vm_addr, total_size)?;
-
-    if check_aligned && !address_is_aligned::<VmSlice<T>>(host_addr) {
-        return Err(SyscallError::UnalignedPointer.into());
-    }
-    Ok(unsafe { from_raw_parts_mut(host_addr as *mut VmSlice<T>, len as usize) })
 }
 
 #[allow(dead_code)]
@@ -713,11 +700,12 @@ fn translate_slice_of_slices_mut<'a, T>(
     len: u64,
     check_aligned: bool,
 ) -> Result<&'a mut [VmSlice<T>], Error> {
-    translate_slice_of_slices_inner::<T>(
+    translate_slice_of_slices_inner!(
         memory_mapping,
         AccessType::Store,
         vm_addr,
         len,
+        T,
         check_aligned,
     )
 }
@@ -728,11 +716,12 @@ fn translate_slice_of_slices<'a, T>(
     len: u64,
     check_aligned: bool,
 ) -> Result<&'a [VmSlice<T>], Error> {
-    translate_slice_of_slices_inner::<T>(
+    translate_slice_of_slices_inner!(
         memory_mapping,
         AccessType::Load,
         vm_addr,
         len,
+        T,
         check_aligned,
     )
     .map(|value| &*value)
@@ -2316,11 +2305,11 @@ mod tests {
         for (ok, start, length, value) in cases {
             if ok {
                 assert_eq!(
-                    translate(&memory_mapping, AccessType::Load, start, length).unwrap(),
+                    translate_inner!(&memory_mapping, AccessType::Load, start, length).unwrap(),
                     value
                 )
             } else {
-                assert!(translate(&memory_mapping, AccessType::Load, start, length).is_err())
+                assert!(translate_inner!(&memory_mapping, AccessType::Load, start, length).is_err())
             }
         }
     }


### PR DESCRIPTION
#### Problem

The `MemoryCowCallback` can be triggered by a `translate_mut()` which in turn calls `MemoryMapping::map()` with `AccessType::Store`. That means `MemoryMapping` can change when using `AccessType::Store` but the `&MemoryMapping` parameter is currently not marked as mutable. This is only possible because the fields of `MemoryRegion` are using `Cell`s.

By turning the private `translate_inner()` functions into macros we pave the way for differentiating the mutability of the `memory_mapping` parameter based on the `AccessType`.

#### Summary of Changes

- Turns `translate_inner()` functions into macros.
- Replaces `translate_slice_of_slices::<T>()` by `translate_slice::<VmSlice<T>>()`.