### PR TITLE
svm: prepare crate to edition 2024 switch

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -7,7 +7,7 @@ authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -8,15 +8,15 @@ use {
     },
     ahash::{AHashMap, AHashSet},
     solana_account::{
-        state_traits::StateMut, Account, AccountSharedData, ReadableAccount, WritableAccount,
-        PROGRAM_OWNERS,
+        Account, AccountSharedData, PROGRAM_OWNERS, ReadableAccount, WritableAccount,
+        state_traits::StateMut,
     },
     solana_fee_structure::FeeDetails,
     solana_instruction::{BorrowedAccountMeta, BorrowedInstruction},
     solana_instructions_sysvar::construct_instructions_data,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_nonce::state::State as NonceState,
-    solana_nonce_account::{get_system_account_kind, SystemAccountKind},
+    solana_nonce_account::{SystemAccountKind, get_system_account_kind},
     solana_program_runtime::execution_budget::{
         SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionBudget,
     },
@@ -66,7 +66,7 @@ pub(crate) enum TransactionLoadResult {
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "svm-internal", field_qualifiers(nonce(pub)))]
 pub struct CheckedTransactionDetails {
-    pub(crate) nonce: Option<NonceInfo>,
+    pub nonce: Option<NonceInfo>,
     pub(crate) compute_budget_and_limits: Result<SVMTransactionExecutionAndFeeBudgetLimits>,
 }
 
