### PR TITLE
validator: Add --wait-for-exit flag to exit subcommand

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpc-core = { workspace = true }
 jsonrpc-core-client = { workspace = true, features = ["ipc"] }
 jsonrpc-derive = { workspace = true }
 jsonrpc-ipc-server = { workspace = true }
+libc = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -153,7 +153,8 @@ pub trait AdminRpc {
     type Metadata;
 
     #[rpc(meta, name = "exit")]
-    fn exit(&self, meta: Self::Metadata) -> Result<()>;
+    /// Initiates validator exit and returns the PID
+    fn exit(&self, meta: Self::Metadata) -> Result<u32>;
 
     #[rpc(meta, name = "reloadPlugin")]
     fn reload_plugin(
@@ -260,7 +261,7 @@ pub struct AdminRpcImpl;
 impl AdminRpc for AdminRpcImpl {
     type Metadata = AdminRpcRequestMetadata;
 
-    fn exit(&self, meta: Self::Metadata) -> Result<()> {
+    fn exit(&self, meta: Self::Metadata) -> Result<u32> {
         debug!("exit admin rpc request received");
 
         thread::Builder::new()
@@ -270,7 +271,7 @@ impl AdminRpc for AdminRpcImpl {
                 // receive a confusing error as the validator shuts down before a response is sent back.
                 thread::sleep(Duration::from_millis(100));
 
-                warn!("validator exit requested");
+                info!("validator exit requested");
                 meta.validator_exit.write().unwrap().exit();
 
                 if !meta.validator_exit_backpressure.is_empty() {
@@ -312,7 +313,7 @@ impl AdminRpc for AdminRpcImpl {
             })
             .unwrap();
 
-        Ok(())
+        Ok(std::process::id())
     }
 
     fn reload_plugin(
@@ -1548,9 +1549,13 @@ mod tests {
             expected_validator_id.pubkey().to_string()
         );
 
-        let contact_info_request =
-            r#"{"jsonrpc":"2.0","id":1,"method":"exit","params":[]}"#.to_string();
-        let exit_response = test_validator.handle_request(&contact_info_request);
+        let expected_parsed_response: Value = serde_json::from_str(&format!(
+            r#"{{"id": 1, "jsonrpc": "2.0", "result": {} }}"#,
+            std::process::id()
+        ))
+        .unwrap();
+        let exit_request = r#"{"jsonrpc":"2.0","id":1,"method":"exit","params":[]}"#.to_string();
+        let exit_response = test_validator.handle_request(&exit_request);
         let actual_parsed_response: Value =
             serde_json::from_str(&exit_response.expect("actual response"))
                 .expect("actual response deserialization");

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -152,9 +152,9 @@ impl solana_cli_output::QuietDisplay for AdminRpcRepairWhitelist {}
 pub trait AdminRpc {
     type Metadata;
 
-    #[rpc(meta, name = "exit")]
     /// Initiates validator exit; exit is asynchronous so the validator
     /// will almost certainly still be running when this method returns
+    #[rpc(meta, name = "exit")]
     fn exit(&self, meta: Self::Metadata) -> Result<()>;
 
     /// Return the process id (pid)

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -190,8 +190,8 @@ fn poll_until_pid_terminates(pid: u32) -> Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn poll_until_pid_terminates(pid: u32) -> Result<()> {
-    println!("Unable to monitor agave-validator process {pid} on this platform");
+fn poll_until_pid_terminates(_pid: u32) -> Result<()> {
+    println!("Unable to wait for agave-validator process termination on this platform");
     Ok(())
 }
 

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -130,7 +130,7 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     //
     // Additionally, delay checking the result until it will actually be used.
     // In an upgrade scenario, it is possible that a binary that calls pid()
-    // will be iniating exit against a process that doesn't support pid().
+    // will be initating exit against a process that doesn't support pid().
     // Since PostExitAction::Wait case is opt-in (via --wait-for-exit), the
     // result is checked ONLY in that case to provide a friendlier upgrade
     // path for user who are NOT using --wait-for-exit

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -15,7 +15,7 @@ const COMMAND: &str = "exit";
 const DEFAULT_MIN_IDLE_TIME: &str = "10";
 const DEFAULT_MAX_DELINQUENT_STAKE: &str = "5";
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PostExitAction {
     // Run the agave-validator monitor command indefinitely
     Monitor,
@@ -128,26 +128,35 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     // Grab the pid from the process before initiating exit as the running
     // validator will be unable to respond after exit has returned.
     //
-    // Additionally, delay checking the result until it will actually be used.
+    // Additionally, only check the pid() RPC call result if it will be used.
     // In an upgrade scenario, it is possible that a binary that calls pid()
     // will be initating exit against a process that doesn't support pid().
     // Since PostExitAction::Wait case is opt-in (via --wait-for-exit), the
     // result is checked ONLY in that case to provide a friendlier upgrade
-    // path for user who are NOT using --wait-for-exit
-    let validator_pid_result = admin_rpc_service::runtime().block_on(async move {
+    // path for users who are NOT using --wait-for-exit
+    const WAIT_FOR_EXIT_UNSUPPORTED_ERROR: &str =
+        "remote process exit cannot be waited on. `--wait-for-exit` is not supported by the remote process";
+    let post_exit_action = exit_args.post_exit_action.clone();
+    let validator_pid = admin_rpc_service::runtime().block_on(async move {
         let admin_client = admin_rpc_service::connect(ledger_path).await?;
-        let validator_pid_result = admin_client.pid().await;
+        let validator_pid = match post_exit_action {
+            Some(PostExitAction::Wait) => admin_client
+                .pid()
+                .await
+                .map_err(|_err| Error::Dynamic(WAIT_FOR_EXIT_UNSUPPORTED_ERROR.into()))?,
+            _ => 0,
+        };
         admin_client.exit().await?;
 
-        validator_pid_result
-    });
+        Ok::<u32, Error>(validator_pid)
+    })?;
 
     println!("Exit request sent");
 
     match exit_args.post_exit_action {
         None => Ok(()),
         Some(PostExitAction::Monitor) => monitor::execute(matches, ledger_path),
-        Some(PostExitAction::Wait) => poll_until_pid_terminates(validator_pid_result?),
+        Some(PostExitAction::Wait) => poll_until_pid_terminates(validator_pid),
     }?;
 
     Ok(())

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use std::{io, thread, time::Duration};
 use {
     crate::{
         admin_rpc_service,
@@ -7,8 +9,6 @@ use {
     solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
     std::path::Path,
 };
-#[cfg(target_os = "linux")]
-use {std::io, std::thread, std::time::Duration};
 
 const COMMAND: &str = "exit";
 

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -1,14 +1,14 @@
-#[cfg(target_os = "linux")]
-use {crate::commands::Error, std::io, std::thread, std::time::Duration};
 use {
     crate::{
         admin_rpc_service,
-        commands::{monitor, wait_for_restart_window, FromClapArgMatches, Result},
+        commands::{monitor, wait_for_restart_window, Error, FromClapArgMatches, Result},
     },
     clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand},
     solana_clap_utils::input_validators::{is_parsable, is_valid_percentage},
     std::path::Path,
 };
+#[cfg(target_os = "linux")]
+use {std::io, std::thread, std::time::Duration};
 
 const COMMAND: &str = "exit";
 
@@ -204,8 +204,9 @@ fn poll_until_pid_terminates(pid: u32) -> Result<()> {
 
 #[cfg(not(target_os = "linux"))]
 fn poll_until_pid_terminates(_pid: u32) -> Result<()> {
-    println!("Unable to wait for agave-validator process termination on this platform");
-    Ok(())
+    Err(Error::Dynamic(
+        "Unable to wait for agave-validator process termination on this platform".into(),
+    ))
 }
 
 #[cfg(test)]

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    TryFromInt(#[from] std::num::TryFromIntError),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
#### Problem
_Copied from https://github.com/anza-xyz/agave/pull/6233_

Currently, `agave-validator` exit will return immediately when the `AdminRpc` function call returns, even though the actual validator process might still be running. This isn't ideal if someone is trying to do something like:
```rust
agave-validator exit && ./restart_validator_script.sh
```

#### Summary of Changes
- Add a new `pid` method to `AdminRpc` interface
- Add a new `--wait-for-exit` flag option to `exit` subcommand
    - It works by querying the `PID` from a running validator, initiating exit (same as before) and then using waiting until the returned PID is no longer alive
    
#### Previous Attempt
This change was previously introduced in https://github.com/anza-xyz/agave/pull/6233; however, there was a minor issue discoverd that affects upgrade scenarios. Namely, if a "new" `agave-validator` binary (one that calls `pid()`) is used to exit an "old" `agave-validator` (one that predates this change), it would error out since the old bin wouldn't recognize the `pid()` request.

This is mitigated by calling `pid()` BUT only checking the result if using `--wait-for-exit`. Since the new flag is opt-in, it seems more reasonable to expect that someone who opted in to a new feature would keep an eye on it. Once a version with this change is widely adopted, `pid()` will be available and more direct error handling will work just fine

Since this is re-adding a reverted commit, I left the original two commits as-is and added a third commit for the change in behavior. Hopefully this makes things easier for folks who might have previously reviewed this change