### PR TITLE
ledger: Make use of `#[test_matrix]`

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1053,7 +1053,7 @@ mod tests {
         solana_keypair::keypair_from_seed,
         solana_signer::Signer,
         std::io::{Cursor, Seek, SeekFrom, Write},
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     const SIZE_OF_SHRED_INDEX: usize = 4;
@@ -1215,10 +1215,10 @@ mod tests {
         );
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_should_discard_shred(chained: bool, is_last_in_slot: bool) {
         solana_logger::setup();
         let mut rng = rand::thread_rng();
@@ -1868,10 +1868,10 @@ mod tests {
         assert!(flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_is_shred_duplicate(chained: bool, is_last_in_slot: bool) {
         fn fill_retransmitter_signature<R: Rng>(
             rng: &mut R,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1321,7 +1321,7 @@ mod test {
         solana_packet::PACKET_DATA_SIZE,
         solana_signer::Signer,
         std::{cmp::Ordering, collections::HashMap, iter::repeat_with},
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     // Total size of a data shred including headers and merkle proof.
@@ -1623,22 +1623,11 @@ mod test {
         }
     }
 
-    #[test_case(0, false, false)]
-    #[test_case(0, false, true)]
-    #[test_case(0, true, false)]
-    #[test_case(0, true, true)]
-    #[test_case(15600, false, false)]
-    #[test_case(15600, false, true)]
-    #[test_case(15600, true, false)]
-    #[test_case(15600, true, true)]
-    #[test_case(31200, false, false)]
-    #[test_case(31200, false, true)]
-    #[test_case(31200, true, false)]
-    #[test_case(31200, true, true)]
-    #[test_case(46800, false, false)]
-    #[test_case(46800, false, true)]
-    #[test_case(46800, true, false)]
-    #[test_case(46800, true, true)]
+    #[test_matrix(
+        [0, 15600, 31200, 46800],
+        [true, false],
+        [true, false]
+    )]
     fn test_make_shreds_from_data(data_size: usize, chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let data_size = data_size.saturating_sub(16);
@@ -1654,10 +1643,10 @@ mod test {
         }
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_make_shreds_from_data_rand(chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let reed_solomon_cache = ReedSolomonCache::default();
@@ -1674,10 +1663,10 @@ mod test {
     }
 
     #[ignore]
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_make_shreds_from_data_paranoid(chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let reed_solomon_cache = ReedSolomonCache::default();

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -447,7 +447,7 @@ mod tests {
         rand::Rng,
         solana_perf::packet::PacketFlags,
         std::io::{Cursor, Write},
-        test_case::test_case,
+        test_case::test_matrix,
     };
 
     fn make_dummy_signature<R: Rng>(rng: &mut R) -> Signature {
@@ -486,14 +486,11 @@ mod tests {
         packet.meta_mut().size = usize::try_from(cursor.position()).unwrap();
     }
 
-    #[test_case(false, false, false)]
-    #[test_case(false, false, true)]
-    #[test_case(false, true, false)]
-    #[test_case(false, true, true)]
-    #[test_case(true, false, false)]
-    #[test_case(true, false, true)]
-    #[test_case(true, true, false)]
-    #[test_case(true, true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false],
+        [true, false]
+    )]
     fn test_merkle_shred_wire_layout(repaired: bool, chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let slot = 318_230_963 + rng.gen_range(0..318_230_963);

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -558,7 +558,7 @@ mod tests {
         solana_signer::Signer,
         solana_system_transaction as system_transaction,
         std::{collections::HashSet, convert::TryInto, iter::repeat_with, sync::Arc},
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     fn verify_test_code_shred(shred: &Shred, index: u32, slot: Slot, pk: &Pubkey, verify: bool) {
@@ -660,18 +660,18 @@ mod tests {
         assert_eq!(entries, deshred_entries);
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_data_shredder(chained: bool, is_last_in_slot: bool) {
         run_test_data_shredder(0x1234_5678_9abc_def0, chained, is_last_in_slot);
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_deserialize_shred_payload(chained: bool, is_last_in_slot: bool) {
         let keypair = Arc::new(Keypair::new());
         let shredder = Shredder::new(
@@ -709,10 +709,10 @@ mod tests {
         }
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_shred_reference_tick(chained: bool, is_last_in_slot: bool) {
         let keypair = Arc::new(Keypair::new());
         let slot = 1;
@@ -751,10 +751,10 @@ mod tests {
         assert_eq!(deserialized_shred.reference_tick(), 5);
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_shred_reference_tick_overflow(chained: bool, is_last_in_slot: bool) {
         let keypair = Arc::new(Keypair::new());
         let slot = 1;
@@ -848,10 +848,10 @@ mod tests {
         }
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_data_and_code_shredder(chained: bool, is_last_in_slot: bool) {
         run_test_data_and_code_shredder(0x1234_5678_9abc_def0, chained, is_last_in_slot);
     }
@@ -1170,10 +1170,10 @@ mod tests {
         }
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_shred_version(chained: bool, is_last_in_slot: bool) {
         let keypair = Arc::new(Keypair::new());
         let hash = hash(Hash::default().as_ref());
@@ -1208,10 +1208,10 @@ mod tests {
             .any(|s| s.version() != version));
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_shred_fec_set_index(chained: bool, is_last_in_slot: bool) {
         let keypair = Arc::new(Keypair::new());
         let hash = hash(Hash::default().as_ref());

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -544,7 +544,7 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
         std::iter::{once, repeat_with},
-        test_case::test_case,
+        test_case::test_matrix,
     };
 
     fn run_test_sigverify_shred_cpu(slot: Slot) {
@@ -815,10 +815,10 @@ mod tests {
         packets
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_verify_shreds_fuzz(chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
@@ -867,10 +867,10 @@ mod tests {
         );
     }
 
-    #[test_case(false, false)]
-    #[test_case(false, true)]
-    #[test_case(true, false)]
-    #[test_case(true, true)]
+    #[test_matrix(
+        [true, false],
+        [true, false]
+    )]
     fn test_sign_shreds_gpu(chained: bool, is_last_in_slot: bool) {
         let mut rng = rand::thread_rng();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));


### PR DESCRIPTION
#### Problem

Some tests were using `#[test_case]` and listing all the combinations explicitly.

#### Summary of Changes

To simplify them, use `#[test_matrix]` instead.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
