### PR TITLE
Geyser: Add initial accounts data before transaction execution in notify_transaction update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,9 @@ name = "agave-geyser-plugin-interface"
 version = "3.0.0"
 dependencies = [
  "log",
+ "solana-account",
  "solana-clock",
+ "solana-pubkey",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -71,6 +71,7 @@ impl Committer {
             processing_results,
             processed_counts,
             &mut execute_and_commit_timings.execute_timings,
+            self.transaction_status_sender_enabled()
         ));
         execute_and_commit_timings.commit_us = commit_time_us;
 

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -14,7 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = { workspace = true, features = ["std"] }
+solana-account = { workspace = true }
 solana-clock = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,7 +3,9 @@
 /// In addition, the dynamic library must export a "C" function _create_plugin which
 /// creates the implementation of the plugin.
 use {
+    solana_account::AccountSharedData,
     solana_clock::{Slot, UnixTimestamp},
+    solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
@@ -176,26 +178,7 @@ pub struct ReplicaTransactionInfoV3<'a> {
     /// The transaction's index in the block
     pub index: usize,
     /// States of accounts that was in transaction
-    pub post_accounts_states: Vec<(&'a [u8], TxnReplicaAccountInfo<'a>)>,
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[repr(C)]
-/// Information about an account being updated in txn
-pub struct TxnReplicaAccountInfo<'a> {
-    /// The lamports for the account
-    pub lamports: u64,
-
-    /// The Pubkey of the owner program account
-    pub owner: &'a [u8],
-
-    /// This account's data contains a loaded program (and is now read-only)
-    pub executable: bool,
-
-    /// The epoch at which this account will next owe rent
-    pub rent_epoch: u64,
-
-    /// The data held in this account.
-    pub data: &'a [u8],
+    pub post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
 }
 
 /// A wrapper to future-proof ReplicaTransactionInfo handling.

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -157,6 +157,47 @@ pub struct ReplicaTransactionInfoV2<'a> {
     pub index: usize,
 }
 
+/// Information about a transaction, including index in block and post accounts states data
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaTransactionInfoV3<'a> {
+    /// The first signature of the transaction, used for identifying the transaction.
+    pub signature: &'a Signature,
+
+    /// Indicates if the transaction is a simple vote transaction.
+    pub is_vote: bool,
+
+    /// The sanitized transaction.
+    pub transaction: &'a SanitizedTransaction,
+
+    /// Metadata of the transaction status.
+    pub transaction_status_meta: &'a TransactionStatusMeta,
+
+    /// The transaction's index in the block
+    pub index: usize,
+    /// States of accounts that was in transaction
+    pub post_accounts_states: Vec<(&'a [u8], TxnReplicaAccountInfo<'a>)>,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Information about an account being updated in txn
+pub struct TxnReplicaAccountInfo<'a> {
+    /// The lamports for the account
+    pub lamports: u64,
+
+    /// The Pubkey of the owner program account
+    pub owner: &'a [u8],
+
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: u64,
+
+    /// The data held in this account.
+    pub data: &'a [u8],
+}
+
 /// A wrapper to future-proof ReplicaTransactionInfo handling.
 /// If there were a change to the structure of ReplicaTransactionInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -165,6 +206,7 @@ pub struct ReplicaTransactionInfoV2<'a> {
 pub enum ReplicaTransactionInfoVersions<'a> {
     V0_0_1(&'a ReplicaTransactionInfo<'a>),
     V0_0_2(&'a ReplicaTransactionInfoV2<'a>),
+    V0_0_3(&'a ReplicaTransactionInfoV3<'a>),
 }
 
 #[derive(Clone, Debug)]

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -179,7 +179,7 @@ pub struct ReplicaTransactionInfoV3<'a> {
     pub index: usize,
 
     /// States of accounts that were involved in the transaction
-    pub post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
+    pub post_accounts_states: &'a [(Pubkey, AccountSharedData)],
 }
 
 /// A wrapper to future-proof ReplicaTransactionInfo handling.

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -177,7 +177,8 @@ pub struct ReplicaTransactionInfoV3<'a> {
 
     /// The transaction's index in the block
     pub index: usize,
