### PR TITLE
Enabling scan support for obsolete accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1197,6 +1197,19 @@ impl AccountStorageEntry {
             .collect()
     }
 
+    /// Returns whether the account at a given offset is obsolete at a given slot
+    /// or earlier. If the passed in slot is None, then slot will be assumed to
+    /// be the max root and any obsolete accounts will be returned regardless of slot
+    pub fn is_account_obsolete(&self, offset: Offset, slot: Option<Slot>) -> bool {
+        self.obsolete_accounts
+            .read()
+            .unwrap()
+            .iter()
+            .any(|(stored_offset, _, stored_slot)| {
+                *stored_offset == offset && (slot.is_none_or(|s| *stored_slot <= s))
+            })
+    }
+
     /// Returns the number of bytes that were marked obsolete as of the passed
     /// in slot or earlier. If slot is None, then slot will be assumed to be the
     /// max root, and all obsolete bytes will be returned.

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -38,6 +38,7 @@ trait AppendVecScan: Send + Sync + Clone {
     /// initialize accumulator
     fn init_accum(&mut self, count: usize);
     /// The slot at which the scan is being performed
+    /// Any updates from slots after this slot should not be included in the scan
     fn scan_slot(&self) -> Slot;
 }
 


### PR DESCRIPTION
#### Problem
The scan_single_account_storage function needs to be able to determine the account status at a given slot to calculate the accounts hash (incremental or full). With obsolete accounts, a newer slot may mark an older slot as obsolete.  If the newer slot is > the slot that the hash should be calculated for, the account should be included. If the newer slot is <= the slot that the hash should be calculated for, the account should be ignored. 

#### Summary of Changes
- Adding the slot being scanned at to the scan filter.
- Modifying the found account code to check the slot at which the account was invalidated at to determine whether it should be included or not. 
- Unit tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
