### PR TITLE
Minor Fix: Add logging when worker thread fails

### DIFF
--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -254,9 +254,10 @@ impl SnapshotStorageRebuilder {
     ) {
         thread_pool.spawn(move || {
             for path in rebuilder.file_receiver.iter() {
-                match rebuilder.process_append_vec_file(path) {
+                match rebuilder.process_append_vec_file(path.clone()) {
                     Ok(_) => {}
                     Err(err) => {
+                        error!("Rebuilder worker thread exited while processing file {:?} with error: {}", path, err);
                         exit_sender
                             .send(Err(err))
                             .expect("sender should be connected");


### PR DESCRIPTION
#### Problem
Following #6600, in file [snapshot_storage_rebuilder.rs](https://github.com/anza-xyz/agave/blob/64630de411e5a61e1f5d97ff66eafa5846575edd/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs#L4).
In case of any error in `process_append_vec_file` the node is failing without indication of original reason, err is not logged anywhere upstream.

#### Summary of Changes
Adding a logging line to depict the **error** faced when processing a **file**


<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
