### PR TITLE
validator: Reduce the admin rpc client side threadpool size

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -852,10 +852,14 @@ pub async fn connect(ledger_path: &Path) -> std::result::Result<gen_client::Clie
     }
 }
 
+// Create a runtime for use by client side admin RPC interface calls
 pub fn runtime() -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .thread_name("solAdminRpcRt")
         .enable_all()
+        // The agave-validator subcommands make few admin RPC calls and block
+        // on the results so two workers is plenty
+        .worker_threads(2)
         .build()
         .expect("new tokio runtime")
 }


### PR DESCRIPTION
#### Problem
This pool is used to issue admin RPC commands by the various agave-validator commands. Most commands make a single call only, and all results are blocked on. Thus, there isn't much parallelism happening here.

#### Summary of Changes
So, reduce the thread count from num_cpus to 2
