### PR TITLE
deprecate `--gossip-host` in favor of `--bind-address`

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -28,6 +28,9 @@ while [[ -n $1 ]]; do
     if [[ $1 = --init-complete-file ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --bind-address ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -28,9 +28,6 @@ while [[ -n $1 ]]; do
     if [[ $1 = --init-complete-file ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --gossip-host ]]; then
-      args+=("$1" "$2")
-      shift 2
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -271,7 +271,6 @@ EOF
       fi
     fi
     args=(
-      --gossip-host "$entrypointIp"
       --gossip-port 8001
       --init-complete-file "$initCompleteFile"
     )

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -271,6 +271,7 @@ EOF
       fi
     fi
     args=(
+      --bind-address "$entrypointIp"
       --gossip-port 8001
       --init-complete-file "$initCompleteFile"
     )

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -158,12 +158,6 @@ fn main() {
     let faucet_port = value_t_or_exit!(matches, "faucet_port", u16);
     let ticks_per_slot = value_t!(matches, "ticks_per_slot", u64).ok();
     let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
-    let gossip_host = matches.value_of("gossip_host").map(|gossip_host| {
-        solana_net_utils::parse_host(gossip_host).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --gossip-host: {err}");
-            exit(1);
-        })
-    });
     let gossip_port = value_t!(matches, "gossip_port", u16).ok();
     let dynamic_port_range = matches.value_of("dynamic_port_range").map(|port_range| {
         solana_net_utils::parse_port_range(port_range).unwrap_or_else(|| {
@@ -171,15 +165,21 @@ fn main() {
             exit(1);
         })
     });
-    let bind_address = solana_net_utils::parse_host(
-        matches
-            .value_of("bind_address")
-            .expect("Bind address has default value"),
-    )
-    .unwrap_or_else(|err| {
-        eprintln!("Failed to parse --bind-address: {err}");
-        exit(1);
-    });
+    let bind_address = if let Some(addr) = matches.value_of("bind_address") {
+        solana_net_utils::parse_host(addr).unwrap_or_else(|err| {
+            eprintln!("Failed to parse --bind-address: {err}");
+            exit(1);
+        })
+    } else if let Some(addr) = matches.value_of("gossip_host") {
+        warn!("--gossip-host is deprecated. Use --bind-address instead.");
+        solana_net_utils::parse_host(addr).unwrap_or_else(|err| {
+            eprintln!("Failed to parse --gossip-host: {err}");
+            exit(1);
+        })
+    } else {
+        // fallback if neither is specified
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    };
     let compute_unit_limit = value_t!(matches, "compute_unit_limit", u64).ok();
 
     let faucet_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), faucet_port);
@@ -559,9 +559,7 @@ fn main() {
         genesis.rent = Rent::with_slots_per_epoch(slots_per_epoch);
     }
 
-    if let Some(gossip_host) = gossip_host {
-        genesis.gossip_host(gossip_host);
-    }
+    genesis.gossip_host(bind_address);
 
     if let Some(gossip_port) = gossip_port {
         genesis.gossip_port(gossip_port);

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -158,6 +158,13 @@ fn main() {
     let faucet_port = value_t_or_exit!(matches, "faucet_port", u16);
     let ticks_per_slot = value_t!(matches, "ticks_per_slot", u64).ok();
     let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
+    let gossip_host = matches.value_of("gossip_host").map(|gossip_host| {
+        warn!("--gossip-host is deprecated. Use --bind-address instead.");
+        solana_net_utils::parse_host(gossip_host).unwrap_or_else(|err| {
+            eprintln!("Failed to parse --gossip-host: {err}");
+            exit(1);
+        })
+    });
     let gossip_port = value_t!(matches, "gossip_port", u16).ok();
     let dynamic_port_range = matches.value_of("dynamic_port_range").map(|port_range| {
         solana_net_utils::parse_port_range(port_range).unwrap_or_else(|| {
@@ -165,21 +172,24 @@ fn main() {
             exit(1);
         })
     });
-    let bind_address = if let Some(addr) = matches.value_of("bind_address") {
-        solana_net_utils::parse_host(addr).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --bind-address: {err}");
-            exit(1);
-        })
-    } else if let Some(addr) = matches.value_of("gossip_host") {
-        warn!("--gossip-host is deprecated. Use --bind-address instead.");
-        solana_net_utils::parse_host(addr).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --gossip-host: {err}");
-            exit(1);
-        })
+    let bind_address = solana_net_utils::parse_host(
+        matches
+            .value_of("bind_address")
+            .expect("Bind address has default value"),
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to parse --bind-address: {err}");
+        exit(1);
+    });
+
+    let advertised_ip = if let Some(ip) = gossip_host {
+        ip
+    } else if !bind_address.is_unspecified() && !bind_address.is_loopback() {
+        bind_address
     } else {
-        // fallback if neither is specified
         IpAddr::V4(Ipv4Addr::LOCALHOST)
     };
