### PR TITLE
remove skip_rents_rewrite featurized code

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -362,7 +362,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
-    test_skip_rewrites_but_include_in_bank_hash: false,
     storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     enable_experimental_accumulator_hash: false,
@@ -389,7 +388,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
-    test_skip_rewrites_but_include_in_bank_hash: false,
     storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
     enable_experimental_accumulator_hash: false,
@@ -517,7 +515,6 @@ pub struct AccountsDbConfig {
     pub ancient_storage_ideal_size: Option<u64>,
     pub max_ancient_storages: Option<usize>,
     pub hash_calculation_pubkey_bins: Option<usize>,
-    pub test_skip_rewrites_but_include_in_bank_hash: bool,
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
@@ -1371,9 +1368,6 @@ pub struct AccountsDb {
 
     pub storage: AccountStorage,
 
-    /// true if this client should skip rewrites but still include those rewrites in the bank hash as if rewrites had occurred.
-    pub test_skip_rewrites_but_include_in_bank_hash: bool,
-
     pub accounts_cache: AccountsCache,
 
     write_cache_limit_bytes: Option<u64>,
@@ -1919,8 +1913,6 @@ impl AccountsDb {
             write_cache_limit_bytes: accounts_db_config.write_cache_limit_bytes,
             partitioned_epoch_rewards_config: accounts_db_config.partitioned_epoch_rewards_config,
             exhaustively_verify_refcounts: accounts_db_config.exhaustively_verify_refcounts,
-            test_skip_rewrites_but_include_in_bank_hash: accounts_db_config
-                .test_skip_rewrites_but_include_in_bank_hash,
             storage_access: accounts_db_config.storage_access,
             scan_filter_for_shrinking: accounts_db_config.scan_filter_for_shrinking,
             is_experimental_accumulator_hash_enabled: accounts_db_config
@@ -6116,12 +6108,7 @@ impl AccountsDb {
                     .delta_hash_accumulate_time_total_us
                     .swap(0, Ordering::Relaxed),
                 i64
-            ),
-            (
-                "skipped_rewrites_num",
-                self.stats.skipped_rewrites_num.swap(0, Ordering::Relaxed),
-                i64
-            ),
+            )
         );
     }
 
