### PR TITLE
fix leaders_fanout.connect configuration for sts

### DIFF
--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -301,8 +301,9 @@ impl TpuClientNextClient {
             // experimentally found parameter values
             worker_channel_size: 64,
             max_reconnect_attempts: 4,
+            // We open connection to one more leader in advance, which time-wise means ~1.6s
             leaders_fanout: Fanout {
-                connect: leader_forward_count,
+                connect: leader_forward_count + 1,
                 send: leader_forward_count,
             },
         }


### PR DESCRIPTION
#### Problem

We should look at one leader forward when trying to create connections before using them.

#### Summary of Changes


