### PR TITLE
chore: bump itertools from 0.10.1 to 0.12.1

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7932,7 +7932,7 @@ dependencies = [
  "borsh 1.5.7",
  "byteorder 1.5.0",
  "elf",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "miow",
  "net2",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -100,7 +100,7 @@ borsh = "1.5.1"
 byteorder = "1.3.2"
 elf = "0.0.10"
 getrandom = "0.2.10"
-itertools = "0.10.1"
+itertools = "0.12.1"
 libsecp256k1 = { version = "0.7.0", default-features = false }
 log = "0.4.11"
 miow = "0.3.6"


### PR DESCRIPTION
#### Problem

the root workspace is already using 0.12.1, not sure why `programs/sbf` is still using the older one
https://github.com/anza-xyz/agave/blob/528d984671c18e870ee94461a400751c8feddfbd/Cargo.toml#L286

#### Summary of Changes

try to bump it and sync the version