### PR TITLE
xdp: always populate the fill ring

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -241,7 +241,6 @@ impl RingConsumer {
         }
     }
 
-    #[cfg(test)]
     pub fn available(&self) -> u32 {
         self.cached_producer.wrapping_sub(self.cached_consumer)
     }


### PR DESCRIPTION
Even when doing TX only, most drivers (wrongly) assume that the fill ring contains at least $ring_size entries when creating the xsk pool (on bind()). The only driver that behaves correctly is the mellanox driver.

In particular the ice/i40e drivers have a fallback mechanism if the fill ring isn't populated that over time leaks buffers and leads to the NIC not being able to receive any buffers.