### PR TITLE
Use new to avoid unneeded vector allocation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7124,7 +7124,7 @@ impl AccountsDb {
         let len = std::cmp::min(accounts.len(), infos.len());
 
         let update = |start, end| {
-            let mut reclaims = Vec::with_capacity((end - start) / 2);
+            let mut reclaims = Vec::new();
 
             (start..end).for_each(|i| {
                 let info = infos[i];


### PR DESCRIPTION
#### Problem
Update_index allocates a vector of a fixed that is never used. 
Using new will avoid allocating memory unless the vector is used

#### Summary of Changes
- Remove the unused vector allocation

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
