### PR TITLE
Add v4 option to `cargo-build-sbf`

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -876,7 +876,7 @@ fn main() {
         .arg(
             Arg::new("arch")
                 .long("arch")
-                .possible_values(["v0", "v1", "v2", "v3"])
+                .possible_values(["v0", "v1", "v2", "v3", "v4"])
                 .default_value("v0")
                 .help("Build for the given target architecture"),
         )

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -220,6 +220,18 @@ fn test_sbpfv3() {
 
 #[test]
 #[serial]
+fn test_sbpfv4() {
+    let assert_v1 = build_noop_and_readelf("v4");
+    assert_v1
+        .stdout(predicate::str::contains(
+            "Flags:                             0x4",
+        ))
+        .success();
+    clean_target("noop");
+}
+
+#[test]
+#[serial]
 fn test_package_metadata_tools_version() {
     run_cargo_build("package-metadata", &[], false);
     clean_target("package-metadata");


### PR DESCRIPTION
#### Problem

We are starting to test ABIv2, which requires the v4 flag on the ELF header. Having it integrated in `cargo-build-sbf` facilitates CI and local testing.

#### Summary of Changes

1. Include `v4` as an option to `--arch`.
2. Add a test
