### PR TITLE
solana-stake-accounts: support configurable commitment level and no wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10502,6 +10502,7 @@ dependencies = [
  "solana-cli-config",
  "solana-client-traits",
  "solana-clock",
+ "solana-commitment-config",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-instruction",

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -18,6 +18,7 @@ solana-account = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-clock = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-instruction = { workspace = true }

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -141,6 +141,7 @@ where
         .arg(
             Arg::with_name("config_file")
                 .long("config")
+                .global(true)
                 .takes_value(true)
                 .value_name("FILEPATH")
                 .default_value(default_config_file)
@@ -153,6 +154,25 @@ where
                 .takes_value(true)
                 .value_name("URL")
                 .help("RPC entrypoint address. i.e. http://api.devnet.solana.com"),
+        )
+        .arg(
+            Arg::with_name("commitment")
+                .long("commitment")
+                .global(true)
+                .takes_value(true)
+                .value_name("COMMITMENT_LEVEL")
+                .possible_values(&["processed", "confirmed", "finalized"])
+                .hide_possible_values(true)
+                .help(
+                    "Return information at the selected commitment level \
+                     [possible values: processed, confirmed, finalized]",
+                ),
+        )
+        .arg(
+            Arg::with_name("no_wait")
+                .long("no-wait")
+                .global(true)
+                .help("Send transactions without waiting for confirmation"),
         )
         .subcommand(
             SubCommand::with_name("new")
@@ -243,11 +263,6 @@ where
                 .arg(new_custodian_arg())
                 .arg(num_accounts_arg())
                 .arg(
-                    Arg::with_name("no_wait")
-                        .long("no-wait")
-                        .help("Send transactions without waiting for confirmation"),
-                )
-                .arg(
                     Arg::with_name("unlock_years")
                         .long("unlock-years")
                         .takes_value(true)
@@ -288,6 +303,7 @@ fn parse_new_args(matches: &ArgMatches<'_>) -> NewArgs<String, String> {
         stake_authority: value_t_or_exit!(matches, "stake_authority", String),
         withdraw_authority: value_t_or_exit!(matches, "withdraw_authority", String),
         index: value_t_or_exit!(matches, "index", usize),
+        no_wait: matches.is_present("no_wait"),
     }
 }
 
@@ -313,6 +329,7 @@ fn parse_authorize_args(matches: &ArgMatches<'_>) -> AuthorizeArgs<String, Strin
         new_stake_authority: value_t_or_exit!(matches, "new_stake_authority", String),
         new_withdraw_authority: value_t_or_exit!(matches, "new_withdraw_authority", String),
         num_accounts: value_t_or_exit!(matches, "num_accounts", usize),
+        no_wait: matches.is_present("no_wait"),
     }
 }
 
@@ -337,6 +354,7 @@ fn parse_rebase_args(matches: &ArgMatches<'_>) -> RebaseArgs<String, String> {
         new_base_keypair: value_t_or_exit!(matches, "new_base_keypair", String),
         stake_authority: value_t_or_exit!(matches, "stake_authority", String),
         num_accounts: value_t_or_exit!(matches, "num_accounts", usize),
+        no_wait: matches.is_present("no_wait"),
     }
 }
 
@@ -355,6 +373,7 @@ where
     let matches = get_matches(args);
     let config_file = matches.value_of("config_file").unwrap().to_string();
     let url = matches.value_of("url").map(|x| x.to_string());
+    let commitment = matches.value_of("commitment").map(|x| x.to_string());
 
     let command = match matches.subcommand() {
         ("new", Some(matches)) => Command::New(parse_new_args(matches)),
@@ -373,6 +392,7 @@ where
     Args {
         config_file,
         url,
+        commitment,
         command,
     }
 }

