### PR TITLE
abstract sender channel in quic streamer, allow for crossbeam + Tokio

### DIFF
--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -159,7 +159,7 @@ mod tests {
             stats: _,
             thread: t,
             max_concurrent_connections: _,
-        } = solana_streamer::nonblocking::quic::spawn_server(
+        } = solana_streamer::nonblocking::quic::spawn_server_for_testing(
             "quic_streamer_test",
             s.try_clone().unwrap(),
             &keypair,

--- a/streamer/src/nonblocking/channel_wrapper.rs
+++ b/streamer/src/nonblocking/channel_wrapper.rs
@@ -1,26 +1,71 @@
-use crossbeam_channel::{Sender, Receiver, unbounded};
+use std::fmt;
+use std::sync::Arc;
+use crossbeam_channel::{Sender};
+use crate::nonblocking::channel_wrapper;
 
-pub trait MyChannelSender<T>: Send + Sync + 'static {
-    fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>>;
-    fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>>;
+pub trait MyChannelSender<T>: Clone + Send + Sync + 'static {
+    fn try_send(&self, value: T) -> Result<(), TrySendError<T>>;
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum TrySendError<T> {
+    Full(T),
+    Disconnected(T),
+}
+
+impl<T> fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            TrySendError::Full(..) => "sending on a full channel".fmt(f),
+            TrySendError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
+        }
+    }
+}
+
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            TrySendError::Full(..) => "Full(..)".fmt(f),
+            TrySendError::Disconnected(..) => "Disconnected(..)".fmt(f),
+        }
+    }
 }
 
 pub struct MyChannelSendWrapper<T> {
-    sender: Sender<T>,
+    sender: Arc<Sender<T>>,
 }
 
 impl<T: Send> MyChannelSendWrapper<T> {
     pub fn new(sender: Sender<T>) -> Self {
-        MyChannelSendWrapper { sender }
+        MyChannelSendWrapper { sender: Arc::new(sender) }
+    }
+}
+
+impl<T: Send + 'static> Clone for MyChannelSendWrapper<T> {
+    fn clone(&self) -> Self {
+        MyChannelSendWrapper {
+            sender: Arc::clone(&self.sender),
+        }
+
     }
 }
 
 impl<T: Send + 'static> MyChannelSender<T> for MyChannelSendWrapper<T> {
-    fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>> {
-        self.sender.send(value)
-    }
+    // fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>> {
+    //     self.sender.send(value)
+    // }
 
-    fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>> {
-        self.sender.try_send(value)
+    #[inline]
+    fn try_send(&self, value: T) -> Result<(), channel_wrapper::TrySendError<T>> {
+        self.sender.try_send(value).map_err(|err| err.into())
+    }
+}
+
+impl<T> From<crossbeam_channel::TrySendError<T>> for TrySendError<T> {
+    fn from(err: crossbeam_channel::TrySendError<T>) -> Self {
+        match err {
+            crossbeam_channel::TrySendError::Full(value) => TrySendError::Full(value),
+            crossbeam_channel::TrySendError::Disconnected(value) => TrySendError::Disconnected(value),
+        }
     }
 }

--- a/streamer/src/nonblocking/channel_wrapper.rs
+++ b/streamer/src/nonblocking/channel_wrapper.rs
@@ -1,22 +1,26 @@
 use crossbeam_channel::{Sender, Receiver, unbounded};
 
+pub trait MyChannelSender<T>: Send + Sync + 'static {
+    fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>>;
+    fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>>;
+}
 
 pub struct MyChannelSendWrapper<T> {
     sender: Sender<T>,
 }
 
