### PR TITLE
Bump version to v2.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agave-accounts-hash-cache-tool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "agave-cargo-registry"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "flate2",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-clock",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "agave-install"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "atty",
  "bincode",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "io-uring",
  "libc",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "agave-ledger-tool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-frozen-abi",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-histogram"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "solana-version",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "agave-store-tool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "clap 2.33.3",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "agave-thread-manager"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "affinity",
  "agave-thread-manager",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-transaction-view",
  "bincode",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_cmd",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "agave-watchtower"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aya",
  "caps",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "regex",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "regex",
 ]
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "protobuf-src",
  "tonic-build",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "rdrand"
@@ -6579,7 +6579,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-io-uring",
  "agave-reserved-account-keys",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "assert_matches",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -6950,7 +6950,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "chrono",
@@ -7016,7 +7016,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-vote"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -7073,7 +7073,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "fnv",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7176,7 +7176,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -7196,7 +7196,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "bytemuck",
@@ -7216,7 +7216,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7235,7 +7235,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -7255,7 +7255,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -7276,7 +7276,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7318,7 +7318,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7446,7 +7446,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -7505,7 +7505,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7551,7 +7551,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "futures-util",
  "serde_json",
@@ -7643,7 +7643,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "qualifier_attr",
  "solana-fee-structure",
@@ -7653,7 +7653,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7693,14 +7693,14 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program-runtime",
 ]
 
 [[package]]
 name = "solana-compute-budget-program-bench"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "criterion",
@@ -7728,7 +7728,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7962,7 +7962,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -8000,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-clock",
@@ -8069,7 +8069,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
@@ -8085,7 +8085,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-reserved-account-keys",
  "assert_matches",
@@ -8189,7 +8189,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8421,7 +8421,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -8462,7 +8462,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "anyhow",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -8687,7 +8687,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8700,7 +8700,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -8971,7 +8971,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
 ]
@@ -8991,15 +8991,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-memory-management"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "fast-math",
  "hex",
@@ -9032,7 +9032,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -9064,7 +9064,7 @@ checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-net-shaper"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 3.2.23",
  "rand 0.8.5",
@@ -9076,7 +9076,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9130,7 +9130,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "reqwest 0.12.16",
@@ -9172,7 +9172,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
@@ -9217,7 +9217,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -9276,7 +9276,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -9504,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -9599,7 +9599,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -9626,7 +9626,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9667,14 +9667,14 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "console",
@@ -9751,7 +9751,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9858,7 +9858,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -9905,7 +9905,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -9925,7 +9925,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -9954,7 +9954,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9979,7 +9979,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "bs58",
@@ -10017,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10310,7 +10310,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10471,7 +10471,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "clap 2.33.3",
  "solana-account",
@@ -10523,7 +10523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10561,7 +10561,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program-tests"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10584,7 +10584,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -10628,7 +10628,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "bs58",
@@ -10652,7 +10652,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -10700,7 +10700,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -10784,7 +10784,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-precompile-error",
@@ -10793,7 +10793,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-conformance"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "prost",
  "prost-build",
@@ -10802,11 +10802,11 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -10821,7 +10821,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -10853,7 +10853,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10949,7 +10949,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -11030,7 +11030,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -11039,7 +11039,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "rustls 0.23.27",
  "solana-keypair",
@@ -11050,7 +11050,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -11097,7 +11097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tps-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-account",
@@ -11128,7 +11128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -11160,7 +11160,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11219,7 +11219,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "serde",
@@ -11239,7 +11239,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -11290,7 +11290,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11308,7 +11308,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -11352,7 +11352,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11373,7 +11373,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
@@ -11430,7 +11430,7 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",
@@ -11439,7 +11439,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -11454,7 +11454,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "solana-instruction",
@@ -11468,7 +11468,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -11507,7 +11507,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -11521,7 +11521,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -11536,7 +11536,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vortexor"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "assert_matches",
@@ -11590,7 +11590,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -11651,7 +11651,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -11691,7 +11691,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11727,7 +11727,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11744,7 +11744,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program-tests"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bytemuck",
  "solana-account",
@@ -11763,7 +11763,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -11782,7 +11782,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11835,7 +11835,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ exclude = ["programs/sbf", "svm/examples", "svm/tests/example-programs"]
 resolver = "2"
 
 [workspace.package]
