### PR TITLE
Run rustfmt on all files

### DIFF
--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -1,9 +1,9 @@
 use {
-    solana_poh::poh_recorder::{BankStart, PohRecorder},
     solana_clock::{
         DEFAULT_TICKS_PER_SLOT, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
         HOLD_TRANSACTIONS_SLOT_OFFSET,
     },
+    solana_poh::poh_recorder::{BankStart, PohRecorder},
     solana_pubkey::Pubkey,
     solana_unified_scheduler_pool::{BankingStageMonitor, BankingStageStatus},
     std::{
@@ -154,10 +154,10 @@ mod tests {
     use {
         super::*,
         core::panic,
+        solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         solana_ledger::{blockstore::Blockstore, genesis_utils::create_genesis_config},
         solana_poh::poh_recorder::create_test_recorder,
         solana_runtime::bank::Bank,
-        solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         std::{
             env::temp_dir,
             sync::{atomic::Ordering, Arc},

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -8,7 +8,10 @@ use {
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     crossbeam_channel::RecvTimeoutError,
     solana_perf::packet::PacketBatch,
-    std::{num::Saturating, time::{Duration, Instant}},
+    std::{
+        num::Saturating,
+        time::{Duration, Instant},
+    },
 };
 
 /// Results from deserializing packet batches.
@@ -125,7 +128,8 @@ impl PacketDeserializer {
             })
             .collect();
         let Saturating(errors) = errors;
-        packet_stats.passed_sigverify_count += errors.saturating_add(deserialized_packets.len()) as u64;
+        packet_stats.passed_sigverify_count +=
+            errors.saturating_add(deserialized_packets.len()) as u64;
         packet_stats.failed_sigverify_count += packet_count
             .saturating_sub(deserialized_packets.len())
             .saturating_sub(errors) as u64;
@@ -184,13 +188,9 @@ impl PacketDeserializer {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        solana_perf::packet::to_packet_batches,
-        solana_hash::Hash,
-        solana_pubkey::Pubkey,
-        solana_keypair::Keypair,
-        solana_system_transaction as system_transaction,
-        solana_transaction::Transaction,
+        super::*, solana_hash::Hash, solana_keypair::Keypair,
+        solana_perf::packet::to_packet_batches, solana_pubkey::Pubkey,
+        solana_system_transaction as system_transaction, solana_transaction::Transaction,
     };
 
     fn random_transfer() -> Transaction {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -18,11 +18,14 @@ use {
         transaction_scheduler::transaction_state_container::StateContainer,
         TOTAL_BUFFERED_PACKETS,
     },
+    solana_clock::MAX_PROCESSING_AGE,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_clock::MAX_PROCESSING_AGE,
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
-    std::{num::Saturating, sync::{Arc, RwLock}},
+    std::{
+        num::Saturating,
+        sync::{Arc, RwLock},
+    },
 };
 
 /// Controls packet and transaction flow into scheduler, and scheduling execution.
@@ -152,14 +155,15 @@ where
 
                 self.count_metrics.update(|count_metrics| {
                     count_metrics.num_scheduled += scheduling_summary.num_scheduled;
-                    count_metrics.num_unschedulable_conflicts += scheduling_summary.num_unschedulable_conflicts;
-                    count_metrics.num_unschedulable_threads += scheduling_summary.num_unschedulable_threads;
+                    count_metrics.num_unschedulable_conflicts +=
+                        scheduling_summary.num_unschedulable_conflicts;
+                    count_metrics.num_unschedulable_threads +=
+                        scheduling_summary.num_unschedulable_threads;
                     count_metrics.num_schedule_filtered_out += scheduling_summary.num_filtered_out;
                 });
 
                 self.timing_metrics.update(|timing_metrics| {
-                    timing_metrics.schedule_filter_time_us +=
-                        scheduling_summary.filter_time_us;
+                    timing_metrics.schedule_filter_time_us += scheduling_summary.filter_time_us;
                     timing_metrics.schedule_time_us += schedule_time_us;
                 });
                 self.scheduling_details.update(&scheduling_summary);
@@ -233,7 +237,7 @@ where
 
         while transaction_ids.len() < MAX_TRANSACTION_CHECKS {
             let Some(id) = self.container.pop() else {
-                break
+                break;
             };
             transaction_ids.push(id);
         }
@@ -332,21 +336,21 @@ mod tests {
         agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
         crossbeam_channel::{unbounded, Receiver, Sender},
         itertools::Itertools,
+        solana_compute_budget_interface::ComputeBudgetInstruction,
+        solana_fee_calculator::FeeRateGovernor,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
         solana_ledger::{
             blockstore::Blockstore, genesis_utils::GenesisConfigInfo,
             get_tmp_ledger_path_auto_delete, leader_schedule_cache::LeaderScheduleCache,
         },
+        solana_message::Message,
         solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
         solana_poh::poh_recorder::PohRecorder,
-        solana_runtime::bank::Bank,
-        solana_runtime_transaction::transaction_meta::StaticMeta,
-        solana_compute_budget_interface::ComputeBudgetInstruction,
-        solana_fee_calculator::FeeRateGovernor,
-        solana_hash::Hash,
-        solana_message::Message,
         solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
-        solana_keypair::Keypair,
+        solana_runtime::bank::Bank,
+        solana_runtime_transaction::transaction_meta::StaticMeta,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::Transaction,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -1,10 +1,13 @@
 use {
     super::scheduler::SchedulingSummary,
     itertools::MinMaxResult,
-    solana_poh::poh_recorder::BankStart,
     solana_clock::Slot,
+    solana_poh::poh_recorder::BankStart,
     solana_time_utils::AtomicInterval,
-    std::{num::Saturating, time::{Duration, Instant}},
+    std::{
+        num::Saturating,
+        time::{Duration, Instant},
+    },
 };
 
 #[derive(Default)]
@@ -124,9 +127,8 @@ impl SchedulerCountMetricsInner {
             num_dropped_on_receive: Saturating(num_dropped_on_receive),
             num_dropped_on_sanitization: Saturating(num_dropped_on_sanitization),
             num_dropped_on_validate_locks: Saturating(num_dropped_on_validate_locks),
-            num_dropped_on_receive_transaction_checks: Saturating(
-                num_dropped_on_receive_transaction_checks,
-            ),
+            num_dropped_on_receive_transaction_checks:
+                Saturating(num_dropped_on_receive_transaction_checks),
             num_dropped_on_clear: Saturating(num_dropped_on_clear),
             num_dropped_on_age_and_status: Saturating(num_dropped_on_age_and_status),
             num_dropped_on_capacity: Saturating(num_dropped_on_capacity),

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/src/lib.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/src/lib.rs
@@ -1,9 +1,7 @@
 //! Example Rust-based SBF noop program
 
 use {
-    solana_account_info::AccountInfo,
-    solana_program_error::ProgramResult,
-    solana_pubkey::Pubkey
+    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
 };
 
 solana_package_metadata::declare_id_with_package_metadata!("solana.program-id");

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/src/lib.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/src/lib.rs
@@ -1,9 +1,7 @@
 //! Example Rust-based SBF noop program
 
 use {
-    solana_account_info::AccountInfo,
-    solana_program_error::ProgramResult,
-    solana_pubkey::Pubkey
+    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
 };
 
 solana_program_entrypoint::entrypoint!(process_instruction);

--- a/svm/tests/example-programs/clock-sysvar/src/lib.rs
+++ b/svm/tests/example-programs/clock-sysvar/src/lib.rs
@@ -1,7 +1,10 @@
 use {
-    solana_account_info::AccountInfo, solana_program_entrypoint::entrypoint,
-    solana_program_error::ProgramResult, solana_pubkey::Pubkey,
-    solana_sysvar::{clock::Clock, Sysvar}, solana_program::program::set_return_data
+    solana_account_info::AccountInfo,
+    solana_program::program::set_return_data,
+    solana_program_entrypoint::entrypoint,
+    solana_program_error::ProgramResult,
+    solana_pubkey::Pubkey,
+    solana_sysvar::{clock::Clock, Sysvar},
 };
 
 entrypoint!(process_instruction);
@@ -11,7 +14,6 @@ fn process_instruction(
     _accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
-
     let time_now = Clock::get().unwrap().unix_timestamp;
     let return_data = time_now.to_be_bytes();
     set_return_data(&return_data);

--- a/svm/tests/example-programs/hello-solana/src/lib.rs
+++ b/svm/tests/example-programs/hello-solana/src/lib.rs
@@ -1,9 +1,6 @@
 use {
-    solana_account_info::AccountInfo,
-    solana_program_entrypoint::entrypoint,
-    solana_program_error::ProgramResult,
-    solana_msg::msg,
-    solana_pubkey::Pubkey,
+    solana_account_info::AccountInfo, solana_msg::msg, solana_program_entrypoint::entrypoint,
+    solana_program_error::ProgramResult, solana_pubkey::Pubkey,
 };
 
 entrypoint!(process_instruction);

--- a/svm/tests/example-programs/simple-transfer/src/lib.rs
+++ b/svm/tests/example-programs/simple-transfer/src/lib.rs
@@ -1,19 +1,18 @@
 use {
-    solana_account_info::{AccountInfo, next_account_info},
+    solana_account_info::{next_account_info, AccountInfo},
+    solana_program::program::invoke,
     solana_program_entrypoint::entrypoint,
     solana_program_error::ProgramResult,
     solana_pubkey::Pubkey,
-    solana_program::program::invoke,
     solana_system_interface::instruction as system_instruction,
 };
 
 entrypoint!(process_instruction);
 
-
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
-    data: &[u8]
+    data: &[u8],
 ) -> ProgramResult {
     let amount = u64::from_be_bytes(data[0..8].try_into().unwrap());
     let accounts_iter = &mut accounts.iter();

--- a/svm/tests/example-programs/transfer-from-account/src/lib.rs
+++ b/svm/tests/example-programs/transfer-from-account/src/lib.rs
@@ -1,19 +1,18 @@
 use {
-    solana_account_info::{AccountInfo, next_account_info},
+    solana_account_info::{next_account_info, AccountInfo},
+    solana_program::program::invoke,
     solana_program_entrypoint::entrypoint,
     solana_program_error::ProgramResult,
     solana_pubkey::Pubkey,
-    solana_program::program::invoke,
     solana_system_interface::instruction as system_instruction,
 };
 
 entrypoint!(process_instruction);
 
-
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
-    _data: &[u8]
+    _data: &[u8],
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let payer = next_account_info(accounts_iter)?;

--- a/svm/tests/example-programs/write-to-account/src/lib.rs
+++ b/svm/tests/example-programs/write-to-account/src/lib.rs
@@ -1,10 +1,10 @@
 use {
     solana_account_info::{next_account_info, AccountInfo},
+    solana_msg::msg,
     solana_program_entrypoint::entrypoint,
-    solana_program_error::ProgramResult,
-    solana_sdk_ids::incinerator, solana_msg::msg,
-    solana_program_error::ProgramError,
+    solana_program_error::{ProgramError, ProgramResult},
     solana_pubkey::Pubkey,
+    solana_sdk_ids::incinerator,
 };
 
 entrypoint!(process_instruction);


### PR DESCRIPTION
#### Problem
I think there's some `cargo fmt` bug that causes some files to be skipped for formatting.

#### Summary of Changes
This is just a bandaid until we can update to rustfmt 2.0 which I think should fix this issue
- Ran `find . -name "*.rs" -exec rustfmt +nightly --edition 2021 {} +` from root dir

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
