### PR TITLE
feature-set: Inherit package version from workspace

### DIFF
--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agave-feature-set"
-version = "3.0.0"
 description = "Solana runtime feature declarations"
+version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem
`agave-feature-set` is a member of the main workspace, so we should just inherit the version from the workspace like we do for all other workspace members:
https://github.com/anza-xyz/agave/blob/7b3de4799393bfdb8f59b10e7c48afaf21b53f13/Cargo.toml#L41

The reoder is for consistency with all other crates that have all the workspace inherited items adjacent