### PR TITLE
clean up rent info/stats in index generation

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5133,7 +5133,7 @@ define_accounts_db_test!(test_calculate_storage_count_and_alive_bytes, |accounts
 
     let storage = accounts.storage.get_slot_storage_entry(slot0).unwrap();
     let storage_info = StorageSizeAndCountMap::default();
-    accounts.generate_index_for_slot(&storage, slot0, 0, &RentCollector::default(), &storage_info);
+    accounts.generate_index_for_slot(&storage, slot0, 0, &storage_info);
     assert_eq!(storage_info.len(), 1);
     for entry in storage_info.iter() {
         let expected_stored_size =
@@ -5156,7 +5156,7 @@ define_accounts_db_test!(
         // empty store
         let storage = accounts.create_and_insert_store(0, 1, "test");
         let storage_info = StorageSizeAndCountMap::default();
-        accounts.generate_index_for_slot(&storage, 0, 0, &RentCollector::default(), &storage_info);
+        accounts.generate_index_for_slot(&storage, 0, 0, &storage_info);
         assert!(storage_info.is_empty());
     }
 );
@@ -5192,7 +5192,7 @@ define_accounts_db_test!(
         );
 
         let storage_info = StorageSizeAndCountMap::default();
-        accounts.generate_index_for_slot(&storage, 0, 0, &RentCollector::default(), &storage_info);
+        accounts.generate_index_for_slot(&storage, 0, 0, &storage_info);
         assert_eq!(storage_info.len(), 1);
         for entry in storage_info.iter() {
             let expected_stored_size =

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -32,7 +32,6 @@ use {
     memmap2::MmapMut,
     meta::StoredAccountNoData,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
-    solana_clock::Epoch,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
@@ -142,8 +141,6 @@ pub(crate) struct IndexInfoInner {
     pub offset: usize,
     pub pubkey: Pubkey,
     pub lamports: u64,
-    pub rent_epoch: Epoch,
-    pub executable: bool,
     pub data_len: u64,
 }
 
@@ -985,8 +982,6 @@ impl AppendVec {
                     lamports: account.lamports(),
                     offset: account.offset(),
                     data_len: account.data_len(),
-                    executable: account.executable(),
-                    rent_epoch: account.rent_epoch(),
                 },
             });
         });
@@ -2287,8 +2282,6 @@ pub mod tests {
                     assert_eq!(index_info.index_info.offset, *offset);
                     assert_eq!(index_info.index_info.pubkey, *pubkey);
                     assert_eq!(index_info.index_info.lamports, account.lamports());
-                    assert_eq!(index_info.index_info.rent_epoch, account.rent_epoch());
-                    assert_eq!(index_info.index_info.executable, account.executable());
                     assert_eq!(index_info.index_info.data_len, account.data().len() as u64);
 
                     i += 1;

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -690,8 +690,6 @@ impl HotStorageReader {
                         lamports,
                         offset: AccountInfo::reduced_offset_to_offset(i),
                         data_len: data_len as u64,
-                        executable: meta.flags().executable(),
-                        rent_epoch: meta.final_rent_epoch(account_block),
                     }
                 },
                 stored_size_aligned: stored_size(data_len),


### PR DESCRIPTION
#### Problem

We no longer collect rents on mainnet since the activation of `disable_rent_collection` feature. However, we are still calculating the rent info/stats at index generation time. 

We should remove rent info/stats collection at index generation time. 


#### Summary of Changes

Remove rent info/stats collection at index generation.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
