### PR TITLE
Keep rpc_client in cli config

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3114,7 +3114,6 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
 
 #[test]
 fn test_cli_program_v4() {
-    solana_logger::setup();
     let mut noop_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     noop_path.push("tests");
     noop_path.push("fixtures");
@@ -3154,7 +3153,6 @@ fn test_cli_program_v4() {
         lamports: 1000,
     };
     process_command(&config).unwrap();
-
     // Initial deployment
     config.output_format = OutputFormat::JsonCompact;
     config.command = CliCommand::ProgramV4(ProgramV4CliCommand::Deploy {
@@ -3167,7 +3165,6 @@ fn test_cli_program_v4() {
         upload_range: None..None,
     });
     assert!(process_command(&config).is_ok());
-
     let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.owner, loader_v4::id());
     assert!(program_account.executable);
@@ -3183,7 +3180,6 @@ fn test_cli_program_v4() {
         upload_range: None..None,
     });
     assert!(process_command(&config).is_ok());
-
     let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.owner, loader_v4::id());
     assert!(program_account.executable);
@@ -3199,7 +3195,6 @@ fn test_cli_program_v4() {
         upload_range: None..None,
     });
     assert!(process_command(&config).is_ok());
-
     let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.owner, loader_v4::id());
     assert!(program_account.executable);
@@ -3218,7 +3213,6 @@ fn test_cli_program_v4() {
         upload_range: None..None,
     });
     assert!(process_command(&config).is_ok());
-
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     assert_eq!(buffer_account.owner, loader_v4::id());
     assert!(buffer_account.executable);

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3153,6 +3153,7 @@ fn test_cli_program_v4() {
         lamports: 1000,
     };
     process_command(&config).unwrap();
+
     // Initial deployment
     config.output_format = OutputFormat::JsonCompact;
     config.command = CliCommand::ProgramV4(ProgramV4CliCommand::Deploy {


### PR DESCRIPTION
#### Problem

In the CLI test each API calls are creating the RpcClient along with TokioRuntime in it when the input config does not have a rpc_client set. This repeated creation and teardown of the runtime unnecessarily and it also impacts the asynchronous tasks in the Runtime. Found this while supporting closing connections on Connection cache shutdown. When the cache is shutdown we will gracefully close connections to let the server know we no longer use it and to free resources. Tearing down the runtime cause the async tasks earlier launched by the QUIC's Quinn library such as EndpointDriver to be closed and hence causing the closing connection effort lost. 

#### Summary of Changes
initialize the rpc_client in the config during test to reduce the Runtime churns.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
