### PR TITLE
Removing Store Uncached entirely

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -52,6 +52,8 @@ fn bench_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let (_, total_lamports) = accounts
         .accounts_db
         .update_accounts_hash_for_tests(0, &ancestors, false, false);
+    accounts.add_root(slot);
+    accounts.accounts_db.flush_accounts_cache(true, Some(slot));
     bencher.iter(|| {
         assert!(accounts
             .accounts_db

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1265,21 +1265,6 @@ impl AccountStorageEntry {
         self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn try_available(&self) -> bool {
-        let mut count_and_status = self.count_and_status.lock_write();
-        let (count, status) = *count_and_status;
-
-        if status == AccountStorageStatus::Available {
-            *count_and_status = (count, AccountStorageStatus::Candidate);
-            true
-        } else {
-            false
-        }
-    }
-
     /// returns # of accounts remaining in the storage
     fn remove_accounts(
         &self,
@@ -1771,8 +1756,8 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         let some_data_len = 5;
         let some_slot: Slot = 0;
         let account = AccountSharedData::new(1, some_data_len, &key);
-        accounts_db.store_uncached(some_slot, &[(&key, &account)]);
-        accounts_db.add_root(0);
+        accounts_db.store_cached((some_slot, &[(&key, &account)][..]), None);
+        accounts_db.add_root_and_flush_write_cache(0);
 
         accounts_db
     }
@@ -5152,44 +5137,6 @@ impl AccountsDb {
         }
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
-        let mut get_slot_stores = Measure::start("get_slot_stores");
-        let store = self.storage.get_slot_storage_entry(slot);
-        get_slot_stores.stop();
-        self.stats
-            .store_get_slot_store
-            .fetch_add(get_slot_stores.as_us(), Ordering::Relaxed);
-        let mut find_existing = Measure::start("find_existing");
-        if let Some(store) = store {
-            if store.try_available() {
-                let ret = store.clone();
-                drop(store);
-                find_existing.stop();
-                self.stats
-                    .store_find_existing
-                    .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-                return ret;
-            }
-        }
-        find_existing.stop();
-        self.stats
-            .store_find_existing
-            .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-
-        let store = self.create_store(slot, self.file_size, "store", &self.paths);
-
-        // try_available is like taking a lock on the store,
-        // preventing other threads from using it.
-        // It must succeed here and happen before insert,
-        // otherwise another thread could also grab it from the index.
-        assert!(store.try_available());
-        self.insert_store(slot, store.clone());
-        store
-    }
-
     fn has_space_available(&self, slot: Slot, size: u64) -> bool {
         let store = self.storage.get_slot_storage_entry(slot).unwrap();
         if store.status() == AccountStorageStatus::Available
@@ -7620,20 +7567,6 @@ impl AccountsDb {
         );
     }
 
-    /// Store the account update.
-    /// only called by tests
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        let storage = self.find_storage_candidate(slot);
-        self.store(
-            (slot, accounts),
-            &StoreTo::Storage(&storage),
-            None,
-            StoreReclaims::Default,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        );
-    }
-
     fn store<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
@@ -9102,6 +9035,7 @@ pub mod test_utils {
             accounts.store_cached((slot, &[(&pubkey, &account)][..]), None);
             pubkeys.push(pubkey);
         }
+        accounts.accounts_db.add_root_and_flush_write_cache(slot);
     }
 
     // Only used by bench, not safe to call otherwise accounts can conflict with the
@@ -9112,5 +9046,6 @@ pub mod test_utils {
             let account = AccountSharedData::new(amount, 0, AccountSharedData::default().owner());
             accounts.store_cached((slot, &[(pubkey, &account)][..]), None);
         }
+        accounts.accounts_db.add_root_and_flush_write_cache(slot);
     }
 }


### PR DESCRIPTION
#### Problem
Store Uncached has been deprecated, but is still used under testing scenarios. This is not required.

#### Summary of Changes
- Removed store_uncached, and moved all callers to store_cached or store_for_tests where appropriate
- Updated geyser plugin test as there is no possibility of an account being stored in the same slot twice
- 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
