### PR TITLE
Return transaction status from all bank process tx methods

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1095,9 +1095,9 @@ mod tests {
 
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
         for entry in entries {
-            bank.process_entry_transactions(entry.transactions)
-                .iter()
-                .for_each(|x| assert_eq!(*x, Ok(())));
+            let _ = bank
+                .try_process_entry_transactions(entry.transactions)
+                .expect("All transactions should be processed");
         }
 
         // Assert the user doesn't hold three lamports. If the stage only outputs one

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4676,10 +4676,7 @@ impl Bank {
     /// Process a Transaction. This is used for unit tests and simply calls the vector
     /// Bank::process_transactions method.
     pub fn process_transaction(&self, tx: &Transaction) -> Result<()> {
-        self.try_process_transactions(std::iter::once(tx))?[0].clone()?;
-        tx.signatures
-            .first()
-            .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
+        self.try_process_transactions(std::iter::once(tx))?[0].clone()
     }
 
     /// Process a Transaction and store metadata. This is used for tests and the banks services. It
@@ -4743,7 +4740,7 @@ impl Bank {
         )
         .0
         .into_iter()
-        .map(|commit_result| commit_result.map(|_| ()))
+        .map(|commit_result| commit_result.and_then(|committed_tx| committed_tx.status))
         .collect()
     }
 


### PR DESCRIPTION
#### Problem
The transaction status isn't returned consistently from bank process transaction methods. 

#### Summary of Changes
- Remove unnecessary status lookup in `Bank::process_transaction`
- Return transaction status through bank process transaction methods
- Fix tests which weren't properly processing transactions successfully

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
