### PR TITLE
Removes OldStoragesPolicy

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1709,23 +1709,13 @@ fn test_clean_max_slot_zero_lamport_account() {
     // updates in later slots in slot 1
     assert_eq!(accounts.alive_account_count_in_slot(0), 1);
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
-    accounts.clean_accounts(
-        Some(0),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    accounts.clean_accounts(Some(0), false, &EpochSchedule::default());
     assert_eq!(accounts.alive_account_count_in_slot(0), 1);
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     assert!(accounts.accounts_index.contains_with(&pubkey, None, None));
 
     // Now the account can be cleaned up
-    accounts.clean_accounts(
-        Some(1),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    accounts.clean_accounts(Some(1), false, &EpochSchedule::default());
     assert_eq!(accounts.alive_account_count_in_slot(0), 0);
     assert_eq!(accounts.alive_account_count_in_slot(1), 0);
 
@@ -3194,12 +3184,7 @@ fn test_zero_lamport_new_root_not_cleaned() {
     db.add_root_and_flush_write_cache(1);
 
     // Only clean zero lamport accounts up to slot 0
-    db.clean_accounts(
-        Some(0),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(0), false, &EpochSchedule::default());
 
     // Should still be able to find zero lamport account in slot 1
     assert_eq!(
@@ -4404,12 +4389,7 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     db.calculate_accounts_delta_hash(1);
 
     // Clean to remove outdated entry from slot 0
-    db.clean_accounts(
-        Some(1),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(1), false, &EpochSchedule::default());
 
     // Shrink Slot 0
     {
@@ -4428,12 +4408,7 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     // Should be one store before clean for slot 0
     db.get_and_assert_single_storage(0);
     db.calculate_accounts_delta_hash(2);
-    db.clean_accounts(
-        Some(2),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(2), false, &EpochSchedule::default());
 
     // No stores should exist for slot 0 after clean
     assert_no_storages_at_slot(&db, 0);
@@ -4478,7 +4453,7 @@ fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
     accounts_db.calculate_accounts_delta_hash(1);
 
     // run clean
-    accounts_db.clean_accounts(Some(1), false, &epoch_schedule, OldStoragesPolicy::Leave);
+    accounts_db.clean_accounts(Some(1), false, &epoch_schedule);
 
     // After clean, both slot0 and slot1 should be marked dead and dropped
     // from the store map.
@@ -4510,12 +4485,7 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
 
     // Clean should mark slot 0 dead and drop it. During the dropping, it
     // will find that slot 1 has a single ref zero accounts and mark it.
-    db.clean_accounts(
-        Some(1),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(1), false, &EpochSchedule::default());
 
     // Assert that after clean, slot 0 is dropped.
     assert!(db.storage.get_slot_storage_entry(0).is_none());
@@ -4556,12 +4526,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     db.calculate_accounts_delta_hash(1);
 
     // Clean to remove outdated entry from slot 0
-    db.clean_accounts(
-        Some(1),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(1), false, &EpochSchedule::default());
 
     // Shrink Slot 0
     {
@@ -4595,12 +4560,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     db.get_and_assert_single_storage(0);
     db.get_and_assert_single_storage(1);
     db.calculate_accounts_delta_hash(2);
-    db.clean_accounts(
-        Some(2),
-        false,
-        &EpochSchedule::default(),
-        OldStoragesPolicy::Leave,
-    );
+    db.clean_accounts(Some(2), false, &EpochSchedule::default());
 
     // No stores should exist for slot 0 after clean
     assert_no_storages_at_slot(&db, 0);
@@ -5414,30 +5374,15 @@ define_accounts_db_test!(
         assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 3);
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
-        accounts_db.clean_accounts(
-            Some(slot2),
-            false,
-            &EpochSchedule::default(),
-            OldStoragesPolicy::Leave,
-        );
+        accounts_db.clean_accounts(Some(slot2), false, &EpochSchedule::default());
         assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 2);
 
         accounts_db.set_latest_full_snapshot_slot(slot2);
-        accounts_db.clean_accounts(
-            None,
-            false,
-            &EpochSchedule::default(),
-            OldStoragesPolicy::Leave,
-        );
+        accounts_db.clean_accounts(None, false, &EpochSchedule::default());
         assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 1);
 
         accounts_db.set_latest_full_snapshot_slot(slot3);
-        accounts_db.clean_accounts(
-            None,
-            false,
-            &EpochSchedule::default(),
-            OldStoragesPolicy::Leave,
-        );
+        accounts_db.clean_accounts(None, false, &EpochSchedule::default());
         assert_eq!(accounts_db.ref_count_for_pubkey(&pubkey), 0);
     }
 );
@@ -7169,12 +7114,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
 
     // calculate the full accounts hash
     let full_accounts_hash = {
-        accounts_db.clean_accounts(
-            Some(slot - 1),
-            false,
-            &EpochSchedule::default(),
-            OldStoragesPolicy::Leave,
-        );
+        accounts_db.clean_accounts(Some(slot - 1), false, &EpochSchedule::default());
         let (storages, _) = accounts_db.get_storages(..=slot);
         let storages = SortedStorages::new(&storages);
         accounts_db.calculate_accounts_hash(
@@ -7240,12 +7180,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
     // calculate the incremental accounts hash
     let incremental_accounts_hash = {
         accounts_db.set_latest_full_snapshot_slot(full_accounts_hash_slot);
-        accounts_db.clean_accounts(
-            Some(slot - 1),
-            false,
-            &EpochSchedule::default(),
-            OldStoragesPolicy::Leave,
-        );
+        accounts_db.clean_accounts(Some(slot - 1), false, &EpochSchedule::default());
         let (storages, _) = accounts_db.get_storages(full_accounts_hash_slot + 1..=slot);
         let storages = SortedStorages::new(&storages);
         accounts_db.calculate_incremental_accounts_hash(

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -678,7 +678,6 @@ impl AccountsBackgroundService {
                                     Some(max_clean_slot_inclusive),
                                     false,
                                     bank.epoch_schedule(),
-                                    bank.clean_accounts_old_storages_policy(),
                                 );
                                 last_cleaned_slot = max_clean_slot_inclusive;
                                 previous_clean_time = Instant::now();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -79,8 +79,7 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{
             AccountStorageEntry, AccountsDb, AccountsDbConfig, CalcAccountsHashDataSource,
-            DuplicatesLtHash, OldStoragesPolicy, PubkeyHashAccount,
-            VerifyAccountsHashAndLamportsConfig,
+            DuplicatesLtHash, PubkeyHashAccount, VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
             AccountHash, AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
@@ -6048,7 +6047,6 @@ impl Bank {
                     Some(latest_full_snapshot_slot),
                     true,
                     self.epoch_schedule(),
-                    self.clean_accounts_old_storages_policy(),
                 );
                 info!("Cleaning... Done.");
             } else {
@@ -6395,7 +6393,6 @@ impl Bank {
             Some(highest_slot_to_clean),
             false,
             self.epoch_schedule(),
-            self.clean_accounts_old_storages_policy(),
         );
     }
 
@@ -6431,15 +6428,6 @@ impl Bank {
             .accounts_db
             .test_skip_rewrites_but_include_in_bank_hash;
         can_skip_rewrites || test_skip_rewrites_but_include_in_bank_hash
-    }
-
-    /// Returns how clean_accounts() should handle old storages
-    pub fn clean_accounts_old_storages_policy(&self) -> OldStoragesPolicy {
-        if self.are_ancient_storages_enabled() {
-            OldStoragesPolicy::Leave
-        } else {
-            OldStoragesPolicy::Clean
-        }
     }
 
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {


### PR DESCRIPTION
#### Problem

Now that skipping rewrites is enabled, ancient storages are also enabled. We no longer need special handling in `clean` for storages older than an epoch when we were doing rewrites.


#### Summary of Changes

Removes OldStoragesPolicy.

OldStoragesPolicy was originally added in #3737.