### PR TITLE
Changelog instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,5 +262,8 @@ This simplifies the process of diffing between versions of the log.
   * Update the edge, beta, and stable links
   * Create new section: `vx.y+1.0 - Unreleased`
   * Remove `Unreleased` annotation from vx.y.0 section.
-* Create vx.y branch starting at that commit
-* Tag that commit as vx.y.0
+* Create vx.y branch starting at that commit.
+* Commit to `vx.y` updating the changelog:
+  * Remove the `vx.y+1.0 - Unreleased` section
+  * Remove the channel links
+* Tag vx.y.0 on the new branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,9 +264,3 @@ This simplifies the process of diffing between versions of the log.
   * Remove `Unreleased` annotation from vx.y.0 section.
 * Create vx.y branch starting at that commit
 * Tag that commit as vx.y.0
-
-### When creating a new patch release:
-* Commit to the release branch updating the changelog:
-  * Remove `Unreleased` annotation from `vx.y.z` section
-  * Add a new section at the top for `vx.y.z+1 - Unreleased`
-* Tag that new commit as the new release


### PR DESCRIPTION
#### Problem
* The changelog includes instructions for creating a new section for every patch release. This was the original plan but we've never done it
* The channels and edge sections at the top of the changelog aren't useful in the release branches and quickly get out of date.

#### Summary of Changes
* Remove the patch release instructions that we've never used
* Add instructions for removing the misleading information after creating a new branch. See #6739 and #6738 for examples of how this should be done.