### PR TITLE
Add length of obsolete account vector to storage hash

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6380,18 +6380,31 @@ impl AccountsDb {
         }
     }
 
-    /// hash info about 'storage' into 'hasher'
-    /// return true iff storage is valid for loading from cache
+    /// Hash information about `storage` into `hasher`.
+    ///
+    /// # Parameters
+    /// - `storage`: The storage to hash.
+    /// - `slot`: The slot of the storage.
+    /// - `hash_slot`: The slot at which the storage is being hashed.
+    ///   Obsolete account data is only relevant for the hash if `hash_slot` is greater than the slot that marked the account obsolete.
+    ///
+    /// # Returns
+    /// `true` if the storage is valid for loading from the cache.
     fn hash_storage_info(
         hasher: &mut impl StdHasher,
         storage: &AccountStorageEntry,
         slot: Slot,
+        hash_slot: Slot,
     ) -> bool {
         // hash info about this storage
         storage.written_bytes().hash(hasher);
 
         // Obsolete accounts change the hash as they may cause accounts to no longer be included in the hash
-        storage.obsolete_accounts.read().unwrap().len().hash(hasher);
+        storage
+            .get_obsolete_accounts(Some(hash_slot))
+            .len()
+            .hash(hasher);
+
         slot.hash(hasher);
         let storage_file = storage.accounts.path();
         storage_file.hash(hasher);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6389,6 +6389,9 @@ impl AccountsDb {
     ) -> bool {
         // hash info about this storage
         storage.written_bytes().hash(hasher);
+
+        // Obsolete accounts change the hash as they may cause accounts to no longer be included in the hash
+        storage.obsolete_accounts.read().unwrap().len().hash(hasher);
         slot.hash(hasher);
         let storage_file = storage.accounts.path();
         storage_file.hash(hasher);

--- a/accounts-db/src/accounts_db/scan_account_storage.rs
+++ b/accounts-db/src/accounts_db/scan_account_storage.rs
@@ -232,6 +232,7 @@ impl AccountsDb {
             .range()
             .end
             .saturating_sub(slots_per_epoch);
+        let max_slot = snapshot_storages.max_slot_inclusive();
 
         stats.scan_chunks = splitter.chunk_count;
 
@@ -254,7 +255,7 @@ impl AccountsDb {
                         self.update_old_slot_stats(stats, storage);
                     }
                     if let Some(storage) = storage {
-                        let ok = Self::hash_storage_info(&mut hasher, storage, slot);
+                        let ok = Self::hash_storage_info(&mut hasher, storage, slot, max_slot);
                         if !ok {
                             load_from_cache = false;
                             break;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6136,36 +6136,48 @@ fn test_hash_storage_info() {
         let mark_alive = false;
         let storage = sample_storage_with_entries(&tf, slot, &pubkey1, mark_alive);
 
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot);
         let hash = hasher.finish();
         // can't assert hash here - it is a function of mod date
         assert!(load);
         let slot = 2; // changed this
         let mut hasher = DefaultHasher::new();
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot);
         let hash2 = hasher.finish();
         assert_ne!(hash, hash2); // slot changed, these should be different
                                  // can't assert hash here - it is a function of mod date
         assert!(load);
         let mut hasher = DefaultHasher::new();
         append_sample_data_to_storage(&storage, &solana_pubkey::new_rand(), false, None);
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot);
         let hash3 = hasher.finish();
         assert_ne!(hash2, hash3); // moddate and written size changed
                                   // can't assert hash here - it is a function of mod date
         assert!(load);
         let mut hasher = DefaultHasher::new();
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot);
         let hash4 = hasher.finish();
         assert_eq!(hash4, hash3); // same
                                   // can't assert hash here - it is a function of mod date
 
         assert!(load);
         let mut hasher = DefaultHasher::new();
-        storage.mark_accounts_obsolete(vec![(0, 136)].into_iter(), slot);
-        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        storage.mark_accounts_obsolete(vec![(0, 136)].into_iter(), slot + 1);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot);
         let hash5 = hasher.finish();
-        assert_ne!(hash5, hash4); // Obsolete accounts changed
+        assert_eq!(hash5, hash4); // Obsolete accounts hasn't changed, as the obsolete account is newer than the slot being hashed
+        assert!(load);
+
+        let mut hasher = DefaultHasher::new();
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot + 1);
+        let hash6 = hasher.finish();
+        assert_ne!(hash6, hash5); // Obsolete accounts has changed, as the obsolete account is now included in the hash
+        assert!(load);
+
+        let mut hasher = DefaultHasher::new();
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot, slot + 2);
+        let hash7 = hasher.finish();
+        assert_eq!(hash7, hash6); // Nothing has changed even though the slot that the hash is being performed at has changed.
         assert!(load);
     }
 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6153,12 +6153,20 @@ fn test_hash_storage_info() {
         let hash3 = hasher.finish();
         assert_ne!(hash2, hash3); // moddate and written size changed
                                   // can't assert hash here - it is a function of mod date
+
         assert!(load);
         let mut hasher = DefaultHasher::new();
         let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
         let hash4 = hasher.finish();
         assert_eq!(hash4, hash3); // same
                                   // can't assert hash here - it is a function of mod date
+
+        assert!(load);
+        let mut hasher = DefaultHasher::new();
+        storage.mark_accounts_obsolete(vec![(0, 136)].into_iter(), slot);
+        let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);
+        let hash5 = hasher.finish();
+        assert_ne!(hash5, hash4); // Obsolete accounts changed
         assert!(load);
     }
 }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6153,7 +6153,6 @@ fn test_hash_storage_info() {
         let hash3 = hasher.finish();
         assert_ne!(hash2, hash3); // moddate and written size changed
                                   // can't assert hash here - it is a function of mod date
-
         assert!(load);
         let mut hasher = DefaultHasher::new();
         let load = AccountsDb::hash_storage_info(&mut hasher, &storage, slot);


### PR DESCRIPTION
#### Problem
Need to account for obsolete accounts in the storage hash as they can cause accounts to no longer be included in the hash

#### Summary of Changes
- Add the length of the vector into the storage hash 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
