### PR TITLE
Boxes inner tonic::Status inside BigTableError::Rpc

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -78,7 +78,7 @@ pub enum Error {
     ObjectCorrupt(String),
 
     #[error("RPC: {0}")]
-    Rpc(tonic::Status),
+    Rpc(Box<tonic::Status>),
 
     #[error("Timeout")]
     Timeout,
@@ -107,7 +107,7 @@ impl std::convert::From<tonic::transport::Error> for Error {
 
 impl std::convert::From<tonic::Status> for Error {
     fn from(err: tonic::Status) -> Self {
-        Self::Rpc(err)
+        Self::Rpc(Box::new(err))
     }
 }
 


### PR DESCRIPTION
#### Problem

Issue #6278: The `BigTableError` triggers the `result_large_err` clippy lint. This is because a variant, `Rpc`, contains a `tonic::Status`, which is 176 bytes. To fix this, and since this is only needed in the error case, we can box the `tonic::Status`.

Similar to https://github.com/anza-xyz/agave/pull/6293.


#### Summary of Changes

Boxes inner tonic::Status inside BigTableError::Rpc.