### PR TITLE
Add `ResolvedTransaction` wrapper around `SanitizedTransaction`

### DIFF
--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -23,11 +23,12 @@ use {
         transaction_recorder::TransactionRecorder,
     },
     solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_signer::Signer,
     solana_system_interface::program as system_program,
     solana_system_transaction as system_transaction,
-    solana_transaction::sanitized::SanitizedTransaction,
     std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc, RwLock,
@@ -66,7 +67,7 @@ fn create_funded_accounts(bank: &Bank, num: usize) -> Vec<Keypair> {
     accounts
 }
 
-fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
+fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<ResolvedTransaction>> {
     let funded_accounts = create_funded_accounts(bank, 2 * num);
     funded_accounts
         .into_par_iter()

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -717,11 +717,13 @@ mod tests {
         solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
         solana_system_transaction as system_transaction,
-        solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+        solana_transaction::Transaction,
         solana_vote::vote_transaction::new_tower_sync_transaction,
         solana_vote_program::vote_state::TowerSync,
         std::{
@@ -742,7 +744,7 @@ mod tests {
 
     pub(crate) fn sanitize_transactions(
         txs: Vec<Transaction>,
-    ) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> Vec<RuntimeTransaction<ResolvedTransaction>> {
         txs.into_iter()
             .map(RuntimeTransaction::from_transaction_for_tests)
             .collect()

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -752,15 +752,14 @@ mod tests {
             bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
             vote_sender_types::ReplayVoteReceiver,
         },
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_signer::Signer,
         solana_svm_transaction::svm_message::SVMMessage,
         solana_system_interface::instruction as system_instruction,
         solana_system_transaction as system_transaction,
-        solana_transaction::{
-            sanitized::{MessageHash, SanitizedTransaction},
-            versioned::VersionedTransaction,
-        },
+        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         solana_transaction_error::TransactionError,
         std::{
             collections::HashSet,
@@ -784,15 +783,15 @@ mod tests {
         _poh_simulator: JoinHandle<()>,
         _replay_vote_receiver: ReplayVoteReceiver,
 
-        consume_sender: Sender<ConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
-        consumed_receiver: Receiver<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
+        consume_sender: Sender<ConsumeWork<RuntimeTransaction<ResolvedTransaction>>>,
+        consumed_receiver: Receiver<FinishedConsumeWork<RuntimeTransaction<ResolvedTransaction>>>,
     }
 
     fn setup_test_frame(
         relax_intrabatch_account_locks: bool,
     ) -> (
         TestFrame,
-        ConsumeWorker<RuntimeTransaction<SanitizedTransaction>>,
+        ConsumeWorker<RuntimeTransaction<ResolvedTransaction>>,
     ) {
         let GenesisConfigInfo {
             genesis_config,

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -9,7 +9,9 @@ use {
     solana_perf::packet::PacketRef,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_sanitize::SanitizeError,
     solana_short_vec::decode_shortu16_len,
     solana_signature::Signature,
@@ -17,7 +19,7 @@ use {
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
     },
     solana_transaction::{
-        sanitized::{MessageHash, SanitizedTransaction},
+        sanitized::MessageHash,
         versioned::{sanitized::SanitizedVersionedTransaction, VersionedTransaction},
     },
     std::{cmp::Ordering, collections::HashSet, mem::size_of},
@@ -129,7 +131,7 @@ impl ImmutableDeserializedPacket {
         votes_only: bool,
         bank: &Bank,
         reserved_account_keys: &HashSet<Pubkey>,
-    ) -> Option<(RuntimeTransaction<SanitizedTransaction>, Slot)> {
+    ) -> Option<(RuntimeTransaction<ResolvedTransaction>, Slot)> {
         if votes_only && !self.is_simple_vote() {
             return None;
         }
@@ -144,7 +146,7 @@ impl ImmutableDeserializedPacket {
             Some(self.is_simple_vote),
         )
         .and_then(|tx| {
-            RuntimeTransaction::<SanitizedTransaction>::try_from(
+            RuntimeTransaction::<ResolvedTransaction>::try_from(
                 tx,
                 address_loader,
                 reserved_account_keys,

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -32,12 +32,12 @@ use {
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
-        transaction_with_meta::TransactionWithMeta,
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        transaction_meta::StaticMeta, transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction::sanitized::{MessageHash, SanitizedTransaction},
+    solana_transaction::sanitized::MessageHash,
     std::{
         num::Saturating,
         sync::{Arc, RwLock},
@@ -73,7 +73,7 @@ pub(crate) struct SanitizedTransactionReceiveAndBuffer {
 }
 
 impl ReceiveAndBuffer for SanitizedTransactionReceiveAndBuffer {
-    type Transaction = RuntimeTransaction<SanitizedTransaction>;
+    type Transaction = RuntimeTransaction<ResolvedTransaction>;
     type Container = TransactionStateContainer<Self::Transaction>;
 
     /// Returns whether the packet receiver is still connected.
@@ -153,7 +153,7 @@ impl SanitizedTransactionReceiveAndBuffer {
 
     fn buffer_packets(
         &mut self,
-        container: &mut TransactionStateContainer<RuntimeTransaction<SanitizedTransaction>>,
+        container: &mut TransactionStateContainer<RuntimeTransaction<ResolvedTransaction>>,
         _timing_metrics: &mut SchedulerTimingMetrics,
         count_metrics: &mut SchedulerCountMetrics,
         packets: Vec<ImmutableDeserializedPacket>,
@@ -694,7 +694,7 @@ mod tests {
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> (
         SanitizedTransactionReceiveAndBuffer,
-        TransactionStateContainer<RuntimeTransaction<SanitizedTransaction>>,
+        TransactionStateContainer<RuntimeTransaction<ResolvedTransaction>>,
     ) {
         let receive_and_buffer = SanitizedTransactionReceiveAndBuffer {
             packet_receiver: PacketDeserializer::new(receiver),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -282,16 +282,21 @@ mod tests {
     use {
         super::*,
         crate::banking_stage::transaction_scheduler::transaction_state_container::TransactionStateContainer,
-        crossbeam_channel::unbounded, solana_hash::Hash, solana_keypair::Keypair,
-        solana_pubkey::Pubkey, solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        crossbeam_channel::unbounded,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_pubkey::Pubkey,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_system_transaction as system_transaction,
-        solana_transaction::sanitized::SanitizedTransaction, test_case::test_case,
+        test_case::test_case,
     };
 
     const NUM_WORKERS: usize = 4;
     const DUMMY_COST: u64 = 1;
 
-    fn simple_transaction() -> RuntimeTransaction<SanitizedTransaction> {
+    fn simple_transaction() -> RuntimeTransaction<ResolvedTransaction> {
         RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
             &Keypair::new(),
             &Pubkey::new_unique(),
@@ -301,7 +306,7 @@ mod tests {
     }
 
     fn add_transactions_to_container(
-        container: &mut TransactionStateContainer<RuntimeTransaction<SanitizedTransaction>>,
+        container: &mut TransactionStateContainer<RuntimeTransaction<ResolvedTransaction>>,
         count: usize,
     ) {
         for index in 0..count {

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -92,15 +92,17 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_message::Message,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
-        solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+        solana_transaction::Transaction,
     };
 
     fn create_transaction_state(
         compute_unit_price: u64,
-    ) -> TransactionState<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> TransactionState<RuntimeTransaction<ResolvedTransaction>> {
         let from_keypair = Keypair::new();
         let ixs = vec![
             system_instruction::transfer(&from_keypair.pubkey(), &solana_pubkey::new_rand(), 1),

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -351,20 +351,19 @@ mod tests {
         solana_keypair::Keypair,
         solana_message::Message,
         solana_perf::packet::Packet,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
-        solana_transaction::{
-            sanitized::{MessageHash, SanitizedTransaction},
-            Transaction,
-        },
+        solana_transaction::{sanitized::MessageHash, Transaction},
         std::collections::HashSet,
     };
 
     /// Returns (transaction_ttl, priority, cost)
     fn test_transaction(
         priority: u64,
-    ) -> (RuntimeTransaction<SanitizedTransaction>, MaxAge, u64, u64) {
+    ) -> (RuntimeTransaction<ResolvedTransaction>, MaxAge, u64, u64) {
         let from_keypair = Keypair::new();
         let ixs = vec![
             system_instruction::transfer(&from_keypair.pubkey(), &solana_pubkey::new_rand(), 1),
@@ -381,7 +380,7 @@ mod tests {
     }
 
     fn push_to_container(
-        container: &mut TransactionStateContainer<RuntimeTransaction<SanitizedTransaction>>,
+        container: &mut TransactionStateContainer<RuntimeTransaction<ResolvedTransaction>>,
         num: usize,
     ) {
         for priority in 0..num as u64 {

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -22,13 +22,13 @@ use {
     solana_poh::poh_recorder::{BankStart, PohRecorderError},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::{
         account_loader::TransactionCheckResult, transaction_error_metrics::TransactionErrorMetrics,
     },
     solana_time_utils::timestamp,
-    solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::TransactionError,
     std::{
         sync::{atomic::Ordering, Arc, RwLock},
@@ -266,7 +266,7 @@ impl VoteWorker {
         &self,
         bank_start: &BankStart,
         reached_end_of_slot: &mut bool,
-        sanitized_transactions: &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
+        sanitized_transactions: &mut Vec<RuntimeTransaction<ResolvedTransaction>>,
         banking_stage_stats: &BankingStageStats,
         consumed_buffered_packets_count: &mut usize,
         rebuffered_packet_count: &mut usize,
@@ -484,7 +484,7 @@ fn consume_scan_should_process_packet(
     packet: &ImmutableDeserializedPacket,
     reached_end_of_slot: bool,
     error_counters: &mut TransactionErrorMetrics,
-    sanitized_transactions: &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
+    sanitized_transactions: &mut Vec<RuntimeTransaction<ResolvedTransaction>>,
     slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
 ) -> bool {
     // If end of the slot, return should process (quick loop after reached end of slot)

--- a/cost-model/benches/cost_model.rs
+++ b/cost-model/benches/cost_model.rs
@@ -7,15 +7,17 @@ use {
     solana_keypair::Keypair,
     solana_message::Message,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
-    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+    solana_transaction::Transaction,
     test::Bencher,
 };
 
 struct BenchSetup {
-    transactions: Vec<RuntimeTransaction<SanitizedTransaction>>,
+    transactions: Vec<RuntimeTransaction<ResolvedTransaction>>,
     feature_set: FeatureSet,
 }
 

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -6,11 +6,11 @@ use {
     solana_hash::Hash,
     solana_message::SimpleAddressLoader,
     solana_perf::test_tx::test_tx,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_transaction::{
-        sanitized::{MessageHash, SanitizedTransaction},
-        versioned::VersionedTransaction,
-        TransactionVerificationMode,
+        sanitized::MessageHash, versioned::VersionedTransaction, TransactionVerificationMode,
     },
     solana_transaction_error::TransactionResult as Result,
     std::sync::Arc,
@@ -30,7 +30,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
     let verify_transaction = {
         move |versioned_tx: VersionedTransaction,
               verification_mode: TransactionVerificationMode|
-              -> Result<RuntimeTransaction<SanitizedTransaction>> {
+              -> Result<RuntimeTransaction<ResolvedTransaction>> {
             let sanitized_tx = {
                 let message_hash =
                     if verification_mode == TransactionVerificationMode::FullVerification {
@@ -80,7 +80,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
         .collect::<Vec<_>>();
 
     let verify_transaction = {
-        move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<SanitizedTransaction>> {
+        move |versioned_tx: VersionedTransaction| -> Result<RuntimeTransaction<ResolvedTransaction>> {
             let sanitized_tx = {
                 let message_hash = versioned_tx.verify_and_hash_message()?;
                 RuntimeTransaction::try_create(

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -977,14 +977,13 @@ mod tests {
         solana_message::SimpleAddressLoader,
         solana_perf::test_tx::{test_invalid_tx, test_tx},
         solana_pubkey::Pubkey,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_sha256_hasher::hash,
         solana_signer::Signer,
         solana_system_transaction as system_transaction,
-        solana_transaction::{
-            sanitized::{MessageHash, SanitizedTransaction},
-            versioned::VersionedTransaction,
-        },
+        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         solana_transaction_error::TransactionResult as Result,
     };
 
@@ -1063,7 +1062,7 @@ mod tests {
         let verify_transaction = {
             move |versioned_tx: VersionedTransaction,
                   verification_mode: TransactionVerificationMode|
-                  -> Result<RuntimeTransaction<SanitizedTransaction>> {
+                  -> Result<RuntimeTransaction<ResolvedTransaction>> {
                 let sanitized_tx = {
                     let message_hash =
                         if verification_mode == TransactionVerificationMode::FullVerification {

--- a/ledger/benches/blockstore_processor.rs
+++ b/ledger/benches/blockstore_processor.rs
@@ -19,12 +19,13 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_signer::Signer,
     solana_system_interface::program as system_program,
     solana_system_transaction as system_transaction,
     solana_timings::ExecuteTimings,
-    solana_transaction::sanitized::SanitizedTransaction,
     std::sync::{Arc, RwLock},
     test::Bencher,
 };
@@ -59,7 +60,7 @@ fn create_funded_accounts(bank: &Bank, num: usize) -> Vec<Keypair> {
     accounts
 }
 
-fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
+fn create_transactions(bank: &Bank, num: usize) -> Vec<RuntimeTransaction<ResolvedTransaction>> {
     let funded_accounts = create_funded_accounts(bank, 2 * num);
     funded_accounts
         .into_par_iter()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -72,7 +72,9 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_utils,
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_send_transaction_service::send_transaction_service::TransactionInfo,
     solana_signature::Signature,
     solana_signer::Signer,
@@ -4382,7 +4384,7 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
     reserved_account_keys: &HashSet<Pubkey>,
-) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+) -> Result<RuntimeTransaction<ResolvedTransaction>> {
     RuntimeTransaction::try_create(
         transaction,
         MessageHash::Compute,

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod instruction_data_len;
 pub(crate) mod instruction_meta;
+pub mod resolved_transaction;
 pub mod runtime_transaction;
 pub mod signature_details;
 pub mod transaction_meta;

--- a/runtime-transaction/src/resolved_transaction.rs
+++ b/runtime-transaction/src/resolved_transaction.rs
@@ -1,0 +1,148 @@
+use {
+    solana_hash::Hash,
+    solana_message::{
+        v0::LoadedAddresses, AccountKeys, AddressLoader, SanitizedMessage, SimpleAddressLoader,
+        VersionedMessage,
+    },
+    solana_pubkey::Pubkey,
+    solana_svm_transaction::{
+        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::SVMMessage,
+    },
+    solana_transaction::{
+        sanitized::SanitizedTransaction, versioned::sanitized::SanitizedVersionedTransaction,
+    },
+    solana_transaction_error::{TransactionError, TransactionResult},
+    std::{collections::HashSet, ops::Deref},
+};
+
+#[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
+#[derive(Debug)]
+pub struct ResolvedTransaction {
+    pub transaction: SanitizedTransaction,
+    pub address_resolution_err: Option<TransactionError>,
+}
+
+impl Deref for ResolvedTransaction {
+    type Target = SanitizedTransaction;
+    fn deref(&self) -> &SanitizedTransaction {
+        &self.transaction
+    }
+}
+
+impl ResolvedTransaction {
+    pub fn try_new(
+        tx: SanitizedVersionedTransaction,
+        message_hash: Hash,
+        is_simple_vote_tx: bool,
+        address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> TransactionResult<Self> {
+        let loaded_addresses_result = match &tx.get_message().message {
+            VersionedMessage::Legacy(_) => Ok(LoadedAddresses::default()),
+            VersionedMessage::V0(message) => {
+                address_loader.load_addresses(&message.address_table_lookups)
+            }
+        };
+
+        // hardcoded for now, but will be configurable via feature gate in the
+        // future.
+        let remove_address_resolution_constraint = false;
+        let (address_loader, address_resolution_err) = match loaded_addresses_result {
+            Ok(loaded_addresses) => (SimpleAddressLoader::Enabled(loaded_addresses), None),
+            Err(err) => {
+                let address_loader = if remove_address_resolution_constraint {
+                    SimpleAddressLoader::Enabled(LoadedAddresses::default())
+                } else {
+                    SimpleAddressLoader::Disabled
+                };
+                (address_loader, Some(err.into()))
+            }
+        };
+
+        Ok(Self {
+            transaction: SanitizedTransaction::try_new(
+                tx,
+                message_hash,
+                is_simple_vote_tx,
+                address_loader,
+                reserved_account_keys,
+            )?,
+            address_resolution_err,
+        })
+    }
+
+    pub fn message(&self) -> &SanitizedMessage {
+        self.transaction.message()
+    }
+}
+
+impl SVMMessage for ResolvedTransaction {
+    fn num_transaction_signatures(&self) -> u64 {
+        self.transaction.num_transaction_signatures()
+    }
+
+    fn num_ed25519_signatures(&self) -> u64 {
+        self.transaction.num_ed25519_signatures()
+    }
+
+    fn num_secp256k1_signatures(&self) -> u64 {
+        self.transaction.num_secp256k1_signatures()
+    }
+
+    fn num_secp256r1_signatures(&self) -> u64 {
+        self.transaction.num_secp256r1_signatures()
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        self.transaction.num_write_locks()
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        self.transaction.recent_blockhash()
+    }
+
+    fn num_instructions(&self) -> usize {
+        self.transaction.num_instructions()
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction> {
+        self.transaction.instructions_iter()
+    }
+
+    fn program_instructions_iter(&self) -> impl Iterator<Item = (&Pubkey, SVMInstruction)> + Clone {
+        self.transaction.program_instructions_iter()
+    }
+
+    fn static_account_keys(&self) -> &[Pubkey] {
+        self.transaction.static_account_keys()
+    }
+
+    fn account_keys(&self) -> AccountKeys {
+        self.transaction.account_keys()
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        self.transaction.fee_payer()
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        self.transaction.is_writable(index)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        self.transaction.is_signer(index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        self.transaction.is_invoked(key_index)
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        self.transaction.num_lookup_tables()
+    }
+
+    fn message_address_table_lookups(&self) -> impl Iterator<Item = SVMMessageAddressTableLookup> {
+        self.transaction.message_address_table_lookups()
+    }
+}

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -14,13 +14,14 @@ use {
     core::ops::Deref,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
     solana_hash::Hash,
-    solana_message::{AccountKeys, TransactionSignatureDetails},
+    solana_message::{v0::LoadedAddresses, AccountKeys, TransactionSignatureDetails},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_svm_transaction::{
         instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
         svm_message::SVMMessage, svm_transaction::SVMTransaction,
     },
+    solana_transaction_error::TransactionError,
 };
 
 mod sdk_transactions;
@@ -59,7 +60,11 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     }
 }
 
-impl<T: SVMMessage> DynamicMeta for RuntimeTransaction<T> {}
+impl<T: DynamicMeta> DynamicMeta for RuntimeTransaction<T> {
+    fn resolved_addresses(&self) -> Result<&LoadedAddresses, &TransactionError> {
+        self.transaction.resolved_addresses()
+    }
+}
 
 impl<T> Deref for RuntimeTransaction<T> {
     type Target = T;

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -2,19 +2,22 @@ use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
         instruction_meta::InstructionMeta,
-        transaction_meta::{StaticMeta, TransactionMeta},
+        resolved_transaction::ResolvedTransaction,
+        transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
-    solana_message::{AddressLoader, TransactionSignatureDetails},
+    solana_message::{
+        v0::LoadedAddresses, AddressLoader, SanitizedMessage, TransactionSignatureDetails,
+    },
     solana_pubkey::Pubkey,
-    solana_svm_transaction::instruction::SVMInstruction,
+    solana_svm_transaction::{instruction::SVMInstruction, svm_transaction::SVMTransaction},
     solana_transaction::{
         sanitized::{MessageHash, SanitizedTransaction},
         simple_vote_transaction_checker::is_simple_vote_transaction,
         versioned::{sanitized::SanitizedVersionedTransaction, VersionedTransaction},
     },
-    solana_transaction_error::TransactionResult as Result,
-    std::{borrow::Cow, collections::HashSet},
+    solana_transaction_error::{TransactionError, TransactionResult},
+    std::{borrow::Cow, collections::HashSet, sync::LazyLock},
 };
 
 impl RuntimeTransaction<SanitizedVersionedTransaction> {
@@ -22,7 +25,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
         sanitized_versioned_tx: SanitizedVersionedTransaction,
         message_hash: MessageHash,
         is_simple_vote_tx: Option<bool>,
-    ) -> Result<Self> {
+    ) -> TransactionResult<Self> {
         let message_hash = match message_hash {
             MessageHash::Precomputed(hash) => hash,
             MessageHash::Compute => sanitized_versioned_tx.get_message().message.hash(),
@@ -71,8 +74,8 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
     }
 }
 
-impl RuntimeTransaction<SanitizedTransaction> {
-    /// Create a new `RuntimeTransaction<SanitizedTransaction>` from an
+impl RuntimeTransaction<ResolvedTransaction> {
+    /// Create a new `RuntimeTransaction<ResolvedTransaction>` from an
     /// unsanitized `VersionedTransaction`.
     pub fn try_create(
         tx: VersionedTransaction,
@@ -80,7 +83,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
-    ) -> Result<Self> {
+    ) -> TransactionResult<Self> {
         let statically_loaded_runtime_tx =
             RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(
                 SanitizedVersionedTransaction::try_from(tx)?,
@@ -94,17 +97,17 @@ impl RuntimeTransaction<SanitizedTransaction> {
         )
     }
 
-    /// Create a new `RuntimeTransaction<SanitizedTransaction>` from a
+    /// Create a new `RuntimeTransaction<ResolvedTransaction>` from a
     /// `RuntimeTransaction<SanitizedVersionedTransaction>` that already has
     /// static metadata loaded.
     pub fn try_from(
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedVersionedTransaction>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
-    ) -> Result<Self> {
+    ) -> TransactionResult<Self> {
         let hash = *statically_loaded_runtime_tx.message_hash();
         let is_simple_vote_tx = statically_loaded_runtime_tx.is_simple_vote_transaction();
-        let sanitized_transaction = SanitizedTransaction::try_new(
+        let transaction = ResolvedTransaction::try_new(
             statically_loaded_runtime_tx.transaction,
             hash,
             is_simple_vote_tx,
@@ -112,34 +115,37 @@ impl RuntimeTransaction<SanitizedTransaction> {
             reserved_account_keys,
         )?;
 
-        let mut tx = Self {
-            transaction: sanitized_transaction,
+        Ok(Self {
+            transaction,
             meta: statically_loaded_runtime_tx.meta,
-        };
-        tx.load_dynamic_metadata()?;
-
-        Ok(tx)
-    }
-
-    fn load_dynamic_metadata(&mut self) -> Result<()> {
-        Ok(())
+        })
     }
 }
 
-impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
+impl SVMTransaction for RuntimeTransaction<ResolvedTransaction> {
+    fn signature(&self) -> &solana_signature::Signature {
+        self.transaction.transaction.signature()
+    }
+
+    fn signatures(&self) -> &[solana_signature::Signature] {
+        self.transaction.transaction.signatures()
+    }
+}
+
+impl TransactionWithMeta for RuntimeTransaction<ResolvedTransaction> {
     #[inline]
     fn as_sanitized_transaction(&self) -> Cow<SanitizedTransaction> {
-        Cow::Borrowed(self)
+        Cow::Borrowed(&self.transaction.transaction)
     }
 
     #[inline]
     fn to_versioned_transaction(&self) -> VersionedTransaction {
-        self.transaction.to_versioned_transaction()
+        self.transaction.transaction.to_versioned_transaction()
     }
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-impl RuntimeTransaction<SanitizedTransaction> {
+impl RuntimeTransaction<ResolvedTransaction> {
     pub fn from_transaction_for_tests(transaction: solana_transaction::Transaction) -> Self {
         let versioned_transaction = VersionedTransaction::from(transaction);
         Self::try_create(
@@ -150,6 +156,21 @@ impl RuntimeTransaction<SanitizedTransaction> {
             &HashSet::new(),
         )
         .expect("failed to create RuntimeTransaction from Transaction")
+    }
+}
+
+static DEFAULT_LOADED_ADDRESSES: LazyLock<LoadedAddresses> =
+    LazyLock::new(LoadedAddresses::default);
+
+impl DynamicMeta for RuntimeTransaction<ResolvedTransaction> {
+    fn resolved_addresses(&self) -> Result<&LoadedAddresses, &TransactionError> {
+        match &self.address_resolution_err {
+            Some(err) => Err(err),
+            None => match &self.transaction.transaction.message() {
+                SanitizedMessage::Legacy(_) => Ok(&DEFAULT_LOADED_ADDRESSES),
+                SanitizedMessage::V0(message) => Ok(&message.loaded_addresses),
+            },
+        }
     }
 }
 
@@ -290,13 +311,13 @@ mod tests {
         assert_eq!(hash, *statically_loaded_transaction.message_hash());
         assert!(!statically_loaded_transaction.is_simple_vote_transaction());
 
-        let dynamically_loaded_transaction = RuntimeTransaction::<SanitizedTransaction>::try_from(
+        let resolved_transaction = RuntimeTransaction::<ResolvedTransaction>::try_from(
             statically_loaded_transaction,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
         );
         let dynamically_loaded_transaction =
-            dynamically_loaded_transaction.expect("created from statically loaded tx");
+            resolved_transaction.expect("created from statically loaded tx");
 
         assert_eq!(hash, *dynamically_loaded_transaction.message_hash());
         assert!(!dynamically_loaded_transaction.is_simple_vote_transaction());

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -95,14 +95,7 @@ impl<D: TransactionData> RuntimeTransaction<ResolvedTransactionView<D>> {
         let transaction =
             ResolvedTransactionView::try_new(transaction, loaded_addresses, reserved_account_keys)
                 .map_err(|_| TransactionError::SanitizeFailure)?;
-        let mut tx = Self { transaction, meta };
-        tx.load_dynamic_metadata()?;
-
-        Ok(tx)
-    }
-
-    fn load_dynamic_metadata(&mut self) -> Result<()> {
-        Ok(())
+        Ok(Self { transaction, meta })
     }
 }
 

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -13,7 +13,9 @@
 //!
 use {
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
-    solana_hash::Hash, solana_message::TransactionSignatureDetails,
+    solana_hash::Hash,
+    solana_message::{v0::LoadedAddresses, TransactionSignatureDetails},
+    solana_transaction_error::TransactionError,
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -27,11 +29,13 @@ pub trait StaticMeta {
 }
 
 /// Statically loaded meta is a supertrait of Dynamically loaded meta, when
-/// transaction transited successfully into dynamically loaded, it should
+/// transaction transitioned successfully into dynamically loaded, it should
 /// have both meta data populated and available.
 /// Dynamic metadata available after accounts addresses are loaded from
 /// on-chain ALT, examples are: transaction usage costs, nonce account.
-pub trait DynamicMeta: StaticMeta {}
+pub trait DynamicMeta: StaticMeta {
+    fn resolved_addresses(&self) -> Result<&LoadedAddresses, &TransactionError>;
+}
 
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -12,9 +12,11 @@ use {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         prioritization_fee_cache::*,
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_system_interface::instruction as system_instruction,
-    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+    solana_transaction::Transaction,
     std::sync::Arc,
     test::Bencher,
 };
@@ -24,7 +26,7 @@ fn build_sanitized_transaction(
     compute_unit_price: u64,
     signer_account: &Pubkey,
     write_account: &Pubkey,
-) -> RuntimeTransaction<SanitizedTransaction> {
+) -> RuntimeTransaction<ResolvedTransaction> {
     let transfer_lamports = 1;
     let transaction = Transaction::new_unsigned(Message::new(
         &[

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -131,7 +131,8 @@ use {
     solana_rent_debits::RentDebits,
     solana_reward_info::RewardInfo,
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk_ids::{bpf_loader_upgradeable, incinerator, native_loader},
     solana_sha256_hasher::{extend_and_hash, hashv},
@@ -166,7 +167,7 @@ use {
     solana_time_utils::years_as_slots,
     solana_timings::{ExecuteTimingType, ExecuteTimings},
     solana_transaction::{
-        sanitized::{MessageHash, SanitizedTransaction, MAX_TX_ACCOUNT_LOCKS},
+        sanitized::{MessageHash, MAX_TX_ACCOUNT_LOCKS},
         versioned::VersionedTransaction,
         Transaction, TransactionVerificationMode,
     },
@@ -3167,7 +3168,7 @@ impl Bank {
     pub fn prepare_entry_batch(
         &self,
         txs: Vec<VersionedTransaction>,
-    ) -> Result<TransactionBatch<RuntimeTransaction<SanitizedTransaction>>> {
+    ) -> Result<TransactionBatch<RuntimeTransaction<ResolvedTransaction>>> {
         let sanitized_txs = txs
             .into_iter()
             .map(|tx| {
@@ -5726,7 +5727,7 @@ impl Bank {
         &self,
         tx: VersionedTransaction,
         verification_mode: TransactionVerificationMode,
-    ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> Result<RuntimeTransaction<ResolvedTransaction>> {
         let sanitized_tx = {
             let size =
                 bincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
@@ -5755,7 +5756,7 @@ impl Bank {
     pub fn fully_verify_transaction(
         &self,
         tx: VersionedTransaction,
-    ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> Result<RuntimeTransaction<ResolvedTransaction>> {
         self.verify_transaction(tx, TransactionVerificationMode::FullVerification)
     }
 
@@ -7126,7 +7127,7 @@ impl Bank {
     pub fn prepare_batch_for_tests(
         &self,
         txs: Vec<Transaction>,
-    ) -> TransactionBatch<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> TransactionBatch<RuntimeTransaction<ResolvedTransaction>> {
         let sanitized_txs = txs
             .into_iter()
             .map(RuntimeTransaction::from_transaction_for_tests)

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -4,7 +4,7 @@
 //! [BankWithScheduler], which can be used by `ReplayStage` and `BankingStage` for transaction
 //! execution. After use, the scheduler will be returned to the pool.
 //!
-//! [InstalledScheduler] can be fed with [SanitizedTransaction]s. Then, it schedules those
+//! [InstalledScheduler] can be fed with [ResolvedTransaction]s. Then, it schedules those
 //! executions and commits those results into the associated _bank_.
 //!
 //! It's generally assumed that each [InstalledScheduler] is backed by multiple threads for
@@ -26,9 +26,10 @@ use {
     log::*,
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+    },
     solana_timings::ExecuteTimings,
-    solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
@@ -174,7 +175,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     /// having &mut.
     fn schedule_execution(
         &self,
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: RuntimeTransaction<ResolvedTransaction>,
         index: usize,
     ) -> ScheduleResult;
 
@@ -512,7 +513,7 @@ impl BankWithScheduler {
     pub fn schedule_transaction_executions(
         &self,
         transactions_with_indexes: impl ExactSizeIterator<
-            Item = (RuntimeTransaction<SanitizedTransaction>, usize),
+            Item = (RuntimeTransaction<ResolvedTransaction>, usize),
         >,
     ) -> Result<()> {
         trace!(

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -441,16 +441,18 @@ mod tests {
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_message::Message,
         solana_pubkey::Pubkey,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_system_interface::instruction as system_instruction,
-        solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+        solana_transaction::Transaction,
     };
 
     fn build_sanitized_transaction_for_test(
         compute_unit_price: u64,
         signer_account: &Pubkey,
         write_account: &Pubkey,
-    ) -> RuntimeTransaction<SanitizedTransaction> {
+    ) -> RuntimeTransaction<ResolvedTransaction> {
         let transaction = Transaction::new_unsigned(Message::new(
             &[
                 system_instruction::transfer(signer_account, write_account, 1),
@@ -466,7 +468,7 @@ mod tests {
     fn sync_update<'a>(
         prioritization_fee_cache: &PrioritizationFeeCache,
         bank: Arc<Bank>,
-        txs: impl ExactSizeIterator<Item = &'a RuntimeTransaction<SanitizedTransaction>>,
+        txs: impl ExactSizeIterator<Item = &'a RuntimeTransaction<ResolvedTransaction>>,
     ) {
         let expected_update_count = prioritization_fee_cache
             .metrics

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -116,9 +116,10 @@ mod tests {
         super::*,
         crate::genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
         solana_keypair::Keypair,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        },
         solana_system_transaction as system_transaction,
-        solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
         test_case::test_case,
     };
@@ -197,7 +198,7 @@ mod tests {
     fn setup(
         insert_conflicting_tx: bool,
         relax_intrabatch_account_locks: bool,
-    ) -> (Bank, Vec<RuntimeTransaction<SanitizedTransaction>>) {
+    ) -> (Bank, Vec<RuntimeTransaction<ResolvedTransaction>>) {
         let dummy_leader_pubkey = solana_pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -24,7 +24,7 @@ use {
 /// A parsed and sanitized transaction view that has had all address lookups
 /// resolved.
 pub struct ResolvedTransactionView<D: TransactionData> {
-    /// The parsed and sanitized transction view.
+    /// The parsed and sanitized transaction view.
     view: TransactionView<true, D>,
     /// The resolved address lookups.
     resolved_addresses: Option<LoadedAddresses>,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -4,7 +4,7 @@
 //! and [`InstalledSchedulerPool`] to provide a concrete transaction scheduling implementation
 //! (including executing txes and committing tx results).
 //!
-//! At the highest level, this crate takes [`SanitizedTransaction`]s via its
+//! At the highest level, this crate takes [`ResolvedTransaction`]s via its
 //! [`InstalledScheduler::schedule_execution`] and commits any side-effects (i.e. on-chain state
 //! changes) into the associated [`Bank`](solana_runtime::bank::Bank) via `solana-ledger`'s helper
 //! function called [`execute_batch`].
@@ -40,10 +40,12 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         vote_sender_types::ReplayVoteSender,
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        resolved_transaction::ResolvedTransaction, runtime_transaction::RuntimeTransaction,
+        transaction_with_meta::TransactionWithMeta,
+    },
     solana_svm::transaction_processing_result::ProcessedTransaction,
     solana_timings::ExecuteTimings,
-    solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_unified_scheduler_logic::{
         SchedulingMode::{self, BlockProduction, BlockVerification},
@@ -291,7 +293,7 @@ impl BankingStageHelper {
 
     pub fn create_new_task(
         &self,
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: RuntimeTransaction<ResolvedTransaction>,
         index: usize,
     ) -> Task {
         SchedulingStateMachine::create_task(transaction, index, &mut |pubkey| {
@@ -940,7 +942,7 @@ impl ExecutedTask {
         })
     }
 
-    fn into_transaction(self) -> RuntimeTransaction<SanitizedTransaction> {
+    fn into_transaction(self) -> RuntimeTransaction<ResolvedTransaction> {
         self.task.into_transaction()
     }
 }
@@ -2281,7 +2283,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
 
     fn schedule_execution(
         &self,
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: RuntimeTransaction<ResolvedTransaction>,
         index: usize,
     ) -> ScheduleResult {
         let task = SchedulingStateMachine::create_task(transaction, index, &mut |pubkey| {
@@ -2379,7 +2381,6 @@ mod tests {
         },
         solana_system_transaction as system_transaction,
         solana_timings::ExecuteTimingType,
-        solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
         std::{
             num::Saturating,
@@ -3844,7 +3845,7 @@ mod tests {
 
         fn schedule_execution(
             &self,
-            transaction: RuntimeTransaction<SanitizedTransaction>,
+            transaction: RuntimeTransaction<ResolvedTransaction>,
             index: usize,
         ) -> ScheduleResult {
             let context = self.context().clone();


### PR DESCRIPTION
#### Problem
Can't make changes to `SanitizedTransaction` because it's in SDK but I need to add some dynamic metadata.

#### Summary of Changes
Introduce `ResolvedTransaction` to wrap `SanitizedTransaction` and can hold dynamic metadata.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
