### PR TITLE
Scans each storage only once when building accounts index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -61,7 +61,7 @@ use {
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
         ancient_append_vecs::get_ancient_append_vec_capacity,
-        append_vec::{aligned_stored_size, STORE_META_OVERHEAD},
+        append_vec::{aligned_stored_size, IndexInfoInner, STORE_META_OVERHEAD},
         cache_hash_data::{CacheHashData, DeletionPolicy as CacheHashDeletionPolicy},
         contains::Contains,
         epoch_accounts_hash::EpochAccountsHashManager,
@@ -7819,18 +7819,45 @@ impl AccountsDb {
 
         let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
             let mut items_local = Vec::default();
-            storage.accounts.scan_index(|info| {
-                stored_size_alive += info.stored_size_aligned;
-                if info.index_info.lamports > 0 {
-                    accounts_data_len += info.index_info.data_len;
-                    all_accounts_are_zero_lamports = false;
-                } else {
-                    // zero lamport accounts
-                    zero_lamport_pubkeys.push(info.index_info.pubkey);
-                }
-                items_local.push(info.index_info);
-            });
+            if secondary {
+                // WITH secondary indexes -- scan accounts WITH account data
+                storage.accounts.scan_accounts(|offset, account| {
+                    let data_len = account.data.len() as u64;
+                    stored_size_alive += storage.accounts.calculate_stored_size(data_len as usize);
+                    if account.lamports > 0 {
+                        accounts_data_len += data_len;
+                        all_accounts_are_zero_lamports = false;
+                    } else {
+                        // zero lamport accounts
+                        zero_lamport_pubkeys.push(*account.pubkey);
+                    }
+                    items_local.push(IndexInfoInner {
+                        offset,
+                        pubkey: *account.pubkey,
+                        lamports: account.lamports,
+                        data_len,
+                    });
 
+                    self.accounts_index.update_secondary_indexes(
+                        account.pubkey,
+                        &account,
+                        &self.account_indexes,
+                    );
+                });
+            } else {
+                // withOUT secondary indexes -- scan accounts withOUT account data
+                storage.accounts.scan_index(|info| {
+                    stored_size_alive += info.stored_size_aligned;
+                    if info.index_info.lamports > 0 {
+                        accounts_data_len += info.index_info.data_len;
+                        all_accounts_are_zero_lamports = false;
+                    } else {
+                        // zero lamport accounts
+                        zero_lamport_pubkeys.push(info.index_info.pubkey);
+                    }
+                    items_local.push(info.index_info);
+                });
+            }
             let items_len = items_local.len();
             let items = items_local.into_iter().map(|info| {
                 (
@@ -7844,16 +7871,6 @@ impl AccountsDb {
             self.accounts_index
                 .insert_new_if_missing_into_primary_index(slot, items_len, items)
         };
-        if secondary {
-            // scan storage a second time to update the secondary index
-            storage.accounts.scan_accounts(|_offset, stored_account| {
-                self.accounts_index.update_secondary_indexes(
-                    stored_account.pubkey(),
-                    &stored_account,
-                    &self.account_indexes,
-                );
-            });
-        }
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
             // there were duplicate pubkeys in this same slot


### PR DESCRIPTION
#### Problem

When building the accounts index, if secondary indexes are on, we scan each account storage file twice. This is bad, performance wise. The second scan is needed to get each account's data, which secondary indexes need.

We should switch on if secondary indexes are enabled or not, and then decide how to scan the storage. E.g. if secondary indexes are on, scan once _with_ account data. If secondary indexes are off, scan once _without_ account data.


#### Summary of Changes

Instead of scanning twice, only scan once! Pick the scan function depending on if secondary indexes are on or off.