### PR TITLE
streamer: Remove default trait from QuicServerParams

### DIFF
--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -250,7 +250,7 @@ fn main() -> Result<()> {
                 max_connections_per_peer,
                 max_staked_connections: max_connections,
                 max_unstaked_connections: 0,
-                ..Default::default()
+                ..QuicServerParams::default_for_tests()
             };
             let (s_reader, r_reader) = unbounded();
             read_channels.push(r_reader);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -120,9 +120,6 @@ use {
     solana_signer::Signer,
     solana_streamer::{quic::QuicServerParams, socket::SocketAddrSpace, streamer::StakedNodes},
     solana_time_utils::timestamp,
-    solana_tpu_client::tpu_client::{
-        DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC, DEFAULT_VOTE_USE_QUIC,
-    },
     solana_turbine::{self, broadcast_stage::BroadcastStageType, xdp::XdpConfig},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_validator_exit::Exit,
@@ -499,30 +496,29 @@ pub struct ValidatorTpuConfig {
     pub vote_quic_server_config: QuicServerParams,
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 impl ValidatorTpuConfig {
     /// A convenient function to build a ValidatorTpuConfig for testing with good
     /// default.
     pub fn new_for_tests(tpu_enable_udp: bool) -> Self {
         let tpu_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
-            coalesce_channel_size: 100_000, // smaller channel size for faster test
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         };
 
         let tpu_fwd_quic_server_config = QuicServerParams {
             max_connections_per_ipaddr_per_min: 32,
             max_unstaked_connections: 0,
-            coalesce_channel_size: 100_000, // smaller channel size for faster test
-            ..Default::default()
+            ..QuicServerParams::default_for_tests()
         };
 
         // vote and tpu_fwd share the same characteristics -- disallow non-staked connections:
         let vote_quic_server_config = tpu_fwd_quic_server_config.clone();
 
         ValidatorTpuConfig {
-            use_quic: DEFAULT_TPU_USE_QUIC,
-            vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            use_quic: solana_tpu_client::tpu_client::DEFAULT_TPU_USE_QUIC,
+            vote_use_quic: solana_tpu_client::tpu_client::DEFAULT_VOTE_USE_QUIC,
+            tpu_connection_pool_size: solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
             tpu_enable_udp,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7114,7 +7114,9 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-clock",
  "solana-hash",
+ "solana-keypair",
  "solana-message",
  "solana-metrics",
  "solana-packet",
@@ -7123,7 +7125,13 @@ dependencies = [
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-system-transaction",
  "solana-time-utils",
+ "solana-transaction",
+ "solana-vote",
+ "solana-vote-program",
 ]
 
 [[package]]

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        nonblocking::quic::{ALPN_TPU_PROTOCOL_ID, DEFAULT_WAIT_FOR_CHUNK_TIMEOUT},
-        streamer::StakedNodes,
-    },
+    crate::{nonblocking::quic::ALPN_TPU_PROTOCOL_ID, streamer::StakedNodes},
     crossbeam_channel::Sender,
     pem::Pem,
     quinn::{
@@ -69,7 +66,7 @@ pub struct SpawnServerResult {
 }
 
 /// Controls the the channel size for the PacketBatch coalesce
-pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 250_000;
+pub const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 250_000;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
@@ -617,32 +614,23 @@ pub struct QuicServerParams {
     pub num_threads: NonZeroUsize,
 }
 
-impl Default for QuicServerParams {
-    fn default() -> Self {
+#[cfg(feature = "dev-context-only-utils")]
+impl QuicServerParams {
+    pub const DEFAULT_NUM_SERVER_THREADS_FOR_TEST: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+    pub fn default_for_tests() -> Self {
         QuicServerParams {
             max_connections_per_peer: 1,
             max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
-            wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+            wait_for_chunk_timeout: crate::nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: DEFAULT_TPU_COALESCE,
-            coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
-            num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
-        }
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl QuicServerParams {
-    pub const DEFAULT_NUM_SERVER_THREADS_FOR_TEST: NonZeroUsize = NonZeroUsize::new(8).unwrap();
-
-    pub fn default_for_tests() -> Self {
-        // Shrink the channel size to avoid a massive allocation for tests
-        Self {
+            // Shrink the channel size from DEFAULT_MAX_COALESCE_CHANNEL_SIZE
+            // to avoid a massive allocation for tests
             coalesce_channel_size: 100_000,
             num_threads: Self::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
-            ..Self::default()
         }
     }
 }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -6926,7 +6926,9 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-clock",
  "solana-hash",
+ "solana-keypair",
  "solana-message",
  "solana-metrics",
  "solana-packet",
@@ -6935,7 +6937,13 @@ dependencies = [
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-system-transaction",
  "solana-time-utils",
+ "solana-transaction",
+ "solana-vote",
+ "solana-vote-program",
 ]
 
 [[package]]
@@ -7682,6 +7690,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-system-interface",
+ "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -8147,6 +8156,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "percentage",
+ "qualifier_attr",
  "serde",
  "serde_derive",
  "solana-account",
@@ -8792,8 +8802,10 @@ dependencies = [
 name = "solana-vote"
 version = "3.0.0"
 dependencies = [
+ "bincode",
  "itertools 0.12.1",
  "log",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-account",

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -27,7 +27,7 @@ solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-core = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-epoch-schedule = { workspace = true }
 solana-feature-gate-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -96,6 +96,7 @@ signal-hook = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -67,7 +67,8 @@ use {
     solana_send_transaction_service::send_transaction_service,
     solana_signer::Signer,
     solana_streamer::{
-        quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
+        nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
+        quic::{QuicServerParams, DEFAULT_MAX_COALESCE_CHANNEL_SIZE, DEFAULT_TPU_COALESCE},
         socket::SocketAddrSpace,
     },
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
@@ -1283,9 +1284,10 @@ pub fn execute(
         max_unstaked_connections: tpu_max_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+        wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
         coalesce: tpu_coalesce,
+        coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
         num_threads: tpu_transaction_receive_threads,
-        ..Default::default()
     };
 
     let tpu_fwd_quic_server_config = QuicServerParams {
@@ -1294,9 +1296,10 @@ pub fn execute(
         max_unstaked_connections: tpu_max_fwd_unstaked_connections.try_into().unwrap(),
         max_streams_per_ms,
         max_connections_per_ipaddr_per_min: tpu_max_connections_per_ipaddr_per_minute,
+        wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
         coalesce: tpu_coalesce,
+        coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
         num_threads: tpu_transaction_forward_receive_threads,
-        ..Default::default()
     };
 
     // Vote shares TPU forward's characteristics, except that we accept 1 connection

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -12,11 +12,15 @@ use {
     solana_quic_definitions::NotifyKeyUpdate,
     solana_streamer::{
         nonblocking::quic::DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
-        quic::{spawn_server_multi, EndpointKeyUpdater, QuicServerParams},
+        quic::{
+            default_num_tpu_transaction_receive_threads, spawn_server_multi, EndpointKeyUpdater,
+            QuicServerParams, DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
+        },
         streamer::StakedNodes,
     },
     std::{
         net::{SocketAddr, UdpSocket},
+        num::NonZeroUsize,
         sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
         thread::{self, JoinHandle},
         time::Duration,
@@ -125,7 +129,8 @@ impl Vortexor {
             max_connections_per_ipaddr_per_min,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             coalesce: tpu_coalesce,
-            ..Default::default()
+            coalesce_channel_size: DEFAULT_MAX_COALESCE_CHANNEL_SIZE,
+            num_threads: NonZeroUsize::new(default_num_tpu_transaction_receive_threads()).unwrap(),
         };
 
         let TpuSockets {


### PR DESCRIPTION
#### Problem
This struct is used to configure the TPU quic servers. While having a set of defaults for tests and benches is fine, filling in the struct with ..Default::default() for production is a potential footgun.

#### Summary of Changes
Remove the custom `Default` implementation
- All test code has been updated to use `QuicServerParams::default_for_tests()`
- All production code now wires up every field