### PR TITLE
Filter out the obsolete accounts before loading during shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3446,7 +3446,6 @@ impl AccountsDb {
         let alive_accounts_collect = Mutex::new(T::with_capacity(len, slot));
         let pubkeys_to_unref_collect = Mutex::new(Vec::with_capacity(len));
         let zero_lamport_single_ref_pubkeys_collect = Mutex::new(Vec::with_capacity(len));
-        let mut obsolete_accounts_filtered = 0;
 
         // Get a set of all obsolete offsets
         // Slot is not needed, as all obsolete accounts can be considered
@@ -3459,9 +3458,7 @@ impl AccountsDb {
 
         // Filter all the accounts that are marked obsolete
         let initial_len = stored_accounts.len();
-        stored_accounts.retain(|account| {
-            !obsolete_offsets.contains(&account.index_info.offset())
-        });
+        stored_accounts.retain(|account| !obsolete_offsets.contains(&account.index_info.offset()));
         let obsolete_accounts_filtered = initial_len - stored_accounts.len();
 
         stats

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3458,15 +3458,11 @@ impl AccountsDb {
             .collect();
 
         // Filter all the accounts that are marked obsolete
+        let initial_len = stored_accounts.len();
         stored_accounts.retain(|account| {
-            if obsolete_offsets.contains(&account.index_info.offset()) {
-                // If the account is obsolete, it is dead
-                obsolete_accounts_filtered += 1;
-                false
-            } else {
-                true
-            }
+            !obsolete_offsets.contains(&account.index_info.offset())
         });
+        let obsolete_accounts_filtered = initial_len - stored_accounts.len();
 
         stats
             .accounts_loaded

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3268,7 +3268,6 @@ impl AccountsDb {
         let mut index_scan_returned_none_count = 0;
         let mut all_are_zero_lamports = true;
         let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
-
         self.accounts_index.scan(
             accounts.iter().map(|account| account.pubkey()),
             |pubkey, slots_refs, _entry| {

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -348,6 +348,7 @@ pub struct ShrinkStats {
     pub alive_accounts: AtomicU64,
     pub index_scan_returned_none: AtomicU64,
     pub index_scan_returned_some: AtomicU64,
+    pub obsolete_accounts_filtered: AtomicU64,
     pub accounts_loaded: AtomicU64,
     pub initial_candidates_count: AtomicU64,
     pub purged_zero_lamports: AtomicU64,
@@ -381,6 +382,11 @@ impl ShrinkStats {
                 (
                     "num_slots_shrunk",
                     self.num_slots_shrunk.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "obsolete_accounts_filtered",
+                    self.obsolete_accounts_filtered.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -773,7 +773,7 @@ impl AccountsDb {
         // Without eager unref, we will collect X at `multi-ref` after shrink.
         // Packing multi-ref is less efficient than `one_ref``. But it might be ok - in next round of clean, hopefully, it can turn this from multi-ref into one-ref.
         let mut accounts_to_combine = accounts_per_storage
-            .iter()
+            .iter_mut()
             .map(|(info, unique_accounts)| {
                 self.shrink_collect::<ShrinkCollectAliveSeparatedByRefs<'_>>(
                     &info.storage,


### PR DESCRIPTION
#### Problem
Obsolete accounts need to be removed during shrink

#### Summary of Changes
- Prior to loading accounts for shrink, filter out all the obsolete accounts as they can be removed
- Add counter for obsolete accounts shrunk during shrink

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
