### PR TITLE
Fix - Direct mapping CPI caller privilege escalation after ownership transfer

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1184,6 +1184,8 @@ fn update_callee_account(
     // Change the owner at the end so that we are allowed to change the lamports and data before
     if callee_account.get_owner() != caller_account.owner {
         callee_account.set_owner(caller_account.owner.as_ref())?;
+        // caller gave ownership and thus write access away, so caller must be updated
+        must_update_caller = true;
     }
 
     Ok(must_update_caller)

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -881,11 +881,12 @@ where
                 direct_mapping,
             )?;
 
-            let caller_account = if instruction_account.is_writable || update_caller {
-                Some(caller_account)
-            } else {
-                None
-            };
+            let caller_account =
+                if instruction_account.is_writable || (direct_mapping && update_caller) {
+                    Some(caller_account)
+                } else {
+                    None
+                };
             accounts.push((instruction_account.index_in_caller, caller_account));
         } else {
             ic_msg!(

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -742,7 +742,7 @@ fn process_instruction<'a>(
                 &create_instruction(
                     *invoked_program_id,
                     &[
-                        (accounts[ARGUMENT_INDEX].key, true, false),
+                        (accounts[ARGUMENT_INDEX].key, false, false),
                         (invoked_program_id, false, false),
                     ],
                     vec![RETURN_OK],


### PR DESCRIPTION
#### Problem

In the original direct mapping implementation a CPI caller can transfer the ownership of an account to a callee before CPI, pass it as a read-only instruction account to a callee during CPI, and then after CPI returns, it is still possible for the caller to write to the account it no longer owns.

Credit for finding this goes to Felix Wilhelm and for testing it goes to Troy Sargent.

#### Summary of Changes

First demonstrates the issue by slightly adjusting `TEST_FORBID_WRITE_AFTER_OWNERSHIP_CHANGE_IN_CALLER`. Then fixes the issue in `update_callee_account()` by setting `must_update_caller` if the owner changes on the CPI call edge.