### PR TITLE
streamer: Remove deprecated MAX_*_CONNECTIONS constants

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -33,19 +33,7 @@ use {
 // allow multiple connections for NAT and any open/close overlap
 pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 
-#[deprecated(
-    since = "2.2.0",
-    note = "Use solana_streamer::quic::DEFAULT_MAX_STAKED_CONNECTIONS"
-)]
-pub const MAX_STAKED_CONNECTIONS: usize = 2000;
-
 pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
-
-#[deprecated(
-    since = "2.2.0",
-    note = "Use solana_streamer::quic::DEFAULT_MAX_UNSTAKED_CONNECTIONS"
-)]
-pub const MAX_UNSTAKED_CONNECTIONS: usize = 500;
 
 pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
 


### PR DESCRIPTION
#### Problem
The constants were deprecated in `v2.2.0` (https://github.com/anza-xyz/agave/pull/4170) so they're fair game to rip out for `v3.0.0`