### PR TITLE
[zk-sdk] Export out `ElGamalSecretKey` for wasm and add wasm constructors for range proof types

### DIFF
--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -445,9 +445,22 @@ impl From<&ElGamalPubkey> for [u8; ELGAMAL_PUBKEY_LEN] {
 /// Secret key for the ElGamal encryption scheme.
 ///
 /// Instances of ElGamal secret key are zeroized on drop.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Clone, Debug, Deserialize, Serialize, Zeroize)]
 #[zeroize(drop)]
 pub struct ElGamalSecretKey(Scalar);
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl ElGamalSecretKey {
+    /// Decrypts a ciphertext using the ElGamal secret key, interpreting the message as a `u32`.
+    ///
+    /// Returns the decrypted amount as a number, or `null` if decryption fails.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = decryptU32))]
+    pub fn decrypt_u32_wasm(&self, ciphertext: &ElGamalCiphertext) -> Option<f64> {
+        self.decrypt_u32(ciphertext).map(|v| v as f64)
+    }
+}
+
 impl ElGamalSecretKey {
     /// Randomly samples an ElGamal secret key.
     ///

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -21,6 +21,11 @@ use {
     },
     bytemuck_derive::{Pod, Zeroable},
 };
+#[cfg(target_arch = "wasm32")]
+use {
+    bytemuck::bytes_of,
+    wasm_bindgen::{prelude::*, JsValue},
+};
 
 /// The instruction data that is needed for the
 /// `ProofInstruction::VerifyBatchedRangeProofU128` instruction.
@@ -71,6 +76,25 @@ impl BatchedRangeProofU128Data {
         Ok(Self { context, proof })
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn new_batched_range_proof_u128(
+    commitments: Vec<PedersenCommitment>,
+    amounts: Vec<u64>,
+    bit_lengths: Vec<usize>,
+    openings: Vec<PedersenOpening>,
+) -> Result<Vec<u8>, JsValue> {
+    let commitment_refs: Vec<&PedersenCommitment> = commitments.iter().collect();
+    let opening_refs: Vec<&PedersenOpening> = openings.iter().collect();
+
+    let proof_data =
+        BatchedRangeProofU128Data::new(commitment_refs, amounts, bit_lengths, opening_refs)
+            .map_err(|e| JsValue::from(e.to_string()))?;
+
+    Ok(bytes_of(&proof_data).to_vec())
+}
+
 
 impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU128Data {
     const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU128;

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -95,7 +95,6 @@ pub fn new_batched_range_proof_u128(
     Ok(bytes_of(&proof_data).to_vec())
 }
 
-
 impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU128Data {
     const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU128;
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
@@ -102,7 +102,6 @@ pub fn new_batched_range_proof_u256(
     Ok(bytes_of(&proof_data).to_vec())
 }
 
-
 impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
     const PROOF_TYPE: ProofType = ProofType::BatchedRangeProofU256;
 

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
@@ -21,6 +21,11 @@ use {
     },
     bytemuck_derive::{Pod, Zeroable},
 };
+#[cfg(target_arch = "wasm32")]
+use {
+    bytemuck::bytes_of,
+    wasm_bindgen::{prelude::*, JsValue},
+};
 
 /// The instruction data that is needed for the
 /// `ProofInstruction::VerifyBatchedRangeProofU64` instruction.
@@ -69,6 +74,24 @@ impl BatchedRangeProofU64Data {
 
         Ok(Self { context, proof })
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn new_batched_range_proof_u64(
+    commitments: Vec<PedersenCommitment>,
+    amounts: Vec<u64>,
+    bit_lengths: Vec<usize>,
+    openings: Vec<PedersenOpening>,
+) -> Result<Vec<u8>, JsValue> {
+    let commitment_refs: Vec<&PedersenCommitment> = commitments.iter().collect();
+    let opening_refs: Vec<&PedersenOpening> = openings.iter().collect();
+
+    let proof_data =
+        BatchedRangeProofU64Data::new(commitment_refs, amounts, bit_lengths, opening_refs)
+            .map_err(|e| JsValue::from(e.to_string()))?;
+
+    Ok(bytes_of(&proof_data).to_vec())
 }
 
 impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU64Data {


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
