### PR TITLE
Boxes inner SnapshotError in BankForksUtilsError::BankFromSnapshotsArchive

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -39,7 +39,7 @@ pub enum BankForksUtilsError {
          incremental snapshot archive: {incremental_snapshot_archive}"
     )]
     BankFromSnapshotsArchive {
-        source: snapshot_utils::SnapshotError,
+        source: Box<snapshot_utils::SnapshotError>,
         full_snapshot_archive: String,
         incremental_snapshot_archive: String,
     },
@@ -320,7 +320,7 @@ fn bank_forks_from_snapshot(
             exit,
         )
         .map_err(|err| BankForksUtilsError::BankFromSnapshotsArchive {
-            source: err,
+            source: Box::new(err),
             full_snapshot_archive: full_snapshot_archive_info.path().display().to_string(),
             incremental_snapshot_archive: incremental_snapshot_archive_info
                 .as_ref()


### PR DESCRIPTION
#### Problem

Issue #6278: The `BankForksUtilsError` triggers the `result_large_err` clippy lint. This is because a variant, `BankFromSnapshotsArchive`, is too big. To fix this, and since this is only needed in the error case, we can box the inner `SnapshotError` (which is 80 bytes).

Similar to https://github.com/anza-xyz/agave/pull/6293.


#### Summary of Changes

Boxes inner SnapshotError.