-    /// States of accounts that was in transaction
+
+    /// States of accounts that were involved in the transaction
     pub post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
 }
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -178,7 +178,10 @@ pub struct ReplicaTransactionInfoV3<'a> {
     /// The transaction's index in the block
     pub index: usize,
 
-    /// States of accounts that were involved in the transaction
+    /// States of accounts that were involved in the transaction before transaction execution
+    pub pre_accounts_states: &'a [(Pubkey, AccountSharedData)],
+
+    /// States of accounts that were involved in the transaction after transaction execution
     pub post_accounts_states: &'a [(Pubkey, AccountSharedData)],
 }
 

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -33,7 +33,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
         signature: &Signature,
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
-        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
+        post_accounts_states: &[(Pubkey, AccountSharedData)],
     ) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
         let transaction_log_info = Self::build_replica_transaction_info(
@@ -93,7 +93,7 @@ impl TransactionNotifierImpl {
         signature: &'a Signature,
         transaction_status_meta: &'a TransactionStatusMeta,
         transaction: &'a SanitizedTransaction,
-        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
+        post_accounts_states: &'a [(Pubkey, AccountSharedData)],
     ) -> ReplicaTransactionInfoV3<'a> {
         ReplicaTransactionInfoV3 {
             index,

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -33,6 +33,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
         signature: &Signature,
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
+        pre_accounts_states: &[(Pubkey, AccountSharedData)],
         post_accounts_states: &[(Pubkey, AccountSharedData)],
     ) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
@@ -41,6 +42,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
             signature,
             transaction_status_meta,
             transaction,
+            pre_accounts_states,
             post_accounts_states,
         );
 