-impl<T> MyChannelSendWrapper<T> {
+impl<T: Send> MyChannelSendWrapper<T> {
     pub fn new(sender: Sender<T>) -> Self {
         MyChannelSendWrapper { sender }
     }
+}
 
-    // TODO inline
-    pub fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>> {
+impl<T: Send + 'static> MyChannelSender<T> for MyChannelSendWrapper<T> {
+    fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>> {
         self.sender.send(value)
     }
 
-    pub fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>> {
+    fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>> {
         self.sender.try_send(value)
     }
-
 }

--- a/streamer/src/nonblocking/channel_wrapper.rs
+++ b/streamer/src/nonblocking/channel_wrapper.rs
@@ -1,0 +1,22 @@
+use crossbeam_channel::{Sender, Receiver, unbounded};
+
+
+pub struct MyChannelSendWrapper<T> {
+    sender: Sender<T>,
+}
+
+impl<T> MyChannelSendWrapper<T> {
+    pub fn new(sender: Sender<T>) -> Self {
+        MyChannelSendWrapper { sender }
+    }
+
+    // TODO inline
+    pub fn send(&self, value: T) -> Result<(), crossbeam_channel::SendError<T>> {
+        self.sender.send(value)
+    }
+
+    pub fn try_send(&self, value: T) -> Result<(), crossbeam_channel::TrySendError<T>> {
+        self.sender.try_send(value)
+    }
+
+}

--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -1,3 +1,4 @@
+mod channel_wrapper;
 pub mod connection_rate_limiter;
 pub mod quic;
 pub mod recvmmsg;
@@ -5,3 +6,4 @@ pub mod sendmmsg;
 mod stream_throttle;
 #[cfg(feature = "dev-context-only-utils")]
 pub mod testing_utilities;
+

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -65,7 +65,7 @@ use {
     },
     tokio_util::sync::CancellationToken,
 };
-use crate::nonblocking::channel_wrapper::MyChannelSendWrapper;
+use crate::nonblocking::channel_wrapper::{MyChannelSendWrapper, MyChannelSender};
 
 pub const DEFAULT_WAIT_FOR_CHUNK_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -199,7 +199,7 @@ pub fn spawn_server_multi(
     name: &'static str,
     sockets: Vec<UdpSocket>,
     keypair: &Keypair,
-    packet_sender: MyChannelSendWrapper<PacketBatch>,
+    packet_sender: impl MyChannelSender<PacketBatch>,
     exit: Arc<AtomicBool>,
     staked_nodes: Arc<RwLock<StakedNodes>>,
     quic_server_params: QuicServerParams,
@@ -306,7 +306,7 @@ impl ClientConnectionTracker {
 async fn run_server(
     name: &'static str,
     endpoints: Vec<Endpoint>,
-    packet_sender: MyChannelSendWrapper<PacketBatch>,
+    packet_sender: impl MyChannelSender<PacketBatch>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
     staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -915,7 +915,7 @@ fn handle_connection_error(e: quinn::ConnectionError, stats: &StreamerStats, fro
 // Holder(s) of the Sender<PacketAccumulator> on the other end should not
 // wait for this function to exit
 fn packet_batch_sender(
-    packet_sender: MyChannelSendWrapper<PacketBatch>,
+    packet_sender: impl MyChannelSender<PacketBatch>,
     packet_receiver: Receiver<PacketAccumulator>,
     exit: Arc<AtomicBool>,
     stats: Arc<StreamerStats>,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1743,7 +1743,7 @@ pub mod test {
             let exit = exit.clone();
             move || {
                 packet_batch_sender(
-                    pkt_batch_sender,
+                    MyChannelSendWrapper::new(pkt_batch_sender),
                     pkt_receiver,
                     exit,
                     stats,

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -32,6 +32,7 @@ use {
     },
     tokio::{task::JoinHandle, time::sleep},
 };
+use crate::nonblocking::quic::spawn_server_multi_crossbeam;
 
 pub fn get_client_config(keypair: &Keypair) -> ClientConfig {
     let (cert, key) = new_dummy_x509_certificate(keypair);
@@ -143,7 +144,7 @@ pub fn setup_quic_server_with_sockets(
         stats,
         thread: handle,
         max_concurrent_connections: _,
-    } = spawn_server_multi(
+    } = spawn_server_multi_crossbeam(
         "quic_streamer_test",
         sockets,
         &keypair,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -642,7 +642,7 @@ pub fn spawn_server_multi(
     let runtime = rt(format!("{thread_name}Rt"));
     let result = {
         let _guard = runtime.enter();
-        crate::nonblocking::quic::spawn_server_multi(
+        crate::nonblocking::quic::spawn_server_multi_crossbeam(
             metrics_name,
             sockets,
             keypair,


### PR DESCRIPTION
#### Problem
Nonblocking quic streamer uses `crossbeam channel` which does force callers to use **blocking** `.recv` operation from Tokio runtime tasks!

#### Summary of Changes
* **this is proof-of-concept and not ready to use**
* idea is to wrapper the channel sender and allow caller to choose between crossbeam and tokio channel implementations
* add abstraction (wrapper) around channel sender which delegates `.try_send` method and corresponding error type
* remove packet_sender from `NewConnectionHandlerParams` (which turns NewConnectionHandlerParams into a braindead DTO)

