### PR TITLE
accounts-db: refactor store_cached method

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -623,7 +623,7 @@ impl Accounts {
     }
 
     pub fn store_accounts_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {
-        self.accounts_db.store_cached(accounts, None)
+        self.accounts_db.store_cached(accounts)
     }
 
     /// Add a slot to root.  Root slots cannot be purged

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7556,15 +7556,11 @@ impl AccountsDb {
             .fetch_add(measure.as_us(), Ordering::Relaxed);
     }
 
-    pub fn store_cached<'a>(
-        &self,
-        accounts: impl StorableAccounts<'a>,
-        transactions: Option<&'a [&'a SanitizedTransaction]>,
-    ) {
+    pub fn store_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {
         self.store(
             accounts,
             &StoreTo::Cache,
-            transactions,
+            None,
             StoreReclaims::Default,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -271,24 +271,24 @@ pub mod tests {
         let account1 =
             AccountSharedData::new(account1_lamports1, 1, AccountSharedData::default().owner());
         let slot0 = 0;
-        accounts.store_cached((slot0, &[(&key1, &account1)][..]), None);
+        accounts.store_cached((slot0, &[(&key1, &account1)][..]));
 
         let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_cached((slot0, &[(&key2, &account2)][..]), None);
+        accounts.store_cached((slot0, &[(&key2, &account2)][..]));
 
         let account1_lamports2 = 2;
         let slot1 = 1;
         let account1 = AccountSharedData::new(account1_lamports2, 1, account1.owner());
-        accounts.store_cached((slot1, &[(&key1, &account1)][..]), None);
+        accounts.store_cached((slot1, &[(&key1, &account1)][..]));
 
         let key3 = solana_pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_cached((slot1, &[(&key3, &account3)][..]), None);
+        accounts.store_cached((slot1, &[(&key3, &account3)][..]));
 
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 2);
         assert_eq!(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -841,7 +841,7 @@ fn run_test_remove_unrooted_slot(is_cached: bool, db: AccountsDb) {
     let ancestors = vec![(unrooted_slot, 1)].into_iter().collect();
     assert!(!db.accounts_index.contains(&key));
     if is_cached {
-        db.store_cached((unrooted_slot, &[(&key, &account0)][..]), None);
+        db.store_cached((unrooted_slot, &[(&key, &account0)][..]));
     } else {
         db.store_for_tests(unrooted_slot, &[(&key, &account0)]);
     }
@@ -2265,7 +2265,7 @@ fn test_verify_accounts_hash_bad_account_hash() {
     db.update_accounts_hash_for_tests(some_slot, &ancestors, false, false);
 
     // provide bogus account hashes
-    db.store_cached((some_slot, accounts), None);
+    db.store_cached((some_slot, accounts));
     db.add_root_and_flush_write_cache(some_slot);
 
     let epoch_schedule = EpochSchedule::default();
@@ -3075,13 +3075,13 @@ fn test_store_clean_after_shrink() {
 
     let account = AccountSharedData::new(1, 16 * 4096, &Pubkey::default());
     let pubkey1 = solana_pubkey::new_rand();
-    accounts.store_cached((0, &[(&pubkey1, &account)][..]), None);
+    accounts.store_cached((0, &[(&pubkey1, &account)][..]));
 
     let pubkey2 = solana_pubkey::new_rand();
-    accounts.store_cached((0, &[(&pubkey2, &account)][..]), None);
+    accounts.store_cached((0, &[(&pubkey2, &account)][..]));
 
     let zero_account = AccountSharedData::new(0, 1, &Pubkey::default());
-    accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]), None);
+    accounts.store_cached((1, &[(&pubkey1, &zero_account)][..]));
 
     // Add root 0 and flush separately
     accounts.calculate_accounts_delta_hash(0);
@@ -3193,7 +3193,7 @@ fn test_store_load_cached() {
     let key = Pubkey::default();
     let account0 = AccountSharedData::new(1, 0, &key);
     let slot = 0;
-    db.store_cached((slot, &[(&key, &account0)][..]), None);
+    db.store_cached((slot, &[(&key, &account0)][..]));
 
     // Load with no ancestors and no root will return nothing
     assert!(db
@@ -3225,7 +3225,7 @@ fn test_store_flush_load_cached() {
     let key = Pubkey::default();
     let account0 = AccountSharedData::new(1, 0, &key);
     let slot = 0;
-    db.store_cached((slot, &[(&key, &account0)][..]), None);
+    db.store_cached((slot, &[(&key, &account0)][..]));
     db.mark_slot_frozen(slot);
 
     // No root was added yet, requires an ancestor to find
@@ -3257,9 +3257,9 @@ fn test_flush_accounts_cache() {
     let unrooted_key = solana_pubkey::new_rand();
     let key5 = solana_pubkey::new_rand();
     let key6 = solana_pubkey::new_rand();
-    db.store_cached((unrooted_slot, &[(&unrooted_key, &account0)][..]), None);
-    db.store_cached((root5, &[(&key5, &account0)][..]), None);
-    db.store_cached((root6, &[(&key6, &account0)][..]), None);
+    db.store_cached((unrooted_slot, &[(&unrooted_key, &account0)][..]));
+    db.store_cached((root5, &[(&key5, &account0)][..]));
+    db.store_cached((root6, &[(&key6, &account0)][..]));
     for slot in &[unrooted_slot, root5, root6] {
         db.mark_slot_frozen(*slot);
     }
@@ -3318,7 +3318,7 @@ fn run_test_flush_accounts_cache_if_needed(num_roots: usize, num_unrooted: usize
     let num_slots = 2 * max_cache_slots();
     for i in 0..num_roots + num_unrooted {
         let key = Pubkey::new_unique();
-        db.store_cached((i as Slot, &[(&key, &account0)][..]), None);
+        db.store_cached((i as Slot, &[(&key, &account0)][..]));
         keys.push(key);
         db.mark_slot_frozen(i as Slot);
         if i < num_roots {
@@ -3371,8 +3371,8 @@ fn test_read_only_accounts_cache() {
     let account_key = Pubkey::new_unique();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-    db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]));
+    db.store_cached((1, &[(&account_key, &slot1_account)][..]));
 
     db.add_root(0);
     db.add_root(1);
@@ -3394,7 +3394,7 @@ fn test_read_only_accounts_cache() {
         .unwrap();
     assert_eq!(account.lamports(), 1);
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
-    db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+    db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]));
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     let account = db
         .load_with_fixed_root(&Ancestors::default(), &account_key)
@@ -3410,8 +3410,8 @@ fn test_load_with_read_only_accounts_cache() {
     let account_key = Pubkey::new_unique();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-    db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]));
+    db.store_cached((1, &[(&account_key, &slot1_account)][..]));
 
     db.add_root(0);
     db.add_root(1);
@@ -3435,7 +3435,7 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     assert_eq!(slot, 1);
 
-    db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]), None);
+    db.store_cached((2, &[(&account_key, &zero_lamport_account)][..]));
     let account = db.load_account_with(&Ancestors::default(), &account_key, |_| false);
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
@@ -3447,7 +3447,7 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
-    db.store_cached((2, &[(&account_key, &slot2_account)][..]), None);
+    db.store_cached((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
         .load_account_with(&Ancestors::default(), &account_key, |_| false)
         .unwrap();
@@ -3456,7 +3456,7 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(slot, 2);
 
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
-    db.store_cached((2, &[(&account_key, &slot2_account)][..]), None);
+    db.store_cached((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
         .load_account_with(&Ancestors::default(), &account_key, |_| true)
         .unwrap();
@@ -3485,10 +3485,10 @@ fn test_account_matches_owners() {
     let account4_key = Pubkey::new_unique();
     let account4 = AccountSharedData::new(0, 1, &owners[1]);
 
-    db.store_cached((0, &[(&account1_key, &account1)][..]), None);
-    db.store_cached((1, &[(&account2_key, &account2)][..]), None);
-    db.store_cached((2, &[(&account3_key, &account3)][..]), None);
-    db.store_cached((3, &[(&account4_key, &account4)][..]), None);
+    db.store_cached((0, &[(&account1_key, &account1)][..]));
+    db.store_cached((1, &[(&account2_key, &account2)][..]));
+    db.store_cached((2, &[(&account3_key, &account3)][..]));
+    db.store_cached((3, &[(&account4_key, &account4)][..]));
 
     db.add_root(0);
     db.add_root(1);
@@ -3570,8 +3570,8 @@ fn test_flush_cache_clean() {
     let account_key = Pubkey::new_unique();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     let slot1_account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-    db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]));
+    db.store_cached((1, &[(&account_key, &slot1_account)][..]));
 
     db.add_root(0);
     db.add_root(1);
@@ -3619,22 +3619,16 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0, and then flush the slot to storage
-    db.store_cached(
-        (0, &[(&zero_lamport_account_key, &slot0_account)][..]),
-        None,
-    );
+    db.store_cached((0, &[(&zero_lamport_account_key, &slot0_account)][..]));
     // Second key keeps other lamport account entry for slot 0 alive,
     // preventing clean of the zero_lamport_account in slot 1.
-    db.store_cached((0, &[(&other_account_key, &slot0_account)][..]), None);
+    db.store_cached((0, &[(&other_account_key, &slot0_account)][..]));
     db.add_root(0);
     db.flush_accounts_cache(true, None);
     assert!(db.storage.get_slot_storage_entry(0).is_some());
 
     // Store into slot 1, a dummy slot that will be dead and purged before flush
-    db.store_cached(
-        (1, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
-        None,
-    );
+    db.store_cached((1, &[(&zero_lamport_account_key, &zero_lamport_account)][..]));
 
     // Store into slot 2, which makes all updates from slot 1 outdated.
     // This means slot 1 is a dead slot. Later, slot 1 will be cleaned/purged
@@ -3642,10 +3636,7 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
     // the refcount of `zero_lamport_account_key` because cached keys do not bump
     // the refcount in the index. This means clean should *not* remove
     // `zero_lamport_account_key` from slot 2
-    db.store_cached(
-        (2, &[(&zero_lamport_account_key, &zero_lamport_account)][..]),
-        None,
-    );
+    db.store_cached((2, &[(&zero_lamport_account_key, &zero_lamport_account)][..]));
     db.add_root(1);
     db.add_root(2);
 
@@ -3697,7 +3688,7 @@ fn test_flush_cache_populates_uncleaned_pubkeys() {
     let account = AccountSharedData::new(10, 0, &Pubkey::default());
 
     // storing accounts doesn't add anything to uncleaned_pubkeys
-    accounts_db.store_cached((slot, [(pubkey, account)].as_slice()), None);
+    accounts_db.store_cached((slot, [(pubkey, account)].as_slice()));
     assert_eq!(accounts_db.get_len_of_slots_with_uncleaned_pubkeys(), 0);
 
     // ...but ensure that rooting and flushing the write cache does
@@ -3782,11 +3773,11 @@ fn test_scan_flush_accounts_cache_then_clean_drop() {
                             /        \
                           1            2 (root)
     */
-    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]), None);
-    db.store_cached((1, &[(&account_key, &slot1_account)][..]), None);
+    db.store_cached((0, &[(&account_key, &zero_lamport_account)][..]));
+    db.store_cached((1, &[(&account_key, &slot1_account)][..]));
     // Fodder for the scan so that the lock on `account_key` is not held
-    db.store_cached((1, &[(&account_key2, &slot1_account)][..]), None);
-    db.store_cached((2, &[(&account_key, &slot2_account)][..]), None);
+    db.store_cached((1, &[(&account_key2, &slot1_account)][..]));
+    db.store_cached((2, &[(&account_key, &slot2_account)][..]));
     db.calculate_accounts_delta_hash(0);
 
     let max_scan_root = 0;
@@ -3881,7 +3872,7 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
 
     for data_size in 0..num_keys {
         let account = AccountSharedData::new(1, data_size, &Pubkey::default());
-        accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]), None);
+        accounts_db.store_cached((slot, &[(&Pubkey::new_unique(), &account)][..]));
     }
 
     accounts_db.add_root(slot);
@@ -3929,7 +3920,7 @@ define_accounts_db_test!(
             let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
             let key = Pubkey::new_unique();
-            accounts_db.store_cached((slot, &[(&key, &zero_account)][..]), None);
+            accounts_db.store_cached((slot, &[(&key, &zero_account)][..]));
             pubkeys.push(key);
         }
 
@@ -4006,7 +3997,6 @@ fn setup_accounts_db_cache_clean(
                     &AccountSharedData::new(1, 0, &Pubkey::default()),
                 )][..],
             ),
