### PR TITLE
Refactor `NodeConfig` to improve clarity

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1122,7 +1122,6 @@ pub fn execute(
         solana_net_utils::find_available_port_in_range(bind_address, (0, 1))
             .map_err(|err| format!("unable to find an available gossip port: {err}"))
     })?;
-    let gossip_addr = SocketAddr::new(advertised_ip, gossip_port);
 
     let public_tpu_addr = matches
         .value_of("public_tpu_addr")
@@ -1158,7 +1157,8 @@ pub fn execute(
     let max_streams_per_ms = value_t_or_exit!(matches, "tpu_max_streams_per_ms", u64);
 
     let node_config = NodeConfig {
-        gossip_addr,
+        advertised_ip,
+        gossip_port,
         port_range: dynamic_port_range,
         bind_ip_addr: bind_address,
         public_tpu_addr,


### PR DESCRIPTION
#### Problem
`NodeConfig` struct uses `gossip_addr: SocketAddr` to represent the IP and port that the validator advertises in gossip. This field blurs the distinction between:
1) The IP to advertise externally (e.g., for NAT -> not sure we even need to support this anymore)
2) The port used for gossip -> set with `--gossip-port` or chosen from `--dynamic-port-range`
3) The bind IP -> IP to bind to locally

#### Summary of Changes
Replace `NodeConfig::gossip_addr: SocketAddr` with:
1) advertised_ip: IpAddr — the public IP to advertise via gossip
2) gossip_port: u16 — the selected gossip port to advertise

This is the first step in supporting multihoming on the cli:
1) refactor NodeConfig to distinguish between advertised IP and bind IP (this PR)
2) deprecate `--gossip-host` in favor of `--bind-address` (Who is using NAT?): https://github.com/anza-xyz/agave/pull/6519
3) update `--bind-address` to take in multiple IPs for multihoming support: https://github.com/anza-xyz/agave/pull/6522