### PR TITLE
Implement transaction area for ABIv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10222,8 +10222,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 [[package]]
 name = "solana-sbpf"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+source = "git+https://github.com/anza-xyz/sbpf.git?rev=967c2a2eba03816ee14f4c6338476690d374f511#967c2a2eba03816ee14f4c6338476690d374f511"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,7 +497,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=3.0.0" }
 solana-runtime = { path = "runtime", version = "=3.0.0" }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=3.0.0" }
 solana-sanitize = "2.2.1"
-solana-sbpf = "=0.11.1"
+solana-sbpf = { git = "https://github.com/anza-xyz/sbpf.git", rev = "967c2a2eba03816ee14f4c6338476690d374f511" }
 solana-sdk-ids = "2.2.1"
 solana-secp256k1-program = "2.2.3"
 solana-secp256k1-recover = "2.2.1"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -99,6 +99,14 @@ test-stable-sbf)
   _ make -C programs/sbf clean-all
   _ cargo_build_sbf_sanity "v3"
 
+  # SBPFv4 (ABIv2) tests
+  _ make -C programs/sbf clean-all
+
+  pushd programs/sbf
+  _ "$cargo_build_sbf" --manifest-path rust/abiv2/Cargo.toml --arch v4
+  _ cargo test --features=abi_v2 --test abi_v2
+  popd
+
   exit 0
   ;;
 test-docs)

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -158,6 +158,7 @@ impl FeatureSet {
                 .is_active(&disable_zk_elgamal_proof_program::id()),
             reenable_zk_elgamal_proof_program: self
                 .is_active(&reenable_zk_elgamal_proof_program::id()),
+            enable_abi_v2_programs: self.is_active(&enable_abi_v2_programs::id()),
         }
     }
 }
@@ -1116,6 +1117,10 @@ pub mod reenable_zk_elgamal_proof_program {
     solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
 }
 
