### PR TITLE
CI: keyword required for correct crate ordering

### DIFF
--- a/ci/order-crates-for-publishing.py
+++ b/ci/order-crates-for-publishing.py
@@ -82,7 +82,7 @@ def is_path_dev_dep(dependency):
     )
 
 def should_add(package, dependency, wrong_self_dev_dependencies):
-    related_to_solana = dependency['name'].startswith('solana')
+    related_to_solana = dependency['name'].startswith(('solana','agave'))
     self_dev_dep_with_dev_context_only_utils = is_self_dev_dep_with_dev_context_only_utils(
         package, dependency, wrong_self_dev_dependencies
     )


### PR DESCRIPTION
#### Problem

Crate publishing fails because `agave` crates are not accounted for during dependency sorting

#### Summary of Changes

Add `agave-` prefix to dependency sorter.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
