### PR TITLE
Reclaim support for obsolete accounts

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -177,7 +177,7 @@ mod tests {
         let offset = 0;
         // Mark the obsolete accounts in storage
         let mut size = storage.accounts.get_account_data_lens(&[0]);
-        storage.mark_account_obsolete(offset, size.pop().unwrap(), 0);
+        storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())], 0);
 
         _ = AccountStorageReader::new(&storage, None).unwrap();
     }
@@ -260,10 +260,10 @@ mod tests {
         assert_eq!(obsolete_account_offset.len(), number_of_accounts_to_remove);
 
         // Mark the obsolete accounts in storage
-        obsolete_account_offset.into_iter().for_each(|offset| {
-            let mut size = storage.accounts.get_account_data_lens(&[offset]);
-            storage.mark_account_obsolete(offset, size.pop().unwrap(), 0);
-        });
+        let data_lens = storage
+            .accounts
+            .get_account_data_lens(&obsolete_account_offset);
+        storage.mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
 
         let storage = storage
             .reopen_as_readonly(storage_access)
@@ -375,7 +375,7 @@ mod tests {
         let mut slot_marked_dead = 0;
         obsolete_account_offset.into_iter().for_each(|offset| {
             let mut size = storage.accounts.get_account_data_lens(&[offset]);
-            storage.mark_account_obsolete(offset, size.pop().unwrap(), slot_marked_dead);
+            storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())], slot_marked_dead);
             slot_marked_dead += 1;
         });
 

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -177,7 +177,7 @@ mod tests {
         let offset = 0;
         // Mark the obsolete accounts in storage
         let mut size = storage.accounts.get_account_data_lens(&[0]);
-        storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())], 0);
+        storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())].into_iter(), 0);
 
         _ = AccountStorageReader::new(&storage, None).unwrap();
     }
@@ -375,7 +375,10 @@ mod tests {
         let mut slot_marked_dead = 0;
         obsolete_account_offset.into_iter().for_each(|offset| {
             let mut size = storage.accounts.get_account_data_lens(&[offset]);
-            storage.mark_accounts_obsolete(vec![(offset, size.pop().unwrap())], slot_marked_dead);
+            storage.mark_accounts_obsolete(
+                vec![(offset, size.pop().unwrap())].into_iter(),
+                slot_marked_dead,
+            );
             slot_marked_dead += 1;
         });
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1174,12 +1174,13 @@ impl AccountStorageEntry {
     /// Marks the accounts at the given offsets as obsolete
     pub fn mark_accounts_obsolete(
         &self,
-        obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
+        newly_obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
         slot: Slot,
     ) {
         let mut obsolete_accounts_list = self.obsolete_accounts.write().unwrap();
-        obsolete_accounts_list.reserve(obsolete_accounts.len());
-        for (offset, data_len) in obsolete_accounts {
+        obsolete_accounts_list.reserve(newly_obsolete_accounts.len());
+
+        for (offset, data_len) in newly_obsolete_accounts {
             obsolete_accounts_list.push((offset, data_len, slot));
         }
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1174,10 +1174,11 @@ impl AccountStorageEntry {
     /// Marks the accounts at the given offsets as obsolete
     pub fn mark_accounts_obsolete(
         &self,
-        obsolete_accounts: impl IntoIterator<Item = (Offset, usize)>,
+        obsolete_accounts: impl ExactSizeIterator<Item = (Offset, usize)>,
         slot: Slot,
     ) {
         let mut obsolete_accounts_list = self.obsolete_accounts.write().unwrap();
+        obsolete_accounts_list.reserve(obsolete_accounts.len());
         for (offset, data_len) in obsolete_accounts {
             obsolete_accounts_list.push((offset, data_len, slot));
         }

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -1119,7 +1119,7 @@ mod tests {
 
         // Mark each account obsolete at a different slot
         for (i, offsets) in offsets.unwrap().offsets.iter().enumerate() {
-            storage.mark_account_obsolete(*offsets, 0, i as Slot);
+            storage.mark_accounts_obsolete(vec![(*offsets, 0)], i as Slot);
         }
 
         // Perform scans of the storage assuming a different slot and verify the number of accounts found matches

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -1119,7 +1119,7 @@ mod tests {
 
         // Mark each account obsolete at a different slot
         for (i, offsets) in offsets.unwrap().offsets.iter().enumerate() {
-            storage.mark_accounts_obsolete(vec![(*offsets, 0)], i as Slot);
+            storage.mark_accounts_obsolete(vec![(*offsets, 0)].into_iter(), i as Slot);
         }
 
         // Perform scans of the storage assuming a different slot and verify the number of accounts found matches

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1310,7 +1310,7 @@ mod tests {
         bank1.fill_bank_with_ticks_for_tests();
 
         // Mark the entry for pubkey1 as obsolete in slot0
-        account_storage_entry.mark_account_obsolete(offset, 0, slot);
+        account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)], slot);
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1310,7 +1310,7 @@ mod tests {
         bank1.fill_bank_with_ticks_for_tests();
 
         // Mark the entry for pubkey1 as obsolete in slot0
-        account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)], slot);
+        account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)].into_iter(), slot);
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
#### Problem
Reclaims need to support marking obsolete accounts 

#### Summary of Changes
- Added enum for whether obsolete accounts should be marked during reclaims or not
- Marked obsolete accounts during reclaim
- Added some test coverage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
