### PR TITLE
deprecate NodeConfig in preparation for refactor

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2331,6 +2331,7 @@ pub struct Sockets {
     pub rpc_sts_client: UdpSocket,
 }
 
+#[deprecated(since = "2.3.0", note = "NodeConfig will be refactored in 3.0")]
 pub struct NodeConfig {
     pub gossip_addr: SocketAddr,
     pub port_range: PortRange,
@@ -2658,7 +2659,9 @@ impl Node {
         }
     }
 
+    #[allow(deprecated)]
     pub fn new_with_external_ip(pubkey: &Pubkey, config: NodeConfig) -> Node {
+        #[allow(deprecated)]
         let NodeConfig {
             gossip_addr,
             port_range,
@@ -3282,6 +3285,7 @@ mod tests {
     fn new_with_external_ip_test_random() {
         let ip = Ipv4Addr::LOCALHOST;
         let port_range = localhost_port_range_for_tests();
+        #[allow(deprecated)]
         let config = NodeConfig {
             gossip_addr: socketaddr!(ip, 0),
             port_range,
@@ -3305,6 +3309,7 @@ mod tests {
         let port_range = localhost_port_range_for_tests();
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port = port_range.0;
+        #[allow(deprecated)]
         let config = NodeConfig {
             gossip_addr: socketaddr!(Ipv4Addr::LOCALHOST, port),
             port_range,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1,3 +1,5 @@
+#[allow(deprecated)]
+use solana_gossip::cluster_info::NodeConfig;
 use {
     crate::{
         admin_rpc_service::{self, load_staked_nodes_overrides, StakedNodesOverrides},
@@ -36,10 +38,7 @@ use {
             ValidatorStartProgress, ValidatorTpuConfig,
         },
     },
-    solana_gossip::{
-        cluster_info::{Node, NodeConfig},
-        contact_info::ContactInfo,
-    },
+    solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
@@ -1157,6 +1156,7 @@ pub fn execute(
         value_t_or_exit!(matches, "tpu_max_connections_per_ipaddr_per_minute", u64);
     let max_streams_per_ms = value_t_or_exit!(matches, "tpu_max_streams_per_ms", u64);
 
+    #[allow(deprecated)]
     let node_config = NodeConfig {
         gossip_addr,
         port_range: dynamic_port_range,


### PR DESCRIPTION
#### Problem
need to deprecate NodeConfig before we can change the API so we can then eliminate `--gossip-host` arg

#### Summary of Changes
deprecate `NodeConfig` but let people use 
