### PR TITLE
changelog: Move deprecated snapshot archive note to Breaking section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ Release channels have their own copy of this changelog:
   * `--replay-slots-concurrently`
   * `--rpc-pubsub-max-connections`, `--rpc-pubsub-max-fragment-size`, `--rpc-pubsub-max-in-buffer-capacity`, `--rpc-pubsub-max-out-buffer-capacity`, `--enable-cpi-and-log-storage`, `--minimal-rpc-api`
   * `--skip-poh-verify`
-
-#### Changes
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 
 ## 2.3.0


### PR DESCRIPTION
#### Problem
- In `v1.17`, we supported a bunch of snapshot archive formats
- In `v1.18`, we deprecated some of them with https://github.com/solana-labs/solana/pull/33484
    - We disallowed creating new snapshot with the deprecated formats, but allowed reading from them
- In `v3.0`, we fully removed read support of these deprecated formats with https://github.com/anza-xyz/agave/pull/6541

Due to other changes in snapshot format, it wouldn't be possible to load a v1.17 snapshot in v3.0 (regardless of the compression algorithm).

#### Summary of Changes
To make the changelog more "proper", move the note about deprecated formats from `Changes` to `Breaking` section