### PR TITLE
PoH: track_transaction_indexes static after startup

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -559,7 +559,6 @@ fn main() {
                 &bank_forks,
                 &poh_recorder,
                 new_bank,
-                false,
             );
             bank = bank_forks.read().unwrap().working_bank_with_scheduler();
             assert_matches!(poh_recorder.read().unwrap().bank(), Some(_));

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -501,7 +501,6 @@ impl SimulatorLoop {
                     &self.bank_forks,
                     &self.poh_recorder,
                     new_bank,
-                    false,
                 );
                 (bank, bank_created) = (
                     self.bank_forks

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -674,13 +674,9 @@ pub(crate) fn update_bank_forks_and_poh_recorder_for_new_tpu_bank(
     bank_forks: &RwLock<BankForks>,
     poh_recorder: &RwLock<PohRecorder>,
     tpu_bank: Bank,
-    track_transaction_indexes: bool,
 ) {
     let tpu_bank = bank_forks.write().unwrap().insert(tpu_bank);
-    poh_recorder
-        .write()
-        .unwrap()
-        .set_bank(tpu_bank, track_transaction_indexes);
+    poh_recorder.write().unwrap().set_bank(tpu_bank);
 }
 
 #[cfg(test)]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1172,7 +1172,6 @@ impl ReplayStage {
                         &mut skipped_slots_info,
                         &banking_tracer,
                         has_new_vote_been_rooted,
-                        transaction_status_sender.is_some(),
                     );
 
                     let poh_bank = poh_recorder.read().unwrap().bank();
