### PR TITLE
Add missing features to banks-client crate deps

### DIFF
--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 [dependencies]
 borsh = { workspace = true }
 futures = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-banks-interface = { workspace = true }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
@@ -22,7 +22,7 @@ solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-signature = { workspace = true }
-solana-sysvar = { workspace = true }
+solana-sysvar = { workspace = true, features = ["bincode"] }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }


### PR DESCRIPTION
#### Problem

Crate fails to publish because of missing dependency features

#### Summary of Changes

Add `bincode` feature to the dependencies that require it.

Required to fix CI for #6332