### PR TITLE
Add optional FeatureSet arg to `Bank::new_from_fields()`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1787,6 +1787,7 @@ impl Bank {
         additional_builtins: Option<&[BuiltinPrototype]>,
         debug_do_not_add_builtins: bool,
         accounts_data_size_initial: u64,
+        #[cfg(feature = "dev-context-only-utils")] feature_set: Option<FeatureSet>,
     ) -> Self {
         let now = Instant::now();
         let ancestors = Ancestors::from(&fields.ancestors);
@@ -1859,6 +1860,9 @@ impl Bank {
             transaction_log_collector_config: Arc::<RwLock<TransactionLogCollectorConfig>>::default(
             ),
             transaction_log_collector: Arc::<RwLock<TransactionLogCollector>>::default(),
+            #[cfg(feature = "dev-context-only-utils")]
+            feature_set: Arc::new(feature_set.unwrap_or_default()),
+            #[cfg(not(feature = "dev-context-only-utils"))]
             feature_set: Arc::<FeatureSet>::default(),
             reserved_account_keys: Arc::<ReservedAccountKeys>::default(),
             drop_callback: RwLock::new(OptionalDropCallback(None)),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -898,6 +898,8 @@ where
         additional_builtins,
         debug_do_not_add_builtins,
         reconstructed_accounts_db_info.accounts_data_len,
+        #[cfg(feature = "dev-context-only-utils")]
+        None,
     );
 
     info!("rent_collector: {:?}", bank.rent_collector());


### PR DESCRIPTION
#### Problem

Working from [solfuzz-agave](https://github.com/firedancer-io/solfuzz-agave) to be able to fuzz blocks, we manually construct the fields to initialize the bank with `Bank::new_from_fields()`. We would like to provide our own feature set as an input to the bank initialization. This does not affect production.

#### Summary of Changes
* Add a `dev-context-only-utils` feature-guarded optional `FeatureSet` argument to `Bank::new_from_fields()`

Fixes #