### PR TITLE
ci: add 'NO_INSTALL' flag to ci/rust-version.sh

### DIFF
--- a/ci/docker/env.sh
+++ b/ci/docker/env.sh
@@ -3,7 +3,7 @@
 ci_docker_env_sh_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck disable=SC1091
-source "${ci_docker_env_sh_here}/../rust-version.sh"
+NO_INSTALL=1 source "${ci_docker_env_sh_here}/../rust-version.sh"
 
 if [[ -z "${rust_stable}" || -z "${rust_nightly}" ]]; then
   echo "Error: rust_stable or rust_nightly is empty. Please check rust-version.sh." >&2

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -37,6 +37,10 @@ export rust_stable="$stable_version"
 
 export rust_nightly=nightly-"$nightly_version"
 
+if [[ -n $NO_INSTALL ]]; then
+  return
+fi
+
 [[ -z $1 ]] || (
 
   rustup_install() {


### PR DESCRIPTION
#### Problem

there is a confusing message in our build:
<img width="756" alt="Screenshot 2025-06-20 at 20 32 48" src="https://github.com/user-attachments/assets/d1e92d1e-76ed-4349-b4b4-b3d7c051af7d" />

the message comes from 

https://github.com/anza-xyz/agave/blob/557bfcb1028103d6383535f374c358dbd10e6e92/ci/rust-version.sh#L65

#### Summary of Changes

add an option, NO_INSTALL, in the script