### PR TITLE
streamer: Remove unnecessary TestServerConfig struct

### DIFF
--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -40,4 +40,3 @@ solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
-

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -39,3 +39,5 @@ solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
+solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
+

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -80,13 +80,7 @@ mod tests {
             sender,
             exit.clone(),
             staked_nodes,
-            QuicServerParams {
-                max_connections_per_peer: 1,
-                max_staked_connections: 10,
-                max_unstaked_connections: 10,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
-            },
+            QuicServerParams::default_for_tests(),
         )
         .unwrap();
 
@@ -166,14 +160,7 @@ mod tests {
             sender,
             exit.clone(),
             staked_nodes,
-            QuicServerParams {
-                max_connections_per_peer: 1,
-                max_staked_connections: 10,
-                max_unstaked_connections: 10,
-                wait_for_chunk_timeout: Duration::from_secs(1),
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
-            },
+            QuicServerParams::default_for_tests(),
         )
         .unwrap();
 
@@ -231,13 +218,7 @@ mod tests {
             sender,
             request_recv_exit.clone(),
             staked_nodes.clone(),
-            QuicServerParams {
-                max_connections_per_peer: 1,
-                max_staked_connections: 10,
-                max_unstaked_connections: 10,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
-            },
+            QuicServerParams::default_for_tests(),
         )
         .unwrap();
 
@@ -261,13 +242,7 @@ mod tests {
             sender2,
             response_recv_exit.clone(),
             staked_nodes,
-            QuicServerParams {
-                max_connections_per_peer: 1,
-                max_staked_connections: 10,
-                max_unstaked_connections: 10,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
-            },
+            QuicServerParams::default_for_tests(),
         )
         .unwrap();
 

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1563,7 +1563,7 @@ pub mod test {
                 quic::compute_max_allowed_uni_streams,
                 testing_utilities::{
                     check_multiple_streams, get_client_config, make_client_endpoint,
-                    setup_quic_server, SpawnTestServerResult, TestServerConfig,
+                    setup_quic_server, SpawnTestServerResult,
                 },
             },
             quic::DEFAULT_TPU_COALESCE,
@@ -1687,7 +1687,7 @@ pub mod test {
             receiver: _,
             server_address: _,
             stats: _,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
     }
