### PR TITLE
Do not clean past enqueued snapshot request in AccountsBackgroundService

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6434,7 +6434,7 @@ impl Bank {
     }
 
     /// Returns how clean_accounts() should handle old storages
-    fn clean_accounts_old_storages_policy(&self) -> OldStoragesPolicy {
+    pub fn clean_accounts_old_storages_policy(&self) -> OldStoragesPolicy {
         if self.are_ancient_storages_enabled() {
             OldStoragesPolicy::Leave
         } else {


### PR DESCRIPTION
#### Problem

Please see #6295.


#### Summary of Changes

Do not clean past enqueued snapshot request.

Fixes #6295

Note, needs to be backported to v2.3.