### PR TITLE
Remove conditional feature as it is not supported

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -75,14 +75,12 @@ solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-timings = { workspace = true }
-solana-transaction-context = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["debug-signature"] }
 solana-transaction-error = { workspace = true }
 solana-type-overrides = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
-[target.'cfg(debug_assertions)'.dependencies]
-solana-transaction-context = { workspace = true, features = ["debug-signature"] }
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -81,7 +81,6 @@ solana-type-overrides = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
-
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }


### PR DESCRIPTION
#### Problem

Adding dependencies based on configuration values is currently not supported. Cargo generates an error when trying to build this crate (see https://github.com/anza-xyz/agave/pull/6440#issuecomment-2968027425)

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies

`The same applies to cfg(debug_assertions), cfg(test) and cfg(proc_macro). These values will not work as expected and will always have the default value returned by rustc --print=cfg. There is currently no way to add dependencies based on these configuration values.`

#### Summary of Changes

Remove condition and add feature directly to dependency.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
