### PR TITLE
Quic streamer runtime threads configuration

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -190,6 +190,7 @@ pub fn spawn_server_multi(
         wait_for_chunk_timeout,
         coalesce,
         coalesce_channel_size,
+        worker_threads: _, // Caller setup the runtime worker threads
     } = quic_server_params;
     let concurrent_connections = max_staked_connections + max_unstaked_connections;
     let max_concurrent_connections = concurrent_connections + concurrent_connections / 4;

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -8,7 +8,7 @@ use {
         quic::{
             QuicServerParams, StreamerStats, DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             DEFAULT_MAX_STAKED_CONNECTIONS, DEFAULT_MAX_STREAMS_PER_MS,
-            DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_TPU_COALESCE,
+            DEFAULT_MAX_UNSTAKED_CONNECTIONS, DEFAULT_TPU_COALESCE, DEFAULT_WORKER_THREADS,
         },
         streamer::StakedNodes,
     },
@@ -137,6 +137,7 @@ pub fn setup_quic_server_with_sockets(
         wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
         coalesce: DEFAULT_TPU_COALESCE,
         coalesce_channel_size,
+        worker_threads: DEFAULT_WORKER_THREADS,
     };
     let SpawnNonBlockingServerResult {
         endpoints: _,

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -61,6 +61,12 @@ pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;
 
 pub const DEFAULT_TPU_COALESCE: Duration = Duration::from_millis(5);
 
+/// The default number of threads for the QUIC server runtime.
+pub const DEFAULT_WORKER_THREADS: usize = 8;
+
+/// The minimum number of threads for the QUIC server runtime.
+pub const MINIMUM_WORKER_THREADS: usize = 1;
+
 pub struct SpawnServerResult {
     pub endpoints: Vec<Endpoint>,
     pub thread: thread::JoinHandle<()>,
@@ -114,9 +120,10 @@ pub(crate) fn configure_server(
     Ok((server_config, cert_chain_pem))
 }
 
-pub fn rt(name: String) -> Runtime {
+pub fn rt(name: String, worker_threads: usize) -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .thread_name(name)
+        .worker_threads(worker_threads)
         .enable_all()
         .build()
         .unwrap()
@@ -612,6 +619,7 @@ pub struct QuicServerParams {
     pub wait_for_chunk_timeout: Duration,
     pub coalesce: Duration,
     pub coalesce_channel_size: usize,
+    pub worker_threads: usize,
 }
 
 impl Default for QuicServerParams {
@@ -625,6 +633,7 @@ impl Default for QuicServerParams {
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: DEFAULT_TPU_COALESCE,
             coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
+            worker_threads: DEFAULT_WORKER_THREADS,
         }
     }
 }
@@ -639,7 +648,10 @@ pub fn spawn_server_multi(
     staked_nodes: Arc<RwLock<StakedNodes>>,
     quic_server_params: QuicServerParams,
 ) -> Result<SpawnServerResult, QuicServerError> {
-    let runtime = rt(format!("{thread_name}Rt"));
+    let runtime = rt(
+        format!("{thread_name}Rt"),
+        quic_server_params.worker_threads,
+    );
     let result = {
         let _guard = runtime.enter();
         crate::nonblocking::quic::spawn_server_multi(
@@ -724,7 +736,7 @@ mod test {
     fn test_quic_timeout() {
         solana_logger::setup();
         let (t, exit, receiver, server_address) = setup_quic_server();
-        let runtime = rt("solQuicTestRt".to_string());
+        let runtime = rt("solQuicTestRt".to_string(), DEFAULT_WORKER_THREADS);
         runtime.block_on(check_timeout(receiver, server_address));
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();
@@ -735,7 +747,7 @@ mod test {
         solana_logger::setup();
         let (t, exit, _receiver, server_address) = setup_quic_server();
 
-        let runtime = rt("solQuicTestRt".to_string());
+        let runtime = rt("solQuicTestRt".to_string(), DEFAULT_WORKER_THREADS);
         runtime.block_on(check_block_multiple_connections(server_address));
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();
@@ -770,7 +782,7 @@ mod test {
         )
         .unwrap();
 
-        let runtime = rt("solQuicTestRt".to_string());
+        let runtime = rt("solQuicTestRt".to_string(), DEFAULT_WORKER_THREADS);
         runtime.block_on(check_multiple_streams(receiver, server_address, None));
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();
@@ -781,7 +793,7 @@ mod test {
         solana_logger::setup();
         let (t, exit, receiver, server_address) = setup_quic_server();
 
-        let runtime = rt("solQuicTestRt".to_string());
+        let runtime = rt("solQuicTestRt".to_string(), DEFAULT_WORKER_THREADS);
         runtime.block_on(check_multiple_writes(receiver, server_address, None));
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();
@@ -816,7 +828,7 @@ mod test {
         )
         .unwrap();
 
-        let runtime = rt("solQuicTestRt".to_string());
+        let runtime = rt("solQuicTestRt".to_string(), DEFAULT_WORKER_THREADS);
         runtime.block_on(check_unstaked_node_connect_failure(server_address));
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -310,7 +310,7 @@ impl ThreadArg for RocksdbFlushThreadsArg {
 struct TpuWorkerThreadsArg;
 impl ThreadArg for TpuWorkerThreadsArg {
     const NAME: &'static str = "tpu_worker_threads";
-    const LONG_NAME: &'static str = "tpu-receive-threads";
+    const LONG_NAME: &'static str = "tpu-worker-threads";
     const HELP: &'static str = "Numner of the QUIC server runtime worker threads.";
 
     fn default() -> usize {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -114,6 +114,7 @@ pub fn execute(
         tvu_receive_threads,
         tvu_retransmit_threads,
         tvu_sigverify_threads,
+        tpu_worker_threads,
     } = cli::thread_args::parse_num_threads_args(matches);
 
     let identity_keypair = keypair_of(matches, "identity").unwrap_or_else(|| {
@@ -1269,6 +1270,7 @@ pub fn execute(
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,
+        worker_threads: tpu_worker_threads.into(),
         ..Default::default()
     };
 
@@ -1279,6 +1281,7 @@ pub fn execute(
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
         coalesce: tpu_coalesce,
+        worker_threads: tpu_worker_threads.into(),
         ..Default::default()
     };
 


### PR DESCRIPTION
#### Problem
The QUIC Tokio runtime starts worker threads based on the number of CPUs which is unnecessarily high. 

#### Summary of Changes
Based on @alessandrod's profiling -- setting the default to 8 threads. And make it configurable via the following

--tpu-worker-threads CLI argument.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

Notes#

This only handles configuring the worker threads for the runtime. 
Refactor QUIC out of streamer and controlling runtime by caller will be done in future PRs.