@@ -2095,7 +2094,6 @@ impl ReplayStage {
         skipped_slots_info: &mut SkippedSlotsInfo,
         banking_tracer: &Arc<BankingTracer>,
         has_new_vote_been_rooted: bool,
-        track_transaction_indexes: bool,
     ) -> bool {
         // all the individual calls to poh_recorder.read() are designed to
         // increase granularity, decrease contention
@@ -2226,12 +2224,7 @@ impl ReplayStage {
             // new()-ing of its child bank
             banking_tracer.hash_event(parent.slot(), &parent.last_blockhash(), &parent.hash());
 
-            update_bank_forks_and_poh_recorder_for_new_tpu_bank(
-                bank_forks,
-                poh_recorder,
-                tpu_bank,
-                track_transaction_indexes,
-            );
+            update_bank_forks_and_poh_recorder_for_new_tpu_bank(bank_forks, poh_recorder, tpu_bank);
             true
         } else {
             error!("{} No next leader found", my_pubkey);
@@ -8667,7 +8660,6 @@ pub(crate) mod tests {
         // A vote has not technically been rooted, but it doesn't matter for
         // this test to use true to avoid skipping the leader slot
         let has_new_vote_been_rooted = true;
-        let track_transaction_indexes = false;
 
         assert!(!ReplayStage::maybe_start_leader(
             my_pubkey,
@@ -8681,7 +8673,6 @@ pub(crate) mod tests {
             &mut SkippedSlotsInfo::default(),
             &banking_tracer,
             has_new_vote_been_rooted,
-            track_transaction_indexes,
         ));
     }
 
@@ -9322,7 +9313,6 @@ pub(crate) mod tests {
         // A vote has not technically been rooted, but it doesn't matter for
         // this test to use true to avoid skipping the leader slot
         let has_new_vote_been_rooted = true;
-        let track_transaction_indexes = false;
 
         // We should not attempt to start leader for the dummy_slot
         assert_matches!(
@@ -9341,7 +9331,6 @@ pub(crate) mod tests {
             &mut SkippedSlotsInfo::default(),
             &banking_tracer,
             has_new_vote_been_rooted,
-            track_transaction_indexes,
         ));
 
         // Register another slots worth of ticks  with PoH recorder
@@ -9368,7 +9357,6 @@ pub(crate) mod tests {
             &mut SkippedSlotsInfo::default(),
             &banking_tracer,
             has_new_vote_been_rooted,
-            track_transaction_indexes,
         ));
         // Get the new working bank, which is also the new leader bank/slot
         let working_bank = bank_forks.read().unwrap().working_bank();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -934,7 +934,7 @@ impl Validator {
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let startup_verification_complete;
-        let (poh_recorder, entry_receiver) = {
+        let (mut poh_recorder, entry_receiver) = {
             let bank = &bank_forks.read().unwrap().working_bank();
             startup_verification_complete = Arc::clone(bank.get_startup_verification_complete());
             PohRecorder::new_with_clear_signal(
@@ -951,6 +951,9 @@ impl Validator {
                 exit.clone(),
             )
         };
+        if transaction_status_sender.is_some() {
+            poh_recorder.track_transaction_indexes();
+        }
         let (record_sender, record_receiver) = unbounded();
         let transaction_recorder =
             TransactionRecorder::new(record_sender, poh_recorder.is_exited.clone());

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -281,7 +281,7 @@ fn test_scheduler_producing_blocks() {
     poh_recorder
         .write()
         .unwrap()
-        .set_bank(tpu_bank.clone_with_scheduler(), false);
+        .set_bank(tpu_bank.clone_with_scheduler());
     tpu_bank.unpause_new_block_production_scheduler();
     let tpu_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     assert_eq!(tpu_bank.transaction_count(), 0);

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -97,9 +97,10 @@ fn bench_poh_recorder_record_transaction_index(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
+    poh_recorder.track_transaction_indexes();
     let h1 = hash(b"hello Agave, hello Anza!");
 
-    poh_recorder.set_bank_with_transaction_index_for_test(bank.clone());
+    poh_recorder.set_bank_for_test(bank.clone());
     poh_recorder.tick();
     let txs: [SanitizedTransaction; 7] = [
         SanitizedTransaction::from_transaction_for_tests(test_tx()),
@@ -145,8 +146,9 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
+    poh_recorder.track_transaction_indexes();
     bencher.iter(|| {
-        poh_recorder.set_bank_with_transaction_index_for_test(bank.clone());
+        poh_recorder.set_bank_for_test(bank.clone());
         poh_recorder.tick();
         poh_recorder.clear_bank_for_test();
     });

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -57,10 +57,7 @@ fn bench_record_transactions(c: &mut Criterion) {
         &genesis_config_info.genesis_config.poh_config,
         exit.clone(),
     );
-    poh_recorder.set_bank(
-        BankWithScheduler::new_without_scheduler(bank.clone()),
-        false,
-    );
+    poh_recorder.set_bank(BankWithScheduler::new_without_scheduler(bank.clone()));
 
     let (record_sender, record_receiver) = crossbeam_channel::unbounded();
     let transaction_recorder = TransactionRecorder::new(record_sender, exit.clone());
@@ -103,10 +100,10 @@ fn bench_record_transactions(c: &mut Criterion) {
                     &Pubkey::default(),
                     bank.slot().wrapping_add(1),
                 ));
-                poh_recorder.write().unwrap().set_bank(
-                    BankWithScheduler::new_without_scheduler(bank.clone()),
-                    false,
-                );
+                poh_recorder
+                    .write()
+                    .unwrap()
+                    .set_bank(BankWithScheduler::new_without_scheduler(bank.clone()));
 
                 let start = Instant::now();
                 for txs in tx_batches {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -3686,7 +3686,7 @@ mod tests {
         poh_recorder
             .write()
             .unwrap()
-            .set_bank(bank.clone_with_scheduler(), true);
+            .set_bank(bank.clone_with_scheduler());
         bank.schedule_transaction_executions([(tx, ORIGINAL_TRANSACTION_INDEX)].into_iter())
             .unwrap();
         bank.unpause_new_block_production_scheduler();
@@ -3722,7 +3722,7 @@ mod tests {
         poh_recorder
             .write()
             .unwrap()
-            .set_bank(bank.clone_with_scheduler(), true);
+            .set_bank(bank.clone_with_scheduler());
         bank.unpause_new_block_production_scheduler();
 
         // Calling wait_for_completed_scheduler() for block production scheduler causes it to be


### PR DESCRIPTION
#### Problem
- `track_transaction_indexes` doesn't change from bank-to-bank, it's static after start up.
- PoH refactoring to have `set_bank` and `reset` be message-based for PoH improvements, don't want to include the bool on the messages unneccessarily 

#### Summary of Changes
- Store `track_transaction_indexes` on the PohRecorder
    - Set true by `track_transaction_indexes()` function, only when necessary
    - With upcoming changes, this `bool` will be moved to the channel between `PohService` and worker threads
