### PR TITLE
Do not unwrap evicted entry in ReadOnlyAccountsCache

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -344,7 +344,7 @@ impl ReadOnlyAccountsCache {
         rng: &mut R,
         #[cfg(feature = "dev-context-only-utils")] mut callback: impl FnMut(
             &Pubkey,
-            ReadOnlyAccountCacheEntry,
+            Option<ReadOnlyAccountCacheEntry>,
         ),
     ) -> u64
     where
@@ -384,7 +384,7 @@ impl ReadOnlyAccountsCache {
             #[cfg(feature = "dev-context-only-utils")]
             {
                 #[allow(clippy::used_underscore_binding)]
-                callback(&key, _entry.unwrap());
+                callback(&key, _entry);
             }
             num_evicts = num_evicts.saturating_add(1);
         }
@@ -409,7 +409,7 @@ impl ReadOnlyAccountsCache {
     ) -> u64
     where
         R: Rng,
-        C: FnMut(&Pubkey, ReadOnlyAccountCacheEntry),
+        C: FnMut(&Pubkey, Option<ReadOnlyAccountCacheEntry>),
     {
         #[allow(clippy::used_underscore_binding)]
         let target_data_size = self._max_data_size_lo;

--- a/accounts-db/tests/read_only_accounts_cache.rs
+++ b/accounts-db/tests/read_only_accounts_cache.rs
@@ -55,6 +55,7 @@ fn test_read_only_accounts_cache_eviction(num_accounts: (usize, usize), evict_sa
     let mut evicted = vec![];
     for _ in 0..1000 {
         cache.evict_in_foreground(evict_sample_size, &mut rng, |pubkey, entry| {
+            let entry = entry.unwrap();
             evicts = evicts.saturating_add(1);
             if newer_half.contains(pubkey) {
                 evicts_from_newer_half = evicts_from_newer_half.saturating_add(1);


### PR DESCRIPTION
#### Problem

See https://github.com/anza-xyz/agave/issues/6354. The tl;dr is that dcou is getting enabled for release builds. This causes panics in the read-only accounts cache, which calls `.unwrap()` unconditionally. This was only meant to be executed during tests though. When the real agave-validator is running, this can (and does!) call `.unwrap()` on None (bad!).

For this PR, we only fix the ReadOnlyAccountsCache DCOU issue, as that's the only one currently affecting `agave-validator` regularly.


#### Summary of Changes

Do not unwrap the evicted entry, instead pass it to the callback.

Note, this PR will be backported to v2.2. Thus, this impl was chosen for ease of backporting.