### PR TITLE
Publish agave-xdp crate

### DIFF
--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-publish = false
+publish = true
 
 [dependencies]
 crossbeam-channel = { workspace = true }


### PR DESCRIPTION
#### Problem

Publishing `solana-turbine` crate  fails because the `agave-xdp` crate is configured to not publish

```
error: no matching package named `agave-xdp` found
location searched: `kellnr` index
required by package `solana-turbine v2.3.0 (/solana/turbine)`
couldn't publish 'solana-turbine'
```

#### Summary of Changes

Configure `agave-xdp` to publish

Required to fix CI for #6332
