### PR TITLE
increase QUIC DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE to 16

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -53,9 +53,9 @@ pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
 pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
 
 /// The new connections per minute from a particular IP address.
-/// Heuristically set to the default maximum concurrent connections
+/// Heuristically set to twice the default maximum concurrent connections
 /// per IP address. Might be adjusted later.
-pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 8;
+pub const DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE: u64 = 16;
 
 // This will be adjusted and parameterized in follow-on PRs.
 pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;


### PR DESCRIPTION
#### Problem

There are reported problems having trouble to make connections due the limit is too low when connection is evicted by the server or timed out or other errors.

#### Summary of Changes

Double the DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
