### PR TITLE
Avoid allocations when preparing items for insertion to primary index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7857,7 +7857,6 @@ impl AccountsDb {
                 // withOUT secondary indexes -- scan accounts withOUT account data
                 storage.accounts.scan_index(itemizer);
             }
-            let items_len = items_local.len();
             let items = items_local.into_iter().map(|info| {
                 (
                     info.pubkey,
@@ -7868,7 +7867,7 @@ impl AccountsDb {
                 )
             });
             self.accounts_index
-                .insert_new_if_missing_into_primary_index(slot, items_len, items)
+                .insert_new_if_missing_into_primary_index(slot, items)
         };
 
         if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1908,7 +1908,7 @@ pub mod tests {
             AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(slot0, &mut items);
         assert!(items.is_empty());
         assert!(removed.is_none());
-        let mut items = vec![(pk1, (slot0, 1u64)), (pk2, (slot0, 2))];
+        let mut items = vec![(pk1, 1u64), (pk2, 2)];
         let expected = items.clone();
         let removed =
             AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(slot0, &mut items);
@@ -1918,17 +1918,17 @@ pub mod tests {
         for dup in 0..3 {
             for other in 0..dup + 2 {
                 let first_info = 10u64;
-                let mut items = vec![(pk1, (slot0, first_info))];
-                let mut expected_dups = items.clone();
+                let mut items = vec![(pk1, first_info)];
+                let mut expected_dups = vec![(pk1, (slot0, first_info))];
                 for i in 0..dup {
                     let this_dup = (pk1, (slot0, i + 10u64 + 1));
                     if i < dup.saturating_sub(1) {
                         expected_dups.push(this_dup);
                     }
-                    items.push(this_dup);
+                    items.push((this_dup.0, this_dup.1 .1));
                 }
                 let mut expected = vec![*items.last().unwrap()];
-                let other_item = (pk2, (slot0, info2));
+                let other_item = (pk2, info2);
                 if other == dup + 1 {
                     // don't insert
                 } else if other == dup {
@@ -1938,8 +1938,10 @@ pub mod tests {
                     expected.push(other_item);
                     items.insert(other as usize, other_item);
                 }
-                let result =
-                    AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(&mut items);
+                items.sort();
+                let result = AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(
+                    slot0, &mut items,
+                );
                 assert_eq!(items, expected);
                 if dup != 0 {
                     expected_dups.reverse();

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1454,9 +1454,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let duplicates =
             Self::remove_older_adjacent_duplicate_pubkeys(&mut items).unwrap_or_default();
 
-        while let Some((last_pubkey, _)) = items.last() {
-            let pubkey_bin = self.bin_calculator.bin_from_pubkey(last_pubkey);
+        while !items.is_empty() {
             let mut start_index = items.len() - 1;
+            let pubkey_bin = self.bin_calculator.bin_from_pubkey(&items[start_index].0);
+            // Find the smallest index with the same pubkey bin
             while start_index > 0 {
                 let next = start_index - 1;
                 if self.bin_calculator.bin_from_pubkey(&items[next].0) != pubkey_bin {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1448,7 +1448,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // stable sort by bin with random offset *and* pubkey such that duplicates are adjacent.
         // Earlier entries are overwritten by later entries
         let bin_calc = self.bin_calculator;
-        items.sort_by(|&(ref pubkey_a, _), &(ref pubkey_b, _)| {
+        items.sort_by(|(pubkey_a, _), (pubkey_b, _)| {
             ((bin_calc.bin_from_pubkey(pubkey_a) + random_bin_offset) % bins)
                 .cmp(&((bin_calc.bin_from_pubkey(pubkey_b) + random_bin_offset) % bins))
                 .then_with(|| pubkey_a.cmp(pubkey_b))

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -767,14 +767,17 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// Queue up these insertions for when the flush thread is dealing with this bin.
     /// This is very fast and requires no lookups or disk access.
-    pub fn startup_insert_only(&self, items: impl ExactSizeIterator<Item = (Pubkey, (Slot, T))>) {
+    pub fn startup_insert_only(
+        &self,
+        slot: Slot,
+        items: impl ExactSizeIterator<Item = (Pubkey, T)>,
+    ) {
         assert!(self.storage.get_startup());
         assert!(self.bucket.is_some());
 
         let mut insert = self.startup_info.insert.lock().unwrap();
-        insert.reserve(items.len());
         let m = Measure::start("copy");
-        items.for_each(|(k, (slot, v))| insert.push((k, (slot, v.into()))));
+        insert.extend(items.map(|(k, v)| (k, (slot, v.into()))));
         self.startup_stats
             .copy_data_us
             .fetch_add(m.end_as_us(), Ordering::Relaxed);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -767,15 +767,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// Queue up these insertions for when the flush thread is dealing with this bin.
     /// This is very fast and requires no lookups or disk access.
-    pub fn startup_insert_only(&self, items: impl Iterator<Item = (Pubkey, (Slot, T))>) {
+    pub fn startup_insert_only(&self, items: impl ExactSizeIterator<Item = (Pubkey, (Slot, T))>) {
         assert!(self.storage.get_startup());
         assert!(self.bucket.is_some());
 
         let mut insert = self.startup_info.insert.lock().unwrap();
+        insert.reserve(items.len());
         let m = Measure::start("copy");
-        items
-            .into_iter()
-            .for_each(|(k, (slot, v))| insert.push((k, (slot, v.into()))));
+        items.for_each(|(k, (slot, v))| insert.push((k, (slot, v.into()))));
         self.startup_stats
             .copy_data_us
             .fetch_add(m.end_as_us(), Ordering::Relaxed);

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -1,6 +1,6 @@
 use solana_pubkey::Pubkey;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct PubkeyBinCalculator24 {
     // how many bits from the first 3 bytes to shift away to ignore when calculating bin
     shift_bits: u32,


### PR DESCRIPTION
#### Problem
Inserting accounts into primary index is doing a lot of shuffling of data to split items into pubkey bins and avoid contention when inserting into shared map. Current implementation to do that makes a lot intermediate `Vec` allocations that come up on profiles.

#### Summary of Changes
* Use a single vec with exact size allocation to sort and deduplicate pubkeys and feed its chunks into insertion.
* in_mem_account_index::startup_insert_only is passed an exact size iterator such that it can immediately reserve enough memory (through `extend` specialization) instead of growing many times

Measured performance metrics:
- baseline [measurement for "insert time" was extended to a whole `insert_new_if_missing_into_primary_index` fn]
  * generate_index overall_us=184562930i total_us=120452279i scan_stores_us=4094666i insertion_time_us=173340733i storage_size_storages_us=62412i index_flush_us=12560708i total_items_including_duplicates=946755502i accounts_data_len_dedup_time_us=4402994i total_duplicate_slot_keys=13264700i total_num_unique_duplicate_keys=5502366i num_duplicate_accounts=7762334i populate_duplicate_keys_us=16103163i total_slots=460550i copy_data_us=38366826i par_duplicates_lt_hash_us=22692364i num_zero_lamport_single_refs=7434177i visit_zero_lamports_us=30850102i all_accounts_are_zero_lamports_slots=86i
  * generate_index overall_us=187165460i total_us=124692480i scan_stores_us=3656444i insertion_time_us=174257603i storage_size_storages_us=61828i index_flush_us=10127710i total_items_including_duplicates=946755502i accounts_data_len_dedup_time_us=4073882i total_duplicate_slot_keys=13264700i total_num_unique_duplicate_keys=5502366i num_duplicate_accounts=7762334i populate_duplicate_keys_us=16643725i total_slots=460550i copy_data_us=39622463i par_duplicates_lt_hash_us=22534584i num_zero_lamport_single_refs=7434177i visit_zero_lamports_us=31423641i all_accounts_are_zero_lamports_slots=86i

- this PR
  * generate_index overall_us=179515901i total_us=107335987i scan_stores_us=1753379i insertion_time_us=82900009i storage_size_storages_us=58959i index_flush_us=16094619i total_items_including_duplicates=946755502i accounts_data_len_dedup_time_us=4489672i total_duplicate_slot_keys=13264700i total_num_unique_duplicate_keys=5502366i num_duplicate_accounts=7762334i populate_duplicate_keys_us=19633008i total_slots=460550i copy_data_us=41120110i par_duplicates_lt_hash_us=22486296i num_zero_lamport_single_refs=7434177i visit_zero_lamports_us=31767856i all_accounts_are_zero_lamports_slots=86i
  * datapoint: generate_index overall_us=172241038i total_us=99359554i scan_stores_us=1820484i insertion_time_us=83863770i storage_size_storages_us=47356i index_flush_us=23687123i total_items_including_duplicates=946755502i accounts_data_len_dedup_time_us=2497810i total_duplicate_slot_keys=13264700i total_num_unique_duplicate_keys=5502366i num_duplicate_accounts=7762334i populate_duplicate_keys_us=16058067i total_slots=460550i copy_data_us=39061290i par_duplicates_lt_hash_us=19875417i num_zero_lamport_single_refs=7434177i visit_zero_lamports_us=30485251i all_accounts_are_zero_lamports_slots=86

(both `inserttion_time_us` and `overall_us` go down)