### PR TITLE
TestValidator checks usability of programs added to genesis during startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11011,6 +11011,7 @@ dependencies = [
  "solana-signer",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction",
  "solana-validator-exit",
  "tokio",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9304,6 +9304,7 @@ dependencies = [
  "solana-signer",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction",
  "solana-validator-exit",
  "tokio",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8404,6 +8404,7 @@ dependencies = [
  "solana-signer",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction",
  "solana-validator-exit",
  "tokio",
 ]

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -52,6 +52,7 @@ solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction = { workspace = true }
 solana-validator-exit = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 


### PR DESCRIPTION
#### Problem

- programs added to TestValidator's genesis isn't immediately usable. Runtime needs time to mark the program as "deployed";
- TestValidator [has a hack](https://github.com/anza-xyz/agave/blob/5b18ef8dea92bb62cdeee0f221ce868f107dde73/test-validator/src/lib.rs#L1063-L1066) during startup to wait for fee stabilizes.
- During this wait period, programs in TestValidator genesis usually will become ready for use; But this isn't always reliable, sometime cause test to fail due to "Program is not deployed":

```
Waiting for fees to stabilize 1...

thread 'main' panicked at clients/cli/tests/command.rs:278:14:
called `Result::unwrap()` on an `Err` value: Error { request: Some(SendTransaction), kind: RpcError(RpcResponseError { code: -32002, message: "Transaction simulation failed: Error processing Instruction 0: Unsupported program id", data: SendTransactionPreflightFailure(RpcSimulateTransactionResult { err: Some(InstructionError(0, UnsupportedProgramId)), logs: Some(["Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb invoke [1]", "Program is not deployed", "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb failed: Unsupported program id"]), accounts: None, units_consumed: Some(0), return_data: None, inner_instructions: None, replacement_blockhash: None }) }) }
```

#### Summary of Changes

Actively check for "Program is not deployed", wait till program becomes usable.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
