### PR TITLE
Removes outdated comments on snapshot NonZero constants

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -74,10 +74,6 @@ const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 const VERSION_STRING_V1_2_0: &str = "1.2.0";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
-// The following unsafes are
-// - Safe because the values are fixed, known non-zero constants
-// - Necessary in order to have a plain NonZeroUsize as the constant, NonZeroUsize
-//   returns an Option<NonZeroUsize> and we can't .unwrap() at compile time
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
     NonZeroU64::new(50_000).unwrap();
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =


### PR DESCRIPTION
Addressing https://github.com/anza-xyz/agave/pull/6612#discussion_r2153249154. Comments are now out of date, so remove them.