@@ -852,18 +852,18 @@ mod tests {
         solana_keypair::Keypair,
         solana_loader_v3_interface::state::UpgradeableLoaderState,
         solana_message::{
+            LegacyMessage, Message, MessageHeader, SanitizedMessage,
             compiled_instruction::CompiledInstruction,
             v0::{LoadedAddresses, LoadedMessage},
-            LegacyMessage, Message, MessageHeader, SanitizedMessage,
         },
-        solana_native_token::{sol_to_lamports, LAMPORTS_PER_SOL},
+        solana_native_token::{LAMPORTS_PER_SOL, sol_to_lamports},
         solana_nonce::{self as nonce, versions::Versions as NonceVersions},
         solana_program_runtime::execution_budget::{
             DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
-        solana_rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
+        solana_rent_collector::{RENT_EXEMPT_RENT_EPOCH, RentCollector},
         solana_sdk_ids::{
             bpf_loader, bpf_loader_upgradeable, native_loader, system_program, sysvar,
         },
@@ -871,7 +871,7 @@ mod tests {
         solana_signer::Signer,
         solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
         solana_system_transaction::transfer,
-        solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+        solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::{TransactionAccount, TransactionContext},
         solana_transaction_error::{TransactionError, TransactionResult as Result},
         std::{borrow::Cow, cell::RefCell, collections::HashMap, fs::File, io::Read},
@@ -1362,13 +1362,15 @@ mod tests {
         let requested_data_size_limit = NonZeroU32::new(data_size as u32).unwrap();
 
         // OK - loaded data size is up to limit
-        assert!(accumulate_and_check_loaded_account_data_size(
-            &mut accumulated_data_size,
-            data_size,
-            requested_data_size_limit,
-            &mut error_metrics
-        )
-        .is_ok());
+        assert!(
+            accumulate_and_check_loaded_account_data_size(
+                &mut accumulated_data_size,
+                data_size,
+                requested_data_size_limit,
+                &mut error_metrics
+            )
+            .is_ok()
+        );
         assert_eq!(data_size as u32, accumulated_data_size.0);
 
         // fail - loading more data that would exceed limit
@@ -2858,7 +2860,7 @@ mod tests {
                 1,
                 vec![0; rng.gen_range(0, 128)],
                 Pubkey::new_unique(),
-                rng.gen(),
+                rng.r#gen(),
                 u64::MAX,
             );
             mock_bank.accounts_map.insert(Pubkey::new_unique(), account);
@@ -2872,7 +2874,7 @@ mod tests {
                 LAMPORTS_PER_SOL,
                 vec![0; rng.gen_range(0, 32)],
                 system_program::id(),
-                rng.gen(),
+                rng.r#gen(),
                 u64::MAX,
             );
             mock_bank.accounts_map.insert(fee_payer, account);
@@ -2889,7 +2891,7 @@ mod tests {
                     1,
                     vec![0; rng.gen_range(0, 512)],
                     *loader,
-                    !remove_accounts_executable_flag_checks || rng.gen(),
+                    !remove_accounts_executable_flag_checks || rng.r#gen(),
                     u64::MAX,
                 );
 
@@ -2900,14 +2902,14 @@ mod tests {
                 // this will always fail at execution but we are merely testing the data size accounting here
                 if *loader == bpf_loader_upgradeable::id() && account.data().len() >= 64 {
                     let programdata_address = Pubkey::new_unique();
-                    let has_programdata = rng.gen();
+                    let has_programdata = rng.r#gen();
 
                     if has_programdata {
                         let programdata_account = AccountSharedData::create(
                             1,
                             vec![0; rng.gen_range(0, 512)],
                             *loader,
-                            !remove_accounts_executable_flag_checks || rng.gen(),
+                            !remove_accounts_executable_flag_checks || rng.r#gen(),
                             u64::MAX,
                         );
                         programdata_tracker.insert(
@@ -2920,7 +2922,7 @@ mod tests {
                         loader_owned_accounts.push(programdata_address);
                     }
 
-                    if has_programdata || rng.gen() {
+                    if has_programdata || rng.r#gen() {
                         account
                             .set_state(&UpgradeableLoaderState::Program {
                                 programdata_address,
@@ -2964,8 +2966,8 @@ mod tests {
 
                     accounts.push(AccountMeta {
                         pubkey,
-                        is_writable: rng.gen(),
-                        is_signer: rng.gen() && rng.gen(),
+                        is_writable: rng.r#gen(),
+                        is_signer: rng.r#gen() && rng.r#gen(),
                     });
                 }
 

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -1,5 +1,14 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
+// Activate some of the Rust 2024 lints to make the future migration easier.
+#![warn(if_let_rescope)]
+#![warn(keyword_idents_2024)]
+#![warn(missing_unsafe_on_extern)]
+#![warn(rust_2024_guarded_string_incompatible_syntax)]
+#![warn(rust_2024_incompatible_pat)]
+#![warn(tail_expr_drop_order)]
+#![warn(unsafe_attr_outside_unsafe)]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 pub mod account_loader;
 pub mod account_overrides;

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -44,7 +44,7 @@ impl NonceInfo {
     ) -> Result<(), AdvanceNonceError> {
         let nonce_versions = StateMut::<NonceVersions>::state(&self.account)
             .map_err(|_| AdvanceNonceError::Invalid)?;
-        if let NonceState::Initialized(ref data) = nonce_versions.state() {
+        if let NonceState::Initialized(data) = nonce_versions.state() {
             let nonce_state =
                 NonceState::new_initialized(&data.authority, durable_nonce, lamports_per_signature);
             let nonce_versions = NonceVersions::new(nonce_state);

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -284,14 +284,15 @@ mod tests {
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
-            if let Some(data) = self.account_shared_data.borrow().get(account) {
-                if data.lamports() == 0 {
-                    None
-                } else {
-                    owners.iter().position(|entry| data.owner() == entry)
+            match self.account_shared_data.borrow().get(account) {
+                Some(data) => {
+                    if data.lamports() == 0 {
+                        None
+                    } else {
+                        owners.iter().position(|entry| data.owner() == entry)
+                    }
                 }
-            } else {
-                None
+                _ => None,
             }
         }
 

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -21,17 +21,18 @@ impl TransactionAccountStateInfo {
         (0..message.account_keys().len())
             .map(|i| {
                 let rent_state = if message.is_writable(i) {
-                    let state = if let Ok(account) = transaction_context
+                    let state = match transaction_context
                         .accounts()
                         .try_borrow(i as IndexOfAccount)
                     {
-                        // Native programs appear to be RentPaying because they carry low lamport
-                        // balances; however they will never be loaded as writable
-                        debug_assert!(!native_loader::check_id(account.owner()));
+                        Ok(account) => {
+                            // Native programs appear to be RentPaying because they carry low lamport
+                            // balances; however they will never be loaded as writable
+                            debug_assert!(!native_loader::check_id(account.owner()));
 
-                        Some(rent_collector.get_account_rent_state(&account))
-                    } else {
-                        None
+                            Some(rent_collector.get_account_rent_state(&account))
+                        }
+                        _ => None,
                     };
                     debug_assert!(
                         state.is_some(),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3,12 +3,12 @@
 
 use {
     crate::mock_bank::{
+        EXECUTION_EPOCH, EXECUTION_SLOT, MockBankCallback, MockForkGraph, WALLCLOCK_TIME,
         create_custom_loader, deploy_program_with_upgrade_authority, program_address,
-        program_data_size, register_builtins, MockBankCallback, MockForkGraph, EXECUTION_EPOCH,
-        EXECUTION_SLOT, WALLCLOCK_TIME,
+        program_data_size, register_builtins,
     },
     agave_feature_set::{self as feature_set, FeatureSet},
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount, PROGRAM_OWNERS},
+    solana_account::{AccountSharedData, PROGRAM_OWNERS, ReadableAccount, WritableAccount},
     solana_clock::Slot,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -21,7 +21,7 @@ use {
     solana_nonce::{self as nonce, state::DurableNonce},
     solana_program_entrypoint::MAX_PERMITTED_DATA_INCREASE,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-    solana_pubkey::{pubkey, Pubkey},
+    solana_pubkey::{Pubkey, pubkey},
     solana_sdk_ids::native_loader,
     solana_signer::Signer,
     solana_svm::{
@@ -39,7 +39,7 @@ use {
     solana_system_interface::{instruction as system_instruction, program as system_program},
     solana_system_transaction as system_transaction,
     solana_sysvar::rent::Rent,
-    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+    solana_transaction::{Transaction, sanitized::SanitizedTransaction},
     solana_transaction_context::TransactionReturnData,
     solana_transaction_error::TransactionError,
     solana_type_overrides::sync::{Arc, RwLock},
@@ -289,10 +289,11 @@ impl SvmTestEntry {
     // inserts it into both account maps, assuming it lives unchanged (except for svm fixing rent epoch)
     // rent-paying accounts must be added by hand because svm will not set rent epoch to u64::MAX
     pub fn add_initial_account(&mut self, pubkey: Pubkey, account: &AccountSharedData) {
-        assert!(self
-            .initial_accounts
-            .insert(pubkey, account.clone())
-            .is_none());
+        assert!(
+            self.initial_accounts
+                .insert(pubkey, account.clone())
+                .is_none()
+        );
 
         self.create_expected_account(pubkey, account);
     }
@@ -322,10 +323,11 @@ impl SvmTestEntry {
 
     // indicate that an existing account is expected to be deallocated
     pub fn drop_expected_account(&mut self, pubkey: Pubkey) {
-        assert!(self
-            .final_accounts
-            .insert(pubkey, AccountSharedData::default())
-            .is_some());
+        assert!(
+            self.final_accounts
+                .insert(pubkey, AccountSharedData::default())
+                .is_some()
+        );
     }
 
     // add lamports to an existing expected final account state
@@ -2802,7 +2804,7 @@ mod balance_collector {
             for _ in 0..50 {
                 // failures result in no balance changes (note we use a separate fee-payer)
                 // we mix some in with the successes to test that we never record changes for failures
-                let expected_status = match rng.gen::<f64>() {
+                let expected_status = match rng.r#gen::<f64>() {
                     n if n < 0.85 => ExecutionStatus::Succeeded,
                     n if n < 0.90 => ExecutionStatus::ExecutedFailed,
                     n if n < 0.95 => ExecutionStatus::ProcessedFailed,


### PR DESCRIPTION
#### Problem
Upgrade rust edition to 2024 https://github.com/anza-xyz/agave/issues/6203

#### Summary of Changes
Added 2024 lints / fixed code
[edition_upgrade.log](https://github.com/user-attachments/files/21056321/edition_upgrade.log)