@@ -93,6 +95,7 @@ impl TransactionNotifierImpl {
         signature: &'a Signature,
         transaction_status_meta: &'a TransactionStatusMeta,
         transaction: &'a SanitizedTransaction,
+        pre_accounts_states: &'a [(Pubkey, AccountSharedData)],
         post_accounts_states: &'a [(Pubkey, AccountSharedData)],
     ) -> ReplicaTransactionInfoV3<'a> {
         ReplicaTransactionInfoV3 {
@@ -101,6 +104,7 @@ impl TransactionNotifierImpl {
             is_vote: transaction.is_simple_vote_transaction(),
             transaction,
             transaction_status_meta,
+            pre_accounts_states,
             post_accounts_states,
         }
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -88,7 +88,9 @@ name = "agave-geyser-plugin-interface"
 version = "3.0.0"
 dependencies = [
  "log",
+ "solana-account",
  "solana-clock",
+ "solana-pubkey",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -15,7 +15,7 @@ pub trait TransactionNotifier {
         signature: &Signature,
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
-        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
+        post_accounts_states: &[(Pubkey, AccountSharedData)],
     );
 }
 

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,11 +1,7 @@
 use {
-    solana_pubkey::Pubkey,
-    solana_sdk::{
-        account::AccountSharedData, clock::Slot, signature::Signature,
-        transaction::SanitizedTransaction,
-    },
-    solana_transaction_status::TransactionStatusMeta,
-    std::sync::Arc,
+    solana_account::AccountSharedData, solana_clock::Slot, solana_pubkey::Pubkey,
+    solana_signature::Signature, solana_transaction::sanitized::SanitizedTransaction,
+    solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
 };
 
 pub trait TransactionNotifier {

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,3 +1,6 @@
+use solana_pubkey::Pubkey;
+use solana_sdk::account::AccountSharedData;
+
 use {
     solana_clock::Slot, solana_signature::Signature,
     solana_transaction::sanitized::SanitizedTransaction,
@@ -12,6 +15,7 @@ pub trait TransactionNotifier {
         signature: &Signature,
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
+        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
     );
 }
 

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,10 +1,11 @@
-use solana_pubkey::Pubkey;
-use solana_sdk::account::AccountSharedData;
-
 use {
-    solana_clock::Slot, solana_signature::Signature,
-    solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
+    solana_pubkey::Pubkey,
+    solana_sdk::{
+        account::AccountSharedData, clock::Slot, signature::Signature,
+        transaction::SanitizedTransaction,
+    },
+    solana_transaction_status::TransactionStatusMeta,
+    std::sync::Arc,
 };
 
 pub trait TransactionNotifier {

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -12,6 +12,7 @@ pub trait TransactionNotifier {
         signature: &Signature,
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &SanitizedTransaction,
+        pre_accounts_states: &[(Pubkey, AccountSharedData)],
         post_accounts_states: &[(Pubkey, AccountSharedData)],
     );
 }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -323,8 +323,6 @@ impl TransactionStatusService {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use solana_sdk::account::AccountSharedData;
-
     use {
         super::*,
         crate::transaction_notifier_interface::TransactionNotifier,
@@ -346,6 +344,7 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_rent_debits::RentDebits,
         solana_runtime::bank::{Bank, TransactionBalancesSet},
+        solana_sdk::account::AccountSharedData,
         solana_signature::Signature,
         solana_signer::Signer,
         solana_svm::transaction_execution_result::TransactionLoadedAccountsStats,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -370,6 +370,7 @@ pub(crate) mod tests {
 
     struct TestNotification {
         _meta: TransactionStatusMeta,
+        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
         transaction: SanitizedTransaction,
     }
 
@@ -393,7 +394,7 @@ pub(crate) mod tests {
             signature: &Signature,
             transaction_status_meta: &TransactionStatusMeta,
             transaction: &SanitizedTransaction,
-            _post_accounts_states: &[(Pubkey, AccountSharedData)],
+            post_accounts_states: &[(Pubkey, AccountSharedData)],
         ) {
             self.notifications.insert(
                 TestNotifierKey {
@@ -403,6 +404,7 @@ pub(crate) mod tests {
                 },
                 TestNotification {
                     _meta: transaction_status_meta.clone(),
+                    post_accounts_states: post_accounts_states.to_vec(),
                     transaction: transaction.clone(),
                 },
             );
@@ -469,7 +471,7 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits,
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
-            post_accounts_states,
+            post_accounts_states: post_accounts_states.clone(),
         });
 
         let balances = TransactionBalancesSet {
@@ -550,6 +552,7 @@ pub(crate) mod tests {
             expected_transaction.signature(),
             result.transaction.signature()
         );
+        assert_eq!(post_accounts_states, result.post_accounts_states);
     }
 
     #[test]

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -370,8 +370,8 @@ pub(crate) mod tests {
 
     struct TestNotification {
         _meta: TransactionStatusMeta,
-        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
         transaction: SanitizedTransaction,
+        post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
     }
 
     struct TestTransactionNotifier {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -453,6 +453,13 @@ pub(crate) mod tests {
         let mut rent_debits = RentDebits::default();
         rent_debits.insert(&pubkey, 123, 456);
 
+        let post_accounts_states: Vec<(Pubkey, AccountSharedData)> = transaction
+            .message()
+            .account_keys()
+            .iter()
+            .map(|x| (*x, bank.get_account(x).unwrap()))
+            .collect();
+
         let commit_result = Ok(CommittedTransaction {
             status: Ok(()),
             log_messages: None,
@@ -462,8 +469,7 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits,
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
-            //Do we need to put something here?
-            post_accounts_states: vec![],
+            post_accounts_states,
         });
 
         let balances = TransactionBalancesSet {
@@ -591,7 +597,6 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits: RentDebits::default(),
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
-            //Do we need to put something here?
             post_accounts_states: vec![],
         });
 

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -459,12 +459,7 @@ pub(crate) mod tests {
         let mut rent_debits = RentDebits::default();
         rent_debits.insert(&pubkey, 123, 456);
 
-        let post_accounts_states: Vec<(Pubkey, AccountSharedData)> = transaction
-            .message()
-            .account_keys()
-            .iter()
-            .map(|key| (*key, bank.get_account(key).unwrap()))
-            .collect();
+        let post_accounts_states: Vec<(Pubkey, AccountSharedData)> = vec![(pubkey, nonce_account)];
         let pre_accounts_states = post_accounts_states.clone();
         let commit_result = Ok(CommittedTransaction {
             status: Ok(()),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -165,6 +165,7 @@ impl TransactionStatusService {
                         executed_units,
                         fee_details,
                         rent_debits,
+                        post_accounts_states,
                         ..
                     } = committed_tx;
 
@@ -211,6 +212,7 @@ impl TransactionStatusService {
                             transaction.signature(),
                             &transaction_status_meta,
                             &transaction,
+                            post_accounts_states,
                         );
                     }
 
@@ -321,6 +323,8 @@ impl TransactionStatusService {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use solana_sdk::account::AccountSharedData;
+
     use {
         super::*,
         crate::transaction_notifier_interface::TransactionNotifier,
@@ -390,6 +394,7 @@ pub(crate) mod tests {
             signature: &Signature,
             transaction_status_meta: &TransactionStatusMeta,
             transaction: &SanitizedTransaction,
+            _post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
         ) {
             self.notifications.insert(
                 TestNotifierKey {
@@ -458,6 +463,8 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits,
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            //Do we need to put something here?
+            post_accounts_states: vec![],
         });
 
         let balances = TransactionBalancesSet {
@@ -585,6 +592,8 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits: RentDebits::default(),
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            //Do we need to put something here?
+            post_accounts_states: vec![],
         });
 
         let balances = TransactionBalancesSet {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -212,7 +212,7 @@ impl TransactionStatusService {
                             transaction.signature(),
                             &transaction_status_meta,
                             &transaction,
-                            &post_accounts_states,
+                            post_accounts_states.as_ref().expect("post_accounts_states should be available because the TransactionNotifier service is on"),
                         );
                     }
 
@@ -329,7 +329,7 @@ pub(crate) mod tests {
         agave_reserved_account_keys::ReservedAccountKeys,
         crossbeam_channel::unbounded,
         dashmap::DashMap,
-        solana_account::state_traits::StateMut,
+        solana_account::{state_traits::StateMut, AccountSharedData},
         solana_account_decoder::{
             parse_account_data::SplTokenAdditionalDataV2, parse_token::token_amount_to_ui_amount_v3,
         },
@@ -344,7 +344,6 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_rent_debits::RentDebits,
         solana_runtime::bank::{Bank, TransactionBalancesSet},
-        solana_sdk::account::AccountSharedData,
         solana_signature::Signature,
         solana_signer::Signer,
         solana_svm::transaction_execution_result::TransactionLoadedAccountsStats,
@@ -471,7 +470,7 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits,
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
-            post_accounts_states: post_accounts_states.clone(),
+            post_accounts_states: Some(post_accounts_states.clone()),
         });
 
         let balances = TransactionBalancesSet {
@@ -600,7 +599,7 @@ pub(crate) mod tests {
             fee_details: FeeDetails::default(),
             rent_debits: RentDebits::default(),
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
-            post_accounts_states: vec![],
+            post_accounts_states: Some(vec![]),
         });
 
         let balances = TransactionBalancesSet {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -459,7 +459,7 @@ pub(crate) mod tests {
             .message()
             .account_keys()
             .iter()
-            .map(|x| (*x, bank.get_account(x).unwrap()))
+            .map(|key| (*key, bank.get_account(key).unwrap()))
             .collect();
 
         let commit_result = Ok(CommittedTransaction {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -212,7 +212,7 @@ impl TransactionStatusService {
                             transaction.signature(),
                             &transaction_status_meta,
                             &transaction,
-                            post_accounts_states,
+                            &post_accounts_states,
                         );
                     }
 
@@ -393,7 +393,7 @@ pub(crate) mod tests {
             signature: &Signature,
             transaction_status_meta: &TransactionStatusMeta,
             transaction: &SanitizedTransaction,
-            _post_accounts_states: Vec<(Pubkey, AccountSharedData)>,
+            _post_accounts_states: &[(Pubkey, AccountSharedData)],
         ) {
             self.notifications.insert(
                 TestNotifierKey {

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -140,7 +140,10 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
 ) {
     let fee_payer_address = transaction.fee_payer();
     match rollback_accounts {
-        RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+        RollbackAccounts::FeePayerOnly {
+            fee_payer_account,
+            fee_payer_address: _,
+        } => {
             collected_accounts.push((fee_payer_address, fee_payer_account));
             if let Some(collected_account_transactions) = collected_account_transactions {
                 collected_account_transactions
@@ -157,6 +160,7 @@ fn collect_accounts_for_failed_tx<'a, T: SVMMessage>(
         RollbackAccounts::SeparateNonceAndFeePayer {
             nonce,
             fee_payer_account,
+            fee_payer_address: _,
         } => {
             collected_accounts.push((fee_payer_address, fee_payer_account));
             if let Some(collected_account_transactions) = collected_account_transactions {
@@ -352,6 +356,7 @@ mod tests {
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::FeePayerOnly {
                 fee_payer_account: from_account_pre.clone(),
+                fee_payer_address: from_address,
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             rent: 0,
@@ -447,6 +452,7 @@ mod tests {
             rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce: nonce.clone(),
                 fee_payer_account: from_account_pre.clone(),
+                fee_payer_address: from_address,
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             rent: 0,
@@ -623,6 +629,7 @@ mod tests {
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::FeePayerOnly {
                     fee_payer_account: from_account_pre.clone(),
+                    fee_payer_address: from_address,
                 },
             },
         )))];

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -287,6 +287,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let loaded1 = LoadedTransaction {
@@ -298,6 +299,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let txs = vec![tx0.clone(), tx1.clone()];
@@ -362,6 +364,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let txs = vec![tx];
@@ -458,6 +461,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let txs = vec![tx];
@@ -566,6 +570,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let txs = vec![tx];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -141,7 +141,6 @@ use {
     solana_svm::{
         account_loader::{collect_rent_from_account, LoadedTransaction},
         account_overrides::AccountOverrides,
-        nonce_info::NonceInfo,
         program_loader::load_program_with_pubkey,
         rollback_accounts::RollbackAccounts,
         transaction_balances::BalanceCollector,
@@ -3908,8 +3907,8 @@ impl Bank {
                                     fee_payer_account,
                                     fee_payer_address,
                                 } => vec![
-                                    (fee_payer_address, fee_payer_account), 
-                                    (nonde.address, nonce.account)
+                                    (fee_payer_address, fee_payer_account),
+                                    (nonce.address, nonce.account),
                                 ],
                             }
                         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3858,13 +3858,12 @@ impl Bank {
                 let processing_result = processing_result?;
                 let executed_units = processing_result.executed_units();
                 let loaded_accounts_data_size = processing_result.loaded_accounts_data_size();
-
                 match processing_result {
                     ProcessedTransaction::Executed(executed_tx) => {
                         let execution_details = executed_tx.execution_details;
                         let LoadedTransaction {
                             rent_debits,
-                            accounts: loaded_accounts,
+                            accounts: mut loaded_accounts,
                             fee_details,
                             ..
                         } = executed_tx.loaded_transaction;
@@ -3889,6 +3888,12 @@ impl Bank {
                                 loaded_accounts_data_size,
                             },
                             post_accounts_states: if is_geyser_present {
+                                //Mutate zero lamports accounts to default state to be in line with current Geyser Account Notification implementation
+                                loaded_accounts.iter_mut().for_each(|(_, acc)| {
+                                    if acc.lamports() == 0 {
+                                        *acc = AccountSharedData::default()
+                                    }
+                                });
                                 Some(loaded_accounts)
                             } else {
                                 None

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3901,17 +3901,16 @@ impl Bank {
                                     vec![(fee_payer_address, fee_payer_account)]
                                 }
                                 RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                                    let NonceInfo { address, account } = nonce;
-                                    vec![(address, account)]
+                                    vec![(nonce.address, nonce.account)]
                                 }
                                 RollbackAccounts::SeparateNonceAndFeePayer {
                                     nonce,
                                     fee_payer_account,
                                     fee_payer_address,
-                                } => {
-                                    let NonceInfo { address, account } = nonce;
-                                    vec![(fee_payer_address, fee_payer_account), (address, account)]
-                                }
+                                } => vec![
+                                    (fee_payer_address, fee_payer_account), 
+                                    (nonde.address, nonce.account)
+                                ],
                             }
                         };
                         Ok(CommittedTransaction {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3864,6 +3864,7 @@ impl Bank {
                         let LoadedTransaction {
                             rent_debits,
                             accounts: mut loaded_accounts,
+                            pre_accounts_states,
                             fee_details,
                             ..
                         } = executed_tx.loaded_transaction;
@@ -3887,6 +3888,7 @@ impl Bank {
                                 loaded_accounts_count: loaded_accounts.len(),
                                 loaded_accounts_data_size,
                             },
+                            pre_accounts_states,
                             post_accounts_states: if is_geyser_present {
                                 //Mutate zero lamports accounts to default state to be in line with current Geyser Account Notification implementation
                                 loaded_accounts.iter_mut().for_each(|(_, acc)| {
@@ -3936,6 +3938,11 @@ impl Bank {
                                 loaded_accounts_data_size,
                             },
                             post_accounts_states,
+                            pre_accounts_states: if is_geyser_present {
+                                Some(vec![])
+                            } else {
+                                None
+                            },
                         })
                     }
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3895,23 +3895,22 @@ impl Bank {
                         let post_accounts_states = {
                             match fees_only_tx.rollback_accounts {
                                 RollbackAccounts::FeePayerOnly {
-                                    fee_payer_account: _,
+                                    fee_payer_account,
+                                    fee_payer_address,
                                 } => {
-                                    //no fee_payer_account address here :C
-                                    vec![]
+                                    vec![(fee_payer_address, fee_payer_account)]
                                 }
                                 RollbackAccounts::SameNonceAndFeePayer { nonce } => {
-                                    //We eliminate cloning here by making NonceInfo fields public
                                     let NonceInfo { address, account } = nonce;
                                     vec![(address, account)]
                                 }
                                 RollbackAccounts::SeparateNonceAndFeePayer {
                                     nonce,
-                                    fee_payer_account: _,
+                                    fee_payer_account,
+                                    fee_payer_address,
                                 } => {
-                                    //no fee_payer_account address here :C
                                     let NonceInfo { address, account } = nonce;
-                                    vec![(address, account)]
+                                    vec![(fee_payer_address, fee_payer_account), (address, account)]
                                 }
                             }
                         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3885,6 +3885,7 @@ impl Bank {
                                 loaded_accounts_count: loaded_accounts.len(),
                                 loaded_accounts_data_size,
                             },
+                            post_accounts_states: loaded_accounts,
                         })
                     }
                     ProcessedTransaction::FeesOnly(fees_only_tx) => Ok(CommittedTransaction {
@@ -3899,6 +3900,7 @@ impl Bank {
                             loaded_accounts_count: fees_only_tx.rollback_accounts.count(),
                             loaded_accounts_data_size,
                         },
+                        post_accounts_states: vec![],
                     }),
                 }
             })

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3289,7 +3289,13 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 loaded_accounts_count: 2,
                 loaded_accounts_data_size: nonce_size as u32,
             },
-            post_accounts_states: vec![],
+            post_accounts_states: vec![
+                (
+                    rent_paying_fee_payer,
+                    bank.get_account(&rent_paying_fee_payer).unwrap()
+                ),
+                (nonce_pubkey, bank.get_account(&nonce_pubkey).unwrap())
+            ],
         })]
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3289,6 +3289,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 loaded_accounts_count: 2,
                 loaded_accounts_data_size: nonce_size as u32,
             },
+            post_accounts_states: vec![],
         })]
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3296,6 +3296,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 ),
                 (nonce_pubkey, bank.get_account(&nonce_pubkey).unwrap())
             ]),
+            pre_accounts_states: Some(vec![])
         })]
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3289,13 +3289,13 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 loaded_accounts_count: 2,
                 loaded_accounts_data_size: nonce_size as u32,
             },
-            post_accounts_states: vec![
+            post_accounts_states: Some(vec![
                 (
                     rent_paying_fee_payer,
                     bank.get_account(&rent_paying_fee_payer).unwrap()
                 ),
                 (nonce_pubkey, bank.get_account(&nonce_pubkey).unwrap())
-            ],
+            ]),
         })]
     );
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -88,7 +88,9 @@ name = "agave-geyser-plugin-interface"
 version = "3.0.0"
 dependencies = [
  "log",
+ "solana-account",
  "solana-clock",
+ "solana-pubkey",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -145,6 +145,9 @@ pub struct LoadedTransaction {
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
     pub loaded_accounts_data_size: u32,
+    /// Account states before transaction execution
+    /// collected if geyser is enabled.
+    pub pre_accounts_states: Option<Vec<TransactionAccount>>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -451,6 +454,7 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
     validation_result: TransactionValidationResult,
     error_metrics: &mut TransactionErrorMetrics,
     rent_collector: &dyn SVMRentCollector,
+    is_geyser_enabled: bool,
 ) -> TransactionLoadResult {
     match validation_result {
         Err(e) => TransactionLoadResult::NotLoaded(e),
@@ -466,6 +470,11 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
 
             match load_result {
                 Ok(loaded_tx_accounts) => TransactionLoadResult::Loaded(LoadedTransaction {
+                    pre_accounts_states: if is_geyser_enabled {
+                        Some(loaded_tx_accounts.accounts.clone())
+                    } else {
+                        None
+                    },
                     accounts: loaded_tx_accounts.accounts,
                     program_indices: loaded_tx_accounts.program_indices,
                     fee_details: tx_details.fee_details,
@@ -1044,6 +1053,7 @@ mod tests {
             }),
             error_metrics,
             rent_collector,
+            false,
         )
     }
 
@@ -1359,6 +1369,7 @@ mod tests {
             Ok(ValidatedTransactionDetails::default()),
             &mut error_metrics,
             &RentCollector::default(),
+            false,
         )
     }
 
@@ -2261,6 +2272,7 @@ mod tests {
             Ok(ValidatedTransactionDetails::default()),
             &mut error_metrics,
             &RentCollector::default(),
+            false,
         );
 
         let TransactionLoadResult::Loaded(loaded_transaction) = load_result else {
@@ -2369,6 +2381,7 @@ mod tests {
             validation_result,
             &mut error_metrics,
             &RentCollector::default(),
+            false,
         );
 
         let loaded_accounts_data_size = base_account_size as u32 * 2;
@@ -2400,6 +2413,7 @@ mod tests {
                 rent: 0,
                 rent_debits: RentDebits::default(),
                 loaded_accounts_data_size,
+                pre_accounts_states: None,
             }
         );
     }
@@ -2435,6 +2449,7 @@ mod tests {
             validation_result.clone(),
             &mut TransactionErrorMetrics::default(),
             &rent_collector,
+            false,
         );
 
         assert!(matches!(
@@ -2453,6 +2468,7 @@ mod tests {
             validation_result,
             &mut TransactionErrorMetrics::default(),
             &rent_collector,
+            false,
         );
 
         assert!(matches!(
@@ -2601,6 +2617,7 @@ mod tests {
             validation_result,
             &mut TransactionErrorMetrics::default(),
             &RentCollector::default(),
+            false,
         );
 
         // ensure the loaded accounts are inspected

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -287,7 +287,10 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     ) {
         let fee_payer_address = message.fee_payer();
         match rollback_accounts {
-            RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+            RollbackAccounts::FeePayerOnly {
+                fee_payer_account,
+                fee_payer_address: _,
+            } => {
                 self.loaded_accounts
                     .insert(*fee_payer_address, fee_payer_account.clone());
             }
@@ -298,6 +301,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce,
                 fee_payer_account,
+                fee_payer_address: _,
             } => {
                 self.loaded_accounts
                     .insert(*nonce.address(), nonce.account().clone());

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2973,7 +2973,10 @@ mod tests {
         fee_payer_account.set_lamports(0);
         account_loader.update_accounts_for_failed_tx(
             &sanitized_message,
-            &RollbackAccounts::FeePayerOnly { fee_payer_account },
+            &RollbackAccounts::FeePayerOnly {
+                fee_payer_account,
+                fee_payer_address: fee_payer,
+            },
         );
 
         assert_eq!(

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -13,8 +13,8 @@ use {solana_account::AccountSharedData, solana_pubkey::Pubkey};
 /// Holds limited nonce info available during transaction checks
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NonceInfo {
-    address: Pubkey,
-    account: AccountSharedData,
+    pub address: Pubkey,
+    pub account: AccountSharedData,
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -1,3 +1,5 @@
+use solana_transaction_context::TransactionAccount;
+
 use {
     crate::transaction_execution_result::TransactionLoadedAccountsStats,
     solana_fee_structure::FeeDetails, solana_message::inner_instruction::InnerInstructionsList,
@@ -18,6 +20,7 @@ pub struct CommittedTransaction {
     pub fee_details: FeeDetails,
     pub rent_debits: RentDebits,
     pub loaded_account_stats: TransactionLoadedAccountsStats,
+    pub post_accounts_states: Vec<TransactionAccount>,
 }
 
 pub trait TransactionCommitResultExtensions {

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -21,6 +21,8 @@ pub struct CommittedTransaction {
     pub rent_debits: RentDebits,
     pub loaded_account_stats: TransactionLoadedAccountsStats,
     ///This is None only if no Geyser plugins are detected.
+    pub pre_accounts_states: Option<Vec<TransactionAccount>>,
+    ///This is None only if no Geyser plugins are detected.
     pub post_accounts_states: Option<Vec<TransactionAccount>>,
 }
 

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -20,7 +20,8 @@ pub struct CommittedTransaction {
     pub fee_details: FeeDetails,
     pub rent_debits: RentDebits,
     pub loaded_account_stats: TransactionLoadedAccountsStats,
-    pub post_accounts_states: Vec<TransactionAccount>,
+    ///This is None only if no Geyser plugins are detected.
+    pub post_accounts_states: Option<Vec<TransactionAccount>>,
 }
 
 pub trait TransactionCommitResultExtensions {

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -1,9 +1,9 @@
-use solana_transaction_context::TransactionAccount;
-
 use {
     crate::transaction_execution_result::TransactionLoadedAccountsStats,
-    solana_fee_structure::FeeDetails, solana_message::inner_instruction::InnerInstructionsList,
-    solana_rent_debits::RentDebits, solana_transaction_context::TransactionReturnData,
+    solana_fee_structure::FeeDetails,
+    solana_message::inner_instruction::InnerInstructionsList,
+    solana_rent_debits::RentDebits,
+    solana_transaction_context::{TransactionAccount, TransactionReturnData},
     solana_transaction_error::TransactionResult,
 };
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -427,6 +427,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 environment
                     .rent_collector
                     .unwrap_or(&RentCollector::default()),
+                config.recording_config.enable_transaction_balance_recording,
             ));
             load_us = load_us.saturating_add(single_load_us);
 
@@ -1375,6 +1376,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 32,
+            pre_accounts_states: None,
         };
 
         let processing_environment = TransactionProcessingEnvironment::default();
@@ -1472,6 +1474,7 @@ mod tests {
             rent: 0,
             rent_debits: RentDebits::default(),
             loaded_accounts_data_size: 0,
+            pre_accounts_states: None,
         };
 
         let processing_config = TransactionProcessingConfig {

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -178,7 +178,10 @@ impl SvmTestEnvironment<'_> {
                     let fee_payer = sanitized_transaction.fee_payer();
 
                     match fees_only_transaction.rollback_accounts.clone() {
-                        RollbackAccounts::FeePayerOnly { fee_payer_account } => {
+                        RollbackAccounts::FeePayerOnly {
+                            fee_payer_account,
+                            fee_payer_address: _,
+                        } => {
                             update_or_dealloc_account(
                                 &mut final_accounts_actual,
                                 *fee_payer,
@@ -195,6 +198,7 @@ impl SvmTestEnvironment<'_> {
                         RollbackAccounts::SeparateNonceAndFeePayer {
                             nonce,
                             fee_payer_account,
+                            fee_payer_address: _,
                         } => {
                             update_or_dealloc_account(
                                 &mut final_accounts_actual,


### PR DESCRIPTION
This should be landed after #5114 or be included in #5114

#### Problem
In order to evict `BalanceCollector` and other RPC components from the validator in the future, we should enrich the Geyser interface.

This change opens the way to calculate pre/post balances on the other side of the Geyser boundary. It also partially resolves the problem in #5114, where, in cases where a transaction changes an account's lamports to 0 we can no longer access its data.

#### Summary of Changes

Add `pre_accounts_states` to Geyser `notify_transaction` update via cloning loaded accounts in `LoadedTransaction` struct



