### PR TITLE
Use more canonical imports with io::Result instead of IoResult

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -100,8 +100,7 @@ use {
         collections::{BTreeSet, HashMap, HashSet, VecDeque},
         fs,
         hash::{Hash as StdHash, Hasher as StdHasher},
-        io::Result as IoResult,
-        iter, mem,
+        io, iter, mem,
         num::{NonZeroUsize, Saturating},
         ops::{Range, RangeBounds},
         path::{Path, PathBuf},
@@ -1274,11 +1273,11 @@ impl AccountStorageEntry {
     }
 }
 
-pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBuf>)> {
-    let temp_dirs: IoResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
+pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<PathBuf>)> {
+    let temp_dirs: io::Result<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
     let temp_dirs = temp_dirs?;
 
-    let paths: IoResult<Vec<_>> = temp_dirs
+    let paths: io::Result<Vec<_>> = temp_dirs
         .iter()
         .map(|temp_dir| {
             utils::create_accounts_run_and_snapshot_dirs(temp_dir)

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -12,7 +12,7 @@ use {
     crate::{append_vec::ValidSlice, file_io::read_more_buffer},
     std::{
         fs::File,
-        io::{BufRead, BufReader, Result as IoResult},
+        io::{self, BufRead, BufReader},
         mem::MaybeUninit,
         ops::Range,
         path::Path,
@@ -128,7 +128,7 @@ where
     T: Backing,
 {
     /// read to make sure we have the minimum amount of data
-    pub fn read(&mut self) -> IoResult<BufferedReaderStatus> {
+    pub fn read(&mut self) -> io::Result<BufferedReaderStatus> {
         let must_read = self
             .read_requirements
             .unwrap_or(self.default_min_read_requirement);
@@ -191,7 +191,7 @@ impl<'a, const N: usize> BufferedReader<'a, Stack<N>> {
 pub fn large_file_buf_reader(
     path: impl AsRef<Path>,
     buf_size: usize,
-) -> IoResult<Box<dyn BufRead>> {
+) -> io::Result<Box<dyn BufRead>> {
     #[cfg(target_os = "linux")]
     if agave_io_uring::io_uring_supported() {
         use crate::io_uring::sequential_file_reader::SequentialFileReader;

--- a/accounts-db/src/tiered_storage/byte_block.rs
+++ b/accounts-db/src/tiered_storage/byte_block.rs
@@ -4,7 +4,7 @@
 use {
     crate::tiered_storage::{footer::AccountBlockFormat, meta::AccountMetaOptionalFields},
     std::{
-        io::{Cursor, Read, Result as IoResult, Write},
+        io::{self, Cursor, Read, Write},
         mem, ptr,
     },
 };
@@ -56,7 +56,7 @@ impl ByteBlockWriter {
     /// Write plain ol' data to the internal buffer of the ByteBlockWriter instance
     ///
     /// Prefer this over `write_type()`, as it prevents some undefined behavior.
-    pub fn write_pod<T: bytemuck::NoUninit>(&mut self, value: &T) -> IoResult<usize> {
+    pub fn write_pod<T: bytemuck::NoUninit>(&mut self, value: &T) -> io::Result<usize> {
         // SAFETY: Since T is NoUninit, it does not contain any uninitialized bytes.
         unsafe { self.write_type(value) }
     }
@@ -72,7 +72,7 @@ impl ByteBlockWriter {
     /// Caller must ensure casting T to bytes is safe.
     /// Refer to the Safety sections in std::slice::from_raw_parts()
     /// and bytemuck's Pod and NoUninit for more information.
-    pub unsafe fn write_type<T>(&mut self, value: &T) -> IoResult<usize> {
+    pub unsafe fn write_type<T>(&mut self, value: &T) -> io::Result<usize> {
         let size = mem::size_of::<T>();
         let ptr = ptr::from_ref(value).cast();
         // SAFETY: The caller ensures that `value` contains no uninitialized bytes,
@@ -90,7 +90,7 @@ impl ByteBlockWriter {
     pub fn write_optional_fields(
         &mut self,
         opt_fields: &AccountMetaOptionalFields,
-    ) -> IoResult<usize> {
+    ) -> io::Result<usize> {
         let mut size = 0;
         if let Some(rent_epoch) = opt_fields.rent_epoch {
             size += self.write_pod(&rent_epoch)?;
@@ -103,7 +103,7 @@ impl ByteBlockWriter {
 
     /// Write the specified typed bytes to the internal buffer of the
     /// ByteBlockWriter instance.
-    pub fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+    pub fn write(&mut self, buf: &[u8]) -> io::Result<()> {
         match &mut self.encoder {
             ByteBlockEncoder::Raw(cursor) => cursor.write_all(buf)?,
             ByteBlockEncoder::Lz4(lz4_encoder) => lz4_encoder.write_all(buf)?,
@@ -114,7 +114,7 @@ impl ByteBlockWriter {
 
     /// Flush the internal byte buffer that collects all the previous writes
     /// into an encoded byte array.
-    pub fn finish(self) -> IoResult<Vec<u8>> {
+    pub fn finish(self) -> io::Result<Vec<u8>> {
         match self.encoder {
             ByteBlockEncoder::Raw(cursor) => Ok(cursor.into_inner()),
             ByteBlockEncoder::Lz4(lz4_encoder) => {
@@ -173,7 +173,7 @@ impl ByteBlockReader {
     ///
     /// Note that calling this function with AccountBlockFormat::AlignedRaw encoding
     /// will result in panic as the input is already decoded.
-    pub fn decode(encoding: AccountBlockFormat, input: &[u8]) -> IoResult<Vec<u8>> {
+    pub fn decode(encoding: AccountBlockFormat, input: &[u8]) -> io::Result<Vec<u8>> {
         match encoding {
             AccountBlockFormat::Lz4 => {
                 let mut decoder = lz4::Decoder::new(input).unwrap();

--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -3,7 +3,7 @@ use {
     bytemuck::{AnyBitPattern, NoUninit, Zeroable},
     std::{
         fs::{File, OpenOptions},
-        io::{BufWriter, Read, Result as IoResult, Seek, SeekFrom, Write},
+        io::{self, BufWriter, Read, Seek, SeekFrom, Write},
         mem,
         path::Path,
         ptr,
@@ -43,7 +43,7 @@ impl TieredReadableFile {
         Ok(file)
     }
 
-    pub fn new_writable(file_path: impl AsRef<Path>) -> IoResult<Self> {
+    pub fn new_writable(file_path: impl AsRef<Path>) -> io::Result<Self> {
         Ok(Self(
             OpenOptions::new()
                 .create_new(true)
@@ -68,7 +68,7 @@ impl TieredReadableFile {
     /// Reads a value of type `T` from the file.
     ///
     /// Type T must be plain ol' data.
-    pub fn read_pod<T: NoUninit + AnyBitPattern>(&self, value: &mut T) -> IoResult<()> {
+    pub fn read_pod<T: NoUninit + AnyBitPattern>(&self, value: &mut T) -> io::Result<()> {
         // SAFETY: Since T is AnyBitPattern, it is safe to cast bytes to T.
         unsafe { self.read_type(value) }
     }
@@ -83,7 +83,7 @@ impl TieredReadableFile {
     /// Caller must ensure casting bytes to T is safe.
     /// Refer to the Safety sections in std::slice::from_raw_parts()
     /// and bytemuck's Pod and AnyBitPattern for more information.
-    pub unsafe fn read_type<T>(&self, value: &mut T) -> IoResult<()> {
+    pub unsafe fn read_type<T>(&self, value: &mut T) -> io::Result<()> {
         let ptr = ptr::from_mut(value).cast();
         // SAFETY: The caller ensures it is safe to cast bytes to T,
         // we ensure the size is safe by querying T directly,
@@ -92,15 +92,15 @@ impl TieredReadableFile {
         self.read_bytes(bytes)
     }
 
-    pub fn seek(&self, offset: u64) -> IoResult<u64> {
+    pub fn seek(&self, offset: u64) -> io::Result<u64> {
         (&self.0).seek(SeekFrom::Start(offset))
     }
 
-    pub fn seek_from_end(&self, offset: i64) -> IoResult<u64> {
+    pub fn seek_from_end(&self, offset: i64) -> io::Result<u64> {
         (&self.0).seek(SeekFrom::End(offset))
     }
 
-    pub fn read_bytes(&self, buffer: &mut [u8]) -> IoResult<()> {
+    pub fn read_bytes(&self, buffer: &mut [u8]) -> io::Result<()> {
         (&self.0).read_exact(buffer)
     }
 }
@@ -109,7 +109,7 @@ impl TieredReadableFile {
 pub struct TieredWritableFile(pub BufWriter<File>);
 
 impl TieredWritableFile {
-    pub fn new(file_path: impl AsRef<Path>) -> IoResult<Self> {
+    pub fn new(file_path: impl AsRef<Path>) -> io::Result<Self> {
         Ok(Self(BufWriter::new(
             OpenOptions::new()
                 .create_new(true)
@@ -121,7 +121,7 @@ impl TieredWritableFile {
     /// Writes `value` to the file.
     ///
     /// `value` must be plain ol' data.
-    pub fn write_pod<T: NoUninit>(&mut self, value: &T) -> IoResult<usize> {
+    pub fn write_pod<T: NoUninit>(&mut self, value: &T) -> io::Result<usize> {
         // SAFETY: Since T is NoUninit, it does not contain any uninitialized bytes.
         unsafe { self.write_type(value) }
     }
@@ -136,21 +136,21 @@ impl TieredWritableFile {
     /// Caller must ensure casting T to bytes is safe.
     /// Refer to the Safety sections in std::slice::from_raw_parts()
     /// and bytemuck's Pod and NoUninit for more information.
-    pub unsafe fn write_type<T>(&mut self, value: &T) -> IoResult<usize> {
+    pub unsafe fn write_type<T>(&mut self, value: &T) -> io::Result<usize> {
         let ptr = ptr::from_ref(value).cast();
         let bytes = unsafe { std::slice::from_raw_parts(ptr, mem::size_of::<T>()) };
         self.write_bytes(bytes)
     }
 
-    pub fn seek(&mut self, offset: u64) -> IoResult<u64> {
+    pub fn seek(&mut self, offset: u64) -> io::Result<u64> {
         self.0.seek(SeekFrom::Start(offset))
     }
 
-    pub fn seek_from_end(&mut self, offset: i64) -> IoResult<u64> {
+    pub fn seek_from_end(&mut self, offset: i64) -> io::Result<u64> {
         self.0.seek(SeekFrom::End(offset))
     }
 
-    pub fn write_bytes(&mut self, bytes: &[u8]) -> IoResult<usize> {
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<usize> {
         self.0.write_all(bytes)?;
 
         Ok(bytes.len())

--- a/accounts-db/src/tiered_storage/mmap_utils.rs
+++ b/accounts-db/src/tiered_storage/mmap_utils.rs
@@ -1,9 +1,9 @@
-use {crate::u64_align, log::*, memmap2::Mmap, std::io::Result as IoResult};
+use {crate::u64_align, log::*, memmap2::Mmap, std::io};
 
 /// Borrows a value of type `T` from `mmap`
 ///
 /// Type T must be plain ol' data to ensure no undefined behavior.
-pub fn get_pod<T: bytemuck::AnyBitPattern>(mmap: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
+pub fn get_pod<T: bytemuck::AnyBitPattern>(mmap: &Mmap, offset: usize) -> io::Result<(&T, usize)> {
     // SAFETY: Since T is AnyBitPattern, it is safe to cast bytes to T.
     unsafe { get_type::<T>(mmap, offset) }
 }
@@ -17,7 +17,7 @@ pub fn get_pod<T: bytemuck::AnyBitPattern>(mmap: &Mmap, offset: usize) -> IoResu
 /// Caller must ensure casting bytes to T is safe.
 /// Refer to the Safety sections in std::slice::from_raw_parts()
 /// and bytemuck's Pod and AnyBitPattern for more information.
-pub unsafe fn get_type<T>(mmap: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
+pub unsafe fn get_type<T>(mmap: &Mmap, offset: usize) -> io::Result<(&T, usize)> {
     let (data, next) = get_slice(mmap, offset, std::mem::size_of::<T>())?;
     let ptr = data.as_ptr().cast();
     debug_assert!(ptr as usize % std::mem::align_of::<T>() == 0);
@@ -31,7 +31,7 @@ pub unsafe fn get_type<T>(mmap: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
 /// doesn't overrun the internal buffer. Otherwise return an Error.
 /// Also return the offset of the first byte after the requested data that
 /// falls on a 64-byte boundary.
-pub fn get_slice(mmap: &Mmap, offset: usize, size: usize) -> IoResult<(&[u8], usize)> {
+pub fn get_slice(mmap: &Mmap, offset: usize, size: usize) -> io::Result<(&[u8], usize)> {
     let (next, overflow) = offset.overflowing_add(size);
     if overflow || next > mmap.len() {
         error!(

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -24,7 +24,7 @@ use {
         snapshot_utils,
     },
     std::{
-        io::Result as IoResult,
+        io,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Mutex,
@@ -217,7 +217,7 @@ impl AccountsHashVerifier {
         accounts_package: AccountsPackage,
         pending_snapshot_packages: &Mutex<PendingSnapshotPackages>,
         snapshot_config: &SnapshotConfig,
-    ) -> IoResult<()> {
+    ) -> io::Result<()> {
         let (merkle_or_lattice_accounts_hash, bank_incremental_snapshot_persistence) =
             Self::calculate_and_verify_accounts_hash(&accounts_package, snapshot_config)?;
 
@@ -239,7 +239,7 @@ impl AccountsHashVerifier {
     fn calculate_and_verify_accounts_hash(
         accounts_package: &AccountsPackage,
         snapshot_config: &SnapshotConfig,
-    ) -> IoResult<(
+    ) -> io::Result<(
         MerkleOrLatticeAccountsHash,
         Option<BankIncrementalSnapshotPersistence>,
     )> {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -38,7 +38,7 @@ use {
         cmp::Ordering,
         collections::{HashMap, HashSet},
         fmt, fs,
-        io::{BufReader, BufWriter, Error as IoError, Read, Result as IoResult, Seek, Write},
+        io::{self, BufReader, BufWriter, Error as IoError, Read, Seek, Write},
         mem,
         num::{NonZeroU64, NonZeroUsize},
         ops::RangeInclusive,
@@ -587,7 +587,7 @@ pub enum GetSnapshotAccountsHardLinkDirError {
 pub fn clean_orphaned_account_snapshot_dirs(
     bank_snapshots_dir: impl AsRef<Path>,
     account_snapshot_paths: &[PathBuf],
-) -> IoResult<()> {
+) -> io::Result<()> {
     // Create the HashSet of the account snapshot hardlink directories referenced by the snapshot dirs.
     // This is used to clean up any hardlinks that are no longer referenced by the snapshot dirs.
     let mut account_snapshot_dirs_referenced = HashSet::new();
@@ -678,7 +678,7 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
 }
 
 /// Marks the bank snapshot as complete
-fn write_snapshot_state_complete_file(bank_snapshot_dir: impl AsRef<Path>) -> IoResult<()> {
+fn write_snapshot_state_complete_file(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<()> {
     let state_complete_path = bank_snapshot_dir
         .as_ref()
         .join(SNAPSHOT_STATE_COMPLETE_FILENAME);
@@ -695,7 +695,7 @@ fn write_snapshot_state_complete_file(bank_snapshot_dir: impl AsRef<Path>) -> Io
 pub fn write_full_snapshot_slot_file(
     bank_snapshot_dir: impl AsRef<Path>,
     full_snapshot_slot: Slot,
-) -> IoResult<()> {
+) -> io::Result<()> {
     let full_snapshot_slot_path = bank_snapshot_dir
         .as_ref()
         .join(SNAPSHOT_FULL_SNAPSHOT_SLOT_FILENAME);
@@ -712,7 +712,7 @@ pub fn write_full_snapshot_slot_file(
 }
 
 // Reads the full snapshot slot file from the bank snapshot dir
-pub fn read_full_snapshot_slot_file(bank_snapshot_dir: impl AsRef<Path>) -> IoResult<Slot> {
+pub fn read_full_snapshot_slot_file(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<Slot> {
     const SLOT_SIZE: usize = std::mem::size_of::<Slot>();
     let full_snapshot_slot_path = bank_snapshot_dir
         .as_ref()
@@ -735,7 +735,7 @@ pub fn read_full_snapshot_slot_file(bank_snapshot_dir: impl AsRef<Path>) -> IoRe
 }
 
 /// Writes the 'snapshot storages have been flushed' file to the bank snapshot dir
-pub fn write_storages_flushed_file(bank_snapshot_dir: impl AsRef<Path>) -> IoResult<()> {
+pub fn write_storages_flushed_file(bank_snapshot_dir: impl AsRef<Path>) -> io::Result<()> {
     let flushed_storages_path = bank_snapshot_dir
         .as_ref()
         .join(SNAPSHOT_STORAGES_FLUSHED_FILENAME);
@@ -1740,7 +1740,7 @@ fn streaming_unarchive_snapshot(
 fn archive_chunker_from_path(
     archive_path: &Path,
     archive_format: ArchiveFormat,
-) -> IoResult<ArchiveChunker<ArchiveFormatDecompressor<Box<dyn std::io::BufRead>>>> {
+) -> io::Result<ArchiveChunker<ArchiveFormatDecompressor<Box<dyn std::io::BufRead>>>> {
     const INPUT_READER_BUF_SIZE: usize = 128 * 1024 * 1024;
     let buf_reader = solana_accounts_db::large_file_buf_reader(archive_path, INPUT_READER_BUF_SIZE)
         .map_err(|err| {


### PR DESCRIPTION
#### Problem
`IoResult` use alias is used while a more direct and almost same length reference of `io::Result` could be used

#### Summary of Changes
Remove use alias and reference `std::io::Result` through `io` import
