### PR TITLE
ledger: swap deprecated shredder function to new merkle one

### DIFF
--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -226,17 +226,20 @@ fn setup_different_sized_fec_blocks(
     let reed_solomon_cache = ReedSolomonCache::default();
     for i in 0..2 {
         let is_last = i == 1;
-        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
-            &keypair,
-            &entries,
-            is_last,
-            chained_merkle_root,
-            next_shred_index,
-            next_code_index,
-            true, // merkle_variant
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
+        let shreds: Vec<Shred> = shredder
+            .make_merkle_shreds_from_entries(
+                &keypair,
+                &entries,
+                is_last,
+                chained_merkle_root,
+                next_shred_index,
+                next_code_index,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .collect();
+        let (data_shreds, coding_shreds): (Vec<Shred>, Vec<Shred>) =
+            shreds.into_iter().partition(Shred::is_data);
         for shred in &data_shreds {
             if (shred.index() as usize) == total_num_data_shreds - 1 {
                 assert!(shred.data_complete());

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -226,7 +226,8 @@ fn setup_different_sized_fec_blocks(
     let reed_solomon_cache = ReedSolomonCache::default();
     for i in 0..2 {
         let is_last = i == 1;
-        let shreds: Vec<Shred> = shredder
+
+        let (data_shreds, coding_shreds): (Vec<Shred>, Vec<Shred>) = shredder
             .make_merkle_shreds_from_entries(
                 &keypair,
                 &entries,
@@ -237,9 +238,8 @@ fn setup_different_sized_fec_blocks(
                 &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             )
-            .collect();
-        let (data_shreds, coding_shreds): (Vec<Shred>, Vec<Shred>) =
-            shreds.into_iter().partition(Shred::is_data);
+            .partition(Shred::is_data);
+
         for shred in &data_shreds {
             if (shred.index() as usize) == total_num_data_shreds - 1 {
                 assert!(shred.data_complete());


### PR DESCRIPTION
#### Problem
Legacy shreds need to go https://github.com/anza-xyz/agave/issues/5982

#### Summary of Changes
As per the https://github.com/anza-xyz/agave/pull/6161

- changed `setup_different_sized_fec_blocks` to use the suggested `make_merkle_shreds_from_entries` 