### PR TITLE
fix logic in version bump script

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -129,7 +129,7 @@ for Cargo_toml in "${Cargo_tomls[@]}"; do
   # Set new crate version
   (
     set -x
-    sed -i "$Cargo_toml" -e "0,/^version =/{s/^version = \"[^\"]*\"$/version = \"$newVersion\"/}"
+    sed -i "$Cargo_toml" -e "s/^version = \"$currentVersion\"$/version = \"$newVersion\"/"
   )
 
   # Fix up the version references to other internal crates

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -183,7 +183,7 @@ scripts/cargo-for-all-lock-files.sh tree >/dev/null
   done
   mv "$tmp_file" filtered-cargo-lock-patch
 
-  git checkout ./**/Cargo.lock
+  git ls-files -- **/Cargo.lock | xargs -I {} git checkout {}
   git apply --unidiff-zero filtered-cargo-lock-patch
   rm cargo-lock-patch filtered-cargo-lock-patch
 )


### PR DESCRIPTION
#### Problem

the release pipeline is broken again... 🤡 there are 2 issues this time:

1. the `sed` only replaces the first match

we've used this for years, but it started failing recently because the cargo sort v2 now moves the `[package]` section to the top, which cause the script to skip updating `[workspace.package]` (the change: https://github.com/anza-xyz/agave/pull/6406/files#diff-17980d6357b4afc4a7db062682433726b53614a42129e784d8a8f931c9d70e8a)

2. the ** pattern matches too many files

in line 186, I try to check out all `Cargo.lock`. however, `**` picks up untracked files, which leads to errors


#### Summary of Changes

1. update the sed command to replace all version matches
2. use `git ls-files` to list only tracked `Cargo.lock` first
