### PR TITLE
ledger: Check whether the shred is resigned before calling `resign_shred`

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib"]
 name = "solana_ledger"
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-perf/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -407,7 +407,7 @@ impl Shred {
     dispatch!(pub(crate) fn erasure_shard(&self) -> Result<&[u8], Error>);
     // Returns the shard index within the erasure coding set.
     dispatch!(pub(crate) fn erasure_shard_index(&self) -> Result<usize, Error>);
-    dispatch!(pub fn retransmitter_signature(&self) -> Result<Signature, Error>);
+    dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);
 
     dispatch!(pub fn into_payload(self) -> Payload);
     dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
@@ -654,20 +654,7 @@ impl Shred {
         get_payload(self) != get_payload(other)
     }
 
-    pub fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
-        match self {
-            Self::ShredCode(ShredCode::Merkle(shred)) => {
-                shred.set_retransmitter_signature(signature)
-            }
-            Self::ShredData(ShredData::Merkle(shred)) => {
-                shred.set_retransmitter_signature(signature)
-            }
-            Self::ShredCode(ShredCode::Legacy(_)) => Err(Error::InvalidShredVariant),
-            Self::ShredData(ShredData::Legacy(_)) => Err(Error::InvalidShredVariant),
-        }
-    }
-
-    pub fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
+    fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
         match self {
             Self::ShredCode(ShredCode::Merkle(shred)) => shred.retransmitter_signature_offset(),
             Self::ShredData(ShredData::Merkle(shred)) => shred.retransmitter_signature_offset(),

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -423,7 +423,7 @@ macro_rules! impl_merkle_shred {
                 .ok_or(Error::InvalidPayloadSize(self.payload.len()))
         }
 
-        fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
+        pub fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
             let offset = self.retransmitter_signature_offset()?;
             let Some(buffer) = self.payload.get_mut(offset..offset + SIZE_OF_SIGNATURE) else {
                 return Err(Error::InvalidPayloadSize(self.payload.len()));

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -423,7 +423,7 @@ macro_rules! impl_merkle_shred {
                 .ok_or(Error::InvalidPayloadSize(self.payload.len()))
         }
 
-        pub fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
+        fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
             let offset = self.retransmitter_signature_offset()?;
             let Some(buffer) = self.payload.get_mut(offset..offset + SIZE_OF_SIGNATURE) else {
                 return Err(Error::InvalidPayloadSize(self.payload.len()));

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -2,7 +2,6 @@ use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
-
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {
     crate::shred::Nonce,

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -489,16 +489,17 @@ mod tests {
         for shred in shreds.iter_mut() {
             let keypair = Keypair::new();
             let signature = make_dummy_signature(&mut rng);
+            let nonce = repaired.then(|| rng.gen::<Nonce>());
             if chained && is_last_in_slot {
                 shred.set_retransmitter_signature(&signature).unwrap();
 
-                let packet = &mut shred.payload().to_packet();
+                let packet = &mut shred.payload().to_packet(nonce);
                 if repaired {
                     packet.meta_mut().flags |= PacketFlags::REPAIR;
                 }
                 resign_packet(&mut packet.into(), &keypair).unwrap();
 
-                let packet = &mut shred.payload().to_bytes_packet();
+                let packet = &mut shred.payload().to_bytes_packet(nonce);
                 if repaired {
                     packet.meta_mut().flags |= PacketFlags::REPAIR;
                 }
@@ -509,7 +510,7 @@ mod tests {
                     Err(Error::InvalidShredVariant)
                 );
 
-                let packet = &mut shred.payload().to_packet();
+                let packet = &mut shred.payload().to_packet(nonce);
                 if repaired {
                     packet.meta_mut().flags |= PacketFlags::REPAIR;
                 }
@@ -518,7 +519,7 @@ mod tests {
                     Err(Error::InvalidShredVariant)
                 );
 
-                let packet = &mut shred.payload().to_bytes_packet();
+                let packet = &mut shred.payload().to_bytes_packet(nonce);
                 if repaired {
                     packet.meta_mut().flags |= PacketFlags::REPAIR;
                 }
@@ -555,7 +556,7 @@ mod tests {
         }
         for shred in &shreds {
             let nonce = repaired.then(|| rng.gen::<Nonce>());
-            let mut packet = shred.payload().to_packet();
+            let mut packet = shred.payload().to_packet(nonce);
             if repaired {
                 packet.meta_mut().flags |= PacketFlags::REPAIR;
             }

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -43,17 +43,8 @@ where
 }
 
 #[inline]
-pub fn get_shred_mut<'a>(packet: &'a mut PacketRefMut) -> Option<&'a mut [u8]> {
-    // This function is used only in turbine for re-signing shreds.
-    match packet {
-        // Currently, turbine uses only `Packet`, which allows mutability.
-        PacketRefMut::Packet(packet) => {
-            let buffer = packet.buffer_mut();
-            buffer.get_mut(..get_shred_size(buffer)?)
-        }
-        // `BytesPacket` is immutable, but not used in turbine.
-        PacketRefMut::Bytes(_) => unreachable!("`BytesPacket` is not used in turbine"),
-    }
+pub fn get_shred_mut(buffer: &mut [u8]) -> Option<&mut [u8]> {
+    buffer.get_mut(..get_shred_size(buffer)?)
 }
 
 #[inline]
@@ -303,7 +294,7 @@ pub fn get_retransmitter_signature(shred: &[u8]) -> Result<Signature, Error> {
     Ok(Signature::from(<[u8; 64]>::try_from(bytes).unwrap()))
 }
 
-pub(crate) fn is_retransmitter_signed_variant(shred: &[u8]) -> Result<bool, Error> {
+pub fn is_retransmitter_signed_variant(shred: &[u8]) -> Result<bool, Error> {
     match get_shred_variant(shred)? {
         ShredVariant::LegacyCode | ShredVariant::LegacyData => Ok(false),
         ShredVariant::MerkleCode {
@@ -326,6 +317,34 @@ pub fn set_retransmitter_signature(shred: &mut [u8], signature: &Signature) -> R
     };
     buffer.copy_from_slice(signature.as_ref());
     Ok(())
+}
+
+/// Resigns the packet's Merkle root as the retransmitter node in the
+/// Turbine broadcast tree. This signature is in addition to leader's
+/// signature which is left intact.
+pub fn resign_packet(packet: &mut PacketRefMut, keypair: &Keypair) -> Result<(), Error> {
+    match packet {
+        PacketRefMut::Packet(packet) => {
+            let shred = get_shred_mut(packet.buffer_mut()).ok_or(Error::InvalidPacketSize)?;
+            resign_shred(shred, keypair)
+        }
+        // `Bytes` are immutable. Therefore, to resign the shred from
+        // `BytesPacket`, we need to copy the packet's buffer, then modify that
+        // copy and assign it to the packet.
+        // We resign only the last FEC set in the block. For 50mbps coming to
+        // turbine, only around 2mbps are resigned. For now, we accept the
+        // necessity of copying that minority of packets.
+        PacketRefMut::Bytes(packet) => {
+            let mut buffer = packet.buffer().to_vec();
+            let shred = get_shred_mut(&mut buffer).ok_or(Error::InvalidPacketSize)?;
+
+            resign_shred(shred, keypair)?;
+
+            packet.set_buffer(buffer);
+
+            Ok(())
+        }
+    }
 }
 
 /// Resigns the shred's Merkle root as the retransmitter node in the
@@ -446,7 +465,6 @@ mod tests {
         assert_matches::assert_matches,
         rand::Rng,
         solana_perf::packet::PacketFlags,
-        std::io::{Cursor, Write},
         test_case::test_matrix,
     };
 
@@ -456,34 +474,60 @@ mod tests {
         Signature::from(signature)
     }
 
-    fn write_shred<R: Rng>(
-        rng: &mut R,
-        shred: impl AsRef<[u8]>,
-        nonce: Option<Nonce>,
-        packet: &mut Packet,
-    ) {
-        let buffer = packet.buffer_mut();
-        let capacity = buffer.len();
-        let mut cursor = Cursor::new(buffer);
-        cursor.write_all(shred.as_ref()).unwrap();
-        // Write some random many bytes trailing shred payload.
-        let mut bytes = {
-            let size = capacity
-                - cursor.position() as usize
-                - if nonce.is_some() {
-                    std::mem::size_of::<Nonce>()
-                } else {
-                    0
-                };
-            vec![0u8; rng.gen_range(0..=size)]
-        };
-        rng.fill(&mut bytes[..]);
-        cursor.write_all(&bytes).unwrap();
-        // Write nonce after random trailing bytes.
-        if let Some(nonce) = nonce {
-            cursor.write_all(&nonce.to_le_bytes()).unwrap();
+    #[test_matrix(
+        [true, false],
+        [true, false],
+        [true, false]
+    )]
+    fn test_resign_packet(repaired: bool, chained: bool, is_last_in_slot: bool) {
+        let mut rng = rand::thread_rng();
+        let slot = 318_230_963 + rng.gen_range(0..318_230_963);
+        let data_size = 1200 * rng.gen_range(32..64);
+        let mut shreds =
+            make_merkle_shreds_for_tests(&mut rng, slot, data_size, chained, is_last_in_slot)
+                .unwrap();
+        for shred in shreds.iter_mut() {
+            let keypair = Keypair::new();
+            let signature = make_dummy_signature(&mut rng);
+            if chained && is_last_in_slot {
+                shred.set_retransmitter_signature(&signature).unwrap();
+
+                let packet = &mut shred.payload().to_packet();
+                if repaired {
+                    packet.meta_mut().flags |= PacketFlags::REPAIR;
+                }
+                resign_packet(&mut packet.into(), &keypair).unwrap();
+
+                let packet = &mut shred.payload().to_bytes_packet();
+                if repaired {
+                    packet.meta_mut().flags |= PacketFlags::REPAIR;
+                }
+                resign_packet(&mut packet.as_mut(), &keypair).unwrap();
+            } else {
+                assert_matches!(
+                    shred.set_retransmitter_signature(&signature),
+                    Err(Error::InvalidShredVariant)
+                );
+
+                let packet = &mut shred.payload().to_packet();
+                if repaired {
+                    packet.meta_mut().flags |= PacketFlags::REPAIR;
+                }
+                assert_matches!(
+                    resign_packet(&mut packet.into(), &keypair),
+                    Err(Error::InvalidShredVariant)
+                );
+
+                let packet = &mut shred.payload().to_bytes_packet();
+                if repaired {
+                    packet.meta_mut().flags |= PacketFlags::REPAIR;
+                }
+                assert_matches!(
+                    resign_packet(&mut packet.as_mut(), &keypair),
+                    Err(Error::InvalidShredVariant)
+                );
+            }
         }
-        packet.meta_mut().size = usize::try_from(cursor.position()).unwrap();
     }
 
     #[test_matrix(
@@ -510,30 +554,22 @@ mod tests {
             }
         }
         for shred in &shreds {
-            let mut packet = Packet::default();
+            let nonce = repaired.then(|| rng.gen::<Nonce>());
+            let mut packet = shred.payload().to_packet();
             if repaired {
                 packet.meta_mut().flags |= PacketFlags::REPAIR;
             }
-            let nonce = repaired.then(|| rng.gen::<Nonce>());
-            write_shred(&mut rng, shred.payload(), nonce, &mut packet);
-            let mut packet = PacketRefMut::Packet(&mut packet);
+            let packet = PacketRef::Packet(&packet);
             assert_eq!(
                 packet.data(..).map(get_shred_size).unwrap().unwrap(),
                 shred.payload().len()
             );
+            let bytes = get_shred(packet).unwrap();
+            assert_eq!(bytes, shred.payload().as_ref());
             assert_eq!(
-                get_shred(packet.as_ref()).unwrap(),
-                shred.payload().as_ref()
-            );
-            assert_eq!(
-                get_shred_mut(&mut packet).unwrap(),
-                shred.payload().as_ref(),
-            );
-            assert_eq!(
-                get_shred_and_repair_nonce(packet.as_ref()).unwrap(),
+                get_shred_and_repair_nonce(packet).unwrap(),
                 (shred.payload().as_ref(), nonce),
             );
-            let bytes = get_shred(packet.as_ref()).unwrap();
             let shred_common_header = shred.common_header();
             assert_eq!(
                 get_common_header_bytes(bytes).unwrap(),

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -50,7 +50,8 @@ impl BytesPacket {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn from_bytes(dest: Option<&SocketAddr>, buffer: Bytes) -> Self {
+    pub fn from_bytes(dest: Option<&SocketAddr>, buffer: impl Into<Bytes>) -> Self {
+        let buffer = buffer.into();
         let mut meta = Meta {
             size: buffer.len(),
             ..Default::default()
@@ -132,6 +133,18 @@ impl BytesPacket {
     #[inline]
     pub fn as_mut(&mut self) -> PacketRefMut<'_> {
         PacketRefMut::Bytes(self)
+    }
+
+    #[inline]
+    pub fn buffer(&self) -> &Bytes {
+        &self.buffer
+    }
+
+    #[inline]
+    pub fn set_buffer(&mut self, buffer: impl Into<Bytes>) {
+        let buffer = buffer.into();
+        self.meta.size = buffer.len();
+        self.buffer = buffer;
     }
 }
 

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -62,8 +62,10 @@ caps = { workspace = true }
 assert_matches = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
+solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }
 test-case = { workspace = true }
 

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -220,7 +220,7 @@ fn run_shred_sigverify<const K: usize>(
             .flatten()
             .filter(|packet| !packet.meta().discard())
             .for_each(|mut packet| {
-                if let Err(_) = maybe_verify_and_resign_packet(
+                if maybe_verify_and_resign_packet(
                     &mut packet,
                     &root_bank,
                     &working_bank,
@@ -229,7 +229,9 @@ fn run_shred_sigverify<const K: usize>(
                     cluster_nodes_cache,
                     stats,
                     keypair,
-                ) {
+                )
+                .is_err()
+                {
                     packet.meta_mut().set_discard(true);
                 }
             })

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -575,7 +575,6 @@ mod tests {
         },
         solana_perf::packet::{Packet, PacketFlags, PinnedPacketBatch},
         solana_runtime::bank::Bank,
-        solana_signature::Signature,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
         solana_time_utils::timestamp,


### PR DESCRIPTION
#### Problem

Currently, Turbine is calling `get_shred_mut` and `resign_shred` on all packets received through the `shred_fetch_receiver` channel. That imposes a requirement for all packets to be mutable.

`BytesPacket`, which is used in QUIC servers, and is going to be gradually introduced in other servers as well, is immutable (it uses `Bytes`, not `BytesMut`). Therefore, mutating it requires making a copy.

`get_shred_mut` is throwing an error if it encounters `PacketRefMut::Bytes`.

#### Summary of Changes

To fix these issues:

* Check whether the shred is resigned before expecting mutability of the packet.
  * If the shred contained in `BytesPacket` is resigned, make a copy. Resigned packets are a minority among all turbine packets. For 50mbps coming to turbine, only around 2mbps are resigned.
* Change `get_shred_mut` to take a buffer, not a packet, to get rid of erroneus expectation for all packet types to be mutable. Turbine is the only caller, let it do the match statement over all packet types.

The change is non-functional on its own, but it's a prerequisite for making Turbine networking stack zero-copy (attempted in anza-xyz/agave#6309).

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
