### PR TITLE
Docs: Add rmem_default & wmem_default to validator sysctl tuning

### DIFF
--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -51,6 +51,8 @@ sudo bash -c "cat >/etc/sysctl.d/21-agave-validator.conf <<EOF
 # Increase max UDP buffer sizes
 net.core.rmem_max = 134217728
 net.core.wmem_max = 134217728
+net.core.rmem_default = 134217728
+net.core.wmem_default = 134217728
 
 # Increase memory mapped files limit
 vm.max_map_count = 1000000

--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -311,6 +311,8 @@ sudo bash -c "cat >/etc/sysctl.d/21-agave-validator.conf <<EOF
 # Increase max UDP buffer sizes
 net.core.rmem_max = 134217728
 net.core.wmem_max = 134217728
+net.core.rmem_default = 134217728
+net.core.wmem_default = 134217728
 
 # Increase memory mapped files limit
 vm.max_map_count = 1000000


### PR DESCRIPTION
#### Problem

The current system tuning documentation for Agave validators is missing recommended `sysctl` settings for `net.core.rmem_default` and `net.core.wmem_default`.

For example, the following warnings were observed when running an RPC node with the current documentation's tuning guide:

```
[2025-06-05T04:01:41.538206515Z WARN  solana_core::system_monitor_service]   net.core.rmem_default: recommended=134217728, current=212992 too small
OS network limit test failed. See: https://docs.solanalabs.com/operations/guides/validator-start#system-tuning
```

```
[2025-06-05T04:05:48.306590702Z WARN  solana_core::system_monitor_service]   net.core.wmem_default: recommended=134217728, current=212992 too small
OS network limit test failed. See: https://docs.solanalabs.com/operations/guides/validator-start#system-tuning
```


#### Summary of Changes

This PR updates the "System Tuning -> Linux -> Optimize sysctl knobs" section of the Agave validator setup documentation.

The following recommended `sysctl` settings have been added to the guide, for inclusion in `/etc/sysctl.d/21-agave-validator.conf`:
```ini
net.core.rmem_default = 134217728
net.core.wmem_default = 134217728
```