### PR TITLE
agave-validator: add args tests for run (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "log",
  "num_cpus",
  "predicates",
+ "pretty_assertions",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -2384,6 +2385,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -5139,6 +5146,16 @@ name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -14116,6 +14133,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,6 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indexmap 2.9.0",
  "indicatif",
  "itertools 0.12.1",
  "jsonrpc-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
+ "indexmap 2.9.0",
  "indicatif",
  "itertools 0.12.1",
  "jsonrpc-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,6 +326,7 @@ percentage = "0.1.0"
 pickledb = { version = "0.5.1", default-features = false }
 predicates = "2.1"
 pretty-hex = "0.3.0"
+pretty_assertions = "1.4.1"
 prio-graph = "0.3.0"
 proc-macro2 = "1.0.95"
 proptest = "1.7"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -161,7 +161,6 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indexmap 2.9.0",
  "indicatif",
  "itertools 0.12.1",
  "jsonrpc-core",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
+ "indexmap 2.9.0",
  "indicatif",
  "itertools 0.12.1",
  "jsonrpc-core",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,7 +21,6 @@ console = { workspace = true }
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 fd-lock = { workspace = true }
-indexmap = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 jsonrpc-core = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,6 +21,7 @@ console = { workspace = true }
 core_affinity = { workspace = true }
 crossbeam-channel = { workspace = true }
 fd-lock = { workspace = true }
+indexmap = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 jsonrpc-core = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -95,6 +95,7 @@ signal-hook = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+pretty_assertions = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -56,7 +56,7 @@ pub const MAX_RPC_CONNECTIONS_EVALUATED_PER_ITERATION: usize = 32;
 
 pub const PING_TIMEOUT: Duration = Duration::from_secs(2);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1,5 +1,4 @@
 use {
-    crate::commands::run::args::rpc_bootstrap_config::RpcBootstrapConfig,
     itertools::Itertools,
     log::*,
     rand::{seq::SliceRandom, thread_rng, Rng},
@@ -56,6 +55,16 @@ const GET_RPC_PEERS_TIMEOUT: Duration = Duration::from_secs(300);
 pub const MAX_RPC_CONNECTIONS_EVALUATED_PER_ITERATION: usize = 32;
 
 pub const PING_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+pub struct RpcBootstrapConfig {
+    pub no_genesis_fetch: bool,
+    pub no_snapshot_fetch: bool,
+    pub only_known_rpc: bool,
+    pub max_genesis_archive_unpacked_size: u64,
+    pub check_vote_account: Option<String>,
+    pub incremental_snapshot_fetch: bool,
+}
 
 fn verify_reachable_ports(
     node: &Node,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1,4 +1,5 @@
 use {
+    crate::commands::run::args::rpc_bootstrap_config::RpcBootstrapConfig,
     itertools::Itertools,
     log::*,
     rand::{seq::SliceRandom, thread_rng, Rng},
@@ -55,16 +56,6 @@ const GET_RPC_PEERS_TIMEOUT: Duration = Duration::from_secs(300);
 pub const MAX_RPC_CONNECTIONS_EVALUATED_PER_ITERATION: usize = 32;
 
 pub const PING_TIMEOUT: Duration = Duration::from_secs(2);
-
-#[derive(Debug)]
-pub struct RpcBootstrapConfig {
-    pub no_genesis_fetch: bool,
-    pub no_snapshot_fetch: bool,
-    pub only_known_rpc: bool,
-    pub max_genesis_archive_unpacked_size: u64,
-    pub check_vote_account: Option<String>,
-    pub incremental_snapshot_fetch: bool,
-}
 
 fn verify_reachable_ports(
     node: &Node,

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -46,7 +46,7 @@ pub mod tests {
     {
         let matches = app.get_matches_from(vec);
         let result = T::from_clap_arg_match(&matches);
-        assert_eq!(result.unwrap(), expected_arg);
+        pretty_assertions::assert_eq!(result.unwrap(), expected_arg);
     }
 
     pub fn verify_args_struct_by_command_is_error<T>(app: clap::App, vec: Vec<&str>)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1,12 +1,9 @@
-pub mod rpc_bootstrap_config;
-
 use {
     crate::{
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
     },
     clap::{values_t, App, Arg, ArgMatches},
-    rpc_bootstrap_config::RpcBootstrapConfig,
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::keypair_of,
@@ -37,13 +34,15 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
+pub mod rpc_bootstrap_config;
+
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
     pub identity_keypair: Keypair,
     pub logfile: String,
     pub entrypoints: Vec<SocketAddr>,
     pub known_validators: Option<HashSet<Pubkey>>,
-    pub rpc_bootstrap_config: RpcBootstrapConfig,
+    pub rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -2277,7 +2276,7 @@ mod tests {
             let default_run_args = RunArgs::default();
             let expected_args = RunArgs {
                 rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
-                    incremental_snapshot_fetch: false,
+                    no_incremental_snapshots: true,
                     ..rpc_bootstrap_config::RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1870,4 +1870,24 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_snapshot_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    no_snapshot_fetch: true,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args.clone(),
+                vec!["--no-snapshot-fetch"],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1,9 +1,12 @@
+pub mod rpc_bootstrap_config;
+
 use {
     crate::{
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
     },
     clap::{values_t, App, Arg, ArgMatches},
+    rpc_bootstrap_config::RpcBootstrapConfig,
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::keypair_of,
@@ -34,15 +37,13 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
-pub mod rpc_bootstrap_config;
-
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
     pub identity_keypair: Keypair,
     pub logfile: String,
     pub entrypoints: Vec<SocketAddr>,
     pub known_validators: Option<HashSet<Pubkey>>,
-    pub rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig,
+    pub rpc_bootstrap_config: RpcBootstrapConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -2276,7 +2277,7 @@ mod tests {
             let default_run_args = RunArgs::default();
             let expected_args = RunArgs {
                 rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
-                    no_incremental_snapshots: true,
+                    incremental_snapshot_fetch: false,
                     ..rpc_bootstrap_config::RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2242,4 +2242,28 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_max_genesis_archive_unpacked_size() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let max_genesis_archive_unpacked_size = 1000000000;
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    max_genesis_archive_unpacked_size,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--max-genesis-archive-unpacked-size",
+                    &max_genesis_archive_unpacked_size.to_string(),
+                ],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2189,4 +2189,57 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_only_known_rpc() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    only_known_rpc: true,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // --known-validator is required
+                    "--known-validator",
+                    &known_validators_pubkey.to_string(),
+                    "--only-known-rpc",
+                ],
+                expected_args,
+            );
+        }
+
+        // alias
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    only_known_rpc: true,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // --known-validator is required
+                    "--known-validator",
+                    &known_validators_pubkey.to_string(),
+                    "--no-untrusted-rpc",
+                ],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -33,10 +33,13 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
+pub mod rpc_bootstrap_config;
+
 #[derive(Debug, PartialEq)]
 pub struct RunArgs {
     pub identity_keypair: Keypair,
     pub logfile: String,
+    pub rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -55,6 +58,9 @@ impl FromClapArgMatches for RunArgs {
         Ok(RunArgs {
             identity_keypair,
             logfile,
+            rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::from_clap_arg_match(
+                matches,
+            )?,
         })
     }
 }
@@ -1720,6 +1726,7 @@ mod tests {
             RunArgs {
                 identity_keypair,
                 logfile,
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::default(),
             }
         }
     }
@@ -1729,6 +1736,7 @@ mod tests {
             RunArgs {
                 identity_keypair: self.identity_keypair.insecure_clone(),
                 logfile: self.logfile.clone(),
+                rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
             }
         }
     }
@@ -1838,6 +1846,26 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
                 vec!["--log", "custom_log.log"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_genesis_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    no_genesis_fetch: true,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args.clone(),
+                vec!["--no-genesis-fetch"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2000,4 +2000,34 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_check_vote_account() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                entrypoints: vec![SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    8000,
+                )],
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    check_vote_account: Some("https://api.mainnet-beta.solana.com".to_string()),
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // entrypoint is required for check-vote-account
+                    "--entrypoint",
+                    "127.0.0.1:8000",
+                    "--check-vote-account",
+                    "https://api.mainnet-beta.solana.com",
+                ],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -22,13 +22,14 @@ use {
     },
     solana_keypair::Keypair,
     solana_ledger::use_snapshot_archives_at_startup,
+    solana_pubkey::Pubkey,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
     solana_send_transaction_service::send_transaction_service::{
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_signer::Signer,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
-    std::{net::SocketAddr, str::FromStr},
+    std::{collections::HashSet, net::SocketAddr, str::FromStr},
 };
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
@@ -41,6 +42,7 @@ pub struct RunArgs {
     pub identity_keypair: Keypair,
     pub logfile: String,
     pub entrypoints: Vec<SocketAddr>,
+    pub known_validators: Option<HashSet<Pubkey>>,
     pub rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig,
 }
 
@@ -69,10 +71,18 @@ impl FromClapArgMatches for RunArgs {
         }
         let entrypoints = parsed_entrypoints.into_iter().collect();
 
+        let known_validators = validators_set(
+            &identity_keypair.pubkey(),
+            matches,
+            "known_validators",
+            "known validator",
+        )?;
+
         Ok(RunArgs {
             identity_keypair,
             logfile,
             entrypoints,
+            known_validators,
             rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::from_clap_arg_match(
                 matches,
             )?,
@@ -1729,6 +1739,32 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     )
 }
 
+fn validators_set(
+    identity_pubkey: &Pubkey,
+    matches: &ArgMatches<'_>,
+    matches_name: &str,
+    arg_name: &str,
+) -> Result<Option<HashSet<Pubkey>>> {
+    if matches.is_present(matches_name) {
+        let validators_set: Option<HashSet<Pubkey>> = values_t!(matches, matches_name, Pubkey)
+            .ok()
+            .map(|validators| validators.into_iter().collect());
+        if let Some(validators_set) = &validators_set {
+            if validators_set.contains(identity_pubkey) {
+                return Err(crate::commands::Error::Dynamic(
+                    Box::<dyn std::error::Error>::from(format!(
+                        "the validator's identity pubkey cannot be a {arg_name}: {}",
+                        identity_pubkey
+                    )),
+                ));
+            }
+        }
+        Ok(validators_set)
+    } else {
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -1741,11 +1777,13 @@ mod tests {
             let identity_keypair = Keypair::new();
             let logfile = format!("agave-validator-{}.log", identity_keypair.pubkey());
             let entrypoints = vec![];
+            let known_validators = None;
 
             RunArgs {
                 identity_keypair,
                 logfile,
                 entrypoints,
+                known_validators,
                 rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::default(),
             }
         }
@@ -1757,6 +1795,7 @@ mod tests {
                 identity_keypair: self.identity_keypair.insecure_clone(),
                 logfile: self.logfile.clone(),
                 entrypoints: self.entrypoints.clone(),
+                known_validators: self.known_validators.clone(),
                 rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
             }
         }
@@ -2027,6 +2066,126 @@ mod tests {
                     "https://api.mainnet-beta.solana.com",
                 ],
                 expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_known_validators() {
+        // long arg + single known validator
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--known-validator", &known_validators_pubkey.to_string()],
+                expected_args,
+            );
+        }
+
+        // alias + single known validator
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--trusted-validator", &known_validators_pubkey.to_string()],
+                expected_args,
+            );
+        }
+
+        // long arg + multiple known validators
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey_1 = Pubkey::new_unique();
+            let known_validators_pubkey_2 = Pubkey::new_unique();
+            let known_validators_pubkey_3 = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([
+                known_validators_pubkey_1,
+                known_validators_pubkey_2,
+                known_validators_pubkey_3,
+            ]));
+            let expected_args = RunArgs {
+                known_validators,
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--known-validator",
+                    &known_validators_pubkey_1.to_string(),
+                    "--known-validator",
+                    &known_validators_pubkey_2.to_string(),
+                    "--known-validator",
+                    &known_validators_pubkey_3.to_string(),
+                ],
+                expected_args,
+            );
+        }
+
+        // long arg + duplicate known validators
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey_1 = Pubkey::new_unique();
+            let known_validators_pubkey_2 = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([
+                known_validators_pubkey_1,
+                known_validators_pubkey_2,
+            ]));
+            let expected_args = RunArgs {
+                known_validators,
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--known-validator",
+                    &known_validators_pubkey_1.to_string(),
+                    "--known-validator",
+                    &known_validators_pubkey_2.to_string(),
+                    "--known-validator",
+                    &known_validators_pubkey_1.to_string(),
+                ],
+                expected_args,
+            );
+        }
+
+        // use identity pubkey as known validator
+        {
+            let default_args = DefaultArgs::default();
+            let default_run_args = RunArgs::default();
+
+            // generate a keypair
+            let tmp_dir = tempfile::tempdir().unwrap();
+            let file = tmp_dir.path().join("id.json");
+            solana_keypair::write_keypair_file(&default_run_args.identity_keypair, &file).unwrap();
+
+            let matches = add_args(App::new("run_command"), &default_args).get_matches_from(vec![
+                "run_command",
+                "--identity",
+                file.to_str().unwrap(),
+                "--known-validator",
+                &default_run_args.identity_keypair.pubkey().to_string(),
+            ]);
+            let result = RunArgs::from_clap_arg_match(&matches);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                format!(
+                    "the validator's identity pubkey cannot be a known validator: {}",
+                    default_run_args.identity_keypair.pubkey()
+                )
             );
         }
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2266,4 +2266,24 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_incremental_snapshot_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                    no_incremental_snapshots: true,
+                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--no-incremental-snapshots"],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        bootstrap::RpcBootstrapConfig,
         cli::{hash_validator, port_range_validator, port_validator, DefaultArgs},
         commands::{FromClapArgMatches, Result},
     },
