### PR TITLE
rpc/runtime: Add simulateTransactionAsStatusMeta API for full simulation result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9940,6 +9940,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-clock",
+ "solana-message",
  "solana-rpc-client-types",
  "solana-signer",
  "solana-transaction-error",

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -191,6 +191,8 @@ fn simulate_transaction(
         loaded_accounts_data_size,
         return_data,
         inner_instructions,
+        fee: _,
+        balance_collector: _,
     } = bank.simulate_transaction_unchecked(&sanitized_transaction, true);
 
     let simulation_details = TransactionSimulationDetails {

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-clock = { workspace = true }
 solana-rpc-client-types = { workspace = true }
+solana-message = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13206,6 +13206,8 @@ fn test_failed_simulation_load_error() {
             loaded_accounts_data_size: 0,
             return_data: None,
             inner_instructions: None,
+            fee: None,
+            balance_collector: None,
         }
     );
 }

--- a/svm/src/transaction_balances.rs
+++ b/svm/src/transaction_balances.rs
@@ -32,7 +32,7 @@ pub(crate) trait BalanceCollectionRoutines {
     );
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(native_pre(pub), native_post(pub), token_pre(pub), token_post(pub),)
@@ -163,7 +163,7 @@ impl BalanceCollectionRoutines for Option<BalanceCollector> {
 
 // this contains all the information we can provide to construct TransactionTokenBalance
 // that type, in ledger, depends on UiTokenAmount from account-decoder, so we cannot build it here
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SvmTokenInfo {
     pub account_index: u8,
     pub mint: Pubkey,


### PR DESCRIPTION
#### Problem

Currently `simulateTransaction` RPC method has limited power. For example it does not return loaded addresses from lookup tables so the user should query or cache the table to guess what program is invoked in CPI. This could be a huge obstacle for devs who simulate Jupiter aggregated transactions which heavily use lookup tables.

#### Summary of Changes

This PR suggests `simulateTransactionAsStatusMeta` RPC method which returns `UiTransactionStatusMeta`. It matches the behavior of `getTransaction` RPC method as best as possible. To achieve this, the bank's simulation result additionally passes fee and balance collector information from execution result.

Alternatively, we can update `RpcSimulateTransactionResult` as a enum which is a sum type of 'the old `RpcSimulateTransactionResult`' and `UiTransactionStatusMeta`, and change the type based on a newly added method parameter field. This would be a breaking change for the RPC client API.

Todo: write test cases for this method? Might want to hear feedback on the method design first.
