### PR TITLE
ci: install openssl 3.4.2 for windows clippy build

### DIFF
--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -6,7 +6,10 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  choco install openssl --version 3.4.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
+  echo "Downloading OpenSSL installer..."
+  curl -L -o "openssl-installer.exe" "https://slproweb.com/download/Win64OpenSSL-3_4_2.exe"
+  echo "Installing OpenSSL..."
+  cmd.exe /c "openssl-installer.exe /verysilent /sp- /suppressmsgboxes /norestart /DIR=C:\OpenSSL"
   export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
   export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
   ;;

--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -6,7 +6,7 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
+  choco install openssl --version 3.4.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
   export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
   export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
   ;;


### PR DESCRIPTION
#### Problem

openssl 3.4.1 has been removed by the provider and replaced with the latest patch release, 3.4.2. the openssl binaries are hosted by SLProWeb. however they remove old versions quite quickly, while updates on chocolatey are often delayed.

#### Summary of Changes

download the bins from their web directly