### PR TITLE
streamer: isolate sync lock

### DIFF
--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -1,9 +1,11 @@
 use {
+    ahash::AHasher,
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     solana_streamer::streamer::StakedNodes,
     std::{
         collections::HashMap,
+        hash::Hasher,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
@@ -19,6 +21,19 @@ pub struct StakedNodesUpdaterService {
     thread_hdl: JoinHandle<()>,
 }
 
+fn hash_overrides(staked_nodes_overrides: &HashMap<Pubkey, u64>) -> Option<u64> {
+    if staked_nodes_overrides.is_empty() {
+        None
+    } else {
+        let mut hasher = AHasher::default();
+        for (pubkey, &stake) in staked_nodes_overrides {
+            hasher.write(pubkey.as_array());
+            hasher.write_u64(stake);
+        }
+        Some(hasher.finish())
+    }
+}
+
 impl StakedNodesUpdaterService {
     pub fn new(
         exit: Arc<AtomicBool>,
@@ -29,13 +44,21 @@ impl StakedNodesUpdaterService {
         let thread_hdl = Builder::new()
             .name("solStakedNodeUd".to_string())
             .spawn(move || {
+                let mut prev_epoch = None;
+                let mut prev_overrides_hash =
+                    hash_overrides(&staked_nodes_overrides.read().unwrap());
                 while !exit.load(Ordering::Relaxed) {
-                    let stakes = {
-                        let root_bank = bank_forks.read().unwrap().root_bank();
-                        root_bank.current_epoch_staked_nodes()
-                    };
+                    let root_bank = bank_forks.read().unwrap().root_bank();
                     let overrides = staked_nodes_overrides.read().unwrap().clone();
-                    *staked_nodes.write().unwrap() = StakedNodes::new(stakes, overrides);
+                    let new_overrides_hash = hash_overrides(&overrides);
+                    if Some(root_bank.epoch()) != prev_epoch
+                        || prev_overrides_hash != new_overrides_hash
+                    {
+                        let stakes = root_bank.current_epoch_staked_nodes();
+                        *staked_nodes.write().unwrap() = StakedNodes::new(stakes, overrides);
+                        prev_epoch = Some(root_bank.epoch());
+                        prev_overrides_hash = new_overrides_hash;
+                    }
                     std::thread::sleep(STAKE_REFRESH_CYCLE);
                 }
             })

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -68,7 +68,7 @@ where
 }
 
 // Total stake and nodes => stake map
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct StakedNodes {
     stakes: Arc<HashMap<Pubkey, u64>>,
     overrides: HashMap<Pubkey, u64>,


### PR DESCRIPTION
#### Problem

During the async setup_connection(), which is invoked for each new incoming connection, a sync lock is taken to determine the amount of stake on the connection’s key. As a result, all tokio setup_connection() tasks compete with each other to read this value, and additionally contend with the StakedNodesUpdaterService, which unconditionally updates it every 5 seconds.

#### Summary of Changes

This PR removes the sync lock from the async setup_connection(). Instead, Arc of the cached value is passed in. The cached value is updated in a dedicated thread every 10 seconds without blocking the other tokio threads.
