### PR TITLE
validator: Revert --wait-for-exit flag on exit subcommand

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -27,7 +27,6 @@ jsonrpc-core = { workspace = true }
 jsonrpc-core-client = { workspace = true, features = ["ipc"] }
 jsonrpc-derive = { workspace = true }
 jsonrpc-ipc-server = { workspace = true }
-libc = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -190,8 +190,8 @@ fn poll_until_pid_terminates(pid: u32) -> Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn poll_until_pid_terminates(_pid: u32) -> Result<()> {
-    println!("Unable to wait for agave-validator process termination on this platform");
+fn poll_until_pid_terminates(pid: u32) -> Result<()> {
+    println!("Unable to monitor agave-validator process {pid} on this platform");
     Ok(())
 }
 

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "linux")]
-use {crate::commands::Error, std::io, std::thread, std::time::Duration};
 use {
     crate::{
         admin_rpc_service,
@@ -16,17 +14,9 @@ const DEFAULT_MIN_IDLE_TIME: &str = "10";
 const DEFAULT_MAX_DELINQUENT_STAKE: &str = "5";
 
 #[derive(Debug, PartialEq)]
-pub enum PostExitAction {
-    // Run the agave-validator monitor command indefinitely
-    Monitor,
-    // Block until the exiting validator process has terminated
-    Wait,
-}
-
-#[derive(Debug, PartialEq)]
 pub struct ExitArgs {
     pub force: bool,
-    pub post_exit_action: Option<PostExitAction>,
+    pub monitor: bool,
     pub min_idle_time: usize,
     pub max_delinquent_stake: u8,
     pub skip_new_snapshot_check: bool,
@@ -35,17 +25,9 @@ pub struct ExitArgs {
 
 impl FromClapArgMatches for ExitArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
-        let post_exit_action = if matches.is_present("monitor") {
-            Some(PostExitAction::Monitor)
-        } else if matches.is_present("wait_for_exit") {
-            Some(PostExitAction::Wait)
-        } else {
-            None
-        };
-
         Ok(ExitArgs {
             force: matches.is_present("force"),
-            post_exit_action,
+            monitor: matches.is_present("monitor"),
             min_idle_time: value_t_or_exit!(matches, "min_idle_time", usize),
             max_delinquent_stake: value_t_or_exit!(matches, "max_delinquent_stake", u8),
             skip_new_snapshot_check: matches.is_present("skip_new_snapshot_check"),
@@ -72,12 +54,6 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .long("monitor")
                 .takes_value(false)
                 .help("Monitor the validator after sending the exit request"),
-        )
-        .arg(
-            Arg::with_name("wait_for_exit")
-                .long("wait-for-exit")
-                .conflicts_with("monitor")
-                .help("Wait for the validator to terminate after sending the exit request"),
         )
         .arg(
             Arg::with_name("min_idle_time")
@@ -126,72 +102,13 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     }
 
     let admin_client = admin_rpc_service::connect(ledger_path);
-    let validator_pid =
-        admin_rpc_service::runtime().block_on(async move { admin_client.await?.exit().await })?;
-
+    admin_rpc_service::runtime().block_on(async move { admin_client.await?.exit().await })?;
     println!("Exit request sent");
 
-    match exit_args.post_exit_action {
-        None => Ok(()),
-        Some(PostExitAction::Monitor) => monitor::execute(matches, ledger_path),
-        Some(PostExitAction::Wait) => poll_until_pid_terminates(validator_pid),
-    }?;
-
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn poll_until_pid_terminates(pid: u32) -> Result<()> {
-    let pid = i32::try_from(pid)?;
-
-    println!("Waiting for agave-validator process {pid} to terminate");
-    loop {
-        // From man kill(2)
-        //
-        // If sig is 0, then no signal is sent, but existence and permission
-        // checks are still performed; this can be used to check for the
-        // existence of a process ID or process group ID that the caller is
-        // permitted to signal.
-        let result = unsafe {
-            libc::kill(pid, /*sig:*/ 0)
-        };
-        if result >= 0 {
-            // Give the process some time to exit before checking again
-            thread::sleep(Duration::from_millis(500));
-        } else {
-            let errno = io::Error::last_os_error()
-                .raw_os_error()
-                .ok_or(Error::Dynamic("unable to read raw os error".into()))?;
-            match errno {
-                libc::ESRCH => {
-                    println!("Done, agave-validator process {pid} has terminated");
-                    break;
-                }
-                libc::EINVAL => {
-                    // An invalid signal was specified, we only pass sig=0 so
-                    // this should not be possible
-                    Err(Error::Dynamic(
-                        format!("unexpected invalid signal error for kill({pid}, 0)").into(),
-                    ))?;
-                }
-                libc::EPERM => {
-                    Err(io::Error::from(io::ErrorKind::PermissionDenied))?;
-                }
-                unknown => {
-                    Err(Error::Dynamic(
-                        format!("unexpected errno for kill({pid}, 0): {unknown}").into(),
-                    ))?;
-                }
-            }
-        }
+    if exit_args.monitor {
+        monitor::execute(matches, ledger_path)?;
     }
 
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn poll_until_pid_terminates(pid: u32) -> Result<()> {
-    println!("Unable to monitor agave-validator process {pid} on this platform");
     Ok(())
 }
 
@@ -209,7 +126,7 @@ mod tests {
                     .parse()
                     .expect("invalid DEFAULT_MAX_DELINQUENT_STAKE"),
                 force: false,
-                post_exit_action: None,
+                monitor: false,
                 skip_new_snapshot_check: false,
                 skip_health_check: false,
             }
@@ -234,21 +151,12 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_exit_with_post_exit_action() {
+    fn verify_args_struct_by_command_exit_with_monitor() {
         verify_args_struct_by_command(
             command(),
             vec![COMMAND, "--monitor"],
             ExitArgs {
-                post_exit_action: Some(PostExitAction::Monitor),
-                ..ExitArgs::default()
-            },
-        );
-
-        verify_args_struct_by_command(
-            command(),
-            vec![COMMAND, "--wait-for-exit"],
-            ExitArgs {
-                post_exit_action: Some(PostExitAction::Wait),
+                monitor: true,
                 ..ExitArgs::default()
             },
         );

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -27,9 +27,6 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
-
-    #[error(transparent)]
-    TryFromInt(#[from] std::num::TryFromIntError),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
#### Problem
Copied form https://github.com/anza-xyz/agave/pull/6706#issuecomment-3001085356:

- The new AdminRpc exit function now returns a u32 (the PID)
- Regardless of whether someone is using the flag or not, exit is called
- When someone goes from "binary that didn't return PID" to "binary that does return PID", they'll error out on this line since the RPC response will look to be malformed (Ie lacking the u32):

#### Summary of Changes
This is breaking our automation at the very least, so I'm backing the change out. Namely, this backs out #6233 and #6708.

I plan to re-add this change, but will do so by making a separate RPC call to get the pid, and I will warn instead of error if we are unable to get the pid. This will make the upgrade case a little friendlier