-            None,
         );
     }
 
@@ -4015,13 +4005,10 @@ fn setup_accounts_db_cache_clean(
     for slot in &slots {
         for key in &keys[*slot as usize..] {
             let space = 1; // 1 byte allows us to track by size
-            accounts_db.store_cached(
-                (
-                    *slot,
-                    &[(key, &AccountSharedData::new(1, space, &Pubkey::default()))][..],
-                ),
-                None,
-            );
+            accounts_db.store_cached((
+                *slot,
+                &[(key, &AccountSharedData::new(1, space, &Pubkey::default()))][..],
+            ));
         }
         accounts_db.add_root(*slot as Slot);
         if Some(*slot) == scan_slot {
@@ -4061,13 +4048,10 @@ fn test_accounts_db_cache_clean_dead_slots() {
     slots.push(alive_slot);
     for key in &keys {
         // Store a slot that overwrites all previous keys, rendering all previous keys dead
-        accounts_db.store_cached(
-            (
-                alive_slot,
-                &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))][..],
-            ),
-            None,
-        );
+        accounts_db.store_cached((
+            alive_slot,
+            &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))][..],
+        ));
         accounts_db.add_root(alive_slot);
     }
 
@@ -4375,7 +4359,7 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     }
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1
-    db.store_cached((1, &[(&account_key1, &account1)][..]), None);
+    db.store_cached((1, &[(&account_key1, &account1)][..]));
     db.add_root(1);
     // Flushes all roots
     db.flush_accounts_cache(true, None);
