### PR TITLE
reduce the size of the workers channel

### DIFF
--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -299,7 +299,7 @@ impl TpuClientNextClient {
             num_connections: MAX_CONNECTIONS,
             skip_check_transaction_age: true,
             // experimentally found parameter values
-            worker_channel_size: 64,
+            worker_channel_size: 8,
             max_reconnect_attempts: 4,
             leaders_fanout: Fanout {
                 connect: leader_forward_count,


### PR DESCRIPTION
#### Problem

The size of the workers channel in tpu-client-next used in STS is a bit exaggerated (64).

#### Summary of Changes

Reduce it to 8.

To confirm it doesn't lead to performance degradation I checked that the time of tx in the system is equivalent before/after changes.

I made the following experiment to measure the `time of a tx in the system` for transactions in the `SendTransactionService` on Testnet:
1. TransactionsBatch when formed saves timestamp, call it `t_1`
2. I measure the time after send by getting timestamp after `stream.write_all().await` call, `t_2`.
3. I compute the sum of `(t_2 - t_1)/num_txs_send` during the execution of bench-tps with `--use-rpc-client` flag over 300s. 

The `time of a tx in the system` ~ `34ms` in both cases. But the number of transactions sent is lower, need to investigate.

