### PR TITLE
arc clean

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -947,7 +947,7 @@ pub struct Bank {
     /// The cache of epoch rewards calculation results
     /// This is used to avoid recalculating the same epoch rewards at epoch boundary.
     /// The hashmap is keyed by parent_hash.
-    epoch_rewards_calculation_cache: Arc<Mutex<HashMap<Hash, PartitionedRewardsCalculation>>>,
+    epoch_rewards_calculation_cache: Arc<Mutex<HashMap<Hash, Arc<PartitionedRewardsCalculation>>>>,
 }
 
 #[derive(Debug)]

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -144,7 +144,7 @@ impl Bank {
         } = rewards_calculation.as_ref();
 
         let total_vote_rewards = vote_account_rewards.total_vote_rewards_lamports;
-        self.store_vote_accounts_partitioned(&vote_account_rewards, metrics);
+        self.store_vote_accounts_partitioned(vote_account_rewards, metrics);
 
         // update reward history of JUST vote_rewards, stake_rewards is vec![] here
         self.update_reward_history(vec![], &vote_account_rewards.rewards[..]);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -128,7 +128,7 @@ impl Bank {
                     "calculated rewards for epoch: {}, parent_slot: {}, parent_hash: {}",
                     self.epoch, self.parent_slot, self.parent_hash
                 );
-                calculation
+                Arc::new(calculation)
             })
             .clone();
         drop(epoch_rewards_calculation_cache);
@@ -141,7 +141,7 @@ impl Bank {
             prev_epoch_duration_in_years,
             capitalization,
             point_value,
-        } = rewards_calculation;
+        } = rewards_calculation.as_ref();
 
         let total_vote_rewards = vote_account_rewards.total_vote_rewards_lamports;
         self.store_vote_accounts_partitioned(&vote_account_rewards, metrics);
@@ -182,12 +182,16 @@ impl Bank {
             "epoch_rewards",
             ("slot", self.slot, i64),
             ("epoch", prev_epoch, i64),
-            ("validator_rate", validator_rate, f64),
-            ("foundation_rate", foundation_rate, f64),
-            ("epoch_duration_in_years", prev_epoch_duration_in_years, f64),
+            ("validator_rate", *validator_rate, f64),
+            ("foundation_rate", *foundation_rate, f64),
+            (
+                "epoch_duration_in_years",
+                *prev_epoch_duration_in_years,
+                f64
+            ),
             ("validator_rewards", total_vote_rewards, i64),
             ("active_stake", active_stake, i64),
-            ("pre_capitalization", capitalization, i64),
+            ("pre_capitalization", *capitalization, i64),
             ("post_capitalization", self.capitalization(), i64),
             ("num_stake_accounts", num_stake_accounts, i64),
             ("num_vote_accounts", num_vote_accounts, i64),
@@ -195,8 +199,8 @@ impl Bank {
 
         CalculateRewardsAndDistributeVoteRewardsResult {
             distributed_rewards: total_vote_rewards,
-            point_value,
-            stake_rewards,
+            point_value: point_value.clone(),
+            stake_rewards: Arc::clone(stake_rewards),
         }
     }
 
@@ -245,7 +249,7 @@ impl Bank {
             .unwrap_or_default();
 
         PartitionedRewardsCalculation {
-            vote_account_rewards: Arc::new(vote_account_rewards),
+            vote_account_rewards,
             stake_rewards,
             validator_rate,
             foundation_rate,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -366,7 +366,7 @@ mod tests {
         fn get_epoch_rewards_from_cache(
             &self,
             parent_hash: &Hash,
-        ) -> Option<PartitionedRewardsCalculation> {
+        ) -> Option<Arc<PartitionedRewardsCalculation>> {
             self.epoch_rewards_calculation_cache
                 .lock()
                 .unwrap()

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -90,7 +90,7 @@ pub(super) struct VoteRewardsAccounts {
     pub(super) total_vote_rewards_lamports: u64,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 /// result of calculating the stake rewards at end of epoch
 pub(super) struct StakeRewardCalculation {
     /// each individual stake account to reward
@@ -129,9 +129,9 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 /// Hold all results from calculating the rewards for partitioned distribution.
 /// This struct exists so we can have a function which does all the calculation with no
 /// side effects.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct PartitionedRewardsCalculation {
-    pub(super) vote_account_rewards: Arc<VoteRewardsAccounts>,
+    pub(super) vote_account_rewards: VoteRewardsAccounts,
     pub(super) stake_rewards: StakeRewardCalculation,
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,


### PR DESCRIPTION
#### Problem

Clean up the Arc for PER cache (credit to @jstarry).

https://github.com/anza-xyz/agave/pull/6306#issuecomment-2935835043


#### Summary of Changes

Move the Arc on an inner field of PER cache element to an outer Arc for the whole cache element. This allow us to remove clone on the element when fetching from the cache (all we need is to clone the Arc). This saves a few bytes copying from the other fields in the element.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
