### PR TITLE
make `DuplicateShred::_unused_shred_type` a `u8`

### DIFF
--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -29,7 +29,10 @@ pub struct DuplicateShred {
     pub(crate) wallclock: u64,
     pub(crate) slot: Slot,
     _unused: u32,
-    _unused_shred_type: ShredType,
+    // NOTE: This field was previously typed as `ShredType`.
+    // It is semantically unused, so we now deserialize it as a plain `u8`
+    // to avoid strict enum validation errors on bad data.
+    _unused_shred_type: u8,
     // Serialized DuplicateSlotProof split into chunks.
     num_chunks: u8,
     chunk_index: u8,
@@ -244,7 +247,7 @@ where
             chunk_index: i as u8,
             chunk,
             _unused: 0,
-            _unused_shred_type: ShredType::Code,
+            _unused_shred_type: ShredType::Code.into(),
         });
     Ok(chunks)
 }
@@ -354,7 +357,7 @@ pub(crate) mod tests {
             from: Pubkey::new_unique(),
             wallclock: u64::MAX,
             slot: Slot::MAX,
-            _unused_shred_type: ShredType::Data,
+            _unused_shred_type: ShredType::Data.into(),
             num_chunks: u8::MAX,
             chunk_index: u8::MAX,
             chunk: Vec::default(),
@@ -491,7 +494,7 @@ pub(crate) mod tests {
                 chunk_index: i as u8,
                 chunk,
                 _unused: 0,
-                _unused_shred_type: ShredType::Code,
+                _unused_shred_type: ShredType::Code.into(),
             });
         Ok(chunks)
     }


### PR DESCRIPTION
#### Problem
if `_unused_shred_type` is not a valid `ShredType`, deser fails. 

#### Summary of Changes
Switch to `u8`. old code behaves the same and new code will deserialize any `u8`