-version = "2.3.1"
+version = "2.3.2"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
@@ -176,16 +176,16 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.1" }
-agave-cargo-registry = { path = "cargo-registry", version = "=2.3.1" }
-agave-feature-set = { path = "feature-set", version = "=2.3.1" }
-agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.1" }
-agave-io-uring = { path = "io-uring", version = "=2.3.1" }
-agave-precompiles = { path = "precompiles", version = "=2.3.1" }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.3.1" }
-agave-thread-manager = { path = "thread-manager", version = "=2.3.1" }
-agave-transaction-view = { path = "transaction-view", version = "=2.3.1" }
-agave-xdp = { path = "xdp", version = "=2.3.1" }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.2" }
+agave-cargo-registry = { path = "cargo-registry", version = "=2.3.2" }
+agave-feature-set = { path = "feature-set", version = "=2.3.2" }
+agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=2.3.2" }
+agave-io-uring = { path = "io-uring", version = "=2.3.2" }
+agave-precompiles = { path = "precompiles", version = "=2.3.2" }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=2.3.2" }
+agave-thread-manager = { path = "thread-manager", version = "=2.3.2" }
+agave-transaction-view = { path = "transaction-view", version = "=2.3.2" }
+agave-xdp = { path = "xdp", version = "=2.3.2" }
 ahash = "0.8.11"
 anyhow = "1.0.98"
 aquamarine = "0.6.0"
@@ -369,71 +369,71 @@ smpl_jwt = "0.7.1"
 socket2 = "0.5.10"
 soketto = "0.7"
 solana-account = "2.2.1"
-solana-account-decoder = { path = "account-decoder", version = "=2.3.1" }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.3.1" }
+solana-account-decoder = { path = "account-decoder", version = "=2.3.2" }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=2.3.2" }
 solana-account-info = "2.2.1"
-solana-accounts-db = { path = "accounts-db", version = "=2.3.1" }
+solana-accounts-db = { path = "accounts-db", version = "=2.3.2" }
 solana-address-lookup-table-interface = "2.2.2"
 solana-atomic-u64 = "2.2.1"
-solana-banks-client = { path = "banks-client", version = "=2.3.1" }
-solana-banks-interface = { path = "banks-interface", version = "=2.3.1" }
-solana-banks-server = { path = "banks-server", version = "=2.3.1" }
-solana-bench-tps = { path = "bench-tps", version = "=2.3.1" }
+solana-banks-client = { path = "banks-client", version = "=2.3.2" }
+solana-banks-interface = { path = "banks-interface", version = "=2.3.2" }
+solana-banks-server = { path = "banks-server", version = "=2.3.2" }
+solana-bench-tps = { path = "bench-tps", version = "=2.3.2" }
 solana-big-mod-exp = "2.2.1"
 solana-bincode = "2.2.1"
 solana-blake3-hasher = "2.2.1"
-solana-bloom = { path = "bloom", version = "=2.3.1" }
+solana-bloom = { path = "bloom", version = "=2.3.2" }
 solana-bn254 = "2.2.2"
 solana-borsh = "2.2.1"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.1" }
