### PR TITLE
Configure vortexor-receiver crate to publish

### DIFF
--- a/vortexor-receiver/Cargo.toml
+++ b/vortexor-receiver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-vortexor-receiver"
 description = "Solana TPU Vortexor Receiver"
 documentation = "https://docs.rs/solana-vortexor-receiver"
-publish = false
+publish = true
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem

Publishing `solana-core` crate  fails because the `solana-vortexor-receiver` crate is configured to not publish

```
error: no matching package named `solana-vortexor-receiver` found
location searched: `kellnr` index
required by package `solana-core v2.3.0 (/solana/core)`
couldn't publish 'solana-core'
```

#### Summary of Changes

Configure `solana-vortexor-receiver` to publish

Required to fix CI for #6332
