### PR TITLE
ci: use cargo sort v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,3 @@
-[profile.release-with-debug]
-inherits = "release"
-debug = true
-strip = false
-split-debuginfo = "off"
-
-[profile.release]
-split-debuginfo = "unpacked"
-lto = "thin"
-
-[profile.release-with-lto]
-inherits = "release"
-split-debuginfo = "unpacked"
-lto = "thin"
-codegen-units = 1
-
 [workspace]
 members = [
     "account-decoder",
@@ -172,15 +156,15 @@ homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
 
+[workspace.lints.rust]
+warnings = "deny"
+
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
     'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
-
-[workspace.lints.rust]
-warnings = "deny"
 
 # Clippy lint configuration that can not be applied in clippy.toml
 [workspace.lints.clippy]
@@ -191,18 +175,19 @@ used_underscore_binding = "deny"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-axum = "0.7.9"
-aya = "0.13"
+aes-gcm-siv = "0.11.1"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.0" }
+agave-cargo-registry = { path = "cargo-registry", version = "=2.3.0" }
 agave-feature-set = { path = "feature-set", version = "=2.3.0" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.0" }
 agave-precompiles = { path = "precompiles", version = "=2.3.0" }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.3.0" }
+agave-thread-manager = { path = "thread-manager", version = "=2.3.0" }
 agave-transaction-view = { path = "transaction-view", version = "=2.3.0" }
 agave-xdp = { path = "xdp", version = "=2.3.0" }
-aquamarine = "0.6.0"
-aes-gcm-siv = "0.11.1"
 ahash = "0.8.11"
 anyhow = "1.0.98"
+aquamarine = "0.6.0"
 arbitrary = "1.4.1"
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
@@ -217,6 +202,8 @@ async-channel = "1.9.0"
 async-lock = "3.4.0"
 async-trait = "0.1.88"
 atty = "0.2.11"
+axum = "0.7.9"
+aya = "0.13"
 backoff = "0.4.0"
 base64 = "0.22.1"
 bincode = "1.3.3"
@@ -233,18 +220,18 @@ bytes = "1.10"
 bzip2 = "0.4.4"
 caps = "0.5.5"
 cargo_metadata = "0.15.4"
-cfg_eval = "0.1.2"
 cfg-if = "1.0.0"
+cfg_eval = "0.1.2"
 chrono = { version = "0.4.41", default-features = false }
 chrono-humanize = "0.2.3"
 clap = "2.33.1"
+# Remove this dependency when procedural macros will support non-inline modules.
+conditional-mod = "0.1.0"
 console = "0.15.11"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.2"
 const_format = "0.2.34"
 core_affinity = "0.5.10"
-# Remove this dependency when procedural macros will support non-inline modules.
-conditional-mod = "0.1.0"
 criterion = "0.5.1"
 criterion-stats = "0.3.0"
 crossbeam-channel = "0.5.15"
@@ -269,8 +256,8 @@ env_logger = "0.9.3"
 etcd-client = "0.11.1"
 fast-math = "0.1"
 fd-lock = "3.0.13"
-flate2 = "1.0.31"
 five8_const = "0.1.4"
+flate2 = "1.0.31"
 fnv = "1.0.7"
 fs_extra = "1.3.0"
 futures = "0.3.31"
@@ -400,8 +387,6 @@ solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.0" }
 solana-bucket-map = { path = "bucket_map", version = "=2.3.0" }
 solana-builtins = { path = "builtins", version = "=2.3.0" }
 solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.3.0" }
-agave-cargo-registry = { path = "cargo-registry", version = "=2.3.0" }
-agave-thread-manager = { path = "thread-manager", version = "=2.3.0" }
 solana-clap-utils = { path = "clap-utils", version = "=2.3.0" }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.3.0" }
 solana-cli = { path = "cli", version = "=2.3.0" }
@@ -428,7 +413,6 @@ solana-derivation-path = "2.2.1"
 solana-download-utils = { path = "download-utils", version = "=2.3.0" }
 solana-ed25519-program = "2.2.3"
 solana-entry = { path = "entry", version = "=2.3.0" }
-solana-program-entrypoint = "2.2.1"
 solana-epoch-info = "2.2.1"
 solana-epoch-rewards = "2.2.1"
 solana-epoch-rewards-hasher = "2.2.1"
@@ -437,17 +421,15 @@ solana-example-mocks = "2.2.1"
 solana-faucet = { path = "faucet", version = "=2.3.0" }
 solana-feature-gate-client = "0.0.2"
 solana-feature-gate-interface = "2.2.2"
-solana-fee-calculator = "2.2.1"
 solana-fee = { path = "fee", version = "=2.3.0" }
+solana-fee-calculator = "2.2.1"
 solana-fee-structure = "2.3.0"
+solana-file-download = "2.2.1"
 solana-frozen-abi = "2.2.2"
 solana-frozen-abi-macro = "2.2.1"
-solana-tps-client = { path = "tps-client", version = "=2.3.0" }
-solana-file-download = "2.2.1"
 solana-genesis = { path = "genesis", version = "=2.3.0" }
 solana-genesis-config = "2.2.1"
 solana-genesis-utils = { path = "genesis-utils", version = "=2.3.0" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.0" }
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.3.0" }
 solana-gossip = { path = "gossip", version = "=2.3.0" }
 solana-hard-forks = "2.2.1"
@@ -487,6 +469,7 @@ solana-poseidon = { path = "poseidon", version = "=2.3.0" }
 solana-precompile-error = "2.2.2"
 solana-presigner = "2.2.1"
 solana-program = { version = "2.2.1", default-features = false }
+solana-program-entrypoint = "2.2.1"
 solana-program-error = "2.2.1"
 solana-program-memory = "2.2.1"
 solana-program-option = "2.2.1"
@@ -503,37 +486,32 @@ solana-rent = "2.2.1"
 solana-rent-collector = "2.2.1"
 solana-rent-debits = "2.2.1"
 solana-reward-info = "2.2.1"
-solana-sanitize = "2.2.1"
-solana-secp256r1-program = "2.2.3"
-solana-seed-derivable = "2.2.1"
-solana-seed-phrase = "2.2.1"
-solana-serde = "2.2.1"
-solana-serde-varint = "2.2.2"
-solana-serialize-utils = "2.2.1"
-solana-sha256-hasher = "2.2.1"
-solana-signature = { version = "2.3.0", default-features = false }
-solana-signer = "2.2.1"
-solana-slot-hashes = "2.2.1"
-solana-slot-history = "2.2.1"
-solana-time-utils = "2.2.1"
-solana-timings = { path = "timings", version = "=2.3.0" }
-solana-tls-utils = { path = "tls-utils", version = "=2.3.0" }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.0" }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.3.0" }
 solana-rpc = { path = "rpc", version = "=2.3.0" }
 solana-rpc-client = { path = "rpc-client", version = "=2.3.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=2.3.0" }
-solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.0" }
+solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.0" }
 solana-runtime = { path = "runtime", version = "=2.3.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.0" }
+solana-sanitize = "2.2.1"
 solana-sbpf = "=0.11.1"
 solana-sdk-ids = "2.2.1"
 solana-secp256k1-program = "2.2.1"
 solana-secp256k1-recover = "2.2.1"
+solana-secp256r1-program = "2.2.3"
+solana-seed-derivable = "2.2.1"
+solana-seed-phrase = "2.2.1"
 solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.0" }
+solana-serde = "2.2.1"
+solana-serde-varint = "2.2.2"
+solana-serialize-utils = "2.2.1"
+solana-sha256-hasher = "2.2.1"
 solana-short-vec = "2.2.1"
 solana-shred-version = "2.2.1"
+solana-signature = { version = "2.3.0", default-features = false }
+solana-signer = "2.2.1"
+solana-slot-hashes = "2.2.1"
+solana-slot-history = "2.2.1"
 solana-stable-layout = "2.2.1"
 solana-stake-interface = { version = "1.2.1" }
 solana-stake-program = { path = "programs/stake", version = "=2.3.0" }
@@ -553,17 +531,23 @@ solana-sysvar = "2.2.2"
 solana-sysvar-id = "2.2.1"
 solana-test-validator = { path = "test-validator", version = "=2.3.0" }
 solana-thin-client = { path = "thin-client", version = "=2.3.0" }
-solana-transaction = "2.2.2"
-solana-transaction-error = "2.2.1"
+solana-time-utils = "2.2.1"
+solana-timings = { path = "timings", version = "=2.3.0" }
+solana-tls-utils = { path = "tls-utils", version = "=2.3.0" }
+solana-tps-client = { path = "tps-client", version = "=2.3.0" }
 solana-tpu-client = { path = "tpu-client", version = "=2.3.0", default-features = false }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=2.3.0" }
+solana-transaction = "2.2.2"
 solana-transaction-context = { path = "transaction-context", version = "=2.3.0", features = ["bincode", "debug-signature"] }
+solana-transaction-error = "2.2.1"
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.3.0" }
 solana-transaction-status = { path = "transaction-status", version = "=2.3.0" }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.3.0" }
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.3.0" }
 solana-turbine = { path = "turbine", version = "=2.3.0" }
 solana-type-overrides = { path = "type-overrides", version = "=2.3.0" }
 solana-udp-client = { path = "udp-client", version = "=2.3.0" }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.0" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.3.0" }
 solana-validator-exit = "2.2.1"
 solana-version = { path = "version", version = "=2.3.0" }
 solana-vortexor-receiver = { path = "vortexor-receiver", version = "=2.3.0" }
@@ -627,6 +611,22 @@ x509-parser = "0.14.0"
 # See "zeroize versioning issues" below if you are updating this version.
 zeroize = { version = "1.7", default-features = false }
 zstd = "0.13.3"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true
+strip = false
+split-debuginfo = "off"
+
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
+
+[profile.release-with-lto]
+inherits = "release"
+split-debuginfo = "unpacked"
+lto = "thin"
+codegen-units = 1
 
 # curve25519-dalek uses the simd backend by default in v4 if possible,
 # which has very slow performance on some platforms with opt-level 0,

--- a/account-decoder-client-types/Cargo.toml
+++ b/account-decoder-client-types/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+zstd = ["dep:zstd"]
+
 [dependencies]
 base64 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
@@ -18,11 +26,3 @@ serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-pubkey = { workspace = true }
 zstd = { workspace = true, optional = true }
-
-[features]
-zstd = ["dep:zstd"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 Inflector = { workspace = true }
 base64 = { workspace = true }
@@ -55,9 +58,6 @@ solana-account = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-pod = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -8,6 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 clap = { workspace = true }
 log = { workspace = true }
@@ -20,9 +26,3 @@ solana-measure = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent-collector = { workspace = true }
 solana-version = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 clap = { workspace = true }
 log = { workspace = true }
@@ -50,6 +53,3 @@ solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -9,6 +9,32 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_accounts_db"
+
+[features]
+dev-context-only-utils = [
+    "dep:qualifier_attr",
+    "dep:solana-keypair",
+    "dep:solana-rent",
+    "dep:solana-signer",
+    "dep:solana-stake-program",
+    "dep:solana-vote-program",
+    "solana-account/dev-context-only-utils",
+    "solana-pubkey/rand",
+    "solana-transaction/dev-context-only-utils",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-fee-calculator/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
+
 [dependencies]
 ahash = { workspace = true }
 bincode = { workspace = true }
@@ -80,10 +106,6 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_accounts_db"
-
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
 assert_matches = { workspace = true }
@@ -104,28 +126,6 @@ static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 test-case = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-keypair",
-    "dep:solana-rent",
-    "dep:solana-signer",
-    "dep:solana-stake-program",
-    "dep:solana-vote-program",
-    "solana-account/dev-context-only-utils",
-    "solana-pubkey/rand",
-    "solana-transaction/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-fee-calculator/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
 
 [[bench]]
 name = "bench_accounts_file"

--- a/accounts-db/accounts-hash-cache-tool/Cargo.toml
+++ b/accounts-db/accounts-hash-cache-tool/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -20,6 +23,3 @@ solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-version = { workspace = true }
-
-[features]
-dev-context-only-utils = []

--- a/accounts-db/store-histogram/Cargo.toml
+++ b/accounts-db/store-histogram/Cargo.toml
@@ -9,9 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 clap = { workspace = true }
 solana-version = { workspace = true }
-
-[features]
-dev-context-only-utils = []

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 ahash = { workspace = true }
 clap = { workspace = true }
@@ -18,6 +21,3 @@ solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-version = { workspace = true }
-
-[features]
-dev-context-only-utils = []

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -8,6 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 assert_matches = { workspace = true }
@@ -39,9 +45,3 @@ solana-time-utils = { workspace = true }
 solana-tpu-client = { workspace = true }
 solana-transaction = { workspace = true }
 solana-version = { workspace = true }
-
-[features]
-dev-context-only-utils = []
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_banks_client"
+
 [dependencies]
 borsh = { workspace = true }
 futures = { workspace = true }
@@ -37,10 +44,3 @@ solana-pubkey = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_banks_client"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_banks_interface"
+
 [dependencies]
 serde = { workspace = true }
 serde_derive = { workspace = true }
@@ -23,10 +30,3 @@ solana-transaction = { workspace = true, features = [ "serde" ] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = [ "serde" ] }
 tarpc = { workspace = true, features = ["full"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_banks_interface"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_banks_server"
+
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
@@ -32,10 +39,3 @@ solana-transaction-error = { workspace = true }
 tarpc = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-serde = { workspace = true, features = ["bincode"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_banks_server"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -8,12 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 crossbeam-channel = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-streamer = { workspace = true }
 solana-version = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -8,6 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 chrono = { workspace = true }
 clap = { workspace = true }
@@ -74,9 +80,3 @@ solana-sdk-ids = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-tps-client = { workspace = true, features = ["bank-client"] }
 tempfile = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []

--- a/bench-vote/Cargo.toml
+++ b/bench-vote/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bincode = { workspace = true }
 clap = { workspace = true }
@@ -26,6 +29,3 @@ solana-streamer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -9,6 +9,20 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_bloom"
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-hash/frozen-abi",
+]
+
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
 fnv = { workspace = true }
@@ -29,20 +43,6 @@ rayon = { workspace = true }
 solana-hash = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signature = { workspace = true, features = ["std"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_bloom"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-hash/frozen-abi",
-]
 
 [lints]
 workspace = true

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -10,6 +10,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["lib"]
+name = "solana_bucket_map"
+
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
@@ -28,10 +32,6 @@ fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_bucket_map"
 
 [[bench]]
 name = "bucket_map"

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -9,6 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+# Add additional builtin programs here
+
+[lib]
+crate-type = ["lib"]
+name = "solana_builtins_default_costs"
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "solana-vote-program/frozen-abi"]
+dev-context-only-utils = []
+
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
@@ -24,25 +36,10 @@ solana-sdk-ids = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
-# Add additional builtin programs here
-
-[lib]
-crate-type = ["lib"]
-name = "solana_builtins_default_costs"
 
 [dev-dependencies]
 rand = "0.8.5"
 static_assertions = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/cargo-registry/Cargo.toml
+++ b/cargo-registry/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 clap = { workspace = true }
 flate2 = { workspace = true }
@@ -38,9 +44,3 @@ tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
 
 [dev-dependencies]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN \
   # uncomment once the dcou-parition related patch is upstreamed...
   # cargo install cargo-hack && \
   cargo install --git https://github.com/anza-xyz/cargo-hack.git --rev 5e59c3ec6c661c02601487c0d4b2a2649fe06c9f cargo-hack && \
-  cargo install cargo-sort && \
+  cargo install cargo-sort@^2 && \
   cargo install mdbook && \
   cargo install mdbook-linkcheck && \
   cargo install svgbob_cli && \

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_clap_utils"
+
 [dependencies]
 chrono = { workspace = true, features = ["default"] }
 clap = "2.33.0"
@@ -37,9 +43,3 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
-
-[lib]
-name = "solana_clap_utils"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_clap_v3_utils"
+
 [dependencies]
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "3.2.23", features = ["cargo"] }
@@ -40,9 +46,3 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
-
-[lib]
-name = "solana_clap_v3_utils"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 dirs-next = { workspace = true }
 serde = { workspace = true }
@@ -20,6 +23,3 @@ url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 Inflector = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -51,6 +54,3 @@ ed25519-dalek = { workspace = true }
 solana-keypair = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction-context = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana"
+path = "src/main.rs"
+
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
@@ -103,10 +110,3 @@ solana-streamer = { workspace = true }
 solana-test-validator = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
-
-[[bin]]
-name = "solana"
-path = "src/main.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -10,6 +10,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 futures-util = { workspace = true }
 serde_json = { workspace = true }
@@ -46,6 +49,3 @@ solana-logger = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
@@ -52,6 +55,3 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 crossbeam-channel = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_compute_budget_instruction"
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 agave-feature-set = { workspace = true }
 log = { workspace = true }
@@ -24,10 +34,6 @@ solana-svm-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_compute_budget_instruction"
-
 [dev-dependencies]
 bincode = { workspace = true }
 criterion = { workspace = true }
@@ -40,12 +46,6 @@ solana-signer = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []
 
 [[bench]]
 name = "process_compute_budget_instructions"

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -9,6 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = ["dep:qualifier_attr"]
+frozen-abi = ["dep:solana-frozen-abi", "solana-fee-structure/frozen-abi"]
+
 [dependencies]
 qualifier_attr = { workspace = true, optional = true }
 solana-fee-structure = { workspace = true }
@@ -16,10 +20,6 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-program-runtime = { workspace = true }
-
-[features]
-dev-context-only-utils = ["dep:qualifier_attr"]
-frozen-abi = ["dep:solana-frozen-abi", "solana-fee-structure/frozen-abi"]
 
 [lints]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,35 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[badges]
-codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = [
+    "solana-perf/dev-context-only-utils",
+    "solana-runtime/dev-context-only-utils",
+    "solana-streamer/dev-context-only-utils",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-accounts-db/frozen-abi",
+    "solana-bloom/frozen-abi",
+    "solana-compute-budget/frozen-abi",
+    "solana-cost-model/frozen-abi",
+    "solana-frozen-abi/frozen-abi",
+    "solana-gossip/frozen-abi",
+    "solana-ledger/frozen-abi",
+    "solana-packet/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-runtime/frozen-abi",
+    "solana-short-vec/frozen-abi",
+    "solana-signature/frozen-abi",
+    "solana-svm/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
@@ -136,7 +163,7 @@ solana-vortexor-receiver = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-wen-restart = { workspace = true }
-static_assertions ={ workspace = true }
+static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 sys-info = { workspace = true }
@@ -145,6 +172,12 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 trees = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
+[target."cfg(unix)".dependencies]
+sysctl = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
@@ -177,38 +210,8 @@ spl-memo = { workspace = true, features = ["no-entrypoint"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
-[target."cfg(unix)".dependencies]
-sysctl = { workspace = true }
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
-
-[features]
-dev-context-only-utils = [
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-    "solana-streamer/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-accounts-db/frozen-abi",
-    "solana-bloom/frozen-abi",
-    "solana-compute-budget/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-frozen-abi/frozen-abi",
-    "solana-gossip/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-packet/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-program-runtime/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-signature/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
+[badges]
+codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
 [[bench]]
 name = "banking_stage"
@@ -226,9 +229,6 @@ harness = false
 [[bench]]
 name = "scheduler"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -9,6 +9,29 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_cost_model"
+
+[features]
+dev-context-only-utils = [
+    "dep:solana-hash",
+    "dep:solana-message",
+    "dep:solana-signature",
+    "dep:solana-transaction",
+    "solana-compute-budget-interface/dev-context-only-utils",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-compute-budget/frozen-abi",
+    "solana-pubkey/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
@@ -41,10 +64,6 @@ solana-transaction = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true }
 solana-vote-program = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_cost_model"
-
 [dev-dependencies]
 agave-reserved-account-keys = { workspace = true }
 itertools = { workspace = true }
@@ -69,25 +88,6 @@ solana-system-transaction = { workspace = true }
 solana-vote = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = [
-    "dep:solana-hash",
-    "dep:solana-message",
-    "dep:solana-signature",
-    "dep:solana-transaction",
-    "solana-compute-budget-interface/dev-context-only-utils"
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-compute-budget/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-vote-program/frozen-abi"
-]
 
 [[bench]]
 name = "cost_tracker"

--- a/curves/curve25519/Cargo.toml
+++ b/curves/curve25519/Cargo.toml
@@ -19,11 +19,11 @@ bytemuck_derive = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, features = ["serde"] }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
 
 [lints]
 workspace = true

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 bincode = { workspace = true }
 clap = { version = "3.1.5", features = ["derive", "cargo"] }
@@ -46,13 +52,7 @@ solana-tpu-client = { workspace = true }
 solana-transaction = { workspace = true }
 solana-version = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [dev-dependencies]
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[features]
-dev-context-only-utils = []

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_download_utils"
+
 [dependencies]
 log = { workspace = true }
 solana-clock = { workspace = true }
@@ -18,10 +25,3 @@ solana-runtime = { workspace = true }
 
 [dev-dependencies]
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_download_utils"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_entry"
+
 [dependencies]
 bincode = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -42,12 +49,5 @@ solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["verify"] }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_entry"
-
 [[bench]]
 name = "entry_sigverify"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -9,6 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_faucet"
+
+[[bin]]
+name = "solana-faucet"
+path = "src/bin/faucet.rs"
+
 [dependencies]
 bincode = { workspace = true }
 clap = { workspace = true }
@@ -35,14 +46,3 @@ solana-version = { workspace = true }
 spl-memo = { version = "=6.0.0", features = ["no-entrypoint"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_faucet"
-
-[[bin]]
-name = "solana-faucet"
-path = "src/bin/faucet.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -9,6 +9,9 @@ license = { workspace = true }
 edition = { workspace = true }
 readme = false
 
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 ahash = { workspace = true }
 solana-epoch-schedule = { workspace = true }
@@ -22,9 +25,6 @@ solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
 solana-sha256-hasher = { workspace = true }
 solana-svm-feature-set = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]
 workspace = true

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_genesis_utils"
+
 [dependencies]
 log = { workspace = true }
 solana-accounts-db = { workspace = true }
@@ -16,10 +23,3 @@ solana-download-utils = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-rpc-client = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_genesis_utils"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_genesis"
+
+[[bin]]
+name = "solana-genesis"
+path = "src/main.rs"
+
 [dependencies]
 agave-feature-set = { workspace = true }
 base64 = { workspace = true }
@@ -54,13 +64,3 @@ tempfile = { workspace = true }
 solana-borsh = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[[bin]]
-name = "solana-genesis"
-path = "src/main.rs"
-
-[lib]
-name = "solana_genesis"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
@@ -16,6 +19,3 @@ solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
 bs58 = { workspace = true }
@@ -33,6 +36,3 @@ solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -9,6 +9,27 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana-gossip"
+path = "src/main.rs"
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-bloom/frozen-abi",
+    "solana-ledger/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-runtime/frozen-abi",
+    "solana-short-vec/frozen-abi",
+    "solana-version/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 arrayvec = { workspace = true }
@@ -92,20 +113,6 @@ solana-vote-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-bloom/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-
 [[bench]]
 name = "crds"
 
@@ -118,13 +125,6 @@ name = "crds_shards"
 [[bench]]
 name = "weighted_shuffle"
 harness = false
-
-[[bin]]
-name = "solana-gossip"
-path = "src/main.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 atty = { workspace = true }
 bincode = { workspace = true }
@@ -48,6 +51,3 @@ url = { workspace = true }
 [target."cfg(windows)".dependencies]
 winapi = { workspace = true, features = ["minwindef", "winuser"] }
 winreg = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana-keygen"
+path = "src/keygen.rs"
+
 [dependencies]
 bs58 = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
@@ -31,10 +38,3 @@ tiny-bip39 = { workspace = true }
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
-
-[[bin]]
-name = "solana-keygen"
-path = "src/keygen.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -87,14 +93,8 @@ tokio = { workspace = true, features = ["full"] }
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
 
-[dev-dependencies]
-assert_cmd = { workspace = true }
-
-[features]
-dev-context-only-utils = []
-
 [target."cfg(unix)".dependencies]
 signal-hook = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dev-dependencies]
+assert_cmd = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -9,6 +9,21 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_ledger"
+
+[features]
+dev-context-only-utils = []
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-runtime/frozen-abi",
+]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -131,27 +146,12 @@ spl-generic-token = { workspace = true }
 spl-pod = { workspace = true }
 test-case = { workspace = true }
 
-[features]
-dev-context-only-utils = []
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-runtime/frozen-abi",
-]
-
-[lib]
-crate-type = ["lib"]
-name = "solana_ledger"
-
 [[bench]]
 name = "blockstore"
 
 [[bench]]
 name = "make_shreds_from_entries"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
@@ -75,9 +81,3 @@ solana-download-utils = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["dev-context-only-utils"] }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana-log-analyzer"
+path = "src/main.rs"
+
 [dependencies]
 byte-unit = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
@@ -17,10 +24,3 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-logger = "=2.3.1"
 solana-version = { workspace = true }
-
-[[bin]]
-name = "solana-log-analyzer"
-path = "src/main.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/log-collector/Cargo.toml
+++ b/log-collector/Cargo.toml
@@ -9,8 +9,8 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-log = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+log = { workspace = true }

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_merkle_tree"
+
 [dependencies]
 fast-math = { workspace = true }
 solana-hash = { workspace = true }
@@ -16,10 +23,3 @@ solana-sha256-hasher = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_merkle_tree"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_metrics"
+
 [dependencies]
 crossbeam-channel = { workspace = true }
 gethostname = { workspace = true }
@@ -24,11 +30,5 @@ env_logger = { workspace = true }
 rand = { workspace = true }
 serial_test = { workspace = true }
 
-[lib]
-name = "solana_metrics"
-
 [[bench]]
 name = "metrics"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana-net-shaper"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 rand = { workspace = true }
@@ -16,10 +23,3 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 solana-logger = "=2.3.1"
-
-[[bin]]
-name = "solana-net-shaper"
-path = "src/main.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -10,8 +10,15 @@ license = { workspace = true }
 edition = { workspace = true }
 rust-version = "1.83.0"
 
-[lints]
-workspace = true
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_net_utils"
+
+[features]
+default = []
+dev-context-only-utils = ["dep:pcap-file", "dep:hxdmp"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -33,12 +40,5 @@ url = { workspace = true }
 [dev-dependencies]
 solana-logger = { workspace = true }
 
-[features]
-default = []
-dev-context-only-utils = ["dep:pcap-file", "dep:hxdmp"]
-
-[lib]
-name = "solana_net_utils"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[lints]
+workspace = true

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -9,14 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_notifier"
+
 [dependencies]
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = { workspace = true }
 solana-hash = { workspace = true }
-
-[lib]
-name = "solana_notifier"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -9,6 +9,30 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_perf"
+
+[features]
+dev-context-only-utils = [
+    "dep:solana-clock",
+    "dep:solana-keypair",
+    "dep:solana-signer",
+    "dep:solana-system-interface",
+    "dep:solana-system-transaction",
+    "dep:solana-transaction",
+    "dep:solana-vote-program",
+    "dep:solana-vote",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-short-vec/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
+
 [dependencies]
 ahash = { workspace = true }
 bincode = { workspace = true }
@@ -51,9 +75,6 @@ caps = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 
-[lib]
-name = "solana_perf"
-
 [dev-dependencies]
 assert_matches = { workspace = true }
 rand_chacha = { workspace = true }
@@ -61,32 +82,11 @@ solana-logger = { workspace = true }
 solana-perf = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
-[features]
-dev-context-only-utils = [
-    "dep:solana-clock",
-    "dep:solana-keypair",
-    "dep:solana-signer",
-    "dep:solana-system-interface",
-    "dep:solana-system-transaction",
-    "dep:solana-transaction",
-    "dep:solana-vote-program",
-    "dep:solana-vote",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-short-vec/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-
 [[bench]]
 name = "sigverify"
 
 [[bench]]
 name = "discard"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[[bin]]
+name = "cargo-build-sbf"
+path = "src/main.rs"
+
+[features]
+program = []
+
 [dependencies]
 bzip2 = { workspace = true }
 cargo_metadata = { workspace = true }
@@ -27,10 +34,3 @@ tar = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 serial_test = { workspace = true }
-
-[features]
-program = []
-
-[[bin]]
-name = "cargo-build-sbf"
-path = "src/main.rs"

--- a/platform-tools-sdk/cargo-test-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-test-sbf/Cargo.toml
@@ -9,6 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[[bin]]
+name = "cargo-test-sbf"
+path = "src/main.rs"
+
 [dependencies]
 cargo_metadata = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo"] }
@@ -16,7 +20,3 @@ itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
 solana-logger = "=2.3.1"
-
-[[bin]]
-name = "cargo-test-sbf"
-path = "src/main.rs"

--- a/platform-tools-sdk/gen-headers/Cargo.toml
+++ b/platform-tools-sdk/gen-headers/Cargo.toml
@@ -8,10 +8,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-log = { workspace = true, features = ["std"] }
-regex = { workspace = true }
-
 [[bin]]
 name = "gen-headers"
 path = "src/main.rs"
+
+[dependencies]
+log = { workspace = true, features = ["std"] }
+regex = { workspace = true }

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 clap = { version = "3.1.5", features = ["cargo"] }
 log = { workspace = true }
@@ -20,6 +23,3 @@ solana-perf = { workspace = true }
 solana-rayon-threadlimit = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-version = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_poh"
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -41,19 +51,9 @@ solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 
-[features]
-dev-context-only-utils = []
-
-[lib]
-crate-type = ["lib"]
-name = "solana_poh"
-
 [[bench]]
 name = "poh"
 
 [[bench]]
 name = "transaction_recorder"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -9,18 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 thiserror = { workspace = true }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 ark-bn254 = { workspace = true }
 light-poseidon = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
 
 [lints]
 workspace = true

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
@@ -33,11 +38,6 @@ solana-instruction = { workspace = true }
 solana-keccak-hasher = { workspace = true }
 solana-logger = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -9,6 +9,20 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_program_runtime"
+
+[features]
+dev-context-only-utils = []
+dummy-for-ci-check = ["metrics"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+metrics = ["dep:solana-metrics"]
+shuttle-test = ["solana-type-overrides/shuttle-test", "solana-sbpf/shuttle-test"]
+
 [dependencies]
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -62,26 +76,6 @@ solana-transaction-context = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
 test-case = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_program_runtime"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = []
-dummy-for-ci-check = ["metrics"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-]
-metrics = ["dep:solana-metrics"]
-shuttle-test = [
-    "solana-type-overrides/shuttle-test",
-    "solana-sbpf/shuttle-test",
-]
 
 [lints]
 workspace = true

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -11,6 +11,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 bincode = { workspace = true }
@@ -26,6 +29,3 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_bpf_loader_program"
+
+[features]
+default = ["metrics"]
+metrics = ["solana-program-runtime/metrics"]
+shuttle-test = [
+    "solana-type-overrides/shuttle-test",
+    "solana-program-runtime/shuttle-test",
+    "solana-sbpf/shuttle-test",
+]
+svm-internal = []
+
 [dependencies]
 bincode = { workspace = true }
 libsecp256k1 = { workspace = true }
@@ -69,10 +86,6 @@ solana-transaction-context = { workspace = true, features = ["dev-context-only-u
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_bpf_loader_program"
-
 [[bench]]
 name = "serialization"
 harness = false
@@ -80,16 +93,3 @@ harness = false
 [[bench]]
 name = "bpf_loader_upgradeable"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-default = ["metrics"]
-metrics = ["solana-program-runtime/metrics"]
-shuttle-test = [
-    "solana-type-overrides/shuttle-test",
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test"
-]
-svm-internal = []

--- a/programs/compute-budget-bench/Cargo.toml
+++ b/programs/compute-budget-bench/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 criterion = { workspace = true }
@@ -22,6 +25,3 @@ solana-svm-transaction = { workspace = true }
 [[bench]]
 name = "compute_budget"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-program-runtime = { workspace = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 crate-type = ["lib"]
 name = "solana_compute_budget_program"
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+solana-program-runtime = { workspace = true }

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
@@ -19,6 +22,3 @@ solana-program-test = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/loader-v4/Cargo.toml
+++ b/programs/loader-v4/Cargo.toml
@@ -8,6 +8,22 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_loader_v4_program"
+
+[features]
+agave-unstable-api = []
+shuttle-test = [
+    "solana-type-overrides/shuttle-test",
+    "solana-program-runtime/shuttle-test",
+    "solana-sbpf/shuttle-test",
+]
+svm-internal = []
+
 [dependencies]
 log = { workspace = true }
 qualifier_attr = { workspace = true }
@@ -31,19 +47,3 @@ solana-type-overrides = { workspace = true }
 bincode = { workspace = true }
 solana-clock = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_loader_v4_program"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
-shuttle-test = [
-    "solana-type-overrides/shuttle-test",
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test"
-]
-svm-internal = []

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,3 +1,77 @@
+
+[package]
+name = "solana-sbf-programs"
+description = "Blockchain, Rebuilt for Scale"
+documentation = "https://docs.rs/solana"
+readme = "README.md"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[workspace]
+members = [
+    "rust/128bit",
+    "rust/128bit_dep",
+    "rust/account_mem",
+    "rust/account_mem_deprecated",
+    "rust/alloc",
+    "rust/alt_bn128",
+    "rust/alt_bn128_compression",
+    "rust/big_mod_exp",
+    "rust/call_args",
+    "rust/call_depth",
+    "rust/caller_access",
+    "rust/curve25519",
+    "rust/custom_heap",
+    "rust/dep_crate",
+    "rust/deprecated_loader",
+    "rust/divide_by_zero",
+    "rust/dup_accounts",
+    "rust/error_handling",
+    "rust/external_spend",
+    "rust/get_minimum_delegation",
+    "rust/inner_instruction_alignment_check",
+    "rust/instruction_introspection",
+    "rust/invoke",
+    "rust/invoke_and_error",
+    "rust/invoke_and_ok",
+    "rust/invoke_and_return",
+    "rust/invoked",
+    "rust/iter",
+    "rust/log_data",
+    "rust/many_args",
+    "rust/many_args_dep",
+    "rust/mem",
+    "rust/mem_dep",
+    "rust/membuiltins",
+    "rust/noop",
+    "rust/panic",
+    "rust/param_passing",
+    "rust/param_passing_dep",
+    "rust/poseidon",
+    "rust/rand",
+    "rust/realloc",
+    "rust/realloc_invoke",
+    "rust/remaining_compute_units",
+    "rust/ro_account_modify",
+    "rust/ro_modify",
+    "rust/sanity",
+    "rust/secp256k1_recover",
+    "rust/sha",
+    "rust/sibling_inner_instructions",
+    "rust/sibling_instructions",
+    "rust/simulation",
+    "rust/spoof1",
+    "rust/spoof1_system",
+    "rust/syscall-get-epoch-stake",
+    "rust/sysvar",
+    "rust/upgradeable",
+    "rust/upgraded",
+]
 [workspace.package]
 version = "2.3.0"
 description = "Solana SBF test program written in Rust"
@@ -12,12 +86,13 @@ level = "warn"
 check-cfg = [
     'cfg(target_os, values("solana"))',
     'cfg(feature, values("custom-panic", "custom-heap"))',
-    'cfg(target_feature, values("dynamic-frames"))'
+    'cfg(target_feature, values("dynamic-frames"))',
 ]
 
 [workspace.dependencies]
 agave-feature-set = { path = "../../feature-set", version = "=2.3.0" }
 agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.3.0" }
+agave-validator = { path = "../../validator", version = "=2.3.0" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -39,16 +114,22 @@ serde_json = "1.0.56"
 solana-account-decoder = { path = "../../account-decoder", version = "=2.3.0" }
 solana-account-info = "=2.2.1"
 solana-accounts-db = { path = "../../accounts-db", version = "=2.3.0" }
+solana-big-mod-exp = "=2.2.1"
+solana-blake3-hasher = { version = "=2.2.1", features = ["blake3"] }
 solana-bn254 = "=2.2.2"
 solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.3.0" }
 solana-cli-output = { path = "../../cli-output", version = "=2.3.0" }
+solana-clock = { version = "=2.2.2", features = ["serde", "sysvar"] }
 solana-compute-budget = { path = "../../compute-budget", version = "=2.3.0" }
 solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.3.0" }
 solana-curve25519 = { path = "../../curves/curve25519", version = "=2.3.0" }
 solana-decode-error = "=2.2.1"
 solana-define-syscall = "=2.3.0"
 solana-fee = { path = "../../fee", version = "=2.3.0" }
+solana-hash = { version = "=2.3.0", features = ["bytemuck", "serde", "std"] }
 solana-instruction = "=2.3.0"
+solana-instructions-sysvar = "=2.2.2"
+solana-keccak-hasher = { version = "=2.2.1", features = ["sha3"] }
 solana-ledger = { path = "../../ledger", version = "=2.3.0" }
 solana-log-collector = { path = "../../log-collector", version = "=2.3.0" }
 solana-logger = "=2.3.1"
@@ -72,11 +153,15 @@ solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version =
 solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.3.0" }
 solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.3.0" }
 solana-sbpf = "=0.11.1"
+solana-sdk-ids = "=2.2.1"
 solana-secp256k1-recover = "=2.2.1"
+solana-sha256-hasher = { version = "=2.2.1", features = ["sha2"] }
+solana-stake-interface = { version = "=1.2.1", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=2.3.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=2.3.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=2.3.0" }
 solana-svm-transaction = { path = "../../svm-transaction", version = "=2.3.0" }
+solana-system-interface = { version = "=1.0", features = ["bincode"] }
 solana-sysvar = "=2.2.2"
 solana-timings = { path = "../../timings", version = "=2.3.0" }
 solana-transaction-context = { path = "../../transaction-context", version = "=2.3.0" }
@@ -84,37 +169,8 @@ solana-transaction-status = { path = "../../transaction-status", version = "=2.3
 solana-type-overrides = { path = "../../type-overrides", version = "=2.3.0" }
 solana-vote = { path = "../../vote", version = "=2.3.0" }
 solana-vote-program = { path = "../../programs/vote", version = "=2.3.0" }
-agave-validator = { path = "../../validator", version = "=2.3.0" }
 solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
-solana-stake-interface = { version = "=1.2.1", features = ["bincode"] }
-solana-clock = { version = "=2.2.2", features = ["serde", "sysvar"] }
-solana-system-interface = { version = "=1.0", features = ["bincode"] }
-solana-big-mod-exp = "=2.2.1"
-solana-blake3-hasher = { version = "=2.2.1", features = ["blake3"] }
-solana-hash = { version = "=2.3.0", features = ["bytemuck", "serde", "std"] }
-solana-keccak-hasher = { version = "=2.2.1", features = ["sha3"] }
-solana-sha256-hasher = { version = "=2.2.1", features = ["sha2"] }
-solana-instructions-sysvar = "=2.2.2"
-solana-sdk-ids = "=2.2.1"
-
-[package]
-name = "solana-sbf-programs"
-description = "Blockchain, Rebuilt for Scale"
-documentation = "https://docs.rs/solana"
-readme = "README.md"
-publish = false
-version = { workspace = true }
-authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
-edition = { workspace = true }
-
-[profile.release]
-# The test programs are build in release mode
-# Minimize their file size so that they fit into the account size limit
-strip = true
 
 [features]
 sbf_c = []
@@ -194,69 +250,13 @@ solana-type-overrides = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 
+[profile.release]
+# The test programs are build in release mode
+# Minimize their file size so that they fit into the account size limit
+strip = true
+
 [[bench]]
 name = "bpf_loader"
-
-[workspace]
-members = [
-    "rust/128bit",
-    "rust/128bit_dep",
-    "rust/account_mem",
-    "rust/account_mem_deprecated",
-    "rust/alloc",
-    "rust/alt_bn128",
-    "rust/alt_bn128_compression",
-    "rust/big_mod_exp",
-    "rust/call_args",
-    "rust/call_depth",
-    "rust/caller_access",
-    "rust/curve25519",
-    "rust/custom_heap",
-    "rust/dep_crate",
-    "rust/deprecated_loader",
-    "rust/divide_by_zero",
-    "rust/dup_accounts",
-    "rust/error_handling",
-    "rust/external_spend",
-    "rust/get_minimum_delegation",
-    "rust/inner_instruction_alignment_check",
-    "rust/instruction_introspection",
-    "rust/invoke",
-    "rust/invoke_and_error",
-    "rust/invoke_and_ok",
-    "rust/invoke_and_return",
-    "rust/invoked",
-    "rust/iter",
-    "rust/log_data",
-    "rust/many_args",
-    "rust/many_args_dep",
-    "rust/mem",
-    "rust/mem_dep",
-    "rust/membuiltins",
-    "rust/noop",
-    "rust/panic",
-    "rust/param_passing",
-    "rust/param_passing_dep",
-    "rust/poseidon",
-    "rust/rand",
-    "rust/realloc",
-    "rust/realloc_invoke",
-    "rust/remaining_compute_units",
-    "rust/ro_account_modify",
-    "rust/ro_modify",
-    "rust/sanity",
-    "rust/secp256k1_recover",
-    "rust/sha",
-    "rust/sibling_inner_instructions",
-    "rust/sibling_instructions",
-    "rust/simulation",
-    "rust/spoof1",
-    "rust/spoof1_system",
-    "rust/syscall-get-epoch-stake",
-    "rust/sysvar",
-    "rust/upgradeable",
-    "rust/upgraded",
-]
 
 [patch.crates-io]
 # We include the following crates as our dependencies from crates.io:

--- a/programs/sbf/rust/128bit/Cargo.toml
+++ b/programs/sbf/rust/128bit/Cargo.toml
@@ -8,12 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-program-entrypoint = { workspace = true }
 solana-sbf-rust-128bit-dep = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/account_mem/Cargo.toml
+++ b/programs/sbf/rust/account_mem/Cargo.toml
@@ -8,15 +8,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/account_mem_deprecated/Cargo.toml
+++ b/programs/sbf/rust/account_mem_deprecated/Cargo.toml
@@ -8,15 +8,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program = { workspace = true }
 solana-program-error = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/alloc/Cargo.toml
+++ b/programs/sbf/rust/alloc/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-msg = { workspace = true }
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/alt_bn128/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 array-bytes = { workspace = true }
 solana-bn254 = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/alt_bn128_compression/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128_compression/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 array-bytes = { workspace = true }
 solana-bn254 = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/big_mod_exp/Cargo.toml
+++ b/programs/sbf/rust/big_mod_exp/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 array-bytes = { workspace = true }
 serde = { workspace = true }
@@ -16,9 +19,6 @@ serde_json = { workspace = true }
 solana-big-mod-exp = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/call_args/Cargo.toml
+++ b/programs/sbf/rust/call_args/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 borsh = { workspace = true }
 solana-account-info = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/call_depth/Cargo.toml
+++ b/programs/sbf/rust/call_depth/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-msg = { workspace = true }
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/caller_access/Cargo.toml
+++ b/programs/sbf/rust/caller_access/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -16,9 +19,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/curve25519/Cargo.toml
+++ b/programs/sbf/rust/curve25519/Cargo.toml
@@ -8,13 +8,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-curve25519 = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -8,19 +8,19 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["custom-heap"]
+custom-heap = []
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[features]
-default = ["custom-heap"]
-custom-heap = []
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/dep_crate/Cargo.toml
+++ b/programs/sbf/rust/dep_crate/Cargo.toml
@@ -8,9 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 byteorder = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -19,9 +22,6 @@ solana-pubkey = { workspace = true }
 solana-sbf-rust-invoke-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sdk-ids = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/divide_by_zero/Cargo.toml
+++ b/programs/sbf/rust/divide_by_zero/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/dup_accounts/Cargo.toml
+++ b/programs/sbf/rust/dup_accounts/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -16,9 +19,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/error_handling/Cargo.toml
+++ b/programs/sbf/rust/error_handling/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 num-derive = { workspace = true }
 num-traits = { workspace = true }
@@ -18,9 +21,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 thiserror = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/external_spend/Cargo.toml
+++ b/programs/sbf/rust/external_spend/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/sbf/rust/get_minimum_delegation/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -15,9 +18,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-stake-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -16,9 +19,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/instruction_introspection/Cargo.toml
+++ b/programs/sbf/rust/instruction_introspection/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -18,9 +21,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -22,9 +25,6 @@ solana-sbf-rust-invoked-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoke_and_error/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_error/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_ok/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoke_and_return/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_return/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoked/Cargo.toml
+++ b/programs/sbf/rust/invoked/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -19,9 +22,6 @@ solana-sbf-rust-invoked-dep = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/iter/Cargo.toml
+++ b/programs/sbf/rust/iter/Cargo.toml
@@ -8,12 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/log_data/Cargo.toml
+++ b/programs/sbf/rust/log_data/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program = { workspace = true }
@@ -15,9 +18,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/many_args/Cargo.toml
+++ b/programs/sbf/rust/many_args/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-msg = { workspace = true }
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-sbf-rust-many-args-dep = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
@@ -15,9 +18,6 @@ solana-program-error = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sbf-rust-mem-dep = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/mem_dep/Cargo.toml
+++ b/programs/sbf/rust/mem_dep/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-
 [lib]
 crate-type = ["lib"]
+
+[dependencies]

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -8,12 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-program-entrypoint = { workspace = true }
 solana-sbf-rust-mem-dep = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/noop/Cargo.toml
+++ b/programs/sbf/rust/noop/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -8,19 +8,19 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["custom-panic"]
+custom-panic = []
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[features]
-default = ["custom-panic"]
-custom-panic = []
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/param_passing/Cargo.toml
+++ b/programs/sbf/rust/param_passing/Cargo.toml
@@ -8,13 +8,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-sbf-rust-param-passing-dep = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 array-bytes = { workspace = true }
 solana-msg = { workspace = true }
 solana-poseidon = { workspace = true }
 solana-program-entrypoint = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/rand/Cargo.toml
+++ b/programs/sbf/rust/rand/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 getrandom = { workspace = true, features = ["custom"] }
 rand = { workspace = true }
@@ -16,9 +19,6 @@ solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/realloc/Cargo.toml
+++ b/programs/sbf/rust/realloc/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -17,9 +20,6 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/realloc_invoke/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -19,9 +22,6 @@ solana-pubkey = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sbf-rust-realloc-invoke-dep = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/remaining_compute_units/Cargo.toml
+++ b/programs/sbf/rust/remaining_compute_units/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/ro_account_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_account_modify/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -16,9 +19,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -16,9 +19,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -16,9 +19,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/sbf/rust/secp256k1_recover/Cargo.toml
@@ -8,15 +8,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 libsecp256k1 = { workspace = true }
 solana-keccak-hasher = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sha/Cargo.toml
+++ b/programs/sbf/rust/sha/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 blake3 = { workspace = true }
 solana-blake3-hasher = { workspace = true }
@@ -15,9 +18,6 @@ solana-keccak-hasher = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true, features = ["syscalls"] }
@@ -15,9 +18,6 @@ solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sibling_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_instructions/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -16,9 +19,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-clock = { workspace = true }
@@ -16,9 +19,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/spoof1/Cargo.toml
+++ b/programs/sbf/rust/spoof1/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -17,9 +20,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-system-interface = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/spoof1_system/Cargo.toml
+++ b/programs/sbf/rust/spoof1_system/Cargo.toml
@@ -8,14 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
+++ b/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -15,9 +18,6 @@ solana-program = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -8,8 +8,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
-bincode =  { workspace = true }
+bincode = { workspace = true }
 solana-account-info = { workspace = true }
 solana-define-syscall = { workspace = true }
 solana-instruction = { workspace = true }
@@ -20,9 +23,6 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/upgradeable/Cargo.toml
+++ b/programs/sbf/rust/upgradeable/Cargo.toml
@@ -8,6 +8,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+name = "solana_sbf_rust_upgradeable"
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -15,10 +19,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-name = "solana_sbf_rust_upgradeable"
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/upgraded/Cargo.toml
+++ b/programs/sbf/rust/upgraded/Cargo.toml
@@ -8,6 +8,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+name = "solana_sbf_rust_upgraded"
+crate-type = ["cdylib"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
@@ -15,10 +19,6 @@ solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[lib]
-name = "solana_sbf_rust_upgraded"
-crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/programs/stake-tests/Cargo.toml
+++ b/programs/stake-tests/Cargo.toml
@@ -11,6 +11,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 assert_matches = { workspace = true }
@@ -29,6 +32,3 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-vote-program = { workspace = true }
 test-case = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_stake_program"
+
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
@@ -46,13 +53,6 @@ solana-svm-feature-set = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-vote-program = { workspace = true, default-features = false }
 test-case = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_stake_program"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [[bench]]
 name = "stake"

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_system_program"
+
 [dependencies]
 bincode = { workspace = true }
 log = { workspace = true }
@@ -42,13 +49,6 @@ solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_system_program"
-
 [[bench]]
 name = "system"
 harness = false
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_vote_program"
+
+[features]
+default = ["metrics"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program-runtime/frozen-abi",
+    "solana-vote-interface/frozen-abi",
+]
+metrics = ["dep:solana-metrics"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
@@ -61,23 +78,6 @@ test-case = { workspace = true }
 [[bench]]
 name = "vote_instructions"
 harness = false
-
-[lib]
-crate-type = ["lib"]
-name = "solana_vote_program"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-default = ["metrics"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
-    "solana-vote-interface/frozen-abi"
-]
-metrics = ["dep:solana-metrics"]
 
 [lints]
 workspace = true

--- a/pubsub-client/Cargo.toml
+++ b/pubsub-client/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
@@ -34,6 +37,3 @@ url = { workspace = true }
 anyhow = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-num_cpus = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+num_cpus = { workspace = true }

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = ["linux-static-hidraw", "hidapi"]
+linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
+linux-shared-libusb = ["hidapi/linux-shared-libusb"]
+linux-static-hidraw = ["hidapi/linux-static-hidraw"]
+linux-static-libusb = ["hidapi/linux-static-libusb"]
+
 [dependencies]
 console = { workspace = true }
 dialoguer = { workspace = true }
@@ -30,13 +40,3 @@ uriparse = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[features]
-default = ["linux-static-hidraw", "hidapi"]
-linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
-linux-shared-libusb = ["hidapi/linux-shared-libusb"]
-linux-static-hidraw = ["hidapi/linux-static-hidraw"]
-linux-static-libusb = ["hidapi/linux-static-libusb"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -23,14 +31,6 @@ solana-sdk-ids = { workspace = true }
 [dev-dependencies]
 solana-message = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 anyhow = { workspace = true }
 jsonrpc-core = { workspace = true }
@@ -24,6 +27,3 @@ solana-signer = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 thiserror = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = []
+clap = ["dep:clap", "dep:solana-clap-utils"]
+
 [dependencies]
 clap = { version = "2.33.0", optional = true }
 solana-account = { workspace = true, features = ["bincode"] }
@@ -35,10 +42,3 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-
-[features]
-default = []
-clap = ["dep:clap", "dep:solana-clap-utils"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client-types/Cargo.toml
+++ b/rpc-client-types/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 base64 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
@@ -32,6 +35,3 @@ thiserror = { workspace = true }
 [dev-dependencies]
 const_format = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = ["spinner"]
+# Support rpc-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = ["dep:indicatif"]
+
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -55,12 +64,3 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-default = ["spinner"]
-# Support rpc-client methods that feature a spinner progress bar for
-# command-line interfaces
-spinner = ["dep:indicatif"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -10,6 +10,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bincode = { workspace = true }
 bs58 = { workspace = true }
@@ -45,6 +48,3 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_rpc"
+
+[features]
+dev-context-only-utils = ["solana-rpc/dev-context-only-utils"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 base64 = { workspace = true }
@@ -119,15 +129,3 @@ solana-vote-interface = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-dev-context-only-utils = [
-    "solana-rpc/dev-context-only-utils",
-]
-
-[lib]
-crate-type = ["lib"]
-name = "solana_rpc"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_runtime_transaction"
+
+[features]
+dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
+
 [dependencies]
 agave-transaction-view = { workspace = true }
 log = { workspace = true }
@@ -23,10 +33,6 @@ solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_runtime_transaction"
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
@@ -44,12 +50,6 @@ solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
 solana-vote-interface = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
 
 [[bench]]
 name = "get_signature_details"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,6 +9,43 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_runtime"
+
+[features]
+dev-context-only-utils = [
+    "dep:solana-system-program",
+    "solana-svm/dev-context-only-utils",
+    "solana-runtime-transaction/dev-context-only-utils",
+    "solana-vote/dev-context-only-utils",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-account/frozen-abi",
+    "solana-accounts-db/frozen-abi",
+    "solana-compute-budget/frozen-abi",
+    "solana-cost-model/frozen-abi",
+    "solana-epoch-schedule/frozen-abi",
+    "solana-hard-forks/frozen-abi",
+    "solana-inflation/frozen-abi",
+    "solana-instruction/frozen-abi",
+    "solana-perf/frozen-abi",
+    "solana-program-runtime/frozen-abi",
+    "solana-rent/frozen-abi",
+    "solana-rent-collector/frozen-abi",
+    "solana-stake-interface/frozen-abi",
+    "solana-svm/frozen-abi",
+    "solana-transaction-error/frozen-abi",
+    "solana-version/frozen-abi",
+    "solana-vote/frozen-abi",
+    "solana-vote-program/frozen-abi",
+]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-precompiles = { workspace = true }
@@ -147,10 +184,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 zstd = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_runtime"
-
 [dev-dependencies]
 agave-transaction-view = { workspace = true }
 ed25519-dalek = { workspace = true }
@@ -173,39 +206,6 @@ solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = [
-    "dep:solana-system-program",
-    "solana-svm/dev-context-only-utils",
-    "solana-runtime-transaction/dev-context-only-utils",
-    "solana-vote/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-account/frozen-abi",
-    "solana-accounts-db/frozen-abi",
-    "solana-compute-budget/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-epoch-schedule/frozen-abi",
-    "solana-hard-forks/frozen-abi",
-    "solana-inflation/frozen-abi",
-    "solana-instruction/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-program-runtime/frozen-abi",
-    "solana-rent/frozen-abi",
-    "solana-rent-collector/frozen-abi",
-    "solana-stake-interface/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-transaction-error/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
 
 [[bench]]
 name = "prioritization_fee_cache"

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+dev-context-only-utils = ["solana-net-utils"]
+
 [dependencies]
 async-trait = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -43,9 +49,3 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
-
-[features]
-dev-context-only-utils = ["solana-net-utils"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 clap = { workspace = true }
 solana-account = { workspace = true }
@@ -35,6 +38,3 @@ solana-version = { workspace = true }
 [dev-dependencies]
 solana-client-traits = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_storage_bigtable"
+
 [dependencies]
 agave-reserved-account-keys = { workspace = true }
 backoff = { workspace = true, features = ["tokio"] }
@@ -53,10 +60,3 @@ solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_storage_bigtable"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_storage_proto"
+
 [dependencies]
 bincode = { workspace = true }
 bs58 = { workspace = true }
@@ -26,16 +33,6 @@ solana-transaction-context = { workspace = true, features = ["serde"] }
 solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 
-[dev-dependencies]
-enum-iterator = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_storage_proto"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [build-dependencies]
 tonic-build = { workspace = true }
 
@@ -43,3 +40,6 @@ tonic-build = { workspace = true }
 # envar to point to the installed binary
 [target."cfg(not(windows))".build-dependencies]
 protobuf-src = { workspace = true }
+
+[dev-dependencies]
+enum-iterator = { workspace = true }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_streamer"
+
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 async-channel = { workspace = true }
 bytes = { workspace = true }
@@ -55,13 +65,3 @@ assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-dev-context-only-utils = []
-
-[lib]
-crate-type = ["lib"]
-name = "solana_streamer"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 prost = { workspace = true }
 prost-types = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -9,6 +9,28 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_svm"
+
+[features]
+dev-context-only-utils = ["dep:qualifier_attr"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-program-runtime/frozen-abi",
+]
+shuttle-test = [
+    "solana-type-overrides/shuttle-test",
+    "solana-program-runtime/shuttle-test",
+    "solana-bpf-loader-program/shuttle-test",
+    "solana-loader-v4-program/shuttle-test",
+]
+svm-internal = []
+
 [dependencies]
 ahash = { workspace = true }
 itertools = { workspace = true }
@@ -59,10 +81,6 @@ solana-type-overrides = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_svm"
-
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -104,24 +122,6 @@ solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 spl-token = { workspace = true }
 test-case = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = ["dep:qualifier_attr"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
-]
-shuttle-test = [
-    "solana-type-overrides/shuttle-test",
-    "solana-program-runtime/shuttle-test",
-    "solana-bpf-loader-program/shuttle-test",
-    "solana-loader-v4-program/shuttle-test",
-]
-svm-internal = []
 
 [lints]
 workspace = true

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -29,22 +29,44 @@ jsonrpc-http-server = "18.0.0"
 log = "0.4.22"
 serde = "1.0.214"
 serde_json = "1.0.132"
+solana-account = "2.2.1"
 solana-account-decoder = { path = "../../account-decoder" }
 solana-bpf-loader-program = { path = "../../programs/bpf_loader" }
 solana-client = { path = "../../client" }
+solana-clock = "2.2.1"
+solana-commitment-config = "2.2.1"
 solana-compute-budget = { path = "../../compute-budget" }
+solana-compute-budget-interface = "2.2.2"
+solana-epoch-schedule = "2.2.1"
+solana-hash = "2.2.1"
+solana-instruction = "2.2.1"
+solana-keypair = "2.2.1"
 solana-logger = "=2.3.1"
+solana-message = "2.3.0"
+solana-nonce = "2.2.1"
 solana-perf = { path = "../../perf" }
+solana-program-pack = "2.2.1"
 solana-program-runtime = { path = "../../program-runtime" }
+solana-pubkey = "2.3.0"
+solana-rent-collector = "2.2.1"
 solana-rpc-client-api = { path = "../../rpc-client-api" }
+solana-sdk-ids = "2.2.1"
+solana-signature = "2.2.1"
+solana-signer = "2.2.1"
 solana-svm = { path = "../" }
 solana-svm-callback = { path = "../../svm-callback" }
 solana-svm-feature-set = { path = "../../svm-feature-set" }
+solana-system-interface = "1.0"
 solana-system-program = { path = "../../programs/system" }
-solana-version = { path = "../../version" }
+solana-sysvar = "2.2.1"
+solana-sysvar-id = "2.2.1"
 solana-test-validator = { path = "../../test-validator" }
+solana-transaction = "2.2.2"
 solana-transaction-context = { path = "../../transaction-context" }
+solana-transaction-error = "2.2.1"
 solana-transaction-status = { path = "../../transaction-status" }
+solana-validator-exit = "2.2.1"
+solana-version = { path = "../../version" }
 spl-associated-token-account = "7.0.0"
 spl-token = "8.0.0"
 spl-token-2022 = "8.0.0"
@@ -53,28 +75,6 @@ thiserror = "1.0.68"
 tokio = "1.29.1"
 tokio-util = "0.7"
 yaml-rust = "0.4"
-solana-account = "2.2.1"
-solana-clock = "2.2.1"
-solana-commitment-config = "2.2.1"
-solana-compute-budget-interface = "2.2.2"
-solana-message = "2.3.0"
-solana-nonce = "2.2.1"
-solana-pubkey = "2.3.0"
-solana-sdk-ids = "2.2.1"
-solana-signature = "2.2.1"
-solana-system-interface = "1.0"
-solana-sysvar = "2.2.1"
-solana-sysvar-id = "2.2.1"
-solana-transaction = "2.2.2"
-solana-transaction-error = "2.2.1"
-solana-validator-exit = "2.2.1"
-solana-instruction = "2.2.1"
-solana-keypair = "2.2.1"
-solana-signer = "2.2.1"
-solana-hash = "2.2.1"
-solana-rent-collector = "2.2.1"
-solana-epoch-schedule = "2.2.1"
-solana-program-pack = "2.2.1"
 
 [patch.crates-io]
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }

--- a/svm/examples/json-rpc/client/Cargo.toml
+++ b/svm/examples/json-rpc/client/Cargo.toml
@@ -5,6 +5,10 @@ version = { workspace = true }
 edition = { workspace = true }
 publish = false
 
+[features]
+dummy-for-ci-check = []
+frozen-abi = []
+
 [dependencies]
 borsh = { workspace = true }
 clap = { workspace = true }
@@ -19,7 +23,3 @@ solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 thiserror = { workspace = true }
 yaml-rust = { workspace = true }
-
-[features]
-dummy-for-ci-check = []
-frozen-abi = []

--- a/svm/examples/json-rpc/server/Cargo.toml
+++ b/svm/examples/json-rpc/server/Cargo.toml
@@ -5,6 +5,10 @@ version = { workspace = true }
 edition = { workspace = true }
 publish = false
 
+[features]
+dummy-for-ci-check = []
+frozen-abi = []
+
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -52,7 +56,3 @@ solana-version = { workspace = true }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "compat"] }
-
-[features]
-dummy-for-ci-check = []
-frozen-abi = []

--- a/svm/examples/paytube/Cargo.toml
+++ b/svm/examples/paytube/Cargo.toml
@@ -5,6 +5,10 @@ version = { workspace = true }
 edition = { workspace = true }
 publish = false
 
+[features]
+dummy-for-ci-check = []
+frozen-abi = []
+
 [dependencies]
 agave-feature-set = { workspace = true }
 solana-account = { workspace = true }
@@ -38,7 +42,3 @@ termcolor = { workspace = true }
 
 [dev-dependencies]
 solana-test-validator = { workspace = true }
-
-[features]
-dummy-for-ci-check = []
-frozen-abi = []

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 base64 = { workspace = true }
@@ -54,6 +57,3 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/thin-client/Cargo.toml
+++ b/thin-client/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bincode = { workspace = true }
 log = { workspace = true }
@@ -34,6 +37,3 @@ solana-transaction-error = { workspace = true }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/thread-manager/Cargo.toml
+++ b/thread-manager/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 anyhow = { workspace = true }
 cfg-if = { workspace = true }
@@ -31,6 +34,3 @@ hyper = { workspace = true, features = ["http1", "client", "stream", "tcp"] }
 serde_json = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
-
-[features]
-dev-context-only-utils = []

--- a/timings/Cargo.toml
+++ b/timings/Cargo.toml
@@ -9,10 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 eager = { workspace = true }
 enum-iterator = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -8,6 +8,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bank-client = ["dep:solana-client-traits", "dep:solana-runtime"]
+
 [dependencies]
 log = { workspace = true }
 solana-account = { workspace = true }
@@ -37,11 +45,3 @@ thiserror = { workspace = true }
 [dev-dependencies]
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-bank-client = ["dep:solana-client-traits", "dep:solana-runtime"]

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -8,6 +8,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+metrics = ["dep:solana-metrics"]
+
 [dependencies]
 async-trait = { workspace = true }
 log = { workspace = true }
@@ -18,7 +24,7 @@ solana-clock = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
-solana-metrics ={ workspace = true, optional = true }
+solana-metrics = { workspace = true, optional = true }
 solana-quic-definitions = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-streamer = { workspace = true }
@@ -38,9 +44,3 @@ solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-metrics =["dep:solana-metrics"]

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -9,6 +9,19 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = ["spinner"]
+# Support tpu-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = [
+    "dep:indicatif",
+    "dep:solana-message",
+    "solana-rpc-client/spinner",
+]
+
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
@@ -36,16 +49,3 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-
-[features]
-default = ["spinner"]
-# Support tpu-client methods that feature a spinner progress bar for
-# command-line interfaces
-spinner = [
-    "dep:indicatif",
-    "dep:solana-message",
-    "solana-rpc-client/spinner"
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -9,6 +9,21 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:bincode", "serde", "solana-account/bincode"]
+debug-signature = ["dep:solana-signature"]
+dev-context-only-utils = [
+    "bincode",
+    "debug-signature",
+    "solana-account/dev-context-only-utils",
+]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -16,11 +31,6 @@ solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bincode = { workspace = true, optional = true }
@@ -35,16 +45,6 @@ solana-transaction-context = { path = ".", features = [
     "dev-context-only-utils",
 ] }
 static_assertions = { workspace = true }
-
-[features]
-bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-debug-signature = ["dep:solana-signature"]
-dev-context-only-utils = [
-    "bincode",
-    "debug-signature",
-    "solana-account/dev-context-only-utils"
-]
-serde = ["dep:serde", "dep:serde_derive"]
 
 [lints]
 workspace = true

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -8,6 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bincode = { workspace = true }
 clap = { workspace = true }
@@ -43,6 +46,3 @@ solana-hash = { workspace = true }
 solana-local-cluster = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -27,6 +30,3 @@ solana-packet = { workspace = true, features = ["dev-context-only-utils"] }
 solana-perf = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -25,6 +28,3 @@ solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 Inflector = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
@@ -51,6 +54,3 @@ thiserror = { workspace = true }
 bytemuck = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-token-confidential-transfer-proof-extraction = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
@@ -31,9 +34,6 @@ solana-signature = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-transaction = { workspace = true, features = ["bincode"] }
-
-[features]
-dev-context-only-utils = []
 
 [[bench]]
 name = "bytes"

--- a/type-overrides/Cargo.toml
+++ b/type-overrides/Cargo.toml
@@ -8,11 +8,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+shuttle-test = ["dep:shuttle"]
+executor = ["dep:futures"]
+
 [dependencies]
 futures = { workspace = true, optional = true }
 rand = { workspace = true }
 shuttle = { workspace = true, optional = true }
-
-[features]
-shuttle-test = ["dep:shuttle"]
-executor = ["dep:futures"]

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 aquamarine = { workspace = true }
@@ -48,6 +51,3 @@ solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-system-transaction = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-dev-context-only-utils = []

--- a/upload-perf/Cargo.toml
+++ b/upload-perf/Cargo.toml
@@ -9,13 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde_json = { workspace = true }
-solana-metrics = { workspace = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [[bin]]
 name = "solana-upload-perf"
 path = "src/upload-perf.rs"
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde_json = { workspace = true }
+solana-metrics = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -10,6 +10,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
@@ -82,6 +85,13 @@ symlink = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
+[target."cfg(unix)".dependencies]
+libc = { workspace = true }
+signal-hook = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
@@ -93,13 +103,3 @@ solana-time-utils = { workspace = true }
 spl-generic-token = { workspace = true }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tempfile = { workspace = true }
-
-[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
-
-[target."cfg(unix)".dependencies]
-libc = { workspace = true }
-signal-hook = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -9,6 +9,16 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_version"
+
+[features]
+dummy-for-ci-check = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 agave-feature-set = { workspace = true }
 rand = { workspace = true }
@@ -23,19 +33,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-sanitize = { workspace = true }
 solana-serde-varint = { workspace = true }
-
-[features]
-dummy-for-ci-check = []
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-]
-
-[lib]
-name = "solana_version"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/vortexor-receiver/Cargo.toml
+++ b/vortexor-receiver/Cargo.toml
@@ -10,6 +10,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_vortexor_receiver"
+
 [dependencies]
 solana-perf = { workspace = true }
 solana-streamer = { workspace = true }
@@ -17,10 +24,3 @@ solana-streamer = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_vortexor_receiver"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -11,6 +11,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_vortexor"
+
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 async-channel = { workspace = true }
@@ -63,10 +70,3 @@ assert_matches = { workspace = true }
 solana-local-cluster = { workspace = true }
 solana-native-token = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
-
-[lib]
-crate-type = ["lib"]
-name = "solana_vortexor"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -9,6 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]
+name = "solana_vote"
+
+[features]
+dev-context-only-utils = ["dep:rand", "dep:bincode"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 itertools = { workspace = true }
@@ -39,10 +50,6 @@ solana-transaction = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_vote"
-
 [dev-dependencies]
 arbitrary = { workspace = true }
 bincode = { workspace = true }
@@ -54,13 +61,6 @@ solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
 static_assertions = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-dev-context-only-utils = ["dep:rand", "dep:bincode"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]
 workspace = true

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 clap = { workspace = true }
 humantime = { workspace = true }
@@ -25,6 +28,3 @@ solana-pubkey = { version = "=2.4.0", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-version = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/wen-restart/Cargo.toml
+++ b/wen-restart/Cargo.toml
@@ -10,6 +10,12 @@ license = { workspace = true }
 edition = { workspace = true }
 publish = true
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_wen_restart"
+
 [dependencies]
 anyhow = { workspace = true }
 log = { workspace = true }
@@ -30,6 +36,14 @@ solana-vote = { workspace = true }
 solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }
 
+[build-dependencies]
+prost-build = { workspace = true }
+
+# windows users should install the protobuf compiler manually and set the PROTOC
+# envar to point to the installed binary
+[target."cfg(not(windows))".build-dependencies]
+protobuf-src = { workspace = true }
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -43,17 +57,3 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }
 tempfile = { workspace = true }
-
-[build-dependencies]
-prost-build = { workspace = true }
-
-# windows users should install the protobuf compiler manually and set the PROTOC
-# envar to point to the installed binary
-[target."cfg(not(windows))".build-dependencies]
-protobuf-src = { workspace = true }
-
-[lib]
-name = "solana_wen_restart"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -15,6 +15,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "solana-zk-keygen"
+path = "src/main.rs"
+
 [dependencies]
 bs58 = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "derive"] }
@@ -31,10 +38,3 @@ tiny-bip39 = { workspace = true }
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
-
-[[bin]]
-name = "solana-zk-keygen"
-path = "src/main.rs"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 base64 = { workspace = true }
 bytemuck = { workspace = true }
@@ -21,9 +24,8 @@ solana-pubkey = { workspace = true, features = ["bytemuck"] }
 solana-sdk-ids = { workspace = true }
 thiserror = { workspace = true }
 
-[dev-dependencies]
-solana-keypair = { workspace = true }
-tiny-bip39 = { workspace = true }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+solana-pubkey = { workspace = true, features = ["bytemuck"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
@@ -43,15 +45,13 @@ solana-signer = { workspace = true }
 subtle = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-solana-pubkey = { workspace = true, features = ["bytemuck"] }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 
-[lib]
-crate-type = ["cdylib", "rlib"]
+[dev-dependencies]
+solana-keypair = { workspace = true }
+tiny-bip39 = { workspace = true }
 
 [lints]
 workspace = true

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 base64 = { workspace = true }
 bytemuck = { workspace = true }
@@ -20,10 +23,6 @@ solana-instruction = { workspace = true, features = ["std"] }
 solana-pubkey = { workspace = true, features = ["bytemuck"] }
 solana-sdk-ids = { workspace = true }
 thiserror = { workspace = true }
-
-[dev-dependencies]
-solana-keypair = { workspace = true }
-tiny-bip39 = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
@@ -44,8 +43,9 @@ solana-signer = { workspace = true }
 subtle = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-[lib]
-crate-type = ["cdylib", "rlib"]
+[dev-dependencies]
+solana-keypair = { workspace = true }
+tiny-bip39 = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1379599822767788043

cargo sort v2 was released ~2 weeks ago and does a decent job at sorting

#### Summary of Changes

- update our ci docker image
- run `./scripts/cargo-for-all-lock-files.sh -- sort --workspace` and commit