### PR TITLE
Fixed a typo in vortexor log message on public-tpu-forwards-address

### DIFF
--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -182,7 +182,7 @@ pub fn main() {
              vortexor, add the following arguments in the validator's start command: \
               --tpu-vortexor-receiver-address {destination} \
               --public-tpu-address {tpu_public_address} \
-              --public-tpu-forward-address {tpu_fwd_public_address}",
+              --public-tpu-forwards-address {tpu_fwd_public_address}",
         );
     }
 


### PR DESCRIPTION
…mation

#### Problem
Fixed a typo in vortexor log message on public-tpu-forwards-address

 public-tpu-forward-address -->  public-tpu-forwards-address

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
