### PR TITLE
Replaces scan_index()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2420,11 +2420,13 @@ impl AccountsDb {
                         }
                         oldest_dirty_slot = oldest_dirty_slot.min(*slot);
 
-                        store.accounts.scan_index(|index| {
-                            let pubkey = index.index_info.pubkey;
-                            let is_zero_lamport = index.index_info.lamports == 0;
-                            insert_candidate(pubkey, is_zero_lamport);
-                        });
+                        store
+                            .accounts
+                            .scan_accounts_without_data(|_offset, account| {
+                                let pubkey = *account.pubkey();
+                                let is_zero_lamport = account.is_zero_lamport();
+                                insert_candidate(pubkey, is_zero_lamport);
+                            });
                     });
                     oldest_dirty_slot
                 })

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7855,7 +7855,23 @@ impl AccountsDb {
                 });
             } else {
                 // withOUT secondary indexes -- scan accounts withOUT account data
-                storage.accounts.scan_index(itemizer);
+                storage
+                    .accounts
+                    .scan_accounts_without_data(|offset, account| {
+                        let data_len = account.data_len as u64;
+                        let stored_size_aligned =
+                            storage.accounts.calculate_stored_size(data_len as usize);
+                        let info = IndexInfo {
+                            stored_size_aligned,
+                            index_info: IndexInfoInner {
+                                offset,
+                                pubkey: *account.pubkey,
+                                lamports: account.lamports,
+                                data_len,
+                            },
+                        };
+                        itemizer(info);
+                    });
             }
             let items_len = items_local.len();
             let items = items_local.into_iter().map(|info| {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3880,33 +3880,40 @@ define_accounts_db_test!(test_alive_bytes, |accounts_db| {
     // Flushing cache should only create one storage entry
     let storage0 = accounts_db.get_and_assert_single_storage(slot);
 
-    storage0.accounts.scan_index(|account| {
-        let before_size = storage0.alive_bytes();
-        let account_info = accounts_db
-            .accounts_index
-            .get_cloned(&account.index_info.pubkey)
-            .unwrap()
-            .slot_list
-            .read()
-            .unwrap()
-            // Should only be one entry per key, since every key was only stored to slot 0
-            [0];
-        assert_eq!(account_info.0, slot);
-        let reclaims = [account_info];
-        num_obsolete_accounts += reclaims.len();
-        accounts_db.remove_dead_accounts(reclaims.iter(), None, MarkAccountsObsolete::Yes(slot));
-        let after_size = storage0.alive_bytes();
-        if storage0.count() == 0 {
-            // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
-            assert_eq!(after_size, 0);
-        } else {
-            assert_eq!(before_size, after_size + account.stored_size_aligned);
-            assert_eq!(
-                storage0.get_obsolete_accounts(None).len(),
-                num_obsolete_accounts
+    storage0
+        .accounts
+        .scan_accounts_without_data(|_offset, account| {
+            let before_size = storage0.alive_bytes();
+            let account_info = accounts_db
+                .accounts_index
+                .get_cloned(account.pubkey())
+                .unwrap()
+                .slot_list
+                .read()
+                .unwrap()
+                // Should only be one entry per key, since every key was only stored to slot 0
+                [0];
+            assert_eq!(account_info.0, slot);
+            let reclaims = [account_info];
+            num_obsolete_accounts += reclaims.len();
+            accounts_db.remove_dead_accounts(
+                reclaims.iter(),
+                None,
+                MarkAccountsObsolete::Yes(slot),
             );
-        }
-    });
+            let after_size = storage0.alive_bytes();
+            if storage0.count() == 0 {
+                // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
+                assert_eq!(after_size, 0);
+            } else {
+                let stored_size_aligned = storage0.accounts.calculate_stored_size(account.data_len);
+                assert_eq!(before_size, after_size + stored_size_aligned);
+                assert_eq!(
+                    storage0.get_obsolete_accounts(None).len(),
+                    num_obsolete_accounts
+                );
+            }
+        });
 });
 
 // Test alive_bytes_exclude_zero_lamport_single_ref_accounts calculation

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -6,7 +6,7 @@ use {
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_db::AccountsFileId,
         accounts_update_notifier_interface::AccountForGeyser,
-        append_vec::{AppendVec, AppendVecError, IndexInfo},
+        append_vec::{AppendVec, AppendVecError},
         storable_accounts::StorableAccounts,
         tiered_storage::{
             error::TieredStorageError, hot::HOT_FORMAT, index::IndexOffset, TieredStorage,
@@ -390,18 +390,6 @@ impl AccountsFile {
                 .reader()
                 .and_then(|reader| reader.get_account_data_lens(sorted_offsets).ok())
                 .unwrap_or_default(),
-        }
-    }
-
-    /// iterate over all entries to put in index
-    pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) {
-        match self {
-            Self::AppendVec(av) => av.scan_index(callback),
-            Self::TieredStorage(ts) => {
-                if let Some(reader) = ts.reader() {
-                    _ = reader.scan_index(callback);
-                }
-            }
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -972,22 +972,6 @@ impl AppendVec {
         }
     }
 
-    /// Iterate over all accounts and call `callback` with `IndexInfo` for each.
-    /// This fn can help generate an index of the data in this storage.
-    pub(crate) fn scan_index(&self, mut callback: impl FnMut(IndexInfo)) {
-        self.scan_stored_accounts_no_data(|account| {
-            callback(IndexInfo {
-                stored_size_aligned: account.stored_size,
-                index_info: IndexInfoInner {
-                    pubkey: *account.pubkey(),
-                    lamports: account.lamports(),
-                    offset: account.offset(),
-                    data_len: account.data_len(),
-                },
-            });
-        });
-    }
-
     /// Iterate over all accounts and call `callback` with each account.
     ///
     /// `callback` parameters:

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -2274,8 +2274,8 @@ pub mod tests {
         });
     }
 
-    /// A helper fn to test scan_index
-    fn test_scan_index_helper(
+    /// A helper fn to test scan_stored_accounts_no_data
+    fn test_scan_stored_accounts_no_data_helper(
         storage_access: StorageAccess,
         modify_fn: impl Fn(&PathBuf, usize) -> usize,
     ) {
@@ -2284,19 +2284,19 @@ pub mod tests {
             modify_fn,
             |append_vec, pubkeys, account_offsets, accounts| {
                 let mut i = 0;
-                append_vec.scan_index(|index_info| {
+                append_vec.scan_stored_accounts_no_data(|stored_account| {
                     let pubkey = pubkeys.get(i).unwrap();
                     let account = accounts.get(i).unwrap();
                     let offset = account_offsets.get(i).unwrap();
 
                     assert_eq!(
-                        index_info.stored_size_aligned,
+                        stored_account.stored_size,
                         aligned_stored_size(account.data().len()),
                     );
-                    assert_eq!(index_info.index_info.offset, *offset);
-                    assert_eq!(index_info.index_info.pubkey, *pubkey);
-                    assert_eq!(index_info.index_info.lamports, account.lamports());
-                    assert_eq!(index_info.index_info.data_len, account.data().len() as u64);
+                    assert_eq!(stored_account.offset(), *offset);
+                    assert_eq!(stored_account.pubkey(), pubkey);
+                    assert_eq!(stored_account.lamports(), account.lamports());
+                    assert_eq!(stored_account.data_len(), account.data().len() as u64);
 
                     i += 1;
                 });
@@ -2307,15 +2307,15 @@ pub mod tests {
 
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
-    fn test_scan_index(storage_access: StorageAccess) {
-        test_scan_index_helper(storage_access, |_, size| size);
+    fn test_scan_stored_accounts_no_data(storage_access: StorageAccess) {
+        test_scan_stored_accounts_no_data_helper(storage_access, |_, size| size);
     }
 
-    /// Test `scan_index` for storage with incomplete account meta data.
+    /// Test `scan_stored_accounts_no_data` for storage with incomplete account meta data.
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
-    fn test_scan_index_incomplete_data(storage_access: StorageAccess) {
-        test_scan_index_helper(storage_access, |path, size| {
+    fn test_scan_stored_accounts_no_data_incomplete_data(storage_access: StorageAccess) {
+        test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
             // Append 1 byte of data at the end of the storage file to simulate
             // incomplete account's meta data.
             let mut f = OpenOptions::new()
@@ -2328,11 +2328,11 @@ pub mod tests {
         });
     }
 
-    /// Test `scan_index` for storage which is missing the last account data
+    /// Test `scan_stored_accounts_no_data` for storage which is missing the last account data
     #[test_case(StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
-    fn test_scan_index_missing_account_data(storage_access: StorageAccess) {
-        test_scan_index_helper(storage_access, |path, size| {
+    fn test_scan_stored_accounts_no_data_missing_account_data(storage_access: StorageAccess) {
+        test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -5,7 +5,6 @@ use {
         account_info::{AccountInfo, Offset},
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_file::{MatchAccountOwnerError, StoredAccountsInfo},
-        append_vec::{IndexInfo, IndexInfoInner},
         tiered_storage::{
             byte_block,
             file::{TieredReadableFile, TieredWritableFile},
@@ -677,35 +676,6 @@ impl HotStorageReader {
             self.get_stored_account_callback(IndexOffset(i), |account| {
                 callback(AccountInfo::reduced_offset_to_offset(i), account)
             })?;
-        }
-        Ok(())
-    }
-
-    /// iterate over all entries to put in index
-    pub(crate) fn scan_index(
-        &self,
-        mut callback: impl FnMut(IndexInfo),
-    ) -> TieredStorageResult<()> {
-        for i in 0..self.footer.account_entry_count {
-            let index_offset = IndexOffset(i);
-            let account_offset = self.get_account_offset(index_offset)?;
-
-            let meta = self.get_account_meta_from_offset(account_offset)?;
-            let pubkey = self.get_account_address(index_offset)?;
-            let lamports = meta.lamports();
-            let account_block = self.get_account_block(account_offset, index_offset)?;
-            let data_len = meta.account_data_size(account_block);
-            callback(IndexInfo {
-                index_info: {
-                    IndexInfoInner {
-                        pubkey: *pubkey,
-                        lamports,
-                        offset: AccountInfo::reduced_offset_to_offset(i),
-                        data_len: data_len as u64,
-                    }
-                },
-                stored_size_aligned: stored_size(data_len),
-            });
         }
         Ok(())
     }

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -3,7 +3,6 @@ use {
         account_info::Offset,
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_file::MatchAccountOwnerError,
-        append_vec::IndexInfo,
         tiered_storage::{
             file::TieredReadableFile,
             footer::{AccountMetaFormat, TieredStorageFooter},
@@ -139,13 +138,6 @@ impl TieredStorageReader {
     pub fn scan_pubkeys(&self, callback: impl FnMut(&Pubkey)) -> TieredStorageResult<()> {
         match self {
             Self::Hot(hot) => hot.scan_pubkeys(callback),
-        }
-    }
-
-    /// iterate over all entries to put in index
-    pub(crate) fn scan_index(&self, callback: impl FnMut(IndexInfo)) -> TieredStorageResult<()> {
-        match self {
-            Self::Hot(hot) => hot.scan_index(callback),
         }
     }
 


### PR DESCRIPTION
#### Problem

The `scan_index()` function is extraneous. It is/can be implemented in terms of other scan_accounts functions. Having `scan_index()` just increases support burden unnecessarily.

Related discussion here: https://github.com/anza-xyz/agave/pull/6744#discussion_r2167873636.


#### Summary of Changes

Replace all call-sites of `scan_index()` with `scan_accounts_without_data()`.


Note to reviewers: I recommend going through this PR commit-by-commit.