### PR TITLE
Removing cached items from the reclaims returned by upsert

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7712,20 +7712,13 @@ impl AccountsDb {
         // after the account are stored by the above `store_accounts_to`
         // call and all the accounts are stored, all reads after this point
         // will know to not check the cache anymore
-        let mut reclaims = self.update_index(
+        let reclaims = self.update_index(
             infos,
             &accounts,
             UpsertReclaim::IgnoreReclaims,
             UpdateIndexThreadSelection::PoolWithThreshold,
             &self.thread_pool_clean,
         );
-
-        // For each updated account, `reclaims` should only have at most one
-        // item (if the account was previously updated in this slot).
-        // filter out the cached reclaims as those don't actually map
-        // to anything that needs to be cleaned in the backing storage
-        // entries
-        reclaims.retain(|(_, r)| !r.is_cached());
 
         update_index_time.stop();
         self.stats

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2518,7 +2518,7 @@ pub mod tests {
                 &mut reclaims,
                 UpsertReclaim::PopulateReclaims,
             );
-            // No reclaims, since the itemr replaced was cached
+            // No reclaims, since the entry replaced was cached
             assert!(reclaims.is_empty());
             index.upsert(
                 slot,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2518,9 +2518,8 @@ pub mod tests {
                 &mut reclaims,
                 UpsertReclaim::PopulateReclaims,
             );
-            // reclaimed
-            assert!(!reclaims.is_empty());
-            reclaims.clear();
+            // No reclaims, since the itemr replaced was cached
+            assert!(reclaims.is_empty());
             index.upsert(
                 slot,
                 slot,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -721,7 +721,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     };
                     match reclaim {
                         UpsertReclaim::PopulateReclaims => {
-                            reclaims.push(reclaim_item);
+                            if !is_cur_account_cached {
+                                reclaims.push(reclaim_item);
+                            }
                         }
                         UpsertReclaim::PreviousSlotEntryWasCached => {
                             assert!(is_cur_account_cached);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -721,6 +721,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     };
                     match reclaim {
                         UpsertReclaim::PopulateReclaims => {
+                            // Reclaims are used to reclaim other versions of accounts when they are
+                            // rewritten elsewhere. Cached accounts are not in storage, so there is
+                            // no reason to store the reclaim.
                             if !is_cur_account_cached {
                                 reclaims.push(reclaim_item);
                             }


### PR DESCRIPTION
#### Problem
Cached accounts index entries are populated in reclaims, but then filtered before reclaiming. This causes needless memory allocations


#### Summary of Changes
- Do not populate reclaims if items are cached
- Do not filter out cached items from reclaims (as they are no longer present)

Note: This path is unused now as reclaims are never enabled but it will be used with obsolete accounts

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
