### PR TITLE
ci: use version bump pat in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.VERSION_BUMP_PAT }}
 
       - name: Parse Info
         id: parse_info


### PR DESCRIPTION
#### Problem

GitHub Actions couldn't push branches because branch protection rules are in effect

https://github.com/anza-xyz/agave/actions/runs/15351297301/job/43199920135#step:4:10173

#### Summary of Changes

use a PAT to bypass branch protection rules.

(the reason why I don't just use github action itself to bypass: https://github.com/orgs/community/discussions/25305)