### PR TITLE
remove usage of 500 for unstaked max connections

### DIFF
--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -48,19 +48,10 @@ impl StakedStreamLoadEMA {
             max_streams_per_ms * EMA_WINDOW_MS
         };
 
-        let max_num_unstaked_connections =
-            u64::try_from(max_unstaked_connections).unwrap_or_else(|_| {
-                error!(
-                    "Failed to convert maximum number of unstaked connections {} to u64.",
-                    max_unstaked_connections
-                );
-                500
-            });
-
         let max_unstaked_load_in_throttling_window = if allow_unstaked_streams {
             Percentage::from(MAX_UNSTAKED_STREAMS_PERCENT)
                 .apply_to(max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS)
-                .saturating_div(max_num_unstaked_connections)
+                .saturating_div(max_unstaked_connections as u64)
         } else {
             0
         };


### PR DESCRIPTION
#### Problem

This code uses `500` (instead of`DEFAULT_MAX_UNSTAKED_CONNECTIONS`) to convert usize to u64.

#### Summary of Changes

 I could have used this constant instead, but better to remove it to simplify the code because usize to u64 cannot fail.