### PR TITLE
blockstore: store slot_meta when modified

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2269,6 +2269,7 @@ impl Blockstore {
             data_index,
         )
         .map(move |indices| CompletedDataSetInfo { slot, indices });
+        self.meta_cf.put_in_batch(write_batch, slot_meta.slot, slot_meta)?;
 
         self.slots_stats.record_shred(
             shred.slot(),


### PR DESCRIPTION
#### Problem

slot_meta gets updated, but not stored in the db. As a result, some data lags behind.

In Frankendancer, for example, we're accessing `slot_meta.last_index` to compute `block_id`. We're doing this a bit earlier than when Agave does it, so we noticed a race condition (last_index should be updated, but it's not stored in the db yet).

#### Summary of Changes

Add slot_meta to the current batch.