-solana-bucket-map = { path = "bucket_map", version = "=2.3.1" }
-solana-builtins = { path = "builtins", version = "=2.3.1" }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.3.1" }
-solana-clap-utils = { path = "clap-utils", version = "=2.3.1" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.3.1" }
-solana-cli = { path = "cli", version = "=2.3.1" }
-solana-cli-config = { path = "cli-config", version = "=2.3.1" }
-solana-cli-output = { path = "cli-output", version = "=2.3.1" }
-solana-client = { path = "client", version = "=2.3.1" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=2.3.2" }
+solana-bucket-map = { path = "bucket_map", version = "=2.3.2" }
+solana-builtins = { path = "builtins", version = "=2.3.2" }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=2.3.2" }
+solana-clap-utils = { path = "clap-utils", version = "=2.3.2" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=2.3.2" }
+solana-cli = { path = "cli", version = "=2.3.2" }
+solana-cli-config = { path = "cli-config", version = "=2.3.2" }
+solana-cli-output = { path = "cli-output", version = "=2.3.2" }
+solana-client = { path = "client", version = "=2.3.2" }
 solana-client-traits = "2.2.1"
 solana-clock = "2.2.2"
 solana-cluster-type = "2.2.1"
 solana-commitment-config = "2.2.1"
-solana-compute-budget = { path = "compute-budget", version = "=2.3.1" }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.1" }
+solana-compute-budget = { path = "compute-budget", version = "=2.3.2" }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=2.3.2" }
 solana-compute-budget-interface = "2.2.2"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.1" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=2.3.2" }
 solana-config-program-client = "0.0.2"
-solana-connection-cache = { path = "connection-cache", version = "=2.3.1", default-features = false }
-solana-core = { path = "core", version = "=2.3.1" }
-solana-cost-model = { path = "cost-model", version = "=2.3.1" }
+solana-connection-cache = { path = "connection-cache", version = "=2.3.2", default-features = false }
+solana-core = { path = "core", version = "=2.3.2" }
+solana-cost-model = { path = "cost-model", version = "=2.3.2" }
 solana-cpi = "2.2.1"
-solana-curve25519 = { path = "curves/curve25519", version = "=2.3.1" }
+solana-curve25519 = { path = "curves/curve25519", version = "=2.3.2" }
 solana-decode-error = "2.2.1"
 solana-define-syscall = "2.3.0"
 solana-derivation-path = "2.2.1"
-solana-download-utils = { path = "download-utils", version = "=2.3.1" }
+solana-download-utils = { path = "download-utils", version = "=2.3.2" }
 solana-ed25519-program = "2.2.3"
-solana-entry = { path = "entry", version = "=2.3.1" }
+solana-entry = { path = "entry", version = "=2.3.2" }
 solana-epoch-info = "2.2.1"
 solana-epoch-rewards = "2.2.1"
 solana-epoch-rewards-hasher = "2.2.1"
 solana-epoch-schedule = "2.2.1"
 solana-example-mocks = "2.2.1"
-solana-faucet = { path = "faucet", version = "=2.3.1" }
+solana-faucet = { path = "faucet", version = "=2.3.2" }
 solana-feature-gate-client = "0.0.2"
 solana-feature-gate-interface = "2.2.2"
-solana-fee = { path = "fee", version = "=2.3.1" }
+solana-fee = { path = "fee", version = "=2.3.2" }
 solana-fee-calculator = "2.2.1"
 solana-fee-structure = "2.3.0"
 solana-file-download = "2.2.1"
 solana-frozen-abi = "2.2.2"
 solana-frozen-abi-macro = "2.2.1"
-solana-genesis = { path = "genesis", version = "=2.3.1" }
+solana-genesis = { path = "genesis", version = "=2.3.2" }
 solana-genesis-config = "2.2.1"
-solana-genesis-utils = { path = "genesis-utils", version = "=2.3.1" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.3.1" }
-solana-gossip = { path = "gossip", version = "=2.3.1" }
+solana-genesis-utils = { path = "genesis-utils", version = "=2.3.2" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=2.3.2" }
+solana-gossip = { path = "gossip", version = "=2.3.2" }
 solana-hard-forks = "2.2.1"
 solana-hash = "2.3.0"
 solana-inflation = "2.2.1"
@@ -442,32 +442,32 @@ solana-instructions-sysvar = "2.2.2"
 solana-keccak-hasher = "2.2.1"
 solana-keypair = "2.2.1"
 solana-last-restart-slot = "2.2.1"
-solana-lattice-hash = { path = "lattice-hash", version = "=2.3.1" }
-solana-ledger = { path = "ledger", version = "=2.3.1" }
+solana-lattice-hash = { path = "lattice-hash", version = "=2.3.2" }
+solana-ledger = { path = "ledger", version = "=2.3.2" }
 solana-loader-v2-interface = "2.2.1"
 solana-loader-v3-interface = "5.0.0"
 solana-loader-v4-interface = "2.2.1"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.3.1" }
-solana-local-cluster = { path = "local-cluster", version = "=2.3.1" }
-solana-log-collector = { path = "log-collector", version = "=2.3.1" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=2.3.2" }
+solana-local-cluster = { path = "local-cluster", version = "=2.3.2" }
+solana-log-collector = { path = "log-collector", version = "=2.3.2" }
 solana-logger = "2.3.1"
-solana-measure = { path = "measure", version = "=2.3.1" }
-solana-merkle-tree = { path = "merkle-tree", version = "=2.3.1" }
+solana-measure = { path = "measure", version = "=2.3.2" }
+solana-merkle-tree = { path = "merkle-tree", version = "=2.3.2" }
 solana-message = "2.4.0"
-solana-metrics = { path = "metrics", version = "=2.3.1" }
+solana-metrics = { path = "metrics", version = "=2.3.2" }
 solana-msg = "2.2.1"
 solana-native-token = "2.2.2"
-solana-net-utils = { path = "net-utils", version = "=2.3.1" }
+solana-net-utils = { path = "net-utils", version = "=2.3.2" }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "2.2.1"
 solana-nonce-account = "2.2.1"
-solana-notifier = { path = "notifier", version = "=2.3.1" }
+solana-notifier = { path = "notifier", version = "=2.3.2" }
 solana-offchain-message = "2.2.1"
 solana-packet = "2.2.1"
-solana-perf = { path = "perf", version = "=2.3.1" }
-solana-poh = { path = "poh", version = "=2.3.1" }
+solana-perf = { path = "perf", version = "=2.3.2" }
+solana-poh = { path = "poh", version = "=2.3.2" }
 solana-poh-config = "2.2.1"
-solana-poseidon = { path = "poseidon", version = "=2.3.1" }
+solana-poseidon = { path = "poseidon", version = "=2.3.2" }
 solana-precompile-error = "2.2.2"
 solana-presigner = "2.2.1"
 solana-program = { version = "2.2.1", default-features = false }
@@ -476,25 +476,25 @@ solana-program-error = "2.2.1"
 solana-program-memory = "2.2.1"
 solana-program-option = "2.2.1"
 solana-program-pack = "2.2.1"
-solana-program-runtime = { path = "program-runtime", version = "=2.3.1" }
-solana-program-test = { path = "program-test", version = "=2.3.1" }
+solana-program-runtime = { path = "program-runtime", version = "=2.3.2" }
+solana-program-test = { path = "program-test", version = "=2.3.2" }
 solana-pubkey = { version = "2.4.0", default-features = false }
-solana-pubsub-client = { path = "pubsub-client", version = "=2.3.1" }
-solana-quic-client = { path = "quic-client", version = "=2.3.1" }
+solana-pubsub-client = { path = "pubsub-client", version = "=2.3.2" }
+solana-quic-client = { path = "quic-client", version = "=2.3.2" }
 solana-quic-definitions = "2.2.1"
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.3.1" }
-solana-remote-wallet = { path = "remote-wallet", version = "=2.3.1", default-features = false }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=2.3.2" }
+solana-remote-wallet = { path = "remote-wallet", version = "=2.3.2", default-features = false }
 solana-rent = "2.2.1"
 solana-rent-collector = "2.2.1"
 solana-rent-debits = "2.2.1"
 solana-reward-info = "2.2.1"
-solana-rpc = { path = "rpc", version = "=2.3.1" }
-solana-rpc-client = { path = "rpc-client", version = "=2.3.1", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=2.3.1" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.1" }
-solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.1" }
-solana-runtime = { path = "runtime", version = "=2.3.1" }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.1" }
+solana-rpc = { path = "rpc", version = "=2.3.2" }
+solana-rpc-client = { path = "rpc-client", version = "=2.3.2", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=2.3.2" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=2.3.2" }
+solana-rpc-client-types = { path = "rpc-client-types", version = "=2.3.2" }
+solana-runtime = { path = "runtime", version = "=2.3.2" }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=2.3.2" }
 solana-sanitize = "2.2.1"
 solana-sbpf = "=0.11.1"
 solana-sdk-ids = "2.2.1"
@@ -503,7 +503,7 @@ solana-secp256k1-recover = "2.2.1"
 solana-secp256r1-program = "2.2.3"
 solana-seed-derivable = "2.2.1"
 solana-seed-phrase = "2.2.1"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.1" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=2.3.2" }
 solana-serde = "2.2.1"
 solana-serde-varint = "2.2.2"
 solana-serialize-utils = "2.2.1"
@@ -516,51 +516,51 @@ solana-slot-hashes = "2.2.1"
 solana-slot-history = "2.2.1"
 solana-stable-layout = "2.2.1"
 solana-stake-interface = { version = "1.2.1" }
-solana-stake-program = { path = "programs/stake", version = "=2.3.1" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=2.3.1" }
-solana-storage-proto = { path = "storage-proto", version = "=2.3.1" }
-solana-streamer = { path = "streamer", version = "=2.3.1" }
-solana-svm = { path = "svm", version = "=2.3.1" }
-solana-svm-callback = { path = "svm-callback", version = "=2.3.1" }
-solana-svm-conformance = { path = "svm-conformance", version = "=2.3.1" }
-solana-svm-feature-set = { path = "svm-feature-set", version = "=2.3.1" }
-solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.3.1" }
-solana-svm-transaction = { path = "svm-transaction", version = "=2.3.1" }
+solana-stake-program = { path = "programs/stake", version = "=2.3.2" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=2.3.2" }
+solana-storage-proto = { path = "storage-proto", version = "=2.3.2" }
+solana-streamer = { path = "streamer", version = "=2.3.2" }
+solana-svm = { path = "svm", version = "=2.3.2" }
+solana-svm-callback = { path = "svm-callback", version = "=2.3.2" }
+solana-svm-conformance = { path = "svm-conformance", version = "=2.3.2" }
+solana-svm-feature-set = { path = "svm-feature-set", version = "=2.3.2" }
+solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.3.2" }
+solana-svm-transaction = { path = "svm-transaction", version = "=2.3.2" }
 solana-system-interface = "1.0"
-solana-system-program = { path = "programs/system", version = "=2.3.1" }
+solana-system-program = { path = "programs/system", version = "=2.3.2" }
 solana-system-transaction = "2.2.1"
 solana-sysvar = "2.2.2"
 solana-sysvar-id = "2.2.1"
-solana-test-validator = { path = "test-validator", version = "=2.3.1" }
-solana-thin-client = { path = "thin-client", version = "=2.3.1" }
+solana-test-validator = { path = "test-validator", version = "=2.3.2" }
+solana-thin-client = { path = "thin-client", version = "=2.3.2" }
 solana-time-utils = "2.2.1"
-solana-timings = { path = "timings", version = "=2.3.1" }
-solana-tls-utils = { path = "tls-utils", version = "=2.3.1" }
-solana-tps-client = { path = "tps-client", version = "=2.3.1" }
-solana-tpu-client = { path = "tpu-client", version = "=2.3.1", default-features = false }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=2.3.1" }
+solana-timings = { path = "timings", version = "=2.3.2" }
+solana-tls-utils = { path = "tls-utils", version = "=2.3.2" }
+solana-tps-client = { path = "tps-client", version = "=2.3.2" }
+solana-tpu-client = { path = "tpu-client", version = "=2.3.2", default-features = false }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=2.3.2" }
 solana-transaction = "2.2.2"
-solana-transaction-context = { path = "transaction-context", version = "=2.3.1", features = ["bincode"] }
+solana-transaction-context = { path = "transaction-context", version = "=2.3.2", features = ["bincode"] }
 solana-transaction-error = "2.2.1"
-solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.3.1" }
-solana-transaction-status = { path = "transaction-status", version = "=2.3.1" }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.3.1" }
-solana-turbine = { path = "turbine", version = "=2.3.1" }
-solana-type-overrides = { path = "type-overrides", version = "=2.3.1" }
-solana-udp-client = { path = "udp-client", version = "=2.3.1" }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.1" }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.3.1" }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=2.3.2" }
+solana-transaction-status = { path = "transaction-status", version = "=2.3.2" }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=2.3.2" }
+solana-turbine = { path = "turbine", version = "=2.3.2" }
+solana-type-overrides = { path = "type-overrides", version = "=2.3.2" }
+solana-udp-client = { path = "udp-client", version = "=2.3.2" }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=2.3.2" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=2.3.2" }
 solana-validator-exit = "2.2.1"
-solana-version = { path = "version", version = "=2.3.1" }
-solana-vote = { path = "vote", version = "=2.3.1" }
+solana-version = { path = "version", version = "=2.3.2" }
+solana-vote = { path = "vote", version = "=2.3.2" }
 solana-vote-interface = "2.2.5"
-solana-vote-program = { path = "programs/vote", version = "=2.3.1", default-features = false }
-solana-wen-restart = { path = "wen-restart", version = "=2.3.1" }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.3.1" }
-solana-zk-keygen = { path = "zk-keygen", version = "=2.3.1" }
-solana-zk-sdk = { path = "zk-sdk", version = "=2.3.1" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.3.1" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.3.1" }
+solana-vote-program = { path = "programs/vote", version = "=2.3.2", default-features = false }
+solana-wen-restart = { path = "wen-restart", version = "=2.3.2" }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=2.3.2" }
+solana-zk-keygen = { path = "zk-keygen", version = "=2.3.2" }
+solana-zk-sdk = { path = "zk-sdk", version = "=2.3.2" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=2.3.2" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=2.3.2" }
 spl-associated-token-account = "7.0.0"
 spl-generic-token = "1.0.1"
 spl-instruction-padding = "0.3.0"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package-metadata"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SBF test program with tools version in package metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-metadata"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SBF test program with tools version in workspace metadata"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-clock",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "io-uring",
  "libc",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "agave-validator"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "chrono",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aya",
  "caps",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-io-uring",
  "ahash 0.8.11",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "fnv",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "libsecp256k1 0.6.0",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5756,7 +5756,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "chrono",
  "clap",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "dirs-next",
  "serde",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-clock",
@@ -6251,7 +6251,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-accounts-db",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "arrayvec",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6715,7 +6715,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
 ]
@@ -6912,11 +6912,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6948,7 +6948,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6977,7 +6977,7 @@ checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7057,7 +7057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -7087,7 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -7119,7 +7119,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7437,7 +7437,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7474,14 +7474,14 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "console",
  "dialoguer",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7637,7 +7637,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7695,7 +7695,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7870,7 +7870,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7895,7 +7895,7 @@ checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
 name = "solana-sbf-programs"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -7965,7 +7965,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-128bit-dep",
@@ -7973,11 +7973,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-sbf-rust-account-mem"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -7988,7 +7988,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-account-mem-deprecated"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8009,7 +8009,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128-compression"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "array-bytes",
  "solana-bn254",
@@ -8029,7 +8029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-big-mod-exp"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "array-bytes",
  "serde",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-args"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "borsh 1.5.7",
  "solana-account-info",
@@ -8054,7 +8054,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-curve25519",
  "solana-msg",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8097,7 +8097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "byteorder 1.5.0",
  "solana-program-entrypoint",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8121,7 +8121,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-divide-by-zero"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8144,7 +8144,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8169,7 +8169,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8228,7 +8228,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8252,7 +8252,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8264,11 +8264,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-dep"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoked-dep"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -8300,7 +8300,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-msg",
  "solana-program",
@@ -8330,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8342,11 +8342,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-mem-dep"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program-entrypoint",
  "solana-sbf-rust-mem-dep",
@@ -8354,7 +8354,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program",
  "solana-program-entrypoint",
@@ -8384,11 +8384,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-sbf-rust-poseidon"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "array-bytes",
  "solana-msg",
@@ -8398,7 +8398,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
@@ -8411,7 +8411,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8425,7 +8425,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-dep"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8449,11 +8449,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke-dep"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-sbf-rust-remaining-compute-units"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8491,7 +8491,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-keccak-hasher",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "blake3",
  "solana-blake3-hasher",
@@ -8527,7 +8527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-inner-instructions"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-clock",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-instruction",
@@ -8579,7 +8579,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
@@ -8589,7 +8589,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "solana-account-info",
@@ -8606,7 +8606,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8618,7 +8618,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8630,7 +8630,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-syscall-get-epoch-stake"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8912,7 +8912,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -8979,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "bs58",
@@ -9002,7 +9002,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-channel",
  "bytes",
@@ -9047,7 +9047,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -9095,7 +9095,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-precompile-error",
@@ -9104,11 +9104,11 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -9122,7 +9122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -9317,7 +9317,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -9326,7 +9326,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "rustls 0.23.27",
  "solana-keypair",
@@ -9337,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9369,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "log",
@@ -9419,7 +9419,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "serde",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -9502,7 +9502,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9523,7 +9523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
@@ -9574,14 +9574,14 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -9595,7 +9595,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -9607,7 +9607,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -9646,7 +9646,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -9711,7 +9711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -9743,7 +9743,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "log",
@@ -9769,7 +9769,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9784,7 +9784,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9818,7 +9818,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -9833,7 +9833,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -73,7 +73,7 @@ members = [
     "rust/upgraded",
 ]
 [workspace.package]
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
@@ -90,9 +90,9 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-agave-feature-set = { path = "../../feature-set", version = "=2.3.1" }
-agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.3.1" }
-agave-validator = { path = "../../validator", version = "=2.3.1" }
+agave-feature-set = { path = "../../feature-set", version = "=2.3.2" }
+agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=2.3.2" }
+agave-validator = { path = "../../validator", version = "=2.3.2" }
 array-bytes = "=1.4.1"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
@@ -111,64 +111,64 @@ rand = "0.8"
 serde = "1.0.112"                                                                             # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = "1.0.112"                                                                      # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.56"
-solana-account-decoder = { path = "../../account-decoder", version = "=2.3.1" }
+solana-account-decoder = { path = "../../account-decoder", version = "=2.3.2" }
 solana-account-info = "=2.2.1"
-solana-accounts-db = { path = "../../accounts-db", version = "=2.3.1" }
+solana-accounts-db = { path = "../../accounts-db", version = "=2.3.2" }
 solana-big-mod-exp = "=2.2.1"
 solana-blake3-hasher = { version = "=2.2.1", features = ["blake3"] }
 solana-bn254 = "=2.2.2"
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.3.1" }
-solana-cli-output = { path = "../../cli-output", version = "=2.3.1" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=2.3.2" }
+solana-cli-output = { path = "../../cli-output", version = "=2.3.2" }
 solana-clock = { version = "=2.2.2", features = ["serde", "sysvar"] }
-solana-compute-budget = { path = "../../compute-budget", version = "=2.3.1" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.3.1" }
-solana-curve25519 = { path = "../../curves/curve25519", version = "=2.3.1" }
+solana-compute-budget = { path = "../../compute-budget", version = "=2.3.2" }
+solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=2.3.2" }
+solana-curve25519 = { path = "../../curves/curve25519", version = "=2.3.2" }
 solana-decode-error = "=2.2.1"
 solana-define-syscall = "=2.3.0"
-solana-fee = { path = "../../fee", version = "=2.3.1" }
+solana-fee = { path = "../../fee", version = "=2.3.2" }
 solana-hash = { version = "=2.3.0", features = ["bytemuck", "serde", "std"] }
 solana-instruction = "=2.3.0"
 solana-instructions-sysvar = "=2.2.2"
 solana-keccak-hasher = { version = "=2.2.1", features = ["sha3"] }
-solana-ledger = { path = "../../ledger", version = "=2.3.1" }
-solana-log-collector = { path = "../../log-collector", version = "=2.3.1" }
+solana-ledger = { path = "../../ledger", version = "=2.3.2" }
+solana-log-collector = { path = "../../log-collector", version = "=2.3.2" }
 solana-logger = "=2.3.1"
-solana-measure = { path = "../../measure", version = "=2.3.1" }
+solana-measure = { path = "../../measure", version = "=2.3.2" }
 solana-msg = "=2.2.1"
-solana-poseidon = { path = "../../poseidon/", version = "=2.3.1" }
+solana-poseidon = { path = "../../poseidon/", version = "=2.3.2" }
 solana-program = "=2.2.1"
 solana-program-entrypoint = "=2.2.1"
 solana-program-error = "=2.2.1"
 solana-program-memory = "=2.2.1"
-solana-program-runtime = { path = "../../program-runtime", version = "=2.3.1" }
+solana-program-runtime = { path = "../../program-runtime", version = "=2.3.2" }
 solana-pubkey = { version = "=2.4.0", default-features = false }
-solana-runtime = { path = "../../runtime", version = "=2.3.1" }
-solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.3.1" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.3.1" }
-solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.3.1" }
-solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.3.1" }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.3.1" }
-solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.3.1" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.3.1" }
-solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.3.1" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.3.1" }
+solana-runtime = { path = "../../runtime", version = "=2.3.2" }
+solana-runtime-transaction = { path = "../../runtime-transaction", version = "=2.3.2" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=2.3.2" }
+solana-sbf-rust-invoke-dep = { path = "rust/invoke_dep", version = "=2.3.2" }
+solana-sbf-rust-invoked-dep = { path = "rust/invoked_dep", version = "=2.3.2" }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=2.3.2" }
+solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=2.3.2" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=2.3.2" }
+solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=2.3.2" }
+solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=2.3.2" }
 solana-sbpf = "=0.11.1"
 solana-sdk-ids = "=2.2.1"
 solana-secp256k1-recover = "=2.2.1"
 solana-sha256-hasher = { version = "=2.2.1", features = ["sha2"] }
 solana-stake-interface = { version = "=1.2.1", features = ["bincode"] }
-solana-svm = { path = "../../svm", version = "=2.3.1" }
-solana-svm-callback = { path = "../../svm-callback", version = "=2.3.1" }
-solana-svm-feature-set = { path = "../../svm-feature-set", version = "=2.3.1" }
-solana-svm-transaction = { path = "../../svm-transaction", version = "=2.3.1" }
+solana-svm = { path = "../../svm", version = "=2.3.2" }
+solana-svm-callback = { path = "../../svm-callback", version = "=2.3.2" }
+solana-svm-feature-set = { path = "../../svm-feature-set", version = "=2.3.2" }
+solana-svm-transaction = { path = "../../svm-transaction", version = "=2.3.2" }
 solana-system-interface = { version = "=1.0", features = ["bincode"] }
 solana-sysvar = "=2.2.2"
-solana-timings = { path = "../../timings", version = "=2.3.1" }
-solana-transaction-context = { path = "../../transaction-context", version = "=2.3.1" }
-solana-transaction-status = { path = "../../transaction-status", version = "=2.3.1" }
-solana-type-overrides = { path = "../../type-overrides", version = "=2.3.1" }
-solana-vote = { path = "../../vote", version = "=2.3.1" }
-solana-vote-program = { path = "../../programs/vote", version = "=2.3.1" }
+solana-timings = { path = "../../timings", version = "=2.3.2" }
+solana-transaction-context = { path = "../../transaction-context", version = "=2.3.2" }
+solana-transaction-status = { path = "../../transaction-status", version = "=2.3.2" }
+solana-type-overrides = { path = "../../type-overrides", version = "=2.3.2" }
+solana-vote = { path = "../../vote", version = "=2.3.2" }
+solana-vote-program = { path = "../../programs/vote", version = "=2.3.2" }
 solana-zk-sdk = "=2.2.1"
 thiserror = "1.0"
 

--- a/svm-callback/Cargo.toml
+++ b/svm-callback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SVM callback"
 authors = { workspace = true }
 repository = { workspace = true }

--- a/svm-feature-set/Cargo.toml
+++ b/svm-feature-set/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 description = "Solana SVM Feature Set"
 authors = { workspace = true }
 repository = { workspace = true }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "solana-epoch-schedule",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "solana-clock",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "io-uring",
  "libc",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aya",
  "caps",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "borsh 1.5.7",
  "clap",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-io-uring",
  "ahash 0.8.11",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "fnv",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -5550,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "chrono",
  "clap",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "dirs-next",
  "serde",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "clap",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6336,7 +6336,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "arrayvec",
@@ -6517,7 +6517,7 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6527,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "log",
 ]
