### PR TITLE
v2.2: Add required feature to svm dependency

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -52,7 +52,7 @@ solana-sdk-ids = { workspace = true }
 solana-svm-rent-collector = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-timings = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["debug-signature"] }
 solana-transaction-error = { workspace = true }
 solana-type-overrides = { workspace = true }
 thiserror = { workspace = true }
@@ -97,7 +97,7 @@ solana-system-program = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["dev-context-only-utils" ] }
+solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
#### Problem

Crate publish fails without required feature. Separate PR had an attempt to only add this feature conditionally, but it turns out this is not possible in cargo right now.

#### Summary of Changes

Add `debug-signature` feature to `solana-transaction-context`
Small formatting change.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
