### PR TITLE
v2.2: Set the spl-token-cli version for CI

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.3.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem
The `v2.3` branch has been created which means `v2.2` is now the stable branch. However, it does not yet set a version of `spl-token-cli` as required by `check-install-all.sh`

#### Summary of Changes
Set the version to `5.3.0` which is the [current latest version](https://crates.io/crates/spl-token-cli) from crates.io.
