### PR TITLE
Remove store uncache

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1240,7 +1240,6 @@ mod tests {
     }
 
     impl Accounts {
-        /// callers used to call store_uncached. But, this is not allowed anymore.
         pub fn store_for_tests(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
             self.accounts_db.store_for_tests(slot, &[(pubkey, account)])
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1265,21 +1265,6 @@ impl AccountStorageEntry {
         self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn try_available(&self) -> bool {
-        let mut count_and_status = self.count_and_status.lock_write();
-        let (count, status) = *count_and_status;
-
-        if status == AccountStorageStatus::Available {
-            *count_and_status = (count, AccountStorageStatus::Candidate);
-            true
-        } else {
-            false
-        }
-    }
-
     /// returns # of accounts remaining in the storage
     fn remove_accounts(
         &self,
@@ -1771,9 +1756,8 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         let some_data_len = 5;
         let some_slot: Slot = 0;
         let account = AccountSharedData::new(1, some_data_len, &key);
-        accounts_db.store_uncached(some_slot, &[(&key, &account)]);
-        accounts_db.add_root(0);
-
+        accounts_db.store_for_tests(some_slot, &[(&key, &account)]);
+        accounts_db.add_root_and_flush_write_cache(0);
         accounts_db
     }
 }
@@ -5116,44 +5100,6 @@ impl AccountsDb {
         }
     }
 
-    // This function is only called by `store_uncached()`, which is DCOU and only called by tests.
-    // So also mark this function as DCOU to squelch an "unused function" clippy warning.
-    #[cfg(feature = "dev-context-only-utils")]
-    fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
-        let mut get_slot_stores = Measure::start("get_slot_stores");
-        let store = self.storage.get_slot_storage_entry(slot);
-        get_slot_stores.stop();
-        self.stats
-            .store_get_slot_store
-            .fetch_add(get_slot_stores.as_us(), Ordering::Relaxed);
-        let mut find_existing = Measure::start("find_existing");
-        if let Some(store) = store {
-            if store.try_available() {
-                let ret = store.clone();
-                drop(store);
-                find_existing.stop();
-                self.stats
-                    .store_find_existing
-                    .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-                return ret;
-            }
-        }
-        find_existing.stop();
-        self.stats
-            .store_find_existing
-            .fetch_add(find_existing.as_us(), Ordering::Relaxed);
-
-        let store = self.create_store(slot, self.file_size, "store", &self.paths);
-
-        // try_available is like taking a lock on the store,
-        // preventing other threads from using it.
-        // It must succeed here and happen before insert,
-        // otherwise another thread could also grab it from the index.
-        assert!(store.try_available());
-        self.insert_store(slot, store.clone());
-        store
-    }
-
     fn has_space_available(&self, slot: Slot, size: u64) -> bool {
         let store = self.storage.get_slot_storage_entry(slot).unwrap();
         if store.status() == AccountStorageStatus::Available
@@ -7581,20 +7527,6 @@ impl AccountsDb {
             transactions,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::Inline,
-        );
-    }
-
-    /// Store the account update.
-    /// only called by tests
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        let storage = self.find_storage_candidate(slot);
-        self.store(
-            (slot, accounts),
-            &StoreTo::Storage(&storage),
-            None,
-            StoreReclaims::Default,
-            UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }
 

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -197,7 +197,6 @@ pub mod tests {
         let mut accounts = AccountsDb::new_single_for_tests();
         let key1 = Pubkey::new_unique();
         let key2 = Pubkey::new_unique();
-        let key3 = Pubkey::new_unique();
         let account = AccountSharedData::new(1, 0, &Pubkey::default());
 
         // Account with key1 is updated twice in two different slots, should get notified twice
@@ -212,11 +211,6 @@ pub mod tests {
         // Account with key2 is updated in a single slot, should get notified once
         accounts.store_for_tests(2, &[(&key2, &account)]);
         accounts.add_root_and_flush_write_cache(2);
-
-        // Account with key3 is updated twice in a single slot, should get notified twice
-        accounts.store_for_tests(3, &[(&key3, &account)]);
-        accounts.store_for_tests(3, &[(&key3, &account)]);
-        accounts.add_root_and_flush_write_cache(3);
 
         // Do the notification
         let notifier = GeyserTestPlugin::default();
@@ -242,15 +236,6 @@ pub mod tests {
             assert_eq!(notified_key2.len(), 1);
             let (slot, write_version, _account) = &notified_key2[0];
             assert_eq!(*slot, 2);
-            assert_eq!(*write_version, 1);
-        }
-
-        // A single slot can only have a single version of an account
-        {
-            let notified_key3 = notifier.accounts_notified.get(&key3).unwrap();
-            assert_eq!(notified_key3.len(), 1);
-            let (slot, write_version, _account) = &notified_key3[0];
-            assert_eq!(*slot, 3);
             assert_eq!(*write_version, 1);
         }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4354,8 +4354,8 @@ fn test_flush_rooted_accounts_cache_with_clean() {
 fn test_flush_rooted_accounts_cache_without_clean() {
     run_flush_rooted_accounts_cache(false);
 }
-
-fn run_test_shrink_unref(do_intra_cache_clean: bool) {
+#[test]
+fn test_shrink_unref() {
     let db = AccountsDb::new_single_for_tests();
     let epoch_schedule = EpochSchedule::default();
     let account_key1 = Pubkey::new_unique();
@@ -4363,16 +4363,9 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     let account1 = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    // This has to be done uncached since we are trying to add another account to the append vec AFTER it has been flushed.
-    // This doesn't work if the flush creates an append vec of exactly the right size.
-    // Normal operations NEVER write the same account to the same append vec twice during a write cache flush.
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.store_uncached(0, &[(&account_key2, &account1)][..]);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.store_for_tests(0, &[(&account_key2, &account1)]);
     db.add_root(0);
-    if !do_intra_cache_clean {
-        // Add an additional ref within the same slot to pubkey 1
-        db.store_uncached(0, &[(&account_key1, &account1)]);
-    }
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1
     db.store_cached((1, &[(&account_key1, &account1)][..]), None);
@@ -4411,16 +4404,6 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     // should be 1, since it was only stored in slot 0 and 1, and slot 0
     // is now dead
     assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
-}
-
-#[test]
-fn test_shrink_unref() {
-    run_test_shrink_unref(false)
-}
-
-#[test]
-fn test_shrink_unref_with_intra_slot_cleaning() {
-    run_test_shrink_unref(true)
 }
 
 #[test]
@@ -4464,8 +4447,8 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     let account0 = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.add_root(0);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.add_root_and_flush_write_cache(0);
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
     // And store one additional live account to make the store still alive after clean.
@@ -4507,9 +4490,9 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     let account0 = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
-    db.store_uncached(0, &[(&account_key1, &account1)][..]);
-    db.store_uncached(0, &[(&account_key2, &account1)][..]);
-    db.add_root(0);
+    db.store_for_tests(0, &[(&account_key1, &account1)]);
+    db.store_for_tests(0, &[(&account_key2, &account1)]);
+    db.add_root_and_flush_write_cache(0);
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
     db.store_cached((1, &[(&account_key1, &account0)][..]), None);
@@ -4574,8 +4557,9 @@ define_accounts_db_test!(test_partial_clean, |db| {
     let account4 = AccountSharedData::new(4, 0, AccountSharedData::default().owner());
 
     // Store accounts into slots 0 and 1
-    db.store_uncached(0, &[(&account_key1, &account1), (&account_key2, &account1)]);
-    db.store_uncached(1, &[(&account_key1, &account2)]);
+    db.store_for_tests(0, &[(&account_key1, &account1), (&account_key2, &account1)]);
+    db.store_for_tests(1, &[(&account_key1, &account2)]);
+
     db.print_accounts_stats("pre-clean1");
 
     // clean accounts - no accounts should be cleaned, since no rooted slots
@@ -4586,15 +4570,16 @@ define_accounts_db_test!(test_partial_clean, |db| {
     db.clean_accounts_for_tests();
 
     db.print_accounts_stats("post-clean1");
-    // Check stores > 0
-    assert!(!db.storage.is_empty_entry(0));
-    assert!(!db.storage.is_empty_entry(1));
+
+    // Assert that cache entries are still present
+    assert!(!db.accounts_cache.slot_cache(0).unwrap().is_empty());
+    assert!(!db.accounts_cache.slot_cache(1).unwrap().is_empty());
 
     // root slot 0
     db.add_root_and_flush_write_cache(0);
 
     // store into slot 2
-    db.store_uncached(2, &[(&account_key2, &account3), (&account_key1, &account3)]);
+    db.store_for_tests(2, &[(&account_key2, &account3), (&account_key1, &account3)]);
     db.clean_accounts_for_tests();
     db.print_accounts_stats("post-clean2");
 
@@ -4604,7 +4589,7 @@ define_accounts_db_test!(test_partial_clean, |db| {
 
     db.print_accounts_stats("post-clean3");
 
-    db.store_uncached(3, &[(&account_key2, &account4)]);
+    db.store_for_tests(3, &[(&account_key2, &account4)]);
     db.add_root_and_flush_write_cache(3);
 
     // Check that we can clean where max_root=3 and slot=2 is not rooted
@@ -4753,7 +4738,7 @@ fn do_test_load_account_and_shrink_race(with_retry: bool) {
     let lamports = 42;
     let mut account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     account.set_lamports(lamports);
-    db.store_uncached(slot, &[(&pubkey, &account)]);
+    db.store_for_tests(slot, &[(&pubkey, &account)]);
 
     // Set the slot as a root so account loads will see the contents of this slot
     db.add_root(slot);


### PR DESCRIPTION
#### Problem
Store uncached is deprecated and should be removed

#### Summary of Changes
- Removed it and surrounding code
- Moved all callers to store_for_tests + flush cache
- Modified geyser snapshot test as previous requirements are not valid 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
