### PR TITLE
Make `InstructionAccount` compatible with `#[repr(C)]`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -409,13 +409,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 pubkey,
                 AccountSharedData::new(0, allocation_size, &Pubkey::new_unique()),
             ));
-            instruction_accounts.push(InstructionAccount {
-                index_in_transaction: 0,
-                index_in_caller: 0,
-                index_in_callee: 0,
-                is_signer: false,
-                is_writable: true,
-            });
+            instruction_accounts.push(InstructionAccount::new(0, 0, 0, false, true));
             vec![]
         }
         Err(_) => {
@@ -486,13 +480,13 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                         transaction_accounts.push((pubkey, account));
                         idx
                     };
-                    InstructionAccount {
-                        index_in_transaction: txn_acct_index as IndexOfAccount,
-                        index_in_caller: txn_acct_index as IndexOfAccount,
-                        index_in_callee: txn_acct_index as IndexOfAccount,
-                        is_signer: account_info.is_signer.unwrap_or(false),
-                        is_writable: account_info.is_writable.unwrap_or(false),
-                    }
+                    InstructionAccount::new(
+                        txn_acct_index as IndexOfAccount,
+                        txn_acct_index as IndexOfAccount,
+                        txn_acct_index as IndexOfAccount,
+                        account_info.is_signer.unwrap_or(false),
+                        account_info.is_writable.unwrap_or(false),
+                    )
                 })
                 .collect();
             input.instruction_data

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -628,13 +628,13 @@ mod tests {
                     .iter()
                     .position(|account_index| account_index == index_in_transaction)
                     .unwrap_or(index_in_instruction);
-                InstructionAccount {
-                    index_in_transaction: *index_in_transaction,
-                    index_in_caller: *index_in_transaction,
-                    index_in_callee: index_in_callee as IndexOfAccount,
-                    is_signer: false,
-                    is_writable: is_writable(index_in_instruction),
-                }
+                InstructionAccount::new(
+                    *index_in_transaction,
+                    *index_in_transaction,
+                    index_in_callee as IndexOfAccount,
+                    false,
+                    is_writable(index_in_instruction),
+                )
             })
             .collect()
     }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -324,7 +324,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
                     .set_owner(account_info.owner.as_ref())
                     .unwrap();
             }
-            if instruction_account.is_writable {
+            if instruction_account.is_writable() {
                 account_indices.push((instruction_account.index_in_caller, account_info_index));
             }
         }

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -93,13 +93,13 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
             .iter()
             .position(|account| account.index_in_transaction == index_in_transaction)
             .unwrap_or(instruction_account_index) as IndexOfAccount;
