### PR TITLE
Uses AccountsFile::get_stored_account_without_data_callback() in generate_index_for_slot()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8104,23 +8104,20 @@ impl AccountsDb {
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
             // there were duplicate pubkeys in this same slot
             // Some were not inserted. This means some info like stored data is off.
-            duplicates_this_slot
-                .into_iter()
-                .filter_map(|(pubkey, (_slot, info))| {
-                    let duplicate = storage.accounts.get_account_index_info(info.offset());
-                    duplicate
-                        .as_ref()
-                        .inspect(|duplicate| assert_eq!(pubkey, duplicate.index_info.pubkey));
-                    duplicate
-                })
-                .for_each(|duplicate| {
-                    stored_size_alive =
-                        stored_size_alive.saturating_sub(duplicate.stored_size_aligned);
-                    if !duplicate.is_zero_lamport() {
-                        accounts_data_len =
-                            accounts_data_len.saturating_sub(duplicate.index_info.data_len);
-                    }
-                });
+            for (pubkey, (_slot, info)) in duplicates_this_slot {
+                storage.accounts.get_stored_account_without_data_callback(
+                    info.offset(),
+                    |duplicate_account| {
+                        assert_eq!(pubkey, *duplicate_account.pubkey());
+                        let data_len = duplicate_account.data_len;
+                        let stored_size_aligned = storage.accounts.calculate_stored_size(data_len);
+                        stored_size_alive = stored_size_alive.saturating_sub(stored_size_aligned);
+                        if !duplicate_account.is_zero_lamport() {
+                            accounts_data_len = accounts_data_len.saturating_sub(data_len as u64);
+                        }
+                    },
+                );
+            }
         }
 
         {

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -1064,9 +1064,12 @@ mod tests {
 
             for account in accounts {
                 let offset = account.0;
-                let stored_account = storage.accounts.get_account_index_info(offset);
-                self.pubkeys_to_skip
-                    .insert(stored_account.unwrap().index_info.pubkey);
+                storage.accounts.get_stored_account_without_data_callback(
+                    offset,
+                    |stored_account| {
+                        self.pubkeys_to_skip.insert(*stored_account.pubkey());
+                    },
+                );
             }
         }
         fn filter(&mut self, pubkey: &Pubkey) -> bool {

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -247,22 +247,6 @@ impl AccountsFile {
         }
     }
 
-    /// returns an `IndexInfo` for an account at `offset`, if any.  Otherwise, return None.
-    ///
-    /// Only intended to be used with the accounts index.
-    pub(crate) fn get_account_index_info(&self, offset: usize) -> Option<IndexInfo> {
-        match self {
-            Self::AppendVec(av) => av.get_account_index_info(offset),
-            Self::TieredStorage(ts) => {
-                // Note: The conversion here is needed as the AccountsDB currently
-                // assumes all offsets are multiple of 8 while TieredStorage uses
-                // IndexOffset that is equivalent to AccountInfo::reduced_offset.
-                let index_offset = IndexOffset(AccountInfo::get_reduced_offset(offset));
-                ts.reader()?.get_account_index_info(index_offset).ok()?
-            }
-        }
-    }
-
     pub fn account_matches_owners(
         &self,
         offset: usize,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -867,23 +867,6 @@ impl AppendVec {
         }
     }
 
-    /// Returns the `IndexInfo` for the account at `offset`.
-    ///
-    /// Only intended to be used with the accounts index.
-    pub(crate) fn get_account_index_info(&self, offset: usize) -> Option<IndexInfo> {
-        self.get_stored_account_no_data_callback(offset, |account| IndexInfo {
-            stored_size_aligned: account.stored_size,
-            index_info: IndexInfoInner {
-                pubkey: *account.pubkey(),
-                lamports: account.lamports(),
-                offset: account.offset(),
-                data_len: account.data_len(),
-                executable: account.executable(),
-                rent_epoch: account.rent_epoch(),
-            },
-        })
-    }
-
     /// Return Ok(index_of_matching_owner) if the account owner at `offset` is one of the pubkeys in `owners`.
     /// Return Err(MatchAccountOwnerError::NoMatch) if the account has 0 lamports or the owner is not one of
     /// the pubkeys in `owners`.

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -610,38 +610,6 @@ impl HotStorageReader {
         )))
     }
 
-    /// Returns the `IndexInfo` for the account located at the specified index offset.
-    ///
-    /// Only intended to be used with the accounts index.
-    pub(crate) fn get_account_index_info(
-        &self,
-        index_offset: IndexOffset,
-    ) -> TieredStorageResult<Option<IndexInfo>> {
-        if index_offset.0 >= self.footer.account_entry_count {
-            return Ok(None);
-        }
-
-        let account_offset = self.get_account_offset(index_offset)?;
-
-        let meta = self.get_account_meta_from_offset(account_offset)?;
-        let account_block = self.get_account_block(account_offset, index_offset)?;
-
-        let account_data_size = meta.account_data_size(account_block);
-
-        let account_index_info = IndexInfo {
-            stored_size_aligned: stored_size(account_data_size),
-            index_info: IndexInfoInner {
-                pubkey: *self.get_account_address(index_offset)?,
-                lamports: meta.lamports(),
-                offset: AccountInfo::reduced_offset_to_offset(index_offset.0),
-                data_len: account_data_size as u64,
-                executable: meta.flags().executable(),
-                rent_epoch: meta.final_rent_epoch(account_block),
-            },
-        };
-        Ok(Some(account_index_info))
-    }
-
     /// iterate over all pubkeys
     pub fn scan_pubkeys(&self, mut callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
         for i in 0..self.footer.account_entry_count {

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -76,18 +76,6 @@ impl TieredStorageReader {
         }
     }
 
-    /// Returns the `IndexInfo` for the account located at the specified index offset.
-    ///
-    /// Only intended to be used with the accounts index.
-    pub(crate) fn get_account_index_info(
-        &self,
-        index_offset: IndexOffset,
-    ) -> TieredStorageResult<Option<IndexInfo>> {
-        match self {
-            Self::Hot(hot) => hot.get_account_index_info(index_offset),
-        }
-    }
-
     /// Calls `callback` with the stored account at `offset`.
     ///
     /// Returns `None` if there is no account at `offset`, otherwise returns the result of


### PR DESCRIPTION
#### Problem

When handling duplicates during index generation, we call `AccountsFile::get_account_index_info()`. Since it returns an Option, we have to handle `None`. This shouldn't happen in practice, but we still have to put the code there.


#### Summary of Changes

Uses AccountsFile::get_stored_account_without_data_callback() in generate_index_for_slot(). This avoids needing to handle a `None`, and can allow us to remove `get_account_index_info()`.

Note, this was the last non-test use age of `get_account_index_info()`. So clippy also warned about this newly unused function. So the other commits remove `get_account_index_info()` to appease clippy.