### PR TITLE
Implement BufRead for accounts_db BufferedReader

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -25,7 +25,7 @@ use {
             StoredAccountsInfo,
         },
         accounts_hash::AccountHash,
-        buffered_reader::{BufferedReader, BufferedReaderStatus, Stack},
+        buffered_reader::{BufferedReader, Stack},
         file_io::read_into_buffer,
         is_zero_lamport::IsZeroLamport,
         storable_accounts::StorableAccounts,
@@ -1068,17 +1068,23 @@ impl AppendVec {
                 // Buffer for account data that doesn't fit within the stack allocated buffer.
                 // This will be re-used for each account that doesn't fit within the stack allocated buffer.
                 let mut data_overflow_buffer = vec![];
-                while let BufferedReaderStatus::Success = reader.read()? {
-                    let (offset, bytes_subset) = reader.get_offset_and_data();
-                    let (meta, next) = Self::get_type::<StoredMeta>(bytes_subset, 0).unwrap();
-                    let (account_meta, next) =
-                        Self::get_type::<AccountMeta>(bytes_subset, next).unwrap();
-                    let (hash, next) = Self::get_type::<AccountHash>(bytes_subset, next).unwrap();
+                loop {
+                    let offset = reader.get_offset();
+                    let bytes = match reader.fill_buf() {
+                        Ok(bytes) if bytes.is_empty() => break,
+                        Ok(bytes) => ValidSlice::new(bytes),
+                        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                        Err(err) => return Err(AccountsFileError::Io(err)),
+                    };
+
+                    let (meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
+                    let (account_meta, next) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
+                    let (hash, next) = Self::get_type::<AccountHash>(bytes, next).unwrap();
                     let data_len = meta.data_len as usize;
-                    let leftover = bytes_subset.len() - next;
+                    let leftover = bytes.len() - next;
                     if leftover >= data_len {
                         // we already read enough data to load this account
-                        let data = &bytes_subset.0[next..(next + data_len)];
+                        let data = &bytes.0[next..(next + data_len)];
                         let stored_size = aligned_stored_size(data_len);
                         let account = StoredAccountMeta {
                             meta,
@@ -1111,7 +1117,7 @@ impl AppendVec {
                         }
 
                         // Copy already read data to overflow buffer.
-                        data_overflow_buffer[..leftover].copy_from_slice(&bytes_subset.0[next..]);
+                        data_overflow_buffer[..leftover].copy_from_slice(&bytes.0[next..]);
 
                         // Read remaining data into overflow buffer.
                         let Ok(bytes_read) = read_into_buffer(
@@ -1261,12 +1267,13 @@ impl AppendVec {
                     mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>(),
                 );
                 loop {
-                    let offset = reader.get_next_fill_offset();
-                    let bytes = reader.fill_buf()?;
-                    if bytes.is_empty() {
-                        break;
-                    }
-                    let bytes = ValidSlice::new(bytes);
+                    let offset = reader.get_offset();
+                    let bytes = match reader.fill_buf() {
+                        Ok(bytes) if bytes.is_empty() => break,
+                        Ok(bytes) => ValidSlice::new(bytes),
+                        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                        Err(err) => return Err(AccountsFileError::Io(err)),
+                    };
                     let (stored_meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
                     let (account_meta, _) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
                     if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -7,6 +7,8 @@
 mod meta;
 pub mod test_utils;
 
+use std::io::BufRead;
+
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
@@ -1087,7 +1089,7 @@ impl AppendVec {
                             hash,
                         };
                         callback(account);
-                        reader.advance_offset(stored_size);
+                        reader.consume(stored_size);
                     } else if STORE_META_OVERHEAD + data_len <= BUFFER_SIZE {
                         reader.set_required_data_len(STORE_META_OVERHEAD + data_len);
                     } else {
@@ -1134,7 +1136,7 @@ impl AppendVec {
                             hash,
                         };
                         callback(account);
-                        reader.advance_offset(stored_size);
+                        reader.consume(stored_size);
                     }
                 }
             }
@@ -1258,8 +1260,13 @@ impl AppendVec {
                     file,
                     mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>(),
                 );
-                while let BufferedReaderStatus::Success = reader.read()? {
-                    let (offset, bytes) = reader.get_offset_and_data();
+                loop {
+                    let offset = reader.get_next_fill_offset();
+                    let bytes = reader.fill_buf()?;
+                    if bytes.is_empty() {
+                        break;
+                    }
+                    let bytes = ValidSlice::new(bytes);
                     let (stored_meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
                     let (account_meta, _) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
                     if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {
@@ -1280,7 +1287,7 @@ impl AppendVec {
                         offset,
                         stored_size,
                     });
-                    reader.advance_offset(stored_size);
+                    reader.consume(stored_size);
                 }
             }
         }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -7,8 +7,6 @@
 mod meta;
 pub mod test_utils;
 
-use std::io::BufRead;
-
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
@@ -42,7 +40,7 @@ use {
         self,
         convert::TryFrom,
         fs::{remove_file, File, OpenOptions},
-        io::{Seek, SeekFrom, Write},
+        io::{BufRead, Seek, SeekFrom, Write},
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1071,7 +1071,7 @@ impl AppendVec {
                 loop {
                     let offset = reader.get_offset();
                     let bytes = match reader.fill_buf() {
-                        Ok(bytes) if bytes.is_empty() => break,
+                        Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
                         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
                         Err(err) => return Err(AccountsFileError::Io(err)),
@@ -1269,7 +1269,7 @@ impl AppendVec {
                 loop {
                     let offset = reader.get_offset();
                     let bytes = match reader.fill_buf() {
-                        Ok(bytes) if bytes.is_empty() => break,
+                        Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
                         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
                         Err(err) => return Err(AccountsFileError::Io(err)),

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -205,10 +205,10 @@ impl<'a, T: Backing> BufRead for BufferedReader<'a, T> {
     /// Note that `amt` is not constrained by the size of the buffer returned by `fill_buf`
     /// and can be thus used to seek/skip reads from the underlying file.
     fn consume(&mut self, amt: usize) {
-        if self.buf_valid_bytes.len() >= delta {
-            self.buf_valid_bytes.start += delta;
+        if self.buf_valid_bytes.len() >= amt {
+            self.buf_valid_bytes.start += amt;
         } else {
-            let additional_amount_to_skip = delta - self.buf_valid_bytes.len();
+            let additional_amount_to_skip = amt - self.buf_valid_bytes.len();
             self.buf_valid_bytes = 0..0;
             self.file_offset_of_next_read += additional_amount_to_skip;
         }

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -1,15 +1,15 @@
 //! File I/O buffered reader for AppendVec
-//! Specialized BufRead-like type for reading account data.
+//! Specialized `BufRead`-like type for reading account data.
 //!
 //! Callers can use this type to iterate efficiently over append vecs. They can do so by repeatedly
-//! calling read(), advance_offset() and set_required_data_len(account_data_len) once the next account
+//! calling `fill_buf()`, `consume()` and `set_required_data_len(account_data_len)` once the next account
 //! data length is known.
 //!
-//! Unlike BufRead/BufReader, this type guarantees that on the next read() after calling
-//! set_required_data_len(len), the whole account data is buffered _linearly_ in memory and available to
+//! Unlike BufRead/BufReader, this type guarantees that on the next `fill_buf()` after calling
+//! `set_required_data_len(len)`, the whole account data is buffered _linearly_ in memory and available to
 //! be returned.
 use {
-    crate::{append_vec::ValidSlice, file_io::read_more_buffer},
+    crate::file_io::read_more_buffer,
     std::{
         fs::File,
         io::{self, BufRead, BufReader},
@@ -57,12 +57,6 @@ impl<const N: usize> Backing for Stack<N> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum BufferedReaderStatus {
-    Eof,
-    Success,
-}
-
 /// read a file a large buffer at a time and provide access to a slice in that buffer
 pub struct BufferedReader<'a, T> {
     /// when we are next asked to read from file, start at this offset
@@ -105,17 +99,6 @@ impl<'a, T> BufferedReader<'a, T> {
         }
     }
 
-    /// advance the offset of where to read next by `delta`
-    pub fn advance_offset(&mut self, delta: usize) {
-        if self.buf_valid_bytes.len() >= delta {
-            self.buf_valid_bytes.start += delta;
-        } else {
-            let additional_amount_to_skip = delta - self.buf_valid_bytes.len();
-            self.buf_valid_bytes = 0..0;
-            self.file_offset_of_next_read += additional_amount_to_skip;
-        }
-    }
-
     /// specify the amount of data required to read next time `read` is called
     #[inline(always)]
     pub fn set_required_data_len(&mut self, len: usize) {
@@ -128,7 +111,7 @@ where
     T: Backing,
 {
     /// read to make sure we have the minimum amount of data
-    pub fn read(&mut self) -> io::Result<BufferedReaderStatus> {
+    fn read_required_bytes(&mut self) -> io::Result<()> {
         let must_read = self
             .read_requirements
             .unwrap_or(self.default_min_read_requirement);
@@ -145,39 +128,28 @@ where
                 &mut self.buf_valid_bytes,
             )?;
             if self.buf_valid_bytes.len() < must_read {
-                return Ok(BufferedReaderStatus::Eof);
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "unable to read enough data",
+                ));
             }
         }
         // reset this once we have checked that we had this much data once
         self.read_requirements = None;
-        Ok(BufferedReaderStatus::Success)
+        Ok(())
     }
 
-    /// return the biggest slice of valid data starting at the current offset
+    /// Return file offset within `file` of the current consume position.
+    ///
+    /// The offset is corresponding to the start of buffer that will be returned
+    /// by the next `fill_buf` call.
     #[inline(always)]
-    fn get_data(&'a self) -> ValidSlice<'a> {
-        // SAFETY: We only read from memory that has been initialized by `read_more_buffer` and lifetime is tied to self.
-        ValidSlice::new(unsafe { &self.buf.as_slice()[self.buf_valid_bytes.clone()] })
-    }
-
-    /// return file offset within `file` corresponding to the start of buffer returned by
-    /// next `fill_buf` call
-    #[inline(always)]
-    pub fn get_next_fill_offset(&'a self) -> usize {
+    pub fn get_offset(&'a self) -> usize {
         if self.buf_valid_bytes.is_empty() {
             self.file_offset_of_next_read
         } else {
             self.file_last_offset + self.buf_valid_bytes.start
         }
-    }
-
-    /// return offset within `file` of start of read at current offset
-    #[inline(always)]
-    pub fn get_offset_and_data(&'a self) -> (usize, ValidSlice<'a>) {
-        (
-            self.file_last_offset + self.buf_valid_bytes.start,
-            self.get_data(),
-        )
     }
 }
 
@@ -210,18 +182,36 @@ impl<'a, T: Backing> io::Read for BufferedReader<'a, T> {
     }
 }
 
+/// `BufferedReader` implements a more permissive API compared to `BufRead`
+/// by allowing `consume` to advance beyond the end of the buffer returned by `fill_buf`.
 impl<'a, T: Backing> BufRead for BufferedReader<'a, T> {
+    /// Return the biggest slice of valid data starting at the current offset.
+    ///
+    /// Note that `fill_buf` has stronger guarantee than `BufRead::fill_buf` and returns
+    /// at least the number of bytes requested by `default_min_read_requirement` and
+    /// `set_required_data_len`. If that condition cannot be met
+    /// `Err(io::ErrorKind::UnexpectedEof)` is returned.
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        match self.read()? {
-            BufferedReaderStatus::Eof => Ok(&[]),
-            BufferedReaderStatus::Success => {
-                Ok(unsafe { &self.buf.as_slice()[self.buf_valid_bytes.clone()] })
-            }
-        }
+        self.read_required_bytes()?;
+
+        // SAFETY: We only read from memory that has been initialized by `read_more_buffer`
+        // and lifetime is tied to self.
+        Ok(unsafe { &self.buf.as_slice()[self.buf_valid_bytes.clone()] })
     }
 
+    /// Advance the offset by `amt` to a `file` position where next `fill_buf` buffer should
+    /// start at.
+    ///
+    /// Note that `amt` is not constrained by the size of the buffer returned by `fill_buf`
+    /// and can be thus used to seek/skip reads from the underlying file.
     fn consume(&mut self, amt: usize) {
-        self.advance_offset(amt);
+        if self.buf_valid_bytes.len() >= delta {
+            self.buf_valid_bytes.start += delta;
+        } else {
+            let additional_amount_to_skip = delta - self.buf_valid_bytes.len();
+            self.buf_valid_bytes = 0..0;
+            self.file_offset_of_next_read += additional_amount_to_skip;
+        }
     }
 }
 
@@ -249,7 +239,10 @@ pub fn large_file_buf_reader(
 
 #[cfg(all(unix, test))]
 mod tests {
-    use {super::*, std::io::Write, tempfile::tempfile, test_case::test_case};
+    use {
+        super::*, crate::append_vec::ValidSlice, std::io::Write, tempfile::tempfile,
+        test_case::test_case,
+    };
 
     #[inline(always)]
     fn rand_bytes<const N: usize>() -> [u8; N] {
@@ -271,45 +264,42 @@ mod tests {
         let default_min_read = 8;
         let mut reader =
             BufferedReader::new(backing, file_len_valid, &sample_file, default_min_read);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         let mut expected_offset = 0;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), buffer_size);
         assert_eq!(slice.slice(), &bytes[0..buffer_size]);
 
-        // Consume the data and attempt to read next 32 bytes, expect to hit EOF and only read 16 bytes
+        // Consume the data and attempt to read next 32 bytes, expect to hit EOF
         let advance = 16;
         let mut required_len = 32;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
-        let expected_slice_len = 16;
         assert_eq!(offset, expected_offset);
-        assert_eq!(slice.len(), expected_slice_len);
-        assert_eq!(slice.slice(), &bytes[offset..FILE_SIZE]);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
 
-        // Continue reading should yield EOF and empty slice.
-        reader.advance_offset(advance);
+        // Continue reading should yield EOF.
+        reader.consume(advance);
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        let expected_slice_len = 0;
-        assert_eq!(slice.len(), expected_slice_len);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
 
         // set_required_data to zero and offset should not change, and slice should be empty.
         required_len = 0;
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         let expected_offset = file_len_valid;
         assert_eq!(offset, expected_offset);
         let expected_slice_len = 0;
@@ -331,9 +321,8 @@ mod tests {
         let default_min_read_size = 8;
         let mut reader =
             BufferedReader::new(backing, valid_len, &sample_file, default_min_read_size);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         let mut expected_offset = 0;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), buffer_size);
@@ -342,56 +331,54 @@ mod tests {
         // Consume the data and attempt read next 32 bytes, expect to hit `valid_len`, and only read 14 bytes
         let mut advance = 16;
         let mut required_data_len = 32;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        let expected_slice_len = valid_len - offset;
-        assert_eq!(slice.len(), expected_slice_len);
-        let expected_slice_range = 16..30;
-        assert_eq!(slice.slice(), &bytes[expected_slice_range]);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
 
-        // Continue reading should yield EOF and empty slice.
+        // Continue reading should yield EOF.
         advance = 14;
         required_data_len = 32;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        let expected_slice_len = 0;
-        assert_eq!(slice.len(), expected_slice_len);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
 
-        // Move the offset passed `valid_len`, expect to hit EOF and return empty slice.
+        // Move the offset passed `valid_len`, expect to hit EOF.
         advance = 1;
         required_data_len = 8;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        let expected_slice_len = 0;
-        assert_eq!(slice.len(), expected_slice_len);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
 
-        // Move the offset passed file_len, expect to hit EOF and return empty slice.
+        // Move the offset passed file_len, expect to hit EOF.
         advance = 3;
         required_data_len = 8;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        let expected_slice_len = 0;
-        assert_eq!(slice.len(), expected_slice_len);
+        assert_eq!(
+            reader.fill_buf().expect_err("Should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
     }
 
     #[test_case(Stack::<16>::new(), 16)]
@@ -407,9 +394,8 @@ mod tests {
         let default_min_read_size = 8;
         let mut reader =
             BufferedReader::new(backing, file_len_valid, &sample_file, default_min_read_size);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         let mut expected_offset = 0;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), buffer_size);
@@ -418,11 +404,10 @@ mod tests {
         // Consume the partial data (8 byte) and attempt to read next 8 bytes
         let mut advance = 8;
         let mut required_len = 8;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), required_len);
@@ -434,11 +419,10 @@ mod tests {
         // Continue reading should succeed and read the rest 16 bytes.
         advance = 8;
         required_len = 16;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), required_len);
@@ -450,14 +434,15 @@ mod tests {
         // Continue reading should yield EOF and empty slice.
         advance = 16;
         required_len = 32;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Eof);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
-        assert_eq!(slice.len(), 0);
+        assert_eq!(
+            reader.fill_buf().expect_err("should hit EOF").kind(),
+            io::ErrorKind::UnexpectedEof
+        );
     }
 
     #[test_case(Stack::<16>::new(), 16)]
@@ -472,9 +457,8 @@ mod tests {
         let valid_len = 32;
         let default_min_read = 8;
         let mut reader = BufferedReader::new(backing, valid_len, &sample_file, default_min_read);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         let mut expected_offset = 0;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), buffer_size);
@@ -484,11 +468,10 @@ mod tests {
         // This will move the leftover 8bytes and read next 8 bytes.
         let mut advance = 8;
         let mut required_data_len = 16;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), required_data_len);
@@ -500,11 +483,10 @@ mod tests {
         // Continue reading should succeed and read the rest 8 bytes.
         advance = 16;
         required_data_len = 8;
-        reader.advance_offset(advance);
+        reader.consume(advance);
         reader.set_required_data_len(required_data_len);
-        let result = reader.read().unwrap();
-        assert_eq!(result, BufferedReaderStatus::Success);
-        let (offset, slice) = reader.get_offset_and_data();
+        let offset = reader.get_offset();
+        let slice = ValidSlice::new(reader.fill_buf().unwrap());
         expected_offset += advance;
         assert_eq!(offset, expected_offset);
         assert_eq!(slice.len(), required_data_len);

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -169,7 +169,7 @@ impl<'a, const N: usize> BufferedReader<'a, Stack<N>> {
     }
 }
 
-impl<'a, T: Backing> io::Read for BufferedReader<'a, T> {
+impl<T: Backing> io::Read for BufferedReader<'_, T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let available = self.fill_buf()?;
         if available.is_empty() {
@@ -184,7 +184,7 @@ impl<'a, T: Backing> io::Read for BufferedReader<'a, T> {
 
 /// `BufferedReader` implements a more permissive API compared to `BufRead`
 /// by allowing `consume` to advance beyond the end of the buffer returned by `fill_buf`.
-impl<'a, T: Backing> BufRead for BufferedReader<'a, T> {
+impl<T: Backing> BufRead for BufferedReader<'_, T> {
     /// Return the biggest slice of valid data starting at the current offset.
     ///
     /// Note that `fill_buf` has stronger guarantee than `BufRead::fill_buf` and returns


### PR DESCRIPTION
#### Problem
`BufferedReader` uses a custom API to implement the same access pattern as `BufRead` trait (though it also relaxes some of its constraints and adds a couple of extensions).
The custom API makes it harder to understand and reason about, but also it's harder to implement/substitute with an alternative implementation (e.g. io_uring read-ahead buffered reader).

#### Summary of Changes
`BufferedReader` provides all the functionality of `BufRead`, so the custom API is converted to use of `fill_buf` and `consume`. The extra functionality like access to current offset and setting min required data is kept as pub API of `BufferedReader` (when alternative impl is available, those should be elevated to separete trait that will extend `BufRead`).