@@ -7041,18 +7028,8 @@ impl AccountsDb {
         &self,
         slot: Slot,
         ignore: Option<Pubkey>,
-        mut skipped_rewrites: HashMap<Pubkey, AccountHash>,
     ) -> AccountsDeltaHash {
         let (mut hashes, scan_us, mut accumulate) = self.get_pubkey_hash_for_slot(slot);
-
-        hashes.iter().for_each(|(k, _h)| {
-            skipped_rewrites.remove(k);
-        });
-
-        let num_skipped_rewrites = skipped_rewrites.len();
-        hashes.extend(skipped_rewrites);
-
-        info!("skipped rewrite hashes {} {}", slot, num_skipped_rewrites);
 
         if let Some(ignore) = ignore {
             hashes.retain(|k| k.0 != ignore);
@@ -7072,9 +7049,6 @@ impl AccountsDb {
             .delta_hash_accumulate_time_total_us
             .fetch_add(accumulate.as_us(), Ordering::Relaxed);
         self.stats.delta_hash_num.fetch_add(1, Ordering::Relaxed);
-        self.stats
-            .skipped_rewrites_num
-            .fetch_add(num_skipped_rewrites, Ordering::Relaxed);
 
         accounts_delta_hash
     }
@@ -8734,7 +8708,7 @@ impl AccountsDb {
 
     /// Wrapper function to calculate accounts delta hash for `slot` (only used for testing and benchmarking.)
     pub fn calculate_accounts_delta_hash(&self, slot: Slot) -> AccountsDeltaHash {
-        self.calculate_accounts_delta_hash_internal(slot, None, HashMap::default())
+        self.calculate_accounts_delta_hash_internal(slot, None)
     }
 
     pub fn load_without_fixed_root(

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -12,7 +12,6 @@ pub struct AccountsStats {
     pub delta_hash_scan_time_total_us: AtomicU64,
     pub delta_hash_accumulate_time_total_us: AtomicU64,
     pub delta_hash_num: AtomicU64,
-    pub skipped_rewrites_num: AtomicUsize,
 
     pub last_store_report: AtomicInterval,
     pub store_hash_accounts: AtomicU64,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -592,10 +592,6 @@ pub mod enable_early_verification_of_account_modifications {
     solana_pubkey::declare_id!("7Vced912WrRnfjaiKRiNBcbuFw7RrnLv3E3z95Y4GTNc");
 }
 
-pub mod skip_rent_rewrites {
-    solana_pubkey::declare_id!("CGB2jM8pwZkeeiXQ66kBMyBR6Np61mggL7XUsmLjVcrw");
-}
-
 pub mod prevent_crediting_accounts_that_end_rent_paying {
     solana_pubkey::declare_id!("812kqX67odAp5NFwM8D2N24cku7WTm9CHUTFUXaDkWPn");
 }
@@ -1221,7 +1217,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (vote_authorize_with_seed::id(), "An instruction you can use to change a vote accounts authority when the current authority is a derived key #25860"),
         (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
         (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),
-        (skip_rent_rewrites::id(), "skip rewriting rent exempt accounts during rent collection #26491"),
         (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
         (disable_rehash_for_rent_epoch::id(), "on accounts hash calculation, do not try to rehash accounts #28934"),
         (account_hash_ignore_slot::id(), "ignore slot when calculating an account hash #28420"),

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -359,7 +359,6 @@ pub fn get_accounts_db_config(
         .ok(),
         exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
-        test_skip_rewrites_but_include_in_bank_hash: false,
         storage_access,
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: !arg_matches

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -82,7 +82,7 @@ use {
             DuplicatesLtHash, PubkeyHashAccount, VerifyAccountsHashAndLamportsConfig,
         },
         accounts_hash::{
-            AccountHash, AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
+            AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
             IncrementalAccountsHash, MerkleOrLatticeAccountsHash,
         },
         accounts_index::{IndexKey, ScanConfig, ScanResult},
@@ -512,7 +512,6 @@ impl PartialEq for Bank {
         // Suppress rustfmt until https://github.com/rust-lang/rustfmt/issues/5920 is fixed ...
         #[rustfmt::skip]
         let Self {
-            skipped_rewrites: _,
             rc: _,
             status_cache: _,
             blockhash_queue,
@@ -881,10 +880,6 @@ pub struct Bank {
     /// The change to accounts data size in this Bank, due to off-chain events (i.e. rent collection)
     accounts_data_size_delta_off_chain: AtomicI64,
 
-    /// until the skipped rewrites feature is activated, it is possible to skip rewrites and still include
-    /// the account hash of the accounts that would have been rewritten as bank hash expects.
-    skipped_rewrites: Mutex<HashMap<Pubkey, AccountHash>>,
-
     epoch_reward_status: EpochRewardStatus,
 
     transaction_processor: TransactionBatchProcessor<BankForks>,
@@ -1068,7 +1063,6 @@ impl AtomicBankHashStats {
 impl Bank {
     fn default_with_accounts(accounts: Accounts) -> Self {
         let mut bank = Self {
-            skipped_rewrites: Mutex::default(),
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
@@ -1305,7 +1299,6 @@ impl Bank {
 
         let accounts_data_size_initial = parent.load_accounts_data_size();
         let mut new = Self {
-            skipped_rewrites: Mutex::default(),
             rc,
             status_cache,
             slot,
@@ -1799,7 +1792,6 @@ impl Bank {
         info!("Loading Stakes took: {stakes_time}");
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
-            skipped_rewrites: Mutex::default(),
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
@@ -1894,7 +1886,6 @@ impl Bank {
         );
         bank.transaction_processor
             .fill_missing_sysvar_cache_entries(&bank);
-        bank.rebuild_skipped_rewrites();
 
         let mut calculate_accounts_lt_hash_duration = None;
         if let Some(accounts_lt_hash) = fields.accounts_lt_hash {
@@ -3914,79 +3905,6 @@ impl Bank {
             });
     }
 
-    /// After deserialize, populate skipped rewrites with accounts that would normally
-    /// have had their data rewritten in this slot due to rent collection (but didn't).
-    ///
-    /// This is required when starting up from a snapshot to verify the bank hash.
-    ///
-    /// A second usage is from the `bank_to_xxx_snapshot_archive()` functions.  These fns call
-    /// `Bank::rehash()` to handle if the user manually modified any accounts and thus requires
-    /// calculating the bank hash again.  Since calculating the bank hash *takes* the skipped
-    /// rewrites, this second time will not have any skipped rewrites, and thus the hash would be
-    /// updated to the wrong value.  So, rebuild the skipped rewrites before rehashing.
-    fn rebuild_skipped_rewrites(&self) {
-        // If the feature gate to *not* add rent collection rewrites to the bank hash is enabled,
-        // then do *not* add anything to our skipped_rewrites.
-        if self.bank_hash_skips_rent_rewrites() {
-            return;
-        }
-
-        let (skipped_rewrites, measure_skipped_rewrites) =
-            measure_time!(self.calculate_skipped_rewrites());
-        info!(
-            "Rebuilding skipped rewrites of {} accounts{measure_skipped_rewrites}",
-            skipped_rewrites.len()
-        );
-
-        *self.skipped_rewrites.lock().unwrap() = skipped_rewrites;
-    }
-
-    /// Calculates (and returns) skipped rewrites for this bank
-    ///
-    /// Refer to `rebuild_skipped_rewrites()` for more documentation.
-    /// This implementation is purposely separate to facilitate testing.
-    ///
-    /// The key observation is that accounts in Bank::skipped_rewrites are only used IFF the
-    /// specific account is *not* already in the accounts delta hash.  If an account is not in
-    /// the accounts delta hash, then it means the account was not modified.  Since (basically)
-    /// all accounts are rent exempt, this means (basically) all accounts are unmodified by rent
-    /// collection.  So we just need to load the accounts that would've been checked for rent
-    /// collection, hash them, and add them to Bank::skipped_rewrites.
-    ///
-    /// As of this writing, there are ~350 million acounts on mainnet-beta.
-    /// Rent collection almost always collects a single slot at a time.
-    /// So 1 slot of 432,000, of 350 million accounts, is ~800 accounts per slot.
-    /// Since we haven't started processing anything yet, it should be fast enough to simply
-    /// load the accounts directly.
-    /// Empirically, this takes about 3-4 milliseconds.
-    fn calculate_skipped_rewrites(&self) -> HashMap<Pubkey, AccountHash> {
-        // The returned skipped rewrites may include accounts that were actually *not* skipped!
-        // (This is safe, as per the fn's documentation above.)
-        self.get_accounts_for_skipped_rewrites()
-            .map(|(pubkey, account_hash, _account)| (pubkey, account_hash))
-            .collect()
-    }
-
-    /// Loads accounts that were selected for rent collection this slot.
-    /// After loading the accounts, also calculate and return the account hashes.
-    /// This is used when dealing with skipped rewrites.
-    fn get_accounts_for_skipped_rewrites(
-        &self,
-    ) -> impl Iterator<Item = (Pubkey, AccountHash, AccountSharedData)> + '_ {
-        self.rent_collection_partitions()
-            .into_iter()
-            .map(accounts_partition::pubkey_range_from_partition)
-            .flat_map(|pubkey_range| {
-                self.rc
-                    .accounts
-                    .load_to_collect_rent_eagerly(&self.ancestors, pubkey_range)
-            })
-            .map(|(pubkey, account, _slot)| {
-                let account_hash = AccountsDb::hash_account(&account, &pubkey);
-                (pubkey, account_hash, account)
-            })
-    }
-
     /// Returns the accounts, sorted by pubkey, that were part of accounts delta hash calculation
     /// This is used when writing a bank hash details file.
     pub(crate) fn get_accounts_for_bank_hash_details(&self) -> Vec<PubkeyHashAccount> {
@@ -3994,28 +3912,6 @@ impl Bank {
 
         let mut accounts_written_this_slot =
             accounts_db.get_pubkey_hash_account_for_slot(self.slot());
-
-        // If we are skipping rewrites but also include them in the accounts delta hash, then we
-        // need to go load those accounts and add them to the list of accounts written this slot.
-        if !self.bank_hash_skips_rent_rewrites()
-            && accounts_db.test_skip_rewrites_but_include_in_bank_hash
-        {
-            let pubkeys_written_this_slot: HashSet<_> = accounts_written_this_slot
-                .iter()
-                .map(|pubkey_hash_account| pubkey_hash_account.pubkey)
-                .collect();
-
-            let rent_collection_accounts = self.get_accounts_for_skipped_rewrites();
-            for (pubkey, hash, account) in rent_collection_accounts {
-                if !pubkeys_written_this_slot.contains(&pubkey) {
-                    accounts_written_this_slot.push(PubkeyHashAccount {
-                        pubkey,
-                        hash,
-                        account,
-                    });
-                }
-            }
-        }
 
         // Sort the accounts by pubkey to match the order of the accounts delta hash.
         // This also makes comparison of files from different nodes deterministic.
@@ -4124,15 +4020,6 @@ impl Bank {
         }
     }
 
-    /// true if rent collection does NOT rewrite accounts whose pubkey indicates
-    ///  it is time for rent collection, but the account is rent exempt.
-    /// false if rent collection DOES rewrite accounts if the account is rent exempt
-    /// This is the default behavior historically.
-    fn bank_hash_skips_rent_rewrites(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::skip_rent_rewrites::id())
-    }
-
     /// Update rent exempt status for `accounts`
     ///
     /// This fn is called inside a parallel loop from `collect_rent_in_partition()`.  Avoid adding
@@ -4150,13 +4037,6 @@ impl Bank {
             Vec::<(&Pubkey, &AccountSharedData)>::with_capacity(accounts.len());
         let mut time_collecting_rent_us = 0;
         let mut time_storing_accounts_us = 0;
-        let can_skip_rewrites = self.bank_hash_skips_rent_rewrites();
-        let test_skip_rewrites_but_include_in_bank_hash = self
-            .rc
-            .accounts
-            .accounts_db
-            .test_skip_rewrites_but_include_in_bank_hash;
-        let mut skipped_rewrites = Vec::default();
         for (pubkey, account, _loaded_slot) in accounts.iter_mut() {
             let rent_epoch_pre = account.rent_epoch();
             let ((), collect_rent_us) = measure_us!(update_rent_exempt_status_for_account(
@@ -4169,36 +4049,20 @@ impl Bank {
             // did the account change in any way due to rent collection?
             let account_changed = rent_epoch_post != rent_epoch_pre;
 
-            // always store the account, regardless if it changed or not
-            let always_store_accounts =
-                !can_skip_rewrites && !test_skip_rewrites_but_include_in_bank_hash;
-
             // only store accounts where we collected rent
             // but get the hash for all these accounts even if collected rent is 0 (= not updated).
             // Also, there's another subtle side-effect from rewrites: this
             // ensures we verify the whole on-chain state (= all accounts)
             // via the bank delta hash slowly once per an epoch.
-            if account_changed || always_store_accounts {
-                if account_changed {
-                    datapoint_info!(
-                        "bank-rent_collection_updated_only_rent_epoch",
-                        ("slot", self.slot(), i64),
-                        ("pubkey", pubkey.to_string(), String),
-                        ("rent_epoch_pre", rent_epoch_pre, i64),
-                        ("rent_epoch_post", rent_epoch_post, i64),
-                    );
-                }
+            if account_changed {
+                datapoint_info!(
+                    "bank-rent_collection_updated_only_rent_epoch",
+                    ("slot", self.slot(), i64),
+                    ("pubkey", pubkey.to_string(), String),
+                    ("rent_epoch_pre", rent_epoch_pre, i64),
+                    ("rent_epoch_post", rent_epoch_post, i64),
+                );
                 accounts_to_store.push((pubkey, account));
-            } else if !account_changed
-                && !can_skip_rewrites
-                && test_skip_rewrites_but_include_in_bank_hash
-            {
-                // include rewrites that we skipped in the accounts delta hash.
-                // This is what consensus requires prior to activation of bank_hash_skips_rent_rewrites.
-                // This code path exists to allow us to test the long term effects on validators when the skipped rewrites
-                // feature is enabled.
-                let hash = AccountsDb::hash_account(account, pubkey);
-                skipped_rewrites.push((*pubkey, hash));
             }
         }
 
@@ -4211,7 +4075,6 @@ impl Bank {
         }
 
         CollectRentFromAccountsInfo {
-            skipped_rewrites,
             time_collecting_rent_us,
             time_storing_accounts_us,
             num_accounts: accounts.len(),
@@ -4284,11 +4147,6 @@ impl Bank {
                     CollectRentInPartitionInfo::default,
                     CollectRentInPartitionInfo::reduce,
                 );
-
-            self.skipped_rewrites
-                .lock()
-                .unwrap()
-                .extend(results.skipped_rewrites);
 
             // We cannot assert here that we collected from all expected keys.
             // Some accounts may have been topped off or may have had all funds removed and gone to 0 lamports.
@@ -5189,11 +5047,7 @@ impl Bank {
                 self.rc
                     .accounts
                     .accounts_db
-                    .calculate_accounts_delta_hash_internal(
-                        slot,
-                        None,
-                        self.skipped_rewrites.lock().unwrap().clone(),
-                    )
+                    .calculate_accounts_delta_hash_internal(slot, None)
             })
         });
 
@@ -6300,26 +6154,10 @@ impl Bank {
     }
 
     pub(crate) fn shrink_ancient_slots(&self) {
-        // Invoke ancient slot shrinking only when the validator is
-        // explicitly configured to do so. This condition may be
-        // removed when the skip rewrites feature is enabled.
-        if self.are_ancient_storages_enabled() {
-            self.rc
-                .accounts
-                .accounts_db
-                .shrink_ancient_slots(self.epoch_schedule())
-        }
-    }
-
-    /// Returns if ancient storages are enabled or not
-    pub fn are_ancient_storages_enabled(&self) -> bool {
-        let can_skip_rewrites = self.bank_hash_skips_rent_rewrites();
-        let test_skip_rewrites_but_include_in_bank_hash = self
-            .rc
+        self.rc
             .accounts
             .accounts_db
-            .test_skip_rewrites_but_include_in_bank_hash;
-        can_skip_rewrites || test_skip_rewrites_but_include_in_bank_hash
+            .shrink_ancient_slots(self.epoch_schedule())
     }
 
     pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {
@@ -7170,14 +7008,13 @@ enum ApplyFeatureActivationsCaller {
     WarpFromParent,
 }
 
-/// Return the computed values from `collect_rent_from_accounts()`
+/// Return the computed values from `update_rent_exempt_status_for_accounts()`
 ///
-/// Since `collect_rent_from_accounts()` is running in parallel, instead of updating the
+/// Since `update_rent_exempt_status_for_accounts()` is running in parallel, instead of updating the
 /// atomics/shared data inside this function, return those values in this struct for the caller to
 /// process later.
 #[derive(Debug, Default)]
 struct CollectRentFromAccountsInfo {
-    skipped_rewrites: Vec<(Pubkey, AccountHash)>,
     time_collecting_rent_us: u64,
     time_storing_accounts_us: u64,
     num_accounts: usize,
@@ -7187,7 +7024,6 @@ struct CollectRentFromAccountsInfo {
 /// `collect_rent_in_partition()`—and then perform a reduce on all of them.
 #[derive(Debug, Default)]
 struct CollectRentInPartitionInfo {
-    skipped_rewrites: Vec<(Pubkey, AccountHash)>,
     time_loading_accounts_us: u64,
     time_collecting_rent_us: u64,
     time_storing_accounts_us: u64,
@@ -7200,7 +7036,6 @@ impl CollectRentInPartitionInfo {
     #[must_use]
     fn new(info: CollectRentFromAccountsInfo, time_loading_accounts: Duration) -> Self {
         Self {
-            skipped_rewrites: info.skipped_rewrites,
             time_loading_accounts_us: time_loading_accounts.as_micros() as u64,
             time_collecting_rent_us: info.time_collecting_rent_us,
             time_storing_accounts_us: info.time_storing_accounts_us,
@@ -7215,7 +7050,6 @@ impl CollectRentInPartitionInfo {
     #[must_use]
     fn reduce(lhs: Self, rhs: Self) -> Self {
         Self {
-            skipped_rewrites: [lhs.skipped_rewrites, rhs.skipped_rewrites].concat(),
             time_loading_accounts_us: lhs
                 .time_loading_accounts_us
                 .saturating_add(rhs.time_loading_accounts_us),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13,9 +13,6 @@ use {
             create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
             genesis_sysvar_and_builtin_program_lamports, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
-        snapshot_bank_utils,
-        snapshot_config::SnapshotConfig,
-        snapshot_utils,
         stake_history::StakeHistory,
         stakes::InvalidCacheEntryReason,
         status_cache::MAX_CACHE_ENTRIES,
@@ -39,11 +36,9 @@ use {
     solana_accounts_db::{
         accounts::AccountAddressFilter,
         accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        accounts_hash::{AccountsDeltaHash, AccountsHasher},
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError, ITER_BATCH_SIZE,
         },
-        accounts_partition,
         ancestors::Ancestors,
     },
     solana_client_traits::SyncClient,
@@ -141,7 +136,6 @@ use {
         thread::Builder,
         time::{Duration, Instant},
     },
-    tempfile::TempDir,
     test_case::test_case,
 };
 
@@ -926,10 +920,6 @@ fn test_rent_eager_collect_rent_in_partition() {
     activate_all_features(&mut genesis_config);
     genesis_config
         .accounts
-        .remove(&feature_set::skip_rent_rewrites::id())
-        .unwrap();
-    genesis_config
-        .accounts
         .remove(&feature_set::disable_partitioned_rent_collection::id())
         .unwrap();
 
@@ -983,10 +973,7 @@ fn test_rent_eager_collect_rent_in_partition() {
         bank.get_account(&rent_exempt_pubkey).unwrap().rent_epoch(),
         RENT_EXEMPT_RENT_EPOCH
     );
-    assert_eq!(
-        bank.slots_by_pubkey(&rent_due_pubkey),
-        vec![genesis_slot, some_slot]
-    );
+    assert_eq!(bank.slots_by_pubkey(&rent_due_pubkey), vec![genesis_slot]);
     assert_eq!(
         bank.slots_by_pubkey(&rent_exempt_pubkey),
         vec![genesis_slot, some_slot]
@@ -1017,68 +1004,55 @@ pub(in crate::bank) fn new_from_parent_next_epoch(
 fn test_collect_rent_from_accounts() {
     solana_logger::setup();
 
-    for skip_rewrites in [false, true] {
-        let address1 = Pubkey::new_unique();
-        let address2 = Pubkey::new_unique();
-        let address3 = Pubkey::new_unique();
+    let address1 = Pubkey::new_unique();
+    let address2 = Pubkey::new_unique();
+    let address3 = Pubkey::new_unique();
 
-        let (genesis_bank, bank_forks) = create_simple_test_arc_bank(100000);
-        let mut first_bank = new_from_parent(genesis_bank.clone());
-        if skip_rewrites {
-            first_bank.activate_feature(&feature_set::skip_rent_rewrites::id());
-        }
-        let first_bank = bank_forks
-            .write()
-            .unwrap()
-            .insert(first_bank)
-            .clone_without_scheduler();
+    let (genesis_bank, bank_forks) = create_simple_test_arc_bank(100000);
+    let first_bank = new_from_parent(genesis_bank.clone());
+    let first_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert(first_bank)
+        .clone_without_scheduler();
 
-        let first_slot = 1;
-        assert_eq!(first_slot, first_bank.slot());
-        let epoch_delta = 4;
-        let later_bank = new_from_parent_next_epoch(first_bank, bank_forks.as_ref(), epoch_delta); // a bank a few epochs in the future
-        let later_slot = later_bank.slot();
-        assert!(later_bank.epoch() == genesis_bank.epoch() + epoch_delta);
+    let first_slot = 1;
+    assert_eq!(first_slot, first_bank.slot());
+    let epoch_delta = 4;
+    let later_bank = new_from_parent_next_epoch(first_bank, bank_forks.as_ref(), epoch_delta); // a bank a few epochs in the future
+    let later_slot = later_bank.slot();
+    assert!(later_bank.epoch() == genesis_bank.epoch() + epoch_delta);
 
-        let data_size = 0; // make sure we're rent exempt
-        let lamports = later_bank.get_minimum_balance_for_rent_exemption(data_size); // cannot be 0 or we zero out rent_epoch in rent collection and we need to be rent exempt
-        let mut account1 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
-        let mut account2 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
-        let mut account3 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
-        account1.set_rent_epoch(later_bank.epoch() - 1); // non-zero, but less than later_bank's epoch
-        account2.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH); // already marked as rent exempt
-        account3.set_rent_epoch(0); // stake accounts in genesis have a rent epoch of 0
+    let data_size = 0; // make sure we're rent exempt
+    let lamports = later_bank.get_minimum_balance_for_rent_exemption(data_size); // cannot be 0 or we zero out rent_epoch in rent collection and we need to be rent exempt
+    let mut account1 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
+    let mut account2 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
+    let mut account3 = AccountSharedData::new(lamports, data_size, &Pubkey::default());
+    account1.set_rent_epoch(later_bank.epoch() - 1); // non-zero, but less than later_bank's epoch
+    account2.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH); // already marked as rent exempt
+    account3.set_rent_epoch(0); // stake accounts in genesis have a rent epoch of 0
 
-        // loaded from previous slot, so we skip rent collection on it
-        let _result = later_bank.update_rent_exempt_status_for_accounts(vec![
-            (address1, account1, later_slot - 1),
-            (address2, account2, later_slot - 1),
-            (address3, account3, later_slot - 1),
-        ]);
+    // loaded from previous slot, so we skip rent collection on it
+    let _result = later_bank.update_rent_exempt_status_for_accounts(vec![
+        (address1, account1, later_slot - 1),
+        (address2, account2, later_slot - 1),
+        (address3, account3, later_slot - 1),
+    ]);
 
-        let deltas = later_bank
-            .rc
-            .accounts
-            .accounts_db
-            .get_pubkey_hash_for_slot(later_slot)
-            .0;
+    let deltas = later_bank
+        .rc
+        .accounts
+        .accounts_db
+        .get_pubkey_hash_for_slot(later_slot)
+        .0;
 
-        // ensure account1 *is* stored because the account *did* change
-        // (its rent epoch must be updated to RENT_EXEMPT_RENT_EPOCH)
-        assert!(deltas.iter().map(|(pubkey, _)| pubkey).contains(&address1));
+    // ensure account1 *is* stored because the account *did* change
+    // (its rent epoch must be updated to RENT_EXEMPT_RENT_EPOCH)
+    assert!(deltas.iter().map(|(pubkey, _)| pubkey).contains(&address1));
 
-        // if doing rewrites, ensure account2 *is* stored
-        // if skipping rewrites, ensure account2 is *not* stored
-        // (because the account did *not* change)
-        assert_eq!(
-            deltas.iter().map(|(pubkey, _)| pubkey).contains(&address2),
-            !skip_rewrites,
-        );
-
-        // ensure account3 *is* stored because the account *did* change
-        // (same as account1 above)
-        assert!(deltas.iter().map(|(pubkey, _)| pubkey).contains(&address3));
-    }
+    // ensure account3 *is* stored because the account *did* change
+    // (same as account1 above)
+    assert!(deltas.iter().map(|(pubkey, _)| pubkey).contains(&address3));
 }
 
 #[test]
@@ -5798,19 +5772,19 @@ fn test_bank_hash_consistency() {
         if bank.slot == 32 {
             assert_eq!(
                 bank.hash().to_string(),
-                "CK1siD9yP37R4ErCECKg1rofsEAk9fdGpsfpMQnSvHBL"
+                "4qjTvZJd4resaoy6XYNgbTBbvPha5oyjBXMC4MuZ5Msn"
             );
         }
         if bank.slot == 64 {
             assert_eq!(
                 bank.hash().to_string(),
-                "5h8yw8oU78G4JeVB28U9ZjZpV5fCgm9gA8LfVJF8YD8W"
+                "5M1CbUrWq8hBfUGtQse6RtECwjeCqzZWb3GcSiqhXU1c"
             );
         }
         if bank.slot == 128 {
             assert_eq!(
                 bank.hash().to_string(),
-                "87cnbyVPkbfpQkjuQ5sCKXNYhvUbpzHNac6GJv1BnqDM"
+                "4xSvqtyQXB7qiMcSTokZTKZSqXZH8a9c8W9VJpQPHq3N"
             );
             break;
         }
@@ -11958,245 +11932,6 @@ fn test_last_restart_slot() {
     let bank7 = Arc::new(Bank::new_from_parent(bank6, &Pubkey::default(), 7));
     assert!(!last_restart_slot_dirty(&bank7));
     assert_eq!(get_last_restart_slot(&bank7), Some(6));
-}
-
-/// Test that rehashing works with skipped rewrites
-///
-/// Since `bank_to_xxx_snapshot_archive()` calls `Bank::rehash()`, we must ensure that rehashing
-/// works properly when also using `test_skip_rewrites_but_include_in_bank_hash`.
-#[test]
-fn test_rehash_with_skipped_rewrites() {
-    let accounts_db_config = AccountsDbConfig {
-        test_skip_rewrites_but_include_in_bank_hash: true,
-        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-    };
-    let bank = Arc::new(Bank::new_with_paths(
-        &GenesisConfig::default(),
-        Arc::new(RuntimeConfig::default()),
-        Vec::default(),
-        None,
-        None,
-        false,
-        Some(accounts_db_config),
-        None,
-        Some(Pubkey::new_unique()),
-        Arc::new(AtomicBool::new(false)),
-        None,
-        None,
-    ));
-    // This test is only meaningful while the bank hash contains rewrites.
-    // Once this feature is enabled, it may be possible to remove this test entirely.
-    assert!(!bank.bank_hash_skips_rent_rewrites());
-
-    // Store an account *in this bank* that will be checked for rent collection *in the next bank*
-    let pubkey = {
-        let rent_collection_partition = bank
-            .variable_cycle_partitions_between_slots(bank.slot(), bank.slot() + 1)
-            .last()
-            .copied()
-            .unwrap();
-        let pubkey_range =
-            accounts_partition::pubkey_range_from_partition(rent_collection_partition);
-        *pubkey_range.end()
-    };
-    let mut account = AccountSharedData::new(123_456_789, 0, &Pubkey::default());
-    // The account's rent epoch must be set to EXEMPT
-    // in order for its rewrite to be skipped by rent collection.
-    account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
-    bank.store_account_and_update_capitalization(&pubkey, &account);
-
-    // Create a new bank that will do rent collection on the account stored in the previous slot
-    let bank = Arc::new(Bank::new_from_parent(
-        bank.clone(),
-        &Pubkey::new_unique(),
-        bank.slot() + 1,
-    ));
-
-    // Freeze the bank to trigger rent collection and hash calculation
-    bank.freeze();
-
-    // Ensure the bank hash is the same before and after rehashing
-    let bank_hash = bank.hash();
-    bank.rehash();
-    let bank_rehash = bank.hash();
-    assert_eq!(bank_rehash, bank_hash);
-}
-
-/// Test that skipped_rewrites are properly rebuilt when booting from a snapshot
-/// that was generated by a node skipping rewrites.
-#[test]
-fn test_rebuild_skipped_rewrites() {
-    let genesis_config = GenesisConfig::default();
-    let accounts_db_config = AccountsDbConfig {
-        test_skip_rewrites_but_include_in_bank_hash: true,
-        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-    };
-    let bank = Arc::new(Bank::new_with_paths(
-        &genesis_config,
-        Arc::new(RuntimeConfig::default()),
-        Vec::default(),
-        None,
-        None,
-        false,
-        Some(accounts_db_config.clone()),
-        None,
-        Some(Pubkey::new_unique()),
-        Arc::new(AtomicBool::new(false)),
-        None,
-        None,
-    ));
-    // This test is only meaningful while the bank hash contains rewrites.
-    // Once this feature is enabled, it may be possible to remove this test entirely.
-    assert!(!bank.bank_hash_skips_rent_rewrites());
-
-    // Store an account *in this bank* that will be checked for rent collection *in the next bank*
-    let pubkey = {
-        let rent_collection_partition = bank
-            .variable_cycle_partitions_between_slots(bank.slot(), bank.slot() + 1)
-            .last()
-            .copied()
-            .unwrap();
-        let pubkey_range =
-            accounts_partition::pubkey_range_from_partition(rent_collection_partition);
-        *pubkey_range.end()
-    };
-    let mut account = AccountSharedData::new(123_456_789, 0, &Pubkey::default());
-    // The account's rent epoch must be set to EXEMPT
-    // in order for its rewrite to be skipped by rent collection.
-    account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
-    bank.store_account_and_update_capitalization(&pubkey, &account);
-
-    // Create a new bank that will do rent collection on the account stored in the previous slot
-    let bank = Arc::new(Bank::new_from_parent(
-        bank.clone(),
-        &Pubkey::new_unique(),
-        bank.slot() + 1,
-    ));
-
-    // This fn is called within freeze(), but freeze() *consumes* Self::skipped_rewrites!
-    // For testing, we want to know what's in the skipped rewrites, so we perform
-    // rent collection manually.
-    bank.run_partitioned_rent_exempt_status_updates();
-    let actual_skipped_rewrites = bank.skipped_rewrites.lock().unwrap().clone();
-    // Ensure skipped rewrites now includes the account we stored above
-    assert!(actual_skipped_rewrites.contains_key(&pubkey));
-    // Ensure the calculated skipped rewrites match the actual ones
-    let calculated_skipped_rewrites = bank.calculate_skipped_rewrites();
-    assert_eq!(calculated_skipped_rewrites, actual_skipped_rewrites);
-
-    // required in order to snapshot the bank
-    bank.fill_bank_with_ticks_for_tests();
-
-    // Now take a snapshot!
-    let (_tmp_dir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
-    let bank_snapshots_dir = TempDir::new().unwrap();
-    let full_snapshot_archives_dir = TempDir::new().unwrap();
-    let incremental_snapshot_archives_dir = TempDir::new().unwrap();
-    let full_snapshot_archive = snapshot_bank_utils::bank_to_full_snapshot_archive(
-        bank_snapshots_dir.path(),
-        &bank,
-        None,
-        full_snapshot_archives_dir.path(),
-        incremental_snapshot_archives_dir.path(),
-        SnapshotConfig::default().archive_format,
-    )
-    .unwrap();
-
-    // Rebuild the bank and ensure it passes verification
-    let (snapshot_bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
-        &[accounts_dir],
-        bank_snapshots_dir.path(),
-        &full_snapshot_archive,
-        None,
-        &genesis_config,
-        &RuntimeConfig::default(),
-        None,
-        None,
-        None,
-        false,
-        false,
-        false,
-        false,
-        Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
-        None,
-        Arc::new(AtomicBool::new(false)),
-    )
-    .unwrap();
-    snapshot_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
-    assert_eq!(bank.as_ref(), &snapshot_bank);
-
-    // Ensure the snapshot bank's skipped rewrites match the original bank's
-    let snapshot_skipped_rewrites = snapshot_bank.calculate_skipped_rewrites();
-    assert_eq!(snapshot_skipped_rewrites, actual_skipped_rewrites);
-}
-
-/// Test that getting accounts for BankHashDetails works with skipped rewrites
-#[test_case(true; "skip rewrites")]
-#[test_case(false; "do rewrites")]
-fn test_get_accounts_for_bank_hash_details(skip_rewrites: bool) {
-    let genesis_config = GenesisConfig::default();
-    let accounts_db_config = AccountsDbConfig {
-        test_skip_rewrites_but_include_in_bank_hash: skip_rewrites,
-        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-    };
-    let bank = Arc::new(Bank::new_with_paths(
-        &genesis_config,
-        Arc::new(RuntimeConfig::default()),
-        Vec::default(),
-        None,
-        None,
-        false,
-        Some(accounts_db_config.clone()),
-        None,
-        Some(Pubkey::new_unique()),
-        Arc::new(AtomicBool::new(false)),
-        None,
-        None,
-    ));
-    // This test is only meaningful while the bank hash contains rewrites.
-    // Once this feature is enabled, it may be possible to remove this test entirely.
-    assert!(!bank.bank_hash_skips_rent_rewrites());
-
-    // Store an account *in this bank* that will be checked for rent collection *in the next bank*
-    let pubkey = {
-        let rent_collection_partition = bank
-            .variable_cycle_partitions_between_slots(bank.slot(), bank.slot() + 1)
-            .last()
-            .copied()
-            .unwrap();
-        let pubkey_range =
-            accounts_partition::pubkey_range_from_partition(rent_collection_partition);
-        *pubkey_range.end()
-    };
-    let mut account = AccountSharedData::new(123_456_789, 0, &Pubkey::default());
-    // The account's rent epoch must be set to EXEMPT
-    // in order for its rewrite to be skipped by rent collection.
-    account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
-    bank.store_account_and_update_capitalization(&pubkey, &account);
-
-    // Create a new bank that will do rent collection on the account stored in the previous slot
-    let bank = Bank::new_from_parent(bank.clone(), &Pubkey::new_unique(), bank.slot() + 1);
-
-    // Freeze the bank to do rent collection and calculate the accounts delta hash
-    bank.freeze();
-
-    // Ensure that the accounts returned by `get_accounts_for_bank_hash_details()` produces the
-    // same AccountsDeltaHash as the actual value stored in the Bank.
-    let calculated_accounts_delta_hash = {
-        let accounts = bank.get_accounts_for_bank_hash_details();
-        let hashes = accounts
-            .into_iter()
-            .map(|account| (account.pubkey, account.hash))
-            .collect();
-        AccountsDeltaHash(AccountsHasher::accumulate_account_hashes(hashes))
-    };
-    let actual_accounts_delta_hash = bank
-        .rc
-        .accounts
-        .accounts_db
-        .get_accounts_delta_hash(bank.slot())
-        .unwrap();
-    assert_eq!(calculated_accounts_delta_hash, actual_accounts_delta_hash);
 }
 
 /// Test that simulations report the compute units of failed transactions

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -488,7 +488,6 @@ pub fn execute(
         )
         .ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
-        test_skip_rewrites_but_include_in_bank_hash: false,
         storage_access,
         scan_filter_for_shrinking,
         enable_experimental_accumulator_hash: !matches


### PR DESCRIPTION
#### Problem

`skip_rent_rewrite` feature hass been activated on mainnet for a while. We should remove the featurized code.


#### Summary of Changes

Remove `skip_rent_rewrite` featurized code.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
