### PR TITLE
Adds logs when building the accounts index begins and ends

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -49,6 +49,7 @@ use {
             Arc,
         },
         thread::Builder,
+        time::Instant,
     },
     storage::SerializableStorage,
     types::SerdeAccountsLtHash,
@@ -1246,6 +1247,8 @@ where
     // This means, either when the cli arg is set, or when the snapshot has an accounts lt hash.
     let is_accounts_lt_hash_enabled =
         accounts_db.is_experimental_accumulator_hash_enabled() || has_accounts_lt_hash;
+    info!("Building accounts index...");
+    let start = Instant::now();
     let IndexGenerationInfo {
         accounts_data_len,
         rent_paying_accounts_by_partition,
@@ -1256,6 +1259,7 @@ where
         genesis_config,
         is_accounts_lt_hash_enabled,
     );
+    info!("Building accounts index... Done in {:?}", start.elapsed());
     accounts_db
         .accounts_index
         .rent_paying_accounts_by_partition


### PR DESCRIPTION
#### Problem

I'd like a log to grep for to know when index generation both begins and ends. This currently does not exist. We do have a datapoint when index generation ends, but not explicitly when it begins.


#### Summary of Changes

Add logs before and after, similar to the initial background accounts verification logs.