### PR TITLE
Remove debug-signature feature from transaction-context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -540,7 +540,7 @@ solana-tps-client = { path = "tps-client", version = "=3.0.0" }
 solana-tpu-client = { path = "tpu-client", version = "=3.0.0", default-features = false }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=3.0.0" }
 solana-transaction = "2.2.3"
-solana-transaction-context = { path = "transaction-context", version = "=3.0.0", features = ["bincode", "debug-signature"] }
+solana-transaction-context = { path = "transaction-context", version = "=3.0.0", features = ["bincode"] }
 solana-transaction-error = "2.2.1"
 solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=3.0.0" }
 solana-transaction-status = { path = "transaction-status", version = "=3.0.0" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9459,7 +9459,6 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
- "solana-signature",
 ]
 
 [[package]]

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -75,7 +75,7 @@ solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-timings = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["debug-signature"] }
+solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-type-overrides = { workspace = true }
 spl-generic-token = { workspace = true }
@@ -105,12 +105,12 @@ solana-logger = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-pubkey = { workspace = true, features = [ "rand" ] }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true }
 solana-secp256k1-program = { workspace = true }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
-solana-signature = { workspace = true, features = [ "rand" ] }
+solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-svm = { path = ".", features = ["dev-context-only-utils", "svm-internal"] }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8559,7 +8559,6 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
- "solana-signature",
 ]
 
 [[package]]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -860,8 +860,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .feature_set
                 .remove_accounts_executable_flag_checks,
         );
-        #[cfg(debug_assertions)]
-        transaction_context.set_signature(tx.signature());
 
         let pre_account_state_info =
             TransactionAccountStateInfo::new(&transaction_context, tx, rent_collector);

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,10 +16,8 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-debug-signature = ["dep:solana-signature"]
 dev-context-only-utils = [
     "bincode",
-    "debug-signature",
     "solana-account/dev-context-only-utils",
 ]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,10 +16,7 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-dev-context-only-utils = [
-    "bincode",
-    "solana-account/dev-context-only-utils",
-]
+dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -2,12 +2,6 @@
 #![deny(clippy::indexing_slicing)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(all(
-    not(target_os = "solana"),
-    feature = "debug-signature",
-    debug_assertions
-))]
-use solana_signature::Signature;
 #[cfg(not(target_os = "solana"))]
 use {solana_account::WritableAccount, solana_rent::Rent, std::mem::MaybeUninit};
 use {
@@ -177,13 +171,6 @@ pub struct TransactionContext {
     remove_accounts_executable_flag_checks: bool,
     #[cfg(not(target_os = "solana"))]
     rent: Rent,
-    /// Useful for debugging to filter by or to look it up on the explorer
-    #[cfg(all(
-        not(target_os = "solana"),
-        feature = "debug-signature",
-        debug_assertions
-    ))]
-    signature: Signature,
 }
 
 impl TransactionContext {
@@ -210,12 +197,6 @@ impl TransactionContext {
             return_data: TransactionReturnData::default(),
             remove_accounts_executable_flag_checks: true,
             rent,
-            #[cfg(all(
-                not(target_os = "solana"),
-                feature = "debug-signature",
-                debug_assertions
-            ))]
-            signature: Signature::default(),
         }
     }
 
@@ -242,26 +223,6 @@ impl TransactionContext {
     #[cfg(not(target_os = "solana"))]
     pub fn accounts(&self) -> &Rc<TransactionAccounts> {
         &self.accounts
-    }
-
-    /// Stores the signature of the current transaction
-    #[cfg(all(
-        not(target_os = "solana"),
-        feature = "debug-signature",
-        debug_assertions
-    ))]
-    pub fn set_signature(&mut self, signature: &Signature) {
-        self.signature = *signature;
-    }
-
-    /// Returns the signature of the current transaction
-    #[cfg(all(
-        not(target_os = "solana"),
-        feature = "debug-signature",
-        debug_assertions
-    ))]
-    pub fn get_signature(&self) -> &Signature {
-        &self.signature
     }
 
     /// Returns the total number of accounts loaded in this Transaction


### PR DESCRIPTION
#### Problem

This feature cannot reliably be filtered from release builds, so the quick solution that was [discussed](https://github.com/anza-xyz/agave/pull/6607#discussion_r2154185260) is to remove it

#### Summary of Changes

Remove usages of `solana_signature::Signature`.

