### PR TITLE
Make use of `StoredTransactionError` when converting between `TransactionError` and `generated::TransactionError`

### DIFF
--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -465,12 +465,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
         } = value;
-        let err = match status {
-            Ok(()) => None,
-            Err(err) => Some(generated::TransactionError {
-                err: bincode::serialize(&err).expect("transaction error to serialize to bytes"),
-            }),
-        };
+        let err = status.err().map(Into::into);
         let inner_instructions_none = inner_instructions.is_none();
         let inner_instructions = inner_instructions
             .unwrap_or_default()
@@ -559,9 +554,9 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
         } = value;
-        let status = match &err {
+        let status = match err {
             None => Ok(()),
-            Some(tx_error) => Err(bincode::deserialize(&tx_error.err)?),
+            Some(e) => Err(e.into()),
         };
         let inner_instructions = if inner_instructions_none {
             None


### PR DESCRIPTION
#### Problem

This is a follow-on from #6434 in which I wrote a newtype to help facilitate serialization/deserialization between `TransactionError` and `generated::TransactionError`, and wrote tests for it, but then forgot to actually use it.

#### Summary of Changes

Replace manual `deseriailze`/`serialize` calls in the code that converts `TransactionError` object for storage in blockstore with calls to `into()`.