@@ -4393,7 +4377,7 @@ fn run_test_shrink_unref(do_intra_cache_clean: bool) {
     db.shrink_candidate_slots(&epoch_schedule);
 
     // Make slot 0 dead by updating the remaining key
-    db.store_cached((2, &[(&account_key2, &account1)][..]), None);
+    db.store_cached((2, &[(&account_key2, &account1)][..]));
     db.add_root(2);
 
     // Flushes all roots
@@ -4434,12 +4418,12 @@ fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
 
     // slot 0 - stored a 1-lamport account
     let slot = 0;
-    accounts_db.store_cached((slot, &[(&key1, &one_account)][..]), None);
+    accounts_db.store_cached((slot, &[(&key1, &one_account)][..]));
     accounts_db.add_root(slot);
 
     // slot 1 - store a 0 -lamport account
     let slot = 1;
-    accounts_db.store_cached((slot, &[(&key1, &zero_account)][..]), None);
+    accounts_db.store_cached((slot, &[(&key1, &zero_account)][..]));
     accounts_db.add_root(slot);
 
     accounts_db.flush_accounts_cache(true, None);
@@ -4469,8 +4453,8 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
     // And store one additional live account to make the store still alive after clean.
-    db.store_cached((1, &[(&account_key1, &account0)][..]), None);
-    db.store_cached((1, &[(&account_key2, &account1)][..]), None);
+    db.store_cached((1, &[(&account_key1, &account0)][..]));
+    db.store_cached((1, &[(&account_key2, &account1)][..]));
     db.add_root(1);
     // Flushes all roots
     db.flush_accounts_cache(true, None);
@@ -4512,7 +4496,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     db.add_root(0);
 
     // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
-    db.store_cached((1, &[(&account_key1, &account0)][..]), None);
+    db.store_cached((1, &[(&account_key1, &account0)][..]));
     db.add_root(1);
     // Flushes all roots
     db.flush_accounts_cache(true, None);
@@ -4544,7 +4528,7 @@ fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
     assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&1));
 
     // Now, make slot 0 dead by updating the remaining key
