### PR TITLE
v2.3: Update CODEOWNERS to backport-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,1 @@
-# The SVM team is in the process of migrating these subdirectories to a new
-# repo and would like to avoid introducing dependencies in the meantime.
-/compute-budget-instruction/ @anza-xyz/fees
-/fee/ @anza-xyz/fees
-/log-collector/ @anza-xyz/svm
-/program-runtime/ @anza-xyz/svm
-/programs/bpf_loader/ @anza-xyz/svm
-/programs/loader-v4/ @anza-xyz/svm
-/runtime-transaction/ @anza-xyz/tx-metadata
-/svm-conformance/ @anza-xyz/svm
-/svm-rent-collector/ @anza-xyz/svm
-/svm-transaction/ @anza-xyz/svm
-/svm/ @anza-xyz/svm
-/svm/examples/Cargo.lock
-/svm-callback/ @anza-xyz/svm
-/transaction-context/ @anza-xyz/svm
-/transaction-view/ @anza-xyz/tx-metadata
+* @anza-xyz/backport-reviewers


### PR DESCRIPTION
#### Problem
We need @anza-xyz/backport-reviewers to be a code owner for the `v2.3` release branch

Similar to https://github.com/anza-xyz/agave/pull/4901, removing groups for specific paths; we'll continue with social enforcement of getting SME reviews for each PR