### PR TITLE
Refactor - `translate_mut!()` for syscalls

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -867,12 +867,11 @@ declare_builtin_function!(
         let Ok(new_address) = Pubkey::create_program_address(&seeds, program_id) else {
             return Ok(1);
         };
-        let address = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            address_addr,
-            32,
             invoke_context.get_check_aligned(),
-        )?;
+            let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
+        );
         address.copy_from_slice(new_address.as_ref());
         Ok(0)
     }
@@ -912,25 +911,12 @@ declare_builtin_function!(
                 if let Ok(new_address) =
                     Pubkey::create_program_address(&seeds_with_bump, program_id)
                 {
-                    let bump_seed_ref = translate_type_mut::<u8>(
+                    translate_mut!(
                         memory_mapping,
-                        bump_seed_addr,
                         invoke_context.get_check_aligned(),
-                    )?;
-                    let address = translate_slice_mut::<u8>(
-                        memory_mapping,
-                        address_addr,
-                        std::mem::size_of::<Pubkey>() as u64,
-                        invoke_context.get_check_aligned(),
-                    )?;
-                    if !is_nonoverlapping(
-                        bump_seed_ref as *const _ as usize,
-                        std::mem::size_of_val(bump_seed_ref),
-                        address.as_ptr() as usize,
-                        std::mem::size_of::<Pubkey>(),
-                    ) {
-                        return Err(SyscallError::CopyOverlapping.into());
-                    }
+                        let bump_seed_ref: &mut u8 = map(bump_seed_addr)?;
+                        let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
+                    );
                     *bump_seed_ref = bump_seed[0];
                     address.copy_from_slice(new_address.as_ref());
                     return Ok(0);
@@ -958,12 +944,11 @@ declare_builtin_function!(
         let cost = invoke_context.get_execution_cost().secp256k1_recover_cost;
         consume_compute_meter(invoke_context, cost)?;
 
-        let secp256k1_recover_result = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            result_addr,
-            SECP256K1_PUBLIC_KEY_LENGTH as u64,
             invoke_context.get_check_aligned(),
-        )?;
+            let secp256k1_recover_result: &mut [u8] = map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
+        );
         let hash = translate_slice::<u8>(
             memory_mapping,
             hash_addr,
@@ -1079,7 +1064,12 @@ declare_builtin_function!(
         result_point_addr: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
-        use solana_curve25519::{curve_syscall_traits::*, edwards, ristretto, scalar};
+        use solana_curve25519::{
+            curve_syscall_traits::*,
+            edwards::{self, PodEdwardsPoint},
+            ristretto::{self, PodRistrettoPoint},
+            scalar,
+        };
         match curve_id {
             CURVE25519_EDWARDS => match group_op {
                 ADD => {
@@ -1088,23 +1078,24 @@ declare_builtin_function!(
                         .curve25519_edwards_add_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let left_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let right_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) = edwards::add_edwards(left_point, right_point) {
-                        *translate_type_mut::<edwards::PodEdwardsPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1116,23 +1107,24 @@ declare_builtin_function!(
                         .curve25519_edwards_subtract_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let left_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let right_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) = edwards::subtract_edwards(left_point, right_point) {
-                        *translate_type_mut::<edwards::PodEdwardsPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1149,18 +1141,19 @@ declare_builtin_function!(
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let input_point = translate_type::<edwards::PodEdwardsPoint>(
+                    let input_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) = edwards::multiply_edwards(scalar, input_point) {
-                        *translate_type_mut::<edwards::PodEdwardsPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1182,23 +1175,24 @@ declare_builtin_function!(
                         .curve25519_ristretto_add_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let left_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let right_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) = ristretto::add_ristretto(left_point, right_point) {
-                        *translate_type_mut::<ristretto::PodRistrettoPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1210,12 +1204,12 @@ declare_builtin_function!(
                         .curve25519_ristretto_subtract_cost;
                     consume_compute_meter(invoke_context, cost)?;
 
-                    let left_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let left_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let right_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let right_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
@@ -1224,11 +1218,12 @@ declare_builtin_function!(
                     if let Some(result_point) =
                         ristretto::subtract_ristretto(left_point, right_point)
                     {
-                        *translate_type_mut::<ristretto::PodRistrettoPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1245,18 +1240,19 @@ declare_builtin_function!(
                         left_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
-                    let input_point = translate_type::<ristretto::PodRistrettoPoint>(
+                    let input_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
                         invoke_context.get_check_aligned(),
                     )?;
 
                     if let Some(result_point) = ristretto::multiply_ristretto(scalar, input_point) {
-                        *translate_type_mut::<ristretto::PodRistrettoPoint>(
+                        translate_mut!(
                             memory_mapping,
-                            result_point_addr,
                             invoke_context.get_check_aligned(),
-                        )? = result_point;
+                            let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                        );
+                        *result_point_ref_mut = result_point;
                         Ok(0)
                     } else {
                         Ok(1)
@@ -1296,7 +1292,12 @@ declare_builtin_function!(
         result_point_addr: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
-        use solana_curve25519::{curve_syscall_traits::*, edwards, ristretto, scalar};
+        use solana_curve25519::{
+            curve_syscall_traits::*,
+            edwards::{self, PodEdwardsPoint},
+            ristretto::{self, PodRistrettoPoint},
+            scalar,
+        };
 
         if points_len > 512 {
             return Err(Box::new(SyscallError::InvalidLength));
@@ -1322,7 +1323,7 @@ declare_builtin_function!(
                     invoke_context.get_check_aligned(),
                 )?;
 
-                let points = translate_slice::<edwards::PodEdwardsPoint>(
+                let points = translate_slice::<PodEdwardsPoint>(
                     memory_mapping,
                     points_addr,
                     points_len,
@@ -1330,11 +1331,12 @@ declare_builtin_function!(
                 )?;
 
                 if let Some(result_point) = edwards::multiscalar_multiply_edwards(scalars, points) {
-                    *translate_type_mut::<edwards::PodEdwardsPoint>(
+                    translate_mut!(
                         memory_mapping,
-                        result_point_addr,
                         invoke_context.get_check_aligned(),
-                    )? = result_point;
+                        let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
+                    );
+                    *result_point_ref_mut = result_point;
                     Ok(0)
                 } else {
                     Ok(1)
@@ -1360,7 +1362,7 @@ declare_builtin_function!(
                     invoke_context.get_check_aligned(),
                 )?;
 
-                let points = translate_slice::<ristretto::PodRistrettoPoint>(
+                let points = translate_slice::<PodRistrettoPoint>(
                     memory_mapping,
                     points_addr,
                     points_len,
@@ -1370,11 +1372,12 @@ declare_builtin_function!(
                 if let Some(result_point) =
                     ristretto::multiscalar_multiply_ristretto(scalars, points)
                 {
-                    *translate_type_mut::<ristretto::PodRistrettoPoint>(
+                    translate_mut!(
                         memory_mapping,
-                        result_point_addr,
                         invoke_context.get_check_aligned(),
-                    )? = result_point;
+                        let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
+                    );
+                    *result_point_ref_mut = result_point;
                     Ok(0)
                 } else {
                     Ok(1)
@@ -1465,17 +1468,12 @@ declare_builtin_function!(
                 .unwrap_or(u64::MAX);
             consume_compute_meter(invoke_context, cost)?;
 
-            let return_data_result = translate_slice_mut::<u8>(
+            translate_mut!(
                 memory_mapping,
-                return_data_addr,
-                length,
                 invoke_context.get_check_aligned(),
-            )?;
-            let program_id_result = translate_type_mut::<Pubkey>(
-                memory_mapping,
-                program_id_addr,
-                invoke_context.get_check_aligned(),
-            )?;
+                let return_data_result: &mut [u8] = map(return_data_addr, length)?;
+                let program_id_result: &mut Pubkey = map(program_id_addr)?;
+            );
 
             let to_slice = return_data_result;
             let from_slice = return_data
@@ -1485,16 +1483,6 @@ declare_builtin_function!(
                 return Err(SyscallError::InvalidLength.into());
             }
             to_slice.copy_from_slice(from_slice);
-
-            if !is_nonoverlapping(
-                to_slice.as_ptr() as usize,
-                length as usize,
-                program_id_result as *const _ as usize,
-                std::mem::size_of::<Pubkey>(),
-            ) {
-                return Err(SyscallError::CopyOverlapping.into());
-            }
-
             *program_id_result = *program_id;
         }
 
@@ -1544,70 +1532,26 @@ declare_builtin_function!(
         }
 
         if let Some(instruction_context) = found_instruction_context {
-            let result_header = translate_type_mut::<ProcessedSiblingInstruction>(
+            translate_mut!(
                 memory_mapping,
-                meta_addr,
                 invoke_context.get_check_aligned(),
-            )?;
+                let result_header: &mut ProcessedSiblingInstruction = map(meta_addr)?;
+            );
 
             if result_header.data_len == (instruction_context.get_instruction_data().len() as u64)
                 && result_header.accounts_len
                     == (instruction_context.get_number_of_instruction_accounts() as u64)
             {
-                let program_id = translate_type_mut::<Pubkey>(
+                translate_mut!(
                     memory_mapping,
-                    program_id_addr,
                     invoke_context.get_check_aligned(),
-                )?;
-                let data = translate_slice_mut::<u8>(
-                    memory_mapping,
-                    data_addr,
-                    result_header.data_len,
-                    invoke_context.get_check_aligned(),
-                )?;
-                let accounts = translate_slice_mut::<AccountMeta>(
-                    memory_mapping,
-                    accounts_addr,
-                    result_header.accounts_len,
-                    invoke_context.get_check_aligned(),
-                )?;
-
-                if !is_nonoverlapping(
-                    result_header as *const _ as usize,
-                    std::mem::size_of::<ProcessedSiblingInstruction>(),
-                    program_id as *const _ as usize,
-                    std::mem::size_of::<Pubkey>(),
-                ) || !is_nonoverlapping(
-                    result_header as *const _ as usize,
-                    std::mem::size_of::<ProcessedSiblingInstruction>(),
-                    accounts.as_ptr() as usize,
-                    std::mem::size_of::<AccountMeta>()
-                        .saturating_mul(result_header.accounts_len as usize),
-                ) || !is_nonoverlapping(
-                    result_header as *const _ as usize,
-                    std::mem::size_of::<ProcessedSiblingInstruction>(),
-                    data.as_ptr() as usize,
-                    result_header.data_len as usize,
-                ) || !is_nonoverlapping(
-                    program_id as *const _ as usize,
-                    std::mem::size_of::<Pubkey>(),
-                    data.as_ptr() as usize,
-                    result_header.data_len as usize,
-                ) || !is_nonoverlapping(
-                    program_id as *const _ as usize,
-                    std::mem::size_of::<Pubkey>(),
-                    accounts.as_ptr() as usize,
-                    std::mem::size_of::<AccountMeta>()
-                        .saturating_mul(result_header.accounts_len as usize),
-                ) || !is_nonoverlapping(
-                    data.as_ptr() as usize,
-                    result_header.data_len as usize,
-                    accounts.as_ptr() as usize,
-                    std::mem::size_of::<AccountMeta>()
-                        .saturating_mul(result_header.accounts_len as usize),
-                ) {
-                    return Err(SyscallError::CopyOverlapping.into());
-                }
+                    let program_id: &mut Pubkey = map(program_id_addr)?;
+                    let data: &mut [u8] = map(data_addr, result_header.data_len)?;
+                    let accounts: &mut [AccountMeta] = map(accounts_addr, result_header.accounts_len)?;
+                    let result_header: &mut ProcessedSiblingInstruction = map(meta_addr)?;
+                );
+                // Marks result_header used. It had to be in translate_mut!() for the overlap checks.
+                let _ = result_header;
 
                 *program_id = *instruction_context
                     .get_last_program_key(invoke_context.transaction_context)?;
@@ -1631,10 +1575,11 @@ declare_builtin_function!(
                     })
                     .collect::<Result<Vec<_>, InstructionError>>()?;
                 accounts.clone_from_slice(account_metas.as_slice());
+            } else {
+                result_header.data_len = instruction_context.get_instruction_data().len() as u64;
+                result_header.accounts_len =
+                    instruction_context.get_number_of_instruction_accounts() as u64;
             }
-            result_header.data_len = instruction_context.get_instruction_data().len() as u64;
-            result_header.accounts_len =
-                instruction_context.get_number_of_instruction_accounts() as u64;
             return Ok(true as u64);
         }
         Ok(false as u64)
@@ -1707,12 +1652,11 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, cost)?;
 
-        let call_result = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            result_addr,
-            output as u64,
             invoke_context.get_check_aligned(),
-        )?;
+            let call_result: &mut [u8] = map(result_addr, output as u64)?;
+        );
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
@@ -1828,13 +1772,12 @@ declare_builtin_function!(
 
         let value = big_mod_exp(base, exponent, modulus);
 
-        let return_value = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            return_value,
-            params.modulus_len,
             invoke_context.get_check_aligned(),
-        )?;
-        return_value.copy_from_slice(value.as_slice());
+            let return_value_ref_mut: &mut [u8] = map(return_value, params.modulus_len)?;
+        );
+        return_value_ref_mut.copy_from_slice(value.as_slice());
 
         Ok(0)
     }
@@ -1874,12 +1817,11 @@ declare_builtin_function!(
         };
         consume_compute_meter(invoke_context, cost.to_owned())?;
 
-        let hash_result = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            result_addr,
-            poseidon::HASH_BYTES as u64,
             invoke_context.get_check_aligned(),
-        )?;
+            let hash_result: &mut [u8] = map(result_addr, poseidon::HASH_BYTES as u64)?;
+        );
         let inputs = translate_slice::<VmSlice<u8>>(
             memory_mapping,
             vals_addr,
@@ -1972,12 +1914,11 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, cost)?;
 
-        let call_result = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            result_addr,
-            output as u64,
             invoke_context.get_check_aligned(),
-        )?;
+            let call_result: &mut [u8] = map(result_addr, output as u64)?;
+        );
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
@@ -2081,12 +2022,11 @@ declare_builtin_function!(
 
         consume_compute_meter(invoke_context, hash_base_cost)?;
 
-        let hash_result = translate_slice_mut::<u8>(
+        translate_mut!(
             memory_mapping,
-            result_addr,
-            std::mem::size_of::<H::Output>() as u64,
             invoke_context.get_check_aligned(),
-        )?;
+            let hash_result: &mut [u8] = map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
+        );
         let mut hasher = H::create_hasher();
         if vals_len > 0 {
             let vals = translate_slice::<VmSlice<u8>>(

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -274,14 +274,6 @@ impl<T> VmSlice<T> {
     ) -> Result<&[T], Error> {
         translate_slice::<T>(memory_mapping, self.ptr, self.len, check_aligned)
     }
-
-    pub fn translate_mut(
-        &mut self,
-        memory_mapping: &MemoryMapping,
-        check_aligned: bool,
-    ) -> Result<&mut [T], Error> {
-        translate_slice_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
-    }
 }
 
 fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4433,34 +4433,10 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
-        let processed_sibling_instruction = translate_type_mut::<ProcessedSiblingInstruction>(
-            &memory_mapping,
-            VM_BASE_ADDRESS,
-            true,
-        )
-        .unwrap();
+        let processed_sibling_instruction =
+            unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
         processed_sibling_instruction.data_len = 1;
         processed_sibling_instruction.accounts_len = 1;
-        let program_id = translate_type_mut::<Pubkey>(
-            &memory_mapping,
-            VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
-            true,
-        )
-        .unwrap();
-        let data = translate_slice_mut::<u8>(
-            &memory_mapping,
-            VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
-            processed_sibling_instruction.data_len,
-            true,
-        )
-        .unwrap();
-        let accounts = translate_slice_mut::<AccountMeta>(
-            &memory_mapping,
-            VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            processed_sibling_instruction.accounts_len,
-            true,
-        )
-        .unwrap();
 
         invoke_context.mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
@@ -4474,6 +4450,26 @@ mod tests {
         );
         assert_eq!(result.unwrap(), 1);
         {
+            let program_id = translate_type::<Pubkey>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
+                true,
+            )
+            .unwrap();
+            let data = translate_slice::<u8>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
+                processed_sibling_instruction.data_len,
+                true,
+            )
+            .unwrap();
+            let accounts = translate_slice::<AccountMeta>(
+                &memory_mapping,
+                VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
+                processed_sibling_instruction.accounts_len,
+                true,
+            )
+            .unwrap();
             let transaction_context = &invoke_context.transaction_context;
             assert_eq!(processed_sibling_instruction.data_len, 1);
             assert_eq!(processed_sibling_instruction.accounts_len, 1);

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -1,4 +1,7 @@
-use {super::*, solana_program_runtime::execution_budget::SVMTransactionExecutionCost};
+use {
+    super::*, crate::translate_mut,
+    solana_program_runtime::execution_budget::SVMTransactionExecutionCost,
+};
 
 fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
@@ -14,7 +17,11 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
             .sysvar_base_cost
             .saturating_add(size_of::<T>() as u64),
     )?;
-    let var = translate_type_mut::<T>(memory_mapping, var_addr, check_aligned)?;
+    translate_mut!(
+        memory_mapping,
+        check_aligned,
+        let var: &mut T = map(var_addr)?;
+    );
 
     // this clone looks unecessary now, but it exists to zero out trailing alignment bytes
     // it is unclear whether this should ever matter
@@ -197,7 +204,11 @@ declare_builtin_function!(
         )?;
 
         // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
-        let var = translate_slice_mut::<u8>(memory_mapping, var_addr, length, check_aligned)?;
+        translate_mut!(
+            memory_mapping,
+            check_aligned,
+            let var: &mut [u8] = map(var_addr, length)?;
+        );
 
         // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
         let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;


### PR DESCRIPTION
#### Problem

The ranges of `translate_*_mut()` and subsequent `is_nonoverlapping` checks must be kept in sync. Also the exactly right combinations of `is_nonoverlapping` have to be in place. These constraints are tedious to adhere to manually.

#### Summary of Changes

- Removes `VmSlice::translate_mut()`
- Removes call sites of `translate_type_mut()` and `translate_slice_mut()` in tests
- Adds `translate_mut!()`
- Uses `translate_mut!()` instead of `translate_slice_mut()` and `translate_type_mut()` for all call sites outside of CPI
- Adds proper lifetimes to `&MemoryMapping` in translation functions (contributed by Andrew Haberlandt)

Could have done [more fanzy macro stuff](https://lukaswirth.dev/tlborm/decl-macros/building-blocks/counting.html) to construct the pairs of `is_nonoverlapping` checks, but for the sake of readability I went with it being done at runtime.