### PR TITLE
Using obsolete accounts structure to generate list of pubkeys to skip during accounts hash calculation

### DIFF
--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -9,6 +9,7 @@ use {
         pubkey_bins::PubkeyBinCalculator24,
         sorted_storages::SortedStorages,
     },
+    ahash::HashSet,
     rayon::prelude::*,
     solana_account::ReadableAccount as _,
     solana_clock::Slot,
@@ -30,7 +31,7 @@ trait AppendVecScan: Send + Sync + Clone {
     /// return true if this pubkey should be included
     fn filter(&mut self, pubkey: &Pubkey) -> bool;
     /// set current slot of the scan
-    fn set_slot(&mut self, slot: Slot, is_ancient: bool);
+    fn set_slot(&mut self, slot: Slot, is_ancient: bool, storage: &AccountStorageEntry);
     /// found `account` in the append vec
     fn found_account(&mut self, account: &LoadedAccount);
     /// scanning is done
@@ -56,14 +57,39 @@ struct ScanState<'a> {
     pubkey_to_bin_index: usize,
     is_ancient: bool,
     stats_num_zero_lamport_accounts_ancient: Arc<AtomicU64>,
+    /// The maximum slot included in the scan. Any updates to accounts due to
+    /// slots newer than scan_slot will be filtered out.
+    scan_slot: Slot,
+    /// When current_slot is set, this hashset gets updated with a list of
+    /// pubkeys to skip when scanning current_slot
+    pub_keys_to_skip: HashSet<Pubkey>,
 }
 
 impl AppendVecScan for ScanState<'_> {
-    fn set_slot(&mut self, slot: Slot, is_ancient: bool) {
+    fn set_slot(&mut self, slot: Slot, is_ancient: bool, storage: &AccountStorageEntry) {
         self.current_slot = slot;
         self.is_ancient = is_ancient;
+
+        // Reinitialize the hashset to remove all entries
+        self.pub_keys_to_skip = HashSet::default();
+
+        // Get a list of all accounts that were marked obsolete at the slot
+        // the scan is being done or earlier
+        let accounts = storage.get_obsolete_accounts(Some(self.scan_slot));
+
+        // For each obsolete account found, add its pubkey to the hashset so it can be skipped
+        for account in accounts {
+            let offset = account.0;
+            let stored_account = storage.accounts.get_account_index_info(offset);
+            self.pub_keys_to_skip
+                .insert(stored_account.unwrap().index_info.pubkey);
+        }
     }
+
     fn filter(&mut self, pubkey: &Pubkey) -> bool {
+        if self.pub_keys_to_skip.contains(pubkey) {
+            return false;
+        }
         self.pubkey_to_bin_index = self.bin_calculator.bin_from_pubkey(pubkey);
         self.bin_range.contains(&self.pubkey_to_bin_index)
     }
@@ -151,6 +177,8 @@ impl AccountsDb {
             stats_num_zero_lamport_accounts_ancient: Arc::clone(
                 &stats.num_zero_lamport_accounts_ancient,
             ),
+            scan_slot: storages.max_slot_inclusive(),
+            pub_keys_to_skip: HashSet::default(),
         };
 
         let result = self.scan_account_storage_no_bank(
@@ -310,7 +338,7 @@ impl AccountsDb {
                                     scanner.init_accum(range);
                                     init_accum = false;
                                 }
-                                scanner.set_slot(slot, ancient);
+                                scanner.set_slot(slot, ancient, storage);
 
                                 Self::scan_single_account_storage(storage, &mut scanner);
                             });
@@ -376,6 +404,7 @@ mod tests {
             cache_hash_data::{CacheHashDataFile, DeletionPolicy as CacheHashDeletionPolicy},
         },
         solana_account::AccountSharedData,
+        std::iter,
         tempfile::TempDir,
         test_case::test_case,
     };
