### PR TITLE
Uses AccountsFile::get_stored_account_without_data_callback() in ScanState::set_slot()

### DIFF
--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -80,13 +80,11 @@ impl AppendVecScan for ScanState<'_> {
         // For each obsolete account found, add its pubkey to the hashset so it can be skipped
         for account in accounts {
             let offset = account.0;
-            let stored_account = storage.accounts.get_account_index_info(offset);
-            self.pubkeys_to_skip.insert(
-                stored_account
-                    .expect("Obsolete account offset is a valid account offset in storage")
-                    .index_info
-                    .pubkey,
-            );
+            storage
+                .accounts
+                .get_stored_account_without_data_callback(offset, |stored_account| {
+                    self.pubkeys_to_skip.insert(*stored_account.pubkey());
+                });
         }
     }
 


### PR DESCRIPTION
#### Problem

We are calling `AccountsFile::get_account_index_info()` in `ScanState::set_info()`, which is really only meant to be by code dealing with the accounts index (i.e. *not* here). Also, `.gaii()` returns an Option, so we additionally have to handle `None`. This shouldn't happen in practice, but we still have to put the code there.


#### Summary of Changes

Replace `get_account_index_info()` with `get_stored_account_without_data_callback()`. This addresses both of the stated problems.