### PR TITLE
Refactor - Use realloc with zero-init

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -365,7 +365,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
 
             // Resize account_info data
             if account_info.data_len() != new_len {
-                account_info.realloc(new_len, false)?;
+                account_info.realloc(new_len, true)?;
             }
 
             // Clone the data

--- a/programs/sbf/rust/deprecated_loader/src/lib.rs
+++ b/programs/sbf/rust/deprecated_loader/src/lib.rs
@@ -57,7 +57,7 @@ fn process_instruction(
             let new_len = usize::from_le_bytes(bytes.try_into().unwrap());
             msg!("realloc to {}", new_len);
             let account = &accounts[0];
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
         }
         Some(&REALLOC_EXTEND_FROM_SLICE) => {
@@ -65,7 +65,7 @@ fn process_instruction(
             let data = &instruction_data[1..];
             let account = &accounts[0];
             let prev_len = account.data_len();
-            account.realloc(prev_len + data.len(), false)?;
+            account.realloc(prev_len + data.len(), true)?;
             account.data.borrow_mut()[prev_len..].copy_from_slice(data);
         }
         Some(&TEST_CPI_ACCOUNT_UPDATE_CALLER_GROWS) => {
@@ -82,7 +82,7 @@ fn process_instruction(
                 // whatever comes after the data slice (owner, executable, rent
                 // epoch etc). When direct mapping is on, you get an
                 // InvalidRealloc error.
-                account.realloc(prev_len + data.len(), false)?;
+                account.realloc(prev_len + data.len(), true)?;
                 account.data.borrow_mut()[prev_len..].copy_from_slice(data);
                 account.data.borrow().to_vec()
             };
@@ -193,7 +193,7 @@ fn process_instruction(
             let prev_data = {
                 let data = &instruction_data[9..];
                 let prev_len = account.data_len();
-                account.realloc(prev_len + data.len(), false)?;
+                account.realloc(prev_len + data.len(), true)?;
                 account.data.borrow_mut()[prev_len..].copy_from_slice(data);
                 unsafe {
                     // write a sentinel value just outside the account data to
@@ -247,7 +247,7 @@ fn process_instruction(
             const ARGUMENT_INDEX: usize = 0;
             let account = &accounts[ARGUMENT_INDEX];
             let new_len = usize::from_le_bytes(instruction_data[1..9].try_into().unwrap());
-            account.realloc(new_len, false).unwrap();
+            account.realloc(new_len, true).unwrap();
         }
         _ => {
             {

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -770,7 +770,7 @@ fn process_instruction<'a>(
             let account = &accounts[ARGUMENT_INDEX];
             let realloc_program_id = accounts[REALLOC_PROGRAM_INDEX].key;
             let invoke_program_id = accounts[INVOKE_PROGRAM_INDEX].key;
-            account.realloc(0, false).unwrap();
+            account.realloc(0, true).unwrap();
             account.assign(realloc_program_id);
 
             // Place a RcBox<RefCell<&mut [u8]>> in the account data. This
@@ -859,9 +859,9 @@ fn process_instruction<'a>(
             let target_account = &accounts[target_account_index];
             let realloc_program_id = accounts[REALLOC_PROGRAM_INDEX].key;
             let invoke_program_id = accounts[INVOKE_PROGRAM_INDEX].key;
-            account.realloc(0, false).unwrap();
+            account.realloc(0, true).unwrap();
             account.assign(realloc_program_id);
-            target_account.realloc(0, false).unwrap();
+            target_account.realloc(0, true).unwrap();
             target_account.assign(realloc_program_id);
 
             let rc_box_addr =
@@ -968,7 +968,7 @@ fn process_instruction<'a>(
             let expected = {
                 let data = &instruction_data[1..];
                 let prev_len = account.data_len();
-                account.realloc(prev_len + data.len(), false)?;
+                account.realloc(prev_len + data.len(), true)?;
                 account.data.borrow_mut()[prev_len..].copy_from_slice(data);
                 account.data.borrow().to_vec()
             };
@@ -1076,7 +1076,7 @@ fn process_instruction<'a>(
             let prev_data = {
                 let data = &instruction_data[9..];
                 let prev_len = account.data_len();
-                account.realloc(prev_len + data.len(), false)?;
+                account.realloc(prev_len + data.len(), true)?;
                 account.data.borrow_mut()[prev_len..].copy_from_slice(data);
                 unsafe {
                     // write a sentinel value just outside the account data to
@@ -1130,7 +1130,7 @@ fn process_instruction<'a>(
             const ARGUMENT_INDEX: usize = 0;
             let account = &accounts[ARGUMENT_INDEX];
             let new_len = usize::from_le_bytes(instruction_data[1..9].try_into().unwrap());
-            account.realloc(new_len, false).unwrap();
+            account.realloc(new_len, true).unwrap();
         }
         TEST_CPI_INVALID_KEY_POINTER => {
             msg!("TEST_CPI_INVALID_KEY_POINTER");
@@ -1398,7 +1398,7 @@ fn process_instruction<'a>(
             let account = &accounts[ARGUMENT_INDEX];
 
             if resize != 0 {
-                account.realloc(resize, false).unwrap();
+                account.realloc(resize, true).unwrap();
             }
 
             if pre_write_offset != 0 {

--- a/programs/sbf/rust/realloc/src/lib.rs
+++ b/programs/sbf/rust/realloc/src/lib.rs
@@ -29,7 +29,7 @@ fn process_instruction(
             let (bytes, _) = instruction_data[2..].split_at(std::mem::size_of::<usize>());
             let new_len = usize::from_le_bytes(bytes.try_into().unwrap());
             msg!("realloc to {}", new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
         }
         REALLOC_EXTEND => {
@@ -37,7 +37,7 @@ fn process_instruction(
             let (bytes, _) = instruction_data[2..].split_at(std::mem::size_of::<usize>());
             let new_len = pre_len.saturating_add(usize::from_le_bytes(bytes.try_into().unwrap()));
             msg!("realloc extend by {}", new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
         }
         REALLOC_EXTEND_AND_UNDO => {
@@ -45,9 +45,9 @@ fn process_instruction(
             let (bytes, _) = instruction_data[2..].split_at(std::mem::size_of::<usize>());
             let new_len = pre_len.saturating_add(usize::from_le_bytes(bytes.try_into().unwrap()));
             msg!("realloc extend by {}", new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             msg!("undo realloc");
-            account.realloc(pre_len, false)?;
+            account.realloc(pre_len, true)?;
             assert_eq!(pre_len, account.data_len());
         }
         REALLOC_EXTEND_AND_FILL => {
@@ -56,7 +56,7 @@ fn process_instruction(
             let (bytes, _) = instruction_data[4..].split_at(std::mem::size_of::<usize>());
             let new_len = pre_len.saturating_add(usize::from_le_bytes(bytes.try_into().unwrap()));
             msg!("realloc extend by {}", new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
             account.try_borrow_mut_data()?[pre_len..].fill(fill);
         }
@@ -66,7 +66,7 @@ fn process_instruction(
             let pre_len = account.data_len();
             let new_len = mem::size_of::<u64>();
             assert!(pre_len < new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
 
             let (bytes, _) = instruction_data[1..].split_at(new_len);
@@ -98,7 +98,7 @@ fn process_instruction(
         }
         REALLOC_AND_ASSIGN => {
             msg!("realloc and assign");
-            account.realloc(MAX_PERMITTED_DATA_INCREASE, false)?;
+            account.realloc(MAX_PERMITTED_DATA_INCREASE, true)?;
             assert_eq!(MAX_PERMITTED_DATA_INCREASE, account.data_len());
             account.assign(&system_program::id());
             assert_eq!(*account.owner, system_program::id());
@@ -133,7 +133,7 @@ fn process_instruction(
                 accounts,
             )?;
             assert_eq!(account.owner, program_id);
-            account.realloc(pre_len.saturating_add(MAX_PERMITTED_DATA_INCREASE), false)?;
+            account.realloc(pre_len.saturating_add(MAX_PERMITTED_DATA_INCREASE), true)?;
             assert_eq!(
                 account.data_len(),
                 pre_len.saturating_add(MAX_PERMITTED_DATA_INCREASE)
@@ -141,7 +141,7 @@ fn process_instruction(
         }
         DEALLOC_AND_ASSIGN_TO_CALLER => {
             msg!("dealloc and assign to caller");
-            account.realloc(0, false)?;
+            account.realloc(0, true)?;
             assert_eq!(account.data_len(), 0);
             account.assign(accounts[1].key);
             assert_eq!(account.owner, accounts[1].key);
@@ -158,7 +158,7 @@ fn process_instruction(
             }
         }
         ZERO_INIT => {
-            account.realloc(10, false)?;
+            account.realloc(10, true)?;
             {
                 let mut data = account.try_borrow_mut_data()?;
                 for i in 0..10 {
@@ -170,16 +170,7 @@ fn process_instruction(
                 }
             }
 
-            account.realloc(5, false)?;
-            account.realloc(10, false)?;
-            {
-                let data = account.try_borrow_data()?;
-                for i in 0..10 {
-                    assert_eq!(1, data[i]);
-                }
-            }
-
-            account.realloc(5, false)?;
+            account.realloc(5, true)?;
             account.realloc(10, true)?;
             {
                 let data = account.try_borrow_data()?;
@@ -195,7 +186,7 @@ fn process_instruction(
             msg!("realloc extend from slice");
             let data = &instruction_data[1..];
             let prev_len = account.data_len();
-            account.realloc(prev_len.saturating_add(data.len()), false)?;
+            account.realloc(prev_len.saturating_add(data.len()), true)?;
             account.data.borrow_mut()[prev_len..].copy_from_slice(data);
         }
         _ => panic!(),

--- a/programs/sbf/rust/realloc_invoke/src/lib.rs
+++ b/programs/sbf/rust/realloc_invoke/src/lib.rs
@@ -94,7 +94,7 @@ fn process_instruction(
             let (bytes, _) = remaining_data.split_at(std::mem::size_of::<usize>());
             let extend_len = usize::from_le_bytes(bytes.try_into().unwrap());
             msg!("realloc extend {} byte(s)", extend_len);
-            account.realloc(new_len.saturating_add(extend_len), false)?;
+            account.realloc(new_len.saturating_add(extend_len), true)?;
             assert_eq!(new_len.saturating_add(extend_len), account.data_len());
         }
         INVOKE_REALLOC_MAX_TWICE => {
@@ -110,7 +110,7 @@ fn process_instruction(
             )?;
             let new_len = pre_len.saturating_add(MAX_PERMITTED_DATA_INCREASE);
             assert_eq!(new_len, account.data_len());
-            account.realloc(new_len.saturating_add(MAX_PERMITTED_DATA_INCREASE), false)?;
+            account.realloc(new_len.saturating_add(MAX_PERMITTED_DATA_INCREASE), true)?;
             assert_eq!(
                 new_len.saturating_add(MAX_PERMITTED_DATA_INCREASE),
                 account.data_len()
@@ -162,7 +162,7 @@ fn process_instruction(
         }
         INVOKE_REALLOC_INVOKE_CHECK => {
             msg!("realloc invoke check size");
-            account.realloc(100, false)?;
+            account.realloc(100, true)?;
             assert_eq!(100, account.data_len());
             account.try_borrow_mut_data()?[pre_len..].fill(2);
             invoke(
@@ -178,7 +178,7 @@ fn process_instruction(
             let (bytes, _) = instruction_data[2..].split_at(std::mem::size_of::<usize>());
             let new_len = usize::from_le_bytes(bytes.try_into().unwrap());
             msg!("realloc to {}", new_len);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
             if pre_len < new_len {
                 account.try_borrow_mut_data()?[pre_len..].fill(instruction_data[1]);
@@ -188,7 +188,7 @@ fn process_instruction(
             msg!("realloc invoke recursive");
             let (bytes, _) = instruction_data[2..].split_at(std::mem::size_of::<usize>());
             let new_len = usize::from_le_bytes(bytes.try_into().unwrap());
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(new_len, account.data_len());
             account.try_borrow_mut_data()?[pre_len..].fill(instruction_data[1]);
             let final_len: usize = 200;
@@ -229,7 +229,7 @@ fn process_instruction(
                 accounts,
             )?;
             assert_eq!(pre_len, accounts[1].data_len());
-            accounts[1].realloc(pre_len.saturating_add(1), false)?;
+            accounts[1].realloc(pre_len.saturating_add(1), true)?;
             assert_eq!(pre_len.saturating_add(1), accounts[1].data_len());
             assert_eq!(accounts[1].owner, program_id);
             let final_len: usize = 200;
@@ -275,7 +275,7 @@ fn process_instruction(
             )?;
             assert_eq!(account.owner, program_id);
             assert_eq!(account.data_len(), 0);
-            account.realloc(new_len, false)?;
+            account.realloc(new_len, true)?;
             assert_eq!(account.data_len(), new_len);
             {
                 let data = account.try_borrow_mut_data()?;
@@ -287,7 +287,7 @@ fn process_instruction(
         INVOKE_REALLOC_MAX_INVOKE_MAX => {
             msg!("invoke realloc max invoke max");
             assert_eq!(0, account.data_len());
-            account.realloc(MAX_PERMITTED_DATA_INCREASE, false)?;
+            account.realloc(MAX_PERMITTED_DATA_INCREASE, true)?;
             assert_eq!(MAX_PERMITTED_DATA_INCREASE, account.data_len());
             account.assign(invoke_program_id);
             assert_eq!(account.owner, invoke_program_id);

--- a/svm/tests/example-programs/write-to-account/src/lib.rs
+++ b/svm/tests/example-programs/write-to-account/src/lib.rs
@@ -50,7 +50,7 @@ fn process_instruction(
         // reallocate account
         3 => {
             let new_size = usize::from_le_bytes(data[1..9].try_into().unwrap());
-            target_account_info.realloc(new_size, false)?;
+            target_account_info.realloc(new_size, true)?;
         }
         // bad ixn
         _ => {


### PR DESCRIPTION
#### Problem

The `zero_init` parameter of `AccountInfo::realloc` being `false` will be deprecated (see https://github.com/anza-xyz/solana-sdk/pull/176).

#### Summary of Changes

Basically https://github.com/solana-program/token-2022/pull/479 but for our program tests.
