### PR TITLE
v2.3 Remove channels section from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and follows a [Backwards Compatibility Policy](https://docs.solanalabs.com/backwards-compatibility)
 
-Release channels have their own copy of this changelog:
-* [edge - v3.0](#edge-channel)
-* [beta - v2.3](https://github.com/anza-xyz/agave/blob/v2.3/CHANGELOG.md)
-* [stable - v2.2](https://github.com/anza-xyz/agave/blob/v2.2/CHANGELOG.md)
-
-<a name="edge-channel"></a>
-## 3.0.0 - Unreleased
-
-
 ## 2.3.0
 
 ### Validator


### PR DESCRIPTION
#### Problem
The channels section and reference to v3.0.0 don't make sense at the top of the v2.3 changelog.

I'll make a master PR soon that updates the changelog instructions so apply this change to new branches in future.

Chaining this on #6736 for now. I'll rebase on tip of v2.3 once 6736 is merged