### PR TITLE
Use store_cached in create_test_accounts

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -81,6 +81,7 @@ fn bench_update_accounts_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new(Arc::new(accounts_db));
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
+    accounts.accounts_db.add_root_and_flush_write_cache(0);
     let ancestors = Ancestors::from(vec![0]);
     bencher.iter(|| {
         accounts
@@ -96,6 +97,7 @@ fn bench_accounts_delta_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new(Arc::new(accounts_db));
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
+    accounts.accounts_db.add_root_and_flush_write_cache(0);
     bencher.iter(|| {
         accounts.accounts_db.calculate_accounts_delta_hash(0);
     });

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -225,7 +225,7 @@ mod serde_snapshot_tests {
         let mut pubkeys: Vec<Pubkey> = vec![];
         create_test_accounts(&accounts, &mut pubkeys, 100, slot);
         check_accounts_local(&accounts, &pubkeys, 100);
-        accounts.add_root(slot);
+        accounts.accounts_db.add_root_and_flush_write_cache(slot);
         let accounts_delta_hash = accounts.accounts_db.calculate_accounts_delta_hash(slot);
         let accounts_hash = AccountsHash(Hash::new_unique());
         accounts


### PR DESCRIPTION
#### Problem
store_uncached is deprecated and can be removed. This is Part1.

#### Summary of Changes
- Change create_test_accounts to use store_cached
- Change update_accounts_bench to use store_cached
- Remove workaround in create_test_accounts that is no longer needed

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
