### PR TITLE
Uses PackedOffsetAndFlags directly in AccountInfo

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -86,30 +86,20 @@ pub struct AccountInfo {
     /// index identifying the append storage
     store_id: AccountsFileId,
 
-    account_offset_and_flags: AccountOffsetAndFlags,
-}
-
-#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
-pub struct AccountOffsetAndFlags {
     /// offset = 'packed_offset_and_flags.offset_reduced()' * ALIGN_BOUNDARY_OFFSET into the storage
     /// Note this is a smaller type than 'Offset'
-    packed_offset_and_flags: PackedOffsetAndFlags,
+    account_offset_and_flags: PackedOffsetAndFlags,
 }
 
 impl IsZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
-        self.account_offset_and_flags
-            .packed_offset_and_flags
-            .is_zero_lamport()
+        self.account_offset_and_flags.is_zero_lamport()
     }
 }
 
 impl IsCached for AccountInfo {
     fn is_cached(&self) -> bool {
-        self.account_offset_and_flags
-            .packed_offset_and_flags
-            .offset_reduced()
-            == CACHED_OFFSET
+        self.account_offset_and_flags.offset_reduced() == CACHED_OFFSET
     }
 }
 
@@ -146,12 +136,9 @@ impl AccountInfo {
             }
         };
         packed_offset_and_flags.set_is_zero_lamport(is_zero_lamport);
-        let account_offset_and_flags = AccountOffsetAndFlags {
-            packed_offset_and_flags,
-        };
         Self {
             store_id,
-            account_offset_and_flags,
+            account_offset_and_flags: packed_offset_and_flags,
         }
     }
 
@@ -166,11 +153,7 @@ impl AccountInfo {
     }
 
     pub fn offset(&self) -> Offset {
-        Self::reduced_offset_to_offset(
-            self.account_offset_and_flags
-                .packed_offset_and_flags
-                .offset_reduced(),
-        )
+        Self::reduced_offset_to_offset(self.account_offset_and_flags.offset_reduced())
     }
 
     pub fn reduced_offset_to_offset(reduced_offset: OffsetReduced) -> Offset {


### PR DESCRIPTION
#### Problem

The AccountOffsetAndFlags struct only contains one field, the PackedOffsetAndFlags. We don't need this additional struct, which is basically only a wrapper.


#### Summary of Changes

Remove it.