### PR TITLE
Bump platform tools to v1.49

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -23,7 +23,7 @@ use {
     tar::Archive,
 };
 
-const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.48";
+const DEFAULT_PLATFORM_TOOLS_VERSION: &str = "v1.49";
 
 #[derive(Debug)]
 pub struct Config<'a> {

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [package.metadata.solana]
-tools-version = "v1.48"
+tools-version = "v1.49"
 program-id = "MyProgram1111111111111111111111111111111111"
 
 [dependencies]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -27,4 +27,4 @@ check-cfg = [
 [workspace]
 
 [workspace.metadata.solana]
-tools-version = "v1.48"
+tools-version = "v1.49"

--- a/platform-tools-sdk/sbf/scripts/install.sh
+++ b/platform-tools-sdk/sbf/scripts/install.sh
@@ -109,7 +109,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install platform tools
-version=v1.48
+version=v1.49
 if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

Platform tools v1.48 does support SBPFv4, which is necessary for us to test ABIv2 in CI.

#### Summary of Changes

I bumped the platform tools version. In addition to the SBPFv4 support, it also brings enables the switch simplify pass (merged in https://github.com/anza-xyz/llvm-project/pull/153)