-    db.store_cached((2, &[(&account_key2, &account1)][..]), None);
+    db.store_cached((2, &[(&account_key2, &account1)][..]));
     db.add_root(2);
 
     // Flushes all roots
@@ -4678,16 +4662,13 @@ fn do_test_load_account_and_cache_flush_race(with_retry: bool) {
     let db = Arc::new(db);
     let pubkey = Arc::new(Pubkey::new_unique());
     let exit = Arc::new(AtomicBool::new(false));
-    db.store_cached(
-        (
-            0,
-            &[(
-                pubkey.as_ref(),
-                &AccountSharedData::new(1, 0, AccountSharedData::default().owner()),
-            )][..],
-        ),
-        None,
-    );
+    db.store_cached((
+        0,
+        &[(
+            pubkey.as_ref(),
+            &AccountSharedData::new(1, 0, AccountSharedData::default().owner()),
+        )][..],
+    ));
     db.add_root(0);
     db.flush_accounts_cache(true, None);
 
@@ -4705,7 +4686,7 @@ fn do_test_load_account_and_cache_flush_race(with_retry: bool) {
                         return;
                     }
                     account.set_lamports(slot + 1);
-                    db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]), None);
+                    db.store_cached((slot, &[(pubkey.as_ref(), &account)][..]));
                     db.add_root(slot);
                     sleep(Duration::from_millis(RACY_SLEEP_MS));
                     db.flush_accounts_cache(true, None);
