### PR TITLE
Add --public-tvu-address arg to set UDP tvu receive address.

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2408,6 +2408,7 @@ pub struct NodeConfig {
     pub bind_ip_addrs: BindIpAddrs,
     pub public_tpu_addr: Option<SocketAddr>,
     pub public_tpu_forwards_addr: Option<SocketAddr>,
+    pub public_tvu_addr: Option<SocketAddr>,
     pub vortexor_receiver_addr: Option<SocketAddr>,
 
     /// The number of TVU receive sockets to create
@@ -2882,6 +2883,7 @@ mod tests {
             bind_ip_addrs: BindIpAddrs::new(vec![IpAddr::V4(ip)]).unwrap(),
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
+            public_tvu_addr: None,
             num_tvu_receive_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_tvu_retransmit_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_quic_endpoints: DEFAULT_NUM_QUIC_ENDPOINTS,
@@ -2907,6 +2909,7 @@ mod tests {
             bind_ip_addrs: BindIpAddrs::new(vec![ip]).unwrap(),
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
+            public_tvu_addr: None,
             num_tvu_receive_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_tvu_retransmit_sockets: MINIMUM_NUM_TVU_RECEIVE_SOCKETS,
             num_quic_endpoints: DEFAULT_NUM_QUIC_ENDPOINTS,

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -66,6 +66,7 @@ impl Node {
             advertised_ip: bind_ip_addr,
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
+            public_tvu_addr: None,
             num_tvu_receive_sockets: NonZero::new(1).unwrap(),
             num_tvu_retransmit_sockets: NonZero::new(1).unwrap(),
             num_quic_endpoints: NonZero::new(DEFAULT_QUIC_ENDPOINTS)
@@ -89,6 +90,7 @@ impl Node {
             bind_ip_addrs,
             public_tpu_addr,
             public_tpu_forwards_addr,
+            public_tvu_addr,
             num_tvu_receive_sockets,
             num_tvu_retransmit_sockets,
             num_quic_endpoints,
@@ -295,7 +297,11 @@ impl Node {
         );
 
         info.set_gossip((advertised_ip, gossip_ports[0])).unwrap();
-        info.set_tvu(UDP, (advertised_ip, tvu_port)).unwrap();
+        info.set_tvu(
+            UDP,
+            public_tvu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, tvu_port)),
+        )
+        .unwrap();
         info.set_tvu(QUIC, (advertised_ip, tvu_quic_port)).unwrap();
         info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, tpu_port)))
             .unwrap();

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1037,6 +1037,7 @@ impl TestValidator {
                 gossip_port: config.node_config.gossip_addr.port(),
                 port_range: config.node_config.port_range,
                 advertised_ip: bind_ip_addr,
+                public_tvu_addr: None,
                 public_tpu_addr: None,
                 public_tpu_forwards_addr: None,
                 num_tvu_receive_sockets: NonZero::new(1).unwrap(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -364,6 +364,18 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("public_tvu_addr")
+            .long("public-tvu-address")
+            .alias("tvu-host-addr")
+            .value_name("HOST:PORT")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host_port)
+            .help(
+                "Specify TVU address to advertise in gossip [default: ask --entrypoint or \
+                 localhost when --entrypoint is not provided]",
+            ),
+    )
+    .arg(
         Arg::with_name("tpu_vortexor_receiver_address")
             .long("tpu-vortexor-receiver-address")
             .value_name("HOST:PORT")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -823,6 +823,20 @@ pub fn execute(
         })
         .transpose()?;
 
+    let public_tvu_addr = matches
+        .value_of("public_tvu_addr")
+        .map(|public_tvu_addr| {
+            solana_net_utils::parse_host_port(public_tvu_addr)
+                .map_err(|err| format!("failed to parse --public-tvu-address: {err}"))
+        })
+        .transpose()?;
+
+    if bind_addresses.len() > 1 && public_tvu_addr.is_some() {
+        Err(String::from(
+            "--public-tvu-address can not be used in a multihoming context",
+        ))?;
+    }
+
     let tpu_vortexor_receiver_address =
         matches
             .value_of("tpu_vortexor_receiver_address")
@@ -865,6 +879,7 @@ pub fn execute(
         bind_ip_addrs: bind_addresses,
         public_tpu_addr,
         public_tpu_forwards_addr,
+        public_tvu_addr,
         num_tvu_receive_sockets: tvu_receive_threads,
         num_tvu_retransmit_sockets: tvu_retransmit_threads,
         num_quic_endpoints,


### PR DESCRIPTION
#### Problem

This allows the agave node to share a specific TVU inbound address that may differ from the gossip address. The impact of this change is that Turbine will direct shreds to specified address instead of gossip address.

#### Summary of Changes

* Add `--public-shred-address` similar to `--public-tpu-address`. Happy to adjust naming but `--public-tvu-address` seemed too similar to the existing command line flag.