-        instruction_accounts.push(InstructionAccount {
-            index_in_caller: instruction_account_index as IndexOfAccount,
+        instruction_accounts.push(InstructionAccount::new(
+            instruction_account_index as IndexOfAccount,
             index_in_transaction,
             index_in_callee,
-            is_signer: false,
-            is_writable: instruction_account_index >= 4,
-        });
+            false,
+            instruction_account_index >= 4,
+        ));
     }
 
     let mut transaction_context =

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -875,8 +875,8 @@ where
             accounts.push(TranslatedAccount {
                 index_in_caller: instruction_account.index_in_caller,
                 caller_account,
-                update_caller_account_region: instruction_account.is_writable || update_caller,
-                update_caller_account_info: instruction_account.is_writable,
+                update_caller_account_region: instruction_account.is_writable() || update_caller,
+                update_caller_account_info: instruction_account.is_writable(),
             });
         } else {
             ic_msg!(
@@ -1324,15 +1324,15 @@ mod tests {
             let instruction_accounts = $instruction_accounts
                 .iter()
                 .enumerate()
-                .map(
-                    |(index_in_callee, index_in_transaction)| InstructionAccount {
-                        index_in_transaction: *index_in_transaction as IndexOfAccount,
-                        index_in_caller: *index_in_transaction as IndexOfAccount,
-                        index_in_callee: index_in_callee as IndexOfAccount,
-                        is_signer: false,
-                        is_writable: $transaction_accounts[*index_in_transaction as usize].2,
-                    },
-                )
+                .map(|(index_in_callee, index_in_transaction)| {
+                    InstructionAccount::new(
+                        *index_in_transaction as IndexOfAccount,
+                        *index_in_transaction as IndexOfAccount,
+                        index_in_callee as IndexOfAccount,
+                        false,
+                        $transaction_accounts[*index_in_transaction as usize].2,
+                    )
+                })
                 .collect::<Vec<_>>();
             let transaction_accounts = $transaction_accounts
                 .into_iter()
@@ -1879,20 +1879,8 @@ mod tests {
 
         let accounts = SyscallInvokeSignedRust::translate_accounts(
             &[
-                InstructionAccount {
-                    index_in_transaction: 1,
-                    index_in_caller: 0,
-                    index_in_callee: 0,
-                    is_signer: false,
-                    is_writable: true,
-                },
-                InstructionAccount {
-                    index_in_transaction: 1,
-                    index_in_caller: 0,
-                    index_in_callee: 0,
-                    is_signer: false,
-                    is_writable: true,
-                },
+                InstructionAccount::new(1, 0, 0, false, true),
+                InstructionAccount::new(1, 0, 0, false, true),
             ],
             vm_addr,
             1,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4438,13 +4438,13 @@ mod tests {
                     .transaction_context
                     .get_instruction_context_stack_height()
             {
-                let instruction_accounts = [InstructionAccount {
-                    index_in_transaction: index_in_trace.saturating_add(1) as IndexOfAccount,
-                    index_in_caller: 0, // This is incorrect / inconsistent but not required
-                    index_in_callee: 0,
-                    is_signer: false,
-                    is_writable: false,
-                }];
+                let instruction_accounts = [InstructionAccount::new(
+                    index_in_trace.saturating_add(1) as IndexOfAccount,
+                    0, // This is incorrect / inconsistent but not required
+                    0,
+                    false,
+                    false,
+                )];
                 invoke_context
                     .transaction_context
                     .get_next_instruction_context()

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -60,13 +60,7 @@ macro_rules! with_mock_invoke_context {
                 AccountSharedData::new(2, $account_size, &program_key),
             ),
         ];
-        let instruction_accounts = vec![InstructionAccount {
-            index_in_transaction: 2,
-            index_in_caller: 2,
-            index_in_callee: 0,
-            is_signer: false,
-            is_writable: true,
-        }];
+        let instruction_accounts = vec![InstructionAccount::new(2, 2, 0, false, true)];
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,
             transaction_context,

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -294,20 +294,8 @@ mod test {
                 (system_program::id(), AccountSharedData::default()),
             ];
             let $instruction_accounts = vec![
-                InstructionAccount {
-                    index_in_transaction: 0,
-                    index_in_caller: 0,
-                    index_in_callee: 0,
-                    is_signer: true,
-                    is_writable: true,
-                },
-                InstructionAccount {
-                    index_in_transaction: 1,
-                    index_in_caller: 1,
-                    index_in_callee: 1,
-                    is_signer: false,
-                    is_writable: true,
-                },
+                InstructionAccount::new(0, 0, 0, true, true),
+                InstructionAccount::new(1, 1, 1, false, true),
             ];
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
         };

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1158,17 +1158,7 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(
-            &[0],
-            &[InstructionAccount {
-                index_in_transaction: 1,
-                index_in_caller: 1,
-                index_in_callee: 0,
-                is_signer: false,
-                is_writable: true,
-            }],
-            &[],
-        );
+        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state
@@ -1313,17 +1303,7 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(
-            &[0],
-            &[InstructionAccount {
-                index_in_transaction: 1,
-                index_in_caller: 1,
-                index_in_callee: 0,
-                is_signer: false,
-                is_writable: true,
-            }],
-            &[],
-        );
+        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -38,13 +38,13 @@ pub(crate) fn process_message(
                 .unwrap_or(instruction_account_index)
                 as IndexOfAccount;
             let index_in_transaction = *index_in_transaction as usize;
-            instruction_accounts.push(InstructionAccount {
-                index_in_transaction: index_in_transaction as IndexOfAccount,
-                index_in_caller: index_in_transaction as IndexOfAccount,
+            instruction_accounts.push(InstructionAccount::new(
+                index_in_transaction as IndexOfAccount,
+                index_in_transaction as IndexOfAccount,
                 index_in_callee,
-                is_signer: message.is_signer(index_in_transaction),
-                is_writable: message.is_writable(index_in_transaction),
-            });
+                message.is_signer(index_in_transaction),
+                message.is_writable(index_in_transaction),
+            ));
         }
 
         let mut compute_units_consumed = 0;

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -383,13 +383,13 @@ fn execute_fixture_as_instr(
             .position(|idx| *idx == *index_txn)
             .unwrap_or(instruction_acct_idx);
 
-        instruction_accounts.push(InstructionAccount {
-            index_in_transaction: *index_txn as IndexOfAccount,
-            index_in_caller: *index_txn as IndexOfAccount,
-            index_in_callee: index_in_callee as IndexOfAccount,
-            is_signer: sanitized_message.is_signer(*index_txn as usize),
-            is_writable: sanitized_message.is_writable(*index_txn as usize),
-        });
+        instruction_accounts.push(InstructionAccount::new(
+            *index_txn as IndexOfAccount,
+            *index_txn as IndexOfAccount,
+            index_in_callee as IndexOfAccount,
+            sanitized_message.is_signer(*index_txn as usize),
+            sanitized_message.is_writable(*index_txn as usize),
+        ));
     }
 
     let mut compute_units_consumed = 0u64;

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -91,11 +91,11 @@ impl InstructionAccount {
     }
 
     pub fn is_signer(&self) -> bool {
-        self.is_signer == 1
+        self.is_signer != 0
     }
 
     pub fn is_writable(&self) -> bool {
-        self.is_writable == 1
+        self.is_writable != 0
     }
 
     pub fn set_is_signer(&mut self, value: bool) {

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -68,9 +68,9 @@ pub struct InstructionAccount {
     /// This excludes the program accounts.
     pub index_in_callee: IndexOfAccount,
     /// Is this account supposed to sign
-    is_signer: bool,
+    is_signer: u8,
     /// Is this account allowed to become writable
-    is_writable: bool,
+    is_writable: u8,
 }
 
 impl InstructionAccount {
@@ -85,25 +85,25 @@ impl InstructionAccount {
             index_in_transaction,
             index_in_caller,
             index_in_callee,
-            is_signer,
-            is_writable,
+            is_signer: is_signer as u8,
+            is_writable: is_writable as u8,
         }
     }
 
     pub fn is_signer(&self) -> bool {
-        self.is_signer
+        self.is_signer == 1
     }
 
     pub fn is_writable(&self) -> bool {
-        self.is_writable
+        self.is_writable == 1
     }
 
     pub fn set_is_signer(&mut self, value: bool) {
-        self.is_signer = value;
+        self.is_signer = value as u8;
     }
 
     pub fn set_is_writable(&mut self, value: bool) {
-        self.is_writable = value;
+        self.is_writable = value as u8;
     }
 }
 
@@ -831,7 +831,7 @@ impl InstructionContext {
             .instruction_accounts
             .get(instruction_account_index as usize)
             .ok_or(InstructionError::MissingAccount)?
-            .is_signer)
+            .is_signer())
     }
 
     /// Returns whether an instruction account is writable
@@ -843,7 +843,7 @@ impl InstructionContext {
             .instruction_accounts
             .get(instruction_account_index as usize)
             .ok_or(InstructionError::MissingAccount)?
-            .is_writable)
+            .is_writable())
     }
 
     /// Calculates the set of all keys of signer instruction accounts in this Instruction
@@ -853,7 +853,7 @@ impl InstructionContext {
     ) -> Result<HashSet<Pubkey>, InstructionError> {
         let mut result = HashSet::new();
         for instruction_account in self.instruction_accounts.iter() {
-            if instruction_account.is_signer {
+            if instruction_account.is_signer() {
                 result.insert(
                     *transaction_context
                         .get_key_of_account_at_index(instruction_account.index_in_transaction)?,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -68,9 +68,43 @@ pub struct InstructionAccount {
     /// This excludes the program accounts.
     pub index_in_callee: IndexOfAccount,
     /// Is this account supposed to sign
-    pub is_signer: bool,
+    is_signer: bool,
     /// Is this account allowed to become writable
-    pub is_writable: bool,
+    is_writable: bool,
+}
+
+impl InstructionAccount {
+    pub fn new(
+        index_in_transaction: IndexOfAccount,
+        index_in_caller: IndexOfAccount,
+        index_in_callee: IndexOfAccount,
+        is_signer: bool,
+        is_writable: bool,
+    ) -> InstructionAccount {
+        InstructionAccount {
+            index_in_transaction,
+            index_in_caller,
+            index_in_callee,
+            is_signer,
+            is_writable,
+        }
+    }
+
+    pub fn is_signer(&self) -> bool {
+        self.is_signer
+    }
+
+    pub fn is_writable(&self) -> bool {
+        self.is_writable
+    }
+
+    pub fn set_is_signer(&mut self, value: bool) {
+        self.is_signer = value;
+    }
+
+    pub fn set_is_writable(&mut self, value: bool) {
+        self.is_writable = value;
+    }
 }
 
 /// An account key and the matching account

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -55,6 +55,7 @@ pub type IndexOfAccount = u16;
 /// Contains account meta data which varies between instruction.
 ///
 /// It also contains indices to other structures for faster lookup.
+#[repr(C)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InstructionAccount {
     /// Points to the account and its key in the `TransactionContext`


### PR DESCRIPTION
#### Problem

In runtime ABIv2, we want to share the same data structures between programs and the validator. In [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177/files), we propose the usage of `InstructionAccount` to hold the information about the accounts an instruction needs in its own memory region.

Exposing the data structure to programs means it must be `#[repr(C)]` in Rust so that it can have a stable layout between Rust versions.

Rust does not support `bool` types in `#[repr(C)]`, so `InstructionAccount` is not stable.

#### Summary of Changes
1. Make `is_signer` and `is_writable` private.
2. Create accessor and modifier functions for the `is_signer` and `is_writable` members.
3. Create a constructor for `InstructionAccount`, since two of its members are now private.
4. Change the inner type of `is_signer` and `is_writable` to `u8`.
5. Adapt the impacted code.
