### PR TITLE
Makes release-with-debug compatible with profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [profile.release-with-debug]
 inherits = "release"
 debug = true
-split-debuginfo = "packed"
-lto = false                # Preserve the 'thin local LTO' for this build.
+strip = false
+split-debuginfo = "off"
 
 [profile.release]
 split-debuginfo = "unpacked"


### PR DESCRIPTION
#### Problem

When running the validator under a profiler, we need to modify Cargo.toml to build with the right flags. Instead, we could have a build profile with these flags already.


#### Summary of Changes

Modify release-with-debug to have the proper flags.