### PR TITLE
Airgap`TransactionError` type from blockstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10642,6 +10642,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
+ "test-case",
  "tonic-build",
 ]
 

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -43,3 +43,4 @@ protobuf-src = { workspace = true }
 
 [dev-dependencies]
 enum-iterator = { workspace = true }
+test-case = { workspace = true }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{StoredExtendedRewards, StoredTransactionStatusMeta},
+    crate::{StoredExtendedRewards, StoredTransactionError, StoredTransactionStatusMeta},
     solana_account_decoder::parse_token::{real_number_string_trimmed, UiTokenAmount},
     solana_hash::{Hash, HASH_BYTES},
     solana_instruction::error::InstructionError,
@@ -283,6 +283,20 @@ impl From<generated::Transaction> for VersionedTransaction {
                 .unwrap(),
             message: value.message.expect("message is required").into(),
         }
+    }
+}
+
+impl From<TransactionError> for generated::TransactionError {
+    fn from(value: TransactionError) -> Self {
+        let stored_error = Into::<StoredTransactionError>::into(value).0;
+        Self { err: stored_error }
+    }
+}
+
+impl From<generated::TransactionError> for TransactionError {
+    fn from(value: generated::TransactionError) -> Self {
+        let stored_error = StoredTransactionError(value.err);
+        stored_error.into()
     }
 }
 

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -288,7 +288,7 @@ impl From<generated::Transaction> for VersionedTransaction {
 
 impl From<TransactionError> for generated::TransactionError {
     fn from(value: TransactionError) -> Self {
-        let stored_error = Into::<StoredTransactionError>::into(value).0;
+        let stored_error = StoredTransactionError::from(value).0;
         Self { err: stored_error }
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -114,7 +114,7 @@ struct StoredTransactionError(Vec<u8>);
 impl From<StoredTransactionError> for TransactionError {
     fn from(value: StoredTransactionError) -> Self {
         let bytes = value.0;
-        bincode::deserialize::<Self>(&bytes).expect("transaction error to deserialize from bytes")
+        bincode::deserialize(&bytes).expect("transaction error to deserialize from bytes")
     }
 }
 

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -7,7 +7,7 @@ use {
     solana_message::v0::LoadedAddresses,
     solana_serde::default_on_eof,
     solana_transaction_context::TransactionReturnData,
-    solana_transaction_error::TransactionResult as Result,
+    solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_transaction_status::{
         InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
     },
@@ -106,6 +106,22 @@ impl From<UiTokenAmount> for StoredTokenAmount {
             decimals,
             amount,
         }
+    }
+}
+
+struct StoredTransactionError(Vec<u8>);
+
+impl From<StoredTransactionError> for TransactionError {
+    fn from(value: StoredTransactionError) -> Self {
+        let bytes = value.0;
+        bincode::deserialize::<Self>(&bytes).expect("transaction error to deserialize from bytes")
+    }
+}
+
+impl From<TransactionError> for StoredTransactionError {
+    fn from(value: TransactionError) -> Self {
+        let bytes = bincode::serialize(&value).expect("transaction error to serialize to bytes");
+        StoredTransactionError(bytes)
     }
 }
 
@@ -263,5 +279,106 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             compute_units_consumed,
             cost_units,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::StoredTransactionError, solana_instruction::error::InstructionError,
+        solana_transaction_error::TransactionError, test_case::test_case,
+    };
+
+    #[test_case(TransactionError::InsufficientFundsForFee; "Named variant error")]
+    #[test_case(TransactionError::InsufficientFundsForRent { account_index: 42 }; "Struct variant error")]
+    #[test_case(TransactionError::DuplicateInstruction(42); "Single-value tuple variant error")]
+    #[test_case(TransactionError::InstructionError(42, InstructionError::Custom(0xdeadbeef)); "`InstructionError`")]
+    fn test_serialize_transaction_error_to_stored_transaction_error_round_trip(
+        err: TransactionError,
+    ) {
+        let serialized: StoredTransactionError = err.clone().into();
+        let deserialized: TransactionError = serialized.into();
+        assert_eq!(deserialized, err);
+    }
+
+    #[test_case(
+        vec![4, 0, 0, 0,  /* Fourth enum variant - `InsufficientFundsForFee` */],
+        TransactionError::InsufficientFundsForFee;
+        "Named variant error"
+    )]
+    #[test_case(
+        vec![
+            31, 0, 0, 0,  /* Thirty-first enum variant - `InsufficientFundsForRent` */
+            42, /* Account index */
+        ],
+        TransactionError::InsufficientFundsForRent { account_index: 42 };
+        "Struct variant error"
+    )]
+    #[test_case(
+        vec![
+            30, 0, 0, 0,  /* Thirtieth enum variant - `DuplicateInstruction` */
+            42, /* Instruction index */
+        ],
+        TransactionError::DuplicateInstruction(42);
+        "Single-value tuple variant error"
+    )]
+    #[test_case(
+        vec![
+            8, 0, 0, 0,  /* Eighth enum variant - `InstructionError` */
+            42, /* Outer instruction index */
+            25, 0, 0, 0, /* InstructionError::Custom */
+            /* 0xdeadbeef */
+            239, 190, 173, 222,
+        ],
+        TransactionError::InstructionError(42, InstructionError::Custom(0xdeadbeef));
+        "`InstructionError`"
+    )]
+    fn test_deserialize_stored_transaction_error(
+        stored_bytes: Vec<u8>,
+        expected_transaction_error: TransactionError,
+    ) {
+        let stored_transaction = StoredTransactionError(stored_bytes);
+        let deserialized: TransactionError = stored_transaction.into();
+        assert_eq!(deserialized, expected_transaction_error);
+    }
+
+    #[test_case(
+        vec![4, 0, 0, 0,  /* Fourth enum variant - `InsufficientFundsForFee` */],
+        TransactionError::InsufficientFundsForFee;
+        "Named variant error"
+    )]
+    #[test_case(
+        vec![
+            31, 0, 0, 0,  /* Thirty-first enum variant - `InsufficientFundsForRent` */
+            42, /* Account index */
+        ],
+        TransactionError::InsufficientFundsForRent { account_index: 42 };
+        "Struct variant error"
+    )]
+    #[test_case(
+        vec![
+            30, 0, 0, 0,  /* Thirtieth enum variant - `DuplicateInstruction` */
+            42, /* Instruction index */
+        ],
+        TransactionError::DuplicateInstruction(42);
+        "Single-value tuple variant error"
+    )]
+    #[test_case(
+        vec![
+            8, 0, 0, 0,  /* Eighth enum variant - `InstructionError` */
+            42, /* Outer instruction index */
+            25, 0, 0, 0, /* InstructionError::Custom */
+            /* 0xdeadbeef */
+            239, 190, 173, 222,
+        ],
+        TransactionError::InstructionError(42, InstructionError::Custom(0xdeadbeef));
+        "`InstructionError`"
+    )]
+    fn test_seserialize_stored_transaction_error(
+        expected_serialized_bytes: Vec<u8>,
+        transaction_error: TransactionError,
+    ) {
+        let StoredTransactionError(serialized_bytes) = transaction_error.into();
+        assert_eq!(serialized_bytes, expected_serialized_bytes);
     }
 }


### PR DESCRIPTION
#### Problem

At present, we leak the serialization format of `TransactionError` straight into blockstore. Any change to the serialization format of `TransactionError` ([this](https://github.com/anza-xyz/solana-sdk/pull/74) being an example) could change the bytes that are stored in blockstore. A change in that serialization could cause old validator clients to fail to load transaction errors stored by newer clients, and vice versa.

#### Summary of Changes

In this PR, we create an ‘airgap’ – `StoredTransaction` between `TransactionError` and the type that is serialized for storage in blockstore.

This provides a locus for custom serialization logic. Now you can conceive of a change to the structure of `TransactionError` that can be handled by the custom serialization logic to produce bytes that are backward compatible with old validator clients, and you can create deserialization logic that handles bytes stored by older validator clients.

We also add tests to verify that the current serialization format for named, struct, tuple, and particularly `InstructionError` variants of `TransactionError` don't change without a test breaking.

This is a prerequisite for https://github.com/anza-xyz/agave/pull/6083