### PR TITLE
Bump version to v2.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-accounts-hash-cache-tool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "flate2",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-clock",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "atty",
  "bincode",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -249,7 +249,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-unified-scheduler-pool",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "clap 2.33.3",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_cmd",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "regex",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "regex",
 ]
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "rdrand"
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -6286,7 +6286,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-program",
  "static_assertions",
  "strum",
@@ -6316,7 +6316,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6333,13 +6333,13 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "assert_matches",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
@@ -6402,7 +6402,7 @@ dependencies = [
  "solana-program",
  "solana-runtime",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -6411,18 +6411,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6442,7 +6442,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "chrono",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "fnv",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6648,7 +6648,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "static_assertions",
  "test-case",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6690,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -6768,7 +6768,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -6830,7 +6830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -6976,7 +6976,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote-program",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "futures-util",
  "rand 0.8.5",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -7127,7 +7127,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7169,7 +7169,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "criterion",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "chrono",
@@ -7212,12 +7212,12 @@ dependencies = [
  "solana-signer",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-clock",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7521,7 +7521,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-reserved-account-keys",
  "assert_matches",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7784,7 +7784,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7846,7 +7846,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -7857,7 +7857,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -8048,7 +8048,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -8178,7 +8178,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -8273,7 +8273,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -8294,13 +8294,13 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-local-cluster"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -8356,7 +8356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
 ]
@@ -8376,15 +8376,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-memory-management"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -8397,7 +8397,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fast-math",
  "hex",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -8467,7 +8467,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-shaper"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 3.2.23",
  "rand 0.8.5",
@@ -8479,7 +8479,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8534,7 +8534,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "reqwest",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -8620,7 +8620,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -8897,7 +8897,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "test-case",
  "thiserror 2.0.11",
@@ -8905,7 +8905,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -8934,7 +8934,7 @@ dependencies = [
  "solana-stake-program",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-program",
  "test-case",
  "thiserror 2.0.11",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8999,7 +8999,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -9049,7 +9049,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "console",
@@ -9140,7 +9140,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9190,7 +9190,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -9208,7 +9208,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -9314,7 +9314,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "bs58",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -9436,7 +9436,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -9455,7 +9455,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9673,7 +9673,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -9817,7 +9817,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -9856,7 +9856,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -9884,7 +9884,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "solana-vote-interface",
  "solana-vote-program",
@@ -9893,7 +9893,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program-tests"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -9906,7 +9906,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -9939,7 +9939,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.11",
@@ -9950,7 +9950,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "bs58",
@@ -9966,7 +9966,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -9974,7 +9974,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -10023,7 +10023,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -10092,7 +10092,7 @@ dependencies = [
  "solana-sysvar",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-type-overrides",
  "test-case",
@@ -10101,7 +10101,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-conformance"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "prost",
  "prost-build",
@@ -10110,15 +10110,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -10149,7 +10149,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10176,7 +10176,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
@@ -10246,7 +10246,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -10278,7 +10278,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -10312,7 +10312,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -10321,7 +10321,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -10332,7 +10332,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -10366,7 +10366,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "serial_test",
@@ -10399,7 +10399,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -10431,7 +10431,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10508,7 +10508,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "serde",
@@ -10521,13 +10521,13 @@ dependencies = [
  "solana-rent",
  "solana-signature",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "static_assertions",
 ]
 
 [[package]]
 name = "solana-transaction-dos"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -10568,7 +10568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10587,7 +10587,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10629,7 +10629,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10643,14 +10643,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10694,7 +10694,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "futures 0.3.31",
  "lazy_static",
@@ -10704,7 +10704,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10719,7 +10719,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -10732,7 +10732,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10769,7 +10769,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -10783,7 +10783,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "semver 1.0.25",
@@ -10797,7 +10797,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -10840,7 +10840,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10896,7 +10896,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10928,7 +10928,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.11",
@@ -10936,7 +10936,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10971,7 +10971,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -10986,7 +10986,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -11005,7 +11005,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -11042,7 +11042,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program-tests"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
@@ -11079,7 +11079,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ exclude = ["programs/sbf", "svm/examples", "svm/tests/example-programs"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.17"
+version = "2.2.18"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
@@ -167,14 +167,14 @@ check-cfg = [
 [workspace.dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.2.17" }
-agave-cargo-registry = { path = "cargo-registry", version = "=2.2.17" }
-agave-feature-set = { path = "feature-set", version = "=2.2.17" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.17" }
-agave-precompiles = { path = "precompiles", version = "=2.2.17" }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.2.17" }
-agave-thread-manager = { path = "thread-manager", version = "=2.2.17" }
-agave-transaction-view = { path = "transaction-view", version = "=2.2.17" }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.2.18" }
+agave-cargo-registry = { path = "cargo-registry", version = "=2.2.18" }
+agave-feature-set = { path = "feature-set", version = "=2.2.18" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.2.18" }
+agave-precompiles = { path = "precompiles", version = "=2.2.18" }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.2.18" }
+agave-thread-manager = { path = "thread-manager", version = "=2.2.18" }
+agave-transaction-view = { path = "transaction-view", version = "=2.2.18" }
 ahash = "0.8.11"
 anyhow = "1.0.95"
 aquamarine = "0.6.0"
@@ -357,109 +357,109 @@ smpl_jwt = "0.7.1"
 socket2 = "0.5.8"
 soketto = "0.7"
 solana-account = "2.2.1"
-solana-account-decoder = { path = "account-decoder", version = "=2.2.17" }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.2.17" }
+solana-account-decoder = { path = "account-decoder", version = "=2.2.18" }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.2.18" }
 solana-account-info = "2.2.1"
-solana-accounts-db = { path = "accounts-db", version = "=2.2.17" }
+solana-accounts-db = { path = "accounts-db", version = "=2.2.18" }
 solana-address-lookup-table-interface = "2.2.2"
-solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.2.17" }
+solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=2.2.18" }
 solana-atomic-u64 = "2.2.1"
-solana-banks-client = { path = "banks-client", version = "=2.2.17" }
-solana-banks-interface = { path = "banks-interface", version = "=2.2.17" }
-solana-banks-server = { path = "banks-server", version = "=2.2.17" }
-solana-bench-tps = { path = "bench-tps", version = "=2.2.17" }
+solana-banks-client = { path = "banks-client", version = "=2.2.18" }
+solana-banks-interface = { path = "banks-interface", version = "=2.2.18" }
+solana-banks-server = { path = "banks-server", version = "=2.2.18" }
+solana-bench-tps = { path = "bench-tps", version = "=2.2.18" }
 solana-big-mod-exp = "2.2.1"
 solana-bincode = "2.2.1"
 solana-blake3-hasher = "2.2.1"
-solana-bloom = { path = "bloom", version = "=2.2.17" }
+solana-bloom = { path = "bloom", version = "=2.2.18" }
 solana-bn254 = "2.2.2"
 solana-borsh = "2.2.1"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.2.17" }
-solana-bucket-map = { path = "bucket_map", version = "=2.2.17" }
-solana-builtins = { path = "builtins", version = "=2.2.17" }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.2.17" }
-solana-clap-utils = { path = "clap-utils", version = "=2.2.17" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.2.17" }
-solana-cli = { path = "cli", version = "=2.2.17" }
-solana-cli-config = { path = "cli-config", version = "=2.2.17" }
-solana-cli-output = { path = "cli-output", version = "=2.2.17" }
-solana-client = { path = "client", version = "=2.2.17" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.2.18" }
+solana-bucket-map = { path = "bucket_map", version = "=2.2.18" }
+solana-builtins = { path = "builtins", version = "=2.2.18" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.2.18" }
+solana-clap-utils = { path = "clap-utils", version = "=2.2.18" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.2.18" }
+solana-cli = { path = "cli", version = "=2.2.18" }
+solana-cli-config = { path = "cli-config", version = "=2.2.18" }
+solana-cli-output = { path = "cli-output", version = "=2.2.18" }
+solana-client = { path = "client", version = "=2.2.18" }
 solana-client-traits = "2.2.1"
 solana-clock = "2.2.1"
 solana-cluster-type = "2.2.1"
 solana-commitment-config = "2.2.1"
-solana-compute-budget = { path = "compute-budget", version = "=2.2.17" }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.2.17" }
+solana-compute-budget = { path = "compute-budget", version = "=2.2.18" }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.2.18" }
 solana-compute-budget-interface = "2.2.1"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.2.17" }
-solana-config-program = { path = "programs/config", version = "=2.2.17" }
-solana-connection-cache = { path = "connection-cache", version = "=2.2.17", default-features = false }
-solana-core = { path = "core", version = "=2.2.17" }
-solana-cost-model = { path = "cost-model", version = "=2.2.17" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.2.18" }
+solana-config-program = { path = "programs/config", version = "=2.2.18" }
+solana-connection-cache = { path = "connection-cache", version = "=2.2.18", default-features = false }
+solana-core = { path = "core", version = "=2.2.18" }
+solana-cost-model = { path = "cost-model", version = "=2.2.18" }
 solana-cpi = "2.2.1"
-solana-curve25519 = { path = "curves/curve25519", version = "=2.2.17" }
+solana-curve25519 = { path = "curves/curve25519", version = "=2.2.18" }
 solana-decode-error = "2.2.1"
 solana-define-syscall = "2.2.1"
 solana-derivation-path = "2.2.1"
-solana-download-utils = { path = "download-utils", version = "=2.2.17" }
+solana-download-utils = { path = "download-utils", version = "=2.2.18" }
 solana-ed25519-program = "2.2.2"
-solana-entry = { path = "entry", version = "=2.2.17" }
+solana-entry = { path = "entry", version = "=2.2.18" }
 solana-epoch-info = "2.2.1"
 solana-epoch-rewards = "2.2.1"
 solana-epoch-rewards-hasher = "2.2.1"
 solana-epoch-schedule = "2.2.1"
 solana-example-mocks = "2.2.1"
-solana-faucet = { path = "faucet", version = "=2.2.17" }
+solana-faucet = { path = "faucet", version = "=2.2.18" }
 solana-feature-gate-client = "0.0.2"
 solana-feature-gate-interface = "2.2.2"
-solana-fee = { path = "fee", version = "=2.2.17" }
+solana-fee = { path = "fee", version = "=2.2.18" }
 solana-fee-calculator = "2.2.1"
 solana-fee-structure = "2.2.1"
 solana-file-download = "2.2.1"
 solana-frozen-abi = "2.2.1"
 solana-frozen-abi-macro = "2.2.1"
-solana-genesis = { path = "genesis", version = "=2.2.17" }
+solana-genesis = { path = "genesis", version = "=2.2.18" }
 solana-genesis-config = "2.2.1"
-solana-genesis-utils = { path = "genesis-utils", version = "=2.2.17" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.17" }
-solana-gossip = { path = "gossip", version = "=2.2.17" }
+solana-genesis-utils = { path = "genesis-utils", version = "=2.2.18" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.2.18" }
+solana-gossip = { path = "gossip", version = "=2.2.18" }
 solana-hard-forks = "2.2.1"
 solana-hash = "2.2.1"
 solana-inflation = "2.2.1"
-solana-inline-spl = { path = "inline-spl", version = "=2.2.17" }
+solana-inline-spl = { path = "inline-spl", version = "=2.2.18" }
 solana-instruction = "2.2.1"
 solana-instructions-sysvar = "2.2.1"
 solana-keccak-hasher = "2.2.1"
 solana-keypair = "2.2.1"
 solana-last-restart-slot = "2.2.1"
-solana-lattice-hash = { path = "lattice-hash", version = "=2.2.17" }
-solana-ledger = { path = "ledger", version = "=2.2.17" }
+solana-lattice-hash = { path = "lattice-hash", version = "=2.2.18" }
+solana-ledger = { path = "ledger", version = "=2.2.18" }
 solana-loader-v2-interface = "2.2.1"
 solana-loader-v3-interface = "5.0.0"
 solana-loader-v4-interface = "2.2.1"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.2.17" }
-solana-local-cluster = { path = "local-cluster", version = "=2.2.17" }
-solana-log-collector = { path = "log-collector", version = "=2.2.17" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.2.18" }
+solana-local-cluster = { path = "local-cluster", version = "=2.2.18" }
+solana-log-collector = { path = "log-collector", version = "=2.2.18" }
 solana-logger = "2.3.1"
-solana-measure = { path = "measure", version = "=2.2.17" }
-solana-merkle-tree = { path = "merkle-tree", version = "=2.2.17" }
+solana-measure = { path = "measure", version = "=2.2.18" }
+solana-merkle-tree = { path = "merkle-tree", version = "=2.2.18" }
 solana-message = "2.2.1"
-solana-metrics = { path = "metrics", version = "=2.2.17" }
+solana-metrics = { path = "metrics", version = "=2.2.18" }
 solana-msg = "2.2.1"
 solana-native-token = "2.2.1"
-solana-net-utils = { path = "net-utils", version = "=2.2.17" }
+solana-net-utils = { path = "net-utils", version = "=2.2.18" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "2.2.1"
 solana-nonce-account = "2.2.1"
-solana-notifier = { path = "notifier", version = "=2.2.17" }
+solana-notifier = { path = "notifier", version = "=2.2.18" }
 solana-offchain-message = "2.2.1"
 solana-package-metadata = "2.2.1"
 solana-package-metadata-macro = "2.2.1"
 solana-packet = "2.2.1"
-solana-perf = { path = "perf", version = "=2.2.17" }
-solana-poh = { path = "poh", version = "=2.2.17" }
+solana-perf = { path = "perf", version = "=2.2.18" }
+solana-poh = { path = "poh", version = "=2.2.18" }
 solana-poh-config = "2.2.1"
-solana-poseidon = { path = "poseidon", version = "=2.2.17" }
+solana-poseidon = { path = "poseidon", version = "=2.2.18" }
 solana-precompile-error = "2.2.1"
 solana-presigner = "2.2.1"
 solana-program = { version = "2.2.1", default-features = false }
@@ -468,24 +468,24 @@ solana-program-error = "2.2.1"
 solana-program-memory = "2.2.1"
 solana-program-option = "2.2.1"
 solana-program-pack = "2.2.1"
-solana-program-runtime = { path = "program-runtime", version = "=2.2.17" }
-solana-program-test = { path = "program-test", version = "=2.2.17" }
+solana-program-runtime = { path = "program-runtime", version = "=2.2.18" }
+solana-program-test = { path = "program-test", version = "=2.2.18" }
 solana-pubkey = { version = "2.2.1", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=2.2.17" }
-solana-quic-client = { path = "quic-client", version = "=2.2.17" }
+solana-pubsub-client = { path = "pubsub-client", version = "=2.2.18" }
+solana-quic-client = { path = "quic-client", version = "=2.2.18" }
 solana-quic-definitions = "2.2.1"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.17" }
-solana-remote-wallet = { path = "remote-wallet", version = "=2.2.17", default-features = false }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.2.18" }
+solana-remote-wallet = { path = "remote-wallet", version = "=2.2.18", default-features = false }
 solana-rent = "2.2.1"
 solana-rent-collector = "2.2.1"
 solana-rent-debits = "2.2.1"
 solana-reward-info = "2.2.1"
-solana-rpc = { path = "rpc", version = "=2.2.17" }
-solana-rpc-client = { path = "rpc-client", version = "=2.2.17", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.17" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.17" }
-solana-runtime = { path = "runtime", version = "=2.2.17" }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.17" }
+solana-rpc = { path = "rpc", version = "=2.2.18" }
+solana-rpc-client = { path = "rpc-client", version = "=2.2.18", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=2.2.18" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.2.18" }
+solana-runtime = { path = "runtime", version = "=2.2.18" }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=2.2.18" }
 solana-sanitize = "2.2.1"
 solana-sbpf = "=0.10.1"
 solana-sdk = "2.2.2"
@@ -496,7 +496,7 @@ solana-secp256k1-recover = "2.2.1"
 solana-secp256r1-program = "2.2.2"
 solana-seed-derivable = "2.2.1"
 solana-seed-phrase = "2.2.1"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.17" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=2.2.18" }
 solana-serde = "2.2.1"
 solana-serde-varint = "2.2.1"
 solana-serialize-utils = "2.2.1"
@@ -509,49 +509,49 @@ solana-slot-hashes = "2.2.1"
 solana-slot-history = "2.2.1"
 solana-stable-layout = "2.2.1"
 solana-stake-interface = { version = "1.2.1" }
-solana-stake-program = { path = "programs/stake", version = "=2.2.17" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.17" }
-solana-storage-proto = { path = "storage-proto", version = "=2.2.17" }
-solana-streamer = { path = "streamer", version = "=2.2.17" }
-solana-svm = { path = "svm", version = "=2.2.17" }
-solana-svm-conformance = { path = "svm-conformance", version = "=2.2.17" }
-solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.17" }
-solana-svm-transaction = { path = "svm-transaction", version = "=2.2.17" }
+solana-stake-program = { path = "programs/stake", version = "=2.2.18" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=2.2.18" }
+solana-storage-proto = { path = "storage-proto", version = "=2.2.18" }
+solana-streamer = { path = "streamer", version = "=2.2.18" }
+solana-svm = { path = "svm", version = "=2.2.18" }
+solana-svm-conformance = { path = "svm-conformance", version = "=2.2.18" }
+solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.2.18" }
+solana-svm-transaction = { path = "svm-transaction", version = "=2.2.18" }
 solana-system-interface = "1.0"
-solana-system-program = { path = "programs/system", version = "=2.2.17" }
+solana-system-program = { path = "programs/system", version = "=2.2.18" }
 solana-system-transaction = "2.2.1"
 solana-sysvar = "2.2.1"
 solana-sysvar-id = "2.2.1"
-solana-test-validator = { path = "test-validator", version = "=2.2.17" }
-solana-thin-client = { path = "thin-client", version = "=2.2.17" }
+solana-test-validator = { path = "test-validator", version = "=2.2.18" }
+solana-thin-client = { path = "thin-client", version = "=2.2.18" }
 solana-time-utils = "2.2.1"
-solana-timings = { path = "timings", version = "=2.2.17" }
-solana-tls-utils = { path = "tls-utils", version = "=2.2.17" }
-solana-tps-client = { path = "tps-client", version = "=2.2.17" }
-solana-tpu-client = { path = "tpu-client", version = "=2.2.17", default-features = false }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.17" }
+solana-timings = { path = "timings", version = "=2.2.18" }
+solana-tls-utils = { path = "tls-utils", version = "=2.2.18" }
+solana-tps-client = { path = "tps-client", version = "=2.2.18" }
+solana-tpu-client = { path = "tpu-client", version = "=2.2.18", default-features = false }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=2.2.18" }
 solana-transaction = "2.2.2"
-solana-transaction-context = { path = "transaction-context", version = "=2.2.17", features = [ "bincode" ] }
+solana-transaction-context = { path = "transaction-context", version = "=2.2.18", features = [ "bincode" ] }
 solana-transaction-error = "2.2.1"
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.17" }
-solana-transaction-status = { path = "transaction-status", version = "=2.2.17" }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.17" }
-solana-turbine = { path = "turbine", version = "=2.2.17" }
-solana-type-overrides = { path = "type-overrides", version = "=2.2.17" }
-solana-udp-client = { path = "udp-client", version = "=2.2.17" }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.2.17" }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.2.17" }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.2.18" }
+solana-transaction-status = { path = "transaction-status", version = "=2.2.18" }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.2.18" }
+solana-turbine = { path = "turbine", version = "=2.2.18" }
+solana-type-overrides = { path = "type-overrides", version = "=2.2.18" }
+solana-udp-client = { path = "udp-client", version = "=2.2.18" }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.2.18" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.2.18" }
 solana-validator-exit = "2.2.1"
-solana-version = { path = "version", version = "=2.2.17" }
-solana-vote = { path = "vote", version = "=2.2.17" }
+solana-version = { path = "version", version = "=2.2.18" }
+solana-vote = { path = "vote", version = "=2.2.18" }
 solana-vote-interface = "2.2.3"
-solana-vote-program = { path = "programs/vote", version = "=2.2.17", default-features = false }
-solana-wen-restart = { path = "wen-restart", version = "=2.2.17" }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.17" }
-solana-zk-keygen = { path = "zk-keygen", version = "=2.2.17" }
-solana-zk-sdk = { path = "zk-sdk", version = "=2.2.17" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.2.17" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.2.17" }
+solana-vote-program = { path = "programs/vote", version = "=2.2.18", default-features = false }
+solana-wen-restart = { path = "wen-restart", version = "=2.2.18" }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.2.18" }
+solana-zk-keygen = { path = "zk-keygen", version = "=2.2.18" }
+solana-zk-sdk = { path = "zk-sdk", version = "=2.2.18" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.2.18" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.2.18" }
 spl-associated-token-account = "6.0.0"
 spl-instruction-padding = "0.3"
 spl-memo = "6.0.0"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "2.2.17"
+version = "2.2.18"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "2.2.17"
+version = "2.2.18"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "2.2.17"
+version = "2.2.18"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "2.2.17"
+version = "2.2.18"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-clock",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5164,7 +5164,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5207,7 +5207,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "thiserror 2.0.11",
 ]
 
@@ -5222,14 +5222,14 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5238,18 +5238,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "fnv",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -5382,14 +5382,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "chrono",
  "clap",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "chrono",
@@ -5694,12 +5694,12 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-clock",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6191,7 +6191,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6434,7 +6434,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6530,13 +6530,13 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
 ]
@@ -6556,11 +6556,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6623,7 +6623,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6947,7 +6947,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6979,14 +6979,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7014,7 +7014,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7074,7 +7074,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7112,7 +7112,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "console",
  "dialoguer",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7250,7 +7250,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7265,7 +7265,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7301,7 +7301,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7345,7 +7345,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7417,7 +7417,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7435,7 +7435,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7460,7 +7460,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7498,7 +7498,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-vote",
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-128bit-dep",
@@ -7515,35 +7515,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7552,7 +7552,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -7561,7 +7561,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "array-bytes",
  "serde",
@@ -7572,7 +7572,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "borsh 1.5.5",
  "solana-program",
@@ -7580,21 +7580,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-curve25519",
  "solana-program",
@@ -7602,14 +7602,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program",
@@ -7617,28 +7617,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -7649,35 +7649,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoke-dep",
@@ -7687,32 +7687,32 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoked-dep",
@@ -7720,28 +7720,28 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-many-args-dep",
@@ -7749,14 +7749,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7764,14 +7764,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem-dep",
@@ -7779,21 +7779,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-param-passing-dep",
@@ -7801,14 +7801,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "array-bytes",
  "solana-poseidon",
@@ -7817,7 +7817,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -7826,7 +7826,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7834,14 +7834,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc-dep",
@@ -7850,39 +7850,39 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-program",
@@ -7891,7 +7891,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "blake3",
  "solana-program",
@@ -7899,42 +7899,42 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "solana-program",
@@ -7942,21 +7942,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-program",
 ]
@@ -8142,7 +8142,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8322,14 +8322,14 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "bs58",
@@ -8384,7 +8384,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -8392,7 +8392,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8437,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -8475,7 +8475,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -8483,15 +8483,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -8537,7 +8537,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
@@ -8605,7 +8605,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8636,7 +8636,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -8669,7 +8669,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8678,7 +8678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8764,7 +8764,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "serde",
@@ -8790,7 +8790,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8859,14 +8859,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8906,7 +8906,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8974,7 +8974,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "semver",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9058,14 +9058,14 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "log",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9105,7 +9105,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9140,7 +9140,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -73,7 +73,7 @@ members = [
     "rust/upgraded",
 ]
 [workspace.package]
-version = "2.2.17"
+version = "2.2.18"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
@@ -89,9 +89,9 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-agave-feature-set = { path = "../../feature-set", version = "=2.2.17" }
-agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.2.17" }
-agave-validator = { path = "../../validator", version = "=2.2.17" }
+agave-feature-set = { path = "../../feature-set", version = "=2.2.18" }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.2.18" }
+agave-validator = { path = "../../validator", version = "=2.2.18" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -110,44 +110,44 @@ rand = "0.8"
 serde = "1.0.112"                                                                             # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = "1.0.112"                                                                      # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.56"
-solana-account-decoder = { path = "../../account-decoder", version = "=2.2.17" }
-solana-accounts-db = { path = "../../accounts-db", version = "=2.2.17" }
+solana-account-decoder = { path = "../../account-decoder", version = "=2.2.18" }
+solana-accounts-db = { path = "../../accounts-db", version = "=2.2.18" }
 solana-bn254 = "=2.2.2"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.2.17" }
-solana-cli-output = { path = "../../cli-output", version = "=2.2.17" }
-solana-compute-budget = { path = "../../compute-budget", version = "=2.2.17" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.2.17" }
-solana-curve25519 = { path = "../../curves/curve25519", version = "=2.2.17" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.2.18" }
+solana-cli-output = { path = "../../cli-output", version = "=2.2.18" }
+solana-compute-budget = { path = "../../compute-budget", version = "=2.2.18" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.2.18" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=2.2.18" }
 solana-decode-error = "=2.2.1"
-solana-fee = { path = "../../fee", version = "=2.2.17" }
-solana-ledger = { path = "../../ledger", version = "=2.2.17" }
-solana-log-collector = { path = "../../log-collector", version = "=2.2.17" }
+solana-fee = { path = "../../fee", version = "=2.2.18" }
+solana-ledger = { path = "../../ledger", version = "=2.2.18" }
+solana-log-collector = { path = "../../log-collector", version = "=2.2.18" }
 solana-logger = "=2.3.1"
-solana-measure = { path = "../../measure", version = "=2.2.17" }
-solana-poseidon = { path = "../../poseidon/", version = "=2.2.17" }
+solana-measure = { path = "../../measure", version = "=2.2.18" }
+solana-poseidon = { path = "../../poseidon/", version = "=2.2.18" }
 solana-program = "=2.2.1"
-solana-program-runtime = { path = "../../program-runtime", version = "=2.2.17" }
-solana-runtime = { path = "../../runtime", version = "=2.2.17" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.2.17" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.2.17" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.2.17" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.2.17" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.2.17" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.2.17" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.2.17" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.17" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.17" }
+solana-program-runtime = { path = "../../program-runtime", version = "=2.2.18" }
+solana-runtime = { path = "../../runtime", version = "=2.2.18" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.2.18" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.2.18" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.2.18" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.2.18" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.2.18" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.2.18" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.2.18" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.2.18" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.2.18" }
 solana-sbpf = "=0.10.1"
 solana-sdk = "=2.2.2"
 solana-secp256k1-recover = "=2.2.1"
-solana-svm = { path = "../../svm", version = "=2.2.17" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.17" }
-solana-timings = { path = "../../timings", version = "=2.2.17" }
-solana-transaction-context = { path = "../../transaction-context", version = "=2.2.17" }
-solana-transaction-status = { path = "../../transaction-status", version = "=2.2.17" }
-solana-type-overrides = { path = "../../type-overrides", version = "=2.2.17" }
-solana-vote = { path = "../../vote", version = "=2.2.17" }
-solana-vote-program = { path = "../../programs/vote", version = "=2.2.17" }
+solana-svm = { path = "../../svm", version = "=2.2.18" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=2.2.18" }
+solana-timings = { path = "../../timings", version = "=2.2.18" }
+solana-transaction-context = { path = "../../transaction-context", version = "=2.2.18" }
+solana-transaction-status = { path = "../../transaction-status", version = "=2.2.18" }
+solana-type-overrides = { path = "../../type-overrides", version = "=2.2.18" }
+solana-vote = { path = "../../vote", version = "=2.2.18" }
+solana-vote-program = { path = "../../programs/vote", version = "=2.2.18" }
 solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "solana-clock",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "lazy_static",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "borsh 1.5.5",
  "clap",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-server"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -2723,7 +2723,7 @@ dependencies = [
  "solana-sdk",
  "solana-svm",
  "solana-system-program",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-version",
  "spl-token-2022 7.0.0",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5031,7 +5031,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5074,7 +5074,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "thiserror 2.0.11",
 ]
 
@@ -5089,14 +5089,14 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "borsh 1.5.5",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5105,18 +5105,18 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "fnv",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -5249,14 +5249,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-address-lookup-table-program",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "chrono",
  "clap",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "chrono",
@@ -5561,12 +5561,12 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "clap",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -5995,7 +5995,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6267,7 +6267,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6363,13 +6363,13 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "log",
 ]
@@ -6389,11 +6389,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.2.17"
+version = "2.2.18"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6456,7 +6456,7 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6538,7 +6538,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6812,14 +6812,14 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -6847,7 +6847,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6945,7 +6945,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6953,7 +6953,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "console",
  "dialoguer",
@@ -7037,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7083,7 +7083,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7098,7 +7098,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7178,7 +7178,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7249,7 +7249,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7267,7 +7267,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7471,7 +7471,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7651,14 +7651,14 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -7698,7 +7698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "bs58",
@@ -7713,7 +7713,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -7721,7 +7721,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-channel",
  "bytes",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7803,7 +7803,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -7811,7 +7811,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-example-paytube"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7830,15 +7830,15 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -7866,7 +7866,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -7884,7 +7884,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-type-overrides",
 ]
 
@@ -7952,7 +7952,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7983,7 +7983,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "log",
@@ -8016,7 +8016,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "rustls 0.23.22",
  "solana-keypair",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "serde",
@@ -8137,7 +8137,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8192,7 +8192,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8206,14 +8206,14 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8253,7 +8253,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8261,7 +8261,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8321,7 +8321,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "semver",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -8380,7 +8380,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8404,14 +8404,14 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.17",
+ "solana-transaction-context 2.2.18",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "anyhow",
  "log",
@@ -8436,7 +8436,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8451,7 +8451,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8486,7 +8486,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -4,7 +4,7 @@ members = ["json-rpc/client", "json-rpc/server", "paytube"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.17"
+version = "2.2.18"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"

--- a/svm/examples/json-rpc/program/Cargo.toml
+++ b/svm/examples/json-rpc/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-example-program"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [features]

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "2.2.17"
+version = "2.2.18"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
note: the version bump content was generated by #6691. since we’ve already tagged a version, as a workaround, I think we bump the version first, then bp the patch for the version bump script.