### PR TITLE
rpc: fix simulated loaded size tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9791,6 +9791,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",
+ "solana-sdk-ids",
  "solana-send-transaction-service",
  "solana-sha256-hasher",
  "solana-signature",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -110,6 +110,7 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
+solana-sdk-ids = { workspace = true }
 solana-send-transaction-service = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::field_qualifiers;
+use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_overrides::AccountOverrides, nonce_info::NonceInfo,
@@ -39,6 +39,7 @@ use {
 
 // Per SIMD-0186, all accounts are assigned a base size of 64 bytes to cover
 // the storage cost of metadata.
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) const TRANSACTION_ACCOUNT_BASE_SIZE: usize = 64;
 
 // Per SIMD-0186, resolved address lookup tables are assigned a base size of 8248


### PR DESCRIPTION
#### Problem
#6063 changed the loaded accounts data size algorithm, and #6023 added loaded size to simulation results, but the latter used the old algorithm in tests

#### Summary of Changes
use the new algorithm. this fixes ci