### PR TITLE
Deprecate explicit reuseport another way

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
     let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
-        SocketConfig::default().reuseport(true),
+        SocketConfig::default(),
         num_sockets,
     )
     .unwrap();

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -3,7 +3,10 @@
 use {
     clap::{crate_description, crate_name, value_t_or_exit, Arg, Command},
     crossbeam_channel::unbounded,
-    solana_net_utils::{bind_to_unspecified, SocketConfig},
+    solana_net_utils::{
+        bind_to_unspecified,
+        sockets::{multi_bind_in_range_with_config, SocketConfiguration},
+    },
     solana_streamer::{
         packet::{Packet, PacketBatchRecycler, PinnedPacketBatch, PACKET_DATA_SIZE},
         sendmmsg::batch_send,
@@ -104,10 +107,10 @@ fn main() -> Result<()> {
 
     let port = 0;
     let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-    let (_port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
+    let (_port, read_sockets) = multi_bind_in_range_with_config(
         ip_addr,
         (port, port + num_sockets as u16),
-        SocketConfig::default(),
+        SocketConfiguration::default(),
         num_sockets,
     )
     .unwrap();

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
         let mut read_channels = Vec::new();
         let mut read_threads = Vec::new();
         let recycler = PacketBatchRecycler::default();
-        let config = SocketConfig::default().reuseport(true);
+        let config = SocketConfig::default();
         let (port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
             ip_addr,
             (port, port + num_sockets as u16),

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -9,7 +9,10 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_message::Message,
-    solana_net_utils::{bind_to_unspecified, SocketConfig},
+    solana_net_utils::{
+        bind_to_unspecified,
+        sockets::{multi_bind_in_range_with_config, SocketConfiguration as SocketConfig},
+    },
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_streamer::{
@@ -188,7 +191,7 @@ fn main() -> Result<()> {
         let mut read_threads = Vec::new();
         let recycler = PacketBatchRecycler::default();
         let config = SocketConfig::default();
-        let (port, read_sockets) = solana_net_utils::multi_bind_in_range_with_config(
+        let (port, read_sockets) = multi_bind_in_range_with_config(
             ip_addr,
             (port, port + num_sockets as u16),
             config,

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -514,7 +514,9 @@ mod tests {
         async_trait::async_trait,
         rand::{Rng, SeedableRng},
         rand_chacha::ChaChaRng,
-        solana_net_utils::SocketConfig,
+        solana_net_utils::sockets::{
+            bind_with_any_port_with_config, SocketConfiguration as SocketConfig,
+        },
         solana_transaction_error::TransportResult,
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -572,7 +574,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 udp_socket: Arc::new(
-                    solana_net_utils::bind_with_any_port_with_config(
+                    bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                         SocketConfig::default(),
                     )
@@ -586,7 +588,7 @@ mod tests {
         fn new() -> Result<Self, ClientError> {
             Ok(Self {
                 udp_socket: Arc::new(
-                    solana_net_utils::bind_with_any_port_with_config(
+                    bind_with_any_port_with_config(
                         IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                         SocketConfig::default(),
                     )

--- a/docs/src/validator/tvu.md
+++ b/docs/src/validator/tvu.md
@@ -23,13 +23,13 @@ Internally, TVU is actually bound with multiple sockets to improve kernel's hand
 
 > **NOTE:** TPU sockets use similar logic
 
-A node advertises one external ip/port for TVU while binding multiple sockets to that same port using SO_REUSEPORT:
+A node advertises one external ip/port for TVU while binding multiple sockets to that same port:
 
 ```rust
 let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
     bind_ip_addr,
     port_range,
-    socket_config_reuseport,
+    socket_config,
     num_tvu_sockets.get(),
 )
 .expect("tvu multi_bind");

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -52,12 +52,14 @@ use {
     solana_keypair::{signable::Signable, Keypair},
     solana_ledger::shred::Shred,
     solana_net_utils::{
-        bind_common_in_range_with_config, bind_in_range, bind_in_range_with_config,
-        bind_more_with_config, bind_to_localhost, bind_to_unspecified, bind_to_with_config,
-        bind_two_in_range_with_offset_and_config, find_available_ports_in_range,
-        multi_bind_in_range_with_config,
-        sockets::{bind_gossip_port_in_range, localhost_port_range_for_tests},
-        PortRange, SocketConfig, VALIDATOR_PORT_RANGE,
+        bind_in_range, bind_to_localhost, bind_to_unspecified, find_available_ports_in_range,
+        sockets::{
+            bind_common_in_range_with_config, bind_gossip_port_in_range, bind_in_range_with_config,
+            bind_more_with_config, bind_to_with_config, bind_two_in_range_with_offset_and_config,
+            localhost_port_range_for_tests, multi_bind_in_range_with_config,
+            SocketConfiguration as SocketConfig,
+        },
+        PortRange, VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
         data_budget::DataBudget,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2368,7 +2368,7 @@ impl Node {
         let localhost_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = localhost_port_range_for_tests();
         let udp_config = SocketConfig::default();
-        let quic_config = SocketConfig::default().reuseport(true);
+        let quic_config = SocketConfig::default();
         let ((_tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 localhost_ip_addr,
@@ -2520,6 +2520,7 @@ impl Node {
             bind_gossip_port_in_range(gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
+        #[allow(deprecated)] // will be cleaned in a separate PR
         let socket_config_reuseport = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
@@ -2674,7 +2675,7 @@ impl Node {
             bind_gossip_port_in_range(&gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        let socket_config_reuseport = SocketConfig::default().reuseport(true);
+        let socket_config_reuseport = SocketConfig::default();
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2520,8 +2520,6 @@ impl Node {
             bind_gossip_port_in_range(gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        #[allow(deprecated)] // will be cleaned in a separate PR
-        let socket_config_reuseport = SocketConfig::default().reuseport(true);
         let (tvu_port, tvu) = Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tvu_quic_port, tvu_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
@@ -2531,12 +2529,11 @@ impl Node {
                 port_range,
                 QUIC_PORT_OFFSET,
                 socket_config,
-                socket_config_reuseport,
+                socket_config,
             )
             .unwrap();
         let tpu_quic: Vec<UdpSocket> =
-            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, socket_config_reuseport)
-                .unwrap();
+            bind_more_with_config(tpu_quic, DEFAULT_QUIC_ENDPOINTS, socket_config).unwrap();
 
         let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
@@ -2544,26 +2541,19 @@ impl Node {
                 port_range,
                 QUIC_PORT_OFFSET,
                 socket_config,
-                socket_config_reuseport,
+                socket_config,
             )
             .unwrap();
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, DEFAULT_QUIC_ENDPOINTS, socket_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
-        let tpu_vote_quic: Vec<UdpSocket> = bind_more_with_config(
-            tpu_vote_quic,
-            DEFAULT_QUIC_ENDPOINTS,
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_vote_quic: Vec<UdpSocket> =
+            bind_more_with_config(tpu_vote_quic, DEFAULT_QUIC_ENDPOINTS, socket_config).unwrap();
 
         let (_, retransmit_socket) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
@@ -2675,12 +2665,11 @@ impl Node {
             bind_gossip_port_in_range(&gossip_addr, port_range, bind_ip_addr);
 
         let socket_config = SocketConfig::default();
-        let socket_config_reuseport = SocketConfig::default();
 
         let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport,
+            socket_config,
             num_tvu_receive_sockets.get(),
         )
         .expect("tvu multi_bind");
@@ -2689,20 +2678,19 @@ impl Node {
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (tpu_port, tpu_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 32)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 32)
                 .expect("tpu multi_bind");
 
         let (_tpu_port_quic, tpu_quic) = Self::bind_with_config(
             bind_ip_addr,
             (tpu_port + QUIC_PORT_OFFSET, tpu_port + QUIC_PORT_OFFSET + 1),
-            socket_config_reuseport,
+            socket_config,
         );
         let tpu_quic =
-            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config_reuseport)
-                .unwrap();
+            bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config).unwrap();
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 8)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 8)
                 .expect("tpu_forwards multi_bind");
 
         let (_tpu_forwards_port_quic, tpu_forwards_quic) = Self::bind_with_config(
@@ -2711,33 +2699,26 @@ impl Node {
                 tpu_forwards_port + QUIC_PORT_OFFSET,
                 tpu_forwards_port + QUIC_PORT_OFFSET + 1,
             ),
-            socket_config_reuseport,
+            socket_config,
         );
-        let tpu_forwards_quic = bind_more_with_config(
-            tpu_forwards_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), socket_config)
+                .unwrap();
 
         let (tpu_vote_port, tpu_vote_sockets) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 1)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 1)
                 .expect("tpu_vote multi_bind");
 
         let (tpu_vote_quic_port, tpu_vote_quic) =
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
-        let tpu_vote_quic = bind_more_with_config(
-            tpu_vote_quic,
-            num_quic_endpoints.get(),
-            socket_config_reuseport,
-        )
-        .unwrap();
+        let tpu_vote_quic =
+            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), socket_config).unwrap();
 
         let (_, retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            socket_config_reuseport,
+            socket_config,
             num_tvu_retransmit_sockets.get(),
         )
         .expect("retransmit multi_bind");
@@ -2751,7 +2732,7 @@ impl Node {
             Self::bind_with_config(bind_ip_addr, port_range, socket_config);
 
         let (_, broadcast) =
-            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config_reuseport, 4)
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 4)
                 .expect("broadcast multi_bind");
 
         let (_, ancestor_hashes_requests) =
@@ -2790,6 +2771,23 @@ impl Node {
         info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
             .unwrap();
 
+        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
+            multi_bind_in_range_with_config(
+                vortexor_receiver_addr.ip(),
+                (
+                    vortexor_receiver_addr.port(),
+                    vortexor_receiver_addr.port() + 1,
+                ),
+                socket_config,
+                32,
+            )
+            .unwrap_or_else(|_| {
+                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
+            })
+            .1
+        });
+
+        info!("vortexor_receivers is {vortexor_receivers:?}");
         trace!("new ContactInfo: {:?}", info);
         let sockets = Sockets {
             gossip,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2771,23 +2771,6 @@ impl Node {
         info.set_serve_repair(QUIC, (addr, serve_repair_quic_port))
             .unwrap();
 
-        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
-            multi_bind_in_range_with_config(
-                vortexor_receiver_addr.ip(),
-                (
-                    vortexor_receiver_addr.port(),
-                    vortexor_receiver_addr.port() + 1,
-                ),
-                socket_config,
-                32,
-            )
-            .unwrap_or_else(|_| {
-                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
-            })
-            .1
-        });
-
-        info!("vortexor_receivers is {vortexor_receivers:?}");
         trace!("new ContactInfo: {:?}", info);
         let sockets = Sockets {
             gossip,

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -225,7 +225,7 @@ pub fn is_host_port(string: String) -> Result<(), String> {
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please use the equivalent struct from solana-net-utils::sockets"
 )]
 #[derive(Clone, Copy, Debug, Default)]
@@ -266,7 +266,7 @@ impl SocketConfig {
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please use the equivalent from solana-net-utils::sockets"
 )]
 #[allow(deprecated)]
@@ -293,7 +293,7 @@ pub fn bind_in_range(ip_addr: IpAddr, range: PortRange) -> io::Result<(u16, UdpS
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please use the equivalent from solana-net-utils::sockets"
 )]
 #[allow(deprecated)]
@@ -319,7 +319,7 @@ pub fn bind_in_range_with_config(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please use the equivalent from solana-net-utils::sockets"
 )]
 #[allow(deprecated)]
@@ -336,7 +336,7 @@ pub fn bind_with_any_port_with_config(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please use the equivalent from solana-net-utils::sockets"
 )]
 #[allow(deprecated)]
@@ -361,8 +361,8 @@ pub fn multi_bind_in_range_with_config(
 }
 
 #[deprecated(
-    since = "2.3.1",
-    note = "Please avoid this function, it is easy to misuse"
+    since = "2.3.2",
+    note = "Please use the eqiuvalent from solana-net-utils::sockets"
 )]
 #[allow(deprecated)]
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
@@ -384,7 +384,7 @@ pub fn bind_to_unspecified() -> io::Result<UdpSocket> {
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function in favor of sockets::bind_to_with_config"
 )]
 #[allow(deprecated)]
@@ -399,7 +399,7 @@ pub fn bind_to_with_config(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function, it is easy to misuse"
 )]
 #[allow(deprecated)]
@@ -418,7 +418,7 @@ pub fn bind_to_with_config_non_blocking(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function in favor of sockets::bind_common_with_config"
 )]
 /// binds both a UdpSocket and a TcpListener
@@ -428,7 +428,7 @@ pub fn bind_common(ip_addr: IpAddr, port: u16) -> io::Result<(UdpSocket, TcpList
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function in favor of sockets::bind_common_with_config"
 )]
 #[allow(deprecated)]
@@ -447,7 +447,7 @@ pub fn bind_common_with_config(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function, in favor of sockets::bind_two_in_range_with_offset_and_config"
 )]
 #[allow(deprecated)]
@@ -467,7 +467,7 @@ pub fn bind_two_in_range_with_offset(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function, in favor of sockets::bind_two_in_range_with_offset_and_config"
 )]
 #[allow(deprecated)]
@@ -552,7 +552,7 @@ pub fn find_available_ports_in_range<const N: usize>(
 }
 
 #[deprecated(
-    since = "2.3.1",
+    since = "2.3.2",
     note = "Please avoid this function, in favor of sockets::bind_more_with_config"
 )]
 #[allow(deprecated)]

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -393,7 +393,6 @@ pub fn multi_bind_in_range(
     multi_bind_in_range_with_config(ip_addr, range, config, num)
 }
 
-//#[deprecated(since = "2.3.0", note = "use `bind_to_with_config` instead")]
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
     let config = SocketConfig {
         reuseport,
@@ -423,7 +422,12 @@ pub fn bind_to_localhost() -> io::Result<UdpSocket> {
 
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
-    bind_to_async(IpAddr::V4(Ipv4Addr::LOCALHOST), /*port:*/ 0, false).await
+    bind_to_async(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        /*port:*/ 0,
+        /*reuseport:*/ false,
+    )
+    .await
 }
 
 pub fn bind_to_unspecified() -> io::Result<UdpSocket> {

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -404,22 +404,6 @@ pub fn multi_bind_in_range_with_config(
     Ok((port, sockets))
 }
 
-// binds many sockets to the same port in a range
-// Note: The `mut` modifier for `num` is unused but kept for compatibility with the public API.
-#[deprecated(
-    since = "2.2.0",
-    note = "use `multi_bind_in_range_with_config` instead"
-)]
-#[allow(unused_mut)]
-pub fn multi_bind_in_range(
-    ip_addr: IpAddr,
-    range: PortRange,
-    mut num: usize,
-) -> io::Result<(u16, Vec<UdpSocket>)> {
-    let config = SocketConfig::default();
-    multi_bind_in_range_with_config(ip_addr, range, config, num)
-}
-
 pub fn bind_to(ip_addr: IpAddr, port: u16, reuseport: bool) -> io::Result<UdpSocket> {
     let config = SocketConfig {
         reuseport,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -1,10 +1,15 @@
 use {
-    crate::{bind_common_in_range_with_config, bind_common_with_config, PortRange, SocketConfig},
+    crate::PortRange,
+    log::warn,
+    socket2::{Domain, SockAddr, Socket, Type},
     std::{
+        io,
         net::{IpAddr, SocketAddr, TcpListener, UdpSocket},
         sync::atomic::{AtomicU16, Ordering},
     },
 };
+#[cfg(feature = "dev-context-only-utils")]
+use {std::net::Ipv4Addr, tokio::net::UdpSocket as TokioUdpSocket};
 // base port for deconflicted allocations
 const BASE_PORT: u16 = 5000;
 // how much to allocate per individual process.
@@ -44,7 +49,7 @@ pub fn bind_gossip_port_in_range(
     port_range: PortRange,
     bind_ip_addr: IpAddr,
 ) -> (u16, (UdpSocket, TcpListener)) {
-    let config = SocketConfig::default();
+    let config = SocketConfiguration::default();
     if gossip_addr.port() != 0 {
         (
             gossip_addr.port(),
@@ -54,5 +59,384 @@ pub fn bind_gossip_port_in_range(
         )
     } else {
         bind_common_in_range_with_config(bind_ip_addr, port_range, config).expect("Failed to bind")
+    }
+}
+
+/// True on platforms that support advanced socket configuration
+pub(crate) const PLATFORM_SUPPORTS_SOCKET_CONFIGS: bool =
+    cfg!(not(any(windows, target_os = "ios")));
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SocketConfiguration {
+    reuseport: bool, // controls SO_REUSEPORT, this is not intended to be set explicitly
+    recv_buffer_size: Option<usize>,
+    send_buffer_size: Option<usize>,
+    non_blocking: bool,
+}
+
+impl SocketConfiguration {
+    /// Sets the receive buffer size for the socket (no effect on windows/ios).
+    ///
+    /// **Note:** On Linux the kernel will double the value you specify.
+    /// For example, if you specify `16MB`, the kernel will configure the
+    /// socket to use `32MB`.
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_RCVBUF
+    pub fn recv_buffer_size(mut self, size: usize) -> Self {
+        self.recv_buffer_size = Some(size);
+        self
+    }
+
+    /// Sets the send buffer size for the socket (no effect on windows/ios)
+    ///
+    /// **Note:** On Linux the kernel will double the value you specify.
+    /// For example, if you specify `16MB`, the kernel will configure the
+    /// socket to use `32MB`.
+    /// See: https://man7.org/linux/man-pages/man7/socket.7.html: SO_SNDBUF
+    pub fn send_buffer_size(mut self, size: usize) -> Self {
+        self.send_buffer_size = Some(size);
+        self
+    }
+
+    /// Configure the socket for non-blocking IO
+    pub fn set_non_blocking(mut self, non_blocking: bool) -> Self {
+        self.non_blocking = non_blocking;
+        self
+    }
+}
+
+#[allow(deprecated)]
+impl From<crate::SocketConfig> for SocketConfiguration {
+    fn from(value: crate::SocketConfig) -> Self {
+        Self {
+            reuseport: value.reuseport,
+            recv_buffer_size: value.recv_buffer_size,
+            send_buffer_size: value.send_buffer_size,
+            non_blocking: false,
+        }
+    }
+}
+
+#[cfg(any(windows, target_os = "ios"))]
+fn set_reuse_port<T>(_socket: &T) -> io::Result<()> {
+    Ok(())
+}
+
+/// Sets SO_REUSEPORT on platforms that support it.
+#[cfg(not(any(windows, target_os = "ios")))]
+fn set_reuse_port<T>(socket: &T) -> io::Result<()>
+where
+    T: std::os::fd::AsFd,
+{
+    use nix::sys::socket::{setsockopt, sockopt::ReusePort};
+    setsockopt(socket, ReusePort, &true).map_err(io::Error::from)
+}
+
+pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<Socket> {
+    let SocketConfiguration {
+        reuseport,
+        recv_buffer_size,
+        send_buffer_size,
+        non_blocking,
+    } = config;
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    if PLATFORM_SUPPORTS_SOCKET_CONFIGS {
+        // Set buffer sizes
+        if let Some(recv_buffer_size) = recv_buffer_size {
+            sock.set_recv_buffer_size(recv_buffer_size)?;
+        }
+        if let Some(send_buffer_size) = send_buffer_size {
+            sock.set_send_buffer_size(send_buffer_size)?;
+        }
+
+        if reuseport {
+            set_reuse_port(&sock)?;
+        }
+    }
+    sock.set_nonblocking(non_blocking)?;
+    Ok(sock)
+}
+
+/// Find a port in the given range with a socket config that is available for both TCP and UDP
+pub fn bind_common_in_range_with_config(
+    ip_addr: IpAddr,
+    range: PortRange,
+    config: SocketConfiguration,
+) -> io::Result<(u16, (UdpSocket, TcpListener))> {
+    for port in range.0..range.1 {
+        if let Ok((sock, listener)) = bind_common_with_config(ip_addr, port, config) {
+            return Result::Ok((sock.local_addr().unwrap().port(), (sock, listener)));
+        }
+    }
+
+    Err(io::Error::other(format!(
+        "No available TCP/UDP ports in {range:?}"
+    )))
+}
+
+pub fn bind_in_range_with_config(
+    ip_addr: IpAddr,
+    range: PortRange,
+    config: SocketConfiguration,
+) -> io::Result<(u16, UdpSocket)> {
+    let socket = udp_socket_with_config(config)?;
+
+    for port in range.0..range.1 {
+        let addr = SocketAddr::new(ip_addr, port);
+
+        if socket.bind(&SockAddr::from(addr)).is_ok() {
+            let udp_socket: UdpSocket = socket.into();
+            return Result::Ok((udp_socket.local_addr().unwrap().port(), udp_socket));
+        }
+    }
+
+    Err(io::Error::other(format!(
+        "No available UDP ports in {range:?}"
+    )))
+}
+
+pub fn bind_with_any_port_with_config(
+    ip_addr: IpAddr,
+    config: SocketConfiguration,
+) -> io::Result<UdpSocket> {
+    let sock = udp_socket_with_config(config)?;
+    let addr = SocketAddr::new(ip_addr, 0);
+    match sock.bind(&SockAddr::from(addr)) {
+        Ok(_) => Result::Ok(sock.into()),
+        Err(err) => Err(io::Error::other(format!("No available UDP port: {err}"))),
+    }
+}
+
+/// binds num sockets to the same port in a range with config
+pub fn multi_bind_in_range_with_config(
+    ip_addr: IpAddr,
+    range: PortRange,
+    config: SocketConfiguration,
+    mut num: usize,
+) -> io::Result<(u16, Vec<UdpSocket>)> {
+    if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
+        // See https://github.com/solana-labs/solana/issues/4607
+        warn!(
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({} requested)",
+            num
+        );
+        num = 1;
+    }
+    let (port, socket) = bind_in_range_with_config(ip_addr, range, config)?;
+    let sockets = bind_more_with_config(socket, num, config)?;
+    Ok((port, sockets))
+}
+
+pub fn bind_to(ip_addr: IpAddr, port: u16) -> io::Result<UdpSocket> {
+    let config = SocketConfiguration {
+        ..Default::default()
+    };
+    bind_to_with_config(ip_addr, port, config)
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+pub async fn bind_to_async(ip_addr: IpAddr, port: u16) -> io::Result<TokioUdpSocket> {
+    let config = SocketConfiguration {
+        non_blocking: true,
+        ..Default::default()
+    };
+    let socket = bind_to_with_config(ip_addr, port, config)?;
+    TokioUdpSocket::from_std(socket)
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
+    bind_to_async(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).await
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+pub async fn bind_to_unspecified_async() -> io::Result<TokioUdpSocket> {
+    bind_to_async(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0).await
+}
+
+pub fn bind_to_with_config(
+    ip_addr: IpAddr,
+    port: u16,
+    config: SocketConfiguration,
+) -> io::Result<UdpSocket> {
+    let sock = udp_socket_with_config(config)?;
+
+    let addr = SocketAddr::new(ip_addr, port);
+
+    sock.bind(&SockAddr::from(addr)).map(|_| sock.into())
+}
+
+/// binds both a UdpSocket and a TcpListener on the same port
+pub fn bind_common_with_config(
+    ip_addr: IpAddr,
+    port: u16,
+    config: SocketConfiguration,
+) -> io::Result<(UdpSocket, TcpListener)> {
+    let sock = udp_socket_with_config(config)?;
+
+    let addr = SocketAddr::new(ip_addr, port);
+    let sock_addr = SockAddr::from(addr);
+    sock.bind(&sock_addr)
+        .and_then(|_| TcpListener::bind(addr).map(|listener| (sock.into(), listener)))
+}
+
+pub fn bind_two_in_range_with_offset_and_config(
+    ip_addr: IpAddr,
+    range: PortRange,
+    offset: u16,
+    sock1_config: SocketConfiguration,
+    sock2_config: SocketConfiguration,
+) -> io::Result<((u16, UdpSocket), (u16, UdpSocket))> {
+    if range.1.saturating_sub(range.0) < offset {
+        return Err(io::Error::other(
+            "range too small to find two ports with the correct offset".to_string(),
+        ));
+    }
+
+    for port in range.0..range.1 {
+        if let Ok(first_bind) = bind_to_with_config(ip_addr, port, sock1_config) {
+            if range.1.saturating_sub(port) >= offset {
+                if let Ok(second_bind) =
+                    bind_to_with_config(ip_addr, port.saturating_add(offset), sock2_config)
+                {
+                    return Ok((
+                        (first_bind.local_addr().unwrap().port(), first_bind),
+                        (second_bind.local_addr().unwrap().port(), second_bind),
+                    ));
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    Err(io::Error::other(
+        "couldn't find two ports with the correct offset in range".to_string(),
+    ))
+}
+
+pub fn bind_more_with_config(
+    socket: UdpSocket,
+    num: usize,
+    mut config: SocketConfiguration,
+) -> io::Result<Vec<UdpSocket>> {
+    if !PLATFORM_SUPPORTS_SOCKET_CONFIGS {
+        if num > 1 {
+            warn!(
+                "bind_more_with_config() only supports 1 socket on this platform ({} requested)",
+                num
+            );
+        }
+        Ok(vec![socket])
+    } else {
+        set_reuse_port(&socket)?;
+        config.reuseport = true;
+        let addr = socket.local_addr().unwrap();
+        let ip = addr.ip();
+        let port = addr.port();
+        std::iter::once(Ok(socket))
+            .chain((1..num).map(|_| bind_to_with_config(ip, port, config)))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use {
+        super::*,
+        crate::{bind_in_range, sockets::localhost_port_range_for_tests},
+        std::net::Ipv4Addr,
+    };
+
+    #[test]
+    fn test_bind() {
+        let (pr_s, pr_e) = localhost_port_range_for_tests();
+        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let config = SocketConfiguration::default();
+        let s = bind_in_range(ip_addr, (pr_s, pr_e)).unwrap();
+        assert_eq!(s.0, pr_s, "bind_in_range should use first available port");
+        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let x = bind_to_with_config(ip_addr, pr_s + 1, config).unwrap();
+        let y = bind_more_with_config(x, 2, config).unwrap();
+        assert_eq!(
+            y[0].local_addr().unwrap().port(),
+            y[1].local_addr().unwrap().port()
+        );
+        bind_to_with_config(ip_addr, pr_s, SocketConfiguration::default()).unwrap_err();
+        bind_in_range(ip_addr, (pr_s, pr_s + 2)).unwrap_err();
+
+        let (port, v) =
+            multi_bind_in_range_with_config(ip_addr, (pr_s + 5, pr_e), config, 10).unwrap();
+        for sock in &v {
+            assert_eq!(port, sock.local_addr().unwrap().port());
+        }
+    }
+
+    #[test]
+    fn test_bind_with_any_port() {
+        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let config = SocketConfiguration::default();
+        let x = bind_with_any_port_with_config(ip_addr, config).unwrap();
+        let y = bind_with_any_port_with_config(ip_addr, config).unwrap();
+        assert_ne!(
+            x.local_addr().unwrap().port(),
+            y.local_addr().unwrap().port()
+        );
+    }
+
+    #[test]
+    fn test_bind_in_range_nil() {
+        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        bind_in_range(ip_addr, (2000, 2000)).unwrap_err();
+        bind_in_range(ip_addr, (2000, 1999)).unwrap_err();
+    }
+
+    #[test]
+    fn test_bind_on_top() {
+        let config = SocketConfiguration::default();
+        let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let port_range = localhost_port_range_for_tests();
+        let (_p, s) = bind_in_range_with_config(localhost, port_range, config).unwrap();
+        let _socks = bind_more_with_config(s, 8, config).unwrap();
+
+        let _socks2 = multi_bind_in_range_with_config(localhost, port_range, config, 8).unwrap();
+    }
+
+    #[test]
+    fn test_bind_common_in_range() {
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let (pr_s, pr_e) = localhost_port_range_for_tests();
+        let config = SocketConfiguration::default();
+        let (port, _sockets) =
+            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
+        assert!((pr_s..pr_e).contains(&port));
+
+        bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
+    }
+
+    #[test]
+    fn test_bind_two_in_range_with_offset() {
+        solana_logger::setup();
+        let config = SocketConfiguration::default();
+        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let offset = 6;
+        if let Ok(((port1, _), (port2, _))) =
+            bind_two_in_range_with_offset_and_config(ip_addr, (1024, 65535), offset, config, config)
+        {
+            assert!(port2 == port1 + offset);
+        }
+        let offset = 42;
+        if let Ok(((port1, _), (port2, _))) =
+            bind_two_in_range_with_offset_and_config(ip_addr, (1024, 65535), offset, config, config)
+        {
+            assert!(port2 == port1 + offset);
+        }
+        assert!(bind_two_in_range_with_offset_and_config(
+            ip_addr,
+            (1024, 1044),
+            offset,
+            config,
+            config
+        )
+        .is_err());
     }
 }

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -17,7 +17,10 @@ use {
     },
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
-    solana_net_utils::{SocketConfig, VALIDATOR_PORT_RANGE},
+    solana_net_utils::{
+        sockets::{bind_in_range_with_config, SocketConfiguration as SocketConfig},
+        VALIDATOR_PORT_RANGE,
+    },
     solana_quic_definitions::{
         QUIC_CONNECTION_HANDSHAKE_TIMEOUT, QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS,
     },
@@ -78,7 +81,7 @@ impl QuicLazyInitializedEndpoint {
             endpoint.clone()
         } else {
             let config = SocketConfig::default();
-            let client_socket = solana_net_utils::bind_in_range_with_config(
+            let client_socket = bind_in_range_with_config(
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 VALIDATOR_PORT_RANGE,
                 config,

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -57,7 +57,7 @@ pub async fn recv_mmsg_exact(
 mod tests {
     use {
         crate::{nonblocking::recvmmsg::*, packet::PACKET_DATA_SIZE},
-        solana_net_utils::{bind_to_async, bind_to_localhost_async},
+        solana_net_utils::sockets::{bind_to_async, bind_to_localhost_async},
         std::{net::SocketAddr, time::Instant},
         tokio::net::UdpSocket,
     };
@@ -68,9 +68,9 @@ mod tests {
         let sock_addr: SocketAddr = ip_str
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        let reader = bind_to_async(sock_addr.ip(), sock_addr.port(), /*reuseport:*/ false).await?;
+        let reader = bind_to_async(sock_addr.ip(), sock_addr.port()).await?;
         let addr = reader.local_addr()?;
-        let sender = bind_to_async(sock_addr.ip(), sock_addr.port(), /*reuseport:*/ false).await?;
+        let sender = bind_to_async(sock_addr.ip(), sock_addr.port()).await?;
         let saddr = sender.local_addr()?;
         Ok((reader, addr, sender, saddr))
     }

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,7 +61,7 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost_async, bind_to_unspecified_async},
+        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unspecified_async},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -96,7 +96,7 @@ pub fn create_quic_server_sockets() -> Vec<UdpSocket> {
     multi_bind_in_range_with_config(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         port_range,
-        SocketConfig::default().reuseport(true),
+        SocketConfig::default(),
         num,
     )
     .expect("bind operation for quic server sockets should succeed")

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -19,8 +19,11 @@ use {
     },
     solana_keypair::Keypair,
     solana_net_utils::{
-        bind_to_localhost, multi_bind_in_range_with_config,
-        sockets::localhost_port_range_for_tests, SocketConfig,
+        bind_to_localhost,
+        sockets::{
+            localhost_port_range_for_tests, multi_bind_in_range_with_config,
+            SocketConfiguration as SocketConfig,
+        },
     },
     solana_perf::packet::PacketBatch,
     solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS},

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -182,8 +182,9 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
 mod tests {
     use {
         crate::{packet::PACKET_DATA_SIZE, recvmmsg::*},
-        solana_net_utils::{
-            bind_in_range_with_config, sockets::localhost_port_range_for_tests, SocketConfig,
+        solana_net_utils::sockets::{
+            bind_in_range_with_config, localhost_port_range_for_tests,
+            SocketConfiguration as SocketConfig,
         },
         std::{
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},

--- a/udp-client/src/lib.rs
+++ b/udp-client/src/lib.rs
@@ -16,7 +16,9 @@ use {
         connection_cache_stats::ConnectionCacheStats,
     },
     solana_keypair::Keypair,
-    solana_net_utils::SocketConfig,
+    solana_net_utils::sockets::{
+        bind_with_any_port_with_config, SocketConfiguration as SocketConfig,
+    },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,
@@ -63,7 +65,7 @@ pub struct UdpConfig {
 
 impl NewConnectionConfig for UdpConfig {
     fn new() -> Result<Self, ClientError> {
-        let socket = solana_net_utils::bind_with_any_port_with_config(
+        let socket = bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             SocketConfig::default(),
         )

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -46,7 +46,9 @@ impl ClientConnection for UdpClientConnection {
 mod tests {
     use {
         super::*,
-        solana_net_utils::{bind_to_async, SocketConfig},
+        solana_net_utils::sockets::{
+            bind_to_async, bind_with_any_port_with_config, SocketConfiguration as SocketConfig,
+        },
         solana_packet::{Packet, PACKET_DATA_SIZE},
         solana_streamer::nonblocking::recvmmsg::recv_mmsg,
         std::net::{IpAddr, Ipv4Addr},
@@ -73,19 +75,13 @@ mod tests {
     async fn test_send_from_addr() {
         let addr_str = "0.0.0.0:50100";
         let addr = addr_str.parse().unwrap();
-        let socket = solana_net_utils::bind_with_any_port_with_config(
+        let socket = bind_with_any_port_with_config(
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             SocketConfig::default(),
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
-        let reader = bind_to_async(
-            addr.ip(),
-            /*port*/ addr.port(),
-            /*reuseport:*/ false,
-        )
-        .await
-        .expect("bind");
+        let reader = bind_to_async(addr.ip(), addr.port()).await.expect("bind");
         check_send_one(&connection, &reader).await;
         check_send_batch(&connection, &reader).await;
     }

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -79,9 +79,13 @@ mod tests {
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
-        let reader = bind_to_async(addr.ip(), /*port*/ addr.port())
-            .await
-            .expect("bind");
+        let reader = bind_to_async(
+            addr.ip(),
+            /*port*/ addr.port(),
+            /*reuseport:*/ false,
+        )
+        .await
+        .expect("bind");
         check_send_one(&connection, &reader).await;
         check_send_batch(&connection, &reader).await;
     }

--- a/udp-client/src/nonblocking/udp_client.rs
+++ b/udp-client/src/nonblocking/udp_client.rs
@@ -79,13 +79,9 @@ mod tests {
         )
         .unwrap();
         let connection = UdpClientConnection::new_from_addr(socket, addr);
-        let reader = bind_to_async(
-            addr.ip(),
-            /*port*/ addr.port(),
-            /*reuseport:*/ false,
-        )
-        .await
-        .expect("bind");
+        let reader = bind_to_async(addr.ip(), /*port*/ addr.port())
+            .await
+            .expect("bind");
         check_send_one(&connection, &reader).await;
         check_send_batch(&connection, &reader).await;
     }

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -5,7 +5,7 @@ use {
     solana_core::banking_trace::BankingTracer,
     solana_keypair::read_keypair_file,
     solana_logger::redirect_stderr_to_file,
-    solana_net_utils::{bind_in_range_with_config, SocketConfig},
+    solana_net_utils::sockets::{bind_in_range_with_config, SocketConfiguration as SocketConfig},
     solana_quic_definitions::QUIC_PORT_OFFSET,
     solana_signer::Signer,
     solana_streamer::streamer::StakedNodes,

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -100,7 +100,7 @@ pub fn main() {
     )
     .unwrap();
 
-    let config = SocketConfig::default().reuseport(false);
+    let config = SocketConfig::default();
 
     let sender_socket =
         bind_in_range_with_config(*bind_address, dynamic_port_range, config).unwrap();

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -61,7 +61,7 @@ impl Vortexor {
         tpu_forward_address: Option<SocketAddr>,
         num_quic_endpoints: usize,
     ) -> TpuSockets {
-        let quic_config = SocketConfig::default().reuseport(true);
+        let quic_config = SocketConfig::default();
 
         let tpu_quic = bind_sockets(
             bind_address,

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -5,7 +5,9 @@ use {
         sigverify_stage::SigVerifyStage,
     },
     solana_keypair::Keypair,
-    solana_net_utils::{multi_bind_in_range_with_config, SocketConfig},
+    solana_net_utils::sockets::{
+        multi_bind_in_range_with_config, SocketConfiguration as SocketConfig,
+    },
     solana_perf::packet::PacketBatch,
     solana_quic_definitions::NotifyKeyUpdate,
     solana_streamer::{


### PR DESCRIPTION
#### Problem

Basically https://github.com/anza-xyz/agave/pull/5965 could not get any progress due to API break concerns, so this is another way to look at the same problem.

#### Summary of Changes

- Add new functions side-by-side which replicate 99% of the behavior of the original ones
- Depreacate original functions
- Patch uses all over agave to point to the new functions