### PR TITLE
optimize zero lamort pubkeys at index generation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7957,7 +7957,7 @@ impl AccountsDb {
                     let mut scan_time_sum = 0;
                     let mut all_accounts_are_zero_lamports_slots_inner = 0;
                     let mut all_zeros_slots_inner = vec![];
-                    let mut zero_pubkeys_for_this_chunk = Vec::new();
+                    let mut local_zero_lamport_pubkeys = Vec::new();
                     let mut insert_time_sum = 0;
                     let mut total_including_duplicates_sum = 0;
                     let mut accounts_data_len_sum = 0;
@@ -7983,7 +7983,7 @@ impl AccountsDb {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,
                                 accounts_data_len: accounts_data_len_this_slot,
-                                zero_lamport_pubkeys: mut zero_pubkeys_this_slot,
+                                zero_lamport_pubkeys: mut zero_lamport_pubkeys_this_slot,
                                 all_accounts_are_zero_lamports,
                                 num_did_not_exist,
                                 num_existed_in_mem,
@@ -8004,7 +8004,7 @@ impl AccountsDb {
                                 all_accounts_are_zero_lamports_slots_inner += 1;
                                 all_zeros_slots_inner.push((*slot, Arc::clone(&storage)));
                             }
-                            zero_pubkeys_for_this_chunk.append(&mut zero_pubkeys_this_slot);
+                            local_zero_lamport_pubkeys.append(&mut zero_lamport_pubkeys_this_slot);
 
                             insert_us
                         } else {
@@ -8038,10 +8038,10 @@ impl AccountsDb {
                     }
 
                     if pass == 0 {
-                        let mut zero_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
-                        zero_pubkeys_lock.reserve(zero_pubkeys_for_this_chunk.len());
-                        zero_pubkeys_lock.extend(zero_pubkeys_for_this_chunk.into_iter());
-                        drop(zero_pubkeys_lock);
+                        let mut zero_lamport_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
+                        zero_lamport_pubkeys_lock.reserve(local_zero_lamport_pubkeys.len());
+                        zero_lamport_pubkeys_lock.extend(local_zero_lamport_pubkeys.into_iter());
+                        drop(zero_lamport_pubkeys_lock);
 
                         // This thread has finished processing its chunk of slots.
                         // Update the index stats now.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8004,7 +8004,7 @@ impl AccountsDb {
                                 all_accounts_are_zero_lamports_slots_inner += 1;
                                 all_zeros_slots_inner.push((*slot, Arc::clone(&storage)));
                             }
-                            zero_pubkeys_for_this_chunk.extend(zero_pubkeys_this_slot.into_iter());
+                            zero_pubkeys_for_this_chunk.append(&zero_pubkeys_this_slot);
 
                             insert_us
                         } else {
@@ -8037,12 +8037,12 @@ impl AccountsDb {
                         insert_time_sum += insert_us;
                     }
 
-                    let mut zero_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
-                    zero_pubkeys_lock.reserve(zero_pubkeys_for_this_chunk.len());
-                    zero_pubkeys_lock.extend(zero_pubkeys_for_this_chunk.into_iter());
-                    drop(zero_pubkeys_lock);
-
                     if pass == 0 {
+                        let mut zero_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
+                        zero_pubkeys_lock.reserve(zero_pubkeys_for_this_chunk.len());
+                        zero_pubkeys_lock.extend(zero_pubkeys_for_this_chunk.into_iter());
+                        drop(zero_pubkeys_lock);
+
                         // This thread has finished processing its chunk of slots.
                         // Update the index stats now.
                         let index_stats = self.accounts_index.bucket_map_holder_stats();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8040,6 +8040,7 @@ impl AccountsDb {
                     let mut zero_pubkeys_lock = zero_lamport_pubkeys.lock().unwrap();
                     zero_pubkeys_lock.reserve(zero_pubkeys_for_this_chunk.len());
                     zero_pubkeys_lock.extend(zero_pubkeys_for_this_chunk.into_iter());
+                    drop(zero_pubkeys_lock);
 
                     if pass == 0 {
                         // This thread has finished processing its chunk of slots.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7983,7 +7983,7 @@ impl AccountsDb {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,
                                 accounts_data_len: accounts_data_len_this_slot,
-                                zero_lamport_pubkeys: zero_pubkeys_this_slot,
+                                zero_lamport_pubkeys: mut zero_pubkeys_this_slot,
                                 all_accounts_are_zero_lamports,
                                 num_did_not_exist,
                                 num_existed_in_mem,
@@ -8004,7 +8004,7 @@ impl AccountsDb {
                                 all_accounts_are_zero_lamports_slots_inner += 1;
                                 all_zeros_slots_inner.push((*slot, Arc::clone(&storage)));
                             }
-                            zero_pubkeys_for_this_chunk.append(&zero_pubkeys_this_slot);
+                            zero_pubkeys_for_this_chunk.append(&mut zero_pubkeys_this_slot);
 
                             insert_us
                         } else {


### PR DESCRIPTION
#### Problem

Collection zero lamport accounts' pubkey at index generation suffers from lock contention and frequent memory allocation. This is evident in the solana profile. 

![image](https://github.com/user-attachments/assets/1044e73d-f37d-4315-a068-52780c925c5b)
  

#### Summary of Changes

Let the thread collect zero lamport locally for all the slots in the chunk and then update the locked hashmap one time at the end. 

#### Performance Result 

Ledger  tool runs show that this PR reduced the `scan_time` for index generation.

```
scan_stores_us=3434436i (this PR)
scan_stores_us=3476279i (base)
```




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
