### PR TITLE
clippy: ptr_eq

### DIFF
--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -4,6 +4,7 @@ use {
     std::{
         collections::HashMap,
         hash::RandomState,
+        ptr,
         sync::{
             atomic::{AtomicU64, Ordering},
             Arc,
@@ -115,7 +116,10 @@ impl SlotSupporters {
     pub(crate) fn recycle(mut self, total_stake: Stake, index_map: &Arc<IndexMap>) -> Self {
         self.total_stake = total_stake;
         self.total_support.store(0, Ordering::Relaxed);
-        let same_epoch = Arc::as_ptr(index_map) == Arc::as_ptr(&self.pubkey_to_index_map);
+        let same_epoch = ptr::eq(
+            Arc::as_ptr(index_map),
+            Arc::as_ptr(&self.pubkey_to_index_map),
+        );
         if !same_epoch {
             let old_len = self.supporting_stakes.len();
             let new_len = index_map.len();


### PR DESCRIPTION
New clippy lint that needs to be resolved before upgrading rust to 1.87.0.

Related to https://github.com/anza-xyz/agave/issues/6279.

```
error: use `std::ptr::eq` when comparing raw pointers
   --> core/src/cluster_slots_service/slot_supporters.rs:118:26
    |
118 |         let same_epoch = Arc::as_ptr(index_map) == Arc::as_ptr(&self.pubkey_to_index_map);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::eq(Arc::as_ptr(index_map), Arc::as_ptr(&self.pubkey_to_index_map))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_eq
    = note: `-D clippy::ptr-eq` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ptr_eq)]`
```