### PR TITLE
geyser: update to ReplicaAccountInfoV4

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -110,6 +110,51 @@ pub struct ReplicaAccountInfoV3<'a> {
     pub txn: Option<&'a SanitizedTransaction>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Updater of the account, which can be either a transaction or the runtime.
+pub enum ReplicaAccountUpdater<'a> {
+    Runtime,
+    Transaction {
+        message_hash: &'a Hash,
+        signature: &'a Signature,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Information about an account being updated
+pub struct ReplicaAccountInfoV4<'a> {
+    /// The Pubkey for the account
+    pub pubkey: &'a [u8],
+
+    /// The lamports for the account
+    pub lamports: u64,
+
+    /// The Pubkey of the owner program account
+    pub owner: &'a [u8],
+
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: u64,
+
+    /// The data held in this account.
+    pub data: &'a [u8],
+
+    /// A global monotonically increasing atomic number, which can be used
+    /// to tell the order of the account update. For example, when an
+    /// account is updated in the same slot multiple times, the update
+    /// with higher write_version should supersede the one with lower
+    /// write_version.
+    pub write_version: u64,
+
+    /// The updater of the account, which can be either a transaction or the
+    /// runtime.
+    pub updater: ReplicaAccountUpdater<'a>,
+}
+
 /// A wrapper to future-proof ReplicaAccountInfo handling.
 /// If there were a change to the structure of ReplicaAccountInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -119,6 +164,7 @@ pub enum ReplicaAccountInfoVersions<'a> {
     V0_0_1(&'a ReplicaAccountInfo<'a>),
     V0_0_2(&'a ReplicaAccountInfoV2<'a>),
     V0_0_3(&'a ReplicaAccountInfoV3<'a>),
+    V0_0_4(&'a ReplicaAccountInfoV4<'a>),
 }
 
 /// Information about a transaction

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -118,6 +118,7 @@ pub enum ReplicaAccountUpdater<'a> {
     Transaction {
         message_hash: &'a Hash,
         signature: &'a Signature,
+        is_simple_vote: bool,
     },
 }
 

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -134,6 +134,7 @@ impl AccountsUpdateNotifierImpl {
                 Some(txn) => ReplicaAccountUpdater::Transaction {
                     signature: txn.signature(),
                     message_hash: txn.message_hash(),
+                    is_simple_vote: txn.is_simple_vote_transaction(),
                 },
                 None => ReplicaAccountUpdater::Runtime,
             },


### PR DESCRIPTION
#### Problem
`SanitizedTransaction` is a runtime type that should have never been exposed to end users via sdk or geyser. Also, in order to implement https://github.com/solana-foundation/solana-improvement-documents/pull/192, accounts will be able to be updated (specifically fee payer and nonce accounts) by transactions which cannot be represented as SanitizedTransaction's due to address lookup failures.

#### Summary of Changes
Effectively revert https://github.com/solana-labs/solana/pull/30189 by removing the transaction reference from account updates. Instead, provide the transaction message hash and signature and make the consumer lookup the transaction OR have them subscribe to transactions updates with pre/post account recording enabled (https://github.com/anza-xyz/agave/pull/5114)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
