### PR TITLE
validator: Adjust --wait-for-exit message on non-linux

### DIFF
--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -190,8 +190,8 @@ fn poll_until_pid_terminates(pid: u32) -> Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn poll_until_pid_terminates(pid: u32) -> Result<()> {
-    println!("Unable to monitor agave-validator process {pid} on this platform");
+fn poll_until_pid_terminates(_pid: u32) -> Result<()> {
+    println!("Unable to wait for agave-validator process termination on this platform");
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem
The validator exit command can have --monitor OR --wait-for-exit specified. The functionality for --wait-for-exit is only supported on linux, and the error message for the non-linux codepath uses the term "monitor"

#### Summary of Changes
Given that the other option is called monitor, this is potentially confusing. So, adjust the message output by --wait-for-exit to use "wait" instead of "monitor"

Follow-on to https://github.com/anza-xyz/agave/pull/6233; pointed out at https://github.com/anza-xyz/agave/pull/6706#discussion_r2162574343