### PR TITLE
Move the append vec module to private

### DIFF
--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -17,7 +17,10 @@ pub mod accounts_update_notifier_interface;
 mod active_stats;
 pub mod ancestors;
 mod ancient_append_vecs;
+#[cfg(feature = "dev-context-only-utils")]
 pub mod append_vec;
+#[cfg(not(feature = "dev-context-only-utils"))]
+mod append_vec;
 pub mod blockhash_queue;
 mod bucket_map_holder;
 mod bucket_map_holder_stats;


### PR DESCRIPTION
#### Problem
Append is not required to be public

#### Summary of Changes
- Move append vec to private for normal builds
- with DCOU allow append vec to be public for test bench purposes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
