### PR TITLE
v2.2: Patch transaction-context to fix crate resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-unified-scheduler-pool",
@@ -6286,7 +6286,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-program",
  "static_assertions",
  "strum",
@@ -6333,7 +6333,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "thiserror 2.0.11",
 ]
 
@@ -6402,7 +6402,7 @@ dependencies = [
  "solana-program",
  "solana-runtime",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -6416,7 +6416,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
 ]
 
@@ -6648,7 +6648,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "static_assertions",
  "test-case",
@@ -6976,7 +6976,7 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote-program",
@@ -7212,7 +7212,7 @@ dependencies = [
  "solana-signer",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -8178,7 +8178,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -8294,7 +8294,7 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -8897,7 +8897,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "test-case",
  "thiserror 2.0.11",
@@ -8934,7 +8934,7 @@ dependencies = [
  "solana-stake-program",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-program",
  "test-case",
  "thiserror 2.0.11",
@@ -9190,7 +9190,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -9436,7 +9436,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -9573,7 +9573,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.1",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
  "thiserror 2.0.11",
@@ -9884,7 +9884,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
  "solana-vote-program",
@@ -9939,7 +9939,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.11",
@@ -9966,7 +9966,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -10092,7 +10092,7 @@ dependencies = [
  "solana-sysvar",
  "solana-timings",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "test-case",
@@ -10113,7 +10113,7 @@ name = "solana-svm-rent-collector"
 version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -10176,7 +10176,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -10492,22 +10492,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-signature",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.2.18"
 dependencies = [
  "bincode",
@@ -10521,7 +10505,7 @@ dependencies = [
  "solana-rent",
  "solana-signature",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "static_assertions",
 ]
 
@@ -10643,7 +10627,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
@@ -10928,7 +10912,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -659,4 +659,5 @@ crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
 solana-curve25519 = { path = "curves/curve25519" }
+solana-transaction-context = { path = "transaction-context" }
 solana-zk-sdk = { path = "zk-sdk" }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5164,7 +5164,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5207,7 +5207,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "thiserror 2.0.11",
 ]
 
@@ -5229,7 +5229,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5243,7 +5243,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
 ]
 
@@ -5382,7 +5382,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
@@ -5694,7 +5694,7 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -6434,7 +6434,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6530,7 +6530,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -6979,7 +6979,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
@@ -7014,7 +7014,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -7250,7 +7250,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7417,7 +7417,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7498,7 +7498,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-type-overrides",
  "solana-vote",
@@ -8042,7 +8042,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.1",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
  "thiserror 2.0.11",
@@ -8322,7 +8322,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
@@ -8384,7 +8384,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -8475,7 +8475,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -8486,7 +8486,7 @@ name = "solana-svm-rent-collector"
 version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -8537,7 +8537,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -8748,22 +8748,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-signature",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.2.18"
 dependencies = [
  "bincode",
@@ -8859,7 +8843,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
@@ -9058,7 +9042,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -255,4 +255,5 @@ name = "bpf_loader"
 # There is a similar override in `../../Cargo.toml`.  Please keep both comments
 # and the overrides in sync.
 solana-curve25519 = { path = "../../curves/curve25519" }
+solana-transaction-context = { path = "../../transaction-context" }
 solana-zk-sdk = { path = "../../zk-sdk" }

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -2723,7 +2723,7 @@ dependencies = [
  "solana-sdk",
  "solana-svm",
  "solana-system-program",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-version",
  "spl-token-2022 7.0.0",
@@ -5031,7 +5031,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5074,7 +5074,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "thiserror 2.0.11",
 ]
 
@@ -5096,7 +5096,7 @@ dependencies = [
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
  "thiserror 2.0.11",
  "tokio",
@@ -5110,7 +5110,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "tarpc",
 ]
 
@@ -5249,7 +5249,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
@@ -5561,7 +5561,7 @@ dependencies = [
  "solana-short-vec",
  "solana-stake-interface",
  "solana-system-interface",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -6267,7 +6267,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6363,7 +6363,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -6812,7 +6812,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "thiserror 2.0.11",
 ]
@@ -6847,7 +6847,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-program",
  "thiserror 2.0.11",
  "tokio",
@@ -7083,7 +7083,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7249,7 +7249,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7371,7 +7371,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context 2.2.1",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
  "thiserror 2.0.11",
@@ -7651,7 +7651,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
  "solana-vote-interface",
 ]
@@ -7713,7 +7713,7 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-build",
@@ -7803,7 +7803,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "solana-type-overrides",
  "thiserror 2.0.11",
@@ -7833,7 +7833,7 @@ name = "solana-svm-rent-collector"
 version = "2.2.18"
 dependencies = [
  "solana-sdk",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -7884,7 +7884,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface",
  "solana-sysvar",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-type-overrides",
 ]
 
@@ -8095,22 +8095,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-signature",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "2.2.18"
 dependencies = [
  "bincode",
@@ -8206,7 +8190,7 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.11",
 ]
@@ -8404,7 +8388,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
- "solana-transaction-context 2.2.18",
+ "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.11",
 ]

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -56,4 +56,5 @@ yaml-rust = "0.4"
 [patch.crates-io]
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
 solana-curve25519 = { path = "../../curves/curve25519" }
+solana-transaction-context = { path = "../../transaction-context" }
 solana-zk-sdk = { path = "../../zk-sdk" }

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,6 +16,7 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
+debug-signature = []
 dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils"]
 serde = ["dep:serde", "dep:serde_derive"]
 


### PR DESCRIPTION
#### Problem

It isn't possible to publish crates because the build step fails. During crate resolution, solana-sdk depends on solana-transaction-context with the debug-signature feature, but it no longer exists.

#### Summary of changes

Add back the debug-signature feature, and patch solana-transaction-context in all lockfiles to avoid bringing in two versions of the crate.

NOTE: This isn't required in v2.3 or master because there's no more dependency on solana-sdk.

ALSO NOTE: I can't test this because it requires a new version of `solana-transaction-context` to be published with the feature back in, but I have a good feeling that it'll work.