### PR TITLE
Do not sanitize append vecs at startup

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -88,6 +88,20 @@ impl AccountsFile {
         Ok((Self::AppendVec(av), num_accounts))
     }
 
+    /// Creates a new AccountsFile for the underlying storage at `path`
+    ///
+    /// This version of `new()` may only be called when reconstructing storages as part of startup.
+    /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
+    /// accounts verification to ensure it is valid.
+    pub fn new_for_startup(
+        path: impl Into<PathBuf>,
+        current_len: usize,
+        storage_access: StorageAccess,
+    ) -> Result<Self> {
+        let av = AppendVec::new_for_startup(path, current_len, storage_access)?;
+        Ok(Self::AppendVec(av))
+    }
+
     /// true if this storage can possibly be appended to (independent of capacity check)
     //
     // NOTE: Only used by ancient append vecs "append" method, which is test-only now.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -916,8 +916,8 @@ pub(crate) fn reconstruct_single_storage(
     append_vec_id: AccountsFileId,
     storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    let (accounts_file, _num_accounts) =
-        AccountsFile::new_from_file(append_vec_path, current_len, storage_access)?;
+    let accounts_file =
+        AccountsFile::new_for_startup(append_vec_path, current_len, storage_access)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         append_vec_id,


### PR DESCRIPTION
#### Problem

At startup from a snapshot, we must rebuild/reconstruct all the `AppendVec`s. This is basically relinking all the storage files on disk to the `AccountStorageEntry`s that were serialized into the bank snapshot (aka snapshot manifest). We use the storage file paths from the snapshot manifest to reconstruct the AppendVecs.

We also do some sanitization of the storage files when reconstructing the new AppendVecs. One step is to sanitize *each account* in the storage file. This involves scanning (i.e. reading) the whole file, and checking every single account to make sure the accounts are valid. Scanning every account in every storage file is rather time consuming. On mainnet-beta, we now have over 900 million accounts. Doing this sanitization step takes over 100 seconds.

An observation is that we also read all the accounts/storages two other times as part of startup. One is for index generation, and the other is for startup accounts verification. If the storages are wrong/invalid, then one (or both) of these other tasks will catch it. Thus, we can avoid the sanitization step during startup reconstruction.

Speeding up reconstructing the storages, speeds up startup. And if startup is faster, that means validators begin replaying faster. If validators begin replaying faster, they catch up faster, *AND* that also means there are fewer blocks they have to repair (vs getting through turbine).


#### Summary of Changes

Skip AppendVec accounts sanitization during startup when reconstructing storages.

Testing against mnb, I saw times drop from ~100-120 seconds to ~2 seconds for reconstructing storages at startup.