### PR TITLE
Add LTO flag for cargo-build-sbf

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -890,7 +890,7 @@ fn main() {
             Arg::new("lto")
                 .long("lto")
                 .takes_value(false)
-                .help("Enable Link-Time Optimization (LTO) for all crates being built. This option may decerease program size and CU consumption.")
+                .help("Enable Link-Time Optimization (LTO) for all crates being built. This option may decrease program size and CU consumption.")
         )
         .get_matches_from(args);
 

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -890,7 +890,9 @@ fn main() {
             Arg::new("lto")
                 .long("lto")
                 .takes_value(false)
-                .help("Enable Link-Time Optimization (LTO) for all crates being built. This option may decrease program size and CU consumption.")
+                .help("Enable Link-Time Optimization (LTO) for all crates being built. \
+                This option may decrease program size and CU consumption. The default option is LTO \
+                disabled, as one may get mixed results with it.")
         )
         .get_matches_from(args);
 

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -47,6 +47,7 @@ pub struct Config<'a> {
     jobs: Option<String>,
     arch: &'a str,
     optimize_size: bool,
+    lto: bool,
 }
 
 impl Default for Config<'_> {
@@ -78,6 +79,7 @@ impl Default for Config<'_> {
             jobs: None,
             arch: "v0",
             optimize_size: false,
+            lto: false,
         }
     }
 }
@@ -553,6 +555,12 @@ fn invoke_cargo(config: &Config) {
     if config.optimize_size {
         target_rustflags = Cow::Owned(format!("{} -C opt-level=s", &target_rustflags));
     }
+    if config.lto {
+        target_rustflags = Cow::Owned(format!(
+            "{} -C embed-bitcode=yes -C lto=fat",
+            &target_rustflags
+        ));
+    }
     if config.debug {
         // Replace with -Zsplit-debuginfo=packed when stabilized.
         target_rustflags = Cow::Owned(format!("{} -g", &target_rustflags));
@@ -878,6 +886,12 @@ fn main() {
                 .takes_value(false)
                 .help("Optimize program for size. This option may reduce program size, potentially increasing CU consumption.")
         )
+        .arg(
+            Arg::new("lto")
+                .long("lto")
+                .takes_value(false)
+                .help("Enable Link-Time Optimization (LTO) for all crates being built. This option may decerease program size and CU consumption.")
+        )
         .get_matches_from(args);
 
     let sbf_sdk: PathBuf = matches.value_of_t_or_exit("sbf_sdk");
@@ -948,6 +962,7 @@ fn main() {
         jobs: matches.value_of_t("jobs").ok(),
         arch: matches.value_of("arch").unwrap(),
         optimize_size: matches.is_present("optimize_size"),
+        lto: matches.is_present("lto"),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -97,7 +97,7 @@ fn test_out_dir() {
 #[serial]
 fn test_target_dir() {
     let target_dir = "./temp-target-dir";
-    run_cargo_build("noop", &["--", "--target-dir", target_dir], false);
+    run_cargo_build("noop", &["--lto", "--", "--target-dir", target_dir], false);
     let cwd = env::current_dir().expect("Unable to get current working directory");
     let normal_target_dir = cwd.join("tests").join("crates").join("noop").join("target");
     assert!(!normal_target_dir.exists());


### PR DESCRIPTION
#### Problem

When https://github.com/anza-xyz/solana-sdk/pull/138 is finally merged, we'll be able to use LTO with programs that include the program and the SDK onmicrates. The usage of LTO for all crates is a little shady in cargo, so I'm adding a flag to `cargo-build-sbf` specially to signal it.

#### Summary of Changes

1. Create the `--lto` command line argument for `cargo-build-sbf`.
2. Modify a test to use that argument.