### PR TITLE
[zk-sdk] Add `c_max_proof` to the sigma proof transcript and add features to disable and reenable zk elgamal proof program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11780,6 +11780,7 @@ dependencies = [
 name = "solana-zk-elgamal-proof-program"
 version = "3.0.0"
 dependencies = [
+ "agave-feature-set",
  "bytemuck",
  "criterion",
  "curve25519-dalek 4.1.3",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -155,6 +155,10 @@ impl FeatureSet {
             enable_extend_program_checked: self.is_active(&enable_extend_program_checked::id()),
             formalize_loaded_transaction_data_size: self
                 .is_active(&formalize_loaded_transaction_data_size::id()),
+            disable_zk_elgamal_proof_program: self
+                .is_active(&disable_zk_elgamal_proof_program::id()),
+            reenable_zk_elgamal_proof_program: self
+                .is_active(&reenable_zk_elgamal_proof_program::id()),
         }
     }
 }
@@ -1101,6 +1105,14 @@ pub mod formalize_loaded_transaction_data_size {
     solana_pubkey::declare_id!("DeS7sR48ZcFTUmt5FFEVDr1v1bh73aAbZiZq3SYr8Eh8");
 }
 
+pub mod disable_zk_elgamal_proof_program {
+    solana_pubkey::declare_id!("zkdoVwnSFnSLtGJG7irJPEYUpmb4i7sGMGcnN6T9rnC");
+}
+
+pub mod reenable_zk_elgamal_proof_program {
+    solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1337,6 +1349,8 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (enshrine_slashing_program::id(), "SIMD-0204: Slashable event verification"),
         (enable_extend_program_checked::id(), "Enable ExtendProgramChecked instruction"),
         (formalize_loaded_transaction_data_size::id(), "SIMD-0186: Loaded transaction data size specification"),
+        (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
+        (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9812,6 +9812,7 @@ dependencies = [
 name = "solana-zk-elgamal-proof-program"
 version = "3.0.0"
 dependencies = [
+ "agave-feature-set",
  "bytemuck",
  "num-derive",
  "num-traits",

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+agave-feature-set = { workspace = true }
 bytemuck = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -171,6 +171,20 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
 }
 
 declare_process_instruction!(Entrypoint, 0, |invoke_context| {
+    if invoke_context
+        .get_feature_set()
+        .disable_zk_elgamal_proof_program
+        && !invoke_context
+            .get_feature_set()
+            .reenable_zk_elgamal_proof_program
+    {
+        ic_msg!(
+            invoke_context,
+            "zk-elgamal-proof program is temporarily disabled"
+        );
+        return Err(InstructionError::InvalidInstructionData);
+    }
+
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -37,6 +37,8 @@ pub struct SVMFeatureSet {
     pub disable_rent_fees_collection: bool,
     pub enable_extend_program_checked: bool,
     pub formalize_loaded_transaction_data_size: bool,
+    pub disable_zk_elgamal_proof_program: bool,
+    pub reenable_zk_elgamal_proof_program: bool,
 }
 
 impl SVMFeatureSet {
@@ -79,6 +81,8 @@ impl SVMFeatureSet {
             disable_rent_fees_collection: true,
             enable_extend_program_checked: true,
             formalize_loaded_transaction_data_size: true,
+            disable_zk_elgamal_proof_program: true,
+            reenable_zk_elgamal_proof_program: true,
         }
     }
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8908,6 +8908,7 @@ dependencies = [
 name = "solana-zk-elgamal-proof-program"
 version = "3.0.0"
 dependencies = [
+ "agave-feature-set",
  "bytemuck",
  "num-derive",
  "num-traits",

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -389,6 +389,7 @@ impl PercentageWithCapProof {
         let c_equality = c - c_max_proof;
 
         transcript.append_scalar(b"z_max", &z_max);
+        transcript.append_scalar(b"c_max_proof", &c_max_proof);
         transcript.append_scalar(b"z_x", &z_x);
         transcript.append_scalar(b"z_delta_real", &z_delta_real);
         transcript.append_scalar(b"z_claimed", &z_claimed);


### PR DESCRIPTION
#### Problem
The `c_max_proof` component of the percentage with cap sigma proof is not hashed into the proof transcript.

#### Summary of Changes
Hash `c_max_proof` into the proof transcript and add feature gates to disable and reenable zk elgamal proof program.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
