### PR TITLE
cleanup remove_accounts_delta_hash feature

### DIFF
--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -135,25 +135,11 @@ impl SlotDetails {
         }
 
         let bank_hash_components = if include_bank_hash_components {
-            let accounts_delta_hash = (!bank
-                .feature_set
-                .is_active(&feature_set::remove_accounts_delta_hash::id()))
-            .then(|| {
-                // This bank is frozen; as a result, we know that the state has been
-                // hashed which means the delta hash is Some(). So, .unwrap() is safe
-                bank.rc
-                    .accounts
-                    .accounts_db
-                    .get_accounts_delta_hash(slot)
-                    .unwrap()
-                    .0
-                    .to_string()
-            });
             let accounts = bank.get_accounts_for_bank_hash_details();
 
             Some(BankHashComponents {
                 parent_bank_hash: bank.parent_hash().to_string(),
-                accounts_delta_hash,
+                accounts_delta_hash: None,
                 signature_count: bank.signature_count(),
                 last_blockhash: bank.last_blockhash().to_string(),
                 // The bank is already frozen so this should not have to wait

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -171,7 +171,7 @@ mod tests {
                 &mut writer,
                 bank_fields,
                 bank2.get_bank_hash_stats(),
-                accounts_db.get_accounts_delta_hash(bank2_slot).unwrap(),
+                AccountsDeltaHash(Hash::default()),
                 expected_accounts_hash,
                 &get_storages_to_serialize(&bank2.get_snapshot_storages(None)),
                 ExtraFieldsToSerialize {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2776,10 +2776,6 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
                 .accounts
                 .remove(&feature_set::accounts_lt_hash::id())
                 .unwrap();
-            genesis_config
-                .accounts
-                .remove(&feature_set::remove_accounts_delta_hash::id())
-                .unwrap();
         }
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         assert_eq!(
@@ -12702,20 +12698,10 @@ fn test_bank_epoch_stakes() {
 }
 
 /// Ensure rehash() does *not* change the bank hash if accounts are unmodified
-#[test_case(true; "with accounts delta hash")]
-#[test_case(false; "without accounts delta hash")]
-fn test_rehash_accounts_unmodified(has_accounts_delta_hash: bool) {
+#[test]
+fn test_rehash_accounts_unmodified() {
     let ten_sol = 10 * LAMPORTS_PER_SOL;
-    let mut genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
-    if has_accounts_delta_hash {
-        // Keep the accounts delta hash by removing the 'remove_accounts_delta_hash'
-        // feature account from genesis.
-        genesis_config_info
-            .genesis_config
-            .accounts
-            .remove(&feature_set::remove_accounts_delta_hash::id())
-            .unwrap();
-    }
+    let genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
     let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
 
     let lamports = 123_456_789;
@@ -12738,14 +12724,7 @@ fn test_rehash_accounts_unmodified(has_accounts_delta_hash: bool) {
 #[should_panic(expected = "rehashing is not allowed to change the account state")]
 fn test_rehash_accounts_modified() {
     let ten_sol = 10 * LAMPORTS_PER_SOL;
-    let mut genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
-    // Keep the accounts delta hash by removing the 'remove_accounts_delta_hash'
-    // feature account from genesis.
-    genesis_config_info
-        .genesis_config
-        .accounts
-        .remove(&feature_set::remove_accounts_delta_hash::id())
-        .unwrap();
+    let genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
     let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
 
     let mut account = AccountSharedData::new(ten_sol, 0, &Pubkey::default());

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2764,24 +2764,12 @@ fn test_bank_hash_internal_state(is_accounts_lt_hash_enabled: bool) {
     assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test(), None,));
 }
 
-#[test_case(false; "accounts lt hash disabled")]
-#[test_case(true; "accounts lt hash enabled")]
-fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
+#[test]
+fn test_bank_hash_internal_state_verify() {
     for pass in 0..4 {
-        let (mut genesis_config, mint_keypair) =
+        let (genesis_config, mint_keypair) =
             create_genesis_config_no_tx_fee_no_rent(sol_to_lamports(1.));
-        if !is_accounts_lt_hash_enabled {
-            // Disable the accounts lt hash feature by removing its account from genesis.
-            genesis_config
-                .accounts
-                .remove(&feature_set::accounts_lt_hash::id())
-                .unwrap();
-        }
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        assert_eq!(
-            bank0.is_accounts_lt_hash_enabled(),
-            is_accounts_lt_hash_enabled,
-        );
 
         let amount = genesis_config.rent.minimum_balance(0);
         let pubkey = solana_pubkey::new_rand();
@@ -2856,18 +2844,6 @@ fn test_bank_hash_internal_state_verify(is_accounts_lt_hash_enabled: bool) {
                 VerifyAccountsHashConfig::default_for_test(),
                 None,
             ));
-
-            if is_accounts_lt_hash_enabled {
-                // Verifying the accounts lt hash is only intended to be called at startup, and
-                // normally in the background.  Since here we're *not* at startup, and doing it
-                // in the foreground, the verification uses the accounts index.  The test just
-                // rooted bank2, and will root bank3 next; but they are on different forks,
-                // which is not valid.  This causes the accounts index to see accounts from
-                // bank2 and bank3, which causes verifying bank3's accounts lt hash to fail.
-                // To workaround this "issue", we cannot root bank2 when the accounts lt hash
-                // is enabled.
-                continue;
-            }
         }
 
         bank3.freeze();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2910,36 +2910,6 @@ fn test_verify_snapshot_bank() {
     assert!(!bank.verify_snapshot_bank(true, false, false, bank.slot(), None, None,));
 }
 
-// Test that two bank forks with the same accounts should not hash to the same value.
-#[test]
-fn test_bank_hash_internal_state_same_account_different_fork() {
-    solana_logger::setup();
-    let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let amount = genesis_config.rent.minimum_balance(0);
-    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let initial_state = bank0.hash_internal_state();
-    let bank1 = new_bank_from_parent_with_bank_forks(
-        bank_forks.as_ref(),
-        bank0.clone(),
-        &Pubkey::default(),
-        1,
-    );
-    assert_ne!(bank1.hash_internal_state(), initial_state);
-
-    info!("transfer bank1");
-    let pubkey = solana_pubkey::new_rand();
-    bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
-    assert_ne!(bank1.hash_internal_state(), initial_state);
-
-    info!("transfer bank2");
-    // bank2 should not hash the same as bank1
-    let bank2 =
-        new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &Pubkey::default(), 2);
-    bank2.transfer(amount, &mint_keypair, &pubkey).unwrap();
-    assert_ne!(bank2.hash_internal_state(), initial_state);
-    assert_ne!(bank1.hash_internal_state(), bank2.hash_internal_state());
-}
-
 #[test]
 fn test_hash_internal_state_genesis() {
     let bank0 = Bank::new_for_tests(&create_genesis_config(10).0);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12665,31 +12665,6 @@ fn test_rehash_accounts_unmodified() {
     assert_eq!(post_bank_hash, prev_bank_hash);
 }
 
-/// Ensure rehash() *does* change the bank hash if accounts are modified
-#[test]
-#[should_panic(expected = "rehashing is not allowed to change the account state")]
-fn test_rehash_accounts_modified() {
-    let ten_sol = 10 * LAMPORTS_PER_SOL;
-    let genesis_config_info = genesis_utils::create_genesis_config(ten_sol);
-    let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
-
-    let mut account = AccountSharedData::new(ten_sol, 0, &Pubkey::default());
-    let pubkey = Pubkey::new_unique();
-    bank.store_account_and_update_capitalization(&pubkey, &account);
-
-    // freeze the bank to trigger hash calculation
-    bank.freeze();
-
-    // change an account, which will cause rehashing to panic
-    account.checked_add_lamports(ten_sol).unwrap();
-    bank.rc
-        .accounts
-        .store_accounts_cached((bank.slot(), [(&pubkey, &account)].as_slice()));
-
-    // let the show begin
-    bank.rehash();
-}
-
 #[test]
 fn test_should_use_vote_keyed_leader_schedule() {
     let genesis_config = genesis_utils::create_genesis_config(10_000).genesis_config;

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -4,7 +4,6 @@ use {
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
     },
-    agave_feature_set as feature_set,
     log::*,
     solana_accounts_db::{
         accounts::Accounts,
@@ -77,17 +76,7 @@ impl AccountsPackage {
         let snapshot_info = {
             let accounts_db = &bank.rc.accounts.accounts_db;
             let write_version = accounts_db.write_version.load(Ordering::Acquire);
-            let accounts_delta_hash = if bank
-                .feature_set
-                .is_active(&feature_set::remove_accounts_delta_hash::id())
-            {
-                AccountsDeltaHash(Hash::default())
-            } else {
-                // SAFETY: There *must* be an accounts delta hash for this slot.
-                // Since we only snapshot rooted slots, and we know rooted slots must be frozen,
-                // that guarantees this slot will have an accounts delta hash.
-                accounts_db.get_accounts_delta_hash(slot).unwrap()
-            };
+            let accounts_delta_hash = AccountsDeltaHash(Hash::default());
             let bank_hash_stats = bank.get_bank_hash_stats();
             let bank_fields_to_serialize = bank.get_fields_to_serialize();
             SupplementalSnapshotInfo {


### PR DESCRIPTION
#### Problem

The [remove_accounts_delta_hash](https://github.com/anza-xyz/feature-gate-tracker/issues/81) feature is activated on all clusters and can be cleaned up

#### Summary of Changes
- Remove obsolete tests
- Clean up "not activated" code path 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
