### PR TITLE
Add options to bench-vote to tweak server and client connection limits

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -110,6 +110,13 @@ fn main() -> Result<()> {
                 .help("Maximum concurrent client connections per peer allowed on the server side."),
         )
         .arg(
+            Arg::with_name("max-connections-per-ipaddr-per-min")
+                .long("max-connections-per-ipaddr-per-min")
+                .value_name("NUM")
+                .takes_value(true)
+                .help("Maximum client connections per ipaddr per minute allowed on the server side."),
+        )
+        .arg(
             Arg::with_name("connection-pool-size")
                 .long("connection-pool-size")
                 .value_name("NUM")
@@ -174,6 +181,8 @@ fn main() -> Result<()> {
         value_t!(matches, "max-connections", usize).unwrap_or(DEFAULT_MAX_STAKED_CONNECTIONS);
     let max_connections_per_peer: usize = value_t!(matches, "max-connections-per-peer", usize)
         .unwrap_or(DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER);
+    let max_connections_per_ipaddr_per_min: usize =
+        value_t!(matches, "max-connections-per-ipaddr-per-min", usize).unwrap_or(1024); // Default value for max connections per ipaddr per minute
     let connection_pool_size: usize =
         value_t!(matches, "connection-pool-size", usize).unwrap_or(256);
 
@@ -235,7 +244,9 @@ fn main() -> Result<()> {
 
         if let Some(quic_params) = &quic_params {
             let quic_server_params = QuicServerParams {
-                max_connections_per_ipaddr_per_min: 8192,
+                max_connections_per_ipaddr_per_min: max_connections_per_ipaddr_per_min
+                    .try_into()
+                    .unwrap(),
                 max_connections_per_peer,
                 max_staked_connections: max_connections,
                 max_unstaked_connections: 0,

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
                 .long("max-connections")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Maximum concurrent client connections allwowed at the server side."),
+                .help("Maximum concurrent client connections allowed on the server side."),
         )
         .arg(
             Arg::with_name("max-connections-per-peer")

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
                 .long("max-connections-per-peer")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Maximum concurrent client connections per peer allwowed at the server side."),
+                .help("Maximum concurrent client connections per peer allowed on the server side."),
         )
         .arg(
             Arg::with_name("connection-pool-size")

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -212,7 +212,8 @@ fn main() -> Result<()> {
 
         QuicParams {
             identity_keypair,
-            staked_nodes
+            staked_nodes,
+            connection_pool_size
         }
     });
 
@@ -350,6 +351,7 @@ enum Transporter {
 struct QuicParams {
     identity_keypair: Keypair,
     staked_nodes: Arc<RwLock<StakedNodes>>,
+    connection_pool_size: usize,
 }
 
 fn producer(
@@ -364,7 +366,7 @@ fn producer(
         if let Some(quic_params) = &quic_params {
             Transporter::Cache(Arc::new(ConnectionCache::new_with_client_options(
                 "connection_cache_vote_quic",
-                256,  // connection_pool_size
+                quic_params.connection_pool_size,
                 None, // client_endpoint
                 Some((
                     &quic_params.identity_keypair,

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<()> {
     let max_connections_per_peer: usize = value_t!(matches, "max-connections-per-peer", usize)
         .unwrap_or(DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER);
     let connection_pool_size: usize =
-        value_t!(matches, "connection-pool-size", usize).unwrap_or(1024);
+        value_t!(matches, "connection-pool-size", usize).unwrap_or(256);
 
     let use_connection_cache = matches.is_present("use-connection-cache");
     let server_only = matches.is_present("server-only");


### PR DESCRIPTION
#### Problem
Add options to bench-vote to tweak server and client connection limits

#### Summary of Changes

Added following options to bench-vote tool

        --max-connections <NUM>             Maximum concurrent client connections allwowed at the server side.
        --max-connections-per-peer <NUM>    Maximum concurrent client connections per peer allwowed at the server side.
        --connection-pool-size <NUM>        Maximum concurrent client connections on the client side.
        --max-connections-per-ipaddr-per-min Maximum client connections per ipaddr per minute allowed on the server side.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
