### PR TITLE
gossip: remove all_tvu_peers

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2677,14 +2677,14 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     // Staked nodes entries will not expire until an epoch after. So it
     // is necessary here to filter for recent entries to establish liveness.
     let peers: HashMap<_, _> = cluster_info
-        .all_tvu_peers()
+        .all_peers()
         .into_iter()
-        .filter(|node| {
-            let age = now.saturating_sub(node.wallclock());
+        .filter(|(_node, node_clock)| {
+            let age = now.saturating_sub(*node_clock);
             // Contact infos are refreshed twice during this period.
             age < CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS
         })
-        .map(|node| (*node.pubkey(), node))
+        .map(|(node, _)| (*node.pubkey(), node))
         .collect();
     let my_shred_version = cluster_info.my_shred_version();
     let my_id = cluster_info.id();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2677,14 +2677,14 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     // Staked nodes entries will not expire until an epoch after. So it
     // is necessary here to filter for recent entries to establish liveness.
     let peers: HashMap<_, _> = cluster_info
-        .all_peers()
+        .tvu_peers(|q| q.clone())
         .into_iter()
-        .filter(|(_node, node_clock)| {
-            let age = now.saturating_sub(*node_clock);
+        .filter(|node| {
+            let age = now.saturating_sub(node.wallclock());
             // Contact infos are refreshed twice during this period.
             age < CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS
         })
-        .map(|(node, _)| (*node.pubkey(), node))
+        .map(|node| (*node.pubkey(), node))
         .collect();
     let my_shred_version = cluster_info.my_shred_version();
     let my_id = cluster_info.id();

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1038,19 +1038,6 @@ impl ClusterInfo {
             .collect()
     }
 
-    /// all validators that have a valid tvu port regardless of `shred_version`.
-    pub fn all_tvu_peers(&self) -> Vec<ContactInfo> {
-        let self_pubkey = self.id();
-        self.time_gossip_read_lock("all_tvu_peers", &self.stats.all_tvu_peers)
-            .get_nodes_contact_info()
-            .filter(|node| {
-                node.pubkey() != &self_pubkey
-                    && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
-            })
-            .cloned()
-            .collect()
-    }
-
     /// all validators that have a valid tvu port and are on the same `shred_version`.
     pub fn tvu_peers<R>(&self, query: impl ContactInfoQuery<R>) -> Vec<R> {
         let self_pubkey = self.id();

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -88,7 +88,6 @@ impl<T> Drop for TimedGuard<'_, T> {
 
 #[derive(Default)]
 pub struct GossipStats {
-    pub(crate) all_tvu_peers: Counter,
     pub(crate) bad_prune_destination: Counter,
     pub(crate) entrypoint2: Counter,
     pub(crate) entrypoint: Counter,
@@ -239,7 +238,6 @@ pub(crate) fn submit_gossip_stats(
         ("push_vote_read", stats.push_vote_read.clear(), i64),
         ("get_votes", stats.get_votes.clear(), i64),
         ("get_votes_count", stats.get_votes_count.clear(), i64),
-        ("all_tvu_peers", stats.all_tvu_peers.clear(), i64),
         ("tvu_peers", stats.tvu_peers.clear(), i64),
         ("table_size", table_size as i64, i64),
         ("purged_values_size", purged_values_size as i64, i64),

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -304,7 +304,7 @@ fn spy(
             .into_iter()
             .map(|x| x.0)
             .collect::<Vec<_>>();
-        tvu_peers = spy_ref.gossip_peers();
+        tvu_peers = spy_ref.tvu_peers(|q| q.clone());
 
         let found_nodes_by_pubkey = if let Some(pubkeys) = find_nodes_by_pubkey {
             pubkeys

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -304,7 +304,7 @@ fn spy(
             .into_iter()
             .map(|x| x.0)
             .collect::<Vec<_>>();
-        tvu_peers = spy_ref.all_tvu_peers();
+        tvu_peers = spy_ref.gossip_peers();
 
         let found_nodes_by_pubkey = if let Some(pubkeys) = find_nodes_by_pubkey {
             pubkeys
@@ -324,8 +324,8 @@ fn spy(
 
         if let Some(num) = num_nodes {
             // Only consider validators and archives for `num_nodes`
-            let mut nodes: Vec<_> = tvu_peers.iter().collect();
-            nodes.sort_unstable_by_key(|node| node.pubkey());
+            let mut nodes: Vec<ContactInfo> = tvu_peers.clone();
+            nodes.sort_unstable_by_key(|node| *node.pubkey());
             nodes.dedup();
 
             if nodes.len() >= num {


### PR DESCRIPTION
#### Problem

- The all_tvu_peers ignored shred_version and was otherwise identical to other gossip functions
- There is no legitimate reason we would want it

#### Summary of Changes

- Replace with alternatives as appropriate