### PR TITLE
Uses an enum for the snapshot interval

### DIFF
--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -32,7 +32,7 @@ use {
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
         snapshot_controller::SnapshotController,
-        snapshot_utils,
+        snapshot_utils::{self, SnapshotInterval},
     },
     solana_signer::Signer,
     solana_streamer::socket::SocketAddrSpace,
@@ -40,6 +40,7 @@ use {
     solana_time_utils::timestamp,
     std::{
         mem::ManuallyDrop,
+        num::NonZeroU64,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Mutex, RwLock,
@@ -79,8 +80,12 @@ impl TestEnvironment {
         incremental_snapshot_archive_interval_slots: Slot,
     ) -> TestEnvironment {
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots,
-            incremental_snapshot_archive_interval_slots,
+            full_snapshot_archive_interval: SnapshotInterval::Slots(
+                NonZeroU64::new(full_snapshot_archive_interval_slots).unwrap(),
+            ),
+            incremental_snapshot_archive_interval: SnapshotInterval::Slots(
+                NonZeroU64::new(incremental_snapshot_archive_interval_slots).unwrap(),
+            ),
             ..SnapshotConfig::default()
         };
         Self::_new(snapshot_config)

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -856,7 +856,7 @@ mod test {
         super::*,
         crate::{
             bank::epoch_accounts_hash_utils, genesis_utils::create_genesis_config,
-            snapshot_config::SnapshotConfig,
+            snapshot_config::SnapshotConfig, snapshot_utils::SnapshotInterval,
         },
         crossbeam_channel::unbounded,
         solana_account::AccountSharedData,
@@ -864,6 +864,7 @@ mod test {
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_pubkey::Pubkey,
+        std::num::NonZeroU64,
     };
 
     #[test]
@@ -910,8 +911,12 @@ mod test {
         const INCREMENTAL_SNAPSHOT_INTERVAL: Slot = 30;
 
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots: FULL_SNAPSHOT_INTERVAL,
-            incremental_snapshot_archive_interval_slots: INCREMENTAL_SNAPSHOT_INTERVAL,
+            full_snapshot_archive_interval: SnapshotInterval::Slots(
+                NonZeroU64::new(FULL_SNAPSHOT_INTERVAL).unwrap(),
+            ),
+            incremental_snapshot_archive_interval: SnapshotInterval::Slots(
+                NonZeroU64::new(INCREMENTAL_SNAPSHOT_INTERVAL).unwrap(),
+            ),
             ..SnapshotConfig::default()
         };
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -53,10 +53,6 @@ use {
     },
 };
 
-pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 50_000;
-pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
-pub const DISABLED_SNAPSHOT_ARCHIVE_INTERVAL: Slot = Slot::MAX;
-
 pub fn serialize_status_cache(
     slot_deltas: &[BankSlotDelta],
     status_cache_path: &Path,

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,9 +1,5 @@
 use {
-    crate::{
-        snapshot_bank_utils,
-        snapshot_utils::{self, ArchiveFormat, SnapshotVersion, ZstdConfig},
-    },
-    solana_clock::Slot,
+    crate::snapshot_utils::{self, ArchiveFormat, SnapshotInterval, SnapshotVersion, ZstdConfig},
     std::{num::NonZeroUsize, path::PathBuf},
 };
 
@@ -14,10 +10,10 @@ pub struct SnapshotConfig {
     pub usage: SnapshotUsage,
 
     /// Generate a new full snapshot archive every this many slots
-    pub full_snapshot_archive_interval_slots: Slot,
+    pub full_snapshot_archive_interval: SnapshotInterval,
 
     /// Generate a new incremental snapshot archive every this many slots
-    pub incremental_snapshot_archive_interval_slots: Slot,
+    pub incremental_snapshot_archive_interval: SnapshotInterval,
 
     /// Path to the directory where full snapshot archives are stored
     pub full_snapshot_archives_dir: PathBuf,
@@ -49,10 +45,12 @@ impl Default for SnapshotConfig {
     fn default() -> Self {
         Self {
             usage: SnapshotUsage::LoadAndGenerate,
-            full_snapshot_archive_interval_slots:
-                snapshot_bank_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-            incremental_snapshot_archive_interval_slots:
-                snapshot_bank_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            full_snapshot_archive_interval: SnapshotInterval::Slots(
+                snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            ),
+            incremental_snapshot_archive_interval: SnapshotInterval::Slots(
+                snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            ),
             full_snapshot_archives_dir: PathBuf::default(),
             incremental_snapshot_archives_dir: PathBuf::default(),
             bank_snapshots_dir: PathBuf::default(),
@@ -74,6 +72,8 @@ impl SnapshotConfig {
     pub fn new_load_only() -> Self {
         Self {
             usage: SnapshotUsage::LoadOnly,
+            full_snapshot_archive_interval: SnapshotInterval::Disabled,
+            incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
             ..Self::default()
         }
     }
@@ -83,6 +83,8 @@ impl SnapshotConfig {
     pub fn new_disabled() -> Self {
         Self {
             usage: SnapshotUsage::Disabled,
+            full_snapshot_archive_interval: SnapshotInterval::Disabled,
+            incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
             ..Self::default()
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -39,7 +39,7 @@ use {
         fmt, fs,
         io::{BufReader, BufWriter, Error as IoError, Read, Result as IoResult, Seek, Write},
         mem,
-        num::NonZeroUsize,
+        num::{NonZeroU64, NonZeroUsize},
         ops::RangeInclusive,
         path::{Path, PathBuf},
         process::ExitStatus,
@@ -58,8 +58,9 @@ use {
 };
 
 mod archive_format;
+mod snapshot_interval;
 pub mod snapshot_storage_rebuilder;
-pub use archive_format::*;
+pub use {archive_format::*, snapshot_interval::SnapshotInterval};
 
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
@@ -77,6 +78,10 @@ pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
 // - Safe because the values are fixed, known non-zero constants
 // - Necessary in order to have a plain NonZeroUsize as the constant, NonZeroUsize
 //   returns an Option<NonZeroUsize> and we can't .unwrap() at compile time
+pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
+    NonZeroU64::new(50_000).unwrap();
+pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
+    NonZeroU64::new(100).unwrap();
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     NonZeroUsize::new(2).unwrap();
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =

--- a/runtime/src/snapshot_utils/snapshot_interval.rs
+++ b/runtime/src/snapshot_utils/snapshot_interval.rs
@@ -1,0 +1,10 @@
+use std::num::NonZeroU64;
+
+/// The interval in between taking snapshots
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SnapshotInterval {
+    /// Snapshots are disabled
+    Disabled,
+    /// Snapshots are taken every this many slots
+    Slots(NonZeroU64),
+}

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -49,6 +49,7 @@ use {
         genesis_utils::{self, create_genesis_config_with_leader_ex_no_features},
         runtime_config::RuntimeConfig,
         snapshot_config::SnapshotConfig,
+        snapshot_utils::SnapshotInterval,
     },
     solana_sdk_ids::address_lookup_table,
     solana_signer::Signer,
@@ -62,6 +63,7 @@ use {
         fs::{self, remove_dir_all, File},
         io::Read,
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroU64,
         path::{Path, PathBuf},
         str::FromStr,
         sync::{Arc, RwLock},
@@ -1061,8 +1063,10 @@ impl TestValidator {
             ],
             run_verification: false, // Skip PoH verification of ledger on startup for speed
             snapshot_config: SnapshotConfig {
-                full_snapshot_archive_interval_slots: 100,
-                incremental_snapshot_archive_interval_slots: Slot::MAX,
+                full_snapshot_archive_interval: SnapshotInterval::Slots(
+                    NonZeroU64::new(100).unwrap(),
+                ),
+                incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
                 bank_snapshots_dir: ledger_path.join("snapshot"),
                 full_snapshot_archives_dir: ledger_path.to_path_buf(),
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -24,16 +24,11 @@ use {
     solana_rayon_threadlimit::get_thread_count,
     solana_rpc::{rpc::MAX_REQUEST_BODY_SIZE, rpc_pubsub_service::PubSubConfig},
     solana_rpc_client_api::request::{DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_MULTIPLE_ACCOUNTS},
-    solana_runtime::{
-        snapshot_bank_utils::{
-            DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-            DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-        },
-        snapshot_utils::{
-            SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        },
+    solana_runtime::snapshot_utils::{
+        SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION, DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+        DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+        DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
     solana_send_transaction_service::send_transaction_service::{self},
     solana_streamer::quic::{
@@ -307,9 +302,12 @@ impl DefaultArgs {
                 DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string(),
             snapshot_packager_niceness_adjustment: "0".to_string(),
             full_snapshot_archive_interval_slots: DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS
+                .get()
                 .to_string(),
             incremental_snapshot_archive_interval_slots:
-                DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS.to_string(),
+                DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS
+                    .get()
+                    .to_string(),
             min_snapshot_download_speed: DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED.to_string(),
             max_snapshot_download_abort: MAX_SNAPSHOT_DOWNLOAD_ABORT.to_string(),
             snapshot_archive_format: DEFAULT_ARCHIVE_COMPRESSION.to_string(),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -60,9 +60,8 @@ use {
     },
     solana_runtime::{
         runtime_config::RuntimeConfig,
-        snapshot_bank_utils::DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
-        snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
+        snapshot_utils::{self, ArchiveFormat, SnapshotInterval, SnapshotVersion},
     },
     solana_send_transaction_service::send_transaction_service,
     solana_signer::Signer,
@@ -76,7 +75,7 @@ use {
         collections::HashSet,
         fs::{self, File},
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        num::NonZeroUsize,
+        num::{NonZeroU64, NonZeroUsize},
         path::{Path, PathBuf},
         process::exit,
         str::FromStr,
@@ -904,35 +903,23 @@ pub fn execute(
         .transpose()?
         .unwrap_or(SnapshotVersion::default());
 
-    let (full_snapshot_archive_interval_slots, incremental_snapshot_archive_interval_slots) =
+    let (full_snapshot_archive_interval, incremental_snapshot_archive_interval) =
         if matches.is_present("no_snapshots") {
             // snapshots are disabled
-            (
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-            )
+            (SnapshotInterval::Disabled, SnapshotInterval::Disabled)
         } else {
             match (
                 !matches.is_present("no_incremental_snapshots"),
-                value_t_or_exit!(matches, "snapshot_interval_slots", u64),
+                value_t_or_exit!(matches, "snapshot_interval_slots", NonZeroU64),
             ) {
-                (_, 0) => {
-                    // snapshots are disabled
-                    warn!(
-                        "Snapshot generation was disabled with `--snapshot-interval-slots 0`, \
-                         which is now deprecated. Use `--no-snapshots` instead.",
-                    );
-                    (
-                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
-                    )
-                }
                 (true, incremental_snapshot_interval_slots) => {
                     // incremental snapshots are enabled
                     // use --snapshot-interval-slots for the incremental snapshot interval
+                    let full_snapshot_interval_slots =
+                        value_t_or_exit!(matches, "full_snapshot_interval_slots", NonZeroU64);
                     (
-                        value_t_or_exit!(matches, "full_snapshot_interval_slots", u64),
-                        incremental_snapshot_interval_slots,
+                        SnapshotInterval::Slots(full_snapshot_interval_slots),
+                        SnapshotInterval::Slots(incremental_snapshot_interval_slots),
                     )
                 }
                 (false, full_snapshot_interval_slots) => {
@@ -941,27 +928,29 @@ pub fn execute(
                     // also warn if --full-snapshot-interval-slots was specified
                     if matches.occurrences_of("full_snapshot_interval_slots") > 0 {
                         warn!(
-                            "Incremental snapshots are disabled, yet --full-snapshot-interval-slots was specified! \
-                             Note that --full-snapshot-interval-slots is *ignored* when incremental snapshots are disabled. \
+                            "Incremental snapshots are disabled, yet \
+                             --full-snapshot-interval-slots was specified! \
+                             Note that --full-snapshot-interval-slots is *ignored* \
+                             when incremental snapshots are disabled. \
                              Use --snapshot-interval-slots instead.",
                         );
                     }
                     (
-                        full_snapshot_interval_slots,
-                        DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
+                        SnapshotInterval::Slots(full_snapshot_interval_slots),
+                        SnapshotInterval::Disabled,
                     )
                 }
             }
         };
 
     validator_config.snapshot_config = SnapshotConfig {
-        usage: if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
+        usage: if full_snapshot_archive_interval == SnapshotInterval::Disabled {
             SnapshotUsage::LoadOnly
         } else {
             SnapshotUsage::LoadAndGenerate
         },
-        full_snapshot_archive_interval_slots,
-        incremental_snapshot_archive_interval_slots,
+        full_snapshot_archive_interval,
+        incremental_snapshot_archive_interval,
         bank_snapshots_dir,
         full_snapshot_archives_dir: full_snapshot_archives_dir.clone(),
         incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.clone(),
@@ -974,28 +963,27 @@ pub fn execute(
 
     info!(
         "Snapshot configuration: full snapshot interval: {}, incremental snapshot interval: {}",
-        if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
-            "disabled".to_string()
-        } else {
-            format!("{full_snapshot_archive_interval_slots} slots")
+        match full_snapshot_archive_interval {
+            SnapshotInterval::Disabled => "disabled".to_string(),
+            SnapshotInterval::Slots(interval) => format!("{interval} slots"),
         },
-        if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
-            "disabled".to_string()
-        } else {
-            format!("{incremental_snapshot_archive_interval_slots} slots")
+        match incremental_snapshot_archive_interval {
+            SnapshotInterval::Disabled => "disabled".to_string(),
+            SnapshotInterval::Slots(interval) => format!("{interval} slots"),
         },
     );
 
     // It is unlikely that a full snapshot interval greater than an epoch is a good idea.
     // Minimally we should warn the user in case this was a mistake.
-    if full_snapshot_archive_interval_slots > DEFAULT_SLOTS_PER_EPOCH
-        && full_snapshot_archive_interval_slots != DISABLED_SNAPSHOT_ARCHIVE_INTERVAL
-    {
-        warn!(
-            "The full snapshot interval is excessively large: {}! This will negatively \
-            impact the background cleanup tasks in accounts-db. Consider a smaller value.",
-            full_snapshot_archive_interval_slots,
-        );
+    if let SnapshotInterval::Slots(full_snapshot_interval_slots) = full_snapshot_archive_interval {
+        let full_snapshot_interval_slots = full_snapshot_interval_slots.get();
+        if full_snapshot_interval_slots > DEFAULT_SLOTS_PER_EPOCH {
+            warn!(
+                "The full snapshot interval is excessively large: {}! This will negatively \
+                impact the background cleanup tasks in accounts-db. Consider a smaller value.",
+                full_snapshot_interval_slots,
+            );
+        }
     }
 
     if !is_snapshot_config_valid(&validator_config.snapshot_config) {


### PR DESCRIPTION
#### Problem

The snapshot interval is a bare u64, which means we use a sentinel value to indicate when snapshots are disabled. We also must be careful to ensure the interval is never zero. Both of these problems are already solved by the rust type system.


#### Summary of Changes

Use an enum for the snapshot interval.