### PR TITLE
fix: update SOL/lamports doc link to point directly to lamports section

### DIFF
--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -216,7 +216,7 @@ Or to see in finer detail:
 solana balance --lamports
 ```
 
-Read more about the [difference between SOL and lamports here](https://docs.solana.com/developing/programming-model/accounts#lamports).
+Read more about the difference between SOL and lamports here: [What is SOL?](https://solana.com/docs/references/terminology#sol), [What is a lamport?](https://solana.com/docs/references/terminology#lamport).
 
 ## Create Authorized Withdrawer Account
 

--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -216,7 +216,7 @@ Or to see in finer detail:
 solana balance --lamports
 ```
 
-Read more about the [difference between SOL and lamports here](https://solana.com/docs/intro#what-are-sols).
+Read more about the [difference between SOL and lamports here](https://docs.solana.com/developing/programming-model/accounts#lamports).
 
 ## Create Authorized Withdrawer Account
 


### PR DESCRIPTION
Replaced the general link to the Solana documentation about SOL and lamports with a direct anchor link (#lamports). This ensures users are taken straight to the relevant section describing lamports as the smallest unit of SOL.