### PR TITLE
ci: Disable downstream jobs temporarily

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -39,6 +39,7 @@ env:
 jobs:
   check:
     if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -77,6 +78,7 @@ jobs:
 
   test_cli:
     if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -107,6 +109,7 @@ jobs:
 
   cargo-test-sbf:
     if: github.repository == 'anza-xyz/agave'
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
#### Problem
I'm attempting to update the version to `v3.0.0` in https://github.com/anza-xyz/agave/pull/6425 but running into issues with CI. One such example is [here](https://github.com/anza-xyz/agave/actions/runs/15483802781/job/43594290903); the problem is:
1. Some stuff in SPL has the following dependency: `solana-cli-output = "^2.2.1"`
2. `solana-cli-output` (which lives in Agave) depends on some sdk crates such as `solana-clock`
3.  Prior to [this PR](https://github.com/anza-xyz/agave/pull/5783), Agave had the versions for sdk crates pinned in the workspace to `=2.2.1`.
    - That PR relaxed things to `^2.2.1`, but didn't land until `v2.2.9`
    - Due to an unrelated issue, we haven't been able to publish all Agave crates since `v2.2.7`
5. This means that the latest (`2.2.7`) `solana-cli-output` crate has `solana-clock` pinned to `=2.2.1`
5. Because of 1. and 4., some SPL stuff inherits `solana-clock = "=2.2.1"`
6. The Agave master branch has since updated to many of the sdk deps such as `solana-clock` (now `^2.2.2`)
7. The Agave bump to `v3.0.0` means `solana-cli-output = "^v2.2.1"` cannot select `3.0.0` (new major version)

Given 6. and 7., we are unable to select a version for some of these crates as shown by below error from previously linked CI run:
```
    error: failed to select a version for `solana-hash`.
        ... required by package `solana-cli-output v2.2.1`
        ... which satisfies dependency `solana-cli-output = "^2.2.0"` of package `spl-token-client v0.16.1`
        ... which satisfies dependency `spl-token-client = "^0.16.1"` of package `spl-single-pool-cli v2.0.0 (/home/runner/work/agave/agave/target/downstream-projects/single-pool/clients/cli)`
    versions that meet the requirements `=2.2.1` are: 2.2.1
    
    all possible versions conflict with previously selected packages.
    
      previously selected package `solana-hash v2.3.0`
        ... which satisfies dependency `solana-hash = "^2.3.0"` of package `solana-cli-output v3.0.0 (/home/runner/work/agave/agave/cli-output)`
        ... which satisfies dependency `solana-cli-output = "^3.0.0"` of package `spl-single-pool-cli v2.0.0 (/home/runner/work/agave/agave/target/downstream-projects/single-pool/clients/cli)`
```

#### Summary of Changes
Temporarily disable the downstream jobs so that I can merge https://github.com/anza-xyz/agave/pull/6425

I think we'd be able to re-enable these jobs on master once we have a set of `v2.3` crates published such that the SPL stuff can get away from the pinned sdk dependencies
