### PR TITLE
Minor Fix: Update Documentation links

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-accounts-db"
 description = "Solana accounts db"
-documentation = "https://docs.rs/solana-acounts-db"
+documentation = "https://docs.rs/solana-accounts-db"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-rpc-client-nonce-utils"
 description = "Solana RPC Client Nonce Utilities"
-documentation = "https://docs.rs/solana-nonce-client"
+documentation = "https://docs.rs/solana-rpc-client-nonce-utils"
 version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
#### Problem
This PR fixes broken docs.rs links for various Solana-related crates found in the documentation. The original links were either pointing to non-existent pages (due to typos or outdated crate names), or referencing crates that no longer publish documentation on docs.rs.

#### Summary of Changes
| Crate Name                 | Broken URL                                          | Fixed URL                                                  |
|---------------------------|-----------------------------------------------------|------------------------------------------------------------|
| Solana Accounts DB        | https://docs.rs/solana-acounts-db                   | https://docs.rs/solana-accounts-db                         |
| RPC Client Nonce Utils    | https://docs.rs/solana-nonce-client                 | https://docs.rs/solana-rpc-client-nonce-utils             |