@@ -419,7 +448,7 @@ mod tests {
         fn filter(&mut self, _pubkey: &Pubkey) -> bool {
             true
         }
-        fn set_slot(&mut self, slot: Slot, _is_ancient: bool) {
+        fn set_slot(&mut self, slot: Slot, _is_ancient: bool, _storage: &AccountStorageEntry) {
             self.current_slot = slot;
         }
         fn init_accum(&mut self, _count: usize) {}
@@ -449,7 +478,7 @@ mod tests {
     }
 
     impl AppendVecScan for TestScanSimple {
-        fn set_slot(&mut self, slot: Slot, _is_ancient: bool) {
+        fn set_slot(&mut self, slot: Slot, _is_ancient: bool, _storage: &AccountStorageEntry) {
             self.current_slot = slot;
         }
         fn filter(&mut self, _pubkey: &Pubkey) -> bool {
@@ -1013,5 +1042,99 @@ mod tests {
             .iter()
             .map(|v| v.iter().map(|v| &v[..]).collect::<Vec<_>>())
             .collect::<Vec<_>>()
+    }
+
+    #[derive(Clone)]
+    struct TestScanObsolete {
+        current_slot: Slot,
+        _slot_expected: Slot,
+        calls: Arc<AtomicU64>,
+        accum: BinnedHashData,
+        pub_keys_to_skip: HashSet<Pubkey>,
+        scan_slot: Slot,
+    }
+
+    impl AppendVecScan for TestScanObsolete {
+        fn set_slot(&mut self, slot: Slot, _is_ancient: bool, storage: &AccountStorageEntry) {
+            self.current_slot = slot;
+            self.pub_keys_to_skip.clear();
+            let accounts = storage.get_obsolete_accounts(Some(self.scan_slot));
+
+            for account in accounts {
+                let offset = account.0;
+                let stored_account = storage.accounts.get_account_index_info(offset);
+                self.pub_keys_to_skip
+                    .insert(stored_account.unwrap().index_info.pubkey);
+            }
+        }
+        fn filter(&mut self, pubkey: &Pubkey) -> bool {
+            if self.pub_keys_to_skip.contains(pubkey) {
+                return false;
+            }
+            true
+        }
+        fn init_accum(&mut self, _count: usize) {}
+        fn found_account(&mut self, _loaded_account: &LoadedAccount) {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+        }
+        fn scanning_complete(self) -> BinnedHashData {
+            self.accum
+        }
+    }
+
+    #[test]
+    fn test_accountsdb_scan_multiple_account_storage_with_obsolete_accounts() {
+        solana_logger::setup();
+
+        let slot: Slot = 0;
+        let num_accounts = 5;
+        let tf = crate::append_vec::test_utils::get_append_vec_path(
+            "test_accountsdb_scan_account_storage_with_obsolete_accounts",
+        );
+
+        let pubkey = solana_pubkey::new_rand();
+        let mark_alive = false;
+
+        let storage = sample_storage_with_entries(&tf, slot, &pubkey, mark_alive);
+
+        // Create some accounts and add them to the storage
+        let accounts: Vec<_> =
+            iter::repeat_with(|| AccountSharedData::new(1, 10, &Pubkey::default()))
+                .take(num_accounts)
+                .collect();
+
+        let accounts_to_append: Vec<_> = accounts
+            .into_iter()
+            .map(|account| (Pubkey::new_unique(), account))
+            .collect();
+
+        let offsets = storage
+            .accounts
+            .append_accounts(&(slot, &accounts_to_append[..]), 0);
+
+        // Mark each account obsolete at a different slot
+        for (i, offsets) in offsets.unwrap().offsets.iter().enumerate() {
+            storage.mark_account_obsolete(*offsets, 0, i as Slot);
+        }
+
+        // Perform scans of the storage assuming a different slot and verify the number of accounts found matches
+        for scan_slot in 0..=(num_accounts - 1) {
+            let calls = Arc::new(AtomicU64::new(0));
+            let expected_count = num_accounts - scan_slot;
+
+            let mut scanner = TestScanObsolete {
+                current_slot: scan_slot as u64,
+                _slot_expected: slot,
+                accum: Vec::default(),
+                calls: calls.clone(),
+                pub_keys_to_skip: HashSet::default(),
+                scan_slot: scan_slot as Slot,
+            };
+            scanner.set_slot(scan_slot as Slot, false, &storage);
+
+            AccountsDb::scan_single_account_storage(&storage, &mut scanner);
+            scanner.scanning_complete();
+            assert_eq!(calls.load(Ordering::Relaxed), expected_count as u64);
+        }
     }
 }

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -1118,7 +1118,7 @@ mod tests {
         }
 
         // Perform scans of the storage assuming a different slot and verify the number of accounts found matches
-        for scan_slot in 0..=(num_accounts - 1) {
+        for scan_slot in 0..num_accounts {
             let calls = Arc::new(AtomicU64::new(0));
             let expected_count = num_accounts - scan_slot;
 


### PR DESCRIPTION
#### Problem
Obsolete accounts marks accounts as obsolete and this data needs to be taken into account when scanning storages to create the incremental accounts hash or epoch accounts hash. 

#### Summary of Changes
- Added a hashset to the ScanState structure to track pubkeys that can be skipped in a given storage
- Populate a hashset when setting scan slot during scan_account_storage_no_bank
- Added testing for new behaviour 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
