### PR TITLE
Clean up bank epoch stakes migration

### DIFF
--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -10,7 +10,7 @@ use {
     solana_account::from_account,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, epoch_stakes::EpochStakes},
+    solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
     solana_sysvar::{self as sysvar, slot_hashes::SlotHashes},
     std::{cmp, sync::Arc},
 };
@@ -42,7 +42,7 @@ impl VoteBatchInsertionMetrics {
 pub struct VoteStorage {
     latest_vote_per_vote_pubkey: HashMap<Pubkey, LatestValidatorVotePacket>,
     num_unprocessed_votes: usize,
-    cached_epoch_stakes: EpochStakes,
+    cached_epoch_stakes: VersionedEpochStakes,
     deprecate_legacy_vote_ixs: bool,
     current_epoch: Epoch,
 }
@@ -68,7 +68,7 @@ impl VoteStorage {
             .iter()
             .map(|pubkey| (*pubkey, (1u64, VoteAccount::new_random())))
             .collect();
-        let epoch_stakes = EpochStakes::new_for_tests(vote_accounts, 0);
+        let epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts, 0);
 
         Self {
             latest_vote_per_vote_pubkey: HashMap::default(),

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -30,7 +30,7 @@ use {
         bank_forks::BankForks,
         bank_hash_cache::{BankHashCache, DumpedSlotSubscription},
         commitment::VOTE_THRESHOLD_SIZE,
-        epoch_stakes::EpochStakes,
+        epoch_stakes::VersionedEpochStakes,
         root_bank_cache::RootBankCache,
         vote_sender_types::ReplayVoteReceiver,
     },
@@ -720,7 +720,7 @@ impl ClusterInfoVoteListener {
             .add_vote_pubkey(pubkey, stake, total_epoch_stake, &THRESHOLDS_TO_CHECK)
     }
 
-    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&EpochStakes>, pubkey: &Pubkey) {
+    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&VersionedEpochStakes>, pubkey: &Pubkey) {
         if let Some(stakes) = epoch_stakes {
             *sum += stakes.stakes().vote_accounts().get_delegated_stake(pubkey)
         }

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -11,7 +11,7 @@ use {
         cluster_info::ClusterInfo, contact_info::ContactInfo, crds::Cursor, epoch_slots::EpochSlots,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, epoch_stakes::EpochStakes},
+    solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
     solana_time_utils::AtomicInterval,
     std::{
         collections::{HashMap, VecDeque},
@@ -42,8 +42,8 @@ struct EpochStakeInfo {
     total_stake: Stake,
 }
 
-impl From<&EpochStakes> for EpochStakeInfo {
-    fn from(stakes: &EpochStakes) -> Self {
+impl From<&VersionedEpochStakes> for EpochStakeInfo {
+    fn from(stakes: &VersionedEpochStakes) -> Self {
         let validator_stakes = ValidatorStakesMap::from_iter(
             stakes
                 .node_id_to_vote_accounts()

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -11,7 +11,7 @@ use {
     solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::BankForks, epoch_stakes::EpochStakes},
+    solana_runtime::{bank::Bank, bank_forks::BankForks, epoch_stakes::VersionedEpochStakes},
     std::{
         borrow::Borrow,
         cmp::Ordering,
@@ -344,7 +344,7 @@ impl HeaviestSubtreeForkChoice {
         &'a mut self,
         // newly updated votes on a fork
         pubkey_votes: impl Iterator<Item = impl Borrow<(Pubkey, SlotHashKey)> + 'b>,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> SlotHashKey {
         // Generate the set of updates
@@ -655,7 +655,7 @@ impl HeaviestSubtreeForkChoice {
         &mut self,
         other: HeaviestSubtreeForkChoice,
         merge_leaf: &SlotHashKey,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) {
         assert!(self.fork_infos.contains_key(merge_leaf));
@@ -974,7 +974,7 @@ impl HeaviestSubtreeForkChoice {
     fn generate_update_operations<'a, 'b>(
         &'a mut self,
         pubkey_votes: impl Iterator<Item = impl Borrow<(Pubkey, SlotHashKey)> + 'b>,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> UpdateOperations {
         let mut update_operations: BTreeMap<(SlotHashKey, UpdateLabel), UpdateOperation> =

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::EpochStakes,
+    solana_runtime::epoch_stakes::VersionedEpochStakes,
     std::{
         collections::{HashMap, HashSet, VecDeque},
         iter,
@@ -87,7 +87,7 @@ impl RepairWeight {
         &mut self,
         blockstore: &Blockstore,
         votes: I,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) where
         I: Iterator<Item = (Slot, Vec<Pubkey>)>,
@@ -204,7 +204,7 @@ impl RepairWeight {
     pub fn get_best_weighted_repairs(
         &mut self,
         blockstore: &Blockstore,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         max_new_shreds: usize,
@@ -528,7 +528,7 @@ impl RepairWeight {
         blockstore: &Blockstore,
         processed_slots: &mut HashSet<Slot>,
         repairs: &mut Vec<ShredRepairType>,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -666,7 +666,7 @@ impl RepairWeight {
         &mut self,
         blockstore: &Blockstore,
         mut orphan_tree_root: Slot,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> Option<Slot> {
         // Must only be called on existing orphan trees
@@ -764,7 +764,7 @@ impl RepairWeight {
     /// It is expected that no two children of a parent could both reach `DUPLICATE_THRESHOLD`.
     pub fn get_popular_pruned_forks(
         &self,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> Vec<Slot> {
         #[cfg(test)]
@@ -946,7 +946,7 @@ impl RepairWeight {
         root1: TreeRoot,
         root2: TreeRoot,
         merge_leaf: Slot,
-        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) {
         // Update self.slot_to_tree to reflect the merge

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -7,7 +7,7 @@ use {
     solana_runtime::{
         bank::Bank,
         bank_client::BankClient,
-        epoch_stakes::EpochStakes,
+        epoch_stakes::VersionedEpochStakes,
         genesis_utils::{
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
@@ -44,7 +44,7 @@ fn test_syscall_get_epoch_stake() {
     // Intentionally overwrite the bank epoch with no stake, to ensure the
     // syscall gets the _current_ epoch stake based on the leader schedule
     // (N + 1).
-    let epoch_stakes_epoch_0 = EpochStakes::new_for_tests(
+    let epoch_stakes_epoch_0 = VersionedEpochStakes::new_for_tests(
         voting_keypairs
             .iter()
             .map(|keypair| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -41,7 +41,7 @@ use {
             partitioned_epoch_rewards::{EpochRewardStatus, StakeRewards, VoteRewardsAccounts},
         },
         bank_forks::BankForks,
-        epoch_stakes::{split_epoch_stakes, EpochStakes, NodeVoteAccounts, VersionedEpochStakes},
+        epoch_stakes::{NodeVoteAccounts, VersionedEpochStakes},
         inflation_rewards::points::InflationPointCalculationEvent,
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         rent_collector::RentCollectorWithMetrics,
@@ -53,7 +53,7 @@ use {
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
         },
-        stakes::{Stakes, StakesCache, StakesEnum},
+        stakes::{SerdeStakesToStakeFormat, Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -452,7 +452,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
     pub(crate) stakes: Stakes<Delegation>,
-    pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
+    pub(crate) versioned_epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
     pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
@@ -499,7 +499,6 @@ pub struct BankFieldsToSerialize {
     pub epoch_schedule: EpochSchedule,
     pub inflation: Inflation,
     pub stakes: StakesEnum,
-    pub epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub is_delta: bool,
     pub accounts_data_len: u64,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
@@ -662,7 +661,6 @@ impl BankFieldsToSerialize {
             epoch_schedule: EpochSchedule::default(),
             inflation: Inflation::default(),
             stakes: Stakes::<Delegation>::default().into(),
-            epoch_stakes: HashMap::default(),
             is_delta: bool::default(),
             accounts_data_len: u64::default(),
             versioned_epoch_stakes: HashMap::default(),
@@ -847,7 +845,7 @@ pub struct Bank {
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
-    epoch_stakes: HashMap<Epoch, EpochStakes>,
+    epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
 
     /// A boolean reflecting whether any entries were recorded into the PoH
     /// stream for the slot == self.slot
@@ -1115,7 +1113,7 @@ impl Bank {
             epoch_schedule: EpochSchedule::default(),
             inflation: Arc::<RwLock<Inflation>>::default(),
             stakes_cache: StakesCache::default(),
-            epoch_stakes: HashMap::<Epoch, EpochStakes>::default(),
+            epoch_stakes: HashMap::<Epoch, VersionedEpochStakes>::default(),
             is_delta: AtomicBool::default(),
             rewards: RwLock::<Vec<(Pubkey, RewardInfo)>>::default(),
             cluster_type: Option::<ClusterType>::default(),
@@ -1205,10 +1203,10 @@ impl Bank {
         //  slot = 0 and genesis configuration
         {
             let stakes = bank.stakes_cache.stakes().clone();
-            let stakes = Arc::new(StakesEnum::from(stakes));
+            let stakes = SerdeStakesToStakeFormat::from(stakes);
             for epoch in 0..=bank.get_leader_schedule_epoch(bank.slot) {
                 bank.epoch_stakes
-                    .insert(epoch, EpochStakes::new(stakes.clone(), epoch));
+                    .insert(epoch, VersionedEpochStakes::new(stakes.clone(), epoch));
             }
             bank.update_stake_history(None);
         }
@@ -1849,7 +1847,7 @@ impl Bank {
             epoch_schedule: fields.epoch_schedule,
             inflation: Arc::new(RwLock::new(fields.inflation)),
             stakes_cache: StakesCache::new(stakes),
-            epoch_stakes: fields.epoch_stakes,
+            epoch_stakes: fields.versioned_epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
             rewards: RwLock::new(vec![]),
             cluster_type: Some(genesis_config.cluster_type),
@@ -2013,7 +2011,6 @@ impl Bank {
 
     /// Return subset of bank fields representing serializable state
     pub(crate) fn get_fields_to_serialize(&self) -> BankFieldsToSerialize {
-        let (epoch_stakes, versioned_epoch_stakes) = split_epoch_stakes(self.epoch_stakes.clone());
         BankFieldsToSerialize {
             blockhash_queue: self.blockhash_queue.read().unwrap().clone(),
             ancestors: AncestorsForSerialization::from(&self.ancestors),
@@ -2042,10 +2039,9 @@ impl Bank {
             epoch_schedule: self.epoch_schedule.clone(),
             inflation: *self.inflation.read().unwrap(),
             stakes: StakesEnum::from(self.stakes_cache.stakes().clone()),
-            epoch_stakes,
             is_delta: self.is_delta.load(Relaxed),
             accounts_data_len: self.load_accounts_data_size(),
-            versioned_epoch_stakes,
+            versioned_epoch_stakes: self.epoch_stakes.clone(),
             accounts_lt_hash: self
                 .is_accounts_lt_hash_enabled()
                 .then(|| self.accounts_lt_hash.lock().unwrap().clone()),
@@ -2314,8 +2310,8 @@ impl Bank {
                 epoch >= leader_schedule_epoch.saturating_sub(MAX_LEADER_SCHEDULE_STAKES)
             });
             let stakes = self.stakes_cache.stakes().clone();
-            let stakes = Arc::new(StakesEnum::from(stakes));
-            let new_epoch_stakes = EpochStakes::new(stakes, leader_schedule_epoch);
+            let stakes = SerdeStakesToStakeFormat::from(stakes);
+            let new_epoch_stakes = VersionedEpochStakes::new(stakes, leader_schedule_epoch);
             info!(
                 "new epoch stakes, epoch: {}, total_stake: {}",
                 leader_schedule_epoch,
@@ -2340,7 +2336,7 @@ impl Bank {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn set_epoch_stakes_for_test(&mut self, epoch: Epoch, stakes: EpochStakes) {
+    pub fn set_epoch_stakes_for_test(&mut self, epoch: Epoch, stakes: VersionedEpochStakes) {
         self.epoch_stakes.insert(epoch, stakes);
     }
 
@@ -6231,7 +6227,7 @@ impl Bank {
     }
 
     /// Get the EpochStakes for the current Bank::epoch
-    pub fn current_epoch_stakes(&self) -> &EpochStakes {
+    pub fn current_epoch_stakes(&self) -> &VersionedEpochStakes {
         // The stakes for a given epoch (E) in self.epoch_stakes are keyed by leader schedule epoch
         // (E + 1) so the stakes for the current epoch are stored at self.epoch_stakes[E + 1]
         self.epoch_stakes
@@ -6240,11 +6236,11 @@ impl Bank {
     }
 
     /// Get the EpochStakes for a given epoch
-    pub fn epoch_stakes(&self, epoch: Epoch) -> Option<&EpochStakes> {
+    pub fn epoch_stakes(&self, epoch: Epoch) -> Option<&VersionedEpochStakes> {
         self.epoch_stakes.get(&epoch)
     }
 
-    pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, EpochStakes> {
+    pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, VersionedEpochStakes> {
         &self.epoch_stakes
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13831,7 +13831,7 @@ fn test_bank_epoch_stakes() {
 
     // Setup new epoch stakes on Bank 1 for both leader schedule epochs.
     let make_new_epoch_stakes = |stake_coefficient: u64| {
-        EpochStakes::new_for_tests(
+        VersionedEpochStakes::new_for_tests(
             voting_keypairs
                 .iter()
                 .map(|keypair| {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,5 +1,5 @@
 use {
-    crate::stakes::{serde_stakes_to_delegation_format, SerdeStakesToStakeFormat, StakesEnum},
+    crate::stakes::SerdeStakesToStakeFormat,
     serde::{Deserialize, Serialize},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -18,22 +18,23 @@ pub struct NodeVoteAccounts {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
-pub struct EpochStakes {
-    #[serde(with = "serde_stakes_to_delegation_format")]
-    stakes: Arc<StakesEnum>,
-    total_stake: u64,
-    node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
-    epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+pub enum VersionedEpochStakes {
+    Current {
+        stakes: SerdeStakesToStakeFormat,
+        total_stake: u64,
+        node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
+        epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+    },
 }
 
-impl EpochStakes {
-    pub(crate) fn new(stakes: Arc<StakesEnum>, leader_schedule_epoch: Epoch) -> Self {
+impl VersionedEpochStakes {
+    pub(crate) fn new(stakes: SerdeStakesToStakeFormat, leader_schedule_epoch: Epoch) -> Self {
         let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
             Self::parse_epoch_vote_accounts(epoch_vote_accounts.as_ref(), leader_schedule_epoch);
-        Self {
+        Self::Current {
             stakes,
             total_stake,
             node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
@@ -47,44 +48,65 @@ impl EpochStakes {
         leader_schedule_epoch: Epoch,
     ) -> Self {
         Self::new(
-            Arc::new(StakesEnum::Accounts(crate::stakes::Stakes::new_for_tests(
+            SerdeStakesToStakeFormat::Account(crate::stakes::Stakes::new_for_tests(
                 0,
                 solana_vote::vote_account::VoteAccounts::from(Arc::new(vote_accounts_hash_map)),
                 im::HashMap::default(),
-            ))),
+            )),
             leader_schedule_epoch,
         )
     }
 
-    pub fn stakes(&self) -> &StakesEnum {
-        &self.stakes
+    pub fn stakes(&self) -> &SerdeStakesToStakeFormat {
+        match self {
+            Self::Current { stakes, .. } => stakes,
+        }
     }
 
     pub fn total_stake(&self) -> u64 {
-        self.total_stake
+        match self {
+            Self::Current { total_stake, .. } => *total_stake,
+        }
     }
 
-    /// For tests
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn set_total_stake(&mut self, total_stake: u64) {
-        self.total_stake = total_stake;
+        match self {
+            Self::Current {
+                total_stake: total_stake_field,
+                ..
+            } => {
+                *total_stake_field = total_stake;
+            }
+        }
     }
 
     pub fn node_id_to_vote_accounts(&self) -> &Arc<NodeIdToVoteAccounts> {
-        &self.node_id_to_vote_accounts
+        match self {
+            Self::Current {
+                node_id_to_vote_accounts,
+                ..
+            } => node_id_to_vote_accounts,
+        }
     }
 
     pub fn node_id_to_stake(&self, node_id: &Pubkey) -> Option<u64> {
-        self.node_id_to_vote_accounts
+        self.node_id_to_vote_accounts()
             .get(node_id)
             .map(|x| x.total_stake)
     }
 
     pub fn epoch_authorized_voters(&self) -> &Arc<EpochAuthorizedVoters> {
-        &self.epoch_authorized_voters
+        match self {
+            Self::Current {
+                epoch_authorized_voters,
+                ..
+            } => epoch_authorized_voters,
+        }
     }
 
     pub fn vote_account_stake(&self, vote_account: &Pubkey) -> u64 {
-        self.stakes
+        self.stakes()
             .vote_accounts()
             .get_delegated_stake(vote_account)
     }
@@ -131,110 +153,11 @@ impl EpochStakes {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum VersionedEpochStakes {
-    Current {
-        stakes: SerdeStakesToStakeFormat,
-        total_stake: u64,
-        node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
-        epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
-    },
-}
-
-impl From<VersionedEpochStakes> for EpochStakes {
-    fn from(versioned: VersionedEpochStakes) -> Self {
-        let VersionedEpochStakes::Current {
-            stakes,
-            total_stake,
-            node_id_to_vote_accounts,
-            epoch_authorized_voters,
-        } = versioned;
-
-        Self {
-            stakes: Arc::new(stakes.into()),
-            total_stake,
-            node_id_to_vote_accounts,
-            epoch_authorized_voters,
-        }
-    }
-}
-
-/// Only the `StakesEnum::Delegations` variant is unable to be serialized as a
-/// `StakesEnum::Stakes` variant, so leave those entries and split off the other
-/// epoch stakes enum variants into a new map which will be serialized into the
-/// new `versioned_epoch_stakes` snapshot field.  After a cluster transitions to
-/// serializing epoch stakes in the new format, `StakesEnum::Delegations`
-/// variants for recent epochs will no longer be created and can be deprecated.
-pub(crate) fn split_epoch_stakes(
-    bank_epoch_stakes: HashMap<Epoch, EpochStakes>,
-) -> (
-    HashMap<Epoch, EpochStakes>,
-    HashMap<Epoch, VersionedEpochStakes>,
-) {
-    let mut old_epoch_stakes = HashMap::new();
-    let mut versioned_epoch_stakes = HashMap::new();
-    for (epoch, epoch_stakes) in bank_epoch_stakes.into_iter() {
-        let EpochStakes {
-            stakes,
-            total_stake,
-            node_id_to_vote_accounts,
-            epoch_authorized_voters,
-        } = epoch_stakes;
-        match stakes.as_ref() {
-            StakesEnum::Delegations(_) => {
-                old_epoch_stakes.insert(
-                    epoch,
-                    EpochStakes {
-                        stakes: stakes.clone(),
-                        total_stake,
-                        node_id_to_vote_accounts,
-                        epoch_authorized_voters,
-                    },
-                );
-            }
-            StakesEnum::Accounts(stakes) => {
-                versioned_epoch_stakes.insert(
-                    epoch,
-                    VersionedEpochStakes::Current {
-                        stakes: SerdeStakesToStakeFormat::Account(stakes.clone()),
-                        total_stake,
-                        node_id_to_vote_accounts,
-                        epoch_authorized_voters,
-                    },
-                );
-            }
-            StakesEnum::Stakes(stakes) => {
-                versioned_epoch_stakes.insert(
-                    epoch,
-                    VersionedEpochStakes::Current {
-                        stakes: SerdeStakesToStakeFormat::Stake(stakes.clone()),
-                        total_stake,
-                        node_id_to_vote_accounts,
-                        epoch_authorized_voters,
-                    },
-                );
-            }
-        }
-    }
-    (old_epoch_stakes, versioned_epoch_stakes)
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        super::*,
-        crate::{
-            stake_account::StakeAccount,
-            stakes::{Stakes, StakesCache},
-        },
-        solana_account::AccountSharedData,
-        solana_rent::Rent,
-        solana_stake_program::stake_state::{self, Delegation, Stake},
-        solana_vote::vote_account::VoteAccount,
-        solana_vote_program::vote_state::{self, create_account_with_authorized},
-        std::iter,
+        super::*, solana_account::AccountSharedData, solana_vote::vote_account::VoteAccount,
+        solana_vote_program::vote_state::create_account_with_authorized, std::iter,
     };
 
     struct VoteAccountInfo {
@@ -327,7 +250,7 @@ pub(crate) mod tests {
             new_epoch_vote_accounts(&vote_accounts_map, |_| stake_per_account);
 
         let (total_stake, mut node_id_to_vote_accounts, epoch_authorized_voters) =
-            EpochStakes::parse_epoch_vote_accounts(&epoch_vote_accounts, 0);
+            VersionedEpochStakes::parse_epoch_vote_accounts(&epoch_vote_accounts, 0);
 
         // Verify the results
         node_id_to_vote_accounts
@@ -352,185 +275,6 @@ pub(crate) mod tests {
         );
     }
 
-    fn create_test_stakes() -> Stakes<StakeAccount<Delegation>> {
-        let stakes_cache = StakesCache::new(Stakes::default());
-
-        let vote_pubkey = Pubkey::new_unique();
-        let vote_account = vote_state::create_account_with_authorized(
-            &Pubkey::new_unique(),
-            &Pubkey::new_unique(),
-            &Pubkey::new_unique(),
-            0,
-            1,
-        );
-
-        let stake = 1_000_000_000;
-        let stake_pubkey = Pubkey::new_unique();
-        let stake_account = stake_state::create_account(
-            &Pubkey::new_unique(),
-            &vote_pubkey,
-            &vote_account,
-            &Rent::default(),
-            stake,
-        );
-
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None);
-
-        let stakes = Stakes::clone(&stakes_cache.stakes());
-
-        stakes
-    }
-
-    #[test]
-    fn test_split_epoch_stakes_empty() {
-        let bank_epoch_stakes = HashMap::new();
-        let (old, versioned) = split_epoch_stakes(bank_epoch_stakes);
-        assert!(old.is_empty());
-        assert!(versioned.is_empty());
-    }
-
-    #[test]
-    fn test_split_epoch_stakes_delegations() {
-        let mut bank_epoch_stakes = HashMap::new();
-        let epoch = 0;
-        let stakes = Arc::new(StakesEnum::Delegations(create_test_stakes().into()));
-        let epoch_stakes = EpochStakes {
-            stakes,
-            total_stake: 100,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch, epoch_stakes.clone());
-
-        let (old, versioned) = split_epoch_stakes(bank_epoch_stakes);
-
-        assert_eq!(old.len(), 1);
-        assert_eq!(old.get(&epoch), Some(&epoch_stakes));
-        assert!(versioned.is_empty());
-    }
-
-    #[test]
-    fn test_split_epoch_stakes_accounts() {
-        let mut bank_epoch_stakes = HashMap::new();
-        let epoch = 0;
-        let test_stakes = create_test_stakes();
-        let stakes = Arc::new(StakesEnum::Accounts(test_stakes.clone()));
-        let epoch_stakes = EpochStakes {
-            stakes,
-            total_stake: 100,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch, epoch_stakes.clone());
-
-        let (old, versioned) = split_epoch_stakes(bank_epoch_stakes);
-
-        assert!(old.is_empty());
-        assert_eq!(versioned.len(), 1);
-        assert_eq!(
-            versioned.get(&epoch),
-            Some(&VersionedEpochStakes::Current {
-                stakes: SerdeStakesToStakeFormat::Account(test_stakes),
-                total_stake: epoch_stakes.total_stake,
-                node_id_to_vote_accounts: epoch_stakes.node_id_to_vote_accounts,
-                epoch_authorized_voters: epoch_stakes.epoch_authorized_voters,
-            })
-        );
-    }
-
-    #[test]
-    fn test_split_epoch_stakes_stakes() {
-        let mut bank_epoch_stakes = HashMap::new();
-        let epoch = 0;
-        let test_stakes: Stakes<Stake> = create_test_stakes().into();
-        let stakes = Arc::new(StakesEnum::Stakes(test_stakes.clone()));
-        let epoch_stakes = EpochStakes {
-            stakes,
-            total_stake: 100,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch, epoch_stakes.clone());
-
-        let (old, versioned) = split_epoch_stakes(bank_epoch_stakes);
-
-        assert!(old.is_empty());
-        assert_eq!(versioned.len(), 1);
-        assert_eq!(
-            versioned.get(&epoch),
-            Some(&VersionedEpochStakes::Current {
-                stakes: SerdeStakesToStakeFormat::Stake(test_stakes),
-                total_stake: epoch_stakes.total_stake,
-                node_id_to_vote_accounts: epoch_stakes.node_id_to_vote_accounts,
-                epoch_authorized_voters: epoch_stakes.epoch_authorized_voters,
-            })
-        );
-    }
-
-    #[test]
-    fn test_split_epoch_stakes_mixed() {
-        let mut bank_epoch_stakes = HashMap::new();
-
-        // Delegations
-        let epoch1 = 0;
-        let stakes1 = Arc::new(StakesEnum::Delegations(Stakes::default()));
-        let epoch_stakes1 = EpochStakes {
-            stakes: stakes1,
-            total_stake: 100,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch1, epoch_stakes1);
-
-        // Accounts
-        let epoch2 = 1;
-        let stakes2 = Arc::new(StakesEnum::Accounts(Stakes::default()));
-        let epoch_stakes2 = EpochStakes {
-            stakes: stakes2,
-            total_stake: 200,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch2, epoch_stakes2);
-
-        // Stakes
-        let epoch3 = 2;
-        let stakes3 = Arc::new(StakesEnum::Stakes(Stakes::default()));
-        let epoch_stakes3 = EpochStakes {
-            stakes: stakes3,
-            total_stake: 300,
-            node_id_to_vote_accounts: Arc::new(HashMap::new()),
-            epoch_authorized_voters: Arc::new(HashMap::new()),
-        };
-        bank_epoch_stakes.insert(epoch3, epoch_stakes3);
-
-        let (old, versioned) = split_epoch_stakes(bank_epoch_stakes);
-
-        assert_eq!(old.len(), 1);
-        assert!(old.contains_key(&epoch1));
-
-        assert_eq!(versioned.len(), 2);
-        assert_eq!(
-            versioned.get(&epoch2),
-            Some(&VersionedEpochStakes::Current {
-                stakes: SerdeStakesToStakeFormat::Account(Stakes::default()),
-                total_stake: 200,
-                node_id_to_vote_accounts: Arc::default(),
-                epoch_authorized_voters: Arc::default(),
-            })
-        );
-        assert_eq!(
-            versioned.get(&epoch3),
-            Some(&VersionedEpochStakes::Current {
-                stakes: SerdeStakesToStakeFormat::Stake(Stakes::default()),
-                total_stake: 300,
-                node_id_to_vote_accounts: Arc::default(),
-                epoch_authorized_voters: Arc::default(),
-            })
-        );
-    }
-
     #[test]
     fn test_node_id_to_stake() {
         let num_nodes = 10;
@@ -545,7 +289,7 @@ pub(crate) mod tests {
         let epoch_vote_accounts = new_epoch_vote_accounts(&vote_accounts_map, |node_id| {
             *node_id_to_stake_map.get(node_id).unwrap()
         });
-        let epoch_stakes = EpochStakes::new_for_tests(epoch_vote_accounts, 0);
+        let epoch_stakes = VersionedEpochStakes::new_for_tests(epoch_vote_accounts, 0);
 
         assert_eq!(epoch_stakes.total_stake(), 11000);
         for (node_id, stake) in node_id_to_stake_map.iter() {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, CString};
 use {
     crate::{
         bank::{Bank, BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankRc},
-        epoch_stakes::{EpochStakes, VersionedEpochStakes},
+        epoch_stakes::VersionedEpochStakes,
         runtime_config::RuntimeConfig,
         serde_snapshot::storage::SerializableAccountStorageEntry,
         snapshot_utils::{SnapshotError, StorageAndNextAccountsFileId},
@@ -158,7 +158,8 @@ struct DeserializableVersionedBank {
     stakes: Stakes<Delegation>,
     #[allow(dead_code)]
     unused_accounts: UnusedAccounts,
-    epoch_stakes: HashMap<Epoch, EpochStakes>,
+    #[allow(dead_code)]
+    unused_epoch_stakes: HashMap<Epoch, ()>,
     is_delta: bool,
 }
 
@@ -193,12 +194,12 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             epoch_schedule: dvb.epoch_schedule,
             inflation: dvb.inflation,
             stakes: dvb.stakes,
-            epoch_stakes: dvb.epoch_stakes,
             is_delta: dvb.is_delta,
             incremental_snapshot_persistence: None,
             epoch_accounts_hash: None,
-            accounts_lt_hash: None, // populated from ExtraFieldsToDeserialize
-            bank_hash_stats: BankHashStats::default(), // populated from AccountsDbFields
+            versioned_epoch_stakes: HashMap::default(), // populated from ExtraFieldsToDeserialize
+            accounts_lt_hash: None,                     // populated from ExtraFieldsToDeserialize
+            bank_hash_stats: BankHashStats::default(),  // populated from AccountsDbFields
         }
     }
 }
@@ -238,7 +239,7 @@ struct SerializableVersionedBank {
     #[serde(serialize_with = "serde_stakes_to_delegation_format::serialize")]
     stakes: StakesEnum,
     unused_accounts: UnusedAccounts,
-    epoch_stakes: HashMap<Epoch, EpochStakes>,
+    unused_epoch_stakes: HashMap<Epoch, ()>,
     is_delta: bool,
 }
 
@@ -275,7 +276,7 @@ impl From<BankFieldsToSerialize> for SerializableVersionedBank {
             inflation: rhs.inflation,
             stakes: rhs.stakes,
             unused_accounts: UnusedAccounts::default(),
-            epoch_stakes: rhs.epoch_stakes,
+            unused_epoch_stakes: HashMap::default(),
             is_delta: rhs.is_delta,
         }
     }
@@ -450,15 +451,7 @@ where
         .clone_with_lamports_per_signature(lamports_per_signature);
     bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
     bank_fields.epoch_accounts_hash = epoch_accounts_hash;
-
-    // If we deserialize the new epoch stakes, add all of the entries into the
-    // other deserialized map which could still have old epoch stakes entries
-    bank_fields.epoch_stakes.extend(
-        versioned_epoch_stakes
-            .into_iter()
-            .map(|(epoch, versioned_epoch_stakes)| (epoch, versioned_epoch_stakes.into())),
-    );
-
+    bank_fields.versioned_epoch_stakes = versioned_epoch_stakes;
     bank_fields.accounts_lt_hash = accounts_lt_hash.map(Into::into);
 
     Ok((bank_fields, accounts_db_fields))

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -7,7 +7,7 @@ use {
 use {
     crate::{
         bank::{Bank, BankSlotDelta},
-        epoch_stakes::EpochStakes,
+        epoch_stakes::VersionedEpochStakes,
         runtime_config::RuntimeConfig,
         serde_snapshot::{bank_from_streams, BankIncrementalSnapshotPersistence},
         snapshot_archive_info::{
@@ -860,7 +860,7 @@ fn verify_epoch_stakes(bank: &Bank) -> std::result::Result<(), VerifyEpochStakes
 /// This version of the function exists to facilitate testing.
 /// Normal callers should use `verify_epoch_stakes()`.
 fn _verify_epoch_stakes(
-    epoch_stakes_map: &HashMap<Epoch, EpochStakes>,
+    epoch_stakes_map: &HashMap<Epoch, VersionedEpochStakes>,
     required_epochs: RangeInclusive<Epoch>,
 ) -> std::result::Result<(), VerifyEpochStakesError> {
     // Ensure epoch stakes from the snapshot does not contain entries for invalid epochs.

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -431,14 +431,6 @@ impl StakesEnum {
             StakesEnum::Stakes(stakes) => stakes.vote_accounts(),
         }
     }
-
-    pub(crate) fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
-        match self {
-            StakesEnum::Accounts(stakes) => stakes.staked_nodes(),
-            StakesEnum::Delegations(stakes) => stakes.staked_nodes(),
-            StakesEnum::Stakes(stakes) => stakes.staked_nodes(),
-        }
-    }
 }
 
 /// This conversion is very memory intensive so should only be used in

--- a/wen-restart/src/heaviest_fork_aggregate.rs
+++ b/wen-restart/src/heaviest_fork_aggregate.rs
@@ -6,7 +6,7 @@ use {
     solana_gossip::restart_crds_values::RestartHeaviestFork,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::EpochStakes,
+    solana_runtime::epoch_stakes::VersionedEpochStakes,
     std::{
         collections::{HashMap, HashSet},
         str::FromStr,
@@ -18,7 +18,7 @@ pub(crate) struct HeaviestForkAggregate {
     my_pubkey: Pubkey,
     // We use the epoch_stakes of the Epoch our heaviest bank is in. Proceed and exit only if
     // enough validator agree with me.
-    epoch_stakes: EpochStakes,
+    epoch_stakes: VersionedEpochStakes,
     heaviest_forks: HashMap<Pubkey, RestartHeaviestFork>,
     block_stake_map: HashMap<(Slot, Hash), u64>,
     active_peers: HashSet<Pubkey>,
@@ -36,7 +36,7 @@ pub enum HeaviestForkAggregateResult {
 impl HeaviestForkAggregate {
     pub(crate) fn new(
         my_shred_version: u16,
-        epoch_stakes: &EpochStakes,
+        epoch_stakes: &VersionedEpochStakes,
         my_heaviest_fork_slot: Slot,
         my_heaviest_fork_hash: Hash,
         my_pubkey: &Pubkey,

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -249,7 +249,7 @@ mod tests {
         solana_hash::Hash,
         solana_runtime::{
             bank::Bank,
-            epoch_stakes::EpochStakes,
+            epoch_stakes::VersionedEpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
@@ -791,8 +791,8 @@ mod tests {
                 )
             })
             .collect();
-        let epoch1_eopch_stakes = EpochStakes::new_for_tests(vote_accounts_hash_map, 1);
-        new_root_bank.set_epoch_stakes_for_test(1, epoch1_eopch_stakes);
+        let epoch1_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 1);
+        new_root_bank.set_epoch_stakes_for_test(1, epoch1_epoch_stakes);
 
         let last_voted_fork_slots = vec![root_bank.slot() + 1, root_bank.get_slots_in_epoch(0) + 1];
         let slots_aggregate = LastVotedForkSlotsAggregate::new(

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1450,7 +1450,7 @@ mod tests {
         },
         solana_pubkey::Pubkey,
         solana_runtime::{
-            epoch_stakes::EpochStakes,
+            epoch_stakes::VersionedEpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
@@ -2018,8 +2018,8 @@ mod tests {
                 )
             })
             .collect();
-        let epoch2_eopch_stakes = EpochStakes::new_for_tests(vote_accounts_hash_map, 2);
-        new_root_bank.set_epoch_stakes_for_test(2, epoch2_eopch_stakes);
+        let epoch2_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 2);
+        new_root_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);
         let _ = insert_slots_into_blockstore(
             test_state.blockstore.clone(),
             0,


### PR DESCRIPTION
The migration from legacy epoch stakes to "versioned" epoch stakes in bank snapshot serialization for [SIMD-0149](https://github.com/solana-foundation/solana-improvement-documents/pull/149) has been finished on all clusters for quite awhile so it can be cleaned up now. There are no longer any entries serialized into the legacy `epoch_stakes` bank field in serialized snapshots.

#### Summary of Changes
- Remove uses of legacy epoch stakes and replace with versioned epoch stakes
- Change snapshot deserialization of the legacy (unused) `epoch_stakes` field to allow removing legacy `EpochStakes` type

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