@@ -6724,11 +6724,11 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6789,7 +6789,7 @@ checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6931,7 +6931,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7249,7 +7249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7286,14 +7286,14 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "console",
  "dialoguer",
@@ -7365,7 +7365,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -7449,7 +7449,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7487,7 +7487,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7522,7 +7522,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -7681,7 +7681,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -7976,7 +7976,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8003,7 +8003,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "bs58",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash 0.8.11",
  "itertools 0.12.1",
@@ -8158,7 +8158,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-precompile-error",
@@ -8167,7 +8167,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-example-paytube"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "solana-account",
@@ -8203,11 +8203,11 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "2.3.2"
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -8383,7 +8383,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "log",
@@ -8416,7 +8416,7 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8425,7 +8425,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "rustls 0.23.27",
  "solana-keypair",
@@ -8436,7 +8436,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8468,7 +8468,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "log",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "bincode",
  "serde",
@@ -8545,7 +8545,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8601,7 +8601,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8622,7 +8622,7 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
@@ -8673,14 +8673,14 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8694,7 +8694,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8745,7 +8745,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -8808,7 +8808,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8839,7 +8839,7 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "log",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8929,7 +8929,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -4,7 +4,7 @@ members = ["json-rpc/client", "json-rpc/server", "paytube"]
 resolver = "2"
 
 [workspace.package]
-version = "2.3.1"
+version = "2.3.2"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"

--- a/svm/examples/json-rpc/program/Cargo.toml
+++ b/svm/examples/json-rpc/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-example-program"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [features]

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock-sysvar-program"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-solana-program"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-transfer-program"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transfer-from-account"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-to-account"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
note: the version bump content was generated by #6691. since we’ve already tagged a version, as a workaround, I think we bump the version first, then bp the patch for the version bump script.