+pub mod enable_abi_v2_programs {
+    solana_pubkey::declare_id!("1ncomp1ete111111111111111111111111111111111");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1355,6 +1360,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (alpenglow::id(), "Enable Alpenglow"),
         (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
+        (enable_abi_v2_programs::id(), "SIMD-0177: Enable ABIv2 programs (SBPFv4)"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/program-runtime/src/guest_transaction.rs
+++ b/program-runtime/src/guest_transaction.rs
@@ -1,0 +1,301 @@
+use {
+    solana_account::ReadableAccount, solana_pubkey::Pubkey, solana_sbpf::ebpf::MM_REGION_SIZE,
+    solana_svm_feature_set::SVMFeatureSet, solana_transaction_context::TransactionContext,
+    std::slice,
+};
+
+/// This is how a slice is represented in the VM.
+/// It should be merged with VmSlice in a future refactor.
+#[repr(C)]
+struct GuestSliceReference {
+    pointer: u64,
+    length: u64,
+}
+
+/// The Return data scratchpad
+#[repr(C)]
+struct ReturnDataScratchpad {
+    /// The key of the last program to write in the scratchpad
+    pubkey: Pubkey,
+    /// Reference to the slice
+    slice: GuestSliceReference,
+}
+
+/// `GuestTransactionAccount` is how a transaction appears to programs in the virtual machine
+#[repr(C)]
+struct GuestTransactionAccount {
+    pubkey: Pubkey,
+    owner: Pubkey,
+    lamports: u64,
+    data: GuestSliceReference,
+}
+
+#[repr(C)]
+struct GuestTransactionContext {
+    return_data_scratchpad: ReturnDataScratchpad,
+    cpi_scratchpad: GuestSliceReference,
+    /// The index of the current executing instruction
+    instruction_idx: u64,
+    /// The number of instructions in the transaction
+    instruction_num: u64,
+    /// The number of accounts in the transaction
+    accounts_no: u64,
+}
+
+/// `RuntimeGuestTransaction` contains both the `GuestTransactionContext` and an array of
+/// `GuestTransactionAccount`. It is the memory region in ABIv2 that contains the transaction
+/// information.
+pub struct RuntimeGuestTransaction {
+    data: Box<[u8]>,
+}
+
+// These values should be declared in the sbpf crate
+const RETURN_DATA_SCRATCHPAD_ADDRESS: u64 = MM_REGION_SIZE * 5;
+const ACCOUNT_DATA_VM_ADDRESS: u64 = MM_REGION_SIZE * 8;
+// This value is a fake and will be updated in a future PR
+const CPI_SCRATCHPAD_ADDRESS: u64 = MM_REGION_SIZE * 255;
+
+impl RuntimeGuestTransaction {
+    pub fn new_with_feature_set(
+        transaction_context: &TransactionContext,
+        num_instructions: usize,
+        feature_set: &SVMFeatureSet,
+    ) -> Option<RuntimeGuestTransaction> {
+        if feature_set.enable_abi_v2_programs {
+            return Some(Self::new(transaction_context, num_instructions));
+        }
+
+        None
+    }
+
+    pub(crate) fn new(
+        transaction_context: &TransactionContext,
+        num_instructions: usize,
+    ) -> RuntimeGuestTransaction {
+        let size = size_of::<GuestTransactionContext>().saturating_add(
+            (transaction_context.get_number_of_accounts() as usize)
+                .saturating_mul(size_of::<GuestTransactionAccount>()),
+        );
+        let mut memory_vec: Vec<u8> = Vec::with_capacity(size);
+        let memory = memory_vec.spare_capacity_mut();
+
+        // SAFETY: The memory region is large enough to contain a GuestTransactionContext
+        let guest_transaction =
+            unsafe { &mut *(memory.as_mut_ptr() as *mut GuestTransactionContext) };
+
+        let scratchpad = transaction_context.get_return_data();
+
+        guest_transaction.return_data_scratchpad = ReturnDataScratchpad {
+            pubkey: *scratchpad.0,
+            slice: GuestSliceReference {
+                pointer: RETURN_DATA_SCRATCHPAD_ADDRESS,
+                length: scratchpad.1.len() as u64,
+            },
+        };
+
+        guest_transaction.cpi_scratchpad = GuestSliceReference {
+            pointer: CPI_SCRATCHPAD_ADDRESS,
+            length: 0,
+        };
+
+        guest_transaction.instruction_idx = 0;
+        guest_transaction.instruction_num = num_instructions as u64;
+        guest_transaction.accounts_no = transaction_context.get_number_of_accounts() as u64;
+
+        // SAFETY: The memory region is large enough to contain a GuestTransactionContext and an
+        // array of `GuestTransactionAccount`
+        let transaction_accounts = unsafe {
+            let ptr = memory
+                .as_mut_ptr()
+                .add(size_of::<GuestTransactionContext>());
+            slice::from_raw_parts_mut(
+                ptr as *mut GuestTransactionAccount,
+                guest_transaction.accounts_no as usize,
+            )
+        };
+
+        for index_in_transaction in 0..transaction_context.get_number_of_accounts() {
+            let transaction_account = transaction_context
+                .accounts()
+                .try_borrow(index_in_transaction)
+                .unwrap();
+
+            let account_ref = transaction_accounts
+                .get_mut(index_in_transaction as usize)
+                .unwrap();
+            account_ref.pubkey = *transaction_context
+                .get_key_of_account_at_index(index_in_transaction)
+                .unwrap();
+            account_ref.owner = *transaction_account.owner();
+            account_ref.lamports = transaction_account.lamports();
+            let vm_data_addr = ACCOUNT_DATA_VM_ADDRESS
+                .saturating_add(MM_REGION_SIZE.saturating_mul(index_in_transaction as u64));
+            account_ref.data = GuestSliceReference {
+                pointer: vm_data_addr,
+                length: transaction_account.data().len() as u64,
+            };
+        }
+
+        // SAFETY: The vector has been allocated with at least `size` bytes.
+        unsafe {
+            memory_vec.set_len(size);
+        }
+
+        RuntimeGuestTransaction {
+            data: memory_vec.into_boxed_slice(),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn set_instruction_index(&mut self, index: usize) {
+        // SAFETY: We assume the transaction was created using `RuntimeGuestTransaction::new`, which
+        // guarantees the safety of size constraints and contents.
+        let context = unsafe { &mut *(self.data.as_mut_ptr() as *mut GuestTransactionContext) };
+
+        context.instruction_idx = index as u64;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        crate::guest_transaction::{
+            GuestTransactionAccount, GuestTransactionContext, RuntimeGuestTransaction,
+            ACCOUNT_DATA_VM_ADDRESS, CPI_SCRATCHPAD_ADDRESS, RETURN_DATA_SCRATCHPAD_ADDRESS,
+        },
+        solana_account::{Account, AccountSharedData, ReadableAccount},
+        solana_rent::Rent,
+        solana_sbpf::ebpf::MM_REGION_SIZE,
+        solana_sdk_ids::bpf_loader,
+        solana_transaction_context::TransactionContext,
+        std::slice,
+    };
+
+    #[test]
+    fn test_creation() {
+        let transaction_accounts = vec![
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 0,
+                    data: vec![],
+                    owner: bpf_loader::id(),
+                    executable: true,
+                    rent_epoch: 0,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 1,
+                    data: vec![1u8, 2, 3, 4, 5],
+                    owner: bpf_loader::id(),
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 2,
+                    data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
+                    owner: bpf_loader::id(),
+                    executable: true,
+                    rent_epoch: 200,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 3,
+                    data: vec![],
+                    owner: bpf_loader::id(),
+                    executable: false,
+                    rent_epoch: 300,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 4,
+                    data: vec![1u8, 2, 3, 4, 5],
+                    owner: bpf_loader::id(),
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 5,
+                    data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
+                    owner: bpf_loader::id(),
+                    executable: true,
+                    rent_epoch: 200,
+                }),
+            ),
+        ];
+        let mut context = TransactionContext::new(transaction_accounts, Rent::default(), 256, 256);
+        let return_data_key = solana_pubkey::new_rand();
+        let data = vec![1u8, 2, 3, 4, 5];
+        context.set_return_data(return_data_key, data).unwrap();
+
+        let mut runtime_transaction = RuntimeGuestTransaction::new(&context, 28);
+
+        let guest_transaction = unsafe {
+            &*(runtime_transaction.as_slice().as_ptr() as *const GuestTransactionContext)
+        };
+
+        assert_eq!(
+            guest_transaction.return_data_scratchpad.pubkey,
+            return_data_key
+        );
+        assert_eq!(
+            guest_transaction.return_data_scratchpad.slice.pointer,
+            RETURN_DATA_SCRATCHPAD_ADDRESS
+        );
+        assert_eq!(guest_transaction.return_data_scratchpad.slice.length, 5);
+
+        assert_eq!(
+            guest_transaction.cpi_scratchpad.pointer,
+            CPI_SCRATCHPAD_ADDRESS
+        );
+        assert_eq!(guest_transaction.cpi_scratchpad.length, 0);
+
+        assert_eq!(guest_transaction.instruction_idx, 0);
+        assert_eq!(guest_transaction.instruction_num, 28);
+        runtime_transaction.set_instruction_index(80);
+        assert_eq!(guest_transaction.instruction_idx, 80);
+
+        assert_eq!(guest_transaction.accounts_no, 6);
+
+        let guest_accounts = unsafe {
+            let ptr = runtime_transaction
+                .as_slice()
+                .as_ptr()
+                .add(size_of::<GuestTransactionContext>());
+            slice::from_raw_parts(
+                ptr as *const GuestTransactionAccount,
+                guest_transaction.accounts_no as usize,
+            )
+        };
+
+        for i in 0..context.get_number_of_accounts() {
+            let guest_account = guest_accounts.get(i as usize).unwrap();
+            let tx_account = context.accounts().try_borrow(i).unwrap();
+
+            assert_eq!(
+                *context.get_key_of_account_at_index(i).unwrap(),
+                guest_account.pubkey
+            );
+            assert_eq!(*tx_account.owner(), guest_account.owner);
+            assert_eq!(tx_account.lamports(), guest_account.lamports);
+            let addr = ACCOUNT_DATA_VM_ADDRESS + MM_REGION_SIZE * i as u64;
+            assert_eq!(addr, guest_account.data.pointer);
+            assert_eq!(tx_account.data().len() as u64, guest_account.data.length);
+        }
+    }
+}

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -8,6 +8,7 @@ extern crate solana_metrics;
 
 pub use solana_sbpf;
 pub mod execution_budget;
+pub mod guest_transaction;
 pub mod invoke_context;
 pub mod loaded_programs;
 pub mod mem_pool;

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -337,9 +337,11 @@ pub fn create_program_runtime_environment_v1<'a>(
         if !feature_set.disable_sbpf_v0_execution || feature_set.reenable_sbpf_v0_execution {
             SBPFVersion::V0
         } else {
-            SBPFVersion::V3
+            SBPFVersion::V4
         };
-    let max_sbpf_version = if feature_set.enable_sbpf_v3_deployment_and_execution {
+    let max_sbpf_version = if feature_set.enable_abi_v2_programs {
+        SBPFVersion::V4
+    } else if feature_set.enable_sbpf_v3_deployment_and_execution {
         SBPFVersion::V3
     } else if feature_set.enable_sbpf_v2_deployment_and_execution {
         SBPFVersion::V2

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8002,6 +8002,13 @@ name = "solana-sbf-rust-128bit-dep"
 version = "3.0.0"
 
 [[package]]
+name = "solana-sbf-rust-abiv2"
+version = "3.0.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-sbf-rust-account-mem"
 version = "3.0.0"
 dependencies = [
@@ -8668,8 +8675,7 @@ dependencies = [
 [[package]]
 name = "solana-sbpf"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+source = "git+https://github.com/anza-xyz/sbpf.git?rev=967c2a2eba03816ee14f4c6338476690d374f511#967c2a2eba03816ee14f4c6338476690d374f511"
 dependencies = [
  "byteorder 1.5.0",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -16,6 +16,7 @@ edition = { workspace = true }
 members = [
     "rust/128bit",
     "rust/128bit_dep",
+    "rust/abiv2",
     "rust/account_mem",
     "rust/account_mem_deprecated",
     "rust/alloc",
@@ -151,7 +152,7 @@ solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=3.0.0" }
 solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=3.0.0" }
 solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=3.0.0" }
 solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=3.0.0" }
-solana-sbpf = "=0.11.1"
+solana-sbpf = { git = "https://github.com/anza-xyz/sbpf.git", rev = "967c2a2eba03816ee14f4c6338476690d374f511" }
 solana-sdk-ids = "=2.2.1"
 solana-secp256k1-recover = "=2.2.1"
 solana-sha256-hasher = { version = "=2.2.1", features = ["sha2"] }
@@ -172,10 +173,11 @@ solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
 
 [features]
+abi_v2 = []
 sbf_c = []
 sbf_rust = []
 sbf_sanity_list = []
-dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list"]
+dummy-for-ci-check = ["abi_v2", "sbf_c", "sbf_rust", "sbf_sanity_list"]
 # This was needed for ci
 frozen-abi = []
 

--- a/programs/sbf/rust/abiv2/Cargo.toml
+++ b/programs/sbf/rust/abiv2/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-sbf-rust-abiv2"
+version = { workspace = true }
+description = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+solana-program = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/abiv2/src/lib.rs
+++ b/programs/sbf/rust/abiv2/src/lib.rs
@@ -1,0 +1,121 @@
+use {
+    solana_program::{
+        custom_heap_default, custom_panic_default, entrypoint::SUCCESS, pubkey::Pubkey,
+    },
+    std::{slice, str::FromStr},
+};
+
+const VIRTUAL_ADDRESS_BITS: usize = 32;
+const MM_REGION_SIZE: u64 = 1 << VIRTUAL_ADDRESS_BITS;
+const SCRATCHPAD_ADDR: u64 = MM_REGION_SIZE * 5;
+const CPI_SCRATCHPAD_ADDRESS: u64 = MM_REGION_SIZE * 255;
+
+/// `ReturnDataScratchPad` contains the return data. Programs will be allowed to read and write to
+/// the data slice.
+#[repr(C)]
+struct ReturnDataScratchPad<'a> {
+    /// Pubkey of the last program to write to the scratchpad slice.
+    pubkey: Pubkey,
+    data: &'a [u8],
+}
+
+/// `TransactionAccount` is the generic representation for an account in the transaction.
+#[repr(C)]
+struct TransactionAccount<'a> {
+    pubkey: Pubkey,
+    owner: Pubkey,
+    lamports: u64,
+    payload: &'a [u8],
+}
+
+/// `ExecutionData` is split from `TransactionContext` to facilitate reading from bytes.
+#[repr(C)]
+struct ExecutionData<'a> {
+    return_data_scratchpad: ReturnDataScratchPad<'a>,
+    cpi_scratchpad: &'a [u8],
+    /// Index in transaction of the currently executing instruction
+    ix_idx: u64,
+    /// Number of instructions in transaction
+    ix_num: u64,
+}
+
+/// `TransactionContext` contains the information extracted from the transaction area
+#[repr(C)]
+struct TransactionContext<'a> {
+    execution_data: &'a ExecutionData<'a>,
+    accounts: &'a [TransactionAccount<'a>],
+}
+
+impl TransactionContext<'_> {
+    fn new(mut addr: *const u8) -> TransactionContext<'static> {
+        let data = unsafe { &*(addr as *const ExecutionData) };
+
+        let accounts = unsafe {
+            addr = addr.add(size_of::<ExecutionData>());
+            let accounts_no = *(addr as *const u64);
+            addr = addr.add(size_of::<u64>());
+            slice::from_raw_parts(addr as *const TransactionAccount, accounts_no as usize)
+        };
+
+        TransactionContext {
+            execution_data: data,
+            accounts,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
+    let ctx = TransactionContext::new(input);
+    let execution_data = ctx.execution_data;
+
+    assert_eq!(
+        execution_data.return_data_scratchpad.pubkey.to_bytes(),
+        [0; 32]
+    );
+    assert_eq!(
+        execution_data.return_data_scratchpad.data.as_ptr() as usize,
+        SCRATCHPAD_ADDR as usize
+    );
+
+    assert_eq!(
+        execution_data.cpi_scratchpad.as_ptr() as usize,
+        CPI_SCRATCHPAD_ADDRESS as usize
+    );
+    assert_eq!(execution_data.cpi_scratchpad.len(), 0);
+
+    assert_eq!(execution_data.ix_idx, 0);
+    assert_eq!(execution_data.ix_num, 1);
+
+    assert_eq!(ctx.accounts.len(), 3);
+    // The first account is the mint account.
+    // The address is not known by the program.
+    assert_eq!(ctx.accounts[0].owner.to_bytes(), [0; 32]);
+    assert_eq!(ctx.accounts[0].payload.as_ptr() as u64, MM_REGION_SIZE * 8);
+    assert_eq!(ctx.accounts[0].payload.len(), 0);
+
+    let mut key_arr = [0u8; 32];
+    for (i, item) in key_arr.iter_mut().enumerate() {
+        *item = i as u8;
+    }
+
+    // The second account is a mocked one
+    assert_eq!(ctx.accounts[1].pubkey.to_bytes(), key_arr);
+    for (i, item) in key_arr.iter_mut().enumerate() {
+        *item = 2usize.saturating_mul(i) as u8;
+    }
+    assert_eq!(ctx.accounts[1].owner.to_bytes(), key_arr);
+    assert_eq!(ctx.accounts[1].lamports, 789);
+    assert_eq!(ctx.accounts[1].payload.as_ptr() as u64, MM_REGION_SIZE * 9);
+    assert_eq!(ctx.accounts[1].payload.len(), 5);
+
+    // The third account is the program account. The program id is not yet available for comparison
+    let loader_v4_key = Pubkey::from_str("LoaderV411111111111111111111111111111111111").unwrap();
+    assert_eq!(ctx.accounts[2].owner, loader_v4_key);
+    assert_eq!(ctx.accounts[2].payload.as_ptr() as u64, MM_REGION_SIZE * 10);
+
+    SUCCESS
+}
+
+custom_heap_default!();
+custom_panic_default!();

--- a/programs/sbf/tests/abi_v2.rs
+++ b/programs/sbf/tests/abi_v2.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "abi_v2")]
+
+use {
+    solana_account::{AccountSharedData, WritableAccount},
+    solana_instruction::{AccountMeta, Instruction},
+    solana_keypair::Keypair,
+    solana_message::Message,
+    solana_pubkey::Pubkey,
+    solana_runtime::{
+        bank::Bank,
+        bank_client::BankClient,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        loader_utils::load_program_of_loader_v4,
+    },
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+};
+
+#[test]
+fn test_abiv2() {
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(50);
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let authority_keypair = Keypair::new();
+
+    let (bank, program_id) = load_program_of_loader_v4(
+        &mut bank_client,
+        bank_forks.as_ref(),
+        &mint_keypair,
+        &authority_keypair,
+        "solana_sbf_rust_abiv2",
+    );
+
+    let mut key_arr = [0u8; 32];
+    for (i, item) in key_arr.iter_mut().enumerate() {
+        *item = i as u8;
+    }
+    let account_key = Pubkey::from(key_arr);
+    for (i, item) in key_arr.iter_mut().enumerate() {
+        *item = 2usize.saturating_mul(i) as u8;
+    }
+
+    let owner_key = Pubkey::from(key_arr);
+    let other_account_data =
+        AccountSharedData::create(789, vec![1, 2, 3, 4, 5], owner_key, false, u64::MAX);
+    bank.store_account(&account_key, &other_account_data);
+
+    bank.freeze();
+
+    let account_metas = vec![
+        AccountMeta::new(mint_keypair.pubkey(), true),
+        AccountMeta::new_readonly(account_key, false),
+    ];
+    let instruction = Instruction::new_with_bytes(program_id, &[0, 2], account_metas.clone());
+
+    let blockhash = bank.last_blockhash();
+    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+    let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
+    let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+    let result = bank.simulate_transaction(&sanitized_tx, false);
+    assert!(result.result.is_ok());
+}

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -13,6 +13,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
+        guest_transaction::RuntimeGuestTransaction,
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::ProgramCacheForTxBatch,
         sysvar_cache::SysvarCache,
@@ -161,6 +162,11 @@ impl Bank {
             struct MockCallback {}
             impl InvokeContextCallback for MockCallback {}
             let feature_set = self.feature_set.runtime_features();
+            let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+                &dummy_transaction_context,
+                1,
+                &feature_set,
+            );
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
                 &mut program_cache_for_tx_batch,
@@ -174,6 +180,7 @@ impl Bank {
                 None,
                 compute_budget.to_budget(),
                 compute_budget.to_cost(),
+                abi_v2_guest_transaction,
             );
 
             let environments = dummy_invoke_context

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -38,6 +38,7 @@ pub struct SVMFeatureSet {
     pub formalize_loaded_transaction_data_size: bool,
     pub disable_zk_elgamal_proof_program: bool,
     pub reenable_zk_elgamal_proof_program: bool,
+    pub enable_abi_v2_programs: bool,
 }
 
 impl SVMFeatureSet {
@@ -81,6 +82,7 @@ impl SVMFeatureSet {
             formalize_loaded_transaction_data_size: true,
             disable_zk_elgamal_proof_program: true,
             reenable_zk_elgamal_proof_program: true,
+            enable_abi_v2_programs: true,
         }
     }
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7733,8 +7733,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 [[package]]
 name = "solana-sbpf"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+source = "git+https://github.com/anza-xyz/sbpf.git?rev=967c2a2eba03816ee14f4c6338476690d374f511#967c2a2eba03816ee14f4c6338476690d374f511"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -48,6 +48,9 @@ pub(crate) fn process_message(
         }
 
         let mut compute_units_consumed = 0;
+        if let Some(guest_transaction) = &mut invoke_context.abi_v2_guest_transaction {
+            guest_transaction.set_instruction_index(top_level_instruction_index);
+        }
         let (result, process_instruction_us) = measure_us!({
             if invoke_context.is_precompile(program_id) {
                 invoke_context.process_precompile(
@@ -119,6 +122,7 @@ mod tests {
         solana_program_runtime::{
             declare_process_instruction,
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
+            guest_transaction::RuntimeGuestTransaction,
             invoke_context::EnvironmentConfig,
             loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
             sysvar_cache::SysvarCache,
@@ -252,6 +256,11 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -259,6 +268,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -306,6 +316,11 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -313,6 +328,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -350,6 +366,11 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -357,6 +378,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -486,6 +508,12 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -493,6 +521,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -525,6 +554,12 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -532,6 +567,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -561,6 +597,11 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -568,6 +609,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,
@@ -709,6 +751,11 @@ mod tests {
             &feature_set,
             &sysvar_cache,
         );
+        let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+            &transaction_context,
+            message.num_instructions(),
+            &feature_set,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             &mut program_cache_for_tx_batch,
@@ -716,6 +763,7 @@ mod tests {
             None,
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
+            abi_v2_guest_transaction,
         );
         let result = process_message(
             &message,

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -15,6 +15,7 @@ use {
     solana_message::SanitizedMessage,
     solana_program_runtime::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
+        guest_transaction::RuntimeGuestTransaction,
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{ProgramCacheEntry, ProgramCacheForTxBatch},
     },
@@ -358,6 +359,11 @@ fn execute_fixture_as_instr(
         sysvar_cache,
     );
 
+    let abi_v2_guest_transaction = RuntimeGuestTransaction::new_with_feature_set(
+        &transaction_context,
+        sanitized_message.instructions().len(),
+        &mock_bank.feature_set,
+    );
     let mut invoke_context = InvokeContext::new(
         &mut transaction_context,
         &mut loaded_programs,
@@ -365,6 +371,7 @@ fn execute_fixture_as_instr(
         Some(log_collector.clone()),
         compute_budget,
         SVMTransactionExecutionCost::default(),
+        abi_v2_guest_transaction,
     );
 
     let mut instruction_accounts: Vec<InstructionAccount> =


### PR DESCRIPTION
#### Problem

[SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177) proposes a new way of surfacing transaction and instruction data to executing programs, in an attempt to decrease the effort to read them.

Implementing the entire SIMD requires a large amount of work, which is going to be split into multiple PRs, potentially in this order:

1. Implement the transaction area (This PR)
2. Implement the instruction area
3. Implement new syscalls
4. Implement CPIs
5. Implement program data readout (it was formerly called deserialization step, but there will be nothing to really deserialize).

#### Summary of Changes

1. Add a feature gate without a proper key for ABIv2.
2. Create `RuntimeGuestTransaction` which maintains data structures to control what the program sees. They will also be used for readout and CPI in the future.
3. Create `TransactionContext` to be used in a future SDK version so that we can seamlessly read transaction information.
