### PR TITLE
reduce connection workers cache size

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -586,9 +586,9 @@ impl TpuClientNextClient {
         ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Socket(bind_socket),
             stake_identity: stake_identity.map(StakeIdentity::new),
-            // Cache size of 128 covers all nodes above the P90 slot count threshold,
-            // which together account for ~75% of total slots in the epoch.
-            num_connections: 128,
+            // Cache size of 64 covers all nodes for at least next 64 * 4 slots
+            // which corresponds to ~100sec.
+            num_connections: 64,
             skip_check_transaction_age: true,
             worker_channel_size: 2,
             max_reconnect_attempts: 4,

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -30,9 +30,9 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-/// How many connections to maintain the tpu-client-next cache. The value is
-/// chosen to match MAX_CONNECTIONS from ConnectionCache
-const MAX_CONNECTIONS: usize = 1024;
+/// How many connections to maintain the tpu-client-next cache.
+/// Size 64 covers 64*4 slots which corresponds to ~100sec.
+const MAX_CONNECTIONS: usize = 64;
 
 // Alias trait to shorten function definitions.
 pub trait TpuInfoWithSendStatic: TpuInfo + std::marker::Send + 'static {}


### PR DESCRIPTION
#### Problem

Currently, we save too many connections in the cache used in tpu-client-next which was for the purpose to mimic size of cache from ConnectionCache.
This creates two problems:
1. Each of these connections sends PING frame because we use keep-alive each second. Which contributes to 1024 useless frames per second.
2. Validator spends memory to have these connections in the client cache.
3. Validators spends memory also on the streamer side to keep these connections.

#### Summary of Changes

This PR reduces the size of the connection workers cache from 1024 to 64 for SendTransactionService and from 128 to 64 for ForwardingStage.

I made the following experiment to measure the `time of a tx in the system` for transactions in the `SendTransactionService` on Testnet:
1. TransactionsBatch when formed saves timestamp, call it `t_1`
2. I measure the time after send by getting timestamp after `stream.write_all().await` call, `t_2`.
3. I compute the sum of `(t_2 - t_1)/num_txs_send` during the execution of bench-tps with `--use-rpc-client` flag over 300s. It generates ~4M txs and the `time of a tx in the system` ~ `34ms` in both cases. 