### PR TITLE
add iter impl to rollback accounts

### DIFF
--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -83,7 +83,6 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                     collect_accounts_for_failed_tx(
                         &mut accounts,
                         &mut transactions,
-                        transaction,
                         transaction_ref,
                         &executed_tx.loaded_transaction.rollback_accounts,
                     );
@@ -93,7 +92,6 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                 collect_accounts_for_failed_tx(
                     &mut accounts,
                     &mut transactions,
-                    transaction,
                     transaction_ref,
                     &fees_only_tx.rollback_accounts,
                 );
@@ -131,44 +129,17 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     }
 }
 
-fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
+fn collect_accounts_for_failed_tx<'a>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
-    transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
     rollback_accounts: &'a RollbackAccounts,
 ) {
-    let fee_payer_address = transaction.fee_payer();
-    match rollback_accounts {
-        RollbackAccounts::FeePayerOnly { fee_payer_account } => {
-            collected_accounts.push((fee_payer_address, fee_payer_account));
-            if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions
-                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
-            }
-        }
-        RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-            collected_accounts.push((nonce.address(), nonce.account()));
-            if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions
-                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
-            }
-        }
-        RollbackAccounts::SeparateNonceAndFeePayer {
-            nonce,
-            fee_payer_account,
-        } => {
-            collected_accounts.push((fee_payer_address, fee_payer_account));
-            if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions
-                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
-            }
-
-            collected_accounts.push((nonce.address(), nonce.account()));
-            if let Some(collected_account_transactions) = collected_account_transactions {
-                collected_account_transactions
-                    .push(transaction_ref.expect("transaction ref must exist if collecting"));
-            }
+    for (address, account) in &rollback_accounts.accounts {
+        collected_accounts.push((address, account));
+        if let Some(collected_account_transactions) = collected_account_transactions {
+            collected_account_transactions
+                .push(transaction_ref.expect("transaction ref must exist if collecting"));
         }
     }
 }
