### PR TITLE
deprecate `get_public_ip_addr` in favor of `get_public_ip_addr_with_binding`

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -41,6 +41,10 @@ pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;
 
 /// Determine the public IP address of this machine by asking an ip_echo_server at the given
 /// address.
+#[deprecated(
+    since = "3.0.0",
+    note = "Use `get_public_ip_addr_with_binding` instead"
+)]
 pub fn get_public_ip_addr(ip_echo_server_addr: &SocketAddr) -> Result<IpAddr, String> {
     let fut = ip_echo_server_request(*ip_echo_server_addr, IpEchoServerMessage::default());
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -791,7 +795,11 @@ mod tests {
 
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
-            get_public_ip_addr(&server_ip_echo_addr).unwrap(),
+            get_public_ip_addr_with_binding(
+                &server_ip_echo_addr,
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+            )
+            .unwrap(),
             parse_host("127.0.0.1").unwrap(),
         );
         assert_eq!(get_cluster_shred_version(&server_ip_echo_addr).unwrap(), 42);
@@ -818,7 +826,11 @@ mod tests {
 
         let ip_echo_server_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
-            get_public_ip_addr(&ip_echo_server_addr).unwrap(),
+            get_public_ip_addr_with_binding(
+                &ip_echo_server_addr,
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+            )
+            .unwrap(),
             parse_host("127.0.0.1").unwrap(),
         );
         assert_eq!(
@@ -913,7 +925,11 @@ mod tests {
         );
 
         assert_eq!(
-            get_public_ip_addr(&ip_echo_server_addr).unwrap(),
+            get_public_ip_addr_with_binding(
+                &ip_echo_server_addr,
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+            )
+            .unwrap(),
             parse_host("127.0.0.1").unwrap(),
         );
 


### PR DESCRIPTION
#### Problem
For multihoming support, we need to know specifically what IP address we are using with these functions. As a result, we do not need `get_public_ip_addr()` anymore.

#### Summary of Changes
deprecate `get_public_ip_addr`

