### PR TITLE
Sets default full snapshot interval to 100k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Release channels have their own copy of this changelog:
 #### Changes
 * Reading snapshot archives requires increased `memlock` limits - recommended setting is `LimitMEMLOCK=2000000000` in systemd service configuration. Lack of sufficient limit will result slower startup times.
 * `--transaction-structure view` is now the default.
+* The default full snapshot interval is now 100,000 slots.
 
 ## 2.3.0
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -76,7 +76,7 @@ const VERSION_STRING_V1_2_0: &str = "1.2.0";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const BANK_SNAPSHOT_PRE_FILENAME_EXTENSION: &str = "pre";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(50_000).unwrap();
+    NonZeroU64::new(100_000).unwrap();
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
     NonZeroU64::new(100).unwrap();
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =


### PR DESCRIPTION
### Problem

* Generating full snapshots is expensive
* Downloading full snapshots is expensive

PR #5877 raised the default full snapshot interval to 50k slots. We see even more benefit by further raising the default full snapshot interval.


### Summary of Changes

This PR changes the default full snapshot interval to 100k slots.


### Justification

#### Generating full snapshots

Generating full snapshots is expensive due to the large amount of disk io and compute that is required for a snapshot. The validator must calculate a full accounts hash (will be going away with lattice hash features in v2.2 soon), then serialize the bank, and finally archive and compress the serialized bank and all the account storage files. Since the accounts hash calculation is going away, I'll ignore that for this discussion.

Archiving a full snapshot takes between 12 and 15 minutes on average for the edge canaries -- even up to 30 minutes for the known validators that compress snapshots more. During this time disk io for both reading and writing is elevated, which reduces available disk io for transaction processing. Many staked validators disable snapshots due to this, since they observe falling behind while snapshots are generating.

Additionally, while full snapshots are being processed, newer incremental snapshots must wait until the full snapshot is done. This results in a large gap of time where no snapshots are being made. If a node crashes during full snapshot archiving, its newest snapshot may be 15+ minutes old.

Increasing the full snapshot interval to 100k from 50k reduces how often full snapshots are taken, which reduces the cost of generating full snapshots, amortized over time. It also reduces the window where a crash can result in extended restart time, and unblocks incremental snapshot generation.


#### Downloading full snapshots

When a node is bootstrapping and joining the network, it must first download snapshots. Also, if a node has crashed (or just stopped for any reason) for long enough time, it will also need to download new snapshots.

A node joining the network for the first time will always need snapshots, so there's no getting around that. But for the nodes that are restarting, it would be preferable to only download an incremental snapshot instead of both a full snapshot and an incremental snapshot. Today full snapshots are around 90 GB and incremental snapshots are around 1 GB. By only downloading an incremental snapshot, the node would save considerable amount of time by not having to download an additional 90 GB. Fewer bytes to download means less downtime.

When downloading snapshots on restart, the node will try to reuse its local snapshots if possible. The current 50k full snapshot interval has a narrow window where it will be reused and only download an incremental snapshot. By increasing the interval to 100k we double how long the full snapshot is valid, and thus increase the likelihood a node only has to download an incremental snapshot.

Do also note that if the *downloader* can skip downloading a new full snapshot, that also means the *downloadee* doesn't need to serve that full snapshot either. This could be a huge savings in egress bandwidth for snapshot providers.


### Performance Considerations

What implications does changing the full snapshot interval have?


#### Snapshot Size

The first thing to check is snapshot size. I ran two similar nodes against mnb, one with the default 50k full snapshot interval (`TTy`), and the other with 100k (`7SP`).

For full snapshots, their sizes are the same (within the margin of the same, given that account storage files are cleaned and shrunk at different times/amounts on different machines).
![size full](https://github.com/user-attachments/assets/e34f14ae-00b8-446b-a18a-e45225ea98ff)


For incremental snapshots, would we see a doubling in size, since there could be twice as many slots in the incremental (up to 100k vs the default up to 50k)?
![size incr](https://github.com/user-attachments/assets/62edf251-80d3-47f1-bafe-7e78f7e562b7)
We *do* see an increase in the incremental snapshot size, but it is not double. Worst case appears to increase about 300 MB from 1.1 GB to 1.4 GB. Overall I consider this a small increase in size, all things considered.


#### Snapshot Archive Time

Next is how long it takes to archive the snapshots.

The time for archiving full snapshots is mostly the same:
![archive time full](https://github.com/user-attachments/assets/1abc70ae-093a-4581-b8b7-fb5396f82480)
(we see the 100k node taking *less* time, so likely not just the snapshot archive interval at play here)


The time for archiving incremental snapshots does increase, and looks like the graph of the incremental snapshot size above. Worst case increases about 3 seconds for incremental snapshot archiving.
![archive time incr](https://github.com/user-attachments/assets/93995751-fe90-49df-b104-57398deb8bfb)


#### Disk IO

For disk IO we see 7SP is active half the time as TTy, which makes sense since it is taking full snapshots half as often. This also shows how io-intensive the full snapshot is, and how *not* io-intensive the incremental snapshot is. Here are the disk read iops:
![disk iops](https://github.com/user-attachments/assets/e0123810-afd0-4226-ba55-59c252d832b2)

Increasing the full snapshot interval is a big win for disk io.


#### Validator Performance

Currently, a validator experiences elevated replay time while taking a full snapshot. So by reducing how often we take a full snapshot, we also reduce how often the validator has elevated replay time. Node operators care about this *a lot*.


#### Accounts DB Background Tasks

Clean times are mostly the same. The big spike is the epoch boundary.
![clean time](https://github.com/user-attachments/assets/51b4bc10-f2e1-4ef4-8d3e-90bc0b4d89a0)

Shrink times are mostly the same too. We can see when full snapshots are taken that we can purge some zero lamport accounts:
![shrink num zero lamport accounts](https://github.com/user-attachments/assets/35488028-5df7-4f99-a30b-cdf329f15daa)

The merkle-based accounts hash calculation reports stats on the number of zero lamport accounts encountered. The spikes are the full snapshots, and the ramps are the incremental snapshots. We see the max number of zero lamport accounts increases from ~7 million to ~10 million with the 100k snapshot interval.
![accounts hash calc num zero lamport accounts](https://github.com/user-attachments/assets/f98bb478-c99a-4e92-88fa-15f1a7ef2407)

The account storage files size can be a proxy for keeping these zero lamport accounts around longer too. We see ~400 MB, which is inline with 3 million accounts (storage overhead is 136 bytes per account in append vecs).
![account storage files size](https://github.com/user-attachments/assets/0b3b458e-e8bf-4316-8a2e-232e037a6ec3)

And lastly the in-memory portion of the accounts index is mostly unchanged:
![accounts index in mem size](https://github.com/user-attachments/assets/43918136-f2ae-418e-bf1e-0de574f66f9b)