### PR TITLE
CI: Allow warnings on downstream job tests

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -148,7 +148,8 @@ jobs:
         run: |
           source ci/downstream-projects/common.sh
           cd "${{ matrix.programs }}"
-          $CARGO_TEST_SBF --arch v0 --manifest-path program/Cargo.toml
+          $CARGO_BUILD_SBF --arch v0 --manifest-path program/Cargo.toml
+          RUSTFLAGS="-Awarnings" SBF_OUT_DIR="../target/deploy"  cargo test --features test-sbf --manifest-path program/Cargo.toml
 
       - name: Test SBPFv1
         shell: bash

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -156,7 +156,8 @@ jobs:
           source ci/downstream-projects/common.sh
           cd "${{ matrix.programs }}"
           rm -rf target/deploy target/sbpf*
-          $CARGO_TEST_SBF --arch v1 --manifest-path program/Cargo.toml
+          $CARGO_BUILD_SBF --arch v1 --manifest-path program/Cargo.toml
+          RUSTFLAGS="-Awarnings" SBF_OUT_DIR="../target/deploy"  cargo test --features test-sbf --manifest-path program/Cargo.toml
 
       - name: Test SBPFv2
         shell: bash
@@ -164,7 +165,8 @@ jobs:
           source ci/downstream-projects/common.sh
           cd "${{ matrix.programs }}"
           rm -rf target/deploy target/sbpf*
-          $CARGO_TEST_SBF --arch v2 --manifest-path program/Cargo.toml
+          $CARGO_BUILD_SBF --arch v2 --manifest-path program/Cargo.toml
+          RUSTFLAGS="-Awarnings" SBF_OUT_DIR="../target/deploy"  cargo test --features test-sbf --manifest-path program/Cargo.toml
 
       - name: Test SBPFv3
         shell: bash
@@ -172,4 +174,5 @@ jobs:
           source ci/downstream-projects/common.sh
           cd "${{ matrix.programs }}"
           rm -rf target/deploy target/sbpf*
-          $CARGO_TEST_SBF --arch v3 --manifest-path program/Cargo.toml
+          $CARGO_BUILD_SBF --arch v3 --manifest-path program/Cargo.toml
+          RUSTFLAGS="-Awarnings" SBF_OUT_DIR="../target/deploy"  cargo test --features test-sbf --manifest-path program/Cargo.toml


### PR DESCRIPTION
#### Problem

During the downstream jobs, the patching step also updates crate versions, causing issues when the updated crate versions have things like deprecation warnings. See
https://github.com/anza-xyz/agave/actions/runs/15462162384/job/43525772248?pr=6415 for an example.

#### Summary of changes

Since we mainly want to be sure that downstream repos don't break, allow warnings on the test step.