### PR TITLE
Removes cluster-type from snapshot integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -98,19 +98,7 @@ filter = 'package(solana-core) & test(/^banking_stage::consumer::tests::test_ban
 slow-timeout = { period = "60s", terminate-after = 8 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_development_expects/)'
-slow-timeout = { period = "60s", terminate-after = 2 }
-
-[[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_testnet_expects/)'
-slow-timeout = { period = "60s", terminate-after = 2 }
-
-[[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_devnet_expects/)'
-slow-timeout = { period = "60s", terminate-after = 2 }
-
-[[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_slots_to_snapshot::v1_2_0_mainnetbeta_expects/)'
+filter = 'package(solana-core) & test(/^test_slots_to_snapshot/)'
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -14,10 +14,7 @@ use {
         accounts_hash_verifier::AccountsHashVerifier,
         snapshot_packager_service::{PendingSnapshotPackages, SnapshotPackagerService},
     },
-    solana_genesis_config::{
-        ClusterType::{self, Development, Devnet, MainnetBeta, Testnet},
-        GenesisConfig,
-    },
+    solana_genesis_config::GenesisConfig,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -75,7 +72,6 @@ struct SnapshotTestConfig {
 impl SnapshotTestConfig {
     fn new(
         snapshot_version: SnapshotVersion,
-        cluster_type: ClusterType,
         full_snapshot_archive_interval: SnapshotInterval,
         incremental_snapshot_archive_interval: SnapshotInterval,
     ) -> SnapshotTestConfig {
@@ -87,12 +83,11 @@ impl SnapshotTestConfig {
         // account will not be stored in accounts-db but still cached in
         // bank stakes which results in mismatch when banks are loaded from
         // snapshots.
-        let mut genesis_config_info = create_genesis_config_with_leader(
+        let genesis_config_info = create_genesis_config_with_leader(
             10_000,                     // mint_lamports
             &solana_pubkey::new_rand(), // validator_pubkey
             1,                          // validator_stake_lamports
         );
-        genesis_config_info.genesis_config.cluster_type = cluster_type;
         let bank0 = Bank::new_with_paths_for_tests(
             &genesis_config_info.genesis_config,
             Arc::<RuntimeConfig>::default(),
@@ -178,7 +173,6 @@ fn restore_from_snapshot(
 // `last_slot` bank
 fn run_bank_forks_snapshot_n<F>(
     snapshot_version: SnapshotVersion,
-    cluster_type: ClusterType,
     last_slot: Slot,
     f: F,
     set_root_interval: u64,
@@ -189,7 +183,6 @@ fn run_bank_forks_snapshot_n<F>(
     // Set up snapshotting config
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
-        cluster_type,
         SnapshotInterval::Slots(NonZeroU64::new(set_root_interval).unwrap()),
         SnapshotInterval::Disabled,
     );
@@ -261,16 +254,12 @@ fn run_bank_forks_snapshot_n<F>(
     );
 }
 
-#[test_case(V1_2_0, Development)]
-#[test_case(V1_2_0, Devnet)]
-#[test_case(V1_2_0, Testnet)]
-#[test_case(V1_2_0, MainnetBeta)]
-fn test_bank_forks_snapshot(snapshot_version: SnapshotVersion, cluster_type: ClusterType) {
+#[test_case(V1_2_0)]
+fn test_bank_forks_snapshot(snapshot_version: SnapshotVersion) {
     // create banks up to slot 4 and create 1 new account in each bank. test that bank 4 snapshots
     // and restores correctly
     run_bank_forks_snapshot_n(
         snapshot_version,
-        cluster_type,
         4,
         |bank, mint_keypair| {
             let key1 = Keypair::new().pubkey();
@@ -297,11 +286,8 @@ fn goto_end_of_slot(bank: &Bank) {
     }
 }
 
-#[test_case(V1_2_0, Development)]
-#[test_case(V1_2_0, Devnet)]
-#[test_case(V1_2_0, Testnet)]
-#[test_case(V1_2_0, MainnetBeta)]
-fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: ClusterType) {
+#[test_case(V1_2_0)]
+fn test_slots_to_snapshot(snapshot_version: SnapshotVersion) {
     solana_logger::setup();
     let num_set_roots = MAX_CACHE_ENTRIES * 2;
 
@@ -310,7 +296,6 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         // Make sure this test never clears bank.slots_since_snapshot
         let snapshot_test_config = SnapshotTestConfig::new(
             snapshot_version,
-            cluster_type,
             SnapshotInterval::Slots(
                 NonZeroU64::new((*add_root_interval * num_set_roots * 2) as Slot).unwrap(),
             ),
@@ -379,14 +364,8 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
     }
 }
 
-#[test_case(V1_2_0, Development)]
-#[test_case(V1_2_0, Devnet)]
-#[test_case(V1_2_0, Testnet)]
-#[test_case(V1_2_0, MainnetBeta)]
-fn test_bank_forks_status_cache_snapshot(
-    snapshot_version: SnapshotVersion,
-    cluster_type: ClusterType,
-) {
+#[test_case(V1_2_0)]
+fn test_bank_forks_status_cache_snapshot(snapshot_version: SnapshotVersion) {
     // create banks up to slot (MAX_CACHE_ENTRIES * 2) + 1 while transferring 1 lamport into 2 different accounts each time
     // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
     // ahead. Also tests the status_cache purge and status cache snapshotting.
@@ -396,7 +375,6 @@ fn test_bank_forks_status_cache_snapshot(
     for set_root_interval in &[1, 4] {
         run_bank_forks_snapshot_n(
             snapshot_version,
-            cluster_type,
             (MAX_CACHE_ENTRIES * 2) as u64,
             |bank, mint_keypair| {
                 let tx = system_transaction::transfer(
@@ -420,14 +398,8 @@ fn test_bank_forks_status_cache_snapshot(
     }
 }
 
-#[test_case(V1_2_0, Development)]
-#[test_case(V1_2_0, Devnet)]
-#[test_case(V1_2_0, Testnet)]
-#[test_case(V1_2_0, MainnetBeta)]
-fn test_bank_forks_incremental_snapshot(
-    snapshot_version: SnapshotVersion,
-    cluster_type: ClusterType,
-) {
+#[test_case(V1_2_0)]
+fn test_bank_forks_incremental_snapshot(snapshot_version: SnapshotVersion) {
     solana_logger::setup();
 
     const SET_ROOT_INTERVAL: Slot = 2;
@@ -447,7 +419,6 @@ fn test_bank_forks_incremental_snapshot(
 
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
-        cluster_type,
         SnapshotInterval::Slots(NonZeroU64::new(FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS).unwrap()),
         SnapshotInterval::Slots(
             NonZeroU64::new(INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS).unwrap(),
@@ -645,13 +616,11 @@ enum VerifySnapshotHashKind {
 /// Spin up the background services fully then test taking & verifying snapshots
 #[test_matrix(
     V1_2_0,
-    [Development, Devnet, Testnet, MainnetBeta],
     [VerifyAccountsKind::Merkle, VerifyAccountsKind::Lattice],
     [VerifySnapshotHashKind::Merkle, VerifySnapshotHashKind::Lattice]
 )]
 fn test_snapshots_with_background_services(
     snapshot_version: SnapshotVersion,
-    cluster_type: ClusterType,
     verify_accounts_kind: VerifyAccountsKind,
     verify_snapshot_hash_kind: VerifySnapshotHashKind,
 ) {
@@ -686,7 +655,6 @@ fn test_snapshots_with_background_services(
 
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
-        cluster_type,
         SnapshotInterval::Slots(NonZeroU64::new(FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS).unwrap()),
         SnapshotInterval::Slots(
             NonZeroU64::new(INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS).unwrap(),


### PR DESCRIPTION
#### Problem

The snapshot integration tests are run multiple times, once per cluster type. However, cluster type does not impact snapshots.

There can be differences in snapshots depending on feature gates (and if the genesis config defaults to features enabled vs disabled), but I'd argue that feature testing should be handled explicitly, not in these generic snapshot tests. (For an example of this testing, see accounts lattice hash and its tests for SIMD-215 and SIMD-220.)


#### Summary of Changes

Removes per-cluster runs of the snapshot integration tests.