### PR TITLE
ci(windows): use vcpkg to install openssl 3.4.1

### DIFF
--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -6,12 +6,31 @@ os_name="$1"
 
 case "$os_name" in
 "Windows")
-  echo "Downloading OpenSSL installer..."
-  curl -L -o "openssl-installer.exe" "https://slproweb.com/download/Win64OpenSSL-3_4_2.exe"
-  echo "Installing OpenSSL..."
-  cmd.exe /c "openssl-installer.exe /verysilent /sp- /suppressmsgboxes /norestart /DIR=C:\OpenSSL"
-  export OPENSSL_LIB_DIR="C:\OpenSSL\lib\VC\x64\MT"
-  export OPENSSL_INCLUDE_DIR="C:\OpenSSL\include"
+  # initialize vcpkg.json. the builtin-baseline is the commit that contains required version.
+  # the commit hash can be found in https://github.com/microsoft/vcpkg with `git log --pretty=format:"%H %s" | grep openssl`
+  # can be verified with:
+  # web:
+  #     https://github.com/microsoft/vcpkg/blob/__COMMIT_HASH__/versions/o-/openssl.json
+  # command:
+  #     git show __COMMIT_HASH__:versions/o-/openssl.json
+  cat > vcpkg.json <<EOL
+{
+  "name": "agave",
+  "version-string": "0.1.0",
+  "dependencies": ["openssl"],
+  "overrides": [
+    {
+      "name": "openssl",
+      "version": "3.4.1"
+    }
+  ],
+  "builtin-baseline": "5ee5eee0d3e9c6098b24d263e9099edcdcef6631"
+}
+EOL
+  vcpkg install --triplet x64-windows-static-md
+  rm vcpkg.json
+  export OPENSSL_LIB_DIR="$PWD/vcpkg_installed/x64-windows-static-md/lib"
+  export OPENSSL_INCLUDE_DIR="$PWD/vcpkg_installed/x64-windows-static-md/include"
   ;;
 "macOS") ;;
 "Linux")

--- a/.github/scripts/install-openssl.sh
+++ b/.github/scripts/install-openssl.sh
@@ -15,8 +15,6 @@ case "$os_name" in
   #     git show __COMMIT_HASH__:versions/o-/openssl.json
   cat > vcpkg.json <<EOL
 {
-  "name": "agave",
-  "version-string": "0.1.0",
   "dependencies": ["openssl"],
   "overrides": [
     {


### PR DESCRIPTION
#### Problem

slproweb doesn’t guarantee that libraries will be hosted indefinitely. if they remove any version unexpectedly, it could break our pipeline

#### Summary of Changes

- compile via vcpkg

note: this reverts the OpenSSL version bump I made in #6804 (from 3.4.1 -> 3.4.2). It’s also simpler for backports. we can bump master's version with another PR