### PR TITLE
report egress gossip crds sample

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -714,3 +714,8 @@ pub(crate) fn should_report_message_signature(signature: &Signature, leading_zer
     };
     u64::from_le_bytes(bytes).trailing_zeros() >= leading_zeros
 }
+
+#[inline]
+pub(crate) fn last_four_chars(s: &str) -> Option<&str> {
+    s.get(s.len().saturating_sub(4)..)
+}

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{crds_gossip::CrdsGossip, protocol::Protocol},
+    crate::{crds_gossip::CrdsGossip, crds_value::CrdsValue, protocol::Protocol},
     itertools::Itertools,
     solana_clock::Slot,
     solana_measure::measure::Measure,
@@ -718,4 +718,25 @@ pub(crate) fn should_report_message_signature(signature: &Signature, leading_zer
 #[inline]
 pub(crate) fn last_four_chars(s: &str) -> Option<&str> {
     s.get(s.len().saturating_sub(4)..)
+}
+
+pub(crate) fn log_gossip_crds_sample_egress(value: &CrdsValue, peer: &Pubkey) {
+    datapoint_info!(
+        "gossip_crds_sample_egress",
+        (
+            "origin",
+            last_four_chars(&value.pubkey().to_string()),
+            Option<String>
+        ),
+        (
+            "signature",
+            last_four_chars(&value.signature().to_string()),
+            Option<String>
+        ),
+        (
+            "peer",
+            last_four_chars(&peer.to_string()),
+            Option<String>
+        ),
+    );
 }

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -57,11 +57,10 @@ const CRDS_SHARDS_BITS: u32 = 12;
 // Number of vote slots to track in an lru-cache for metrics.
 const VOTE_SLOTS_METRICS_CAP: usize = 100;
 // Required number of leading zero bits for crds signature to get reported to influx
-// mean new push messages received per minute per node
-//      testnet: ~500k,
-//      mainnet: ~280k
+// mean new CrdsValues received per minute per node
+//      testnet/mainnet: ~680k as of 2025-06-06
 // target: 1 signature reported per minute
-// log2(500k) = ~18.9.
+// log2(680k) = ~19.375.
 pub(crate) const SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 19;
 
 pub struct Crds {

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -62,7 +62,7 @@ const VOTE_SLOTS_METRICS_CAP: usize = 100;
 //      mainnet: ~280k
 // target: 1 signature reported per minute
 // log2(500k) = ~18.9.
-const SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 19;
+pub(crate) const SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 19;
 
 pub struct Crds {
     /// Stores the map of labels and values

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -27,7 +27,7 @@
 
 use {
     crate::{
-        cluster_info_metrics::should_report_message_signature,
+        cluster_info_metrics::{last_four_chars, should_report_message_signature},
         contact_info::ContactInfo,
         crds_data::CrdsData,
         crds_entry::CrdsEntry,
@@ -718,17 +718,17 @@ impl CrdsDataStats {
                 "gossip_crds_sample",
                 (
                     "origin",
-                    entry.value.pubkey().to_string().get(..8),
+                    last_four_chars(&entry.value.pubkey().to_string()),
                     Option<String>
                 ),
                 (
                     "signature",
-                    entry.value.signature().to_string().get(..8),
+                    last_four_chars(&entry.value.signature().to_string()),
                     Option<String>
                 ),
                 (
                     "from",
-                    from.to_string().get(..8),
+                    last_four_chars(&from.to_string()),
                     Option<String>
                 )
             );

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -14,7 +14,7 @@
 use {
     crate::{
         cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY,
-        cluster_info_metrics::should_report_message_signature,
+        cluster_info_metrics::{last_four_chars, should_report_message_signature},
         crds::{Crds, CrdsError, Cursor, GossipRoute, SIGNATURE_SAMPLE_LEADING_ZEROS},
         crds_gossip,
         crds_value::CrdsValue,
@@ -296,17 +296,17 @@ fn log_gossip_crds_sample_egress(value: &CrdsValue, peer: &Pubkey) {
         "gossip_crds_sample_egress",
         (
             "origin",
-            value.pubkey().to_string().get(..8),
+            last_four_chars(&value.pubkey().to_string()),
             Option<String>
         ),
         (
             "signature",
-            value.signature().to_string().get(..8),
+            last_four_chars(&value.signature().to_string()),
             Option<String>
         ),
         (
             "peer",
-            peer.to_string().get(..8),
+            last_four_chars(&peer.to_string()),
             Option<String>
         ),
     );

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -14,7 +14,7 @@
 use {
     crate::{
         cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY,
-        cluster_info_metrics::{last_four_chars, should_report_message_signature},
+        cluster_info_metrics::{log_gossip_crds_sample_egress, should_report_message_signature},
         crds::{Crds, CrdsError, Cursor, GossipRoute, SIGNATURE_SAMPLE_LEADING_ZEROS},
         crds_gossip,
         crds_value::CrdsValue,
@@ -289,27 +289,6 @@ impl CrdsGossipPush {
             stakes,
         )
     }
-}
-
-fn log_gossip_crds_sample_egress(value: &CrdsValue, peer: &Pubkey) {
-    datapoint_info!(
-        "gossip_crds_sample_egress",
-        (
-            "origin",
-            last_four_chars(&value.pubkey().to_string()),
-            Option<String>
-        ),
-        (
-            "signature",
-            last_four_chars(&value.signature().to_string()),
-            Option<String>
-        ),
-        (
-            "peer",
-            last_four_chars(&peer.to_string()),
-            Option<String>
-        ),
-    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
We don't have a way to properly record gossip message propagation times in the face of clock drift and without the actual send time

#### Summary of Changes
add a new metric: `gossip_crds_sample_egress` that tracks when we send a gossip message (downsampled significantly). This metric is tracking the same messages (w/ the same downsampling) that `gossip_crds_sample` tracks on ingress, but `gossip_crds_sample_egress` tracks egress.

`gossip_crds_sample_egress` also adds which peers it is pushing a message to. Mean push fanout on mainnet is ~2-3 peer nodes. When a message is recorded it will report a new datapoint for each peer node. This means that every message reported by `gossip_crds_sample_egress` will have 2-3 entries in influx (1 for each peer node).

we get approximately 1 new message every ~20s. 

`gossip_crds_sample` (ingress):
<img width="1622" alt="Screenshot 2025-06-06 at 12 45 18 PM" src="https://github.com/user-attachments/assets/fbaf63a6-eb5d-4e3f-91d0-a9ac22e0e668" />

`gossip_crds_sample_egress`:
<img width="1624" alt="Screenshot 2025-06-06 at 12 42 47 PM" src="https://github.com/user-attachments/assets/b877fb75-f5d5-4d5d-9614-666109ccad31" />
