### PR TITLE
geyser: update to `ReplicaTransactionInfoV3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ version = "3.0.0"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-hash",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",
@@ -8465,6 +8466,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
+ "solana-hash",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
+solana-hash = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -162,6 +162,9 @@ pub struct ReplicaTransactionInfoV2<'a> {
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct ReplicaTransactionInfoV3<'a> {
+    /// The transaction signature, used for identifying the transaction.
+    pub signature: &'a Signature,
+
     /// The transaction message hash, used for identifying the transaction.
     pub message_hash: &'a Hash,
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -4,8 +4,9 @@
 /// creates the implementation of the plugin.
 use {
     solana_clock::{Slot, UnixTimestamp},
+    solana_hash::Hash,
     solana_signature::Signature,
-    solana_transaction::sanitized::SanitizedTransaction,
+    solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
     std::{any::Any, error, io},
     thiserror::Error,
@@ -157,6 +158,26 @@ pub struct ReplicaTransactionInfoV2<'a> {
     pub index: usize,
 }
 
+/// Information about a transaction, including index in block
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaTransactionInfoV3<'a> {
+    /// The transaction message hash, used for identifying the transaction.
+    pub message_hash: &'a Hash,
+
+    /// Indicates if the transaction is a simple vote transaction.
+    pub is_vote: bool,
+
+    /// The versioned transaction.
+    pub transaction: &'a VersionedTransaction,
+
+    /// Metadata of the transaction status.
+    pub transaction_status_meta: &'a TransactionStatusMeta,
+
+    /// The transaction's index in the block
+    pub index: usize,
+}
+
 /// A wrapper to future-proof ReplicaTransactionInfo handling.
 /// If there were a change to the structure of ReplicaTransactionInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -165,6 +186,7 @@ pub struct ReplicaTransactionInfoV2<'a> {
 pub enum ReplicaTransactionInfoVersions<'a> {
     V0_0_1(&'a ReplicaTransactionInfo<'a>),
     V0_0_2(&'a ReplicaTransactionInfoV2<'a>),
+    V0_0_3(&'a ReplicaTransactionInfoV3<'a>),
 }
 
 #[derive(Clone, Debug)]

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -25,6 +25,7 @@ solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clock = { workspace = true }
 solana-entry = { workspace = true }
+solana-hash = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,15 +2,15 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV2, ReplicaTransactionInfoVersions,
+        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
     },
     log::*,
     solana_clock::Slot,
+    solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_metrics::*,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
-    solana_signature::Signature,
-    solana_transaction::sanitized::SanitizedTransaction,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta,
     std::sync::{Arc, RwLock},
 };
@@ -28,14 +28,16 @@ impl TransactionNotifier for TransactionNotifierImpl {
         &self,
         slot: Slot,
         index: usize,
-        signature: &Signature,
+        message_hash: &Hash,
+        is_vote: bool,
         transaction_status_meta: &TransactionStatusMeta,
-        transaction: &SanitizedTransaction,
+        transaction: &VersionedTransaction,
     ) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
         let transaction_log_info = Self::build_replica_transaction_info(
             index,
-            signature,
+            message_hash,
+            is_vote,
             transaction_status_meta,
             transaction,
         );
@@ -51,7 +53,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
                 continue;
             }
             match plugin.notify_transaction(
-                ReplicaTransactionInfoVersions::V0_0_2(&transaction_log_info),
+                ReplicaTransactionInfoVersions::V0_0_3(&transaction_log_info),
                 slot,
             ) {
                 Err(err) => {
@@ -86,14 +88,15 @@ impl TransactionNotifierImpl {
 
     fn build_replica_transaction_info<'a>(
         index: usize,
-        signature: &'a Signature,
+        message_hash: &'a Hash,
+        is_vote: bool,
         transaction_status_meta: &'a TransactionStatusMeta,
-        transaction: &'a SanitizedTransaction,
-    ) -> ReplicaTransactionInfoV2<'a> {
-        ReplicaTransactionInfoV2 {
+        transaction: &'a VersionedTransaction,
+    ) -> ReplicaTransactionInfoV3<'a> {
+        ReplicaTransactionInfoV3 {
             index,
-            signature,
-            is_vote: transaction.is_simple_vote_transaction(),
+            message_hash,
+            is_vote,
             transaction,
             transaction_status_meta,
         }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -10,6 +10,7 @@ use {
     solana_measure::measure::Measure,
     solana_metrics::*,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
+    solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta,
     std::sync::{Arc, RwLock},
@@ -28,6 +29,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
         &self,
         slot: Slot,
         index: usize,
+        signature: &Signature,
         message_hash: &Hash,
         is_vote: bool,
         transaction_status_meta: &TransactionStatusMeta,
@@ -36,6 +38,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
         let transaction_log_info = Self::build_replica_transaction_info(
             index,
+            signature,
             message_hash,
             is_vote,
             transaction_status_meta,
@@ -88,6 +91,7 @@ impl TransactionNotifierImpl {
 
     fn build_replica_transaction_info<'a>(
         index: usize,
+        signature: &'a Signature,
         message_hash: &'a Hash,
         is_vote: bool,
         transaction_status_meta: &'a TransactionStatusMeta,
@@ -96,6 +100,7 @@ impl TransactionNotifierImpl {
         ReplicaTransactionInfoV3 {
             index,
             message_hash,
+            signature,
             is_vote,
             transaction,
             transaction_status_meta,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -89,6 +89,7 @@ version = "3.0.0"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-hash",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",
@@ -6516,6 +6517,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
+ "solana-hash",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,5 +1,6 @@
 use {
-    solana_clock::Slot, solana_hash::Hash, solana_transaction::versioned::VersionedTransaction,
+    solana_clock::Slot, solana_hash::Hash, solana_signature::Signature,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
 };
 
@@ -8,6 +9,7 @@ pub trait TransactionNotifier {
         &self,
         slot: Slot,
         transaction_slot_index: usize,
+        signature: &Signature,
         message_hash: &Hash,
         is_vote: bool,
         transaction_status_meta: &TransactionStatusMeta,

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,6 +1,5 @@
 use {
-    solana_clock::Slot, solana_signature::Signature,
-    solana_transaction::sanitized::SanitizedTransaction,
+    solana_clock::Slot, solana_hash::Hash, solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
 };
 
@@ -9,9 +8,10 @@ pub trait TransactionNotifier {
         &self,
         slot: Slot,
         transaction_slot_index: usize,
-        signature: &Signature,
+        message_hash: &Hash,
+        is_vote: bool,
         transaction_status_meta: &TransactionStatusMeta,
-        transaction: &SanitizedTransaction,
+        transaction: &VersionedTransaction,
     );
 }
 

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -207,10 +207,12 @@ impl TransactionStatusService {
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
                         let is_vote = transaction.is_simple_vote_transaction();
                         let message_hash = transaction.message_hash();
+                        let signature = transaction.signature();
                         let transaction = transaction.to_versioned_transaction();
                         transaction_notifier.notify_transaction(
                             slot,
                             transaction_index,
+                            signature,
                             message_hash,
                             is_vote,
                             &transaction_status_meta,
@@ -346,6 +348,7 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_rent_debits::RentDebits,
         solana_runtime::bank::{Bank, TransactionBalancesSet},
+        solana_signature::Signature,
         solana_signer::Signer,
         solana_svm::transaction_execution_result::TransactionLoadedAccountsStats,
         solana_system_transaction as system_transaction,
@@ -390,6 +393,7 @@ pub(crate) mod tests {
             &self,
             slot: Slot,
             transaction_index: usize,
+            _signature: &Signature,
             message_hash: &Hash,
             _is_vote: bool,
             transaction_status_meta: &TransactionStatusMeta,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -205,10 +205,14 @@ impl TransactionStatusService {
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
+                        let is_vote = transaction.is_simple_vote_transaction();
+                        let message_hash = transaction.message_hash();
+                        let transaction = transaction.to_versioned_transaction();
                         transaction_notifier.notify_transaction(
                             slot,
                             transaction_index,
-                            transaction.signature(),
+                            message_hash,
+                            is_vote,
                             &transaction_status_meta,
                             &transaction,
                         );
@@ -342,7 +346,6 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_rent_debits::RentDebits,
         solana_runtime::bank::{Bank, TransactionBalancesSet},
-        solana_signature::Signature,
         solana_signer::Signer,
         solana_svm::transaction_execution_result::TransactionLoadedAccountsStats,
         solana_system_transaction as system_transaction,
@@ -362,12 +365,12 @@ pub(crate) mod tests {
     struct TestNotifierKey {
         slot: Slot,
         transaction_index: usize,
-        signature: Signature,
+        message_hash: Hash,
     }
 
     struct TestNotification {
         _meta: TransactionStatusMeta,
-        transaction: SanitizedTransaction,
+        transaction: VersionedTransaction,
     }
 
     struct TestTransactionNotifier {
@@ -387,15 +390,16 @@ pub(crate) mod tests {
             &self,
             slot: Slot,
             transaction_index: usize,
-            signature: &Signature,
+            message_hash: &Hash,
+            _is_vote: bool,
             transaction_status_meta: &TransactionStatusMeta,
-            transaction: &SanitizedTransaction,
+            transaction: &VersionedTransaction,
         ) {
             self.notifications.insert(
                 TestNotifierKey {
                     slot,
                     transaction_index,
-                    signature: *signature,
+                    message_hash: *message_hash,
                 },
                 TestNotification {
                     _meta: transaction_status_meta.clone(),
@@ -495,7 +499,7 @@ pub(crate) mod tests {
         };
 
         let slot = bank.slot();
-        let signature = *transaction.signature();
+        let message_hash = *transaction.message_hash();
         let transaction_index: usize = bank.transaction_count().try_into().unwrap();
         let transaction_status_batch = TransactionStatusBatch {
             slot,
@@ -529,14 +533,14 @@ pub(crate) mod tests {
         let key = TestNotifierKey {
             slot,
             transaction_index,
-            signature,
+            message_hash,
         };
         assert!(test_notifier.notifications.contains_key(&key));
 
         let result = test_notifier.notifications.get(&key).unwrap();
         assert_eq!(
             expected_transaction.signature(),
-            result.transaction.signature()
+            result.transaction.signatures.first().unwrap()
         );
     }
 
@@ -633,12 +637,12 @@ pub(crate) mod tests {
         let key1 = TestNotifierKey {
             slot,
             transaction_index: transaction_index1,
-            signature: *expected_transaction1.signature(),
+            message_hash: *expected_transaction1.message_hash(),
         };
         let key2 = TestNotifierKey {
             slot,
             transaction_index: transaction_index2,
-            signature: *expected_transaction2.signature(),
+            message_hash: *expected_transaction2.message_hash(),
         };
 
         assert!(test_notifier.notifications.contains_key(&key1));
@@ -649,20 +653,19 @@ pub(crate) mod tests {
 
         assert_eq!(
             expected_transaction1.signature(),
-            result1.transaction.signature()
+            result1.transaction.signatures.first().unwrap()
         );
         assert_eq!(
             expected_transaction1.message_hash(),
-            result1.transaction.message_hash()
+            &result1.transaction.message.hash(),
         );
-
         assert_eq!(
             expected_transaction2.signature(),
-            result2.transaction.signature()
+            result2.transaction.signatures.first().unwrap()
         );
         assert_eq!(
             expected_transaction2.message_hash(),
-            result2.transaction.message_hash()
+            &result2.transaction.message.hash(),
         );
     }
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -89,6 +89,7 @@ version = "3.0.0"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-hash",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",
@@ -6328,6 +6329,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
+ "solana-hash",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",


### PR DESCRIPTION
#### Problem
`SanitizedTransaction` is a runtime type that should have never been exposed to end users via sdk or geyser. Also, in order to implement [SIMD-0192](https://github.com/solana-foundation/solana-improvement-documents/pull/192), we will need to be able to commit transactions which cannot be represented as `SanitizedTransaction`'s due to address lookup failures.

#### Summary of Changes
Introduce a new version (v3) of geyser transaction info using `VersionedTransaction` instead of `SanitizedTransaction`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
