### PR TITLE
Updates ReadOnlyAccountsHash::remove_assume_not_present() to take pubkey by reference

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7651,7 +7651,7 @@ impl AccountsDb {
                 // based on the patterns of how a validator writes accounts, it is almost always the case that there is no read only cache entry
                 // for this pubkey and slot. So, we can give that hint to the `remove` for performance.
                 self.read_only_accounts_cache
-                    .remove_assume_not_present(*accounts.pubkey(index));
+                    .remove_assume_not_present(accounts.pubkey(index));
             });
         }
 

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -211,15 +211,17 @@ impl ReadOnlyAccountsCache {
 
     /// remove entry if it exists.
     /// Assume the entry does not exist for performance.
-    pub(crate) fn remove_assume_not_present(&self, pubkey: Pubkey) -> Option<AccountSharedData> {
+    pub(crate) fn remove_assume_not_present(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         // get read lock first to see if the entry exists
-        _ = self.cache.get(&pubkey)?;
-        self.remove(pubkey)
+        self.cache
+            .contains_key(pubkey)
+            .then(|| self.remove(pubkey))
+            .flatten()
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    pub(crate) fn remove(&self, pubkey: Pubkey) -> Option<AccountSharedData> {
-        Self::do_remove(&pubkey, &self.cache, &self.data_size).map(|entry| entry.account)
+    pub(crate) fn remove(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        Self::do_remove(pubkey, &self.cache, &self.data_size).map(|entry| entry.account)
     }
 
     /// Removes `key` from the cache, if present, and returns the account entry.


### PR DESCRIPTION
#### Problem

`ReadOnlyAccountsHash::remove_assume_not_present()` takes the pubkey parameter by value.


#### Summary of Changes

Change it to a reference.