### PR TITLE
Fix: ensure io_uring SequentialFileReader makes progress

### DIFF
--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -282,8 +282,9 @@ impl<B: AsMut<[u8]>> BufRead for SequentialFileReader<B> {
             match &state.buffers[state.current_buf] {
                 ReadBufState::Full { .. } => break,
                 ReadBufState::Uninit { .. } => unreachable!("should be initialized"),
-                // Still no data, wait for more completions.
-                ReadBufState::Reading => _ = self.inner.submit_and_wait(1, None)?,
+                // Still no data, wait for more completions, but submit in case the SQPOLL
+                // thread is asleep and there are queued entries in the submission queue.
+                ReadBufState::Reading => _ = self.inner.submit()?,
             }
         }
 

--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -284,7 +284,7 @@ impl<B: AsMut<[u8]>> BufRead for SequentialFileReader<B> {
                 ReadBufState::Uninit { .. } => unreachable!("should be initialized"),
                 // Still no data, wait for more completions, but submit in case the SQPOLL
                 // thread is asleep and there are queued entries in the submission queue.
-                ReadBufState::Reading => _ = self.inner.submit()?,
+                ReadBufState::Reading => self.inner.submit()?,
             }
         }
 

--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -283,7 +283,7 @@ impl<B: AsMut<[u8]>> BufRead for SequentialFileReader<B> {
                 ReadBufState::Full { .. } => break,
                 ReadBufState::Uninit { .. } => unreachable!("should be initialized"),
                 // Still no data, wait for more completions.
-                ReadBufState::Reading => (),
+                ReadBufState::Reading => _ = self.inner.submit_and_wait(1, None)?,
             }
         }
 


### PR DESCRIPTION
#### Problem
Sometimes io_uring SequentialFileReader hangs.

When debugging I found that we hang in the loop waiting for current buffer to be Full, it never happens, because apparently the read op pushed after receiving short read is waiting in the submission queue.

#### Summary of Changes
When current buf is still in reading state instead of spin checking completions ensure all work is properly submitted. 

This is safe because we just checked that completions queue is processed and we are still waiting for one of the ops to finish, so we will make progress iff `submit_and_wait` returns with at least 1 new completion.