### PR TITLE
Remove BlockVerificationMethod::BlockstoreProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Release channels have their own copy of this changelog:
   * `--skip-poh-verify`
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 * Using `--snapshot-interval-slots 0` to disable generating snapshots has been removed. Use `--no-snapshots` instead.
+* `--block-verification-method blockstore-processor` has been removed as an option.
 
 #### Changes
 * Reading snapshot archives requires increased `memlock` limits - recommended setting is `LimitMEMLOCK=2000000000` in systemd service configuration. Lack of sufficient limit will result slower startup times.

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -56,26 +56,24 @@ $agave_validator --ledger config/ledger exit --force || true
 
 wait $pid
 
-for method in blockstore-processor unified-scheduler
-do
-  rm -rf config/snapshot-ledger
-  $solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" config/snapshot-ledger
-  cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
-  $solana_ledger_tool copy --ledger config/ledger \
-    --target-db config/snapshot-ledger --starting-slot "$snapshot_slot" --ending-slot "$latest_slot"
+method="unified-scheduler"
+rm -rf config/snapshot-ledger
+$solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" config/snapshot-ledger
+cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
+$solana_ledger_tool copy --ledger config/ledger \
+  --target-db config/snapshot-ledger --starting-slot "$snapshot_slot" --ending-slot "$latest_slot"
 
-  set -x
-  $solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
-    |& grep -q "Log Messages:$" && exit 1
+set -x
+$solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
+  |& grep -q "Log Messages:$" && exit 1
 
-  $solana_ledger_tool verify --abort-on-invalid-block \
-    --ledger config/snapshot-ledger --block-verification-method "$method" \
-    --enable-rpc-transaction-history --enable-extended-tx-metadata-storage
+$solana_ledger_tool verify --abort-on-invalid-block \
+  --ledger config/snapshot-ledger --block-verification-method "$method" \
+  --enable-rpc-transaction-history --enable-extended-tx-metadata-storage
 
-  $solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
-    |& grep -q "Log Messages:$"
-  set +x
-done
+$solana_ledger_tool --ledger config/snapshot-ledger slot "$latest_slot" --verbose --verbose \
+  |& grep -q "Log Messages:$"
+set +x
 
 first_simulated_slot=$((latest_slot / 2))
 purge_slot=$((first_simulated_slot + latest_slot / 4))

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -161,7 +161,6 @@ const WAIT_FOR_WEN_RESTART_SUPERMAJORITY_THRESHOLD_PERCENT: u64 =
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockVerificationMethod {
-    BlockstoreProcessor,
     #[default]
     UnifiedScheduler,
 }
@@ -976,15 +975,6 @@ impl Validator {
         let banking_tracer_channels = banking_tracer.create_channels(false);
 
         match &config.block_verification_method {
-            BlockVerificationMethod::BlockstoreProcessor => {
-                info!("no scheduler pool is installed for block verification...");
-                if let Some(count) = config.unified_scheduler_handler_threads {
-                    warn!(
-                        "--unified-scheduler-handler-threads={count} is ignored because unified \
-                         scheduler isn't enabled"
-                    );
-                }
-            }
             BlockVerificationMethod::UnifiedScheduler => {
                 let scheduler_pool = DefaultSchedulerPool::new_dyn(
                     config.unified_scheduler_handler_threads,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -353,15 +353,6 @@ pub fn load_and_process_ledger(
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
     match block_verification_method {
-        BlockVerificationMethod::BlockstoreProcessor => {
-            info!("no scheduler pool is installed for block verification...");
-            if let Some(count) = unified_scheduler_handler_threads {
-                warn!(
-                    "--unified-scheduler-handler-threads={count} is ignored because unified \
-                     scheduler isn't enabled"
-                );
-            }
-        }
         BlockVerificationMethod::UnifiedScheduler => {
             let no_replay_vote_sender = None;
             let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -883,9 +883,7 @@ impl SchedulingStateMachine {
         //`::validate_account_locks()` regardless of whether unified-scheduler
         // is enabled or not at the blockstore
         // (`Bank::prepare_sanitized_batch()` is called in
-        // `process_entries()`). This verification will be hoisted for
-        // optimization when removing
-        // `--block-verification-method=blockstore-processor`.
+        // `process_entries()`).
         //
         // As for `banking_stage` with unified scheduler, it will need to run
         // `validate_account_locks()` at least once somewhere in the code path.

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1003,17 +1003,6 @@ pub fn execute(
         "block_verification_method",
         BlockVerificationMethod
     );
-    match validator_config.block_verification_method {
-        BlockVerificationMethod::BlockstoreProcessor => {
-            warn!(
-                "The value \"blockstore-processor\" for --block-verification-method has been \
-                deprecated. The value \"blockstore-processor\" is still allowed for now, but \
-                is planned for removal in the near future. To update, either set the value \
-                \"unified-scheduler\" or remove the --block-verification-method argument"
-            );
-        }
-        BlockVerificationMethod::UnifiedScheduler => {}
-    }
     validator_config.block_production_method = value_t_or_exit!(
         matches, // comment to align formatting...
         "block_production_method",


### PR DESCRIPTION
#### Problem
- We want to remove the legacy verification method now that `UnifiedScheduler` is sufficiently tested in production

#### Summary of Changes
- Remove `BlockVerificationMethod::BlockstoreProcessor` variant

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
