### PR TITLE
chore: Fix clippy nightly-2025-03-29 errors

### DIFF
--- a/accounts-db/src/io_uring/memory.rs
+++ b/accounts-db/src/io_uring/memory.rs
@@ -80,7 +80,7 @@ impl PageAlignedMemory {
             )
         };
 
-        if ptr == libc::MAP_FAILED {
+        if std::ptr::eq(ptr, libc::MAP_FAILED) {
             return Err(AllocError);
         }
 

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -378,7 +378,7 @@ pub(crate) unsafe fn mmap_ring<T>(
             ring_type as i64,
         )
     };
-    if map_addr == libc::MAP_FAILED {
+    if ptr::eq(map_addr, libc::MAP_FAILED) {
         return Err(io::Error::last_os_error());
     }
     // Safety: manual pointer arithmetic. We are sure that the given offsets


### PR DESCRIPTION
The new `ptr_eq` check was failing in `xdp` and `accounts-db/io_uring`.