@@ -1701,7 +1701,7 @@ pub mod test {
             receiver,
             server_address,
             stats: _,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
         check_timeout(receiver, server_address).await;
         exit.store(true, Ordering::Relaxed);
@@ -1768,7 +1768,7 @@ pub mod test {
             receiver: _,
             server_address,
             stats,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
         let conn1 = make_client_endpoint(&server_address, None).await;
         assert_eq!(stats.total_streams.load(Ordering::Relaxed), 0);
@@ -1803,7 +1803,7 @@ pub mod test {
             receiver: _,
             server_address,
             stats: _,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
         check_block_multiple_connections(server_address).await;
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
@@ -1821,9 +1821,9 @@ pub mod test {
             stats,
         } = setup_quic_server(
             None,
-            TestServerConfig {
+            QuicServerParams {
                 max_connections_per_peer: 2,
-                ..Default::default()
+                ..QuicServerParams::default_for_tests()
             },
         );
 
@@ -1894,7 +1894,7 @@ pub mod test {
             receiver,
             server_address,
             stats: _,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
         check_multiple_writes(receiver, server_address, None).await;
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
@@ -1916,7 +1916,7 @@ pub mod test {
             receiver,
             server_address,
             stats,
-        } = setup_quic_server(Some(staked_nodes), TestServerConfig::default());
+        } = setup_quic_server(Some(staked_nodes), QuicServerParams::default_for_tests());
         check_multiple_writes(receiver, server_address, Some(&client_keypair)).await;
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
@@ -1948,7 +1948,7 @@ pub mod test {
             receiver,
             server_address,
             stats,
-        } = setup_quic_server(Some(staked_nodes), TestServerConfig::default());
+        } = setup_quic_server(Some(staked_nodes), QuicServerParams::default_for_tests());
         check_multiple_writes(receiver, server_address, Some(&client_keypair)).await;
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
@@ -1972,7 +1972,7 @@ pub mod test {
             receiver,
             server_address,
             stats,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
         check_multiple_writes(receiver, server_address, None).await;
         exit.store(true, Ordering::Relaxed);
         join_handle.await.unwrap();
@@ -2010,8 +2010,7 @@ pub mod test {
             staked_nodes,
             QuicServerParams {
                 max_unstaked_connections: 0, // Do not allow any connection from unstaked clients/nodes
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
+                ..QuicServerParams::default_for_tests()
             },
         )
         .unwrap();
@@ -2044,8 +2043,7 @@ pub mod test {
             staked_nodes,
             QuicServerParams {
                 max_connections_per_peer: 2,
-                coalesce_channel_size: 100_000, // smaller channel size for faster test
-                ..QuicServerParams::default()
+                ..QuicServerParams::default_for_tests()
             },
         )
         .unwrap();
@@ -2397,7 +2395,7 @@ pub mod test {
             receiver,
             server_address,
             stats,
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
         let client_connection = make_client_endpoint(&server_address, None).await;
 
@@ -2456,7 +2454,7 @@ pub mod test {
             stats,
             exit,
             ..
-        } = setup_quic_server(None, TestServerConfig::default());
+        } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
         let client_connection = make_client_endpoint(&server_address, None).await;
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -9,9 +9,10 @@ use {
     solana_signer::Signer,
     solana_streamer::{
         nonblocking::testing_utilities::{
-            make_client_endpoint, setup_quic_server, SpawnTestServerResult, TestServerConfig,
+            make_client_endpoint, setup_quic_server, SpawnTestServerResult,
         },
         packet::PacketBatch,
+        quic::QuicServerParams,
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
@@ -195,7 +196,7 @@ async fn test_basic_transactions_sending() {
         receiver,
         server_address,
         stats: _stats,
-    } = setup_quic_server(None, TestServerConfig::default());
+    } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
     // Setup sending txs
     let tx_size = 1;
@@ -287,7 +288,7 @@ async fn test_connection_denied_until_allowed() {
         receiver,
         server_address,
         stats: _stats,
-    } = setup_quic_server(None, TestServerConfig::default());
+    } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
     // To prevent server from accepting a new connection, we use the following observation.
     // Since max_connections_per_peer == 1 (< max_unstaked_connections == 500), if we create a first
@@ -349,10 +350,10 @@ async fn test_connection_pruned_and_reopened() {
         stats: _stats,
     } = setup_quic_server(
         None,
-        TestServerConfig {
+        QuicServerParams {
             max_connections_per_peer: 100,
             max_unstaked_connections: 1,
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         },
     );
 
@@ -408,13 +409,13 @@ async fn test_staked_connection() {
         stats: _stats,
     } = setup_quic_server(
         Some(staked_nodes),
-        TestServerConfig {
+        QuicServerParams {
             // Must use at least the number of endpoints (10) because
             // `max_staked_connections` and `max_unstaked_connections` are
             // cumulative for all the endpoints.
             max_staked_connections: 10,
             max_unstaked_connections: 0,
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         },
     );
 
@@ -461,7 +462,7 @@ async fn test_connection_throttling() {
         receiver,
         server_address,
         stats: _stats,
-    } = setup_quic_server(None, TestServerConfig::default());
+    } = setup_quic_server(None, QuicServerParams::default_for_tests());
 
     // Setup sending txs
     let tx_size = 1;
@@ -550,10 +551,10 @@ async fn test_rate_limiting() {
         stats: _stats,
     } = setup_quic_server(
         None,
-        TestServerConfig {
+        QuicServerParams {
             max_connections_per_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         },
     );
 
@@ -608,10 +609,10 @@ async fn test_rate_limiting_establish_connection() {
         stats: _stats,
     } = setup_quic_server(
         None,
-        TestServerConfig {
+        QuicServerParams {
             max_connections_per_peer: 100,
             max_connections_per_ipaddr_per_min: 1,
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         },
     );
 
@@ -691,14 +692,14 @@ async fn test_update_identity() {
         stats: _stats,
     } = setup_quic_server(
         Some(staked_nodes),
-        TestServerConfig {
+        QuicServerParams {
             // Must use at least the number of endpoints (10) because
             // `max_staked_connections` and `max_unstaked_connections` are
             // cumulative for all the endpoints.
             max_staked_connections: 10,
             // Deny all unstaked connections.
             max_unstaked_connections: 0,
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         },
     );
 


### PR DESCRIPTION
#### Problem
There is an intermediate test struct that is unnecessary

#### Summary of Changes
Implement a `default_for_tests()` function on the original struct instead