+
     let compute_unit_limit = value_t!(matches, "compute_unit_limit", u64).ok();
 
     let faucet_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), faucet_port);
@@ -559,7 +569,7 @@ fn main() {
         genesis.rent = Rent::with_slots_per_epoch(slots_per_epoch);
     }
 
-    genesis.gossip_host(bind_address);
+    genesis.gossip_host(advertised_ip);
 
     if let Some(gossip_port) = gossip_port {
         genesis.gossip_port(gossip_port);

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -844,10 +844,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .help(
-                    "Gossip DNS name or IP address for the validator to advertise in gossip \
-                     [default: 127.0.0.1]",
-                ),
+                .hidden(hidden_unless_forced())
+                .help("DEPRECATED: Use --bind-address instead."),
         )
         .arg(
             Arg::with_name("dynamic_port_range")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -350,10 +350,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("HOST")
             .takes_value(true)
             .validator(solana_net_utils::is_host)
-            .help(
-                "Gossip DNS name or IP address for the validator to advertise in gossip \
-                 [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]",
-            ),
+            .hidden(hidden_unless_forced())
+            .help("DEPRECATED: Use --bind-address instead."),
     )
     .arg(
         Arg::with_name("public_tpu_addr")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1112,13 +1112,11 @@ pub fn execute(
     let gossip_host = matches
         .value_of("gossip_host")
         .map(|gossip_host| {
+            warn!("--gossip-host is deprecated. Use --bind-address or rely on automatic public IP discovery instead.");
             solana_net_utils::parse_host(gossip_host)
                 .map_err(|err| format!("failed to parse --gossip-host: {err}"))
         })
         .transpose()?;
-    if gossip_host.is_some() {
-        warn!("--gossip-host is deprecated. Use --bind-address or rely on automatic public IP discovery instead.");
-    }
 
     let advertised_ip = if let Some(ip) = gossip_host {
         ip

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1109,45 +1109,51 @@ pub fn execute(
         },
     );
 
-    let gossip_host: IpAddr = matches
+    let gossip_host = matches
         .value_of("gossip_host")
         .map(|gossip_host| {
             solana_net_utils::parse_host(gossip_host)
                 .map_err(|err| format!("failed to parse --gossip-host: {err}"))
         })
-        .transpose()?
-        .or_else(|| {
-            if !entrypoint_addrs.is_empty() {
-                let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
-                order.shuffle(&mut thread_rng());
-                // Return once we determine our IP from an entrypoint
-                order.into_iter().find_map(|i| {
-                    let entrypoint_addr = &entrypoint_addrs[i];
-                    info!(
-                        "Contacting {} to determine the validator's public IP address",
-                        entrypoint_addr
-                    );
-                    solana_net_utils::get_public_ip_addr_with_binding(entrypoint_addr, bind_address)
-                        .map_or_else(
-                            |err| {
-                                warn!(
-                                    "Failed to contact cluster entrypoint {entrypoint_addr}: {err}"
-                                );
-                                None
-                            },
-                            Some,
-                        )
-                })
-            } else {
-                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
-            }
-        })
-        .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?;
+        .transpose()?;
+    if gossip_host.is_some() {
+        warn!("--gossip-host is deprecated. Use --bind-address or rely on automatic public IP discovery instead.");
+    }
+
+    let advertised_ip = if let Some(ip) = gossip_host {
+        ip
+    } else if !bind_address.is_unspecified() && !bind_address.is_loopback() {
+        bind_address
+    } else if !entrypoint_addrs.is_empty() {
+        let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
+        order.shuffle(&mut thread_rng());
+
+        order
+            .into_iter()
+            .find_map(|i| {
+                let entrypoint_addr = &entrypoint_addrs[i];
+                info!(
+                    "Contacting {} to determine the validator's public IP address",
+                    entrypoint_addr
+                );
+                solana_net_utils::get_public_ip_addr_with_binding(entrypoint_addr, bind_address)
+                    .map_or_else(
+                        |err| {
+                            warn!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
+                            None
+                        },
+                        Some,
+                    )
+            })
+            .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?
+    } else {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    };
     let gossip_port = value_t!(matches, "gossip_port", u16).or_else(|_| {
         solana_net_utils::find_available_port_in_range(bind_address, (0, 1))
             .map_err(|err| format!("unable to find an available gossip port: {err}"))
     })?;
-    let gossip_addr = SocketAddr::new(gossip_host, gossip_port);
+    let gossip_addr = SocketAddr::new(advertised_ip, gossip_port);
 
     let public_tpu_addr = matches
         .value_of("public_tpu_addr")


### PR DESCRIPTION
#### Problem
`--gossip-host` isn't actually used for anything and just causes confusion when running a gossip spy and full validator.

`--gossip-host` is constantly misused. Those running a validator behind a NAT may want to use this, but NATing a validator would incur significant performance degradation. It's unclear if anyone does this anyway.



#### Summary of Changes
Replace `--gossip-host` with the already present `--bind-address`