### PR TITLE
chore: remove outdated comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,7 +608,6 @@ wasm-bindgen = "0.2"
 winapi = "0.3.8"
 winreg = "0.50"
 x509-parser = "0.14.0"
-# See "zeroize versioning issues" below if you are updating this version.
 zeroize = { version = "1.7", default-features = false }
 zstd = "0.13.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -588,7 +588,6 @@ test-case = "3.3.1"
 thiserror = "2.0.12"
 thread-priority = "1.2.0"
 tiny-bip39 = "0.8.2"
-# Update solana-tokio patch below when updating this version
 tokio = "1.45.1"
 tokio-serde = "0.8"
 tokio-stream = "0.1.17"


### PR DESCRIPTION
#### Problem

there are some outdated comments in our code, which might confuse people

#### Summary of Changes

remove them!

- 7219c22241fac3807cc97f80d85cb8cd1e345b20

we patched it in https://github.com/solana-labs/solana/pull/34240/files and unpinned it in https://github.com/anza-xyz/agave/pull/4411. we're not using solana-tokio anymore. it should be find to remove it.

- 2f6d8abdd0fbb819865aea077cf4a75216a7e1f5

we added it in https://github.com/solana-labs/solana/pull/33618 due to the version of `aes-gcm-siv`. we've bumped the version, so the restriction no longer exists

