### PR TITLE
Replace bank owned status cache for signatures with recent transaction status service

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -67,7 +67,7 @@ impl AggregateCommitmentService {
     pub fn new(
         exit: Arc<AtomicBool>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-        subscriptions: Arc<RpcSubscriptions>,
+        subscriptions: Option<Arc<RpcSubscriptions>>,
     ) -> (Sender<CommitmentAggregationData>, Self) {
         let (sender, receiver): (
             Sender<CommitmentAggregationData>,
@@ -97,7 +97,7 @@ impl AggregateCommitmentService {
     fn run(
         receiver: &Receiver<CommitmentAggregationData>,
         block_commitment_cache: &RwLock<BlockCommitmentCache>,
-        subscriptions: &Arc<RpcSubscriptions>,
+        rpc_subscriptions: &Option<Arc<RpcSubscriptions>>,
         exit: &AtomicBool,
     ) -> Result<(), RecvTimeoutError> {
         loop {
@@ -136,10 +136,12 @@ impl AggregateCommitmentService {
                 ),
             );
 
-            // Triggers rpc_subscription notifications as soon as new commitment data is available,
-            // sending just the commitment cache slot information that the notifications thread
-            // needs
-            subscriptions.notify_subscribers(update_commitment_slots);
+            if let Some(rpc_subscriptions) = rpc_subscriptions {
+                // Triggers rpc_subscription notifications as soon as new commitment data is
+                // available, sending just the commitment cache slot information that the
+                // notifications thread needs
+                rpc_subscriptions.notify_subscribers(update_commitment_slots);
+            }
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -123,7 +123,7 @@ impl Tpu {
         entry_receiver: Receiver<WorkingBankEntry>,
         retransmit_slots_receiver: Receiver<Slot>,
         sockets: TpuSockets,
-        subscriptions: &Arc<RpcSubscriptions>,
+        subscriptions: &Option<Arc<RpcSubscriptions>>,
         transaction_status_sender: Option<TransactionStatusSender>,
         entry_notification_sender: Option<EntryNotifierSender>,
         blockstore: Arc<Blockstore>,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -133,7 +133,7 @@ impl Tvu {
         sockets: TvuSockets,
         blockstore: Arc<Blockstore>,
         ledger_signal_receiver: Receiver<bool>,
-        rpc_subscriptions: &Arc<RpcSubscriptions>,
+        rpc_subscriptions: &Option<Arc<RpcSubscriptions>>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         tower: Tower,
         tower_storage: Arc<dyn TowerStorage>,
@@ -223,7 +223,7 @@ impl Tvu {
             turbine_quic_endpoint_sender,
             retransmit_receiver,
             max_slots.clone(),
-            Some(rpc_subscriptions.clone()),
+            rpc_subscriptions.clone(),
             slot_status_notifier.clone(),
             tvu_config.retransmit_xdp.clone(),
         );
@@ -556,13 +556,13 @@ pub mod tests {
             },
             blockstore,
             ledger_signal_receiver,
-            &Arc::new(RpcSubscriptions::new_for_tests(
+            &Some(Arc::new(RpcSubscriptions::new_for_tests(
                 exit.clone(),
                 max_complete_transaction_status_slot,
                 bank_forks.clone(),
                 block_commitment_cache.clone(),
                 OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
-            )),
+            ))),
             &poh_recorder,
             Tower::default(),
             Arc::new(FileTowerStorage::default()),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -4,6 +4,7 @@ pub mod filter;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;
 pub mod parsed_token_accounts;
+pub mod recent_transaction_status_service;
 pub mod rpc;
 mod rpc_cache;
 pub mod rpc_completed_slots_service;

--- a/rpc/src/recent_transaction_status_service.rs
+++ b/rpc/src/recent_transaction_status_service.rs
@@ -1,0 +1,111 @@
+use {
+    crossbeam_channel::{Receiver, RecvTimeoutError},
+    itertools::izip,
+    solana_accounts_db::ancestors::Ancestors,
+    solana_clock::Slot,
+    solana_ledger::blockstore_processor::TransactionStatusMessage,
+    solana_runtime::status_cache::StatusCache,
+    solana_signature::Signature,
+    solana_transaction_error::TransactionResult,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        thread::Builder,
+        time::Duration,
+    },
+};
+
+type RecentTransactionResultCache = StatusCache<TransactionResult<()>>;
+
+#[derive(Default)]
+pub struct RecentTransactionStatusService {
+    transaction_result_cache: Arc<RwLock<RecentTransactionResultCache>>,
+}
+
+impl RecentTransactionStatusService {
+    const SERVICE_NAME: &str = "RecentTransactionStatusService";
+
+    pub fn new(
+        transaction_result_cache: RecentTransactionResultCache,
+        transaction_status_receiver: Receiver<TransactionStatusMessage>,
+        exit: Arc<AtomicBool>,
+    ) -> Self {
+        let transaction_result_cache = Arc::new(RwLock::new(transaction_result_cache));
+
+        Builder::new()
+            .name("solRecentTxStatus".to_string())
+            .spawn({
+                let arc_transaction_result_cache = transaction_result_cache.clone();
+                let arc_transaction_status_receiver = Arc::new(transaction_status_receiver.clone());
+                move || {
+                    info!("{} has started", Self::SERVICE_NAME);
+                    loop {
+                        if exit.load(Ordering::Relaxed) {
+                            break;
+                        }
+
+                        let message = match arc_transaction_status_receiver
+                            .recv_timeout(Duration::from_secs(1))
+                        {
+                            Ok(message) => message,
+                            Err(err @ RecvTimeoutError::Disconnected) => {
+                                info!("{} is stopping because: {err}", Self::SERVICE_NAME);
+                                break;
+                            }
+                            Err(RecvTimeoutError::Timeout) => {
+                                continue;
+                            }
+                        };
+
+                        fn handle_message(
+                            transaction_result_cache: &Arc<RwLock<RecentTransactionResultCache>>,
+                            message: TransactionStatusMessage,
+                        ) -> Result<(), Box<dyn std::error::Error + '_>> {
+                            match message {
+                                TransactionStatusMessage::Batch(batch) => {
+                                    let mut status_cache = transaction_result_cache.write()?;
+                                    for (commit_result, transaction) in
+                                        izip!(batch.commit_results, batch.transactions)
+                                    {
+                                        status_cache.insert(
+                                            transaction.message().recent_blockhash(),
+                                            transaction.signature(),
+                                            batch.slot,
+                                            commit_result.map(|_| ()),
+                                        );
+                                    }
+                                    Ok(())
+                                }
+                                _ => Ok(()),
+                            }
+                        }
+
+                        if let Err(err) = handle_message(&arc_transaction_result_cache, message) {
+                            error!("{} is stopping because: {err}", Self::SERVICE_NAME);
+                            exit.store(true, Ordering::Relaxed);
+                            break;
+                        };
+                    }
+                    info!("{} has stopped", Self::SERVICE_NAME);
+                }
+            })
+            .unwrap();
+        Self {
+            transaction_result_cache,
+        }
+    }
+
+    pub fn get_transaction_status(
+        &self,
+        signature: &Signature,
+        ancestors: &Ancestors,
+    ) -> Option<(Slot, TransactionResult<()>)> {
+        let rcache = self
+            .transaction_result_cache
+            .read()
+            .expect("Failed to obtain shared read access to status cache");
+        rcache.get_status_any_blockhash(signature, ancestors)
+    }
+}

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -5,6 +5,7 @@ use {
         cluster_tpu_info::ClusterTpuInfo,
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
+        recent_transaction_status_service::RecentTransactionStatusService,
         rpc::{rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_full::*, rpc_minimal::*, *},
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
@@ -486,6 +487,7 @@ pub struct JsonRpcServiceConfig<'a> {
     pub max_complete_transaction_status_slot: Arc<AtomicU64>,
     pub prioritization_fee_cache: Arc<PrioritizationFeeCache>,
     pub client_option: ClientOption<'a>,
+    pub recent_transaction_status_service: Arc<RecentTransactionStatusService>,
 }
 
 /// [`ClientOption`] enum represents the available client types for TPU
@@ -549,6 +551,7 @@ impl JsonRpcService {
                     config.max_complete_transaction_status_slot,
                     config.prioritization_fee_cache,
                     runtime,
+                    config.recent_transaction_status_service,
                 )?;
                 Ok(json_rpc_service)
             }
@@ -599,6 +602,7 @@ impl JsonRpcService {
                     config.max_complete_transaction_status_slot,
                     config.prioritization_fee_cache,
                     runtime,
+                    config.recent_transaction_status_service,
                 )?;
                 Ok(json_rpc_service)
             }
@@ -628,6 +632,7 @@ impl JsonRpcService {
         connection_cache: Arc<ConnectionCache>,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+        recent_transaction_status_service: Arc<RecentTransactionStatusService>,
     ) -> Result<Self, String> {
         let runtime = service_runtime(
             config.rpc_threads,
@@ -676,6 +681,7 @@ impl JsonRpcService {
             max_complete_transaction_status_slot,
             prioritization_fee_cache,
             runtime,
+            recent_transaction_status_service,
         )?;
         Ok(json_rpc_service)
     }
@@ -710,6 +716,7 @@ impl JsonRpcService {
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         runtime: Arc<TokioRuntime>,
+        recent_transaction_status_service: Arc<RecentTransactionStatusService>,
     ) -> Result<Self, String> {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -802,6 +809,7 @@ impl JsonRpcService {
             max_complete_transaction_status_slot,
             prioritization_fee_cache,
             Arc::clone(&runtime),
+            recent_transaction_status_service,
         );
 
         let _send_transaction_service = Arc::new(SendTransactionService::new_with_client(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5238,18 +5238,6 @@ impl Bank {
         self.signature_count.fetch_add(signature_count, Relaxed);
     }
 
-    pub fn get_signature_status_processed_since_parent(
-        &self,
-        signature: &Signature,
-    ) -> Option<Result<()>> {
-        if let Some((slot, status)) = self.get_signature_status_slot(signature) {
-            if slot <= self.slot() {
-                return Some(status);
-            }
-        }
-        None
-    }
-
     pub fn get_signature_status_with_blockhash(
         &self,
         signature: &Signature,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -238,7 +238,7 @@ struct RentMetrics {
     count: AtomicUsize,
 }
 
-pub type BankStatusCache = StatusCache<Result<()>>;
+pub type BankStatusCache = StatusCache<Hash, Result<()>>;
 #[cfg_attr(
     feature = "frozen-abi",
     frozen_abi(digest = "5dfDCRGWPV7thfoZtLpTJAV8cC93vQUXgTm6BnrfeUsN")

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3028,15 +3028,6 @@ impl Bank {
                     self.slot(),
                     processed_tx.status(),
                 );
-                // Add the transaction signature to the status cache so that transaction status
-                // can be queried by transaction signature over RPC. In the future, this should
-                // only be added for API nodes because voting validators don't need to do this.
-                status_cache.insert(
-                    tx.recent_blockhash(),
-                    tx.signature(),
-                    self.slot(),
-                    processed_tx.status(),
-                );
             }
         }
     }


### PR DESCRIPTION
**ONLY REVIEW THE LAST COMMIT**; this PR is stacked on top of #6516

---

#### Problem

A detailed writeup can be found in #6546.

#### Summary of Changes

* Make status cache only able to store one key type and make `BankStatusCache` specify `Hash` as the key type.
* Create a threaded service that listens for `TransactionStatusMessages` and stuffs them into a `StatusCache` whose key type is `Signature`
* Pass that service into the RPC and have it ask that thing for `TransactionResults` instead of asking `Bank`
* Stop storing `Signature`-to-`TransactionResults` in the `BankStatusCache` (which has the side benefit of them not being stored in snapshots)