### PR TITLE
refactor: remove versioned prefix from epoch stakes

### DIFF
--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -10,7 +10,7 @@ use {
     solana_account::from_account,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
+    solana_runtime::{bank::Bank, epoch_stakes::EpochStakes},
     solana_sysvar::{self as sysvar, slot_hashes::SlotHashes},
     std::{cmp, sync::Arc},
 };
@@ -42,7 +42,7 @@ impl VoteBatchInsertionMetrics {
 pub struct VoteStorage {
     latest_vote_per_vote_pubkey: HashMap<Pubkey, LatestValidatorVotePacket>,
     num_unprocessed_votes: usize,
-    cached_epoch_stakes: VersionedEpochStakes,
+    cached_epoch_stakes: EpochStakes,
     deprecate_legacy_vote_ixs: bool,
     current_epoch: Epoch,
 }
@@ -68,7 +68,7 @@ impl VoteStorage {
             .iter()
             .map(|pubkey| (*pubkey, (1u64, VoteAccount::new_random())))
             .collect();
-        let epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts, 0);
+        let epoch_stakes = EpochStakes::new_for_tests(vote_accounts, 0);
 
         Self {
             latest_vote_per_vote_pubkey: HashMap::default(),

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -30,7 +30,7 @@ use {
         bank_forks::BankForks,
         bank_hash_cache::{BankHashCache, DumpedSlotSubscription},
         commitment::VOTE_THRESHOLD_SIZE,
-        epoch_stakes::VersionedEpochStakes,
+        epoch_stakes::EpochStakes,
         root_bank_cache::RootBankCache,
         vote_sender_types::ReplayVoteReceiver,
     },
@@ -720,7 +720,7 @@ impl ClusterInfoVoteListener {
             .add_vote_pubkey(pubkey, stake, total_epoch_stake, &THRESHOLDS_TO_CHECK)
     }
 
-    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&VersionedEpochStakes>, pubkey: &Pubkey) {
+    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&EpochStakes>, pubkey: &Pubkey) {
         if let Some(stakes) = epoch_stakes {
             *sum += stakes.stakes().vote_accounts().get_delegated_stake(pubkey)
         }

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -11,7 +11,7 @@ use {
         cluster_info::ClusterInfo, contact_info::ContactInfo, crds::Cursor, epoch_slots::EpochSlots,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
+    solana_runtime::{bank::Bank, epoch_stakes::EpochStakes},
     solana_time_utils::AtomicInterval,
     std::{
         collections::{HashMap, VecDeque},
@@ -42,8 +42,8 @@ struct EpochStakeInfo {
     total_stake: Stake,
 }
 
-impl From<&VersionedEpochStakes> for EpochStakeInfo {
-    fn from(stakes: &VersionedEpochStakes) -> Self {
+impl From<&EpochStakes> for EpochStakeInfo {
+    fn from(stakes: &EpochStakes) -> Self {
         let validator_stakes = ValidatorStakesMap::from_iter(
             stakes
                 .node_id_to_vote_accounts()

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -11,7 +11,7 @@ use {
     solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::BankForks, epoch_stakes::VersionedEpochStakes},
+    solana_runtime::{bank::Bank, bank_forks::BankForks, epoch_stakes::EpochStakes},
     std::{
         borrow::Borrow,
         cmp::Ordering,
@@ -344,7 +344,7 @@ impl HeaviestSubtreeForkChoice {
         &'a mut self,
         // newly updated votes on a fork
         pubkey_votes: impl Iterator<Item = impl Borrow<(Pubkey, SlotHashKey)> + 'b>,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> SlotHashKey {
         // Generate the set of updates
@@ -655,7 +655,7 @@ impl HeaviestSubtreeForkChoice {
         &mut self,
         other: HeaviestSubtreeForkChoice,
         merge_leaf: &SlotHashKey,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) {
         assert!(self.fork_infos.contains_key(merge_leaf));
@@ -974,7 +974,7 @@ impl HeaviestSubtreeForkChoice {
     fn generate_update_operations<'a, 'b>(
         &'a mut self,
         pubkey_votes: impl Iterator<Item = impl Borrow<(Pubkey, SlotHashKey)> + 'b>,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> UpdateOperations {
         let mut update_operations: BTreeMap<(SlotHashKey, UpdateLabel), UpdateOperation> =

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -17,7 +17,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::VersionedEpochStakes,
+    solana_runtime::epoch_stakes::EpochStakes,
     std::{
         collections::{HashMap, HashSet, VecDeque},
         iter,
@@ -87,7 +87,7 @@ impl RepairWeight {
         &mut self,
         blockstore: &Blockstore,
         votes: I,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) where
         I: Iterator<Item = (Slot, Vec<Pubkey>)>,
@@ -204,7 +204,7 @@ impl RepairWeight {
     pub fn get_best_weighted_repairs(
         &mut self,
         blockstore: &Blockstore,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         max_new_shreds: usize,
@@ -528,7 +528,7 @@ impl RepairWeight {
         blockstore: &Blockstore,
         processed_slots: &mut HashSet<Slot>,
         repairs: &mut Vec<ShredRepairType>,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -666,7 +666,7 @@ impl RepairWeight {
         &mut self,
         blockstore: &Blockstore,
         mut orphan_tree_root: Slot,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> Option<Slot> {
         // Must only be called on existing orphan trees
@@ -764,7 +764,7 @@ impl RepairWeight {
     /// It is expected that no two children of a parent could both reach `DUPLICATE_THRESHOLD`.
     pub fn get_popular_pruned_forks(
         &self,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) -> Vec<Slot> {
         #[cfg(test)]
@@ -946,7 +946,7 @@ impl RepairWeight {
         root1: TreeRoot,
         root2: TreeRoot,
         merge_leaf: Slot,
-        epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
     ) {
         // Update self.slot_to_tree to reflect the merge

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -7,7 +7,7 @@ use {
     solana_runtime::{
         bank::Bank,
         bank_client::BankClient,
-        epoch_stakes::VersionedEpochStakes,
+        epoch_stakes::EpochStakes,
         genesis_utils::{
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
@@ -44,7 +44,7 @@ fn test_syscall_get_epoch_stake() {
     // Intentionally overwrite the bank epoch with no stake, to ensure the
     // syscall gets the _current_ epoch stake based on the leader schedule
     // (N + 1).
-    let epoch_stakes_epoch_0 = VersionedEpochStakes::new_for_tests(
+    let epoch_stakes_epoch_0 = EpochStakes::new_for_tests(
         voting_keypairs
             .iter()
             .map(|keypair| {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13831,7 +13831,7 @@ fn test_bank_epoch_stakes() {
 
     // Setup new epoch stakes on Bank 1 for both leader schedule epochs.
     let make_new_epoch_stakes = |stake_coefficient: u64| {
-        VersionedEpochStakes::new_for_tests(
+        EpochStakes::new_for_tests(
             voting_keypairs
                 .iter()
                 .map(|keypair| {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -20,7 +20,7 @@ pub struct NodeVoteAccounts {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
-pub enum VersionedEpochStakes {
+pub enum EpochStakes {
     Current {
         stakes: SerdeStakesToStakeFormat,
         total_stake: u64,
@@ -29,7 +29,7 @@ pub enum VersionedEpochStakes {
     },
 }
 
-impl VersionedEpochStakes {
+impl EpochStakes {
     pub(crate) fn new(stakes: SerdeStakesToStakeFormat, leader_schedule_epoch: Epoch) -> Self {
         let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
@@ -250,7 +250,7 @@ pub(crate) mod tests {
             new_epoch_vote_accounts(&vote_accounts_map, |_| stake_per_account);
 
         let (total_stake, mut node_id_to_vote_accounts, epoch_authorized_voters) =
-            VersionedEpochStakes::parse_epoch_vote_accounts(&epoch_vote_accounts, 0);
+            EpochStakes::parse_epoch_vote_accounts(&epoch_vote_accounts, 0);
 
         // Verify the results
         node_id_to_vote_accounts
@@ -289,7 +289,7 @@ pub(crate) mod tests {
         let epoch_vote_accounts = new_epoch_vote_accounts(&vote_accounts_map, |node_id| {
             *node_id_to_stake_map.get(node_id).unwrap()
         });
-        let epoch_stakes = VersionedEpochStakes::new_for_tests(epoch_vote_accounts, 0);
+        let epoch_stakes = EpochStakes::new_for_tests(epoch_vote_accounts, 0);
 
         assert_eq!(epoch_stakes.total_stake(), 11000);
         for (node_id, stake) in node_id_to_stake_map.iter() {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -7,7 +7,7 @@ use {
 use {
     crate::{
         bank::{Bank, BankSlotDelta},
-        epoch_stakes::VersionedEpochStakes,
+        epoch_stakes::EpochStakes,
         runtime_config::RuntimeConfig,
         serde_snapshot::{bank_from_streams, BankIncrementalSnapshotPersistence},
         snapshot_archive_info::{
@@ -860,7 +860,7 @@ fn verify_epoch_stakes(bank: &Bank) -> std::result::Result<(), VerifyEpochStakes
 /// This version of the function exists to facilitate testing.
 /// Normal callers should use `verify_epoch_stakes()`.
 fn _verify_epoch_stakes(
-    epoch_stakes_map: &HashMap<Epoch, VersionedEpochStakes>,
+    epoch_stakes_map: &HashMap<Epoch, EpochStakes>,
     required_epochs: RangeInclusive<Epoch>,
 ) -> std::result::Result<(), VerifyEpochStakesError> {
     // Ensure epoch stakes from the snapshot does not contain entries for invalid epochs.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -936,12 +936,12 @@ fn serialize_snapshot(
         .unzip();
 
         let bank_snapshot_serializer = move |stream: &mut BufWriter<fs::File>| -> Result<()> {
-            let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
+            let epoch_stakes = mem::take(&mut bank_fields.epoch_stakes);
             let extra_fields = ExtraFieldsToSerialize {
                 lamports_per_signature: bank_fields.fee_rate_governor.lamports_per_signature,
                 incremental_snapshot_persistence: bank_incremental_snapshot_persistence,
                 epoch_accounts_hash,
-                versioned_epoch_stakes,
+                epoch_stakes,
                 accounts_lt_hash: bank_fields.accounts_lt_hash.clone().map(Into::into),
             };
             serde_snapshot::serialize_bank_snapshot_into(

--- a/wen-restart/src/heaviest_fork_aggregate.rs
+++ b/wen-restart/src/heaviest_fork_aggregate.rs
@@ -6,7 +6,7 @@ use {
     solana_gossip::restart_crds_values::RestartHeaviestFork,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::VersionedEpochStakes,
+    solana_runtime::epoch_stakes::EpochStakes,
     std::{
         collections::{HashMap, HashSet},
         str::FromStr,
@@ -18,7 +18,7 @@ pub(crate) struct HeaviestForkAggregate {
     my_pubkey: Pubkey,
     // We use the epoch_stakes of the Epoch our heaviest bank is in. Proceed and exit only if
     // enough validator agree with me.
-    epoch_stakes: VersionedEpochStakes,
+    epoch_stakes: EpochStakes,
     heaviest_forks: HashMap<Pubkey, RestartHeaviestFork>,
     block_stake_map: HashMap<(Slot, Hash), u64>,
     active_peers: HashSet<Pubkey>,
@@ -36,7 +36,7 @@ pub enum HeaviestForkAggregateResult {
 impl HeaviestForkAggregate {
     pub(crate) fn new(
         my_shred_version: u16,
-        epoch_stakes: &VersionedEpochStakes,
+        epoch_stakes: &EpochStakes,
         my_heaviest_fork_slot: Slot,
         my_heaviest_fork_hash: Hash,
         my_pubkey: &Pubkey,

--- a/wen-restart/src/last_voted_fork_slots_aggregate.rs
+++ b/wen-restart/src/last_voted_fork_slots_aggregate.rs
@@ -249,7 +249,7 @@ mod tests {
         solana_hash::Hash,
         solana_runtime::{
             bank::Bank,
-            epoch_stakes::VersionedEpochStakes,
+            epoch_stakes::EpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
@@ -791,7 +791,7 @@ mod tests {
                 )
             })
             .collect();
-        let epoch1_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 1);
+        let epoch1_epoch_stakes = EpochStakes::new_for_tests(vote_accounts_hash_map, 1);
         new_root_bank.set_epoch_stakes_for_test(1, epoch1_epoch_stakes);
 
         let last_voted_fork_slots = vec![root_bank.slot() + 1, root_bank.get_slots_in_epoch(0) + 1];

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1450,7 +1450,7 @@ mod tests {
         },
         solana_pubkey::Pubkey,
         solana_runtime::{
-            epoch_stakes::VersionedEpochStakes,
+            epoch_stakes::EpochStakes,
             genesis_utils::{
                 create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
             },
@@ -2018,7 +2018,7 @@ mod tests {
                 )
             })
             .collect();
-        let epoch2_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 2);
+        let epoch2_epoch_stakes = EpochStakes::new_for_tests(vote_accounts_hash_map, 2);
         new_root_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);
         let _ = insert_slots_into_blockstore(
             test_state.blockstore.clone(),


### PR DESCRIPTION
#### Problem
`VersionedEpochStakes` is the defacto `EpochStakes` type now, so can simplify naming

#### Summary of Changes
Rename `VersionedEpochStakes` to `EpochStakes`
Rename `versioned_epoch_stakes` fields to `epoch_stakes`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
