### PR TITLE
Stop writing `TransactionError` into snapshots from status cache

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod runtime_config;
 pub mod serde_snapshot;
 pub mod snapshot_archive_info;
 pub mod snapshot_bank_utils;
+pub mod snapshot_blanked_out_status_cache;
 pub mod snapshot_config;
 pub mod snapshot_controller;
 pub mod snapshot_hash;

--- a/runtime/src/snapshot_blanked_out_status_cache.rs
+++ b/runtime/src/snapshot_blanked_out_status_cache.rs
@@ -1,0 +1,55 @@
+use {
+    crate::{bank::BankSlotDelta, status_cache::Status},
+    std::sync::{Arc, Mutex},
+};
+
+/// It is very difficult to change the format of `TransactionError` because it gets written to disk
+/// when the validator snapshots `BankStatusCache`. The thing is, `BankStatusCache` has no need of
+/// `TransactionErrors` or indeed `TransactionResults` at all; all it needs to track is whether a
+/// given transaction message has been seen or not.
+///
+/// This type exists to wrap a `BankSlotDelta` in such a way that unconditionally drops any
+/// `TransactionErrors` and replaces them with `OK(())`.
+pub struct BankSlotDeltaWithAlwaysOkTransactionResult(BankSlotDelta);
+
+fn status_with_replaced_inner_type<T: Clone, R: Clone>(
+    status: Status<T>,
+    replacement: R,
+) -> Status<R> {
+    let status_guard = status.lock().unwrap();
+    let replaced = status_guard
+        .clone()
+        .into_iter()
+        .map(|(hash, (max_slot, statuses))| {
+            (
+                hash,
+                (
+                    max_slot,
+                    statuses
+                        .into_iter()
+                        .map(|(key_slice, _transaction_status)| (key_slice, replacement.clone()))
+                        .collect(),
+                ),
+            )
+        })
+        .collect();
+    Arc::new(Mutex::new(replaced))
+}
+
+impl From<BankSlotDeltaWithAlwaysOkTransactionResult> for BankSlotDelta {
+    fn from(value: BankSlotDeltaWithAlwaysOkTransactionResult) -> Self {
+        value.0
+    }
+}
+
+impl From<BankSlotDelta> for BankSlotDeltaWithAlwaysOkTransactionResult {
+    fn from(value: BankSlotDelta) -> Self {
+        let (slot, is_root, status) = value;
+        let status_with_result_blanked_out = status_with_replaced_inner_type(
+            status,
+            // Drop the `Result` here; replace it with `Ok(())`.
+            Ok(()),
+        );
+        BankSlotDeltaWithAlwaysOkTransactionResult((slot, is_root, status_with_result_blanked_out))
+    }
+}

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         serde_snapshot::BankIncrementalSnapshotPersistence,
+        snapshot_blanked_out_status_cache::BankSlotDeltaWithAlwaysOkTransactionResult,
         snapshot_hash::SnapshotHash,
     },
     agave_feature_set as feature_set,
@@ -91,7 +92,11 @@ impl AccountsPackage {
             let bank_hash_stats = bank.get_bank_hash_stats();
             let bank_fields_to_serialize = bank.get_fields_to_serialize();
             SupplementalSnapshotInfo {
-                status_cache_slot_deltas,
+                status_cache_slot_deltas: status_cache_slot_deltas
+                    .into_iter()
+                    .map(BankSlotDeltaWithAlwaysOkTransactionResult::from)
+                    .map(Into::into)
+                    .collect(),
                 bank_fields_to_serialize,
                 bank_hash_stats,
                 accounts_delta_hash,


### PR DESCRIPTION
#### Problem

It is _very_ difficult to change the format of `TransactionError` because it gets written to disk when the validator snapshots `BankStatusCache`. The thing is, `BankStatusCache` has _no need_ of `TransactionErrors` or indeed `TransactionResults` at all; all it needs to track is whether a given transaction message has been seen or not.

#### Summary of Changes

In this PR we shim the code that serializes/deserializes the `status_cache` snapshot to unconditionally write `Ok(())` into the snapshot, even if the actual `Result` is `Err(TransactionError)`.

This ensures that:

1. the snapshot _file_ format is backward compatible with old validators (we're only ever writing `Ok(())` to disk)
2. one validator version from now the snapshots will be _forward_ compatible (it doesn't matter if `TransactionError` changes, the snapshot file will only ever contain `Ok(())`)

#### FAQ

**Q**: Doesn't this require a SIMD for the snapshot format?
**A**: No! This doesn't actually change the format of the snapshot, it just makes it so that _conveniently_ the snapshot will never contain `TransactionError`. This is one step along the path to making it so that a change to `TransactionError` [like this](https://github.com/anza-xyz/agave/pull/6083) will not break snapshots, nor require a SIMD at all.

**Q**: Doesn't this bust the ABI hash?
**A**: No! As far as the snapshotter is concerned, it's still serializing `TransactionResult`, even though this change makes every single value a non-error.

Furthers #6457.