### PR TITLE
Repair `scripts/cargo-for-all-lock-files.sh`

### DIFF
--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -41,10 +41,10 @@ fi
 
 for lock_file in $files; do
   if [[ -n $CI ]]; then
-    echo "--- [$lock_file]: cargo " "${shifted_args[@]}" "$@"
+    echo "--- [$lock_file]: cargo check " "${shifted_args[@]}" "$@"
   fi
 
-  if (set -x && cd "$(dirname "$lock_file")" && cargo "${shifted_args[@]}" "$@"); then
+  if (set -x && cd "$(dirname "$lock_file")" && cargo check "${shifted_args[@]}" "$@"); then
     # noop
     true
   else


### PR DESCRIPTION
#### Problem

This script appears as though it's supposed to find all `Cargo.lock` files in the repo and run `cargo` in their directory. If that's ever something that updated lockfiles, it doesn't anymore ([output](https://gist.github.com/steveluscher/e9b29a02f27413173273e58a6392bacc)). The only way to update a lockfile is to run either `cargo build/test/check`.

#### Summary of Changes

This change makes it run `cargo check` which is unnecessarily slow for what it tries to achieve, but at least gets the job done.