@@ -4851,7 +4832,7 @@ fn test_cache_flush_delayed_remove_unrooted_race() {
     let num_trials = 10;
     for _ in 0..num_trials {
         let pubkey = Pubkey::new_unique();
-        db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+        db.store_cached((slot, &[(&pubkey, &account)][..]));
         // Wait for both threads to finish
         flush_trial_start_sender.send(()).unwrap();
         remove_trial_start_sender.send(()).unwrap();
@@ -4935,7 +4916,7 @@ fn test_cache_flush_remove_unrooted_race_multiple_slots() {
         let slot_to_pubkey_map: HashMap<Slot, Pubkey> = (0..num_cached_slots)
             .map(|slot| {
                 let pubkey = Pubkey::new_unique();
-                db.store_cached((slot, &[(&pubkey, &account)][..]), None);
+                db.store_cached((slot, &[(&pubkey, &account)][..]));
                 (slot, pubkey)
             })
             .collect();
@@ -5349,19 +5330,19 @@ define_accounts_db_test!(
 
         let slot1: Slot = 1;
         let account = AccountSharedData::new(111, space, &owner);
-        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot1, &[(&pubkey, &account)][..]));
         accounts_db.calculate_accounts_delta_hash(slot1);
         accounts_db.add_root_and_flush_write_cache(slot1);
 
         let slot2: Slot = 2;
         let account = AccountSharedData::new(222, space, &owner);
-        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot2, &[(&pubkey, &account)][..]));
         accounts_db.calculate_accounts_delta_hash(slot2);
         accounts_db.add_root_and_flush_write_cache(slot2);
 
         let slot3: Slot = 3;
         let account = AccountSharedData::new(0, space, &owner);
-        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]), None);
+        accounts_db.store_cached((slot3, &[(&pubkey, &account)][..]));
         accounts_db.calculate_accounts_delta_hash(slot3);
         accounts_db.add_root_and_flush_write_cache(slot3);
 
@@ -7085,7 +7066,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             (&accounts[2].0, &accounts[2].1),
             (&accounts[3].0, &accounts[3].1),
         ];
-        accounts_db.store_cached((slot, accounts.as_slice()), None);
+        accounts_db.store_cached((slot, accounts.as_slice()));
         accounts_db.add_root_and_flush_write_cache(slot);
     }
 
@@ -7102,7 +7083,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             (&accounts[1].0, &accounts[1].1),
             (&accounts[4].0, &accounts[4].1),
         ];
-        accounts_db.store_cached((slot, accounts.as_slice()), None);
+        accounts_db.store_cached((slot, accounts.as_slice()));
         accounts_db.add_root_and_flush_write_cache(slot);
     }
 
@@ -7146,7 +7127,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             (&accounts[5].0, &accounts[5].1),
             (&accounts[6].0, &accounts[6].1),
         ];
-        accounts_db.store_cached((slot, accounts.as_slice()), None);
+        accounts_db.store_cached((slot, accounts.as_slice()));
         accounts_db.add_root_and_flush_write_cache(slot);
     }
 
@@ -7167,7 +7148,7 @@ define_accounts_db_test!(test_calculate_incremental_accounts_hash, |accounts_db|
             (&accounts[5].0, &accounts[5].1),
             (&accounts[7].0, &accounts[7].1),
         ];
-        accounts_db.store_cached((slot, accounts.as_slice()), None);
+        accounts_db.store_cached((slot, accounts.as_slice()));
         accounts_db.add_root_and_flush_write_cache(slot);
     }
 

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -61,7 +61,7 @@ fn test_bad_bank_hash() {
             .iter()
             .map(|idx| (&accounts_keys[*idx].0, &accounts_keys[*idx].1))
             .collect();
-        db.store_cached((some_slot, &account_refs[..]), None);
+        db.store_cached((some_slot, &account_refs[..]));
         for pass in 0..2 {
             for (key, account) in &account_refs {
                 if pass == 1 {


### PR DESCRIPTION
#### Problem
`AccountsDb::store_cached` is always called with `None` for `transactions` and can be cleaned up

#### Summary of Changes
Remove extra parameter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
