### PR TITLE
Update Solana staking economics link to current official URL

### DIFF
--- a/docs/src/operations/guides/vote-accounts.md
+++ b/docs/src/operations/guides/vote-accounts.md
@@ -40,7 +40,7 @@ The address of a vote account is never needed to sign any transactions, but is
 just used to look up the account information.
 
 When someone wants to
-[delegate tokens in a stake account](https://solana.com/docs/economics/staking),
+[delegate tokens in a stake account](https://solana.com/staking),
 the delegation command is pointed at the vote account address of the validator
 to whom the token-holder wants to delegate.
 


### PR DESCRIPTION
Replaced the outdated link to Solana's staking economics documentation (https://solana.com/docs/economics/staking) with the current official staking page (https://solana.com/staking) in the vote account management guide. This ensures users are directed to the latest and most accurate information about staking on Solana.