### PR TITLE
ci: improve step descriptions

### DIFF
--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -8,31 +8,37 @@ source "$here"/common.sh
 
 agent="${1-solana}"
 
-partitions=$(
-  cat <<EOF
+parallelism=5
+partitions=()
+for i in $(seq 1 $parallelism); do
+  partitions+=("$(
+    cat <<EOF
 {
-  "name": "partitions",
-  "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh",
+  "name": "partition-$i",
+  "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh $i $parallelism",
   "timeout_in_minutes": 25,
   "agent": "$agent",
-  "parallelism": 5,
   "retry": 3
 }
 EOF
-)
+  )")
+done
 
-local_cluster_partitions=$(
-  cat <<EOF
+parallelism=10
+local_cluster_partitions=()
+for i in $(seq 1 $parallelism); do
+  local_cluster_partitions+=("$(
+    cat <<EOF
 {
-  "name": "local-cluster",
-  "command": "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh",
+  "name": "local-cluster-$i",
+  "command": "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh $i $parallelism",
   "timeout_in_minutes": 15,
   "agent": "$agent",
-  "parallelism": 10,
   "retry": 3
 }
 EOF
-)
+  )")
+done
 
 localnet=$(
   cat <<EOF
@@ -46,4 +52,6 @@ EOF
 )
 
 # shellcheck disable=SC2016
-group "stable" "$partitions" "$local_cluster_partitions" "$localnet"
+group "stable" "${partitions[@]}"
+group "local-cluster" "${local_cluster_partitions[@]}"
+group "localnet" "$localnet"

--- a/ci/stable/run-local-cluster-partially.sh
+++ b/ci/stable/run-local-cluster-partially.sh
@@ -8,7 +8,7 @@ TOTAL=$2
 : "${TOTAL:?}"
 
 if [ "$CURRENT" -gt "$TOTAL" ]; then
-  echo "Error: The value of CURRENT (\$1) must be less than the value of TOTAL (\$2)."
+  echo "Error: The value of CURRENT (\$1) cannot be greater than the value of TOTAL (\$2)."
   exit 1
 fi
 

--- a/ci/stable/run-local-cluster-partially.sh
+++ b/ci/stable/run-local-cluster-partially.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+CURRENT=$1
+: "${CURRENT:?}"
+
+TOTAL=$2
+: "${TOTAL:?}"
+
+if [ "$CURRENT" -gt "$TOTAL" ]; then
+  echo "Error: The value of CURRENT (\$1) must be less than the value of TOTAL (\$2)."
+  exit 1
+fi
+
 here="$(dirname "$0")"
 
 #shellcheck source=ci/common/shared-functions.sh
@@ -9,16 +20,10 @@ source "$here"/../common/shared-functions.sh
 #shellcheck source=ci/stable/common.sh
 source "$here"/common.sh
 
-INDEX=${1:-"$BUILDKITE_PARALLEL_JOB"}
-: "${INDEX:?}"
-
-LIMIT=${2:-"$BUILDKITE_PARALLEL_JOB_COUNT"}
-: "${LIMIT:?}"
-
 _ cargo nextest run \
   --profile ci \
   --package solana-local-cluster \
   --test local_cluster \
-  --partition hash:"$((INDEX + 1))/$LIMIT" \
+  --partition hash:"$CURRENT/$TOTAL" \
   --test-threads=1 \
   --no-tests=warn

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -8,7 +8,7 @@ TOTAL=$2
 : "${TOTAL:?}"
 
 if [ "$CURRENT" -gt "$TOTAL" ]; then
-  echo "Error: The value of CURRENT (\$1) must be less than the value of TOTAL (\$2)."
+  echo "Error: The value of CURRENT (\$1) cannot be greater than the value of TOTAL (\$2)."
   exit 1
 fi
 

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+CURRENT=$1
+: "${CURRENT:?}"
+
+TOTAL=$2
+: "${TOTAL:?}"
+
+if [ "$CURRENT" -gt "$TOTAL" ]; then
+  echo "Error: The value of CURRENT (\$1) must be less than the value of TOTAL (\$2)."
+  exit 1
+fi
+
 here="$(dirname "$0")"
 
 #shellcheck source=ci/common/shared-functions.sh
@@ -12,25 +23,12 @@ source "$here"/../common/limit-threads.sh
 #shellcheck source=ci/stable/common.sh
 source "$here"/common.sh
 
-# check partition info
-INDEX=${1:-"$BUILDKITE_PARALLEL_JOB"} # BUILDKITE_PARALLEL_JOB from 0 to (BUILDKITE_PARALLEL_JOB_COUNT - 1)
-: "${INDEX:?}"
-
-# if LIMIT = 3, the valid INDEX is 0~2
-LIMIT=${2:-"$BUILDKITE_PARALLEL_JOB_COUNT"}
-: "${LIMIT:?}"
-
-if [ ! "$LIMIT" -gt "$INDEX" ]; then
-  echo "LIMIT(\$2) should greater than INDEX(\$1)"
-  exit 1
-fi
-
 ARGS=(
   --profile ci
   --workspace
   --tests
   --jobs "$JOBS"
-  --partition hash:"$((INDEX + 1))/$LIMIT"
+  --partition hash:"$CURRENT/$TOTAL"
   --verbose
   --exclude solana-local-cluster
   --no-tests=warn


### PR DESCRIPTION
#### Problem

we can’t easily copy and paste the command from the CI to reproduce errors locally.

<img width="626" alt="Screenshot 2025-06-20 at 20 37 00" src="https://github.com/user-attachments/assets/405bd625-a357-4b7a-9926-805ed4051e39" />

#### Summary of Changes

get the steps more explicit:

<img width="642" alt="Screenshot 2025-06-20 at 20 37 54" src="https://github.com/user-attachments/assets/2ef112b3-e10f-4c56-962e-91f48ea2fa43" />