@@ -42,7 +43,7 @@ pub struct RunArgs {
     pub logfile: String,
     pub entrypoints: Vec<SocketAddr>,
     pub known_validators: Option<HashSet<Pubkey>>,
-    pub rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig,
+    pub rpc_bootstrap_config: RpcBootstrapConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -85,9 +86,7 @@ impl FromClapArgMatches for RunArgs {
             logfile,
             entrypoints,
             known_validators,
-            rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::from_clap_arg_match(
-                matches,
-            )?,
+            rpc_bootstrap_config: RpcBootstrapConfig::from_clap_arg_match(matches)?,
         })
     }
 }
@@ -1786,7 +1785,7 @@ mod tests {
                 logfile,
                 entrypoints,
                 known_validators,
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig::default(),
+                rpc_bootstrap_config: RpcBootstrapConfig::default(),
             }
         }
     }
@@ -1919,9 +1918,9 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let expected_args = RunArgs {
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     no_genesis_fetch: true,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -1939,9 +1938,9 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let expected_args = RunArgs {
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     no_snapshot_fetch: true,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -2052,9 +2051,9 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     8000,
                 )],
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     check_vote_account: Some("https://api.mainnet-beta.solana.com".to_string()),
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -2201,9 +2200,9 @@ mod tests {
             let known_validators = Some(HashSet::from([known_validators_pubkey]));
             let expected_args = RunArgs {
                 known_validators,
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     only_known_rpc: true,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -2226,9 +2225,9 @@ mod tests {
             let known_validators = Some(HashSet::from([known_validators_pubkey]));
             let expected_args = RunArgs {
                 known_validators,
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     only_known_rpc: true,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -2252,9 +2251,9 @@ mod tests {
             let default_run_args = RunArgs::default();
             let max_genesis_archive_unpacked_size = 1000000000;
             let expected_args = RunArgs {
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
+                rpc_bootstrap_config: RpcBootstrapConfig {
                     max_genesis_archive_unpacked_size,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };
@@ -2275,9 +2274,9 @@ mod tests {
         {
             let default_run_args = RunArgs::default();
             let expected_args = RunArgs {
-                rpc_bootstrap_config: rpc_bootstrap_config::RpcBootstrapConfig {
-                    no_incremental_snapshots: true,
-                    ..rpc_bootstrap_config::RpcBootstrapConfig::default()
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    incremental_snapshot_fetch: false,
+                    ..RpcBootstrapConfig::default()
                 },
                 ..default_run_args.clone()
             };

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -1,6 +1,6 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
-    clap::ArgMatches,
+    clap::{value_t, ArgMatches},
 };
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -9,6 +9,7 @@ pub struct RpcBootstrapConfig {
     pub no_snapshot_fetch: bool,
     pub check_vote_account: Option<String>,
     pub only_known_rpc: bool,
+    pub max_genesis_archive_unpacked_size: u64,
 }
 
 impl FromClapArgMatches for RpcBootstrapConfig {
@@ -23,11 +24,19 @@ impl FromClapArgMatches for RpcBootstrapConfig {
 
         let only_known_rpc = matches.is_present("only_known_rpc");
 
+        let max_genesis_archive_unpacked_size =
+            value_t!(matches, "max_genesis_archive_unpacked_size", u64).map_err(|err| {
+                Box::<dyn std::error::Error>::from(format!(
+                    "failed to parse max_genesis_archive_unpacked_size: {err}"
+                ))
+            })?;
+
         Ok(Self {
             no_genesis_fetch,
             no_snapshot_fetch,
             check_vote_account,
             only_known_rpc,
+            max_genesis_archive_unpacked_size,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -6,12 +6,18 @@ use {
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
+    pub no_snapshot_fetch: bool,
 }
 
 impl FromClapArgMatches for RpcBootstrapConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let no_genesis_fetch = matches.is_present("no_genesis_fetch");
 
-        Ok(Self { no_genesis_fetch })
+        let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
+
+        Ok(Self {
+            no_genesis_fetch,
+            no_snapshot_fetch,
+        })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -7,6 +7,7 @@ use {
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
+    pub check_vote_account: Option<String>,
 }
 
 impl FromClapArgMatches for RpcBootstrapConfig {
@@ -15,9 +16,14 @@ impl FromClapArgMatches for RpcBootstrapConfig {
 
         let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
 
+        let check_vote_account = matches
+            .value_of("check_vote_account")
+            .map(|url| url.to_string());
+
         Ok(Self {
             no_genesis_fetch,
             no_snapshot_fetch,
+            check_vote_account,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -8,6 +8,7 @@ pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
     pub check_vote_account: Option<String>,
+    pub only_known_rpc: bool,
 }
 
 impl FromClapArgMatches for RpcBootstrapConfig {
@@ -20,10 +21,13 @@ impl FromClapArgMatches for RpcBootstrapConfig {
             .value_of("check_vote_account")
             .map(|url| url.to_string());
 
+        let only_known_rpc = matches.is_present("only_known_rpc");
+
         Ok(Self {
             no_genesis_fetch,
             no_snapshot_fetch,
             check_vote_account,
+            only_known_rpc,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -1,17 +1,10 @@
 use {
-    crate::commands::{FromClapArgMatches, Result},
+    crate::{
+        bootstrap::RpcBootstrapConfig,
+        commands::{FromClapArgMatches, Result},
+    },
     clap::{value_t, ArgMatches},
 };
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct RpcBootstrapConfig {
-    pub no_genesis_fetch: bool,
-    pub no_snapshot_fetch: bool,
-    pub check_vote_account: Option<String>,
-    pub only_known_rpc: bool,
-    pub max_genesis_archive_unpacked_size: u64,
-    pub no_incremental_snapshots: bool,
-}
 
 #[cfg(test)]
 impl Default for RpcBootstrapConfig {
@@ -22,7 +15,7 @@ impl Default for RpcBootstrapConfig {
             check_vote_account: None,
             only_known_rpc: false,
             max_genesis_archive_unpacked_size: 10485760,
-            no_incremental_snapshots: false,
+            incremental_snapshot_fetch: true,
         }
     }
 }
@@ -54,7 +47,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
             check_vote_account,
             only_known_rpc,
             max_genesis_archive_unpacked_size,
-            no_incremental_snapshots,
+            incremental_snapshot_fetch: !no_incremental_snapshots,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -7,10 +7,10 @@ use {
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
-    pub check_vote_account: Option<String>,
     pub only_known_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
-    pub no_incremental_snapshots: bool,
+    pub check_vote_account: Option<String>,
+    pub incremental_snapshot_fetch: bool,
 }
 
 #[cfg(test)]
@@ -22,7 +22,7 @@ impl Default for RpcBootstrapConfig {
             check_vote_account: None,
             only_known_rpc: false,
             max_genesis_archive_unpacked_size: 10485760,
-            no_incremental_snapshots: false,
+            incremental_snapshot_fetch: true,
         }
     }
 }
@@ -46,7 +46,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
                 ))
             })?;
 
-        let no_incremental_snapshots = matches.is_present("no_incremental_snapshots");
+        let incremental_snapshot_fetch = !matches.is_present("no_incremental_snapshots");
 
         Ok(Self {
             no_genesis_fetch,
@@ -54,7 +54,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
             check_vote_account,
             only_known_rpc,
             max_genesis_archive_unpacked_size,
-            no_incremental_snapshots,
+            incremental_snapshot_fetch,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -7,10 +7,10 @@ use {
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
+    pub check_vote_account: Option<String>,
     pub only_known_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
-    pub check_vote_account: Option<String>,
-    pub incremental_snapshot_fetch: bool,
+    pub no_incremental_snapshots: bool,
 }
 
 #[cfg(test)]
@@ -22,7 +22,7 @@ impl Default for RpcBootstrapConfig {
             check_vote_account: None,
             only_known_rpc: false,
             max_genesis_archive_unpacked_size: 10485760,
-            incremental_snapshot_fetch: true,
+            no_incremental_snapshots: false,
         }
     }
 }
@@ -46,7 +46,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
                 ))
             })?;
 
-        let incremental_snapshot_fetch = !matches.is_present("no_incremental_snapshots");
+        let no_incremental_snapshots = matches.is_present("no_incremental_snapshots");
 
         Ok(Self {
             no_genesis_fetch,
@@ -54,7 +54,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
             check_vote_account,
             only_known_rpc,
             max_genesis_archive_unpacked_size,
-            incremental_snapshot_fetch,
+            no_incremental_snapshots,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -3,13 +3,27 @@ use {
     clap::{value_t, ArgMatches},
 };
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
     pub check_vote_account: Option<String>,
     pub only_known_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
+    pub no_incremental_snapshots: bool,
+}
+
+impl Default for RpcBootstrapConfig {
+    fn default() -> Self {
+        Self {
+            no_genesis_fetch: false,
+            no_snapshot_fetch: false,
+            check_vote_account: None,
+            only_known_rpc: false,
+            max_genesis_archive_unpacked_size: 10485760,
+            no_incremental_snapshots: false,
+        }
+    }
 }
 
 impl FromClapArgMatches for RpcBootstrapConfig {
@@ -31,12 +45,15 @@ impl FromClapArgMatches for RpcBootstrapConfig {
                 ))
             })?;
 
+        let no_incremental_snapshots = matches.is_present("no_incremental_snapshots");
+
         Ok(Self {
             no_genesis_fetch,
             no_snapshot_fetch,
             check_vote_account,
             only_known_rpc,
             max_genesis_archive_unpacked_size,
+            no_incremental_snapshots,
         })
     }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -13,6 +13,7 @@ pub struct RpcBootstrapConfig {
     pub no_incremental_snapshots: bool,
 }
 
+#[cfg(test)]
 impl Default for RpcBootstrapConfig {
     fn default() -> Self {
         Self {

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -1,0 +1,17 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::ArgMatches,
+};
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct RpcBootstrapConfig {
+    pub no_genesis_fetch: bool,
+}
+
+impl FromClapArgMatches for RpcBootstrapConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let no_genesis_fetch = matches.is_present("no_genesis_fetch");
+
+        Ok(Self { no_genesis_fetch })
+    }
+}

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -345,16 +345,7 @@ pub fn execute(
     } else {
         AccountShrinkThreshold::IndividualStore { shrink_ratio }
     };
-    let entrypoint_addrs = values_t!(matches, "entrypoint", String)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|entrypoint| {
-            solana_net_utils::parse_host_port(&entrypoint)
-                .map_err(|err| format!("failed to parse entrypoint address: {err}"))
-        })
-        .collect::<Result<HashSet<_>, _>>()?
-        .into_iter()
-        .collect::<Vec<_>>();
+    let entrypoint_addrs = run_args.entrypoints;
     for addr in &entrypoint_addrs {
         if !socket_addr_space.check(addr) {
             Err(format!("invalid entrypoint address: {addr}"))?;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -173,7 +173,7 @@ pub fn execute(
         no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
         no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
         check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
-        only_known_rpc: matches.is_present("only_known_rpc"),
+        only_known_rpc: run_args.rpc_bootstrap_config.only_known_rpc,
         max_genesis_archive_unpacked_size: value_t_or_exit!(
             matches,
             "max_genesis_archive_unpacked_size",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -171,7 +171,7 @@ pub fn execute(
 
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
-        no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
+        no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
         check_vote_account: matches
             .value_of("check_vote_account")
             .map(|url| url.to_string()),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -177,7 +177,7 @@ pub fn execute(
         max_genesis_archive_unpacked_size: run_args
             .rpc_bootstrap_config
             .max_genesis_archive_unpacked_size,
-        incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
+        incremental_snapshot_fetch: !run_args.rpc_bootstrap_config.no_incremental_snapshots,
     };
 
     let private_rpc = matches.is_present("private_rpc");
@@ -894,7 +894,7 @@ pub fn execute(
             (SnapshotInterval::Disabled, SnapshotInterval::Disabled)
         } else {
             match (
-                !matches.is_present("no_incremental_snapshots"),
+                !run_args.rpc_bootstrap_config.no_incremental_snapshots,
                 value_t_or_exit!(matches, "snapshot_interval_slots", NonZeroU64),
             ) {
                 (true, incremental_snapshot_interval_slots) => {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -169,16 +169,7 @@ pub fn execute(
 
     let init_complete_file = matches.value_of("init_complete_file");
 
-    let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
-        no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
-        no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
-        check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
-        only_known_rpc: run_args.rpc_bootstrap_config.only_known_rpc,
-        max_genesis_archive_unpacked_size: run_args
-            .rpc_bootstrap_config
-            .max_genesis_archive_unpacked_size,
-        incremental_snapshot_fetch: !run_args.rpc_bootstrap_config.no_incremental_snapshots,
-    };
+    let rpc_bootstrap_config = run_args.rpc_bootstrap_config;
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
@@ -892,7 +883,7 @@ pub fn execute(
             (SnapshotInterval::Disabled, SnapshotInterval::Disabled)
         } else {
             match (
-                !run_args.rpc_bootstrap_config.no_incremental_snapshots,
+                rpc_bootstrap_config.incremental_snapshot_fetch,
                 value_t_or_exit!(matches, "snapshot_interval_slots", NonZeroU64),
             ) {
                 (true, incremental_snapshot_interval_slots) => {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -170,7 +170,7 @@ pub fn execute(
     let init_complete_file = matches.value_of("init_complete_file");
 
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
-        no_genesis_fetch: matches.is_present("no_genesis_fetch"),
+        no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
         no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
         check_vote_account: matches
             .value_of("check_vote_account")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -169,17 +169,6 @@ pub fn execute(
 
     let init_complete_file = matches.value_of("init_complete_file");
 
-    let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
-        no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
-        no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
-        check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
-        only_known_rpc: run_args.rpc_bootstrap_config.only_known_rpc,
-        max_genesis_archive_unpacked_size: run_args
-            .rpc_bootstrap_config
-            .max_genesis_archive_unpacked_size,
-        incremental_snapshot_fetch: !run_args.rpc_bootstrap_config.no_incremental_snapshots,
-    };
-
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
     let tpu_coalesce = value_t!(matches, "tpu_coalesce_ms", u64)
@@ -892,7 +881,7 @@ pub fn execute(
             (SnapshotInterval::Disabled, SnapshotInterval::Disabled)
         } else {
             match (
-                !run_args.rpc_bootstrap_config.no_incremental_snapshots,
+                run_args.rpc_bootstrap_config.incremental_snapshot_fetch,
                 value_t_or_exit!(matches, "snapshot_interval_slots", NonZeroU64),
             ) {
                 (true, incremental_snapshot_interval_slots) => {
@@ -1233,7 +1222,7 @@ pub fn execute(
             authorized_voter_keypairs.clone(),
             &cluster_entrypoints,
             &mut validator_config,
-            rpc_bootstrap_config,
+            run_args.rpc_bootstrap_config,
             do_port_check,
             use_progress_bar,
             maximum_local_snapshot_age,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -174,11 +174,9 @@ pub fn execute(
         no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
         check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
         only_known_rpc: run_args.rpc_bootstrap_config.only_known_rpc,
-        max_genesis_archive_unpacked_size: value_t_or_exit!(
-            matches,
-            "max_genesis_archive_unpacked_size",
-            u64
-        ),
+        max_genesis_archive_unpacked_size: run_args
+            .rpc_bootstrap_config
+            .max_genesis_archive_unpacked_size,
         incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
     };
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -268,12 +268,8 @@ pub fn execute(
         None
     };
 
-    let known_validators = validators_set(
-        &identity_keypair.pubkey(),
-        matches,
-        "known_validators",
-        "--known-validator",
-    )?;
+    let known_validators = run_args.known_validators;
+
     let repair_validators = validators_set(
         &identity_keypair.pubkey(),
         matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -266,8 +266,6 @@ pub fn execute(
         None
     };
 
-    let known_validators = run_args.known_validators;
-
     let repair_validators = validators_set(
         &identity_keypair.pubkey(),
         matches,
@@ -661,7 +659,7 @@ pub fn execute(
         },
         voting_disabled: matches.is_present("no_voting") || restricted_repair_only_mode,
         wait_for_supermajority: value_t!(matches, "wait_for_supermajority", Slot).ok(),
-        known_validators,
+        known_validators: run_args.known_validators,
         repair_validators,
         repair_whitelist,
         gossip_validators,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -172,9 +172,7 @@ pub fn execute(
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
         no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
-        check_vote_account: matches
-            .value_of("check_vote_account")
-            .map(|url| url.to_string()),
+        check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
         only_known_rpc: matches.is_present("only_known_rpc"),
         max_genesis_archive_unpacked_size: value_t_or_exit!(
             matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -169,7 +169,16 @@ pub fn execute(
 
     let init_complete_file = matches.value_of("init_complete_file");
 
-    let rpc_bootstrap_config = run_args.rpc_bootstrap_config;
+    let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
+        no_genesis_fetch: run_args.rpc_bootstrap_config.no_genesis_fetch,
+        no_snapshot_fetch: run_args.rpc_bootstrap_config.no_snapshot_fetch,
+        check_vote_account: run_args.rpc_bootstrap_config.check_vote_account,
+        only_known_rpc: run_args.rpc_bootstrap_config.only_known_rpc,
+        max_genesis_archive_unpacked_size: run_args
+            .rpc_bootstrap_config
+            .max_genesis_archive_unpacked_size,
+        incremental_snapshot_fetch: !run_args.rpc_bootstrap_config.no_incremental_snapshots,
+    };
 
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
@@ -883,7 +892,7 @@ pub fn execute(
             (SnapshotInterval::Disabled, SnapshotInterval::Disabled)
         } else {
             match (
-                rpc_bootstrap_config.incremental_snapshot_fetch,
+                !run_args.rpc_bootstrap_config.no_incremental_snapshots,
                 value_t_or_exit!(matches, "snapshot_interval_slots", NonZeroU64),
             ) {
                 (true, incremental_snapshot_interval_slots) => {


### PR DESCRIPTION
### Problem

https://github.com/anza-xyz/agave/issues/4082

### Summary of Changes

#### --no-genesis-fetch

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### --no-snapshot-fetch

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### --entrypoint

split the method chain and use `IndexSet` in the middle steps for ensuring the input order

#### --check-vote-account

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### --known-validator

port validators_set without an exit func

#### --only-known-rpc

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### --max-genesis-archive-unpacked-size

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### --no-incremental-snapshots

extract to `./validator/src/commands/run/args/rpc_bootstrap_config.rs`

#### misc

- introduce `pretty_assertions`