### PR TITLE
cli: Full snapshot interval doesn't need to be a multiple of the incremental

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -444,8 +444,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.full_snapshot_archive_interval_slots)
             .help("Number of slots between generating full snapshots")
             .long_help(
-                "Number of slots between generating full snapshots. Must be a multiple of the \
-                 incremental snapshot interval. Only used when incremental snapshots are enabled.",
+                "Number of slots between generating full snapshots. \
+                 Only used when incremental snapshots are enabled.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -445,7 +445,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Number of slots between generating full snapshots")
             .long_help(
                 "Number of slots between generating full snapshots. \
-                 Only used when incremental snapshots are enabled.",
+                 Only used when incremental snapshots are enabled. \
+                 Must be greater than the incremental snapshot interval.",
             ),
     )
     .arg(


### PR DESCRIPTION
Since PR #5519, the cli help for `--full-snapshot-interval-slots` is wrong: the full snapshot interval does not need to be a multiple of the incremental snapshot interval.

