### PR TITLE
Simplify primary index insert on startup assuming no dups within single slot.

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7858,19 +7858,26 @@ impl AccountsDb {
         let mut zero_lamport_pubkeys = vec![];
         let mut all_accounts_are_zero_lamports = true;
 
-        let (dirty_pubkeys, insert_time_us, mut generate_index_results) = {
-            let mut items_local = Vec::default();
+        let (insert_time_us, generate_index_results) = {
+            let mut keyed_account_infos = vec![];
             // this closure is the shared code when scanning the storage
             let mut itemizer = |info: IndexInfo| {
                 stored_size_alive += info.stored_size_aligned;
-                if info.index_info.lamports > 0 {
-                    accounts_data_len += info.index_info.data_len;
+                let index_info = &info.index_info;
+                if index_info.lamports > 0 {
+                    accounts_data_len += index_info.data_len;
                     all_accounts_are_zero_lamports = false;
                 } else {
                     // zero lamport accounts
-                    zero_lamport_pubkeys.push(info.index_info.pubkey);
+                    zero_lamport_pubkeys.push(index_info.pubkey);
                 }
-                items_local.push(info.index_info);
+                keyed_account_infos.push((
+                    index_info.pubkey,
+                    AccountInfo::new(
+                        StorageLocation::AppendVec(store_id, index_info.offset), // will never be cached
+                        index_info.is_zero_lamport(),
+                    ),
+                ));
             };
 
             if secondary {
@@ -7916,37 +7923,9 @@ impl AccountsDb {
                     })
             }
             .expect("must scan accounts storage");
-            let items = items_local.into_iter().map(|info| {
-                (
-                    info.pubkey,
-                    AccountInfo::new(
-                        StorageLocation::AppendVec(store_id, info.offset), // will never be cached
-                        info.is_zero_lamport(),
-                    ),
-                )
-            });
             self.accounts_index
-                .insert_new_if_missing_into_primary_index(slot, items)
+                .insert_new_if_missing_into_primary_index(slot, keyed_account_infos)
         };
-
-        if let Some(duplicates_this_slot) = std::mem::take(&mut generate_index_results.duplicates) {
-            // there were duplicate pubkeys in this same slot
-            // Some were not inserted. This means some info like stored data is off.
-            for (pubkey, (_slot, info)) in duplicates_this_slot {
-                storage.accounts.get_stored_account_without_data_callback(
-                    info.offset(),
-                    |duplicate_account| {
-                        assert_eq!(pubkey, *duplicate_account.pubkey());
-                        let data_len = duplicate_account.data_len;
-                        let stored_size_aligned = storage.accounts.calculate_stored_size(data_len);
-                        stored_size_alive = stored_size_alive.saturating_sub(stored_size_aligned);
-                        if !duplicate_account.is_zero_lamport() {
-                            accounts_data_len = accounts_data_len.saturating_sub(data_len as u64);
-                        }
-                    },
-                );
-            }
-        }
 
         {
             // second, collect into the shared DashMap once we've figured out all the info per store_id
@@ -7962,11 +7941,13 @@ impl AccountsDb {
             );
         }
 
-        // dirty_pubkeys will contain a pubkey if an item has multiple rooted entries for
+        // zero_lamport_pubkeys will contain a pubkey if an item has multiple rooted entries for
         // a given pubkey. If there is just a single item, there is no cleaning to
         // be done on that pubkey. Use only those pubkeys with multiple updates.
-        if !dirty_pubkeys.is_empty() {
-            let old = self.uncleaned_pubkeys.insert(slot, dirty_pubkeys);
+        if !zero_lamport_pubkeys.is_empty() {
+            let old = self
+                .uncleaned_pubkeys
+                .insert(slot, zero_lamport_pubkeys.clone());
             assert!(old.is_none());
         }
         SlotIndexGenerationInfo {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7863,19 +7863,18 @@ impl AccountsDb {
             // this closure is the shared code when scanning the storage
             let mut itemizer = |info: IndexInfo| {
                 stored_size_alive += info.stored_size_aligned;
-                let index_info = &info.index_info;
-                if index_info.lamports > 0 {
-                    accounts_data_len += index_info.data_len;
+                if info.index_info.lamports > 0 {
+                    accounts_data_len += info.index_info.data_len;
                     all_accounts_are_zero_lamports = false;
                 } else {
                     // zero lamport accounts
-                    zero_lamport_pubkeys.push(index_info.pubkey);
+                    zero_lamport_pubkeys.push(info.index_info.pubkey);
                 }
                 keyed_account_infos.push((
-                    index_info.pubkey,
+                    info.index_info.pubkey,
                     AccountInfo::new(
-                        StorageLocation::AppendVec(store_id, index_info.offset), // will never be cached
-                        index_info.is_zero_lamport(),
+                        StorageLocation::AppendVec(store_id, info.index_info.offset), // will never be cached
+                        info.index_info.is_zero_lamport(),
                     ),
                 ));
             };
@@ -7940,9 +7939,8 @@ impl AccountsDb {
                 info.stored_size, storage.accounts.len(), store_id
             );
         }
-
-        // zero_lamport_pubkeys will contain a pubkey if an item has multiple rooted entries for
-        // a given pubkey. If there is just a single item, there is no cleaning to
+        // zero_lamport_pubkeys are candidates for cleaning. So add them to uncleaned_pubkeys
+        // for later cleaning. If there is just a single item, there is no cleaning to
         // be done on that pubkey. Use only those pubkeys with multiple updates.
         if !zero_lamport_pubkeys.is_empty() {
             let old = self

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -181,7 +181,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
 
 define_accounts_db_test!(
     test_generate_index_duplicates_within_slot,
-    panic = "Duplicate pub keys are not allowed within single slot items",
+    panic = "Accounts may only be stored once per slot:",
     |db| {
         run_generate_index_duplicates_within_slot_test(db, false);
     }
@@ -189,7 +189,7 @@ define_accounts_db_test!(
 
 define_accounts_db_test!(
     test_generate_index_duplicates_within_slot_reverse,
-    panic = "Duplicate pub keys are not allowed within single slot items",
+    panic = "Accounts may only be stored once per slot:",
     |db| {
         run_generate_index_duplicates_within_slot_test(db, true);
     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -147,64 +147,6 @@ macro_rules! define_accounts_db_test {
 }
 pub(crate) use define_accounts_db_test;
 
-fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool) {
-    let slot0 = 0;
-
-    let pubkey = Pubkey::from([1; 32]);
-
-    let append_vec = db.create_and_insert_store(slot0, 1000, "test");
-
-    let mut account_small = AccountSharedData::default();
-    account_small.set_data(vec![1]);
-    account_small.set_lamports(1);
-    let mut account_big = AccountSharedData::default();
-    account_big.set_data(vec![5; 10]);
-    account_big.set_lamports(2);
-    assert_ne!(
-        aligned_stored_size(account_big.data().len()),
-        aligned_stored_size(account_small.data().len())
-    );
-    // same account twice with different data lens
-    // Rules are the last one of each pubkey is the one that ends up in the index.
-    let mut data = vec![(&pubkey, &account_big), (&pubkey, &account_small)];
-    if reverse {
-        data = data.into_iter().rev().collect();
-    }
-    let expected_accounts_data_len = data.last().unwrap().1.data().len();
-    let expected_alive_bytes = aligned_stored_size(expected_accounts_data_len);
-    let storable_accounts = (slot0, &data[..]);
-
-    // construct append vec with account to generate an index from
-    append_vec.accounts.append_accounts(&storable_accounts, 0);
-
-    assert!(!db.accounts_index.contains(&pubkey));
-    let result = db.generate_index(None, false, false);
-    // index entry should only contain a single entry for the pubkey since index cannot hold more than 1 entry per slot
-    let entry = db.accounts_index.get_cloned(&pubkey).unwrap();
-    assert_eq!(entry.slot_list.read().unwrap().len(), 1);
-    if db.accounts_file_provider == AccountsFileProvider::AppendVec {
-        // alive bytes doesn't match account size for tiered storage
-        assert_eq!(append_vec.alive_bytes(), expected_alive_bytes);
-    }
-    // total # accounts in append vec
-    assert_eq!(append_vec.accounts_count(), 2);
-    // # alive accounts
-    assert_eq!(append_vec.count(), 1);
-    // all account data alive
-    assert_eq!(
-        result.accounts_data_len as usize, expected_accounts_data_len,
-        "reverse: {reverse}"
-    );
-}
-
-define_accounts_db_test!(test_generate_index_duplicates_within_slot, |db| {
-    run_generate_index_duplicates_within_slot_test(db, false);
-});
-
-define_accounts_db_test!(test_generate_index_duplicates_within_slot_reverse, |db| {
-    run_generate_index_duplicates_within_slot_test(db, true);
-});
-
 #[test]
 fn test_generate_index_for_single_ref_zero_lamport_slot() {
     let db = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -173,29 +173,6 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     );
 }
 
-#[test]
-fn test_generate_index_duplicates_within_slot_with_secondary_indexes() {
-    let secondary_indexes = AccountSecondaryIndexes {
-        keys: None,
-        indexes: HashSet::from([
-            AccountIndex::ProgramId,
-            AccountIndex::SplTokenMint,
-            AccountIndex::SplTokenOwner,
-        ]),
-    };
-    let accounts_db_config = AccountsDbConfig {
-        account_indexes: Some(secondary_indexes),
-        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-    };
-    let accounts_db = AccountsDb::new_with_config(
-        Vec::new(),
-        Some(accounts_db_config),
-        None,
-        AtomicBool::new(false).into(),
-    );
-    run_generate_index_duplicates_within_slot_test(accounts_db, false);
-}
-
 fn generate_sample_account_from_storage(i: u8) -> AccountFromStorage {
     // offset has to be 8 byte aligned
     let offset = (i as usize) * std::mem::size_of::<u64>();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5,7 +5,7 @@ use {
         account_info::StoredSize,
         accounts_file::AccountsFileProvider,
         accounts_hash::MERKLE_FANOUT,
-        accounts_index::{tests::*, AccountIndex, AccountSecondaryIndexesIncludeExclude},
+        accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
         ancient_append_vecs,
         append_vec::{
             aligned_stored_size, test_utils::TempFile, AccountMeta, AppendVec, StoredAccountMeta,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1405,7 +1405,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 let next_pubkey = &items[next].0;
                 assert_ne!(
                     next_pubkey, last_pubkey,
-                    "Duplicate pub keys are not allowed within single slot items"
+                    "Accounts may only be stored once per slot: {slot}"
                 );
                 if bin_calc.bin_from_pubkey(next_pubkey) != pubkey_bin {
                     break;
@@ -1936,7 +1936,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Accounts may only be stored once per slot:")]
     fn test_insert_duplicates() {
         let key = solana_pubkey::new_rand();
         let pubkey = &key;

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -78,11 +78,9 @@ pub type RefCount = u64;
 pub type AtomicRefCount = AtomicU64;
 
 #[derive(Default, Debug, PartialEq, Eq)]
-pub(crate) struct GenerateIndexResult<T: IndexValue> {
+pub(crate) struct GenerateIndexResult {
     /// number of accounts inserted in the index
     pub count: usize,
-    /// pubkeys which were present multiple times in the insertion request.
-    pub duplicates: Option<Vec<(Pubkey, (Slot, T))>>,
     /// Number of accounts added to the index that didn't already exist in the index
     pub num_did_not_exist: u64,
     /// Number of accounts added to the index that already existed, and were in-mem
@@ -1362,75 +1360,21 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.account_maps.len()
     }
 
-    /// remove the earlier instances of each pubkey when consecutive positions of the same
-    /// pubkey exist in the `Vec`.
-    /// The input can be partially sorted, only adjacent duplicates are removed.
-    /// Returns `Vec` of duplicate pubkeys.
-    fn remove_adjacent_older_duplicate_pubkeys(
-        slot: Slot,
-        items: &mut Vec<(Pubkey, T)>,
-    ) -> Option<Vec<(Pubkey, (Slot, T))>> {
-        if items.len() < 2 {
-            return None;
-        }
-        let mut duplicates = None::<Vec<(Pubkey, (Slot, T))>>;
-
-        // Iterate the items vec from the end to the beginning. Adjacent duplicated items will be
-        // written to the front of the vec.
-        let n = items.len();
-        let mut last_key = items[n - 1].0;
-        let mut write = n - 1;
-        let mut curr = write;
-
-        while curr > 0 {
-            let curr_item = items[curr - 1];
-
-            if curr_item.0 == last_key {
-                let mut duplicates_insert = duplicates.unwrap_or_default();
-                duplicates_insert.push((curr_item.0, (slot, curr_item.1)));
-                duplicates = Some(duplicates_insert);
-                curr -= 1;
-            } else {
-                if curr < write {
-                    items[write - 1] = curr_item;
-                }
-                curr -= 1;
-                write -= 1;
-                last_key = curr_item.0;
-            }
-        }
-
-        items.drain(..(write - curr));
-
-        duplicates
-    }
-
     // Same functionally to upsert, but:
     // 1. operates on a batch of items
     // 2. holds the write lock for the duration of adding the items
     // Can save time when inserting lots of new keys.
     // But, does NOT update secondary index
     // This is designed to be called at startup time.
-    // returns (dirty_pubkeys, insertion_time_us, GenerateIndexResult)
+    // returns (insertion_time_us, GenerateIndexResult)
     pub(crate) fn insert_new_if_missing_into_primary_index(
         &self,
         slot: Slot,
-        items: impl ExactSizeIterator<Item = (Pubkey, T)>,
-    ) -> (Vec<Pubkey>, u64, GenerateIndexResult<T>) {
+        mut items: Vec<(Pubkey, T)>,
+    ) -> (u64, GenerateIndexResult) {
         let mut insert_time = Measure::start("insert_into_primary_index");
 
         let use_disk = self.storage.storage.is_disk_index_enabled();
-        let mut dirty_pubkeys = vec![];
-        let mut items = items
-            .map(|(pubkey, account_info)| {
-                // this value is equivalent to what update() below would have created if we inserted a new item
-                let is_zero_lamport = account_info.is_zero_lamport();
-                if is_zero_lamport {
-                    dirty_pubkeys.push(pubkey)
-                }
-                (pubkey, account_info)
-            })
-            .collect::<Vec<_>>();
 
         let mut count = 0;
 
@@ -1444,17 +1388,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // lock contention.
         let bins = self.bins();
         let random_bin_offset = thread_rng().gen_range(0..bins);
-
-        // stable sort by bin with random offset *and* pubkey such that duplicates are adjacent.
-        // Earlier entries are overwritten by later entries
         let bin_calc = self.bin_calculator;
-        items.sort_by(|(pubkey_a, _), (pubkey_b, _)| {
+        items.sort_unstable_by(|(pubkey_a, _), (pubkey_b, _)| {
             ((bin_calc.bin_from_pubkey(pubkey_a) + random_bin_offset) % bins)
                 .cmp(&((bin_calc.bin_from_pubkey(pubkey_b) + random_bin_offset) % bins))
-                .then_with(|| pubkey_a.cmp(pubkey_b))
         });
-        let duplicates =
-            Self::remove_adjacent_older_duplicate_pubkeys(slot, &mut items).unwrap_or_default();
 
         while !items.is_empty() {
             let mut start_index = items.len() - 1;
@@ -1518,11 +1456,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         insert_time.stop();
 
         (
-            dirty_pubkeys,
             insert_time.as_us(),
             GenerateIndexResult {
                 count,
-                duplicates: (!duplicates.is_empty()).then_some(duplicates),
                 num_did_not_exist,
                 num_existed_in_mem,
                 num_existed_on_disk,
@@ -1898,62 +1834,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_remove_older_duplicate_pubkeys() {
-        let pk1 = Pubkey::new_from_array([0; 32]);
-        let pk2 = Pubkey::new_from_array([1; 32]);
-        let slot0 = 0;
-        let info2 = 55;
-        let mut items = vec![];
-        let removed =
-            AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(slot0, &mut items);
-        assert!(items.is_empty());
-        assert!(removed.is_none());
-        let mut items = vec![(pk1, 1u64), (pk2, 2)];
-        let expected = items.clone();
-        let removed =
-            AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(slot0, &mut items);
-        assert_eq!(items, expected);
-        assert!(removed.is_none());
-
-        for dup in 0..3 {
-            for other in 0..dup + 2 {
-                let first_info = 10u64;
-                let mut items = vec![(pk1, first_info)];
-                let mut expected_dups = vec![(pk1, (slot0, first_info))];
-                for i in 0..dup {
-                    let this_dup = (pk1, (slot0, i + 10u64 + 1));
-                    if i < dup.saturating_sub(1) {
-                        expected_dups.push(this_dup);
-                    }
-                    items.push((this_dup.0, this_dup.1 .1));
-                }
-                let mut expected = vec![*items.last().unwrap()];
-                let other_item = (pk2, info2);
-                if other == dup + 1 {
-                    // don't insert
-                } else if other == dup {
-                    expected.push(other_item);
-                    items.push(other_item);
-                } else {
-                    expected.push(other_item);
-                    items.insert(other as usize, other_item);
-                }
-                items.sort();
-                let result = AccountsIndex::<u64, u64>::remove_adjacent_older_duplicate_pubkeys(
-                    slot0, &mut items,
-                );
-                assert_eq!(items, expected);
-                if dup != 0 {
-                    expected_dups.reverse();
-                    assert_eq!(result.unwrap(), expected_dups);
-                } else {
-                    assert!(result.is_none());
-                }
-            }
-        }
-    }
-
-    #[test]
     fn test_secondary_index_include_exclude() {
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
@@ -2048,30 +1928,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_insert_duplicates() {
-        let key = solana_pubkey::new_rand();
-        let pubkey = &key;
-        let slot = 0;
-        let mut ancestors = Ancestors::default();
-        ancestors.insert(slot, 0);
-
-        let account_info = true;
-        let index = AccountsIndex::<bool, bool>::default_for_tests();
-        let account_info2: bool = !account_info;
-        let items = vec![(*pubkey, account_info), (*pubkey, account_info2)];
-        index.set_startup(Startup::Startup);
-        let (_, _, result) =
-            index.insert_new_if_missing_into_primary_index(slot, items.into_iter());
-        assert_eq!(result.count, 1);
-        index.set_startup(Startup::Normal);
-        let index_entry = index.get_cloned(pubkey).unwrap();
-        let slot_list = index_entry.slot_list.read().unwrap();
-        // make sure the one with the correct info is added, and wasn't inserted twice
-        assert_eq!(slot_list.len(), 1);
-        assert_eq!(slot_list[0], (slot, account_info2));
-    }
-
-    #[test]
     fn test_insert_new_with_lock_no_ancestors() {
         let key = solana_pubkey::new_rand();
         let pubkey = &key;
@@ -2082,8 +1938,7 @@ pub mod tests {
         let items = vec![(*pubkey, account_info)];
         index.set_startup(Startup::Startup);
         let expected_len = items.len();
-        let (_, _, result) =
-            index.insert_new_if_missing_into_primary_index(slot, items.into_iter());
+        let (_, result) = index.insert_new_if_missing_into_primary_index(slot, items);
         assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
@@ -2116,8 +1971,7 @@ pub mod tests {
         let items = vec![(*pubkey, account_info)];
         index.set_startup(Startup::Startup);
         let expected_len = items.len();
-        let (_, _, result) =
-            index.insert_new_if_missing_into_primary_index(slot, items.into_iter());
+        let (_, result) = index.insert_new_if_missing_into_primary_index(slot, items);
         assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
@@ -2222,8 +2076,7 @@ pub mod tests {
         index.set_startup(Startup::Startup);
         let items = vec![(key0, account_infos[0]), (key1, account_infos[1])];
         let expected_len = items.len();
-        let (_, _, result) =
-            index.insert_new_if_missing_into_primary_index(slot0, items.into_iter());
+        let (_, result) = index.insert_new_if_missing_into_primary_index(slot0, items);
         assert_eq!(result.count, expected_len);
         index.set_startup(Startup::Normal);
 
@@ -2279,8 +2132,7 @@ pub mod tests {
             let items = vec![(key, account_infos[0])];
             index.set_startup(Startup::Startup);
             let expected_len = items.len();
-            let (_, _, result) =
-                index.insert_new_if_missing_into_primary_index(slot0, items.into_iter());
+            let (_, result) = index.insert_new_if_missing_into_primary_index(slot0, items);
             assert_eq!(result.count, expected_len);
             index.set_startup(Startup::Normal);
         }
@@ -2327,8 +2179,7 @@ pub mod tests {
             let items = vec![(key, account_infos[1])];
             index.set_startup(Startup::Startup);
             let expected_len = items.len();
-            let (_, _, result) =
-                index.insert_new_if_missing_into_primary_index(slot1, items.into_iter());
+            let (_, result) = index.insert_new_if_missing_into_primary_index(slot1, items);
             assert_eq!(result.count, expected_len);
             index.set_startup(Startup::Normal);
         }


### PR DESCRIPTION
#### Problem
* Primary index insert function on startup is doing calculations to de-duplicate provided pubkeys, but we don't allow duplicates in stores anymore
* It also builds a vector of zero lamport keys, but those are independently gathered by scan callback
* It allocates a new vector based on provided iterator, but that iterator is local and could be inlined 

#### Summary of Changes
* Remove de-duplication logic from `insert_new_if_missing_into_primary_index`
* Don't calculate and return `dirty_pubkeys` - use already gathered in scan `zero_lamport_pubkeys` instead
* Inline conversion of index info into `(pubkey, account_info)` to create vector used in `insert_new_if_missing_into_primary_index` instead of passing iterator

Generate index time - `insertion_time_us` changes from ~*193125607i* to ~*172851990i*:
* master
  - `datapoint: generate_index overall_us=174271837i total_us=114115488i scan_stores_us=11846468i insertion_time_us=193125607i storage_size_storages_us=69165i index_flush_us=16824073i total_items_including_duplicates=952734796i accounts_data_len_dedup_time_us=3290496i total_duplicate_slot_keys=12675704i total_num_unique_duplicate_keys=5256015i num_duplicate_accounts=7419689i populate_duplicate_keys_us=13310740i total_slots=476126i copy_data_us=37786121i par_duplicates_lt_hash_us=21413799i num_zero_lamport_single_refs=7894685i visit_zero_lamports_us=26512120i all_accounts_are_zero_lamports_slots=94i`
* this PR
  - `datapoint: generate_index overall_us=174463244i total_us=110442322i scan_stores_us=11167531i insertion_time_us=172851990i storage_size_storages_us=68131i index_flush_us=18716218i total_items_including_duplicates=952734796i accounts_data_len_dedup_time_us=3353305i total_duplicate_slot_keys=12675704i total_num_unique_duplicate_keys=5256015i num_duplicate_accounts=7419689i populate_duplicate_keys_us=13564634i total_slots=476126i copy_data_us=42753359i par_duplicates_lt_hash_us=21337928i num_zero_lamport_single_refs=7894685i visit_zero_lamports_us=27620401i all_accounts_are_zero_lamports_slots=94i`
