### PR TITLE
Adds TieredStorage::scan_accounts_without_data()

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -675,6 +675,22 @@ impl HotStorageReader {
     }
 
     /// Iterate over all accounts and call `callback` with each account.
+    ///
+    /// Note that account data is not read/passed to the callback.
+    pub fn scan_accounts_without_data(
+        &self,
+        mut callback: impl for<'local> FnMut(StoredAccountInfoWithoutData<'local>),
+    ) -> TieredStorageResult<()> {
+        for i in 0..self.footer.account_entry_count {
+            self.get_stored_account_without_data_callback(IndexOffset(i), &mut callback)?;
+        }
+        Ok(())
+    }
+
+    /// Iterate over all accounts and call `callback` with each account.
+    ///
+    /// Prefer scan_accounts_without_data() when account data is not needed,
+    /// as it can potentially read less and be faster.
     pub fn scan_accounts(
         &self,
         mut callback: impl for<'local> FnMut(StoredAccountInfo<'local>),

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -11,7 +11,7 @@ use {
             TieredStorageResult,
         },
     },
-    solana_account::{AccountSharedData, ReadableAccount},
+    solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
     std::path::Path,
 };
@@ -165,20 +165,11 @@ impl TieredStorageReader {
     /// Note that account data is not read/passed to the callback.
     pub fn scan_accounts_without_data(
         &self,
-        mut callback: impl for<'local> FnMut(StoredAccountInfoWithoutData<'local>),
+        callback: impl for<'local> FnMut(StoredAccountInfoWithoutData<'local>),
     ) -> TieredStorageResult<()> {
-        // Note, this should be reimplemented to not read account data
-        self.scan_accounts(|stored_account| {
-            let account = StoredAccountInfoWithoutData {
-                pubkey: stored_account.pubkey(),
-                lamports: stored_account.lamports(),
-                owner: stored_account.owner(),
-                data_len: stored_account.data().len(),
-                executable: stored_account.executable(),
-                rent_epoch: stored_account.rent_epoch(),
-            };
-            callback(account);
-        })
+        match self {
+            Self::Hot(hot) => hot.scan_accounts_without_data(callback),
+        }
     }
 
     /// Iterate over all accounts and call `callback` with each account.


### PR DESCRIPTION
#### Problem

The impl of `TieredStorage::scan_accounts_without_data()` *does* load the account data, which is sub optimal.


#### Summary of Changes

Adds a proper impl that doesn't load account data.