### PR TITLE
Update Solana warm-up period link to current documentation

### DIFF
--- a/docs/src/operations/guides/validator-stake.md
+++ b/docs/src/operations/guides/validator-stake.md
@@ -62,7 +62,7 @@ solana delegate-stake ~/validator-stake-keypair.json ~/some-other-vote-account-k
 ## Validator Stake Warm-up
 
 To combat various attacks on consensus, new stake delegations are subject to a
-[warm-up](https://solana.com/docs/economics/staking/stake-accounts#delegation-warmup-and-cooldown) period.
+[warm-up](https://solana.com/docs/references/staking/stake-accounts#delegation-warmup-and-cooldown) period.
 
 Monitor a validator's stake during warmup by:
 


### PR DESCRIPTION
#### Problem

Broken link

#### Summary of Changes

Replaced the outdated link to the Solana delegation warm-up and cooldown documentation with the current official reference. This ensures users are directed to the latest and most accurate information regarding stake activation and deactivation periods. No other content was changed.