@@ -193,7 +164,7 @@ mod tests {
         solana_signer::{signers::Signers, Signer},
         solana_svm::{
             account_loader::{FeesOnlyTransaction, LoadedTransaction},
-            nonce_info::NonceInfo,
+            rollback_accounts::RollbackAccountsKind,
             transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
         },
         solana_system_interface::{instruction as system_instruction, program as system_program},
@@ -345,8 +316,9 @@ mod tests {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts::FeePayerOnly {
-                fee_payer_account: from_account_pre.clone(),
+            rollback_accounts: RollbackAccounts {
+                kind: RollbackAccountsKind::FeePayerOnly,
+                accounts: vec![(from_address, from_account_pre.clone())],
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -432,14 +404,16 @@ mod tests {
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
-        let nonce = NonceInfo::new(nonce_address, nonce_account_pre.clone());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
-                nonce: nonce.clone(),
-                fee_payer_account: from_account_pre.clone(),
+            rollback_accounts: RollbackAccounts {
+                kind: RollbackAccountsKind::SeparateNonceAndFeePayer,
+                accounts: vec![
+                    (nonce_address, nonce_account_pre.clone()),
+                    (from_address, from_account_pre.clone()),
+                ],
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -539,13 +513,13 @@ mod tests {
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
 
-        let nonce = NonceInfo::new(nonce_address, nonce_account_pre.clone());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
-                nonce: nonce.clone(),
+            rollback_accounts: RollbackAccounts {
+                kind: RollbackAccountsKind::SameNonceAndFeePayer,
+                accounts: vec![(nonce_address, nonce_account_pre.clone())],
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -610,8 +584,9 @@ mod tests {
             FeesOnlyTransaction {
                 load_error: TransactionError::InvalidProgramForExecution,
                 fee_details: FeeDetails::default(),
-                rollback_accounts: RollbackAccounts::FeePayerOnly {
-                    fee_payer_account: from_account_pre.clone(),
+                rollback_accounts: RollbackAccounts {
+                    kind: RollbackAccountsKind::FeePayerOnly,
+                    accounts: vec![(from_address, from_account_pre.clone())],
                 },
             },
         )))];

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -135,7 +135,7 @@ fn collect_accounts_for_failed_tx<'a>(
     transaction_ref: Option<&'a SanitizedTransaction>,
     rollback_accounts: &'a RollbackAccounts,
 ) {
-    for (address, account) in &rollback_accounts.accounts {
+    for (address, account) in rollback_accounts {
         collected_accounts.push((address, account));
         if let Some(collected_account_transactions) = collected_account_transactions {
             collected_account_transactions
@@ -164,7 +164,6 @@ mod tests {
         solana_signer::{signers::Signers, Signer},
         solana_svm::{
             account_loader::{FeesOnlyTransaction, LoadedTransaction},
-            rollback_accounts::RollbackAccountsKind,
             transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
         },
         solana_system_interface::{instruction as system_instruction, program as system_program},
@@ -316,9 +315,8 @@ mod tests {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts {
-                kind: RollbackAccountsKind::FeePayerOnly,
-                accounts: vec![(from_address, from_account_pre.clone())],
+            rollback_accounts: RollbackAccounts::FeePayerOnly {
+                fee_payer: (from_address, from_account_pre.clone()),
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -408,12 +406,9 @@ mod tests {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts {
-                kind: RollbackAccountsKind::SeparateNonceAndFeePayer,
-                accounts: vec![
-                    (nonce_address, nonce_account_pre.clone()),
-                    (from_address, from_account_pre.clone()),
-                ],
+            rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
+                nonce: (nonce_address, nonce_account_pre.clone()),
+                fee_payer: (from_address, from_account_pre.clone()),
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -517,9 +512,8 @@ mod tests {
             accounts: transaction_accounts,
             program_indices: vec![],
             fee_details: FeeDetails::default(),
-            rollback_accounts: RollbackAccounts {
-                kind: RollbackAccountsKind::SameNonceAndFeePayer,
-                accounts: vec![(nonce_address, nonce_account_pre.clone())],
+            rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
+                nonce: (nonce_address, nonce_account_pre.clone()),
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -584,9 +578,8 @@ mod tests {
             FeesOnlyTransaction {
                 load_error: TransactionError::InvalidProgramForExecution,
                 fee_details: FeeDetails::default(),
-                rollback_accounts: RollbackAccounts {
-                    kind: RollbackAccountsKind::FeePayerOnly,
-                    accounts: vec![(from_address, from_account_pre.clone())],
+                rollback_accounts: RollbackAccounts::FeePayerOnly {
+                    fee_payer: (from_address, from_account_pre.clone()),
                 },
             },
         )))];

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -268,36 +268,15 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             );
         } else {
             self.update_accounts_for_failed_tx(
-                message,
                 &executed_transaction.loaded_transaction.rollback_accounts,
             );
         }
     }
 
-    pub(crate) fn update_accounts_for_failed_tx(
-        &mut self,
-        message: &impl SVMMessage,
-        rollback_accounts: &RollbackAccounts,
-    ) {
-        let fee_payer_address = message.fee_payer();
-        match rollback_accounts {
-            RollbackAccounts::FeePayerOnly { fee_payer_account } => {
-                self.loaded_accounts
-                    .insert(*fee_payer_address, fee_payer_account.clone());
-            }
-            RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                self.loaded_accounts
-                    .insert(*nonce.address(), nonce.account().clone());
-            }
-            RollbackAccounts::SeparateNonceAndFeePayer {
-                nonce,
-                fee_payer_account,
-            } => {
-                self.loaded_accounts
-                    .insert(*nonce.address(), nonce.account().clone());
-                self.loaded_accounts
-                    .insert(*fee_payer_address, fee_payer_account.clone());
-            }
+    pub(crate) fn update_accounts_for_failed_tx(&mut self, rollback_accounts: &RollbackAccounts) {
+        for (account_address, account) in &rollback_accounts.accounts {
+            self.loaded_accounts
+                .insert(*account_address, account.clone());
         }
     }
 
@@ -863,7 +842,10 @@ fn construct_instructions_account(message: &impl SVMMessage) -> AccountSharedDat
 mod tests {
     use {
         super::*,
-        crate::transaction_account_state_info::TransactionAccountStateInfo,
+        crate::{
+            rollback_accounts::RollbackAccountsKind,
+            transaction_account_state_info::TransactionAccountStateInfo,
+        },
         agave_reserved_account_keys::ReservedAccountKeys,
         rand0_7::prelude::*,
         solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -2776,14 +2758,6 @@ mod tests {
     #[test]
     fn test_account_loader_wrappers() {
         let fee_payer = Pubkey::new_unique();
-        let message = Message {
-            account_keys: vec![fee_payer],
-            header: MessageHeader::default(),
-            instructions: vec![],
-            recent_blockhash: Hash::default(),
-        };
-        let sanitized_message = new_unchecked_sanitized_message(message);
-
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_rent_epoch(u64::MAX);
         fee_payer_account.set_lamports(5000);
@@ -2853,10 +2827,10 @@ mod tests {
 
         // drop the account and ensure all deliver the updated state
         fee_payer_account.set_lamports(0);
-        account_loader.update_accounts_for_failed_tx(
-            &sanitized_message,
-            &RollbackAccounts::FeePayerOnly { fee_payer_account },
-        );
+        account_loader.update_accounts_for_failed_tx(&RollbackAccounts {
+            kind: RollbackAccountsKind::FeePayerOnly,
+            accounts: vec![(fee_payer, fee_payer_account)],
+        });
 
         assert_eq!(
             account_loader.load_transaction_account(&fee_payer, false),

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -274,7 +274,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     }
 
     pub(crate) fn update_accounts_for_failed_tx(&mut self, rollback_accounts: &RollbackAccounts) {
-        for (account_address, account) in &rollback_accounts.accounts {
+        for (account_address, account) in rollback_accounts {
             self.loaded_accounts
                 .insert(*account_address, account.clone());
         }
@@ -842,10 +842,7 @@ fn construct_instructions_account(message: &impl SVMMessage) -> AccountSharedDat
 mod tests {
     use {
         super::*,
-        crate::{
-            rollback_accounts::RollbackAccountsKind,
-            transaction_account_state_info::TransactionAccountStateInfo,
-        },
+        crate::transaction_account_state_info::TransactionAccountStateInfo,
         agave_reserved_account_keys::ReservedAccountKeys,
         rand0_7::prelude::*,
         solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -2827,9 +2824,8 @@ mod tests {
 
         // drop the account and ensure all deliver the updated state
         fee_payer_account.set_lamports(0);
-        account_loader.update_accounts_for_failed_tx(&RollbackAccounts {
-            kind: RollbackAccountsKind::FeePayerOnly,
-            accounts: vec![(fee_payer, fee_payer_account)],
+        account_loader.update_accounts_for_failed_tx(&RollbackAccounts::FeePayerOnly {
+            fee_payer: (fee_payer, fee_payer_account),
         });
 
         assert_eq!(

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -13,8 +13,8 @@ use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
 /// Holds limited nonce info available during transaction checks
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NonceInfo {
-    address: Pubkey,
-    account: AccountSharedData,
+    pub address: Pubkey,
+    pub account: AccountSharedData,
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -3,29 +3,30 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
+    solana_transaction_context::TransactionAccount,
 };
 
 /// Captured account state used to rollback account state for nonce and fee
 /// payer accounts after a failed executed transaction.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum RollbackAccounts {
-    FeePayerOnly {
-        fee_payer_account: AccountSharedData,
-    },
-    SameNonceAndFeePayer {
-        nonce: NonceInfo,
-    },
-    SeparateNonceAndFeePayer {
-        nonce: NonceInfo,
-        fee_payer_account: AccountSharedData,
-    },
+pub struct RollbackAccounts {
+    pub kind: RollbackAccountsKind,
+    pub accounts: Vec<TransactionAccount>,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum RollbackAccountsKind {
+    FeePayerOnly,
+    SameNonceAndFeePayer,
+    SeparateNonceAndFeePayer,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 impl Default for RollbackAccounts {
     fn default() -> Self {
-        Self::FeePayerOnly {
-            fee_payer_account: AccountSharedData::default(),
+        Self {
+            kind: RollbackAccountsKind::FeePayerOnly,
+            accounts: vec![(Pubkey::default(), AccountSharedData::default())],
         }
     }
 }
@@ -45,13 +46,17 @@ impl RollbackAccounts {
                 // so we capture both the data change for the nonce and the lamports/rent epoch change for the fee payer
                 fee_payer_account.set_data_from_slice(nonce.account().data());
 
-                RollbackAccounts::SameNonceAndFeePayer {
-                    nonce: NonceInfo::new(fee_payer_address, fee_payer_account),
+                RollbackAccounts {
+                    kind: RollbackAccountsKind::SameNonceAndFeePayer,
+                    accounts: vec![(fee_payer_address, fee_payer_account)],
                 }
             } else {
-                RollbackAccounts::SeparateNonceAndFeePayer {
-                    nonce,
-                    fee_payer_account,
+                RollbackAccounts {
+                    kind: RollbackAccountsKind::SeparateNonceAndFeePayer,
+                    accounts: vec![
+                        (nonce.address, nonce.account),
+                        (fee_payer_address, fee_payer_account),
+                    ],
                 }
             }
         } else {
@@ -62,32 +67,26 @@ impl RollbackAccounts {
             // alter this behavior such that rent epoch updates are handled the
             // same for both nonce and non-nonce failed transactions.
             fee_payer_account.set_rent_epoch(fee_payer_loaded_rent_epoch);
-            RollbackAccounts::FeePayerOnly { fee_payer_account }
+            RollbackAccounts {
+                kind: RollbackAccountsKind::FeePayerOnly,
+                accounts: vec![(fee_payer_address, fee_payer_account)],
+            }
         }
     }
 
     /// Number of accounts tracked for rollback
     pub fn count(&self) -> usize {
-        match self {
-            Self::FeePayerOnly { .. } | Self::SameNonceAndFeePayer { .. } => 1,
-            Self::SeparateNonceAndFeePayer { .. } => 2,
-        }
+        self.accounts.len()
     }
 
     /// Size of accounts tracked for rollback, used when calculating the actual
     /// cost of transaction processing in the cost model.
     pub fn data_size(&self) -> usize {
-        match self {
-            Self::FeePayerOnly { fee_payer_account } => fee_payer_account.data().len(),
-            Self::SameNonceAndFeePayer { nonce } => nonce.account().data().len(),
-            Self::SeparateNonceAndFeePayer {
-                nonce,
-                fee_payer_account,
-            } => fee_payer_account
-                .data()
-                .len()
-                .saturating_add(nonce.account().data().len()),
+        let mut total_size: usize = 0;
+        for (_, account) in &self.accounts {
+            total_size = total_size.saturating_add(account.data().len());
         }
+        total_size
     }
 }
 
@@ -124,13 +123,12 @@ mod tests {
             fee_payer_rent_epoch,
         );
 
-        let expected_fee_payer_account = fee_payer_account;
-        match rollback_accounts {
-            RollbackAccounts::FeePayerOnly { fee_payer_account } => {
-                assert_eq!(expected_fee_payer_account, fee_payer_account);
-            }
-            _ => panic!("Expected FeePayerOnly variant"),
-        }
+        let expected_rollback_accounts = RollbackAccounts {
+            kind: RollbackAccountsKind::FeePayerOnly,
+            accounts: vec![(fee_payer_address, fee_payer_account)],
+        };
+
+        assert_eq!(expected_rollback_accounts, rollback_accounts);
     }
 
     #[test]
@@ -163,13 +161,12 @@ mod tests {
             u64::MAX, // ignored
         );
 
-        match rollback_accounts {
-            RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                assert_eq!(nonce.address(), &nonce_address);
-                assert_eq!(nonce.account(), &nonce_account);
-            }
-            _ => panic!("Expected SameNonceAndFeePayer variant"),
-        }
+        let expected_rollback_accounts = RollbackAccounts {
+            kind: RollbackAccountsKind::SameNonceAndFeePayer,
+            accounts: vec![(nonce_address, nonce_account)],
+        };
+
+        assert_eq!(expected_rollback_accounts, rollback_accounts);
     }
 
     #[test]
@@ -205,17 +202,14 @@ mod tests {
             u64::MAX, // ignored
         );
 
-        let expected_fee_payer_account = fee_payer_account;
-        match rollback_accounts {
-            RollbackAccounts::SeparateNonceAndFeePayer {
-                nonce,
-                fee_payer_account,
-            } => {
-                assert_eq!(nonce.address(), &nonce_address);
-                assert_eq!(nonce.account(), &nonce_account);
-                assert_eq!(expected_fee_payer_account, fee_payer_account);
-            }
-            _ => panic!("Expected SeparateNonceAndFeePayer variant"),
-        }
+        let expected_rollback_accounts = RollbackAccounts {
+            kind: RollbackAccountsKind::SeparateNonceAndFeePayer,
+            accounts: vec![
+                (nonce_address, nonce_account),
+                (fee_payer_address, fee_payer_account),
+            ],
+        };
+
+        assert_eq!(expected_rollback_accounts, rollback_accounts);
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -439,8 +439,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 TransactionLoadResult::NotLoaded(err) => Err(err),
                 TransactionLoadResult::FeesOnly(fees_only_tx) => {
                     // Update loaded accounts cache with nonce and fee-payer
-                    account_loader
-                        .update_accounts_for_failed_tx(tx, &fees_only_tx.rollback_accounts);
+                    account_loader.update_accounts_for_failed_tx(&fees_only_tx.rollback_accounts);
 
                     Ok(ProcessedTransaction::FeesOnly(Box::new(fees_only_tx)))
                 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -27,7 +27,6 @@ use {
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
         nonce_info::NonceInfo,
-        rollback_accounts::RollbackAccounts,
         transaction_execution_result::TransactionExecutionDetails,
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
         transaction_processor::{
@@ -175,38 +174,13 @@ impl SvmTestEnvironment<'_> {
                     }
                 }
                 Ok(ProcessedTransaction::FeesOnly(fees_only_transaction)) => {
-                    let fee_payer = sanitized_transaction.fee_payer();
-
-                    match fees_only_transaction.rollback_accounts.clone() {
-                        RollbackAccounts::FeePayerOnly { fee_payer_account } => {
-                            update_or_dealloc_account(
-                                &mut final_accounts_actual,
-                                *fee_payer,
-                                fee_payer_account,
-                            );
-                        }
-                        RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                            update_or_dealloc_account(
-                                &mut final_accounts_actual,
-                                *nonce.address(),
-                                nonce.account().clone(),
-                            );
-                        }
-                        RollbackAccounts::SeparateNonceAndFeePayer {
-                            nonce,
-                            fee_payer_account,
-                        } => {
-                            update_or_dealloc_account(
-                                &mut final_accounts_actual,
-                                *fee_payer,
-                                fee_payer_account,
-                            );
-                            update_or_dealloc_account(
-                                &mut final_accounts_actual,
-                                *nonce.address(),
-                                nonce.account().clone(),
-                            );
-                        }
+                    for (pubkey, account_data) in &fees_only_transaction.rollback_accounts.accounts
+                    {
+                        update_or_dealloc_account(
+                            &mut final_accounts_actual,
+                            *pubkey,
+                            account_data.clone(),
+                        );
                     }
                 }
                 Err(_) => {}

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -174,8 +174,7 @@ impl SvmTestEnvironment<'_> {
                     }
                 }
                 Ok(ProcessedTransaction::FeesOnly(fees_only_transaction)) => {
-                    for (pubkey, account_data) in &fees_only_transaction.rollback_accounts.accounts
-                    {
+                    for (pubkey, account_data) in &fees_only_transaction.rollback_accounts {
                         update_or_dealloc_account(
                             &mut final_accounts_actual,
                             *pubkey,


### PR DESCRIPTION
#### Problem
- It would be useful to get a vec of the rollback accounts for https://github.com/anza-xyz/agave/pull/5114
- A lot of verbose code for all of the rollback accounts variants

#### Summary of Changes
- Add iterator impl to `RollbackAccounts`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
