### PR TITLE
runtime: Use the same deserialized snapshot for storage and banks rebuild

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -529,6 +529,7 @@ pub(crate) fn fields_from_stream<R: Read>(
     deserialize_bank_fields(snapshot_stream)
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub(crate) fn fields_from_streams(
     snapshot_streams: &mut SnapshotStreams<impl Read>,
 ) -> std::result::Result<

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -300,6 +300,13 @@ pub struct SnapshotBankFields {
 }
 
 impl SnapshotBankFields {
+    pub fn new(
+        full: BankFieldsToDeserialize,
+        incremental: Option<BankFieldsToDeserialize>,
+    ) -> Self {
+        Self { full, incremental }
+    }
+
     /// Collapse the SnapshotBankFields into a single (the latest) BankFieldsToDeserialize.
     pub fn collapse_into(self) -> BankFieldsToDeserialize {
         self.incremental.unwrap_or(self.full)
@@ -559,6 +566,7 @@ pub struct BankFromStreamsInfo {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) fn bank_from_streams<R>(
     snapshot_streams: &mut SnapshotStreams<R>,
     account_paths: &[PathBuf],

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -852,6 +852,12 @@ impl Serialize for SerializableAccountsDb<'_> {
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountsDb<'_> {}
 
+/// This struct contains side-info while reconstructing the bank from fields
+#[derive(Debug)]
+pub(crate) struct ReconstructedBankInfo {
+    pub(crate) duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn reconstruct_bank_from_fields<E>(
     bank_fields: SnapshotBankFields,
@@ -867,7 +873,7 @@ pub(crate) fn reconstruct_bank_from_fields<E>(
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> Result<(Bank, BankFromStreamsInfo), Error>
+) -> Result<(Bank, ReconstructedBankInfo), Error>
 where
     E: SerializableStorage + std::marker::Sync,
 {
@@ -915,7 +921,7 @@ where
     info!("rent_collector: {:?}", bank.rent_collector());
     Ok((
         bank,
-        BankFromStreamsInfo {
+        ReconstructedBankInfo {
             duplicates_lt_hash: reconstructed_accounts_db_info.duplicates_lt_hash,
         },
     ))

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -33,7 +33,7 @@ impl SerializableAccountStorageEntry {
     }
 }
 
-pub(super) trait SerializableStorage {
+pub(crate) trait SerializableStorage {
     fn id(&self) -> SerializedAccountsFileId;
     fn current_len(&self) -> usize;
 }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -270,8 +270,6 @@ pub fn bank_from_snapshot_archives(
 
     bank.status_cache.write().unwrap().append(&slot_deltas);
 
-    info!("Rebuilt bank for slot: {}", bank.slot());
-
     let snapshot_archive_info = incremental_snapshot_archive_info.map_or_else(
         || full_snapshot_archive_info.snapshot_archive_info(),
         |incremental_snapshot_archive_info| {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1,6 +1,13 @@
 #[cfg(feature = "dev-context-only-utils")]
 use {
-    crate::{bank::BankFieldsToDeserialize, serde_snapshot::fields_from_streams},
+    crate::{
+        bank::BankFieldsToDeserialize,
+        serde_snapshot::fields_from_streams,
+        snapshot_utils::{
+            deserialize_snapshot_data_files, verify_unpacked_snapshots_dir_and_version,
+            SnapshotRootPaths, UnpackedSnapshotsDirAndVersion,
+        },
+    },
     solana_accounts_db::accounts_file::StorageAccess,
     tempfile::TempDir,
 };
@@ -20,14 +27,12 @@ use {
         snapshot_hash::SnapshotHash,
         snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
         snapshot_utils::{
-            self, deserialize_snapshot_data_file, deserialize_snapshot_data_files,
-            get_highest_bank_snapshot_post, get_highest_full_snapshot_archive_info,
-            get_highest_incremental_snapshot_archive_info, rebuild_storages_from_snapshot_dir,
-            serialize_snapshot_data_file, verify_and_unarchive_snapshots,
-            verify_unpacked_snapshots_dir_and_version, ArchiveFormat, BankSnapshotInfo,
-            SnapshotError, SnapshotRootPaths, SnapshotVersion, StorageAndNextAccountsFileId,
-            UnarchivedSnapshot, UnpackedSnapshotsDirAndVersion, VerifyEpochStakesError,
-            VerifySlotDeltasError,
+            self, deserialize_snapshot_data_file, get_highest_bank_snapshot_post,
+            get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
+            rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
+            verify_and_unarchive_snapshots, ArchiveFormat, BankSnapshotInfo, SnapshotError,
+            SnapshotVersion, StorageAndNextAccountsFileId, UnarchivedSnapshot,
+            VerifyEpochStakesError, VerifySlotDeltasError,
         },
         status_cache,
     },
@@ -612,6 +617,7 @@ fn verify_bank_against_expected_slot_hash(
 }
 
 /// Returns the validated version and root paths for the given snapshots.
+#[cfg(feature = "dev-context-only-utils")]
 fn snapshot_version_and_root_paths(
     full_snapshot_unpacked_snapshots_dir_and_version: &UnpackedSnapshotsDirAndVersion,
     incremental_snapshot_unpacked_snapshots_dir_and_version: Option<

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1757,9 +1757,9 @@ enum SnapshotFileKind {
 
 /// Determines `SnapshotFileKind` for `filename` if any
 fn get_snapshot_file_kind(filename: &str) -> Option<SnapshotFileKind> {
-    static VERSION_FILE_REGEX: std::sync::LazyLock<Regex> =
+    static VERSION_FILE_REGEX: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^version$").unwrap());
-    static BANK_FIELDS_FILE_REGEX: std::sync::LazyLock<Regex> =
+    static BANK_FIELDS_FILE_REGEX: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^[0-9]+(\.pre)?$").unwrap());
 
     if VERSION_FILE_REGEX.is_match(filename) {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -306,7 +306,7 @@ pub struct UnarchivedSnapshots {
 /// Once dropped, the unpack directories are removed.
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct UnarchivedSnapshotGuard {
+pub struct UnarchivedSnapshotsGuard {
     full_unpack_dir: TempDir,
     incremental_unpack_dir: Option<TempDir>,
 }
@@ -1591,7 +1591,7 @@ pub fn verify_and_unarchive_snapshots(
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
     storage_access: StorageAccess,
-) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotGuard)> {
+) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotsGuard)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
@@ -1674,7 +1674,7 @@ pub fn verify_and_unarchive_snapshots(
             incremental_measure_untar,
             next_append_vec_id,
         },
-        UnarchivedSnapshotGuard {
+        UnarchivedSnapshotsGuard {
             full_unpack_dir,
             incremental_unpack_dir,
         },

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -302,7 +302,7 @@ pub struct UnarchivedSnapshots {
     pub next_append_vec_id: AtomicAccountsFileId,
 }
 
-/// Guard type whick keeps the unpack directories of snapshots alive.
+/// Guard type that keeps the unpack directories of snapshots alive.
 /// Once dropped, the unpack directories are removed.
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -46,7 +46,7 @@ use {
         path::{Path, PathBuf},
         process::ExitStatus,
         str::FromStr,
-        sync::Arc,
+        sync::{Arc, LazyLock},
         thread::{Builder, JoinHandle},
     },
     tar::{self, Archive},
@@ -1758,9 +1758,9 @@ enum SnapshotFileKind {
 /// Determines `SnapshotFileKind` for `filename` if any
 fn get_snapshot_file_kind(filename: &str) -> Option<SnapshotFileKind> {
     static VERSION_FILE_REGEX: std::sync::LazyLock<Regex> =
-        std::sync::LazyLock::new(|| Regex::new(r"^version$").unwrap());
+        LazyLock::new(|| Regex::new(r"^version$").unwrap());
     static BANK_FIELDS_FILE_REGEX: std::sync::LazyLock<Regex> =
-        std::sync::LazyLock::new(|| Regex::new(r"^[0-9]+(\.pre)?$").unwrap());
+        LazyLock::new(|| Regex::new(r"^[0-9]+(\.pre)?$").unwrap());
 
     if VERSION_FILE_REGEX.is_match(filename) {
         Some(SnapshotFileKind::Version)


### PR DESCRIPTION
#### Problem

Previously, storage and banks rebuilds were retrieving and deserializing snapshots the same snapshot separately, on their own. That means, deserialization of the same snapshot was done twice.

Time of unarchiving the snapshot and rebuiding the bank before the change:

```
[2025-06-17T12:39:15.319932624Z INFO  solana_metrics::metrics] datapoint: bank_from_snapshot_archives untar_full_snapshot_archive_us=131656371i untar_incremental_snapshot_archive_us=13321844i rebuild_bank_us=204383882i verify_bank_us=59909i
```

| untar (full) | untar (incremental) | rebuild bank | verify bank |
| --------------- | ---------------------------- | ------------------- | ---------------- |
| 131.66 s     | 13.32 s                       | 204.38 s          | 59.90 ms    |

| total        |
| ------------ |
| 349.42 s |

Rebuilding bank takes the most of time, and almost twice longer than full untar. That's because it deseriaizes the same snapshot again.

#### Summary of Changes

Fix that by parsing the accounts and banks fields beforehand and then using them for rebuilding the storage and banks.

```
[2025-06-17T12:59:35.723032351Z INFO  solana_metrics::metrics] datapoint: bank_from_snapshot_archives untar_full_snapshot_archive_us=141921499i untar_incremental_snapshot_archive_us=743541i rebuild_bank_us=189680752i verify_bank_us=72609i
```

| untar (full) | untar (incremental) | rebuild bank | verify bank |
| --------------- | ---------------------------- | ------------------- | ---------------- |
| 141.92 s     | 743.54 ms                  | 189.68 s          | 72.60 ms    |

| total        |
| ------------ |
| 332.42 s |

Fixes #6539
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
