### PR TITLE
turbine, bench: move remaining benches to merkle variant

### DIFF
--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -38,7 +38,7 @@ fn get_retransmit_peers_deterministic(
     num_simulated_shreds: usize,
 ) {
     let keypair = Keypair::new();
-    let merkle_root = Some(Hash::new_unique());
+    let merkle_root = Some(Hash::default());
     let reed_solomon_cache = ReedSolomonCache::default();
     let mut stats = ProcessShredsStats::default();
     let parent_slot = if slot > 0 { slot - 1 } else { 0 };

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -19,8 +19,6 @@ use {
     test::Bencher,
 };
 
-const NUM_SIMULATED_SHREDS: usize = 4;
-
 fn make_cluster_nodes<R: Rng>(
     rng: &mut R,
     unstaked_ratio: Option<(u32, u32)>,
@@ -35,7 +33,6 @@ fn get_retransmit_peers_deterministic(
     cluster_nodes: &ClusterNodes<RetransmitStage>,
     slot: Slot,
     slot_leader: &Pubkey,
-    num_simulated_shreds: usize,
 ) {
     let keypair = Keypair::new();
     let merkle_root = Some(Hash::default());
@@ -57,7 +54,7 @@ fn get_retransmit_peers_deterministic(
         )
         .collect::<Vec<_>>();
 
-    for shred in shreds.iter().take(num_simulated_shreds) {
+    for shred in shreds.iter() {
         let _retransmit_peers = cluster_nodes.get_retransmit_addrs(
             slot_leader,
             &shred.id(),
@@ -72,9 +69,7 @@ fn get_retransmit_peers_deterministic_wrapper(b: &mut Bencher, unstaked_ratio: O
     let (nodes, cluster_nodes) = make_cluster_nodes(&mut rng, unstaked_ratio);
     let slot_leader = *nodes[1..].choose(&mut rng).unwrap().pubkey();
     let slot = rand::random::<u64>();
-    b.iter(|| {
-        get_retransmit_peers_deterministic(&cluster_nodes, slot, &slot_leader, NUM_SIMULATED_SHREDS)
-    });
+    b.iter(|| get_retransmit_peers_deterministic(&cluster_nodes, slot, &slot_leader));
 }
 
 #[bench]

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -7,7 +7,7 @@ use {
     solana_clock::Slot,
     solana_cluster_type::ClusterType,
     solana_gossip::contact_info::ContactInfo,
-    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
+    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     solana_pubkey::Pubkey,
     solana_streamer::socket::SocketAddrSpace,
     solana_turbine::{

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -7,6 +7,8 @@ use {
     solana_clock::Slot,
     solana_cluster_type::ClusterType,
     solana_gossip::contact_info::ContactInfo,
+    solana_hash::Hash,
+    solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     solana_pubkey::Pubkey,
     solana_streamer::socket::SocketAddrSpace,
@@ -35,7 +37,6 @@ fn get_retransmit_peers_deterministic(
     slot_leader: &Pubkey,
     num_simulated_shreds: usize,
 ) {
-    use {solana_hash::Hash, solana_keypair::Keypair};
     let keypair = Keypair::new();
     let merkle_root = Some(Hash::new_unique());
     let reed_solomon_cache = ReedSolomonCache::default();

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -41,20 +41,18 @@ fn get_retransmit_peers_deterministic(
     let parent_slot = if slot > 0 { slot - 1 } else { 0 };
     let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
 
-    let shreds = shredder
-        .make_merkle_shreds_from_entries(
-            &keypair,
-            &[],  // entries
-            true, // is_last_in_slot
-            merkle_root,
-            0, // next_shred_index
-            0, // next_code_index
-            &reed_solomon_cache,
-            &mut stats,
-        )
-        .collect::<Vec<_>>();
+    let shreds = shredder.make_merkle_shreds_from_entries(
+        &keypair,
+        &[],  // entries
+        true, // is_last_in_slot
+        merkle_root,
+        0, // next_shred_index
+        0, // next_code_index
+        &reed_solomon_cache,
+        &mut stats,
+    );
 
-    for shred in shreds.iter() {
+    for shred in shreds {
         let _retransmit_peers = cluster_nodes.get_retransmit_addrs(
             slot_leader,
             &shred.id(),

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -29,6 +29,7 @@ fn make_cluster_nodes<R: Rng>(
     (nodes, cluster_nodes)
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 fn get_retransmit_peers_deterministic(
     cluster_nodes: &ClusterNodes<RetransmitStage>,
     slot: Slot,

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -7,7 +7,7 @@ use {
     solana_clock::Slot,
     solana_cluster_type::ClusterType,
     solana_gossip::contact_info::ContactInfo,
-    solana_ledger::shred::{Shred, ShredFlags},
+    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags, Shredder},
     solana_pubkey::Pubkey,
     solana_streamer::socket::SocketAddrSpace,
     solana_turbine::{
@@ -35,19 +35,28 @@ fn get_retransmit_peers_deterministic(
     slot_leader: &Pubkey,
     num_simulated_shreds: usize,
 ) {
-    let parent_offset = u16::from(slot != 0);
-    for i in 0..num_simulated_shreds {
-        let index = i as u32;
-        let shred = Shred::new_from_data(
-            slot,
-            index,
-            parent_offset,
-            &[],
-            ShredFlags::empty(),
-            0,
-            0,
-            0,
-        );
+    use {solana_hash::Hash, solana_keypair::Keypair};
+    let keypair = Keypair::new();
+    let merkle_root = Some(Hash::new_unique());
+    let reed_solomon_cache = ReedSolomonCache::default();
+    let mut stats = ProcessShredsStats::default();
+    let parent_slot = if slot > 0 { slot - 1 } else { 0 };
+    let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
+
+    let shreds = shredder
+        .make_merkle_shreds_from_entries(
+            &keypair,
+            &[],  // entries
+            true, // is_last_in_slot
+            merkle_root,
+            0, // next_shred_index
+            0, // next_code_index
+            &reed_solomon_cache,
+            &mut stats,
+        )
+        .collect::<Vec<_>>();
+
+    for shred in shreds.iter().take(num_simulated_shreds) {
         let _retransmit_peers = cluster_nodes.get_retransmit_addrs(
             slot_leader,
             &shred.id(),


### PR DESCRIPTION
#### Problem
Legacy shreds need to go #5982

#### Summary of Changes
Moved remaining bench to merkle variant. Removed NUM_SIMULATED_SHREDS entirely.