### PR TITLE
Add sanitized paths cache

### DIFF
--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -103,6 +103,8 @@ where
     let mut total_count: u64 = 0;
 
     let mut total_entries = 0;
+    let mut sanitized_paths_cache = Vec::new();
+
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?;
@@ -167,9 +169,9 @@ where
             // account_paths returned by `entry_checker`. We want to unpack into
             // account_path/<account> instead of account_path/accounts/<account> so we strip the
             // accounts/ prefix.
-            sanitize_path(&account, unpack_dir)
+            sanitize_path(&account, unpack_dir, &mut sanitized_paths_cache)
         } else {
-            sanitize_path(&path, unpack_dir)
+            sanitize_path(&path, unpack_dir, &mut sanitized_paths_cache)
         }?; // ? handles file system errors
         let Some(entry_path) = entry_path else {
             continue; // skip it
@@ -216,7 +218,11 @@ where
 // return Err on file system error
 // return Some(path) if path is good
 // return None if we should skip this file
-fn sanitize_path(entry_path: &Path, dst: &Path) -> Result<Option<PathBuf>> {
+fn sanitize_path(
+    entry_path: &Path,
+    dst: &Path,
+    cache: &mut Vec<(PathBuf, PathBuf)>,
+) -> Result<Option<PathBuf>> {
     // We cannot call unpack_in because it errors if we try to use 2 account paths.
     // So, this code is borrowed from unpack_in
     // ref: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack_in
@@ -253,11 +259,19 @@ fn sanitize_path(entry_path: &Path, dst: &Path) -> Result<Option<PathBuf>> {
         return SKIP;
     };
 
-    fs::create_dir_all(parent)?;
+    match cache.binary_search_by(|(dst_cache, parent_cache)| {
+        dst.cmp(dst_cache).then(parent.cmp(parent_cache))
+    }) {
+        Ok(_) => (),
+        Err(insert_at) => {
+            fs::create_dir_all(parent)?;
 
-    // Here we are different than untar_in. The code for tar::unpack_in internally calling unpack is a little different.
-    // ignore return value here
-    validate_inside_dst(dst, parent)?;
+            // Here we are different than untar_in. The code for tar::unpack_in internally calling unpack is a little different.
+            // ignore return value here
+            validate_inside_dst(dst, parent)?;
+            cache.insert(insert_at, (dst.to_path_buf(), parent.to_path_buf()));
+        }
+    }
     let target = parent.join(entry_path.file_name().unwrap());
 
     Ok(Some(target))

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -260,7 +260,7 @@ fn sanitize_path(
     };
 
     match cache.binary_search_by(|(dst_cache, parent_cache)| {
-        dst.cmp(dst_cache).then(parent.cmp(parent_cache))
+        parent.cmp(parent_cache).then_with(|| dst.cmp(dst_cache))
     }) {
         Ok(_) => (),
         Err(insert_at) => {

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -259,18 +259,15 @@ fn sanitize_path(
         return SKIP;
     };
 
-    match cache.binary_search_by(|(dst_cache, parent_cache)| {
-        parent.cmp(parent_cache).then_with(|| dst.cmp(dst_cache))
+    if let Err(insert_at) = cache.binary_search_by(|(dst_cached, parent_cached)| {
+        parent.cmp(parent_cached).then_with(|| dst.cmp(dst_cached))
     }) {
-        Ok(_) => (),
-        Err(insert_at) => {
-            fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent)?;
 
-            // Here we are different than untar_in. The code for tar::unpack_in internally calling unpack is a little different.
-            // ignore return value here
-            validate_inside_dst(dst, parent)?;
-            cache.insert(insert_at, (dst.to_path_buf(), parent.to_path_buf()));
-        }
+        // Here we are different than untar_in. The code for tar::unpack_in internally calling unpack is a little different.
+        // ignore return value here
+        validate_inside_dst(dst, parent)?;
+        cache.insert(insert_at, (dst.to_path_buf(), parent.to_path_buf()));
     }
     let target = parent.join(entry_path.file_name().unwrap());
 


### PR DESCRIPTION
#### Problem
For each unpacked file from snapshot tar we do syscalls:
* create parent dir (and ancestors) 
* canonicalize parent dir path (resolves symlinks, ../, etc.)
* canonicalize unpacking root dir path -> then we check if parent is descendant of root

This shows up as noticeable chunk on the profile, especially for the code where proper writes are moved to io_uring.

#### Summary of Changes
In practice parent and root dirs are almost always the same, so this PR introduces a small cache for a pair of `(root, parent)` paths.

(In fact for the purpose of snapshot unpacking we could restrict allowed paths and pre-create / sanitize them... but this is beyond the scope of this PR)