### PR TITLE
Fix - `test_cpi_account_ownership_writability()`

### DIFF
--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -722,13 +722,9 @@ fn process_instruction<'a>(
             )
             .unwrap();
             let account = &accounts[ARGUMENT_INDEX];
+            let byte_offset = usize::from_le_bytes(instruction_data[1..9].try_into().unwrap());
             // this should cause the tx to fail since the callee changed ownership
-            unsafe {
-                *account
-                    .data
-                    .borrow_mut()
-                    .get_unchecked_mut(instruction_data[1] as usize) = 42
-            };
+            unsafe { *account.data.borrow_mut().get_unchecked_mut(byte_offset) = 42 };
         }
         TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLEE_NESTED => {
             msg!("TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLEE_NESTED");
@@ -754,14 +750,10 @@ fn process_instruction<'a>(
                 accounts,
             )
             .unwrap();
+            let byte_offset = usize::from_le_bytes(instruction_data[1..9].try_into().unwrap());
             // this should cause the tx to failsince invoked_program_id now owns
             // the account
-            unsafe {
-                *account
-                    .data
-                    .borrow_mut()
-                    .get_unchecked_mut(instruction_data[1] as usize) = 42
-            };
+            unsafe { *account.data.borrow_mut().get_unchecked_mut(byte_offset) = 42 };
         }
         TEST_FORBID_LEN_UPDATE_AFTER_OWNERSHIP_CHANGE_MOVING_DATA_POINTER => {
             msg!("TEST_FORBID_LEN_UPDATE_AFTER_OWNERSHIP_CHANGE_MOVING_DATA_POINTER");

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3771,6 +3771,15 @@ fn test_cpi_account_ownership_writability() {
                 assert_eq!(account.data(), vec![0; 40]);
             }
         }
+
+        // Test that the caller can write to an account which it received from the callee
+        let account = AccountSharedData::new(42, 0, &invoked_program_id);
+        bank.store_account(&account_keypair.pubkey(), &account);
+        let instruction_data = vec![TEST_ALLOW_WRITE_AFTER_OWNERSHIP_CHANGE_TO_CALLER, 1, 42, 42];
+        let instruction =
+            Instruction::new_with_bytes(invoke_program_id, &instruction_data, account_metas);
+        let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+        result.unwrap();
     }
 }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3646,12 +3646,12 @@ fn test_cpi_account_ownership_writability() {
         ];
 
         for (account_size, byte_index) in [
-            (0, 0),                                     // first realloc byte
-            (0, MAX_PERMITTED_DATA_INCREASE as u8),     // last realloc byte
-            (2, 0),                                     // first data byte
-            (2, 1),                                     // last data byte
-            (2, 3),                                     // first realloc byte
-            (2, 2 + MAX_PERMITTED_DATA_INCREASE as u8), // last realloc byte
+            (0, 0),                                   // first realloc byte
+            (0, MAX_PERMITTED_DATA_INCREASE - 1),     // last realloc byte
+            (2, 0),                                   // first data byte
+            (2, 1),                                   // last data byte
+            (2, 3),                                   // first realloc byte
+            (2, 2 + MAX_PERMITTED_DATA_INCREASE - 1), // last realloc byte
         ] {
             for instruction_id in [
                 TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLEE,
@@ -3660,10 +3660,12 @@ fn test_cpi_account_ownership_writability() {
                 bank.register_unique_recent_blockhash_for_test();
                 let account = AccountSharedData::new(42, account_size, &invoke_program_id);
                 bank.store_account(&account_keypair.pubkey(), &account);
+                let mut instruction_data = vec![instruction_id];
+                instruction_data.extend_from_slice(byte_index.to_le_bytes().as_ref());
 
                 let instruction = Instruction::new_with_bytes(
                     invoke_program_id,
-                    &[instruction_id, byte_index, 42, 42],
+                    &instruction_data,
                     account_metas.clone(),
                 );
 


### PR DESCRIPTION
#### Problem

`TEST_ALLOW_WRITE_AFTER_OWNERSHIP_CHANGE_TO_CALLER` is never called and the `byte_index` is only a `u8` thus `MAX_PERMITTED_DATA_INCREASE` overflows.

#### Summary of Changes

- Use `TEST_ALLOW_WRITE_AFTER_OWNERSHIP_CHANGE_TO_CALLER`.
- Fixes overflow in parameter `byte_index`.