### PR TITLE
Removes unused parameter from AccountsDb::new_existing()

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -311,8 +311,7 @@ mod tests {
             );
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage =
-                AccountStorageEntry::new_existing(slot, 0, accounts_file, num_accounts);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file);
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
@@ -401,13 +400,12 @@ mod tests {
             // Close the file
             drop(output_file);
 
-            let (accounts_file, num_accounts) =
+            let (accounts_file, _num_accounts) =
                 AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
                     .unwrap();
 
             // Create a new AccountStorageEntry from the output file
-            let new_storage =
-                AccountStorageEntry::new_existing(slot, 0, accounts_file, num_accounts);
+            let new_storage = AccountStorageEntry::new_existing(slot, 0, accounts_file);
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1126,12 +1126,7 @@ impl AccountStorageEntry {
         })
     }
 
-    pub fn new_existing(
-        slot: Slot,
-        id: AccountsFileId,
-        accounts: AccountsFile,
-        _num_accounts: usize,
-    ) -> Self {
+    pub fn new_existing(slot: Slot, id: AccountsFileId, accounts: AccountsFile) -> Self {
         Self {
             id,
             slot,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -67,7 +67,7 @@ mod tests {
             std::fs::copy(storage_path, &output_path)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, num_accounts) = AccountsFile::new_from_file(
+            let (accounts_file, _num_accounts) = AccountsFile::new_from_file(
                 output_path,
                 storage_entry.accounts.len(),
                 storage_access,
@@ -76,7 +76,6 @@ mod tests {
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                num_accounts,
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -916,13 +916,12 @@ pub(crate) fn reconstruct_single_storage(
     append_vec_id: AccountsFileId,
     storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    let (accounts_file, num_accounts) =
+    let (accounts_file, _num_accounts) =
         AccountsFile::new_from_file(append_vec_path, current_len, storage_access)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,
         accounts_file,
-        num_accounts,
     )))
 }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -147,13 +147,12 @@ mod serde_snapshot_tests {
             io::copy(&mut reader, &mut writer)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, num_accounts) =
+            let (accounts_file, _num_accounts) =
                 AccountsFile::new_from_file(output_path, reader.len(), storage_access)?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.id(),
                 accounts_file,
-                num_accounts,
             );
             next_append_vec_id = next_append_vec_id.max(new_storage_entry.id());
             storage.insert(new_storage_entry.slot(), Arc::new(new_storage_entry));


### PR DESCRIPTION
#### Problem

`AccountsDb::new_existing()` has an unused parameter, `num_accounts`, that can be removed.


#### Summary of Changes

Remove it.