--- a/stake-accounts/src/args.rs
+++ b/stake-accounts/src/args.rs
@@ -16,6 +16,7 @@ pub(crate) struct NewArgs<P, K> {
     pub stake_authority: P,
     pub withdraw_authority: P,
     pub index: usize,
+    pub no_wait: bool,
 }
 
 pub(crate) struct CountArgs<P> {
@@ -35,6 +36,7 @@ pub(crate) struct AuthorizeArgs<P, K> {
     pub new_stake_authority: P,
     pub new_withdraw_authority: P,
     pub num_accounts: usize,
+    pub no_wait: bool,
 }
 
 pub(crate) struct SetLockupArgs<P, K> {
@@ -55,6 +57,7 @@ pub(crate) struct RebaseArgs<P, K> {
     pub new_base_keypair: K,
     pub stake_authority: K,
     pub num_accounts: usize,
+    pub no_wait: bool,
 }
 
 pub(crate) struct MoveArgs<P, K> {
@@ -76,6 +79,7 @@ pub(crate) enum Command<P, K> {
 pub(crate) struct Args<P, K> {
     pub config_file: String,
     pub url: Option<String>,
+    pub commitment: Option<String>,
     pub command: Command<P, K>,
 }
 
@@ -176,6 +180,7 @@ fn resolve_authorize_args(
             &args.new_withdraw_authority,
         )?,
         num_accounts: args.num_accounts,
+        no_wait: args.no_wait,
     };
     Ok(resolved_args)
 }
@@ -208,6 +213,7 @@ fn resolve_rebase_args(
         new_base_keypair: resolve_new_base_keypair(wallet_manager, &args.new_base_keypair)?,
         stake_authority: resolve_stake_authority(wallet_manager, &args.stake_authority)?,
         num_accounts: args.num_accounts,
+        no_wait: args.no_wait,
     };
     Ok(resolved_args)
 }
@@ -247,6 +253,7 @@ pub(crate) fn resolve_command(
                 )?,
                 lamports: args.lamports,
                 index: args.index,
+                no_wait: args.no_wait,
             };
             Ok(Command::New(resolved_args))
         }

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -11,6 +11,7 @@ use {
         },
     },
     solana_cli_config::Config,
+    solana_commitment_config::CommitmentConfig,
     solana_message::Message,
     solana_native_token::lamports_to_sol,
     solana_pubkey::Pubkey,
@@ -21,7 +22,7 @@ use {
     solana_stake_interface::{instruction::LockupArgs, state::Lockup},
     solana_stake_program::stake_state,
     solana_transaction::Transaction,
-    std::{env, error::Error},
+    std::{env, error::Error, str::FromStr},
 };
 
 fn get_balance_at(client: &RpcClient, pubkey: &Pubkey, i: usize) -> Result<u64, ClientError> {
@@ -83,7 +84,7 @@ fn process_new_stake_account(
         &*args.funding_keypair,
         &*args.base_keypair,
     ]);
-    let signature = send_and_confirm_message(client, message, &signers, false)?;
+    let signature = send_and_confirm_message(client, message, &signers, args.no_wait)?;
     Ok(signature)
 }
 
@@ -105,7 +106,7 @@ fn process_authorize_stake_accounts(
         &*args.stake_authority,
         &*args.withdraw_authority,
     ]);
-    send_and_confirm_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, args.no_wait)?;
     Ok(())
 }
 
@@ -161,7 +162,7 @@ fn process_rebase_stake_accounts(
         &*args.new_base_keypair,
         &*args.stake_authority,
     ]);
-    send_and_confirm_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, args.no_wait)?;
     Ok(())
 }
 
@@ -194,7 +195,7 @@ fn process_move_stake_accounts(
         &*args.stake_authority,
         &*authorize_args.withdraw_authority,
     ]);
-    send_and_confirm_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, args.no_wait)?;
     Ok(())
 }
 
@@ -235,7 +236,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     let command_args = parse_args(env::args_os());
     let config = Config::load(&command_args.config_file).unwrap_or_default();
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
-    let client = RpcClient::new(json_rpc_url);
+    let client = RpcClient::new_with_commitment(
+        json_rpc_url,
+        CommitmentConfig::from_str(
+            command_args
+                .commitment
+                .as_ref()
+                .unwrap_or(&config.commitment),
+        )?,
+    );
 
     match resolve_command(&command_args.command)? {
         Command::New(args) => {


### PR DESCRIPTION
#### Problem
solana-stake-accounts always submits transactions at commitment level finalised which is time consuming and ignores the commitment level configured in the configuration file. Additionally there is no way to override the commitment level on the command line.

The set-lockup subcommand of solana-stake-accounts support submitting transactions without waiting for confirmation by specifying the --no-wait command line flag, however none of the other subcommands support this flag.

#### Summary of Changes
- add new global option --commitment to solana-stake-accounts
- add new global option --no-wait to solana-stake-accounts
- remove redundant local option --no-wait from solana-stake-accounts set-lockup subcommand
- create the rpc client with commitment level as per the configuration file, possibly overridden by --commitment cli option
- implement no-wait support in new, authorize, move and rebase subcommands