### PR TITLE
Removes RentPayingAccountsByPartition

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -57,7 +57,6 @@ use {
             UpsertReclaim, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
         },
         accounts_index_storage::Startup,
-        accounts_partition::RentPayingAccountsByPartition,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
@@ -567,7 +566,6 @@ pub enum ScanStorageResult<R, B> {
 #[derive(Debug, Default)]
 pub struct IndexGenerationInfo {
     pub accounts_data_len: u64,
-    pub rent_paying_accounts_by_partition: RentPayingAccountsByPartition,
     /// The lt hash of the old/duplicate accounts identified during index generation.
     /// Will be used when verifying the accounts lt hash, after rebuilding a Bank.
     pub duplicates_lt_hash: Option<Box<DuplicatesLtHash>>,
@@ -7958,8 +7956,6 @@ impl AccountsDb {
         );
         let accounts_data_len = AtomicU64::new(0);
 
-        let rent_paying_accounts_by_partition =
-            Mutex::new(RentPayingAccountsByPartition::new(schedule));
         let zero_lamport_pubkeys = Mutex::new(HashSet::new());
         let mut outer_duplicates_lt_hash = None;
 
@@ -8321,9 +8317,6 @@ impl AccountsDb {
 
         IndexGenerationInfo {
             accounts_data_len: accounts_data_len.load(Ordering::Relaxed),
-            rent_paying_accounts_by_partition: rent_paying_accounts_by_partition
-                .into_inner()
-                .unwrap(),
             duplicates_lt_hash: outer_duplicates_lt_hash,
         }
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -6,7 +6,6 @@ mod secondary;
 use {
     crate::{
         accounts_index_storage::{AccountsIndexStorage, Startup},
-        accounts_partition::RentPayingAccountsByPartition,
         ancestors::Ancestors,
         bucket_map_holder::Age,
         bucket_map_holder_stats::BucketMapHolderStats,
@@ -40,7 +39,7 @@ use {
         path::PathBuf,
         sync::{
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-            Arc, Mutex, OnceLock, RwLock,
+            Arc, Mutex, RwLock,
         },
     },
     thiserror::Error,
@@ -315,9 +314,6 @@ pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub active_scans: AtomicUsize,
     /// # of slots between latest max and latest scan
     pub max_distance_to_min_scan_slot: AtomicU64,
-
-    /// populated at generate_index time - accounts that could possibly be rent paying
-    pub rent_paying_accounts_by_partition: OnceLock<RentPayingAccountsByPartition>,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
@@ -350,7 +346,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             roots_removed: AtomicUsize::default(),
             active_scans: AtomicUsize::default(),
             max_distance_to_min_scan_slot: AtomicU64::default(),
-            rent_paying_accounts_by_partition: OnceLock::default(),
         }
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1251,7 +1251,6 @@ where
     let start = Instant::now();
     let IndexGenerationInfo {
         accounts_data_len,
-        rent_paying_accounts_by_partition,
         duplicates_lt_hash,
     } = accounts_db.generate_index(
         limit_load_slot_count_from_snapshot,
@@ -1260,11 +1259,6 @@ where
         is_accounts_lt_hash_enabled,
     );
     info!("Building accounts index... Done in {:?}", start.elapsed());
-    accounts_db
-        .accounts_index
-        .rent_paying_accounts_by_partition
-        .set(rent_paying_accounts_by_partition)
-        .unwrap();
 
     handle.join().unwrap();
     measure_notify.stop();


### PR DESCRIPTION
#### Problem

There are no more rent-paying accounts. We can clean up that code.

For this PR, we no longer need RentPayingAccountsByPartition, as we do not populate it during index generation anymore (as of #6700).


#### Summary of Changes

Removes RentPayingAccountsByPartition