### PR TITLE
clippy: uninlined_format_args

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -134,7 +134,7 @@ fn main() {
             );
             time_store.stop();
             if results != results_store {
-                error!("results different: \n{:?}\n{:?}", results, results_store);
+                error!("results different: \n{results:?}\n{results_store:?}");
             }
             println!(
                 "hash,{},{},{},{}%",
@@ -150,9 +150,9 @@ fn main() {
     }
 
     for x in elapsed {
-        info!("update_accounts_hash(us),{}", x);
+        info!("update_accounts_hash(us),{x}");
     }
     for x in elapsed_store {
-        info!("calculate_accounts_hash_from_storages(us),{}", x);
+        info!("calculate_accounts_hash_from_storages(us),{x}");
     }
 }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -62,8 +62,7 @@ pub fn poll_slot_height(client: &RpcClient) -> Slot {
         } else {
             num_retries -= 1;
             warn!(
-                "get_slot_height failure: {:?}. remaining retries {}",
-                response, num_retries
+                "get_slot_height failure: {response:?}. remaining retries {num_retries}"
             );
         }
         if num_retries == 0 {
@@ -82,8 +81,7 @@ pub fn poll_get_latest_blockhash(client: &RpcClient) -> Option<Hash> {
         } else {
             num_retries -= 1;
             warn!(
-                "get_latest_blockhash failure: {:?}. remaining retries {}",
-                response, num_retries
+                "get_latest_blockhash failure: {response:?}. remaining retries {num_retries}"
             );
         }
         if num_retries == 0 {
@@ -103,8 +101,7 @@ pub fn poll_get_fee_for_message(client: &RpcClient, message: &mut Message) -> (O
         } else {
             num_retries -= 1;
             warn!(
-                "get_fee_for_message failure: {:?}. remaining retries {}",
-                response, num_retries
+                "get_fee_for_message failure: {response:?}. remaining retries {num_retries}"
             );
 
             let blockhash = poll_get_latest_blockhash(client).expect("blockhash");
@@ -119,7 +116,7 @@ pub fn poll_get_fee_for_message(client: &RpcClient, message: &mut Message) -> (O
 
 fn airdrop_lamports(client: &RpcClient, id: &Keypair, desired_balance: u64) -> bool {
     let starting_balance = client.get_balance(&id.pubkey()).unwrap_or(0);
-    info!("starting balance {}", starting_balance);
+    info!("starting balance {starting_balance}");
 
     if starting_balance < desired_balance {
         let airdrop_amount = desired_balance - starting_balance;
@@ -143,7 +140,7 @@ fn airdrop_lamports(client: &RpcClient, id: &Keypair, desired_balance: u64) -> b
         let current_balance = client.get_balance(&id.pubkey()).unwrap_or_else(|e| {
             panic!("airdrop error {e}");
         });
-        info!("current balance {}...", current_balance);
+        info!("current balance {current_balance}...");
 
         if current_balance - starting_balance != airdrop_amount {
             info!(
@@ -396,10 +393,10 @@ fn process_get_multiple_accounts(
                 stats.total_errors_time_us += rpc_time.as_us();
                 stats.errors += 1;
                 if last_error.elapsed().as_secs() > 2 {
-                    info!("error: {:?}", e);
+                    info!("error: {e:?}");
                     *last_error = Instant::now();
                 }
-                debug!("error: {:?}", e);
+                debug!("error: {e:?}");
             }
         }
     }
@@ -519,7 +516,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_account_info error: {:?}", e);
+                            info!("get_account_info error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -545,7 +542,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_block error: {:?}", e);
+                            info!("get_block error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -569,7 +566,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_blocks error: {:?}", e);
+                            info!("get_blocks error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -588,7 +585,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_first_available_block error: {:?}", e);
+                            info!("get_first_available_block error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -607,7 +604,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_slot error: {:?}", e);
+                            info!("get_slot error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -626,7 +623,7 @@ fn run_rpc_bench_loop(
                         stats.total_errors_time_us += rpc_time.as_us();
                         stats.errors += 1;
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get_token_supply error: {:?}", e);
+                            info!("get_token_supply error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -659,7 +656,7 @@ fn run_rpc_bench_loop(
                         stats.errors += 1;
                         stats.total_errors_time_us += rpc_time.as_us();
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get-program-accounts error: {:?}", e);
+                            info!("get-program-accounts error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -679,7 +676,7 @@ fn run_rpc_bench_loop(
                         stats.errors += 1;
                         stats.total_errors_time_us += rpc_time.as_us();
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get-token-accounts-by-delegate error: {:?}", e);
+                            info!("get-token-accounts-by-delegate error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -699,7 +696,7 @@ fn run_rpc_bench_loop(
                         stats.errors += 1;
                         stats.total_errors_time_us += rpc_time.as_us();
                         if last_error.elapsed().as_secs() > 2 {
-                            info!("get-token-accounts-by-owner error: {:?}", e);
+                            info!("get-token-accounts-by-owner error: {e:?}");
                             last_error = Instant::now();
                         }
                     }
@@ -781,7 +778,7 @@ fn make_rpc_bench_threads(
                 let transaction_signature_tracker = transaction_signature_tracker.clone();
                 let mint = *mint;
                 Builder::new()
-                    .name(format!("rpc-bench-{}", thread))
+                    .name(format!("rpc-bench-{thread}"))
                     .spawn(move || {
                         start_bench.wait();
                         run_rpc_bench_loop(
@@ -853,7 +850,7 @@ fn run_accounts_bench(
     let transaction_signature_tracker =
         TransactionSignatureTracker(Arc::new(RwLock::new(VecDeque::with_capacity(5000))));
 
-    info!("Starting balance(s): {:?}", balances);
+    info!("Starting balance(s): {balances:?}");
 
     let executor = TransactionExecutor::new_with_rpc_client(client.clone());
 
@@ -918,8 +915,7 @@ fn run_accounts_bench(
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
                     info!(
-                        "Balance {} is less than needed: {}, doing airdrop...",
-                        balance, lamports
+                        "Balance {balance} is less than needed: {lamports}, doing airdrop..."
                     );
                     if !airdrop_lamports(&client, payer_keypairs[i], lamports * 100_000) {
                         warn!("failed airdrop, exiting");
@@ -934,7 +930,7 @@ fn run_accounts_bench(
         if sigs_len < batch_size {
             let num_to_create = batch_size - sigs_len;
             if num_to_create >= payer_keypairs.len() {
-                info!("creating {} new", num_to_create);
+                info!("creating {num_to_create} new");
                 let chunk_size = num_to_create / payer_keypairs.len();
                 if chunk_size > 0 {
                     for (i, keypair) in payer_keypairs.iter().enumerate() {
@@ -1018,8 +1014,7 @@ fn run_accounts_bench(
             || max_accounts_met
         {
             info!(
-                "total_accounts_created: {} total_accounts_closed: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
-                total_accounts_created, total_accounts_closed, tx_sent_count, count, balances
+                "total_accounts_created: {total_accounts_created} total_accounts_closed: {total_accounts_closed} tx_sent_count: {tx_sent_count} loop_count: {count} balance(s): {balances:?}"
             );
             last_log = Instant::now();
         }
@@ -1061,9 +1056,9 @@ fn run_accounts_bench(
                     (max_created_seed - max_closed_seed) as usize,
                 );
                 if num_to_close >= payer_keypairs.len() {
-                    info!("closing {} accounts", num_to_close);
+                    info!("closing {num_to_close} accounts");
                     let chunk_size = num_to_close / payer_keypairs.len();
-                    info!("{:?} chunk_size", chunk_size);
+                    info!("{chunk_size:?} chunk_size");
                     if chunk_size > 0 {
                         for (i, keypair) in payer_keypairs.iter().enumerate() {
                             let txs: Vec<_> = (0..chunk_size)
@@ -1101,8 +1096,7 @@ fn run_accounts_bench(
             count += 1;
             if last_log.elapsed().as_millis() > 3000 || max_closed_seed >= max_created_seed {
                 info!(
-                    "total_accounts_closed: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
-                    total_accounts_closed, tx_sent_count, count, balances
+                    "total_accounts_closed: {total_accounts_closed} tx_sent_count: {tx_sent_count} loop_count: {count} balance(s): {balances:?}"
                 );
                 last_log = Instant::now();
             }
@@ -1333,7 +1327,7 @@ fn main() {
                 Some(
                     solana_net_utils::get_cluster_shred_version(&entrypoint_addr).unwrap_or_else(
                         |err| {
-                            eprintln!("Failed to get shred version: {}", err);
+                            eprintln!("Failed to get shred version: {err}");
                             exit(1);
                         },
                     ),
@@ -1344,7 +1338,7 @@ fn main() {
         };
 
         let rpc_addr = if !skip_gossip {
-            info!("Finding cluster entry: {:?}", entrypoint_addr);
+            info!("Finding cluster entry: {entrypoint_addr:?}");
             let (gossip_nodes, _validators) = discover(
                 None, // keypair
                 Some(&entrypoint_addr),
@@ -1364,7 +1358,7 @@ fn main() {
             info!("done found {} nodes", gossip_nodes.len());
             gossip_nodes[0].rpc().unwrap()
         } else {
-            info!("Using {:?} as the RPC address", entrypoint_addr);
+            info!("Using {entrypoint_addr:?} as the RPC address");
             entrypoint_addr
         };
 
@@ -1500,7 +1494,7 @@ pub mod test {
         );
         let post_txs = client.get_transaction_count().unwrap();
         start.stop();
-        info!("{} pre {} post {}", start, pre_txs, post_txs);
+        info!("{start} pre {pre_txs} post {post_txs}");
     }
 
     #[test]
@@ -1550,7 +1544,7 @@ pub mod test {
         );
         let post_txs = client.get_transaction_count().unwrap();
         start.stop();
-        info!("{} pre {} post {}", start, pre_txs, post_txs);
+        info!("{start} pre {pre_txs} post {post_txs}");
     }
 
     #[test]
@@ -1649,6 +1643,6 @@ pub mod test {
             0,
         );
         start.stop();
-        info!("{}", start);
+        info!("{start}");
     }
 }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -61,9 +61,7 @@ pub fn poll_slot_height(client: &RpcClient) -> Slot {
             return slot;
         } else {
             num_retries -= 1;
-            warn!(
-                "get_slot_height failure: {response:?}. remaining retries {num_retries}"
-            );
+            warn!("get_slot_height failure: {response:?}. remaining retries {num_retries}");
         }
         if num_retries == 0 {
             panic!("failed to get_slot_height(), rpc node down?")
@@ -80,9 +78,7 @@ pub fn poll_get_latest_blockhash(client: &RpcClient) -> Option<Hash> {
             return Some(blockhash);
         } else {
             num_retries -= 1;
-            warn!(
-                "get_latest_blockhash failure: {response:?}. remaining retries {num_retries}"
-            );
+            warn!("get_latest_blockhash failure: {response:?}. remaining retries {num_retries}");
         }
         if num_retries == 0 {
             panic!("failed to get_latest_blockhash(), rpc node down?")
@@ -100,9 +96,7 @@ pub fn poll_get_fee_for_message(client: &RpcClient, message: &mut Message) -> (O
             return (Some(fee), message.recent_blockhash);
         } else {
             num_retries -= 1;
-            warn!(
-                "get_fee_for_message failure: {response:?}. remaining retries {num_retries}"
-            );
+            warn!("get_fee_for_message failure: {response:?}. remaining retries {num_retries}");
 
             let blockhash = poll_get_latest_blockhash(client).expect("blockhash");
             message.recent_blockhash = blockhash;
@@ -914,9 +908,7 @@ fn run_accounts_bench(
                 }
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
-                    info!(
-                        "Balance {balance} is less than needed: {lamports}, doing airdrop..."
-                    );
+                    info!("Balance {balance} is less than needed: {lamports}, doing airdrop...");
                     if !airdrop_lamports(&client, payer_keypairs[i], lamports * 100_000) {
                         warn!("failed airdrop, exiting");
                         return;

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -242,7 +242,7 @@ mod tests {
 
         // Generate a seed from entropy and log the original seed
         let seed: u64 = rand::random();
-        info!("Generated seed: {}", seed);
+        info!("Generated seed: {seed}");
 
         // Use a seedable RNG with the generated seed for reproducibility
         let mut rng = StdRng::seed_from_u64(seed);
@@ -343,7 +343,7 @@ mod tests {
 
         // Generate a seed from entropy and log the original seed
         let seed: u64 = rand::random();
-        info!("Generated seed: {}", seed);
+        info!("Generated seed: {seed}");
 
         // Use a seedable RNG with the generated seed for reproducibility
         let mut rng = StdRng::seed_from_u64(seed);

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1417,7 +1417,7 @@ mod tests {
             accounts.add_root_and_flush_write_cache(i);
 
             if i % 1_000 == 0 {
-                info!("  store {}", i);
+                info!("  store {i}");
             }
         }
         info!("done..cleaning..");

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2048,7 +2048,7 @@ impl AccountsDb {
             MarkAccountsObsolete::No,
         );
         measure.stop();
-        debug!("{}", measure);
+        debug!("{measure}");
         self.clean_accounts_stats
             .clean_old_root_reclaim_us
             .fetch_add(measure.as_us(), Ordering::Relaxed);
@@ -3757,7 +3757,7 @@ impl AccountsDb {
         }
         let mut unique_accounts =
             self.get_unique_accounts_from_storage_for_shrink(&store, &self.shrink_stats);
-        debug!("do_shrink_slot_store: slot: {}", slot);
+        debug!("do_shrink_slot_store: slot: {slot}");
         let shrink_collect = self.shrink_collect::<AliveAccounts<'_>>(
             &store,
             &mut unique_accounts,
@@ -3939,7 +3939,7 @@ impl AccountsDb {
     // Reads all accounts in given slot's AppendVecs and filter only to alive,
     // then create a minimum AppendVec filled with the alive.
     fn shrink_slot_forced(&self, slot: Slot) {
-        debug!("shrink_slot_forced: slot: {}", slot);
+        debug!("shrink_slot_forced: slot: {slot}");
 
         if let Some(store) = self
             .storage
@@ -6767,7 +6767,7 @@ impl AccountsDb {
                 .filter_map(|r| r.as_ref().err())
                 .next()
             {
-                panic!("failed generating accounts hash files: {:?}", err);
+                panic!("failed generating accounts hash files: {err:?}");
             }
 
             // convert mmapped cache files into slices of data
@@ -6874,8 +6874,7 @@ impl AccountsDb {
                 self.calculate_accounts_hash(&calc_config, &sorted_storages, HashStats::default());
             if calculated_lamports != total_lamports {
                 warn!(
-                    "Mismatched total lamports: {} calculated: {}",
-                    total_lamports, calculated_lamports
+                    "Mismatched total lamports: {total_lamports} calculated: {calculated_lamports}"
                 );
                 return Err(AccountsHashVerificationError::MismatchedTotalLamports(
                     calculated_lamports,
@@ -7416,7 +7415,7 @@ impl AccountsDb {
                 "remove_dead_slots_metadata: {} dead slots",
                 dead_slots.len()
             );
-            trace!("remove_dead_slots_metadata: dead_slots: {:?}", dead_slots);
+            trace!("remove_dead_slots_metadata: dead_slots: {dead_slots:?}");
         }
         self.accounts_index
             .update_roots_stats(&mut accounts_index_root_stats);
@@ -8506,7 +8505,7 @@ impl AccountsDb {
                     .alive_bytes
                     .store(entry.stored_size, Ordering::Release);
             } else {
-                trace!("id: {} clearing count", id);
+                trace!("id: {id} clearing count");
                 store.count_and_status.lock_write().0 = 0;
             }
         }
@@ -8523,7 +8522,7 @@ impl AccountsDb {
         let mut alive_roots: Vec<_> = self.accounts_index.all_alive_roots();
         #[allow(clippy::stable_sort_primitive)]
         alive_roots.sort();
-        info!("{}: accounts_index alive_roots: {:?}", label, alive_roots,);
+        info!("{label}: accounts_index alive_roots: {alive_roots:?}",);
         let full_pubkey_range = Pubkey::from([0; 32])..=Pubkey::from([0xff; 32]);
 
         self.accounts_index.account_maps.iter().for_each(|map| {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1812,7 +1812,7 @@ fn test_accounts_db_purge1() {
     accounts.print_accounts_stats("pre_purge");
 
     let ancestors = linear_ancestors(current_slot);
-    info!("ancestors: {:?}", ancestors);
+    info!("ancestors: {ancestors:?}");
     let hash = accounts.update_accounts_hash_for_tests(current_slot, &ancestors, true, true);
 
     accounts.clean_accounts_for_tests();
@@ -2945,9 +2945,9 @@ fn test_delete_dependencies() {
             },
         ) in candidates_bin.iter()
         {
-            info!(" purge {} ref_count {} =>", key, ref_count);
+            info!(" purge {key} ref_count {ref_count} =>");
             for x in list {
-                info!("  {:?}", x);
+                info!("  {x:?}");
             }
         }
     }
@@ -3017,7 +3017,7 @@ fn test_store_overhead() {
     accounts.add_root_and_flush_write_cache(0);
     let store = accounts.storage.get_slot_storage_entry(0).unwrap();
     let total_len = store.accounts.len();
-    info!("total: {}", total_len);
+    info!("total: {total_len}");
     assert_eq!(total_len, STORE_META_OVERHEAD);
 }
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -551,7 +551,7 @@ impl AccountsHasher<'_> {
             })
             .collect();
         time.stop();
-        debug!("hashing {} {}", total_hashes, time);
+        debug!("hashing {total_hashes} {time}");
 
         if result.len() == 1 {
             result[0]
@@ -725,7 +725,7 @@ impl AccountsHasher<'_> {
             })
             .collect();
         time.stop();
-        debug!("hashing {} {}", total_hashes, time);
+        debug!("hashing {total_hashes} {time}");
 
         if let Some(mut specific_level_count_value) = specific_level_count {
             specific_level_count_value -= levels_hashed;
@@ -2282,7 +2282,7 @@ mod tests {
             |start| &reduced[start..],
             None,
         );
-        assert_eq!(result, result2.0, "len: {}", len);
+        assert_eq!(result, result2.0, "len: {len}");
 
         let result2 = AccountsHasher::compute_merkle_root_from_slices(
             len,
@@ -2291,7 +2291,7 @@ mod tests {
             |start| &reduced[start..],
             None,
         );
-        assert_eq!(result, result2.0, "len: {}", len);
+        assert_eq!(result, result2.0, "len: {len}");
 
         let max = std::cmp::min(reduced.len(), fanout * 2);
         for left in 0..max {

--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -280,6 +280,6 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
             .iter()
             .rev()
             .take(20)
-            .for_each(|(v, k)| info!("owner: {}, accounts: {}", k, v));
+            .for_each(|(v, k)| info!("owner: {k}, accounts: {v}"));
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -516,7 +516,7 @@ impl AppendVec {
             let result = MmapMut::map_mut(&data);
             if result.is_err() {
                 // for vm.max_map_count, error is: {code: 12, kind: Other, message: "Cannot allocate memory"}
-                info!("memory map error: {:?}. This may be because vm.max_map_count is not set correctly.", result);
+                info!("memory map error: {result:?}. This may be because vm.max_map_count is not set correctly.");
             }
             result?
         };

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -267,9 +267,7 @@ impl<R: Read> ArchiveChunker<R> {
 }
 
 fn checked_total_size_sum(total_size: u64, entry_size: u64, limit_size: u64) -> Result<u64> {
-    trace!(
-        "checked_total_size_sum: {total_size} + {entry_size} < {limit_size}",
-    );
+    trace!("checked_total_size_sum: {total_size} + {entry_size} < {limit_size}",);
     let total_size = total_size.saturating_add(entry_size);
     if total_size > limit_size {
         return Err(UnpackError::Archive(format!(

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -268,10 +268,7 @@ impl<R: Read> ArchiveChunker<R> {
 
 fn checked_total_size_sum(total_size: u64, entry_size: u64, limit_size: u64) -> Result<u64> {
     trace!(
-        "checked_total_size_sum: {} + {} < {}",
-        total_size,
-        entry_size,
-        limit_size,
+        "checked_total_size_sum: {total_size} + {entry_size} < {limit_size}",
     );
     let total_size = total_size.saturating_add(entry_size);
     if total_size > limit_size {
@@ -413,7 +410,7 @@ where
 
         total_entries += 1;
     }
-    info!("unpacked {} entries total", total_entries);
+    info!("unpacked {total_entries} entries total");
 
     return Ok(());
 
@@ -697,7 +694,7 @@ pub fn unpack_genesis_archive(
     destination_dir: &Path,
     max_genesis_archive_unpacked_size: u64,
 ) -> std::result::Result<(), UnpackError> {
-    info!("Extracting {:?}...", archive_filename);
+    info!("Extracting {archive_filename:?}...");
     let extract_start = Instant::now();
 
     fs::create_dir_all(destination_dir)?;
@@ -733,7 +730,7 @@ fn is_valid_genesis_archive_entry<'a>(
     parts: &[&str],
     kind: tar::EntryType,
 ) -> UnpackPath<'a> {
-    trace!("validating: {:?} {:?}", parts, kind);
+    trace!("validating: {parts:?} {kind:?}");
     #[allow(clippy::match_like_matches_macro)]
     match (parts, kind) {
         ([DEFAULT_GENESIS_FILE], GNUSparse) => UnpackPath::Valid(unpack_dir),

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -45,7 +45,7 @@ impl std::fmt::Debug for RollingBitField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bits = String::from("[");
         let mut prev = self.bits[0];
-        bits.push_str(&format!("{}", prev));
+        bits.push_str(&format!("{prev}"));
         let mut index = 1;
         while index < self.bits.len() {
             if self.bits[index] != prev {
@@ -55,26 +55,26 @@ impl std::fmt::Debug for RollingBitField {
             index += 1;
         }
         if index > 1 {
-            bits.push_str(&format!(";{}", index));
+            bits.push_str(&format!(";{index}"));
         }
         if index < self.bits.len() {
-            bits.push_str(&format!(", {}", prev));
+            bits.push_str(&format!(", {prev}"));
         }
         let mut count = 0;
         while index < self.bits.len() {
             if self.bits[index] != prev {
                 if count > 1 {
-                    bits.push_str(&format!(";{}", count));
+                    bits.push_str(&format!(";{count}"));
                 }
                 count = 0;
                 prev = self.bits[index];
-                bits.push_str(&format!(", {}", prev));
+                bits.push_str(&format!(", {prev}"));
             }
             count += 1;
             index += 1;
         }
         if count > 1 {
-            bits.push_str(&format!(";{}", count));
+            bits.push_str(&format!(";{count}"));
         }
         bits.push(']');
         // The order of the `count` and `bits` fields is changed on

--- a/accounts-db/store-histogram/src/main.rs
+++ b/accounts-db/store-histogram/src/main.rs
@@ -49,7 +49,7 @@ fn calc(info: &[(usize, usize)], bin_widths: Vec<usize>, offset: i64) {
     eprintln!("lowest slot: {min}");
     eprintln!("highest slot: {max_inclusive}");
     eprintln!("slot range: {}", max_inclusive - min + 1);
-    eprintln!("ancient boundary: {}", outside_slot);
+    eprintln!("ancient boundary: {outside_slot}");
     eprintln!(
         "number of slots beyond ancient boundary: {}",
         info.iter()
@@ -305,10 +305,10 @@ fn main() {
             calc(&info, normal_ancient(offset), offset);
             eprintln!("========");
         } else {
-            panic!("couldn't read folder: {path:?}, {:?}", dir);
+            panic!("couldn't read folder: {path:?}, {dir:?}");
         }
     } else {
-        panic!("not a folder: {:?}", path);
+        panic!("not a folder: {path:?}");
     }
 }
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -378,8 +378,7 @@ fn main() {
         .map(|packets_for_single_iteration| packets_for_single_iteration.transactions.len() as u64)
         .sum();
     info!(
-        "threads: {} txs: {}",
-        num_banking_threads, total_num_transactions
+        "threads: {num_banking_threads} txs: {total_num_transactions}"
     );
 
     // fund all the accounts
@@ -490,7 +489,7 @@ fn main() {
     let collector = solana_pubkey::new_rand();
     let mut total_sent = 0;
     for current_iteration_index in 0..iterations {
-        trace!("RUNNING ITERATION {}", current_iteration_index);
+        trace!("RUNNING ITERATION {current_iteration_index}");
         let now = Instant::now();
         let mut sent = 0;
 
@@ -599,7 +598,7 @@ fn main() {
         .unwrap()
         .working_bank()
         .transaction_count();
-    debug!("processed: {} base: {}", txs_processed, base_tx_count);
+    debug!("processed: {txs_processed} base: {base_tx_count}");
 
     eprintln!("[total_sent: {}, base_tx_count: {}, txs_processed: {}, txs_landed: {}, total_us: {}, tx_total_us: {}]",
             total_sent, base_tx_count, txs_processed, (txs_processed - base_tx_count), total_us, tx_total_us);

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -377,9 +377,7 @@ fn main() {
         .iter()
         .map(|packets_for_single_iteration| packets_for_single_iteration.transactions.len() as u64)
         .sum();
-    info!(
-        "threads: {num_banking_threads} txs: {total_num_transactions}"
-    );
+    info!("threads: {num_banking_threads} txs: {total_num_transactions}");
 
     // fund all the accounts
     all_packets.iter().for_each(|packets_for_single_iteration| {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -266,9 +266,7 @@ where
     T: 'static + TpsClient + Send + Sync + ?Sized,
 {
     if target_slots_per_epoch != 0 {
-        info!(
-            "Waiting until epochs are {target_slots_per_epoch} slots long.."
-        );
+        info!("Waiting until epochs are {target_slots_per_epoch} slots long..");
         loop {
             if let Ok(epoch_info) = client.get_epoch_info() {
                 if epoch_info.slots_in_epoch >= target_slots_per_epoch {
@@ -1083,9 +1081,7 @@ fn compute_and_report_stats(
     if total_maxes > 0.0 {
         let num_nodes_with_tps = maxes.read().unwrap().len() - nodes_with_zero_tps;
         let average_max = total_maxes / num_nodes_with_tps as f32;
-        info!(
-            "\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS"
-        );
+        info!("\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS");
     }
 
     let total_tx_send_count = total_tx_send_count as u64;

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -267,13 +267,12 @@ where
 {
     if target_slots_per_epoch != 0 {
         info!(
-            "Waiting until epochs are {} slots long..",
-            target_slots_per_epoch
+            "Waiting until epochs are {target_slots_per_epoch} slots long.."
         );
         loop {
             if let Ok(epoch_info) = client.get_epoch_info() {
                 if epoch_info.slots_in_epoch >= target_slots_per_epoch {
-                    info!("Done epoch_info: {:?}", epoch_info);
+                    info!("Done epoch_info: {epoch_info:?}");
                     break;
                 }
                 info!(
@@ -295,7 +294,7 @@ fn create_sampler_thread<T>(
 where
     T: 'static + TpsClient + Send + Sync + ?Sized,
 {
-    info!("Sampling TPS every {} second...", sample_period);
+    info!("Sampling TPS every {sample_period} second...");
     let maxes = maxes.clone();
     let client = client.clone();
     Builder::new()
@@ -440,12 +439,12 @@ where
         match client.get_transaction_count() {
             Ok(count) => break count,
             Err(err) => {
-                info!("Couldn't get transaction count: {:?}", err);
+                info!("Couldn't get transaction count: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         }
     };
-    info!("Initial transaction count {}", first_tx_count);
+    info!("Initial transaction count {first_tx_count}");
 
     let exit_signal = Arc::new(AtomicBool::new(false));
 
@@ -516,28 +515,28 @@ where
 
     info!("Waiting for sampler threads...");
     if let Err(err) = sample_thread.join() {
-        info!("  join() failed with: {:?}", err);
+        info!("  join() failed with: {err:?}");
     }
 
     // join the tx send threads
     info!("Waiting for transmit threads...");
     for t in sender_threads {
         if let Err(err) = t.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
     if let Some(blockhash_thread) = blockhash_thread {
         info!("Waiting for blockhash thread...");
         if let Err(err) = blockhash_thread.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
     if let Some(log_transaction_service) = log_transaction_service {
         info!("Waiting for log_transaction_service thread...");
         if let Err(err) = log_transaction_service.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
@@ -560,7 +559,7 @@ where
 }
 
 fn metrics_submit_lamport_balance(lamport_balance: u64) {
-    info!("Token balance: {}", lamport_balance);
+    info!("Token balance: {lamport_balance}");
     datapoint_info!(
         "bench-tps-lamport_balance",
         ("balance", lamport_balance, i64)
@@ -700,7 +699,7 @@ fn get_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?Sized>(
                 return nonce_accounts;
             }
             Err(err) => {
-                info!("Couldn't get durable nonce account: {:?}", err);
+                info!("Couldn't get durable nonce account: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         }
@@ -883,7 +882,7 @@ fn get_new_latest_blockhash<T: TpsClient + ?Sized>(
                 return Some(new_blockhash);
             }
         }
-        debug!("Got same blockhash ({:?}), will retry...", blockhash);
+        debug!("Got same blockhash ({blockhash:?}), will retry...");
 
         // Retry ~twice during a slot
         sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2));
@@ -962,7 +961,7 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
         if let Some(txs) = txs {
             shared_tx_thread_count.fetch_add(1, Ordering::Relaxed);
             let num_txs = txs.len();
-            info!("Transferring 1 unit {} times...", num_txs);
+            info!("Transferring 1 unit {num_txs} times...");
             let transfer_start = Instant::now();
             let mut old_transactions = false;
             let mut min_timestamp = u64::MAX;
@@ -1006,7 +1005,7 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
             }
 
             if let Err(error) = client.send_batch(transactions) {
-                warn!("send_batch_sync in do_tx_transfers failed: {}", error);
+                warn!("send_batch_sync in do_tx_transfers failed: {error}");
             }
 
             datapoint_info!(
@@ -1085,8 +1084,7 @@ fn compute_and_report_stats(
         let num_nodes_with_tps = maxes.read().unwrap().len() - nodes_with_zero_tps;
         let average_max = total_maxes / num_nodes_with_tps as f32;
         info!(
-            "\nAverage max TPS: {:.2}, {} nodes had 0 TPS",
-            average_max, nodes_with_zero_tps
+            "\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS"
         );
     }
 
@@ -1121,7 +1119,7 @@ pub fn generate_and_fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>
     let rent = client.get_minimum_balance_for_rent_exemption(0)?;
     let lamports_per_account = lamports_per_account + rent;
 
-    info!("Creating {} keypairs...", keypair_count);
+    info!("Creating {keypair_count} keypairs...");
     let (mut keypairs, extra) = generate_keypairs(funding_key, keypair_count as u64);
     fund_keypairs(
         client,
@@ -1181,8 +1179,7 @@ pub fn fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>(
 
         let funding_key_balance = client.get_balance(&funding_key.pubkey()).unwrap_or(0);
         info!(
-            "Funding keypair balance: {} max_fee: {} lamports_per_account: {} extra: {} total: {}",
-            funding_key_balance, max_fee, lamports_per_account, extra, total
+            "Funding keypair balance: {funding_key_balance} max_fee: {max_fee} lamports_per_account: {lamports_per_account} extra: {extra} total: {total}"
         );
 
         if funding_key_balance < total + rent {

--- a/bench-tps/src/keypairs.rs
+++ b/bench-tps/src/keypairs.rs
@@ -25,7 +25,7 @@ where
         let path = Path::new(client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        info!("Reading {}", client_ids_and_stake_file);
+        info!("Reading {client_ids_and_stake_file}");
         let accounts: HashMap<String, Base64Account> = serde_yaml::from_reader(file).unwrap();
         let mut keypairs = vec![];
         let mut last_balance = 0;

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -47,7 +47,7 @@ fn find_node_activated_stake(
 ) -> Result<(u64, u64), ()> {
     let vote_accounts = rpc_client.get_vote_accounts();
     if let Err(error) = vote_accounts {
-        error!("Failed to get vote accounts, error: {}", error);
+        error!("Failed to get vote accounts, error: {error}");
         return Err(());
     }
 
@@ -207,7 +207,7 @@ fn main() {
 
     let keypair_count = *tx_count * keypair_multiplier;
     if *write_to_client_file {
-        info!("Generating {} keypairs", keypair_count);
+        info!("Generating {keypair_count} keypairs");
         let (keypairs, _) = generate_keypairs(id, keypair_count as u64);
         let num_accounts = keypairs.len() as u64;
         let max_fee = FeeRateGovernor::new(*target_lamports_per_signature, 0)
@@ -228,7 +228,7 @@ fn main() {
             );
         });
 
-        info!("Writing {}", client_ids_and_stake_file);
+        info!("Writing {client_ids_and_stake_file}");
         let serialized = serde_yaml::to_string(&accounts).unwrap();
         let path = Path::new(&client_ids_and_stake_file);
         let mut file = File::create(path).unwrap();

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -45,7 +45,7 @@ pub fn sample_txs<T>(
         let mut txs =
             match client.get_transaction_count_with_commitment(CommitmentConfig::processed()) {
                 Err(e) => {
-                    info!("Couldn't get transaction count {:?}", e);
+                    info!("Couldn't get transaction count {e:?}");
                     sleep(Duration::from_secs(sample_period));
                     continue;
                 }
@@ -53,7 +53,7 @@ pub fn sample_txs<T>(
             };
 
         if txs < last_txs {
-            info!("Expected txs({}) >= last_txs({})", txs, last_txs);
+            info!("Expected txs({txs}) >= last_txs({last_txs})");
             txs = last_txs;
         }
         total_txs = txs - initial_txs;

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -31,7 +31,7 @@ pub fn get_latest_blockhash<T: TpsClient + ?Sized>(client: &T) -> Hash {
         match client.get_latest_blockhash() {
             Ok(blockhash) => return blockhash,
             Err(err) => {
-                info!("Couldn't get last blockhash: {:?}", err);
+                info!("Couldn't get last blockhash: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         };
@@ -110,7 +110,7 @@ pub fn generate_durable_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?S
     let (mut nonce_keypairs, _extra) = generate_keypairs(seed_keypair, count as u64);
     nonce_keypairs.truncate(count);
 
-    info!("Creating {} nonce accounts...", count);
+    info!("Creating {count} nonce accounts...");
     let to_fund: Vec<NonceCreateSigners> = authority_keypairs
         .iter()
         .zip(nonce_keypairs.iter())
@@ -155,7 +155,7 @@ fn verify_funding_transfer<T: TpsClient + ?Sized>(
     for a in &tx.message().account_keys[1..] {
         match client.get_balance_with_commitment(a, CommitmentConfig::processed()) {
             Ok(balance) => return balance >= amount,
-            Err(err) => error!("failed to get balance {:?}", err),
+            Err(err) => error!("failed to get balance {err:?}"),
         }
     }
     false
@@ -231,7 +231,7 @@ where
             //  retry
             tries += 1;
         }
-        info!("transactions sent in {} tries", tries);
+        info!("transactions sent in {tries} tries");
     }
 
     fn sign(&mut self, blockhash: Hash) {
@@ -295,16 +295,14 @@ where
                     if failed_verify > 100 && failed_verify > verified_txs {
                         too_many_failures.store(true, Ordering::Relaxed);
                         warn!(
-                            "Too many failed transfers... {} remaining, {} verified, {} failures",
-                            remaining_count, verified_txs, failed_verify
+                            "Too many failed transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
                         );
                     }
                     if remaining_count > 0 {
                         let mut time_l = time.lock().unwrap();
                         if time_l.elapsed().as_secs() > 2 {
                             info!(
-                                "Verifying transfers... {} remaining, {} verified, {} failures",
-                                remaining_count, verified_txs, failed_verify
+                                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
                             );
                             *time_l = Instant::now();
                         }
@@ -324,8 +322,7 @@ where
             let failed_verify = failed_verify.load(Ordering::Relaxed);
             let remaining_count = starting_txs.saturating_sub(verified_txs + failed_verify);
             info!(
-                "Verifying transfers... {} remaining, {} verified, {} failures",
-                remaining_count, verified_txs, failed_verify
+                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
             );
             sleep(Duration::from_millis(100));
         }

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -452,7 +452,7 @@ impl<O: BucketOccupied> BucketStorage<O> {
         let r = thread_rng().gen_range(0..drives.len());
         let drive = &drives[r];
         let file_random = thread_rng().gen_range(0..u128::MAX);
-        let pos = format!("{}", file_random,);
+        let pos = format!("{file_random}",);
         let file = drive.join(pos);
         let res = Self::map_open_file(file.clone(), true, bytes, stats).unwrap();
 

--- a/bucket_map/src/restart.rs
+++ b/bucket_map/src/restart.rs
@@ -104,7 +104,7 @@ impl Debug for RestartableBucket {
 impl Debug for Restart {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let header = self.get_header();
-        writeln!(f, "{:?}", header)?;
+        writeln!(f, "{header:?}")?;
         write!(
             f,
             "{:?}",

--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -204,7 +204,7 @@ impl Client {
         let port = value_t_or_exit!(matches, "port", u16);
 
         let server_url =
-            value_t!(matches, "server_url", String).unwrap_or(format!("http://0.0.0.0:{}", port));
+            value_t!(matches, "server_url", String).unwrap_or(format!("http://0.0.0.0:{port}"));
 
         let skip_preflight = matches.is_present("skip_preflight");
 

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -297,11 +297,10 @@ impl UnpackedCrate {
 
         let lib_name = UnpackedCrate::program_library_name(&tempdir, &meta)?;
 
-        let program_path =
-            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
-                .into_os_string()
-                .into_string()
-                .map_err(|_| "Failed to get program file path")?;
+        let program_path = UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "Failed to get program file path")?;
 
         let keypair = Keypair::read_from_file(UnpackedCrate::make_path(
             &tempdir,

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -137,8 +137,8 @@ impl Program {
             None..None,
         )
         .map_err(|e| {
-            error!("Failed to deploy the program: {}", e);
-            format!("Failed to deploy the program: {}", e)
+            error!("Failed to deploy the program: {e}");
+            format!("Failed to deploy the program: {e}")
         })?;
 
         Ok(())
@@ -154,8 +154,8 @@ impl Program {
             &self.path,
         )
         .map_err(|e| {
-            error!("Failed to fetch the program: {}", e);
-            format!("Failed to fetch the program: {}", e)
+            error!("Failed to fetch the program: {e}");
+            format!("Failed to fetch the program: {e}")
         })?;
 
         if APPEND_CRATE_TO_ELF {
@@ -298,7 +298,7 @@ impl UnpackedCrate {
         let lib_name = UnpackedCrate::program_library_name(&tempdir, &meta)?;
 
         let program_path =
-            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{}.so", lib_name))
+            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
                 .into_os_string()
                 .into_string()
                 .map_err(|_| "Failed to get program file path")?;
@@ -306,9 +306,9 @@ impl UnpackedCrate {
         let keypair = Keypair::read_from_file(UnpackedCrate::make_path(
             &tempdir,
             &meta,
-            format!("out/{}-keypair.json", lib_name),
+            format!("out/{lib_name}-keypair.json"),
         ))
-        .map_err(|e| format!("Failed to get keypair from the file: {}", e))?;
+        .map_err(|e| format!("Failed to get keypair from the file: {e}"))?;
 
         Ok(UnpackedCrate {
             meta,
@@ -406,7 +406,7 @@ impl UnpackedCrate {
         fs::create_dir_all(base_path)
             .map_err(|_| "Failed to create the base directory for output")?;
 
-        let program_path = Self::make_path(&tempdir, &meta, format!("out/{}.so", id))
+        let program_path = Self::make_path(&tempdir, &meta, format!("out/{id}.so"))
             .into_os_string()
             .into_string()
             .map_err(|_| "Failed to get program file path")?;

--- a/cargo-registry/src/main.rs
+++ b/cargo-registry/src/main.rs
@@ -55,12 +55,12 @@ impl CargoRegistryService {
                 };
 
                 if result.is_ok() {
-                    info!("Published the crate successfully. {:?}", result);
+                    info!("Published the crate successfully. {result:?}");
                     response_builder::success_response()
                 } else {
                     response_builder::error_response(
                         hyper::StatusCode::BAD_REQUEST,
-                        format!("Failed to publish the crate. {:?}", result).as_str(),
+                        format!("Failed to publish the crate. {result:?}").as_str(),
                     )
                 }
             }
@@ -283,7 +283,7 @@ async fn main() {
     });
 
     let server = Server::bind(&bind_addr).serve(registry_service);
-    info!("Server running on http://{}", bind_addr);
+    info!("Server running on http://{bind_addr}");
 
     let _ = server.await;
 }

--- a/cargo-registry/src/response_builder.rs
+++ b/cargo-registry/src/response_builder.rs
@@ -1,7 +1,7 @@
 use log::error;
 
 pub(crate) fn error_response(status: hyper::StatusCode, msg: &str) -> hyper::Response<hyper::Body> {
-    error!("{}", msg);
+    error!("{msg}");
     hyper::Response::builder()
         .status(status)
         .body(hyper::Body::from(

--- a/cargo-registry/src/sparse_index.rs
+++ b/cargo-registry/src/sparse_index.rs
@@ -81,13 +81,13 @@ impl From<PackageMetaData> for IndexEntry {
 impl RegistryIndex {
     pub(crate) fn new(root: &str, server_url: &str) -> Self {
         let registry_config = RegistryConfig {
-            dl: format!("{}/api/v1/crates", server_url),
+            dl: format!("{server_url}/api/v1/crates"),
             api: Some(server_url.to_string()),
         };
         let config =
             serde_json::to_string(&registry_config).expect("Failed to create registry config");
 
-        info!("Registry index is available at {}{}/", server_url, root);
+        info!("Registry index is available at {server_url}{root}/");
         Self {
             index_root: root.to_string(),
             config,
@@ -127,7 +127,7 @@ impl RegistryIndex {
         let mut write_index = self
             .index
             .write()
-            .map_err(|e| format!("Failed to lock the index for writing: {}", e))?;
+            .map_err(|e| format!("Failed to lock the index for writing: {e}"))?;
         info!("Inserting {}-{} in registry index", entry.name, entry.vers);
         write_index.insert(entry.name.clone(), entry);
         Ok(())
@@ -144,12 +144,12 @@ impl RegistryIndex {
             2 => path == "/2",
             3 => {
                 let first_char = crate_name.chars().next()?;
-                path == format!("/3/{}", first_char)
+                path == format!("/3/{first_char}")
             }
             _ => {
                 let (first_two_char, rest) = crate_name.split_at(2);
                 let (next_two_char, _) = rest.split_at(2);
-                path == format!("/{}/{}", first_two_char, next_two_char)
+                path == format!("/{first_two_char}/{next_two_char}")
             }
         }
         .then_some(crate_name)
@@ -167,7 +167,7 @@ impl RegistryIndex {
             );
         };
 
-        info!("Looking up index for {:?}", crate_name);
+        info!("Looking up index for {crate_name:?}");
 
         let Ok(read_index) = self.index.read() else {
             return response_builder::error_response(

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -198,7 +198,7 @@ pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {
             let lamports = if lamports.is_empty() {
                 0
             } else {
-                format!("{:0<9}", lamports)[..9].parse().ok()?
+                format!("{lamports:0<9}")[..9].parse().ok()?
             };
             Some(
                 LAMPORTS_PER_SOL

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1342,7 +1342,7 @@ mod tests {
             legacy: false,
         };
 
-        let signer_arg = format!("{}={}", pubkey, signature);
+        let signer_arg = format!("{pubkey}={signature}");
 
         let clap_app = Command::new("test").arg(
             Arg::new(SIGNER_ARG.name)
@@ -1383,7 +1383,7 @@ mod tests {
             legacy: false,
         };
 
-        let signer_arg = format!("{}={}", pubkey, signature);
+        let signer_arg = format!("{pubkey}={signature}");
 
         let clap_app = Command::new("test").arg(
             Arg::new(SIGNER_ARG.name)

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -117,9 +117,9 @@ impl VerboseDisplay for CliPrioritizationFeeStats {
     fn write_str(&self, f: &mut dyn std::fmt::Write) -> fmt::Result {
         writeln!(f, "{:<11} prioritization_fee", "slot")?;
         for fee in &self.fees {
-            write!(f, "{}", fee)?;
+            write!(f, "{fee}")?;
         }
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1838,8 +1838,7 @@ pub fn process_show_stakes(
 
             if !pubkeys.is_empty() {
                 return Err(CliError::RpcRequestError(format!(
-                    "Failed to retrieve matching vote account for {:?}.",
-                    pubkeys
+                    "Failed to retrieve matching vote account for {pubkeys:?}."
                 ))
                 .into());
             }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1534,8 +1534,7 @@ fn fetch_verified_buffer_program_data(
 
     verify_elf(&buffer_program_data, feature_set).map_err(|err| {
         format!(
-            "Buffer account {buffer_pubkey} has invalid program data: {:?}",
-            err
+            "Buffer account {buffer_pubkey} has invalid program data: {err:?}"
         )
     })?;
 
@@ -1569,8 +1568,7 @@ fn fetch_buffer_program_data(
         }
         if authority_address != Some(buffer_authority) {
             return Err(format!(
-                "Buffer's authority {:?} does not match authority provided {}",
-                authority_address, buffer_authority
+                "Buffer's authority {authority_address:?} does not match authority provided {buffer_authority}"
             )
             .into());
         }
@@ -3248,7 +3246,7 @@ fn send_deploy_messages(
 
             if !transaction_errors.is_empty() {
                 for transaction_error in &transaction_errors {
-                    error!("{:?}", transaction_error);
+                    error!("{transaction_error:?}");
                 }
                 return Err(
                     format!("{} write transactions failed", transaction_errors.len()).into(),
@@ -3715,8 +3713,8 @@ mod tests {
             "test",
             "program",
             "upgrade",
-            format!("{}", buffer_key).as_str(),
-            format!("{}", program_key).as_str(),
+            format!("{buffer_key}").as_str(),
+            format!("{program_key}").as_str(),
             "--skip-feature-verify",
         ]);
         assert_eq!(

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1533,9 +1533,7 @@ fn fetch_verified_buffer_program_data(
     };
 
     verify_elf(&buffer_program_data, feature_set).map_err(|err| {
-        format!(
-            "Buffer account {buffer_pubkey} has invalid program data: {err:?}"
-        )
+        format!("Buffer account {buffer_pubkey} has invalid program data: {err:?}")
     })?;
 
     Ok(buffer_program_data)

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -814,14 +814,13 @@ pub fn process_deploy_program(
     if upload_signer_index.is_none() {
         if upload_account.is_none() {
             return Err(format!(
-                "No ELF was provided or uploaded to the account {:?}",
-                upload_address,
+                "No ELF was provided or uploaded to the account {upload_address:?}",
             )
             .into());
         }
     } else {
         if upload_range.is_empty() {
-            return Err(format!("Attempting to upload empty range {:?}", upload_range).into());
+            return Err(format!("Attempting to upload empty range {upload_range:?}").into());
         }
         let first_write_message = Message::new(
             &[instruction::write(
@@ -1257,7 +1256,7 @@ fn send_messages(
 
         if !transaction_errors.is_empty() {
             for transaction_error in &transaction_errors {
-                error!("{:?}", transaction_error);
+                error!("{transaction_error:?}");
             }
             return Err(format!("{} write transactions failed", transaction_errors.len()).into());
         }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1987,8 +1987,7 @@ fn test_cli_program_write_buffer() {
         &config,
         "It should not be possible to deploy a program into an account that is too small",
         &format!(
-            "Buffer account data size ({}) is smaller than the minimum size ({})",
-            buffer_account_len, min_buffer_account_len
+            "Buffer account data size ({buffer_account_len}) is smaller than the minimum size ({min_buffer_account_len})"
         ),
     );
 }

--- a/client/src/transaction_executor.rs
+++ b/client/src/transaction_executor.rs
@@ -76,7 +76,7 @@ impl TransactionExecutor {
                     return Some((sig, timestamp(), id));
                 }
                 Err(e) => {
-                    info!("error: {:#?}", e);
+                    info!("error: {e:#?}");
                 }
             }
             None
@@ -136,7 +136,7 @@ impl TransactionExecutor {
                             let mut retain = true;
                             let sent_ts = sigs_w[i].1;
                             if let Some(e) = &statuses[j] {
-                                debug!("error: {:?}", e);
+                                debug!("error: {e:?}");
                                 if e.status.is_ok() {
                                     success += 1;
                                 } else {
@@ -169,8 +169,7 @@ impl TransactionExecutor {
                         );
                         if last_log.elapsed().as_millis() > 5000 {
                             info!(
-                                "success: {} error: {} timed_out: {}",
-                                success, error_count, timed_out,
+                                "success: {success} error: {error_count} timed_out: {timed_out}",
                             );
                             last_log = Instant::now();
                         }

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -193,8 +193,7 @@ impl BankingTraceEvents {
             ) {
                 // Silence errors here as this can happen under normal operation...
                 warn!(
-                    "Reading {:?} failed {:?} due to file corruption or unclean validator shutdown",
-                    event_file_path, read_result,
+                    "Reading {event_file_path:?} failed {read_result:?} due to file corruption or unclean validator shutdown",
                 );
             } else {
                 read_result?
@@ -595,8 +594,7 @@ impl<'a> SenderLoopLogger<'a> {
         tx_count: usize,
     ) {
         debug!(
-            "sent {:?} {} batches ({} txes)",
-            label, batch_count, tx_count
+            "sent {label:?} {batch_count} batches ({tx_count} txes)"
         );
 
         use ChannelLabel::*;
@@ -764,8 +762,7 @@ impl BankingSimulator {
         .unwrap();
         assert!(retracer.is_enabled());
         info!(
-            "Enabled banking retracer (dir_byte_limit: {})",
-            BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
+            "Enabled banking retracer (dir_byte_limit: {BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT})",
         );
 
         // Create a partially-dummy ClusterInfo for the banking stage.

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -593,9 +593,7 @@ impl<'a> SenderLoopLogger<'a> {
         batch_count: usize,
         tx_count: usize,
     ) {
-        debug!(
-            "sent {label:?} {batch_count} batches ({tx_count} txes)"
-        );
+        debug!("sent {label:?} {batch_count} batches ({tx_count} txes)");
 
         use ChannelLabel::*;
         let (total_batch_count, total_tx_count) = match label {
@@ -761,9 +759,7 @@ impl BankingSimulator {
         )))
         .unwrap();
         assert!(retracer.is_enabled());
-        info!(
-            "Enabled banking retracer (dir_byte_limit: {BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT})",
-        );
+        info!("Enabled banking retracer (dir_byte_limit: {BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT})",);
 
         // Create a partially-dummy ClusterInfo for the banking stage.
         let cluster_info_for_banking = Arc::new(DummyClusterInfo {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -450,9 +450,7 @@ impl TracedSender {
                         TracedEvent::PacketBatch(self.label, BankingPacketBatch::clone(&batch)),
                     ))
                     .map_err(|err| {
-                        error!(
-                            "unexpected error when tracing a banking event...: {err:?}"
-                        );
+                        error!("unexpected error when tracing a banking event...: {err:?}");
                         SendError(BankingPacketBatch::clone(&batch))
                     })?;
             }

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -451,8 +451,7 @@ impl TracedSender {
                     ))
                     .map_err(|err| {
                         error!(
-                            "unexpected error when tracing a banking event...: {:?}",
-                            err
+                            "unexpected error when tracing a banking event...: {err:?}"
                         );
                         SendError(BankingPacketBatch::clone(&batch))
                     })?;

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -545,7 +545,7 @@ impl ClusterInfoVoteListener {
                         sender
                             .send(BankNotification::OptimisticallyConfirmed(slot))
                             .unwrap_or_else(|err| {
-                                warn!("bank_notification_sender failed: {:?}", err)
+                                warn!("bank_notification_sender failed: {err:?}")
                             });
                     }
                 }

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -247,7 +247,7 @@ impl ClusterSlots {
         let epoch_metadata = self.epoch_metadata.read().unwrap();
         //startup init, this is very slow but only ever happens once
         if cluster_slots.is_empty() {
-            info!("Init cluster_slots at range {:?}", slot_range);
+            info!("Init cluster_slots at range {slot_range:?}");
             for slot in slot_range.clone() {
                 // Epoch should be defined for all slots in the window
                 let epoch = self
@@ -515,8 +515,7 @@ mod tests {
             assert_eq!(
                 rg.len(),
                 CLUSTER_SLOTS_TRIM_SIZE,
-                "ring should have exactly {} elements",
-                CLUSTER_SLOTS_TRIM_SIZE
+                "ring should have exactly {CLUSTER_SLOTS_TRIM_SIZE} elements"
             );
             assert_eq!(rg.front().unwrap().slot, 1, "first slot should be root + 1");
             assert_eq!(

--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -74,7 +74,7 @@ impl CompletedDataSetsService {
                         rpc_subscriptions.notify_signatures_received((slot, transactions));
                     }
                 }
-                Err(e) => warn!("completed-data-set-service deserialize error: {:?}", e),
+                Err(e) => warn!("completed-data-set-service deserialize error: {e:?}"),
             }
             slot
         };

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1255,9 +1255,7 @@ impl Tower {
         );
         let new_check = Some((switch_slot, decision.clone()));
         if new_check != self.last_switch_threshold_check {
-            trace!(
-                "new switch threshold check: slot {switch_slot}: {decision:?}",
-            );
+            trace!("new switch threshold check: slot {switch_slot}: {decision:?}",);
             self.last_switch_threshold_check = new_check;
         }
         decision

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -407,7 +407,7 @@ impl Tower {
             if voted_stake == 0 {
                 continue;
             }
-            trace!("{} {} with stake {}", vote_account_pubkey, key, voted_stake);
+            trace!("{vote_account_pubkey} {key} with stake {voted_stake}");
             let mut vote_state = TowerVoteState::from(account.vote_state_view());
             for vote in &vote_state.votes {
                 lockout_intervals
@@ -418,7 +418,7 @@ impl Tower {
 
             if key == *vote_account_pubkey {
                 my_latest_landed_vote = vote_state.nth_recent_lockout(0).map(|l| l.slot());
-                debug!("vote state {:?}", vote_state);
+                debug!("vote state {vote_state:?}");
                 debug!(
                     "observed slot {}",
                     vote_state
@@ -961,7 +961,7 @@ impl Tower {
                      vote({last_voted_slot}), meaning some inconsistency between saved tower and \
                      ledger."
                 );
-                warn!("{}", message);
+                warn!("{message}");
                 datapoint_warn!("tower_warn", ("warn", message, String));
             }
             &empty_ancestors
@@ -1256,9 +1256,7 @@ impl Tower {
         let new_check = Some((switch_slot, decision.clone()));
         if new_check != self.last_switch_threshold_check {
             trace!(
-                "new switch threshold check: slot {}: {:?}",
-                switch_slot,
-                decision,
+                "new switch threshold check: slot {switch_slot}: {decision:?}",
             );
             self.last_switch_threshold_check = new_check;
         }
@@ -1472,7 +1470,7 @@ impl Tower {
                     "For some reason, we're REPROCESSING slots which has already been voted and \
                      ROOTED by us; VOTING will be SUSPENDED UNTIL {last_voted_slot}!",
                 );
-                error!("{}", message);
+                error!("{message}");
                 datapoint_error!("tower_error", ("error", message, String));
 
                 // Let's pass-through adjust_lockouts_with_slot_history just for sanitization,
@@ -1571,7 +1569,7 @@ impl Tower {
         }
 
         // Check for errors if not anchored
-        info!("adjusted tower's anchored slot: {:?}", anchored_slot);
+        info!("adjusted tower's anchored slot: {anchored_slot:?}");
         if anchored_slot.is_none() {
             // this error really shouldn't happen unless ledger/tower is corrupted
             return Err(TowerError::FatallyInconsistent(
@@ -1737,9 +1735,8 @@ pub fn reconcile_blockstore_roots_with_external_source(
             .collect();
         if !new_roots.is_empty() {
             info!(
-                "Reconciling slots as root based on external root: {:?} (external: {:?}, \
-                 blockstore: {})",
-                new_roots, external_source, last_blockstore_root
+                "Reconciling slots as root based on external root: {new_roots:?} (external: {external_source:?}, \
+                 blockstore: {last_blockstore_root})"
             );
 
             // Unfortunately, we can't supply duplicate-confirmed hashes,
@@ -1761,10 +1758,9 @@ pub fn reconcile_blockstore_roots_with_external_source(
             // That's because we might have a chance of recovering properly with
             // newer snapshot.
             warn!(
-                "Couldn't find any ancestor slots from external source ({:?}) towards blockstore \
-                 root ({}); blockstore pruned or only tower moved into new ledger or just hard \
+                "Couldn't find any ancestor slots from external source ({external_source:?}) towards blockstore \
+                 root ({last_blockstore_root}); blockstore pruned or only tower moved into new ledger or just hard \
                  fork?",
-                external_source, last_blockstore_root,
             );
         }
     }

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -935,9 +935,7 @@ impl HeaviestSubtreeForkChoice {
         let fork_info = self.fork_infos.get_mut(&slot_hash_key).unwrap();
         if is_duplicate_confirmed {
             if !fork_info.is_duplicate_confirmed {
-                info!(
-                    "Fork choice setting {slot_hash_key:?} to duplicate confirmed"
-                );
+                info!("Fork choice setting {slot_hash_key:?} to duplicate confirmed");
             }
             fork_info.set_duplicate_confirmed();
         }
@@ -1329,9 +1327,7 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
     }
 
     fn mark_fork_invalid_candidate(&mut self, invalid_slot_hash_key: &SlotHashKey) {
-        info!(
-            "marking fork starting at: {invalid_slot_hash_key:?} invalid candidate"
-        );
+        info!("marking fork starting at: {invalid_slot_hash_key:?} invalid candidate");
         let fork_info = self.fork_infos.get_mut(invalid_slot_hash_key);
         if let Some(fork_info) = fork_info {
             // Should not be marking duplicate confirmed blocks as invalid candidates
@@ -1356,9 +1352,7 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
     }
 
     fn mark_fork_valid_candidate(&mut self, valid_slot_hash_key: &SlotHashKey) -> Vec<SlotHashKey> {
-        info!(
-            "marking fork starting at: {valid_slot_hash_key:?} valid candidate"
-        );
+        info!("marking fork starting at: {valid_slot_hash_key:?} valid candidate");
         let mut newly_duplicate_confirmed_ancestors = vec![];
 
         for ancestor_key in std::iter::once(*valid_slot_hash_key)

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -143,9 +143,8 @@ impl ForkInfo {
         if let Some(latest_invalid_ancestor) = self.latest_invalid_ancestor {
             if latest_invalid_ancestor <= newly_valid_ancestor {
                 info!(
-                    "Fork choice for {:?} clearing latest invalid ancestor {:?} because {:?} was \
-                     duplicate confirmed",
-                    my_key, latest_invalid_ancestor, newly_valid_ancestor
+                    "Fork choice for {my_key:?} clearing latest invalid ancestor {latest_invalid_ancestor:?} because {newly_valid_ancestor:?} was \
+                     duplicate confirmed"
                 );
                 self.latest_invalid_ancestor = None;
             }
@@ -937,8 +936,7 @@ impl HeaviestSubtreeForkChoice {
         if is_duplicate_confirmed {
             if !fork_info.is_duplicate_confirmed {
                 info!(
-                    "Fork choice setting {:?} to duplicate confirmed",
-                    slot_hash_key
+                    "Fork choice setting {slot_hash_key:?} to duplicate confirmed"
                 );
             }
             fork_info.set_duplicate_confirmed();
@@ -1332,8 +1330,7 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
 
     fn mark_fork_invalid_candidate(&mut self, invalid_slot_hash_key: &SlotHashKey) {
         info!(
-            "marking fork starting at: {:?} invalid candidate",
-            invalid_slot_hash_key
+            "marking fork starting at: {invalid_slot_hash_key:?} invalid candidate"
         );
         let fork_info = self.fork_infos.get_mut(invalid_slot_hash_key);
         if let Some(fork_info) = fork_info {
@@ -1360,8 +1357,7 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
 
     fn mark_fork_valid_candidate(&mut self, valid_slot_hash_key: &SlotHashKey) -> Vec<SlotHashKey> {
         info!(
-            "marking fork starting at: {:?} valid candidate",
-            valid_slot_hash_key
+            "marking fork starting at: {valid_slot_hash_key:?} valid candidate"
         );
         let mut newly_duplicate_confirmed_ancestors = vec![];
 

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -292,7 +292,7 @@ impl TowerStorage for EtcdTowerStorage {
         self.runtime
             .block_on(async { self.client.lock().await.txn(txn).await })
             .map_err(|err| {
-                error!("Failed to acquire etcd instance lock: {}", err);
+                error!("Failed to acquire etcd instance lock: {err}");
                 Self::etdc_to_tower_error(err)
             })?;
 
@@ -308,7 +308,7 @@ impl TowerStorage for EtcdTowerStorage {
             .runtime
             .block_on(async { self.client.lock().await.txn(txn).await })
             .map_err(|err| {
-                error!("Failed to read etcd saved tower: {}", err);
+                error!("Failed to read etcd saved tower: {err}");
                 Self::etdc_to_tower_error(err)
             })?;
 
@@ -353,7 +353,7 @@ impl TowerStorage for EtcdTowerStorage {
             .runtime
             .block_on(async { self.client.lock().await.txn(txn).await })
             .map_err(|err| {
-                error!("Failed to write etcd saved tower: {}", err);
+                error!("Failed to write etcd saved tower: {err}");
                 err
             })
             .map_err(Self::etdc_to_tower_error)?;

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -238,7 +238,7 @@ impl FetchStage {
                         Error::RecvTimeout(RecvTimeoutError::Timeout) => (),
                         Error::Recv(_) => break,
                         Error::Send => break,
-                        _ => error!("{:?}", e),
+                        _ => error!("{e:?}"),
                     }
                 }
             })

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -128,7 +128,7 @@ impl AncestorRepairRequestsStats {
 
         let repair_total = self.ancestor_requests.count;
         if self.last_report.elapsed().as_secs() > 2 && repair_total > 0 {
-            info!("ancestor_repair_requests_stats: {:?}", slot_to_count);
+            info!("ancestor_repair_requests_stats: {slot_to_count:?}");
             datapoint_info!(
                 "ancestor-repair",
                 ("ancestor-repair-count", self.ancestor_requests.count, i64)

--- a/core/src/repair/cluster_slot_state_verifier.rs
+++ b/core/src/repair/cluster_slot_state_verifier.rs
@@ -377,8 +377,7 @@ fn check_duplicate_confirmed_hash_against_bank_status(
             // If the cluster duplicate confirmed some version of this slot, then
             // there's another version of our dead slot
             warn!(
-                "Cluster duplicate confirmed slot {} with hash {}, but we marked slot dead",
-                slot, duplicate_confirmed_hash
+                "Cluster duplicate confirmed slot {slot} with hash {duplicate_confirmed_hash}, but we marked slot dead"
             );
             state_changes.push(ResultingStateChange::RepairDuplicateConfirmedVersion(
                 duplicate_confirmed_hash,
@@ -397,8 +396,7 @@ fn check_duplicate_confirmed_hash_against_bank_status(
             // Modify fork choice rule to exclude our version from being voted
             // on and also repair the correct version
             warn!(
-                "Cluster duplicate confirmed slot {} with hash {}, but our version has hash {}",
-                slot, duplicate_confirmed_hash, bank_frozen_hash
+                "Cluster duplicate confirmed slot {slot} with hash {duplicate_confirmed_hash}, but our version has hash {bank_frozen_hash}"
             );
             state_changes.push(ResultingStateChange::MarkSlotDuplicate(bank_frozen_hash));
             state_changes.push(ResultingStateChange::RepairDuplicateConfirmedVersion(
@@ -857,8 +855,7 @@ pub(crate) fn check_slot_agrees_with_cluster(
     slot_state_update: SlotStateUpdate,
 ) {
     info!(
-        "check_slot_agrees_with_cluster() slot: {}, root: {}, slot_state_update: {:?}",
-        slot, root, slot_state_update
+        "check_slot_agrees_with_cluster() slot: {slot}, root: {root}, slot_state_update: {slot_state_update:?}"
     );
 
     if slot <= root {

--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -360,9 +360,9 @@ impl AncestorRequestStatus {
                             self.requested_mismatched_slot
                         );
                     }
-                    (Some(decision), true) => panic!(
-                        "Programmer error, {decision:?} should not be set in decision loop"
-                    ),
+                    (Some(decision), true) => {
+                        panic!("Programmer error, {decision:?} should not be set in decision loop")
+                    }
                     (Some(_), false) => { /* Already found a mismatch, descendants continue to mismatch as well */
                     }
                     (None, true) => { /* Mismatch hasn't been found yet */ }

--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -361,8 +361,7 @@ impl AncestorRequestStatus {
                         );
                     }
                     (Some(decision), true) => panic!(
-                        "Programmer error, {:?} should not be set in decision loop",
-                        decision
+                        "Programmer error, {decision:?} should not be set in decision loop"
                     ),
                     (Some(_), false) => { /* Already found a mismatch, descendants continue to mismatch as well */
                     }

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -171,7 +171,7 @@ impl RepairStats {
             .chain(self.orphan.slot_pubkeys.iter())
             .map(|(slot, slot_repairs)| (slot, slot_repairs.pubkey_repairs.values().sum::<u64>()))
             .collect();
-        info!("repair_stats: {:?}", slot_to_count);
+        info!("repair_stats: {slot_to_count:?}");
         if repair_total > 0 {
             let nonzero_num = |x| if x == 0 { None } else { Some(x) };
             datapoint_info!(
@@ -609,8 +609,7 @@ impl RepairService {
         });
         if !popular_pruned_forks.is_empty() {
             warn!(
-                "Notifying repair of popular pruned forks {:?}",
-                popular_pruned_forks
+                "Notifying repair of popular pruned forks {popular_pruned_forks:?}"
             );
             popular_pruned_forks_sender
                 .send(popular_pruned_forks)
@@ -1063,7 +1062,7 @@ impl RepairService {
                 debug!("successfully sent repair request to {pubkey} / {address}!");
             }
             Err(SendPktsError::IoError(err, _num_failed)) => {
-                error!("batch_send failed to send packet - error = {:?}", err);
+                error!("batch_send failed to send packet - error = {err:?}");
             }
         }
     }
@@ -1179,8 +1178,7 @@ impl RepairService {
                             Ok(req) => {
                                 if let Err(e) = repair_socket.send_to(&req, repair_addr) {
                                     info!(
-                                        "repair req send_to {} ({}) error {:?}",
-                                        repair_pubkey, repair_addr, e
+                                        "repair req send_to {repair_pubkey} ({repair_addr}) error {e:?}"
                                     );
                                 }
                             }

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -608,9 +608,7 @@ impl RepairService {
             }
         });
         if !popular_pruned_forks.is_empty() {
-            warn!(
-                "Notifying repair of popular pruned forks {popular_pruned_forks:?}"
-            );
+            warn!("Notifying repair of popular pruned forks {popular_pruned_forks:?}");
             popular_pruned_forks_sender
                 .send(popular_pruned_forks)
                 .unwrap_or_else(|err| error!("failed to send popular pruned forks {err}"));

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -322,13 +322,13 @@ impl RepairWeight {
     pub fn split_off(&mut self, slot: Slot) -> HashSet<Slot> {
         assert!(slot >= self.root);
         if slot == self.root {
-            error!("Trying to orphan root of repair tree {}", slot);
+            error!("Trying to orphan root of repair tree {slot}");
             return HashSet::new();
         }
         match self.slot_to_tree.get(&slot).copied() {
             Some(TreeRoot::Root(subtree_root)) => {
                 if subtree_root == slot {
-                    info!("{} is already orphan, skipping", slot);
+                    info!("{slot} is already orphan, skipping");
                     return HashSet::new();
                 }
                 let subtree = self
@@ -351,8 +351,7 @@ impl RepairWeight {
                 // `update_orphan_ancestors`.
 
                 info!(
-                    "Dumping pruned slot {} of tree {} in repair",
-                    slot, subtree_root
+                    "Dumping pruned slot {slot} of tree {subtree_root} in repair"
                 );
                 let mut subtree = self
                     .pruned_trees
@@ -379,8 +378,7 @@ impl RepairWeight {
             }
             None => {
                 warn!(
-                    "Trying to split off slot {} which doesn't currently exist in repair",
-                    slot
+                    "Trying to split off slot {slot} which doesn't currently exist in repair"
                 );
                 HashSet::new()
             }
@@ -440,7 +438,7 @@ impl RepairWeight {
 
             // Find all descendants of `self.root` that are not reachable from `new_root`.
             // Prune these out and add to `self.pruned_trees`
-            trace!("pruning tree {} with {}", new_root_tree_root, new_root);
+            trace!("pruning tree {new_root_tree_root} with {new_root}");
             let (removed, pruned) = new_root_tree.purge_prune((new_root, Hash::default()));
             for pruned_tree in pruned {
                 let pruned_tree_root = pruned_tree.tree_root().0;
@@ -471,7 +469,7 @@ impl RepairWeight {
             .drain()
             .flat_map(|(tree_root, mut pruned_tree)| {
                 if tree_root < new_root {
-                    trace!("pruning tree {} with {}", tree_root, new_root);
+                    trace!("pruning tree {tree_root} with {new_root}");
                     let (removed, pruned) = pruned_tree.purge_prune((new_root, Hash::default()));
                     for (slot, _) in removed {
                         self.slot_to_tree.remove(&slot);

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -350,9 +350,7 @@ impl RepairWeight {
                 // If not they will once again be attached to the pruned set in
                 // `update_orphan_ancestors`.
 
-                info!(
-                    "Dumping pruned slot {slot} of tree {subtree_root} in repair"
-                );
+                info!("Dumping pruned slot {slot} of tree {subtree_root} in repair");
                 let mut subtree = self
                     .pruned_trees
                     .remove(&subtree_root)
@@ -377,9 +375,7 @@ impl RepairWeight {
                 }
             }
             None => {
-                warn!(
-                    "Trying to split off slot {slot} which doesn't currently exist in repair"
-                );
+                warn!("Trying to split off slot {slot} which doesn't currently exist in repair");
                 HashSet::new()
             }
         }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -516,7 +516,7 @@ impl ServeRepair {
     fn report_time_spent(label: &str, time: &Duration, extra: &str) {
         let count = time.as_millis();
         if count > 5 {
-            info!("{} took: {} ms {}", label, count, extra);
+            info!("{label} took: {count} ms {extra}");
         }
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -636,9 +636,7 @@ impl ReplayStage {
                         return;
                     }
                 };
-                warn!(
-                    "Identity changed during startup from {my_old_pubkey} to {my_pubkey}"
-                );
+                warn!("Identity changed during startup from {my_old_pubkey} to {my_pubkey}");
             }
             let (mut progress, mut heaviest_subtree_fork_choice) =
                 Self::initialize_progress_and_fork_choice_with_locked_bank_forks(
@@ -2002,9 +2000,7 @@ impl ReplayStage {
                 } else {
                     ""
                 };
-                info!(
-                    "LEADER CHANGE at slot: {bank_slot} leader: {new_leader}{msg}"
-                );
+                info!("LEADER CHANGE at slot: {bank_slot} leader: {new_leader}{msg}");
             }
         }
         current_leader.replace(new_leader.to_owned());
@@ -2125,9 +2121,7 @@ impl ReplayStage {
             warn!("{my_pubkey} already have bank in forks at {poh_slot}?");
             return false;
         }
-        trace!(
-            "{my_pubkey} poh_slot {poh_slot} parent_slot {parent_slot}"
-        );
+        trace!("{my_pubkey} poh_slot {poh_slot} parent_slot {parent_slot}");
 
         if let Some(next_leader) = leader_schedule_cache.slot_leader_at(poh_slot, Some(&parent)) {
             if !has_new_vote_been_rooted {
@@ -2135,9 +2129,7 @@ impl ReplayStage {
                 return false;
             }
 
-            trace!(
-                "{my_pubkey} leader {next_leader} at poh slot: {poh_slot}"
-            );
+            trace!("{my_pubkey} leader {next_leader} at poh slot: {poh_slot}");
 
             // I guess I missed my slot
             if next_leader != *my_pubkey {
@@ -2184,9 +2176,7 @@ impl ReplayStage {
 
             let root_slot = bank_forks.read().unwrap().root();
             datapoint_info!("replay_stage-my_leader_slot", ("slot", poh_slot, i64),);
-            info!(
-                "new fork:{poh_slot} parent:{parent_slot} (leader) root:{root_slot}"
-            );
+            info!("new fork:{poh_slot} parent:{parent_slot} (leader) root:{root_slot}");
 
             let root_distance = poh_slot - root_slot;
             let vote_only_bank = if root_distance > MAX_ROOT_DISTANCE_FOR_VOTE_ONLY {
@@ -2494,9 +2484,7 @@ impl ReplayStage {
         }
         let vote_account = match bank.get_vote_account(vote_account_pubkey) {
             None => {
-                warn!(
-                    "Vote account {vote_account_pubkey} does not exist.  Unable to vote",
-                );
+                warn!("Vote account {vote_account_pubkey} does not exist.  Unable to vote",);
                 return GenerateVoteTxResult::Failed;
             }
             Some(vote_account) => vote_account,
@@ -3383,9 +3371,7 @@ impl ReplayStage {
     ) -> bool /* completed a bank */ {
         let active_bank_slots = bank_forks.read().unwrap().active_bank_slots();
         let num_active_banks = active_bank_slots.len();
-        trace!(
-            "{num_active_banks} active bank(s) to replay: {active_bank_slots:?}"
-        );
+        trace!("{num_active_banks} active bank(s) to replay: {active_bank_slots:?}");
         if active_bank_slots.is_empty() {
             return false;
         }
@@ -4438,7 +4424,9 @@ pub(crate) mod tests {
         } = vote_simulator;
 
         let blockstore = Arc::new(blockstore);
-        let validator_node_to_vote_keys: HashMap<Pubkey, Pubkey> = validator_keypairs.values().map(|keypairs| {
+        let validator_node_to_vote_keys: HashMap<Pubkey, Pubkey> = validator_keypairs
+            .values()
+            .map(|keypairs| {
                 (
                     keypairs.node_keypair.pubkey(),
                     keypairs.vote_keypair.pubkey(),

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -67,7 +67,7 @@ impl SamplePerformanceService {
 
                 let highest_slot = snapshot.highest_slot;
                 if let Err(e) = blockstore.write_perf_sample(highest_slot, &perf_sample) {
-                    error!("write_perf_sample failed: slot {:?} {:?}", highest_slot, e);
+                    error!("write_perf_sample failed: slot {highest_slot:?} {e:?}");
                 }
             }
             sleep(SLEEP_INTERVAL);

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -415,7 +415,7 @@ impl SigVerifyStage {
                             SigVerifyServiceError::Send(_) => {
                                 break;
                             }
-                            _ => error!("{:?}", e),
+                            _ => error!("{e:?}"),
                         }
                     }
                     if last_print.elapsed().as_secs() > 2 {
@@ -526,7 +526,7 @@ mod tests {
         }
         let mut packet_s = Some(packet_s);
         let mut valid_received = 0;
-        trace!("sent: {}", sent_len);
+        trace!("sent: {sent_len}");
         loop {
             if let Ok(verifieds) = verified_r.recv() {
                 valid_received += verifieds
@@ -544,7 +544,7 @@ mod tests {
                 packet_s.take();
             }
         }
-        trace!("received: {}", valid_received);
+        trace!("received: {valid_received}");
 
         if use_same_tx {
             assert_eq!(valid_received, 1);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -426,8 +426,7 @@ impl Tpu {
         if let Some(tracer_thread_hdl) = self.tracer_thread_hdl {
             if let Err(tracer_result) = tracer_thread_hdl.join()? {
                 error!(
-                    "banking tracer thread returned error after successful thread join: {:?}",
-                    tracer_result
+                    "banking tracer thread returned error after successful thread join: {tracer_result:?}"
                 );
             }
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -817,9 +817,7 @@ impl Validator {
             (root_bank.slot(), root_bank.hard_forks())
         };
         let shred_version = compute_shred_version(&genesis_config.hash(), Some(&hard_forks));
-        info!(
-            "shred version: {shred_version}, hard forks: {hard_forks:?}"
-        );
+        info!("shred version: {shred_version}, hard forks: {hard_forks:?}");
 
         if let Some(expected_shred_version) = config.expected_shred_version {
             if expected_shred_version != shred_version {
@@ -1473,9 +1471,7 @@ impl Validator {
                 tower
             }
             Err(e) => {
-                warn!(
-                    "Unable to retrieve tower: {e:?} creating default tower...."
-                );
+                warn!("Unable to retrieve tower: {e:?} creating default tower....");
                 Tower::default()
             }
         };
@@ -2715,9 +2711,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 
     let online_stake_percentage = (online_stake as f64 / total_activated_stake as f64) * 100.;
     if log {
-        info!(
-            "{online_stake_percentage:.3}% of active stake visible in gossip"
-        );
+        info!("{online_stake_percentage:.3}% of active stake visible in gossip");
 
         if !wrong_shred_nodes.is_empty() {
             info!(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -468,7 +468,7 @@ impl BlockstoreRootScan {
     fn join(self) {
         if let Some(blockstore_root_scan) = self.thread {
             if let Err(err) = blockstore_root_scan.join() {
-                warn!("blockstore_root_scan failed to join {:?}", err);
+                warn!("blockstore_root_scan failed to join {err:?}");
             }
         }
     }
@@ -667,7 +667,7 @@ impl Validator {
         }
 
         for cluster_entrypoint in &cluster_entrypoints {
-            info!("entrypoint: {:?}", cluster_entrypoint);
+            info!("entrypoint: {cluster_entrypoint:?}");
         }
 
         if solana_perf::perf_libs::api().is_some() {
@@ -818,8 +818,7 @@ impl Validator {
         };
         let shred_version = compute_shred_version(&genesis_config.hash(), Some(&hard_forks));
         info!(
-            "shred version: {shred_version}, hard forks: {:?}",
-            hard_forks
+            "shred version: {shred_version}, hard forks: {hard_forks:?}"
         );
 
         if let Some(expected_shred_version) = config.expected_shred_version {
@@ -1470,13 +1469,12 @@ impl Validator {
         };
         let tower = match process_blockstore.process_to_create_tower() {
             Ok(tower) => {
-                info!("Tower state: {:?}", tower);
+                info!("Tower state: {tower:?}");
                 tower
             }
             Err(e) => {
                 warn!(
-                    "Unable to retrieve tower: {:?} creating default tower....",
-                    e
+                    "Unable to retrieve tower: {e:?} creating default tower...."
                 );
                 Tower::default()
             }
@@ -1943,7 +1941,7 @@ fn post_process_restored_tower(
             let message =
                 format!("Hard fork is detected; discarding tower restoration result: {tower:?}");
             datapoint_error!("tower_error", ("error", message, String),);
-            error!("{}", message);
+            error!("{message}");
 
             // unconditionally relax tower requirement so that we can always restore tower
             // from root bank.
@@ -1990,8 +1988,7 @@ fn post_process_restored_tower(
             } else {
                 error!(
                     "Rebuilding a new tower from the latest vote account due to failed tower \
-                     restore: {}",
-                    err
+                     restore: {err}"
                 );
             }
 
@@ -2017,7 +2014,7 @@ fn load_genesis(
     assert!(leader_epoch_offset <= MAX_LEADER_SCHEDULE_EPOCH_OFFSET);
 
     let genesis_hash = genesis_config.hash();
-    info!("genesis hash: {}", genesis_hash);
+    info!("genesis hash: {genesis_hash}");
 
     if let Some(expected_genesis_hash) = config.expected_genesis_hash {
         if genesis_hash != expected_genesis_hash {
@@ -2057,7 +2054,7 @@ fn load_blockstore(
     ),
     String,
 > {
-    info!("loading ledger from {:?}...", ledger_path);
+    info!("loading ledger from {ledger_path:?}...");
     *start_progress.write().unwrap() = ValidatorStartProgress::LoadingLedger;
 
     let blockstore = Blockstore::open_with_options(ledger_path, config.blockstore_options.clone())
@@ -2312,7 +2309,7 @@ fn maybe_warp_slot(
                 working_bank.slot()
             ));
         }
-        info!("warping to slot {}", warp_slot);
+        info!("warping to slot {warp_slot}");
 
         let root_bank = bank_forks.root_bank();
 
@@ -2471,8 +2468,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
     // Backing up the shreds that will be deleted from primary blockstore is
     // not critical, so swallow errors from backup blockstore operations.
     let backup_folder = format!(
-        "{}_backup_{}_{}_{}",
-        BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, incorrect_shred_version, start_slot, end_slot
+        "{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL}_backup_{incorrect_shred_version}_{start_slot}_{end_slot}"
     );
     match Blockstore::open_with_options(
         &blockstore.ledger_path().join(backup_folder),
@@ -2648,8 +2644,7 @@ fn wait_for_supermajority(
 
                 if gossip_stake_percent >= WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT {
                     info!(
-                        "Supermajority reached, {}% active stake detected, starting up now.",
-                        gossip_stake_percent,
+                        "Supermajority reached, {gossip_stake_percent}% active stake detected, starting up now.",
                     );
                     break;
                 }
@@ -2703,9 +2698,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         if let Some(peer) = peers.get(&vote_state_node_pubkey) {
             if peer.shred_version() == my_shred_version {
                 trace!(
-                    "observed {} in gossip, (activated_stake={})",
-                    vote_state_node_pubkey,
-                    activated_stake
+                    "observed {vote_state_node_pubkey} in gossip, (activated_stake={activated_stake})"
                 );
                 online_stake += activated_stake;
             } else {
@@ -2723,8 +2716,7 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     let online_stake_percentage = (online_stake as f64 / total_activated_stake as f64) * 100.;
     if log {
         info!(
-            "{:.3}% of active stake visible in gossip",
-            online_stake_percentage
+            "{online_stake_percentage:.3}% of active stake visible in gossip"
         );
 
         if !wrong_shred_nodes.is_empty() {

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -113,7 +113,7 @@ impl VotingService {
         if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
             let mut measure = Measure::start("tower storage save");
             if let Err(err) = tower_storage.store(saved_tower) {
-                error!("Unable to save tower to storage: {:?}", err);
+                error!("Unable to save tower to storage: {err:?}");
                 std::process::exit(1);
             }
             measure.stop();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -96,7 +96,7 @@ impl WindowServiceMetrics {
             Error::RecvTimeout(_) => self.num_errors_cross_beam_recv_timeout += 1,
             Error::Blockstore(err) => {
                 self.num_errors_blockstore += 1;
-                error!("blockstore error: {}", err);
+                error!("blockstore error: {err}");
             }
             _ => self.num_errors_other += 1,
         }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -396,12 +396,8 @@ fn test_bank_forks_incremental_snapshot() {
     const LAST_SLOT: Slot = FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS * 2 - 1;
 
     info!(
-        "Running bank forks incremental snapshot test, full snapshot interval: {} slots, \
-         incremental snapshot interval: {} slots, last slot: {}, set root interval: {} slots",
-        FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-        INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-        LAST_SLOT,
-        SET_ROOT_INTERVAL
+        "Running bank forks incremental snapshot test, full snapshot interval: {FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS} slots, \
+         incremental snapshot interval: {INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS} slots, last slot: {LAST_SLOT}, set root interval: {SET_ROOT_INTERVAL} slots"
     );
 
     let snapshot_test_config = SnapshotTestConfig::new(
@@ -625,16 +621,11 @@ fn test_snapshots_with_background_services(
     info!("Running snapshots with background services test...");
     trace!(
         "Test configuration parameters:\
-         \n\tfull snapshot archive interval: {} slots\
-         \n\tincremental snapshot archive interval: {} slots\
-         \n\tbank snapshot interval: {} slots\
-         \n\tset root interval: {} slots\
-         \n\tlast slot: {}",
-        FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-        INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-        BANK_SNAPSHOT_INTERVAL_SLOTS,
-        SET_ROOT_INTERVAL_SLOTS,
-        LAST_SLOT
+         \n\tfull snapshot archive interval: {FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS} slots\
+         \n\tincremental snapshot archive interval: {INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS} slots\
+         \n\tbank snapshot interval: {BANK_SNAPSHOT_INTERVAL_SLOTS} slots\
+         \n\tset root interval: {SET_ROOT_INTERVAL_SLOTS} slots\
+         \n\tlast slot: {LAST_SLOT}"
     );
 
     let snapshot_test_config = SnapshotTestConfig::new(

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -438,9 +438,9 @@ fn get_target(
     } else {
         info!("************ NODE ***********");
         for node in nodes {
-            info!("{:?}", node);
+            info!("{node:?}");
         }
-        info!("ADDR = {}", entrypoint_addr);
+        info!("ADDR = {entrypoint_addr}");
 
         for node in nodes {
             if node.gossip() == Some(entrypoint_addr) {
@@ -652,7 +652,7 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
         && params.transaction_params.unique_transactions
     {
         let (_, target_addr) = target.expect("should have target");
-        info!("Targeting {}", target_addr);
+        info!("Targeting {target_addr}");
         run_dos_transactions(
             target_addr,
             iterations,
@@ -664,7 +664,7 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
         );
     } else {
         let (target_id, target_addr) = target.expect("should have target");
-        info!("Targeting {}", target_addr);
+        info!("Targeting {target_addr}");
         let mut data = match params.data_type {
             DataType::RepairHighest => {
                 let slot = 100;
@@ -700,7 +700,7 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
             }
             DataType::Transaction => {
                 let tp = params.transaction_params;
-                info!("{:?}", tp);
+                info!("{tp:?}");
 
                 let valid_blockhash = tp.valid_blockhash;
                 let payers: Vec<Option<Keypair>> =
@@ -720,7 +720,7 @@ fn run_dos<T: 'static + TpsClient + Send + Sync>(
 
                 let mut transaction_generator = TransactionGenerator::new(tp);
                 let tx = transaction_generator.generate(payer, keypairs_chunk, client.as_ref());
-                info!("{:?}", tx);
+                info!("{tx:?}");
                 bincode::serialize(&tx).unwrap()
             }
             _ => panic!("Unsupported data_type detected"),
@@ -768,7 +768,7 @@ fn main() {
         cmd_params.shred_version = Some(
             solana_net_utils::get_cluster_shred_version(&cmd_params.entrypoint_addr)
                 .unwrap_or_else(|err| {
-                    eprintln!("Failed to get shred version: {}", err);
+                    eprintln!("Failed to get shred version: {err}");
                     exit(1);
                 }),
         );

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -106,7 +106,7 @@ pub fn download_snapshot_archive(
             progress_notify_callback,
         ) {
             Ok(()) => return Ok(()),
-            Err(err) => info!("{}", err),
+            Err(err) => info!("{err}"),
         }
     }
     Err(format!(

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -50,7 +50,7 @@ pub fn init_poh() {
 fn init(name: &OsStr) {
     static INIT_HOOK: Once = Once::new();
 
-    info!("Loading {:?}", name);
+    info!("Loading {name:?}");
     INIT_HOOK.call_once(|| {
         let path;
         let lib_name = if let Some(perf_libs_path) = solana_perf::perf_libs::locate_perf_libs() {
@@ -888,10 +888,7 @@ impl EntrySlice for [Entry] {
             if entry.is_tick() {
                 if *tick_hash_count != hashes_per_tick {
                     warn!(
-                        "invalid tick hash count!: entry: {:#?}, tick_hash_count: {}, hashes_per_tick: {}",
-                        entry,
-                        tick_hash_count,
-                        hashes_per_tick
+                        "invalid tick hash count!: entry: {entry:#?}, tick_hash_count: {tick_hash_count}, hashes_per_tick: {hashes_per_tick}"
                     );
                     return false;
                 }
@@ -1406,7 +1403,7 @@ mod tests {
         for _ in 0..100 {
             let mut time = Measure::start("ticks");
             let num_ticks = thread_rng().gen_range(1..100);
-            info!("create {} ticks:", num_ticks);
+            info!("create {num_ticks} ticks:");
             let mut entries = create_random_ticks(num_ticks, 100, Hash::default());
             time.stop();
 
@@ -1417,12 +1414,12 @@ mod tests {
                 entries[modify_idx].hash = hash(&[1, 2, 3]);
             }
 
-            info!("done.. {}", time);
+            info!("done.. {time}");
             let mut time = Measure::start("poh");
             let res = entries.verify(&Hash::default(), &thread_pool_for_tests());
             assert_eq!(res, !modified);
             time.stop();
-            info!("{} {}", time, res);
+            info!("{time} {res}");
         }
     }
 

--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -148,7 +148,7 @@ impl Poh {
 }
 
 pub fn compute_hash_time(hashes_sample_size: u64) -> Duration {
-    info!("Running {} hashes...", hashes_sample_size);
+    info!("Running {hashes_sample_size} hashes...");
     let mut v = Hash::default();
     let start = Instant::now();
     for _ in 0..hashes_sample_size {

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -176,7 +176,7 @@ impl Faucet {
         req: FaucetRequest,
         ip: IpAddr,
     ) -> Result<FaucetTransaction, FaucetError> {
-        trace!("build_airdrop_transaction: {:?}", req);
+        trace!("build_airdrop_transaction: {req:?}");
         match req {
             FaucetRequest::GetAirdrop {
                 lamports,
@@ -235,7 +235,7 @@ impl Faucet {
     ) -> Result<Vec<u8>, FaucetError> {
         let req: FaucetRequest = deserialize(bytes)?;
 
-        info!("Airdrop transaction requested...{:?}", req);
+        info!("Airdrop transaction requested...{req:?}");
         let res = self.build_airdrop_transaction(req, ip);
         match res {
             Ok(tx) => {
@@ -245,7 +245,7 @@ impl Faucet {
                         tx
                     }
                     FaucetTransaction::Memo((tx, memo)) => {
-                        warn!("Memo transaction returned: {}", memo);
+                        warn!("Memo transaction returned: {memo}");
                         tx
                     }
                 };
@@ -258,7 +258,7 @@ impl Faucet {
                 Ok(response_vec_with_length)
             }
             Err(err) => {
-                warn!("Airdrop transaction failed: {}", err);
+                warn!("Airdrop transaction failed: {err}");
                 Err(err)
             }
         }
@@ -278,8 +278,7 @@ pub fn request_airdrop_transaction(
     blockhash: Hash,
 ) -> Result<Transaction, FaucetError> {
     info!(
-        "request_airdrop_transaction: faucet_addr={} id={} lamports={} blockhash={}",
-        faucet_addr, id, lamports, blockhash
+        "request_airdrop_transaction: faucet_addr={faucet_addr} id={id} lamports={lamports} blockhash={blockhash}"
     );
 
     let mut stream = TcpStream::connect_timeout(faucet_addr, Duration::new(3, 0))?;
@@ -296,8 +295,7 @@ pub fn request_airdrop_transaction(
     let mut buffer = [0; 2];
     stream.read_exact(&mut buffer).map_err(|err| {
         info!(
-            "request_airdrop_transaction: buffer length read_exact error: {:?}",
-            err
+            "request_airdrop_transaction: buffer length read_exact error: {err:?}"
         );
         err
     })?;
@@ -312,8 +310,7 @@ pub fn request_airdrop_transaction(
     let mut buffer = vec![0; transaction_length];
     stream.read_exact(&mut buffer).map_err(|err| {
         info!(
-            "request_airdrop_transaction: buffer read_exact error: {:?}",
-            err
+            "request_airdrop_transaction: buffer read_exact error: {err:?}"
         );
         err
     })?;
@@ -373,12 +370,12 @@ pub async fn run_faucet(
 
     let listener = match listener {
         Err(err) => {
-            error!("Faucet failed to start: {}", err);
+            error!("Faucet failed to start: {err}");
             return;
         }
         Ok(listener) => listener,
     };
-    info!("Faucet started. Listening on: {}", faucet_addr);
+    info!("Faucet started. Listening on: {faucet_addr}");
     info!(
         "Faucet account address: {}",
         faucet.lock().unwrap().faucet_keypair.pubkey()
@@ -390,11 +387,11 @@ pub async fn run_faucet(
             Ok((stream, _)) => {
                 tokio::spawn(async move {
                     if let Err(e) = process(stream, faucet).await {
-                        info!("failed to process request; error = {:?}", e);
+                        info!("failed to process request; error = {e:?}");
                     }
                 });
             }
-            Err(e) => debug!("failed to accept socket; error = {:?}", e),
+            Err(e) => debug!("failed to accept socket; error = {e:?}"),
         }
     }
 }
@@ -413,7 +410,7 @@ async fn process(
         .unwrap() as usize
     ];
     while stream.read_exact(&mut request).await.is_ok() {
-        trace!("{:?}", request);
+        trace!("{request:?}");
 
         let response = {
             match stream.peer_addr() {
@@ -423,15 +420,15 @@ async fn process(
                 }
                 Ok(peer_addr) => {
                     let ip = peer_addr.ip();
-                    info!("Request IP: {:?}", ip);
+                    info!("Request IP: {ip:?}");
 
                     match faucet.lock().unwrap().process_faucet_request(&request, ip) {
                         Ok(response_bytes) => {
-                            trace!("Airdrop response_bytes: {:?}", response_bytes);
+                            trace!("Airdrop response_bytes: {response_bytes:?}");
                             response_bytes
                         }
                         Err(e) => {
-                            info!("Error in request: {}", e);
+                            info!("Error in request: {e}");
                             ERROR_RESPONSE.to_vec()
                         }
                     }

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -294,9 +294,7 @@ pub fn request_airdrop_transaction(
     // Read length of transaction
     let mut buffer = [0; 2];
     stream.read_exact(&mut buffer).map_err(|err| {
-        info!(
-            "request_airdrop_transaction: buffer length read_exact error: {err:?}"
-        );
+        info!("request_airdrop_transaction: buffer length read_exact error: {err:?}");
         err
     })?;
     let transaction_length = u16::from_le_bytes(buffer) as usize;
@@ -309,9 +307,7 @@ pub fn request_airdrop_transaction(
     // Read the transaction
     let mut buffer = vec![0; transaction_length];
     stream.read_exact(&mut buffer).map_err(|err| {
-        info!(
-            "request_airdrop_transaction: buffer read_exact error: {err:?}"
-        );
+        info!("request_airdrop_transaction: buffer read_exact error: {err:?}");
         err
     })?;
 

--- a/genesis-utils/src/lib.rs
+++ b/genesis-utils/src/lib.rs
@@ -79,7 +79,7 @@ fn set_and_verify_expected_genesis_hash(
 ) -> Result<(), String> {
     let genesis_hash = genesis_config.hash();
     if expected_genesis_hash.is_none() {
-        info!("Expected genesis hash set to {}", genesis_hash);
+        info!("Expected genesis hash set to {genesis_hash}");
         *expected_genesis_hash = Some(genesis_hash);
     }
     let expected_genesis_hash = expected_genesis_hash.unwrap();

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -79,8 +79,7 @@ impl GeyserPluginService {
         )>,
     ) -> Result<Self, GeyserPluginServiceError> {
         info!(
-            "Starting GeyserPluginService from config files: {:?}",
-            geyser_plugin_config_files
+            "Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}"
         );
         let mut plugin_manager = GeyserPluginManager::new();
 

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -78,9 +78,7 @@ impl GeyserPluginService {
             Arc<AtomicBool>,
         )>,
     ) -> Result<Self, GeyserPluginServiceError> {
-        info!(
-            "Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}"
-        );
+        info!("Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}");
         let mut plugin_manager = GeyserPluginManager::new();
 
         for geyser_plugin_config_file in geyser_plugin_config_files {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -372,7 +372,7 @@ impl ClusterInfo {
         let mut gossip_crds = self.gossip.crds.write().unwrap();
         for node in nodes {
             if let Err(err) = gossip_crds.insert(node, now, GossipRoute::LocalMessage) {
-                warn!("crds insert failed {:?}", err);
+                warn!("crds insert failed {err:?}");
             }
         }
     }
@@ -679,7 +679,7 @@ impl ClusterInfo {
         let now = timestamp();
         for entry in entries {
             if let Err(err) = gossip_crds.insert(entry, now, GossipRoute::LocalMessage) {
-                error!("push_epoch_slots failed: {:?}", err);
+                error!("push_epoch_slots failed: {err:?}");
             }
         }
     }
@@ -768,7 +768,7 @@ impl ClusterInfo {
         let vote = CrdsValue::new(vote, &self.keypair());
         let mut gossip_crds = self.gossip.crds.write().unwrap();
         if let Err(err) = gossip_crds.insert(vote, now, GossipRoute::LocalMessage) {
-            error!("push_vote failed: {:?}", err);
+            error!("push_vote failed: {err:?}");
         }
     }
 
@@ -869,8 +869,7 @@ impl ClusterInfo {
             // restarted, and need to repush and evict the oldest vote
             let Some(vote_index) = self.find_vote_index_to_evict(refresh_vote_slot) else {
                 warn!(
-                    "trying to refresh slot {} but all votes in gossip table are for newer slots",
-                    refresh_vote_slot,
+                    "trying to refresh slot {refresh_vote_slot} but all votes in gossip table are for newer slots",
                 );
                 return;
             };
@@ -1400,7 +1399,7 @@ impl ClusterInfo {
                 self.stats.trim_crds_table_failed.add_relaxed(1);
                 // TODO: Stakes are coming from the root-bank. Debug why/when
                 // they are empty/zero.
-                debug!("crds table trim failed: {:?}", err);
+                debug!("crds table trim failed: {err:?}");
             }
             Ok(num_purged) => {
                 self.stats
@@ -2213,7 +2212,7 @@ impl ClusterInfo {
                     // A send operation can only fail if the receiving end of a
                     // channel is disconnected.
                     Err(GossipError::SendError) => break,
-                    Err(err) => error!("gossip consume: {}", err),
+                    Err(err) => error!("gossip consume: {err}"),
                     Ok(()) => (),
                 }
             }
@@ -2264,7 +2263,7 @@ impl ClusterInfo {
                                 // that this will exit cleanly.
                                 std::process::exit(1);
                             }
-                            _ => error!("gossip run_listen failed: {}", err),
+                            _ => error!("gossip run_listen failed: {err}"),
                         }
                     }
                 }
@@ -2386,8 +2385,7 @@ impl BindIpAddrs {
             for ip in &addrs {
                 if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
                     return Err(format!(
-                        "Invalid configuration: {:?} is not allowed with multiple --bind-address values (loopback, unspecified, or multicast)",
-                        ip
+                        "Invalid configuration: {ip:?} is not allowed with multiple --bind-address values (loopback, unspecified, or multicast)"
                     ));
                 }
             }
@@ -2645,7 +2643,7 @@ impl Node {
         });
 
         info!("vortexor_receivers is {vortexor_receivers:?}");
-        trace!("new ContactInfo: {:?}", info);
+        trace!("new ContactInfo: {info:?}");
         let sockets = Sockets {
             gossip: AtomicUdpSocket::new(gossip),
             tvu: tvu_sockets,
@@ -4055,7 +4053,7 @@ mod tests {
 
         let cluster_info44 = Arc::new({
             let node = Node::new_localhost_with_pubkey(&keypair44.pubkey());
-            info!("{:?}", node);
+            info!("{node:?}");
             ClusterInfo::new(node.info, keypair44.clone(), SocketAddrSpace::Unspecified)
         });
         let cluster_info43 = Arc::new({
@@ -4067,19 +4065,19 @@ mod tests {
         assert_eq!(keypair44.pubkey().to_string().len(), 44);
 
         let trace = cluster_info44.contact_info_trace();
-        info!("cluster:\n{}", trace);
+        info!("cluster:\n{trace}");
         assert_eq!(trace.len(), 431);
 
         let trace = cluster_info44.rpc_info_trace();
-        info!("rpc:\n{}", trace);
+        info!("rpc:\n{trace}");
         assert_eq!(trace.len(), 335);
 
         let trace = cluster_info43.contact_info_trace();
-        info!("cluster:\n{}", trace);
+        info!("cluster:\n{trace}");
         assert_eq!(trace.len(), 431);
 
         let trace = cluster_info43.rpc_info_trace();
-        info!("rpc:\n{}", trace);
+        info!("rpc:\n{trace}");
         assert_eq!(trace.len(), 335);
     }
 }

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -148,7 +148,7 @@ impl CrdsGossip {
         let now = timestamp();
         for entry in entries {
             if let Err(err) = crds.insert(entry, now, GossipRoute::LocalMessage) {
-                error!("push_duplicate_shred failed: {:?}", err);
+                error!("push_duplicate_shred failed: {err:?}");
             }
         }
         Ok(())

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -201,10 +201,10 @@ pub fn discover(
     );
 
     let id = spy_ref.id();
-    info!("Entrypoint: {:?}", entrypoint);
-    info!("Node Id: {:?}", id);
+    info!("Entrypoint: {entrypoint:?}");
+    info!("Node Id: {id:?}");
     if let Some(my_gossip_addr) = my_gossip_addr {
-        info!("Gossip Address: {:?}", my_gossip_addr);
+        info!("Gossip Address: {my_gossip_addr:?}");
     }
 
     let _ip_echo_server = ip_echo.map(|tcp_listener| {

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -276,9 +276,7 @@ fn network_simulator_pull_only(thread_pool: &ThreadPool, network: &Network) {
         let _ = crds.insert(entry, timestamp(), GossipRoute::LocalMessage);
     }
     let (converged, bytes_tx) = network_run_pull(thread_pool, network, 0, num * 2, 0.9);
-    trace!(
-        "network_simulator_pull_{num}: converged: {converged} total_bytes: {bytes_tx}"
-    );
+    trace!("network_simulator_pull_{num}: converged: {converged} total_bytes: {bytes_tx}");
     assert!(converged >= 0.9);
 }
 
@@ -326,9 +324,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
         // push for a bit
         let (queue_size, bytes_tx) = network_run_push(thread_pool, network, start, end);
         total_bytes += bytes_tx;
-        trace!(
-            "network_simulator_push_{num}: queue_size: {queue_size} bytes: {bytes_tx}"
-        );
+        trace!("network_simulator_push_{num}: queue_size: {queue_size} bytes: {bytes_tx}");
         // pull for a bit
         let (converged, bytes_tx) = network_run_pull(thread_pool, network, start, end, 1.0);
         total_bytes += bytes_tx;

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -277,10 +277,7 @@ fn network_simulator_pull_only(thread_pool: &ThreadPool, network: &Network) {
     }
     let (converged, bytes_tx) = network_run_pull(thread_pool, network, 0, num * 2, 0.9);
     trace!(
-        "network_simulator_pull_{}: converged: {} total_bytes: {}",
-        num,
-        converged,
-        bytes_tx
+        "network_simulator_pull_{num}: converged: {converged} total_bytes: {bytes_tx}"
     );
     assert!(converged >= 0.9);
 }
@@ -289,7 +286,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     let num = network.len();
     // run for a small amount of time
     let (converged, bytes_tx) = network_run_pull(thread_pool, network, 0, 10, 1.0);
-    trace!("network_simulator_push_{}: converged: {}", num, converged);
+    trace!("network_simulator_push_{num}: converged: {converged}");
     // make sure there is someone in the active set
     let network_values: Vec<Node> = network.values().cloned().collect();
     network_values.par_iter().for_each(|node| {
@@ -330,20 +327,13 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
         let (queue_size, bytes_tx) = network_run_push(thread_pool, network, start, end);
         total_bytes += bytes_tx;
         trace!(
-            "network_simulator_push_{}: queue_size: {} bytes: {}",
-            num,
-            queue_size,
-            bytes_tx
+            "network_simulator_push_{num}: queue_size: {queue_size} bytes: {bytes_tx}"
         );
         // pull for a bit
         let (converged, bytes_tx) = network_run_pull(thread_pool, network, start, end, 1.0);
         total_bytes += bytes_tx;
         trace!(
-            "network_simulator_push_{}: converged: {} bytes: {} total_bytes: {}",
-            num,
-            converged,
-            bytes_tx,
-            total_bytes
+            "network_simulator_push_{num}: converged: {converged} bytes: {bytes_tx} total_bytes: {total_bytes}"
         );
         if converged > max_convergance {
             break;
@@ -489,15 +479,7 @@ fn network_run_push(
             .map(|node| node.gossip.push.num_pending(&node.gossip.crds))
             .sum();
         trace!(
-                "network_run_push_{}: now: {} queue: {} bytes: {} num_msgs: {} prunes: {} stake_pruned: {} delivered: {}",
-                num,
-                now,
-                total,
-                bytes,
-                num_msgs,
-                prunes,
-                stake_pruned,
-                delivered,
+                "network_run_push_{num}: now: {now} queue: {total} bytes: {bytes} num_msgs: {num_msgs} prunes: {prunes} stake_pruned: {stake_pruned} delivered: {delivered}",
             );
     }
 
@@ -664,14 +646,7 @@ fn network_run_pull(
             break;
         }
         trace!(
-                "network_run_pull_{}: now: {} connections: {} convergance: {} bytes: {} msgs: {} overhead: {}",
-                num,
-                now,
-                total,
-                convergance,
-                bytes,
-                msgs,
-                overhead
+                "network_run_pull_{num}: now: {now} connections: {total} convergance: {convergance} bytes: {bytes} msgs: {msgs} overhead: {overhead}"
             );
     }
     (convergance, bytes)

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -346,7 +346,7 @@ pub fn cluster_info_scale() {
         sleep(Duration::from_secs(1));
     }
     time.stop();
-    warn!("found {} nodes in {} success: {}", num_nodes, time, success);
+    warn!("found {num_nodes} nodes in {time} success: {success}");
 
     for num_votes in 1..1000 {
         let mut time = Measure::start("votes");
@@ -390,10 +390,10 @@ pub fn cluster_info_scale() {
                 }
             }
             warn!("not_done: {}/{}", not_done, nodes.len());
-            warn!("num_old: {}", num_old);
-            warn!("num_push_total: {}", num_push_total);
-            warn!("num_pushes: {}", num_pushes);
-            warn!("num_pulls: {}", num_pulls);
+            warn!("num_old: {num_old}");
+            warn!("num_push_total: {num_push_total}");
+            warn!("num_pushes: {num_pushes}");
+            warn!("num_pulls: {num_pulls}");
             success = not_done < (nodes.len() / 20);
             if success {
                 break;
@@ -402,8 +402,7 @@ pub fn cluster_info_scale() {
         }
         time.stop();
         warn!(
-            "propagated vote {} in {} success: {}",
-            num_votes, time, success
+            "propagated vote {num_votes} in {time} success: {success}"
         );
         sleep(Duration::from_millis(200));
         for (node, _, _) in nodes.iter() {

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -401,9 +401,7 @@ pub fn cluster_info_scale() {
             sleep(Duration::from_millis(200));
         }
         time.stop();
-        warn!(
-            "propagated vote {num_votes} in {time} success: {success}"
-        );
+        warn!("propagated vote {num_votes} in {time} success: {success}");
         sleep(Duration::from_millis(200));
         for (node, _, _) in nodes.iter() {
             node.gossip.push.num_old.store(0, Ordering::Relaxed);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -83,7 +83,7 @@ fn grind_parser(grind_type: GrindType) -> ValueParser {
         };
         if v.matches(':').count() != required_div_count || (v.starts_with(':') || v.ends_with(':'))
         {
-            return Err(format!("Expected : between {} and COUNT", prefix_suffix));
+            return Err(format!("Expected : between {prefix_suffix} and COUNT"));
         }
         // `args` is guaranteed to have length at least 1 by the previous if statement
         let mut args: Vec<&str> = v.split(':').collect();

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -773,32 +773,32 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             }
                         };
                     } else {
-                        let confirmed_block =
-                            match source_bigtable_clone.get_confirmed_block(slot).await {
-                                Ok(block) => match VersionedConfirmedBlock::try_from(block) {
-                                    Ok(block) => block,
-                                    Err(err) => {
-                                        error!(
-                                            "failed to convert confirmed block to versioned \
-                                             confirmed block, slot: {slot}, err: {err}"
-                                        );
-                                        failed_slots_clone.lock().unwrap().push(slot);
-                                        continue;
-                                    }
-                                },
-                                Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
-                                    debug!("block not found, slot: {slot}");
-                                    block_not_found_slots_clone.lock().unwrap().push(slot);
-                                    continue;
-                                }
+                        let confirmed_block = match source_bigtable_clone
+                            .get_confirmed_block(slot)
+                            .await
+                        {
+                            Ok(block) => match VersionedConfirmedBlock::try_from(block) {
+                                Ok(block) => block,
                                 Err(err) => {
                                     error!(
-                                        "failed to get confirmed block, slot: {slot}, err: {err}"
+                                        "failed to convert confirmed block to versioned \
+                                             confirmed block, slot: {slot}, err: {err}"
                                     );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
-                            };
+                            },
+                            Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
+                                debug!("block not found, slot: {slot}");
+                                block_not_found_slots_clone.lock().unwrap().push(slot);
+                                continue;
+                            }
+                            Err(err) => {
+                                error!("failed to get confirmed block, slot: {slot}, err: {err}");
+                                failed_slots_clone.lock().unwrap().push(slot);
+                                continue;
+                            }
+                        };
 
                         match destination_bigtable_clone
                             .upload_confirmed_block(slot, confirmed_block)

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -93,7 +93,7 @@ async fn upload(
             Arc::new(AtomicBool::new(false)),
         )
         .await?;
-        info!("last slot checked: {}", last_slot_checked);
+        info!("last slot checked: {last_slot_checked}");
         starting_slot = last_slot_checked.saturating_add(1);
     }
     info!("No more blocks to upload.");
@@ -676,7 +676,7 @@ impl CopyArgs {
 async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     let from_slot = args.from_slot;
     let to_slot = args.to_slot.unwrap_or(from_slot);
-    debug!("from_slot: {}, to_slot: {}", from_slot, to_slot);
+    debug!("from_slot: {from_slot}, to_slot: {to_slot}");
 
     if from_slot > to_slot {
         return Err("starting slot should be less than or equal to ending slot")?;
@@ -708,7 +708,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let workers = min(to_slot - from_slot + 1, num_cpus::get().try_into().unwrap());
-    debug!("worker num: {}", workers);
+    debug!("worker num: {workers}");
 
     let success_slots = Arc::new(Mutex::new(vec![]));
     let skip_slots = Arc::new(Mutex::new(vec![]));
@@ -727,7 +727,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
             let failed_slots_clone = Arc::clone(&failed_slots);
             tokio::spawn(async move {
                 while let Ok(slot) = r.try_recv() {
-                    debug!("worker {}: received slot {}", i, slot);
+                    debug!("worker {i}: received slot {slot}");
 
                     if !args.force {
                         match destination_bigtable_clone
@@ -743,8 +743,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             Err(err) => {
                                 error!(
                                     "confirmed_block_exists() failed from the destination \
-                                     Bigtable, slot: {}, err: {}",
-                                    slot, err
+                                     Bigtable, slot: {slot}, err: {err}"
                                 );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
@@ -756,10 +755,10 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                         match source_bigtable_clone.confirmed_block_exists(slot).await {
                             Ok(exist) => {
                                 if exist {
-                                    debug!("will write block: {}", slot);
+                                    debug!("will write block: {slot}");
                                     success_slots_clone.lock().unwrap().push(slot);
                                 } else {
-                                    debug!("block not found, slot: {}", slot);
+                                    debug!("block not found, slot: {slot}");
                                     block_not_found_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
@@ -767,8 +766,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             Err(err) => {
                                 error!(
                                     "failed to get a confirmed block from the source Bigtable, \
-                                     slot: {}, err: {}",
-                                    slot, err
+                                     slot: {slot}, err: {err}"
                                 );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
@@ -782,22 +780,20 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                                     Err(err) => {
                                         error!(
                                             "failed to convert confirmed block to versioned \
-                                             confirmed block, slot: {}, err: {}",
-                                            slot, err
+                                             confirmed block, slot: {slot}, err: {err}"
                                         );
                                         failed_slots_clone.lock().unwrap().push(slot);
                                         continue;
                                     }
                                 },
                                 Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
-                                    debug!("block not found, slot: {}", slot);
+                                    debug!("block not found, slot: {slot}");
                                     block_not_found_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
                                 Err(err) => {
                                     error!(
-                                        "failed to get confirmed block, slot: {}, err: {}",
-                                        slot, err
+                                        "failed to get confirmed block, slot: {slot}, err: {err}"
                                     );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
@@ -809,11 +805,11 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             .await
                         {
                             Ok(()) => {
-                                debug!("wrote block: {}", slot);
+                                debug!("wrote block: {slot}");
                                 success_slots_clone.lock().unwrap().push(slot);
                             }
                             Err(err) => {
-                                error!("write failed, slot: {}, err: {}", slot, err);
+                                error!("write failed, slot: {slot}, err: {err}");
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
                             }
@@ -821,7 +817,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                debug!("worker {}: exit", i);
+                debug!("worker {i}: exit");
             })
         })
         .collect::<FuturesUnordered<_>>();
@@ -837,10 +833,10 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut failed_slots = failed_slots.lock().unwrap();
     failed_slots.sort();
 
-    debug!("success slots: {:?}", success_slots);
-    debug!("skip slots: {:?}", skip_slots);
-    debug!("blocks not found slots: {:?}", block_not_found_slots);
-    debug!("failed slots: {:?}", failed_slots);
+    debug!("success slots: {success_slots:?}");
+    debug!("skip slots: {skip_slots:?}");
+    debug!("blocks not found slots: {block_not_found_slots:?}");
+    debug!("failed slots: {failed_slots:?}");
 
     println!(
         "success: {}, skip: {}, block not found: {}, failed: {}",

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -676,7 +676,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
                 if target.insert_cow_shreds(shreds, None, true).is_err() {
-                    warn!("error inserting shreds for slot {}", slot);
+                    warn!("error inserting shreds for slot {slot}");
                 }
             }
         }
@@ -920,7 +920,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                     .dead_slots_iterator(start_slot)?
                     .take_while(|s| *s <= end_slot);
                 for dead_slot in dead_slots_iter {
-                    info!("Purging dead slot {}", dead_slot);
+                    info!("Purging dead slot {dead_slot}");
                     purge_from_blockstore(dead_slot, dead_slot);
                 }
             }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -236,8 +236,7 @@ pub fn load_and_process_ledger(
             .join(LEDGER_TOOL_DIRECTORY)
             .join("accounts");
         info!(
-            "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
-            non_primary_accounts_path
+            "Default accounts path is switched aligning with Blockstore's secondary access: {non_primary_accounts_path:?}"
         );
         vec![non_primary_accounts_path]
     };
@@ -347,8 +346,7 @@ pub fn load_and_process_ledger(
         BlockVerificationMethod
     );
     info!(
-        "Using: block-verification-method: {}",
-        block_verification_method,
+        "Using: block-verification-method: {block_verification_method}",
     );
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
@@ -499,8 +497,7 @@ pub fn open_blockstore(
             )
             .unwrap_or_else(|err| {
                 eprintln!(
-                    "Failed to open blockstore (with --force-update-to-open) at {:?}: {:?}",
-                    ledger_path, err
+                    "Failed to open blockstore (with --force-update-to-open) at {ledger_path:?}: {err:?}"
                 );
                 exit(1);
             })
@@ -536,8 +533,7 @@ fn open_blockstore_with_temporary_primary_access(
     }
     // Now, attempt to open the blockstore with original AccessType
     info!(
-        "Blockstore forced open succeeded, retrying with original access: {:?}",
-        original_access_type
+        "Blockstore forced open succeeded, retrying with original access: {original_access_type:?}"
     );
     Blockstore::open_with_options(
         ledger_path,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -345,9 +345,7 @@ pub fn load_and_process_ledger(
         "block_verification_method",
         BlockVerificationMethod
     );
-    info!(
-        "Using: block-verification-method: {block_verification_method}",
-    );
+    info!("Using: block-verification-method: {block_verification_method}",);
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
     match block_verification_method {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -476,7 +476,7 @@ fn compute_slot_cost(
                     &reserved_account_keys.active,
                 )
                 .map_err(|err| {
-                    warn!("Failed to compute cost of transaction: {:?}", err);
+                    warn!("Failed to compute cost of transaction: {err:?}");
                 })
                 .ok()
             })
@@ -2336,7 +2336,7 @@ fn main() {
                                 exit(1);
                             }
                         } else {
-                            warn!("Warping to slot {}", minimum_warp_slot);
+                            warn!("Warping to slot {minimum_warp_slot}");
                             warp_slot = Some(minimum_warp_slot);
                         }
                     }
@@ -2738,9 +2738,8 @@ fn main() {
                                 base_bank.set_capitalization(new_cap);
                                 warn!(
                                     "Skewing capitalization a bit to enable \
-                                         credits_auto_rewind as requested: increasing {} from {} \
-                                         to {}",
-                                    feature_account_balance, old_cap, new_cap,
+                                         credits_auto_rewind as requested: increasing {feature_account_balance} from {old_cap} \
+                                         to {new_cap}",
                                 );
                                 assert_eq!(
                                     old_cap + feature_account_balance * store_failed_count,
@@ -3100,7 +3099,7 @@ fn main() {
                                 }
                                 overall_delta += delta;
                             } else {
-                                error!("new account!?: {}", pubkey);
+                                error!("new account!?: {pubkey}");
                             }
                         }
                         if overall_delta > 0 {
@@ -3150,5 +3149,5 @@ fn main() {
         }
     };
     measure_total_execution_time.stop();
-    info!("{}", measure_total_execution_time);
+    info!("{measure_total_execution_time}");
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -320,7 +320,7 @@ impl VerboseDisplay for CliDuplicateSlotProof {
         write!(w, "    Shred2 ")?;
         VerboseDisplay::write_str(&self.shred2, w)?;
         if let Some(erasure_consistency) = self.erasure_consistency {
-            writeln!(w, "    Erasure consistency {}", erasure_consistency)?;
+            writeln!(w, "    Erasure consistency {erasure_consistency}")?;
         }
         Ok(())
     }
@@ -331,7 +331,7 @@ impl fmt::Display for CliDuplicateSlotProof {
         write!(f, "    Shred1 {}", self.shred1)?;
         write!(f, "    Shred2 {}", self.shred2)?;
         if let Some(erasure_consistency) = self.erasure_consistency {
-            writeln!(f, "    Erasure consistency {}", erasure_consistency)?;
+            writeln!(f, "    Erasure consistency {erasure_consistency}")?;
         }
         Ok(())
     }
@@ -440,8 +440,7 @@ impl EncodedConfirmedBlockWithEntries {
                 .transactions
                 .get(entry.starting_transaction_index..ending_transaction_index)
                 .ok_or(LedgerToolError::Generic(format!(
-                    "Mismatched entry data and transactions: entry {:?}",
-                    i
+                    "Mismatched entry data and transactions: entry {i:?}"
                 )))?;
             entries.push(CliPopulatedEntry {
                 num_hashes: entry.num_hashes,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -447,7 +447,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                                 programdata_address,
                             }) = account.state()
                             {
-                                debug!("Program data address {}", programdata_address);
+                                debug!("Program data address {programdata_address}");
                                 if bank
                                     .get_account_with_fixed_root(&programdata_address)
                                     .is_some()
@@ -523,7 +523,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             bank.load_program(&key, false, bank.epoch())
                 .expect("Couldn't find program account"),
         );
-        debug!("Loaded program {}", key);
+        debug!("Loaded program {key}");
     }
     invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 

--- a/ledger/src/bigtable_delete.rs
+++ b/ledger/src/bigtable_delete.rs
@@ -44,7 +44,7 @@ pub async fn delete_confirmed_blocks(
     }
 
     measure.stop();
-    info!("{}", measure);
+    info!("{measure}");
     if failures > 0 {
         Err(format!("Incomplete deletion, {failures} operations failed").into())
     } else {

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -54,9 +54,7 @@ pub async fn upload_confirmed_blocks(
 ) -> Result<Slot, Box<dyn std::error::Error>> {
     let mut measure = Measure::start("entire upload");
 
-    info!(
-        "Loading ledger slots from {starting_slot} to {ending_slot}"
-    );
+    info!("Loading ledger slots from {starting_slot} to {ending_slot}");
     let blockstore_slots: Vec<_> = blockstore
         .rooted_slot_iterator(starting_slot)
         .map_err(|err| {

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -55,8 +55,7 @@ pub async fn upload_confirmed_blocks(
     let mut measure = Measure::start("entire upload");
 
     info!(
-        "Loading ledger slots from {} to {}",
-        starting_slot, ending_slot
+        "Loading ledger slots from {starting_slot} to {ending_slot}"
     );
     let blockstore_slots: Vec<_> = blockstore
         .rooted_slot_iterator(starting_slot)
@@ -84,8 +83,7 @@ pub async fn upload_confirmed_blocks(
     let bigtable_slots = if !config.force_reupload {
         let mut bigtable_slots = vec![];
         info!(
-            "Loading list of bigtable blocks between slots {} and {}...",
-            first_blockstore_slot, last_blockstore_slot
+            "Loading list of bigtable blocks between slots {first_blockstore_slot} and {last_blockstore_slot}..."
         );
 
         let mut start_slot = first_blockstore_slot;
@@ -98,7 +96,7 @@ pub async fn upload_confirmed_blocks(
                 {
                     Ok(slots) => break slots,
                     Err(err) => {
-                        error!("get_confirmed_blocks for {} failed: {:?}", start_slot, err);
+                        error!("get_confirmed_blocks for {start_slot} failed: {err:?}");
                         // Consider exponential backoff...
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
@@ -135,8 +133,7 @@ pub async fn upload_confirmed_blocks(
 
     if blocks_to_upload.is_empty() {
         info!(
-            "No blocks between {} and {} need to be uploaded to bigtable",
-            starting_slot, ending_slot
+            "No blocks between {starting_slot} and {ending_slot} need to be uploaded to bigtable"
         );
         return Ok(ending_slot);
     }
@@ -185,8 +182,7 @@ pub async fn upload_confirmed_blocks(
                                     }
                                     Err(err) => {
                                         warn!(
-                                            "Failed to get load confirmed block from slot {}: {:?}",
-                                            slot, err
+                                            "Failed to get load confirmed block from slot {slot}: {err:?}"
                                         );
                                         sender.send((slot, None))
                                     }
@@ -217,7 +213,7 @@ pub async fn upload_confirmed_blocks(
 
         let mut measure_upload = Measure::start("Upload");
         let mut num_blocks = blocks.len();
-        info!("Preparing the next {} blocks for upload", num_blocks);
+        info!("Preparing the next {num_blocks} blocks for upload");
 
         let uploads = blocks.into_iter().filter_map(|(slot, block)| match block {
             None => {
@@ -235,20 +231,20 @@ pub async fn upload_confirmed_blocks(
 
         for result in futures::future::join_all(uploads).await {
             if let Err(err) = result {
-                error!("upload_confirmed_block() join failed: {:?}", err);
+                error!("upload_confirmed_block() join failed: {err:?}");
                 failures += 1;
             } else if let Err(err) = result.unwrap() {
-                error!("upload_confirmed_block() upload failed: {:?}", err);
+                error!("upload_confirmed_block() upload failed: {err:?}");
                 failures += 1;
             }
         }
 
         measure_upload.stop();
-        info!("{} for {} blocks", measure_upload, num_blocks);
+        info!("{measure_upload} for {num_blocks} blocks");
     }
 
     measure.stop();
-    info!("{}", measure);
+    info!("{measure}");
 
     let blockstore_results = loader_threads.into_iter().map(|t| t.join());
 
@@ -263,7 +259,7 @@ pub async fn upload_confirmed_blocks(
                 blockstore_load_wallclock = max(stats.elapsed, blockstore_load_wallclock);
             }
             Err(e) => {
-                error!("error joining blockstore thread: {:?}", e);
+                error!("error joining blockstore thread: {e:?}");
                 blockstore_errors += 1;
             }
         }

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -110,7 +110,7 @@ impl BigTableUploadService {
             match result {
                 Ok(last_slot_uploaded) => start_slot = last_slot_uploaded.saturating_add(1),
                 Err(err) => {
-                    warn!("bigtable: upload_confirmed_blocks: {}", err);
+                    warn!("bigtable: upload_confirmed_blocks: {err}");
                     std::thread::sleep(std::time::Duration::from_secs(2));
                     if start_slot == 0 {
                         start_slot = blockstore.get_first_available_block().unwrap_or_default();

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -610,8 +610,7 @@ mod tests {
                 .collect();
             assert_eq!(
                 result, expected,
-                "Failed for bounds: start={:?}, end={:?}",
-                start_bound, end_bound
+                "Failed for bounds: start={start_bound:?}, end={end_bound:?}"
             );
         }
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1382,9 +1382,9 @@ impl Blockstore {
         // we must retain the chain by preserving `next_slots`.
         match self.purge_slot_cleanup_chaining(slot) {
             Ok(_) => {}
-            Err(BlockstoreError::SlotUnavailable) => error!(
-                "clear_unconfirmed_slot() called on slot {slot} with no SlotMeta"
-            ),
+            Err(BlockstoreError::SlotUnavailable) => {
+                error!("clear_unconfirmed_slot() called on slot {slot} with no SlotMeta")
+            }
             Err(e) => panic!("Purge database operations failed {e}"),
         }
     }
@@ -4277,9 +4277,7 @@ impl Blockstore {
         if root_meta.is_connected() {
             return Ok(());
         }
-        info!(
-            "Marking slot {root} and any full children slots as connected"
-        );
+        info!("Marking slot {root} and any full children slots as connected");
         let mut write_batch = self.get_write_batch()?;
 
         // Mark both connected bits on the root slot so that the flags for this

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -392,7 +392,7 @@ impl Blockstore {
 
         // Open the database
         let mut measure = Measure::start("blockstore open");
-        info!("Opening blockstore at {:?}", blockstore_path);
+        info!("Opening blockstore at {blockstore_path:?}");
         let db = Arc::new(Rocks::open(blockstore_path, options)?);
 
         let address_signatures_cf = db.column();
@@ -917,7 +917,7 @@ impl Blockstore {
                         }
                         Err(InsertDataShredError::BlockstoreError(err)) => {
                             metrics.num_data_shreds_blockstore_error += 1;
-                            error!("blockstore error: {}", err);
+                            error!("blockstore error: {err}");
                         }
                         Ok(()) => {
                             if is_repaired {
@@ -1383,10 +1383,9 @@ impl Blockstore {
         match self.purge_slot_cleanup_chaining(slot) {
             Ok(_) => {}
             Err(BlockstoreError::SlotUnavailable) => error!(
-                "clear_unconfirmed_slot() called on slot {} with no SlotMeta",
-                slot
+                "clear_unconfirmed_slot() called on slot {slot} with no SlotMeta"
             ),
-            Err(e) => panic!("Purge database operations failed {}", e),
+            Err(e) => panic!("Purge database operations failed {e}"),
         }
     }
 
@@ -2274,7 +2273,7 @@ impl Blockstore {
             Some(slot_meta),
         );
 
-        trace!("inserted shred into slot {:?} and index {:?}", slot, index);
+        trace!("inserted shred into slot {slot:?} and index {index:?}");
 
         Ok(newly_completed_data_sets)
     }
@@ -2738,8 +2737,7 @@ impl Blockstore {
                     .map(|transaction| {
                         if let Err(err) = transaction.sanitize() {
                             warn!(
-                                "Blockstore::get_block sanitize failed: {:?}, slot: {:?}, {:?}",
-                                err, slot, transaction,
+                                "Blockstore::get_block sanitize failed: {err:?}, slot: {slot:?}, {transaction:?}",
                             );
                         }
                         transaction
@@ -3240,9 +3238,8 @@ impl Blockstore {
             .map(|transaction| {
                 if let Err(err) = transaction.sanitize() {
                     warn!(
-                        "Blockstore::find_transaction_in_slot sanitize failed: {:?}, slot: {:?}, \
-                         {:?}",
-                        err, slot, transaction,
+                        "Blockstore::find_transaction_in_slot sanitize failed: {err:?}, slot: {slot:?}, \
+                         {transaction:?}",
                     );
                 }
                 transaction
@@ -4242,7 +4239,7 @@ impl Blockstore {
                 if exit.load(Ordering::Relaxed) {
                     return Ok(i * chunk_size);
                 }
-                trace!("{:?}", chunk);
+                trace!("{chunk:?}");
                 self.set_roots(chunk.iter())?;
             }
         } else {
@@ -4281,8 +4278,7 @@ impl Blockstore {
             return Ok(());
         }
         info!(
-            "Marking slot {} and any full children slots as connected",
-            root
+            "Marking slot {root} and any full children slots as connected"
         );
         let mut write_batch = self.get_write_batch()?;
 
@@ -5318,8 +5314,7 @@ fn adjust_ulimit_nofile(enforce_ulimit_nofile: bool) -> Result<()> {
 
             if cfg!(target_os = "macos") {
                 error!(
-                    "On mac OS you may need to run |sudo launchctl limit maxfiles {} {}| first",
-                    desired_nofile, desired_nofile,
+                    "On mac OS you may need to run |sudo launchctl limit maxfiles {desired_nofile} {desired_nofile}| first",
                 );
             }
             if enforce_ulimit_nofile {
@@ -6517,7 +6512,7 @@ pub mod tests {
         let (shreds, _) = make_many_slot_entries(start_slot, num_slots, entries_per_slot);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         for slot in start_slot..start_slot + num_slots {
-            info!("Evaluating slot {}", slot);
+            info!("Evaluating slot {slot}");
             let meta = blockstore.meta(slot).unwrap().unwrap();
             assert!(meta.is_parent_connected());
             assert!(meta.is_connected());

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -56,9 +56,7 @@ impl Blockstore {
             )
         );
         if let Err(e) = purge_result {
-            error!(
-                "Error: {e:?}; Purge failed in range {from_slot:?} to {to_slot:?}"
-            );
+            error!("Error: {e:?}; Purge failed in range {from_slot:?} to {to_slot:?}");
         }
     }
 
@@ -176,9 +174,7 @@ impl Blockstore {
             .put_in_batch(&mut write_batch, slot, &slot_meta)?;
 
         self.write_batch(write_batch).inspect_err(|e| {
-            error!(
-                "Error: {e:?} while submitting write batch for slot {slot:?}"
-            )
+            error!("Error: {e:?} while submitting write batch for slot {slot:?}")
         })?;
         Ok(columns_purged)
     }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -57,8 +57,7 @@ impl Blockstore {
         );
         if let Err(e) = purge_result {
             error!(
-                "Error: {:?}; Purge failed in range {:?} to {:?}",
-                e, from_slot, to_slot
+                "Error: {e:?}; Purge failed in range {from_slot:?} to {to_slot:?}"
             );
         }
     }
@@ -104,8 +103,7 @@ impl Blockstore {
             count += 1;
             if last_print.elapsed().as_millis() > 2000 {
                 info!(
-                    "purged: {} slots rewritten: {} retain_time: {}us",
-                    count, rewritten, total_retain_us
+                    "purged: {count} slots rewritten: {rewritten} retain_time: {total_retain_us}us"
                 );
                 count = 0;
                 rewritten = 0;
@@ -179,8 +177,7 @@ impl Blockstore {
 
         self.write_batch(write_batch).inspect_err(|e| {
             error!(
-                "Error: {:?} while submitting write batch for slot {:?}",
-                e, slot
+                "Error: {e:?} while submitting write batch for slot {slot:?}"
             )
         })?;
         Ok(columns_purged)
@@ -211,8 +208,7 @@ impl Blockstore {
         let mut write_timer = Measure::start("write_batch");
         self.write_batch(write_batch).inspect_err(|e| {
             error!(
-                "Error: {:?} while submitting write batch for purge from_slot {} to_slot {}",
-                e, from_slot, to_slot
+                "Error: {e:?} while submitting write batch for purge from_slot {from_slot} to_slot {to_slot}"
             )
         })?;
         write_timer.stop();

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -387,7 +387,7 @@ mod tests {
         let (shreds, _) = make_many_slot_entries(0, initial_slots, initial_entries);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         first_insert.stop();
-        info!("{}", first_insert);
+        info!("{first_insert}");
 
         let mut last_purge_slot = 0;
         let mut slot = initial_slots;
@@ -400,7 +400,7 @@ mod tests {
                 let (shreds, _) = make_many_slot_entries(slot + i * batch_size, batch_size, 5);
                 blockstore.insert_shreds(shreds, None, false).unwrap();
                 if i % 100 == 0 {
-                    info!("inserting..{} of {}", i, batches);
+                    info!("inserting..{i} of {batches}");
                 }
             }
             insert_time.stop();
@@ -415,8 +415,7 @@ mod tests {
             );
             time.stop();
             info!(
-                "slot: {} size: {} {} {}",
-                slot, num_slots, insert_time, time
+                "slot: {slot} size: {num_slots} {insert_time} {time}"
             );
             slot += num_slots;
             num_slots *= 2;

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -414,9 +414,7 @@ mod tests {
                 10,
             );
             time.stop();
-            info!(
-                "slot: {slot} size: {num_slots} {insert_time} {time}"
-            );
+            info!("slot: {slot} size: {num_slots} {insert_time} {time}");
             slot += num_slots;
             num_slots *= 2;
         }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1093,8 +1093,7 @@ mod test {
             let result: Vec<_> = index.range((start_bound, end_bound)).collect();
             assert_eq!(
                 result, expected,
-                "Failed for bounds: start={:?}, end={:?}",
-                start_bound, end_bound
+                "Failed for bounds: start={start_bound:?}, end={end_bound:?}"
             );
         }
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -120,9 +120,7 @@ fn do_get_first_error<T, Tx: SVMTransaction>(
             if first_err.is_none() {
                 first_err = Some((Err(err.clone()), *transaction.signature()));
             }
-            warn!(
-                "Unexpected validator error: {err:?}, transaction: {transaction:?}"
-            );
+            warn!("Unexpected validator error: {err:?}, transaction: {transaction:?}");
             datapoint_error!(
                 "validator_process_entry_error",
                 (
@@ -1002,9 +1000,7 @@ pub fn process_blockstore_from_root(
         let bank = bank_forks.read().unwrap().root_bank();
         #[cfg(feature = "dev-context-only-utils")]
         if let Some(hash_overrides) = &opts.hash_overrides {
-            info!(
-                "Will override following slots' hashes: {hash_overrides:#?}"
-            );
+            info!("Will override following slots' hashes: {hash_overrides:#?}");
             bank.set_hash_overrides(hash_overrides.clone());
         }
         if opts.no_block_cost_limits {
@@ -1066,9 +1062,7 @@ pub fn process_blockstore_from_root(
         //
         // If the ledger has any data at all, the snapshot was likely taken at
         // a slot that is not within the range of ledger min/max slot(s).
-        warn!(
-            "Starting slot {start_slot} is not in Blockstore, unable to process"
-        );
+        warn!("Starting slot {start_slot} is not in Blockstore, unable to process");
         (0, 0)
     };
 
@@ -2253,9 +2247,7 @@ impl TransactionStatusSender {
                 transaction_indexes,
             }))
         {
-            trace!(
-                "Slot {slot} transaction_status send batch failed: {e:?}"
-            );
+            trace!("Slot {slot} transaction_status send batch failed: {e:?}");
         }
     }
 
@@ -2265,9 +2257,7 @@ impl TransactionStatusSender {
             .send(TransactionStatusMessage::Freeze(bank.clone()))
         {
             let slot = bank.slot();
-            warn!(
-                "Slot {slot} transaction_status send freeze message failed: {e:?}"
-            );
+            warn!("Slot {slot} transaction_status send freeze message failed: {e:?}");
         }
     }
 }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -177,8 +177,7 @@ impl LeaderScheduleCache {
         let bank_epoch = self.epoch_schedule.get_epoch_and_slot_index(slot).0;
         if bank_epoch > *self.max_epoch.read().unwrap() {
             debug!(
-                "Requested leader in slot: {} of unconfirmed epoch: {}",
-                slot, bank_epoch
+                "Requested leader in slot: {slot} of unconfirmed epoch: {bank_epoch}"
             );
             return None;
         }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -176,9 +176,7 @@ impl LeaderScheduleCache {
         // Forbid asking for slots in an unconfirmed epoch
         let bank_epoch = self.epoch_schedule.get_epoch_and_slot_index(slot).0;
         if bank_epoch > *self.max_epoch.read().unwrap() {
-            debug!(
-                "Requested leader in slot: {slot} of unconfirmed epoch: {bank_epoch}"
-            );
+            debug!("Requested leader in slot: {slot} of unconfirmed epoch: {bank_epoch}");
             return None;
         }
         if cache_result.is_some() {

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -53,14 +53,14 @@ pub fn verify_shred_cpu(
     let Some(slot) = shred::layout::get_slot(shred) else {
         return false;
     };
-    trace!("slot {}", slot);
+    trace!("slot {slot}");
     let Some(pubkey) = slot_leaders.get(&slot) else {
         return false;
     };
     let Some(signature) = shred::layout::get_signature(shred) else {
         return false;
     };
-    trace!("signature {}", signature);
+    trace!("signature {signature}");
     let Some(data) = shred::layout::get_signed_data(shred) else {
         return false;
     };
@@ -87,7 +87,7 @@ fn verify_shreds_cpu(
     cache: &RwLock<LruCache>,
 ) -> Vec<Vec<u8>> {
     let packet_count = count_packets_in_batches(batches);
-    debug!("CPU SHRED ECDSA for {}", packet_count);
+    debug!("CPU SHRED ECDSA for {packet_count}");
     let rv = thread_pool.install(|| {
         batches
             .into_par_iter()
@@ -156,8 +156,8 @@ fn slot_key_data_for_gpu(
         offsets.push(key_offsets[&slot] as u32);
     }
     trace!("keyvec.len: {}", keyvec.len());
-    trace!("keyvec: {:?}", keyvec);
-    trace!("offsets: {:?}", offsets);
+    trace!("keyvec: {keyvec:?}");
+    trace!("offsets: {offsets:?}");
     (keyvec, offsets)
 }
 
@@ -317,7 +317,7 @@ pub fn verify_shreds_gpu(
         num: batch.len() as u32,
     }));
     let num_packets = elems.iter().map(|elem| elem.num).sum();
-    trace!("Starting verify num packets: {}", num_packets);
+    trace!("Starting verify num packets: {num_packets}");
     trace!("elem len: {}", elems.len() as u32);
     trace!("packet sizeof: {}", size_of::<Packet>() as u32);
     const USE_NON_DEFAULT_STREAM: u8 = 1;
@@ -336,11 +336,11 @@ pub fn verify_shreds_gpu(
             USE_NON_DEFAULT_STREAM,
         );
         if res != 0 {
-            trace!("RETURN!!!: {}", res);
+            trace!("RETURN!!!: {res}");
         }
     }
     trace!("done verify");
-    trace!("out buf {:?}", out);
+    trace!("out buf {out:?}");
 
     // Each shred has exactly one signature.
     let v_sig_lens = batches
@@ -364,7 +364,7 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
         "packet is not large enough for a signature"
     );
     let signature = keypair.sign_message(msg.as_ref());
-    trace!("signature {:?}", signature);
+    trace!("signature {signature:?}");
     let mut buffer = packet
         .data(..)
         .expect("packet should not be discarded")
@@ -376,7 +376,7 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
 #[cfg(test)]
 fn sign_shreds_cpu(thread_pool: &ThreadPool, keypair: &Keypair, batches: &mut [PacketBatch]) {
     let packet_count = count_packets_in_batches(batches);
-    debug!("CPU SHRED ECDSA for {}", packet_count);
+    debug!("CPU SHRED ECDSA for {packet_count}");
     thread_pool.install(|| {
         batches.par_iter_mut().for_each(|batch| {
             batch
@@ -441,7 +441,7 @@ fn sign_shreds_gpu(
             .map(move |offset| Some(offset? + shift))
     };
     let offset = pinned_keypair.len() + merkle_roots.len();
-    trace!("offset: {}", offset);
+    trace!("offset: {offset}");
     let (signature_offsets, msg_start_offsets, msg_sizes) =
         shred_gpu_offsets(offset, batches, merkle_roots_offsets, recycler_cache);
     let total_sigs = signature_offsets.len();
@@ -469,7 +469,7 @@ fn sign_shreds_gpu(
         num: batch.len() as u32,
     }));
     let num_packets = elems.iter().map(|elem| elem.num).sum();
-    trace!("Starting verify num packets: {}", num_packets);
+    trace!("Starting verify num packets: {num_packets}");
     trace!("elem len: {}", elems.len() as u32);
     trace!("packet sizeof: {}", size_of::<Packet>() as u32);
     const USE_NON_DEFAULT_STREAM: u8 = 1;
@@ -488,7 +488,7 @@ fn sign_shreds_gpu(
             USE_NON_DEFAULT_STREAM,
         );
         if res != 0 {
-            trace!("RETURN!!!: {}", res);
+            trace!("RETURN!!!: {res}");
         }
     }
     trace!("done sign");

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -218,7 +218,7 @@ pub fn sleep_n_epochs(
     let num_ticks_per_second = config.target_tick_duration.as_secs_f64().recip();
     let num_ticks_to_sleep = num_epochs * ticks_per_slot as f64 * slots_per_epoch as f64;
     let secs = ((num_ticks_to_sleep + num_ticks_per_second - 1.0) / num_ticks_per_second) as u64;
-    warn!("sleep_n_epochs: {} seconds", secs);
+    warn!("sleep_n_epochs: {secs} seconds");
     sleep(Duration::from_secs(secs));
 }
 
@@ -320,7 +320,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
                 &transaction,
             ) {
                 Err(e) => {
-                    info!("poll_all_nodes_for_signature() failed {:?}", e);
+                    info!("poll_all_nodes_for_signature() failed {e:?}");
                     result = Err(e);
                 }
                 Ok(()) => {
@@ -405,8 +405,7 @@ pub fn check_for_new_roots(
             done = num_roots >= num_new_roots;
             if done || last_print.elapsed().as_secs() > 3 {
                 info!(
-                    "{} waiting for {} new roots.. observed: {:?}",
-                    test_name, num_new_roots, num_roots_map
+                    "{test_name} waiting for {num_new_roots} new roots.. observed: {num_roots_map:?}"
                 );
                 last_print = Instant::now();
             }
@@ -572,7 +571,7 @@ pub fn start_gossip_voter(
                     if latest_push_attempt.elapsed() > Duration::from_millis(refresh_ms) {
                         for (leader_vote_tx, parsed_vote) in refreshable_votes.iter().rev() {
                             let vote_slot = parsed_vote.last_voted_slot().unwrap();
-                            info!("gossip voter refreshing vote {}", vote_slot);
+                            info!("gossip voter refreshing vote {vote_slot}");
                             process_vote_tx(vote_slot, leader_vote_tx, parsed_vote, &cluster_info);
                             latest_push_attempt = Instant::now();
                         }
@@ -594,7 +593,7 @@ pub fn start_gossip_voter(
 
                 for (parsed_vote, leader_vote_tx) in &parsed_vote_iter {
                     if let Some(vote_slot) = parsed_vote.last_voted_slot() {
-                        info!("received vote for {}", vote_slot);
+                        info!("received vote for {vote_slot}");
                         if vote_slot > latest_voted_slot {
                             latest_voted_slot = vote_slot;
                             refreshable_votes

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -203,8 +203,7 @@ pub fn run_kill_partition_switch_threshold<C>(
     // with the confirmation supermajority 2/3
     static_assertions::const_assert!(SWITCH_FORK_THRESHOLD >= 1f64 / 3f64);
     info!(
-        "stakes_to_kill: {:?}, alive_stakes: {:?}",
-        stakes_to_kill, alive_stakes
+        "stakes_to_kill: {stakes_to_kill:?}, alive_stakes: {alive_stakes:?}"
     );
 
     // This test:
@@ -237,7 +236,7 @@ pub fn run_kill_partition_switch_threshold<C>(
             [0..stakes_to_kill.len()]
             .iter()
             .map(|validator_to_kill| {
-                info!("Killing validator with id: {}", validator_to_kill);
+                info!("Killing validator with id: {validator_to_kill}");
                 cluster.exit_node(validator_to_kill)
             })
             .collect();

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -202,9 +202,7 @@ pub fn run_kill_partition_switch_threshold<C>(
     // Needs to be at least 1/3 or there will be no overlap
     // with the confirmation supermajority 2/3
     static_assertions::const_assert!(SWITCH_FORK_THRESHOLD >= 1f64 / 3f64);
-    info!(
-        "stakes_to_kill: {stakes_to_kill:?}, alive_stakes: {alive_stakes:?}"
-    );
+    info!("stakes_to_kill: {stakes_to_kill:?}, alive_stakes: {alive_stakes:?}");
 
     // This test:
     // 1) Spins up three partitions

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -525,7 +525,7 @@ impl LocalCluster {
         // Give the validator some lamports to setup vote accounts
         if is_listener {
             // setup as a listener
-            info!("listener {} ", validator_pubkey,);
+            info!("listener {validator_pubkey} ",);
         } else if should_create_vote_pubkey {
             Self::transfer_with_client(
                 &client,
@@ -539,8 +539,7 @@ impl LocalCluster {
                 .expect("received response")
                 .value;
             info!(
-                "validator {} balance {}",
-                validator_pubkey, validator_balance
+                "validator {validator_pubkey} balance {validator_balance}"
             );
             Self::setup_vote_and_stake_accounts(
                 &client,
@@ -622,7 +621,7 @@ impl LocalCluster {
             .map(|v| v.info.contact_info.clone())
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
-        info!("{} discovering nodes", test_name);
+        info!("{test_name} discovering nodes");
         let cluster_nodes = discover_validators(
             &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
@@ -642,8 +641,7 @@ impl LocalCluster {
     ) {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
         info!(
-            "{} looking minimum root {} on all nodes",
-            test_name, min_root
+            "{test_name} looking minimum root {min_root} on all nodes"
         );
         cluster_tests::check_min_slot_is_rooted(
             min_root,
@@ -651,7 +649,7 @@ impl LocalCluster {
             &self.connection_cache,
             test_name,
         );
-        info!("{} done waiting for roots", test_name);
+        info!("{test_name} done waiting for roots");
     }
 
     pub fn check_for_new_roots(
@@ -661,14 +659,14 @@ impl LocalCluster {
         socket_addr_space: SocketAddrSpace,
     ) {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
-        info!("{} looking for new roots on all nodes", test_name);
+        info!("{test_name} looking for new roots on all nodes");
         cluster_tests::check_for_new_roots(
             num_new_roots,
             &alive_node_contact_infos,
             &self.connection_cache,
             test_name,
         );
-        info!("{} done waiting for roots", test_name);
+        info!("{test_name} done waiting for roots");
     }
 
     pub fn check_no_new_roots(
@@ -683,7 +681,7 @@ impl LocalCluster {
             .map(|node| &node.info.contact_info)
             .collect();
         assert!(!alive_node_contact_infos.is_empty());
-        info!("{} discovering nodes", test_name);
+        info!("{test_name} discovering nodes");
         let cluster_nodes = discover_validators(
             &alive_node_contact_infos[0].gossip().unwrap(),
             alive_node_contact_infos.len(),
@@ -692,14 +690,14 @@ impl LocalCluster {
         )
         .unwrap();
         info!("{} discovered {} nodes", test_name, cluster_nodes.len());
-        info!("{} making sure no new roots on any nodes", test_name);
+        info!("{test_name} making sure no new roots on any nodes");
         cluster_tests::check_no_new_roots(
             num_slots_to_wait,
             &alive_node_contact_infos,
             &self.connection_cache,
             test_name,
         );
-        info!("{} done waiting for roots", test_name);
+        info!("{test_name} done waiting for roots");
     }
 
     /// Poll RPC to see if transaction was processed. Return an error if unable
@@ -797,8 +795,7 @@ impl LocalCluster {
         let vote_account_pubkey = vote_account.pubkey();
         let node_pubkey = from_account.pubkey();
         info!(
-            "setup_vote_and_stake_accounts: {}, {}, amount: {}",
-            node_pubkey, vote_account_pubkey, amount,
+            "setup_vote_and_stake_accounts: {node_pubkey}, {vote_account_pubkey}, amount: {amount}",
         );
         let stake_account_keypair = Keypair::new();
         let stake_account_pubkey = stake_account_keypair.pubkey();
@@ -888,11 +885,10 @@ impl LocalCluster {
                 .expect("get balance");
         } else {
             warn!(
-                "{} vote_account already has a balance?!?",
-                vote_account_pubkey
+                "{vote_account_pubkey} vote_account already has a balance?!?"
             );
         }
-        info!("Checking for vote account registration of {}", node_pubkey);
+        info!("Checking for vote account registration of {node_pubkey}");
         match (
             client
                 .rpc_client()
@@ -917,8 +913,7 @@ impl LocalCluster {
                                     Err(Error::other("invalid vote account state"))
                                 } else {
                                     info!(
-                                        "node {} {:?} {:?}",
-                                        node_pubkey, stake_state, vote_state
+                                        "node {node_pubkey} {stake_state:?} {vote_state:?}"
                                     );
 
                                     return Ok(());
@@ -953,7 +948,7 @@ impl LocalCluster {
         rpc_client: Arc<RpcClient>,
         rpc_pubsub_addr: SocketAddr,
     ) -> Result<QuicTpuClient> {
-        let rpc_pubsub_url = format!("ws://{}/", rpc_pubsub_addr);
+        let rpc_pubsub_url = format!("ws://{rpc_pubsub_addr}/");
 
         let cache = match &*self.connection_cache {
             ConnectionCache::Quic(cache) => cache,
@@ -968,7 +963,7 @@ impl LocalCluster {
             TpuClientConfig::default(),
             cache.clone(),
         )
-        .map_err(|err| Error::other(format!("TpuSenderError: {}", err)))?;
+        .map_err(|err| Error::other(format!("TpuSenderError: {err}")))?;
 
         Ok(tpu_client)
     }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -538,9 +538,7 @@ impl LocalCluster {
                 .get_balance_with_commitment(&validator_pubkey, CommitmentConfig::processed())
                 .expect("received response")
                 .value;
-            info!(
-                "validator {validator_pubkey} balance {validator_balance}"
-            );
+            info!("validator {validator_pubkey} balance {validator_balance}");
             Self::setup_vote_and_stake_accounts(
                 &client,
                 voting_keypair.as_ref().unwrap(),
@@ -640,9 +638,7 @@ impl LocalCluster {
         socket_addr_space: SocketAddrSpace,
     ) {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
-        info!(
-            "{test_name} looking minimum root {min_root} on all nodes"
-        );
+        info!("{test_name} looking minimum root {min_root} on all nodes");
         cluster_tests::check_min_slot_is_rooted(
             min_root,
             &alive_node_contact_infos,
@@ -884,9 +880,7 @@ impl LocalCluster {
                 )
                 .expect("get balance");
         } else {
-            warn!(
-                "{vote_account_pubkey} vote_account already has a balance?!?"
-            );
+            warn!("{vote_account_pubkey} vote_account already has a balance?!?");
         }
         info!("Checking for vote account registration of {node_pubkey}");
         match (
@@ -912,9 +906,7 @@ impl LocalCluster {
                                 } else if vote_state.node_pubkey != node_pubkey {
                                     Err(Error::other("invalid vote account state"))
                                 } else {
-                                    info!(
-                                        "node {node_pubkey} {stake_state:?} {vote_state:?}"
-                                    );
+                                    info!("node {node_pubkey} {stake_state:?} {vote_state:?}");
 
                                     return Ok(());
                                 }

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -86,10 +86,7 @@ impl LocalCluster {
 
         // Wait for a snapshot for a bank > last_slot to be made
         trace!(
-            "Waiting for {:?} snapshot archive to be generated with slot > {}, max wait duration: {:?}",
-            next_snapshot_type,
-            last_slot,
-            max_wait_duration,
+            "Waiting for {next_snapshot_type:?} snapshot archive to be generated with slot > {last_slot}, max wait duration: {max_wait_duration:?}",
         );
         let timer = Instant::now();
         let next_snapshot = loop {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1953,9 +1953,7 @@ fn test_validator_saves_tower() {
             .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::finalized())
         {
-            trace!(
-                "current root: {root}, last_replayed_root: {last_replayed_root}"
-            );
+            trace!("current root: {root}, last_replayed_root: {last_replayed_root}");
             if root > last_replayed_root {
                 break root;
             }
@@ -2821,9 +2819,7 @@ fn test_oc_bad_signatures() {
             move |vote_slot, leader_vote_tx, parsed_vote, _cluster_info| {
                 info!("received vote for {vote_slot}");
                 let vote_hash = parsed_vote.hash();
-                info!(
-                    "Simulating vote from our node on slot {vote_slot}, hash {vote_hash}"
-                );
+                info!("Simulating vote from our node on slot {vote_slot}, hash {vote_hash}");
 
                 // Add all recent vote slots on this fork to allow cluster to pass
                 // vote threshold checks in replay. Note this will instantly force a
@@ -3316,15 +3312,9 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     let val_b_ledger_path = cluster.ledger_path(&validator_b_pubkey);
     let val_c_ledger_path = cluster.ledger_path(&validator_c_pubkey);
 
-    info!(
-        "val_a {validator_a_pubkey} ledger path {val_a_ledger_path:?}"
-    );
-    info!(
-        "val_b {validator_b_pubkey} ledger path {val_b_ledger_path:?}"
-    );
-    info!(
-        "val_c {validator_c_pubkey} ledger path {val_c_ledger_path:?}"
-    );
+    info!("val_a {validator_a_pubkey} ledger path {val_a_ledger_path:?}");
+    info!("val_b {validator_b_pubkey} ledger path {val_b_ledger_path:?}");
+    info!("val_c {validator_c_pubkey} ledger path {val_c_ledger_path:?}");
 
     info!("Exiting validator C");
     let mut validator_c_info = cluster.exit_node(&validator_c_pubkey);
@@ -3353,9 +3343,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         .0;
     let base_slot = next_slot_on_a - 1;
 
-    info!(
-        "base slot: {base_slot}, next_slot_on_a: {next_slot_on_a}"
-    );
+    info!("base slot: {base_slot}, next_slot_on_a: {next_slot_on_a}");
 
     // Step 2:
     // Truncate ledger, copy over B's ledger to C
@@ -4014,9 +4002,7 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
                 info!("received vote for {latest_vote_slot}");
                 // Add to EpochSlots. Mark all slots frozen between slot..=max_vote_slot.
                 let new_epoch_slots: Vec<Slot> = (0..latest_vote_slot + 1).collect();
-                info!(
-                    "Simulating epoch slots from our node: {new_epoch_slots:?}"
-                );
+                info!("Simulating epoch slots from our node: {new_epoch_slots:?}");
                 cluster_info.push_epoch_slots(&new_epoch_slots);
 
                 for slot in duplicate_slot_receiver.try_iter() {
@@ -4129,9 +4115,7 @@ fn test_switch_threshold_uses_gossip_votes() {
         )
         .unwrap();
 
-        info!(
-            "Lighter validator's latest vote is for slot {lighter_validator_latest_vote}"
-        );
+        info!("Lighter validator's latest vote is for slot {lighter_validator_latest_vote}");
 
         // Lighter partition should stop voting after detecting the heavier partition and try
         // to switch. Loop until we see a greater vote by the heavier validator than the last
@@ -4199,14 +4183,10 @@ fn test_switch_threshold_uses_gossip_votes() {
                         new_lighter_validator_latest_vote,
                         lighter_validator_latest_vote
                     );
-                    info!(
-                        "Incrementing voting opportunities: {total_voting_opportunities}"
-                    );
+                    info!("Incrementing voting opportunities: {total_voting_opportunities}");
                     total_voting_opportunities += 1;
                 } else {
-                    info!(
-                        "Tower still locked out, can't vote for slot: {latest_slot}"
-                    );
+                    info!("Tower still locked out, can't vote for slot: {latest_slot}");
                 }
             } else if latest_slot > heavier_validator_latest_vote {
                 warn!(
@@ -4217,9 +4197,7 @@ fn test_switch_threshold_uses_gossip_votes() {
         }
 
         // Make a vote from the killed validator for slot `heavier_validator_latest_vote` in gossip
-        info!(
-            "Simulate vote for slot: {heavier_validator_latest_vote} from dead validator"
-        );
+        info!("Simulate vote for slot: {heavier_validator_latest_vote} from dead validator");
         let vote_keypair = &context
             .dead_validator_info
             .as_ref()
@@ -4776,15 +4754,9 @@ fn test_duplicate_with_pruned_ancestor() {
     let minority_ledger_path = cluster.ledger_path(&minority_pubkey);
     let our_node_ledger_path = cluster.ledger_path(&our_node_pubkey);
 
-    info!(
-        "majority {majority_pubkey} ledger path {majority_ledger_path:?}"
-    );
-    info!(
-        "minority {minority_pubkey} ledger path {minority_ledger_path:?}"
-    );
-    info!(
-        "our_node {our_node_pubkey} ledger path {our_node_ledger_path:?}"
-    );
+    info!("majority {majority_pubkey} ledger path {majority_ledger_path:?}");
+    info!("minority {minority_pubkey} ledger path {minority_ledger_path:?}");
+    info!("our_node {our_node_pubkey} ledger path {our_node_ledger_path:?}");
 
     info!("Killing our node");
     let our_node_info = cluster.exit_node(&our_node_pubkey);
@@ -4829,9 +4801,7 @@ fn test_duplicate_with_pruned_ancestor() {
         }
     }
 
-    info!(
-        "Killing minority validator, fork created successfully: {last_minority_vote:?}"
-    );
+    info!("Killing minority validator, fork created successfully: {last_minority_vote:?}");
     let last_minority_vote =
         wait_for_last_vote_in_tower_to_land_in_ledger(&minority_ledger_path, &minority_pubkey)
             .unwrap();
@@ -5348,9 +5318,7 @@ fn test_duplicate_shreds_switch_failure() {
     fn wait_for_duplicate_fork_frozen(ledger_path: &Path, dup_slot: Slot) -> Hash {
         // Ensure all the slots <= dup_slot are also full so we know we can replay up to dup_slot
         // on restart
-        info!(
-            "Waiting to receive and replay entire duplicate fork with tip {dup_slot}"
-        );
+        info!("Waiting to receive and replay entire duplicate fork with tip {dup_slot}");
         loop {
             let duplicate_fork_validator_blockstore = open_blockstore(ledger_path);
             if let Some(frozen_hash) = duplicate_fork_validator_blockstore.get_bank_hash(dup_slot) {
@@ -5392,9 +5360,7 @@ fn test_duplicate_shreds_switch_failure() {
         let ledger_path = cluster.ledger_path(pubkey);
 
         // Lift the partition after `pubkey` votes on the `dup_slot`
-        info!(
-            "Waiting on duplicate fork to vote on duplicate slot: {dup_slot}"
-        );
+        info!("Waiting on duplicate fork to vote on duplicate slot: {dup_slot}");
         loop {
             let last_vote = last_vote_in_tower(&ledger_path, pubkey);
             if let Some((latest_vote_slot, _hash)) = last_vote {
@@ -5627,9 +5593,7 @@ fn test_duplicate_shreds_switch_failure() {
     assert_eq!(dup_shred1.slot(), dup_slot);
 
     // Purge everything including the `dup_slot` from the `target_switch_fork_validator_pubkey`
-    info!(
-        "Purging towers and ledgers for: {duplicate_leader_validator_pubkey:?}"
-    );
+    info!("Purging towers and ledgers for: {duplicate_leader_validator_pubkey:?}");
     Blockstore::destroy(&target_switch_fork_validator_ledger_path).unwrap();
     {
         let blockstore1 = open_blockstore(&duplicate_leader_ledger_path);
@@ -5642,18 +5606,14 @@ fn test_duplicate_shreds_switch_failure() {
         dup_slot,
     );
 
-    info!(
-        "Purging towers and ledgers for: {duplicate_fork_validator1_pubkey:?}"
-    );
+    info!("Purging towers and ledgers for: {duplicate_fork_validator1_pubkey:?}");
     clear_ledger_and_tower(
         &duplicate_fork_validator1_ledger_path,
         &duplicate_fork_validator1_pubkey,
         dup_slot + 1,
     );
 
-    info!(
-        "Purging towers and ledgers for: {duplicate_fork_validator2_pubkey:?}"
-    );
+    info!("Purging towers and ledgers for: {duplicate_fork_validator2_pubkey:?}");
     // Copy validator 1's ledger to validator 2 so that they have the same version
     // of the duplicate slot
     clear_ledger_and_tower(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -595,8 +595,7 @@ fn test_incremental_snapshot_download() {
         .incremental_snapshot_archives_dir;
 
     debug!(
-        "snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}",
-        full_snapshot_interval, incremental_snapshot_interval,
+        "snapshot config:\n\tfull snapshot interval: {full_snapshot_interval}\n\tincremental snapshot interval: {incremental_snapshot_interval}",
     );
     debug!(
         "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
@@ -760,8 +759,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
     info!(
-        "snapshot config:\n\tfull snapshot interval: {:?}\n\tincremental snapshot interval: {:?}",
-        full_snapshot_interval, incremental_snapshot_interval,
+        "snapshot config:\n\tfull snapshot interval: {full_snapshot_interval:?}\n\tincremental snapshot interval: {incremental_snapshot_interval:?}",
     );
     debug!(
         "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
@@ -1134,9 +1132,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
                     if incremental_snapshot_slot >= validator_next_incremental_snapshot_slot {
                         // specific incremental snapshot is not important, just that one was created
                         info!(
-                             "Validator made new snapshots, full snapshot slot: {}, incremental snapshot slot: {}",
-                             full_snapshot_slot,
-                             incremental_snapshot_slot,
+                             "Validator made new snapshots, full snapshot slot: {full_snapshot_slot}, incremental snapshot slot: {incremental_snapshot_slot}",
                         );
                         break;
                     }
@@ -1377,7 +1373,7 @@ fn test_snapshots_blockstore_floor() {
     // Let this validator run a while with repair
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
-        trace!("current_slot: {}", current_slot);
+        trace!("current_slot: {current_slot}");
         if let Ok(slot) = validator_client
             .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
@@ -1431,7 +1427,7 @@ fn test_snapshots_restart_validity() {
     let mut expected_balances = HashMap::new();
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     for i in 1..num_runs {
-        info!("run {}", i);
+        info!("run {i}");
         // Push transactions to one of the nodes and confirm that transactions were
         // forwarded to and processed.
         trace!("Sending transactions");
@@ -1580,7 +1576,7 @@ fn test_wait_for_max_stake() {
         (100 / num_validators_activating_stake) as f32,
         timeout,
     ) {
-        panic!("wait_for_max_stake failed: {:?}", err);
+        panic!("wait_for_max_stake failed: {err:?}");
     }
     assert!(client.get_slot().unwrap() > 10);
 }
@@ -1899,7 +1895,7 @@ fn test_validator_saves_tower() {
             .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::processed())
         {
-            trace!("current slot: {}", slot);
+            trace!("current slot: {slot}");
             if slot > 2 {
                 break;
             }
@@ -1910,7 +1906,7 @@ fn test_validator_saves_tower() {
     // Stop validator and check saved tower
     let validator_info = cluster.exit_node(&validator_id);
     let tower1 = Tower::restore(&file_tower_storage, &validator_id).unwrap();
-    trace!("tower1: {:?}", tower1);
+    trace!("tower1: {tower1:?}");
     assert_eq!(tower1.root(), 0);
     assert!(tower1.last_voted_slot().is_some());
 
@@ -1926,7 +1922,7 @@ fn test_validator_saves_tower() {
             .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::finalized())
         {
-            trace!("current root: {}", root);
+            trace!("current root: {root}");
             if root > 0 {
                 break root;
             }
@@ -1937,7 +1933,7 @@ fn test_validator_saves_tower() {
     // Stop validator, and check saved tower
     let validator_info = cluster.exit_node(&validator_id);
     let tower2 = Tower::restore(&file_tower_storage, &validator_id).unwrap();
-    trace!("tower2: {:?}", tower2);
+    trace!("tower2: {tower2:?}");
     assert_eq!(tower2.root(), last_replayed_root);
 
     // Rollback saved tower to `tower1` to simulate a validator starting from a newer snapshot
@@ -1958,9 +1954,7 @@ fn test_validator_saves_tower() {
             .get_slot_with_commitment(CommitmentConfig::finalized())
         {
             trace!(
-                "current root: {}, last_replayed_root: {}",
-                root,
-                last_replayed_root
+                "current root: {root}, last_replayed_root: {last_replayed_root}"
             );
             if root > last_replayed_root {
                 break root;
@@ -1972,7 +1966,7 @@ fn test_validator_saves_tower() {
     // Check the new root is reflected in the saved tower state
     let mut validator_info = cluster.exit_node(&validator_id);
     let tower3 = Tower::restore(&file_tower_storage, &validator_id).unwrap();
-    trace!("tower3: {:?}", tower3);
+    trace!("tower3: {tower3:?}");
     let tower3_root = tower3.root();
     assert!(tower3_root >= new_root);
 
@@ -1992,7 +1986,7 @@ fn test_validator_saves_tower() {
             .rpc_client()
             .get_slot_with_commitment(CommitmentConfig::finalized())
         {
-            trace!("current root: {}, last tower root: {}", root, tower3_root);
+            trace!("current root: {root}, last tower root: {tower3_root}");
             if root > tower3_root {
                 break root;
             }
@@ -2003,7 +1997,7 @@ fn test_validator_saves_tower() {
     cluster.close_preserve_ledgers();
 
     let tower4 = Tower::restore(&file_tower_storage, &validator_id).unwrap();
-    trace!("tower4: {:?}", tower4);
+    trace!("tower4: {tower4:?}");
     assert!(tower4.root() >= new_root);
 }
 
@@ -2074,8 +2068,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
     {
         // create a warped future tower without mangling the tower itself
         info!(
-            "Revert blockstore before slot {} and effectively create a future tower",
-            purged_slot_before_restart,
+            "Revert blockstore before slot {purged_slot_before_restart} and effectively create a future tower",
         );
         let blockstore = open_blockstore(&val_a_ledger_path);
         purge_slots_with_count(&blockstore, purged_slot_before_restart, 100);
@@ -2826,11 +2819,10 @@ fn test_oc_bad_signatures() {
             let vote_keypair = vote_keypair.insecure_clone();
             let num_votes_simulated = num_votes_simulated.clone();
             move |vote_slot, leader_vote_tx, parsed_vote, _cluster_info| {
-                info!("received vote for {}", vote_slot);
+                info!("received vote for {vote_slot}");
                 let vote_hash = parsed_vote.hash();
                 info!(
-                    "Simulating vote from our node on slot {}, hash {}",
-                    vote_slot, vote_hash
+                    "Simulating vote from our node on slot {vote_slot}, hash {vote_hash}"
                 );
 
                 // Add all recent vote slots on this fork to allow cluster to pass
@@ -2952,8 +2944,7 @@ fn test_votes_land_in_fork_during_long_partition() {
                 )
                 .unwrap();
                 info!(
-                    "Checking heavier validator's last vote {} is on a separate fork",
-                    heavier_validator_latest_vote_slot
+                    "Checking heavier validator's last vote {heavier_validator_latest_vote_slot} is on a separate fork"
                 );
                 let lighter_validator_blockstore = open_blockstore(&lighter_validator_ledger_path);
                 if lighter_validator_blockstore
@@ -3058,7 +3049,7 @@ fn setup_transfer_scan_threads(
                         blockhash,
                     );
                     if result.is_err() {
-                        debug!("Failed in transfer for starting keypair: {:?}", result);
+                        debug!("Failed in transfer for starting keypair: {result:?}");
                     }
                 }
                 for i in 0..starting_keypairs_.len() {
@@ -3069,7 +3060,7 @@ fn setup_transfer_scan_threads(
                         blockhash,
                     );
                     if result.is_err() {
-                        debug!("Failed in transfer for starting keypair: {:?}", result);
+                        debug!("Failed in transfer for starting keypair: {result:?}");
                     }
                 }
             }
@@ -3326,16 +3317,13 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     let val_c_ledger_path = cluster.ledger_path(&validator_c_pubkey);
 
     info!(
-        "val_a {} ledger path {:?}",
-        validator_a_pubkey, val_a_ledger_path
+        "val_a {validator_a_pubkey} ledger path {val_a_ledger_path:?}"
     );
     info!(
-        "val_b {} ledger path {:?}",
-        validator_b_pubkey, val_b_ledger_path
+        "val_b {validator_b_pubkey} ledger path {val_b_ledger_path:?}"
     );
     info!(
-        "val_c {} ledger path {:?}",
-        validator_c_pubkey, val_c_ledger_path
+        "val_c {validator_c_pubkey} ledger path {val_c_ledger_path:?}"
     );
 
     info!("Exiting validator C");
@@ -3366,8 +3354,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     let base_slot = next_slot_on_a - 1;
 
     info!(
-        "base slot: {}, next_slot_on_a: {}",
-        base_slot, next_slot_on_a
+        "base slot: {base_slot}, next_slot_on_a: {next_slot_on_a}"
     );
 
     // Step 2:
@@ -3480,7 +3467,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         }
     }
 
-    info!("Observed A's votes on: {:?}", a_votes);
+    info!("Observed A's votes on: {a_votes:?}");
 
     // an elaborate way of assert!(with_tower && !bad_vote_detected || ...)
     let expects_optimistic_confirmation_violation = !with_tower;
@@ -3589,7 +3576,7 @@ fn test_fork_choice_refresh_old_votes() {
                 MAX_PROCESSING_AGE as u64 * total_slots_to_lighter_partition_ratio as u64,
                 ticks_per_slot,
             );
-            info!("Wait for blockhashes to expire, {} ms", sleep_time_ms);
+            info!("Wait for blockhashes to expire, {sleep_time_ms} ms");
 
             // Wait for blockhashes to expire
             sleep(Duration::from_millis(sleep_time_ms));
@@ -3609,8 +3596,7 @@ fn test_fork_choice_refresh_old_votes() {
                 .ledger_path
                 .clone();
             info!(
-                "smallest validator key: {}, path: {:?}",
-                smallest_validator_key, smallest_ledger_path
+                "smallest validator key: {smallest_validator_key}, path: {smallest_ledger_path:?}"
             );
             let lighter_fork_ledger_path = cluster.ledger_path(&context.lighter_fork_validator_key);
             let heaviest_ledger_path = cluster.ledger_path(&context.heaviest_validator_key);
@@ -3804,7 +3790,7 @@ fn test_kill_heaviest_partition() {
     let empty = |_: &mut LocalCluster, _: &mut ()| {};
     let validator_to_kill = validator_keys[0].pubkey();
     let on_partition_resolved = |cluster: &mut LocalCluster, _: &mut ()| {
-        info!("Killing validator with id: {}", validator_to_kill);
+        info!("Killing validator with id: {validator_to_kill}");
         cluster.exit_node(&validator_to_kill);
         cluster.check_for_new_roots(16, "PARTITION_TEST", SocketAddrSpace::Unspecified);
     };
@@ -4025,12 +4011,11 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
             let mut gossip_vote_index = 0;
             let mut duplicate_slots = vec![];
             move |latest_vote_slot, leader_vote_tx, parsed_vote, cluster_info| {
-                info!("received vote for {}", latest_vote_slot);
+                info!("received vote for {latest_vote_slot}");
                 // Add to EpochSlots. Mark all slots frozen between slot..=max_vote_slot.
                 let new_epoch_slots: Vec<Slot> = (0..latest_vote_slot + 1).collect();
                 info!(
-                    "Simulating epoch slots from our node: {:?}",
-                    new_epoch_slots
+                    "Simulating epoch slots from our node: {new_epoch_slots:?}"
                 );
                 cluster_info.push_epoch_slots(&new_epoch_slots);
 
@@ -4040,8 +4025,7 @@ fn run_duplicate_shreds_broadcast_leader(vote_on_duplicate: bool) {
                 let vote_hash = parsed_vote.hash();
                 if vote_on_duplicate || !duplicate_slots.contains(&latest_vote_slot) {
                     info!(
-                        "Simulating vote from our node on slot {}, hash {}",
-                        latest_vote_slot, vote_hash
+                        "Simulating vote from our node on slot {latest_vote_slot}, hash {vote_hash}"
                     );
 
                     // Add all recent vote slots on this fork to allow cluster to pass
@@ -4146,8 +4130,7 @@ fn test_switch_threshold_uses_gossip_votes() {
         .unwrap();
 
         info!(
-            "Lighter validator's latest vote is for slot {}",
-            lighter_validator_latest_vote
+            "Lighter validator's latest vote is for slot {lighter_validator_latest_vote}"
         );
 
         // Lighter partition should stop voting after detecting the heavier partition and try
@@ -4217,20 +4200,17 @@ fn test_switch_threshold_uses_gossip_votes() {
                         lighter_validator_latest_vote
                     );
                     info!(
-                        "Incrementing voting opportunities: {}",
-                        total_voting_opportunities
+                        "Incrementing voting opportunities: {total_voting_opportunities}"
                     );
                     total_voting_opportunities += 1;
                 } else {
                     info!(
-                        "Tower still locked out, can't vote for slot: {}",
-                        latest_slot
+                        "Tower still locked out, can't vote for slot: {latest_slot}"
                     );
                 }
             } else if latest_slot > heavier_validator_latest_vote {
                 warn!(
-                    "validator is still generating blocks on its own fork, last processed slot: {}",
-                    latest_slot
+                    "validator is still generating blocks on its own fork, last processed slot: {latest_slot}"
                 );
             }
             sleep(Duration::from_millis(50));
@@ -4238,8 +4218,7 @@ fn test_switch_threshold_uses_gossip_votes() {
 
         // Make a vote from the killed validator for slot `heavier_validator_latest_vote` in gossip
         info!(
-            "Simulate vote for slot: {} from dead validator",
-            heavier_validator_latest_vote
+            "Simulate vote for slot: {heavier_validator_latest_vote} from dead validator"
         );
         let vote_keypair = &context
             .dead_validator_info
@@ -4283,8 +4262,7 @@ fn test_switch_threshold_uses_gossip_votes() {
 
             if new_lighter_validator_latest_vote != lighter_validator_latest_vote {
                 info!(
-                    "Lighter validator switched forks at slot: {}",
-                    new_lighter_validator_latest_vote
+                    "Lighter validator switched forks at slot: {new_lighter_validator_latest_vote}"
                 );
                 let (heavier_validator_latest_vote, _) = last_vote_in_tower(
                     &heavier_validator_ledger_path,
@@ -4369,10 +4347,10 @@ fn find_latest_replayed_slot_from_ledger(
 
         if let Some(new_latest_slot) = new_latest_slots.first() {
             latest_slot = *new_latest_slot;
-            info!("Checking latest_slot {}", latest_slot);
+            info!("Checking latest_slot {latest_slot}");
             // Wait for the slot to be fully received by the validator
             loop {
-                info!("Waiting for slot {} to be full", latest_slot);
+                info!("Waiting for slot {latest_slot} to be full");
                 if blockstore.is_full(latest_slot) {
                     break;
                 } else {
@@ -4382,7 +4360,7 @@ fn find_latest_replayed_slot_from_ledger(
             }
             // Wait for the slot to be replayed
             loop {
-                info!("Waiting for slot {} to be replayed", latest_slot);
+                info!("Waiting for slot {latest_slot} to be replayed");
                 if blockstore.get_bank_hash(latest_slot).is_some() {
                     return (
                         latest_slot,
@@ -4597,7 +4575,7 @@ fn test_slot_hash_expiry() {
             // Update common_ancestor_slot because A is still running
             if let Some(s) = a_tower.last_voted_slot() {
                 common_ancestor_slot = s;
-                info!("New common_ancestor_slot {}", common_ancestor_slot);
+                info!("New common_ancestor_slot {common_ancestor_slot}");
             } else {
                 panic!("A's tower has no votes");
             }
@@ -4799,16 +4777,13 @@ fn test_duplicate_with_pruned_ancestor() {
     let our_node_ledger_path = cluster.ledger_path(&our_node_pubkey);
 
     info!(
-        "majority {} ledger path {:?}",
-        majority_pubkey, majority_ledger_path
+        "majority {majority_pubkey} ledger path {majority_ledger_path:?}"
     );
     info!(
-        "minority {} ledger path {:?}",
-        minority_pubkey, minority_ledger_path
+        "minority {minority_pubkey} ledger path {minority_ledger_path:?}"
     );
     info!(
-        "our_node {} ledger path {:?}",
-        our_node_pubkey, our_node_ledger_path
+        "our_node {our_node_pubkey} ledger path {our_node_ledger_path:?}"
     );
 
     info!("Killing our node");
@@ -4855,8 +4830,7 @@ fn test_duplicate_with_pruned_ancestor() {
     }
 
     info!(
-        "Killing minority validator, fork created successfully: {:?}",
-        last_minority_vote
+        "Killing minority validator, fork created successfully: {last_minority_vote:?}"
     );
     let last_minority_vote =
         wait_for_last_vote_in_tower_to_land_in_ledger(&minority_ledger_path, &minority_pubkey)
@@ -5375,8 +5349,7 @@ fn test_duplicate_shreds_switch_failure() {
         // Ensure all the slots <= dup_slot are also full so we know we can replay up to dup_slot
         // on restart
         info!(
-            "Waiting to receive and replay entire duplicate fork with tip {}",
-            dup_slot
+            "Waiting to receive and replay entire duplicate fork with tip {dup_slot}"
         );
         loop {
             let duplicate_fork_validator_blockstore = open_blockstore(ledger_path);
@@ -5410,7 +5383,7 @@ fn test_duplicate_shreds_switch_failure() {
         let disable_turbine = Arc::new(AtomicBool::new(true));
         duplicate_fork_validator_info.config.voting_disabled = false;
         duplicate_fork_validator_info.config.turbine_disabled = disable_turbine.clone();
-        info!("Restarting node: {}", pubkey);
+        info!("Restarting node: {pubkey}");
         cluster.restart_node(
             pubkey,
             duplicate_fork_validator_info,
@@ -5420,13 +5393,12 @@ fn test_duplicate_shreds_switch_failure() {
 
         // Lift the partition after `pubkey` votes on the `dup_slot`
         info!(
-            "Waiting on duplicate fork to vote on duplicate slot: {}",
-            dup_slot
+            "Waiting on duplicate fork to vote on duplicate slot: {dup_slot}"
         );
         loop {
             let last_vote = last_vote_in_tower(&ledger_path, pubkey);
             if let Some((latest_vote_slot, _hash)) = last_vote {
-                info!("latest vote: {}", latest_vote_slot);
+                info!("latest vote: {latest_vote_slot}");
                 if latest_vote_slot == dup_slot {
                     break;
                 }
@@ -5616,7 +5588,7 @@ fn test_duplicate_shreds_switch_failure() {
     );
 
     // 3) Force `duplicate_fork_validator1_pubkey` to see a duplicate proof
-    info!("Waiting for duplicate proof for slot: {}", dup_slot);
+    info!("Waiting for duplicate proof for slot: {dup_slot}");
     let duplicate_proof = {
         // Grab the other version of the slot from the `duplicate_leader_validator_pubkey`
         // which we confirmed to have a different version of the frozen hash in the loop
@@ -5638,7 +5610,7 @@ fn test_duplicate_shreds_switch_failure() {
             &cluster.ledger_path(&duplicate_fork_validator1_pubkey),
             dup_slot,
         )
-        .unwrap_or_else(|| panic!("Duplicate proof for slot {} not found", dup_slot))
+        .unwrap_or_else(|| panic!("Duplicate proof for slot {dup_slot} not found"))
     };
 
     // 3) Kill all the validators
@@ -5656,8 +5628,7 @@ fn test_duplicate_shreds_switch_failure() {
 
     // Purge everything including the `dup_slot` from the `target_switch_fork_validator_pubkey`
     info!(
-        "Purging towers and ledgers for: {:?}",
-        duplicate_leader_validator_pubkey
+        "Purging towers and ledgers for: {duplicate_leader_validator_pubkey:?}"
     );
     Blockstore::destroy(&target_switch_fork_validator_ledger_path).unwrap();
     {
@@ -5672,8 +5643,7 @@ fn test_duplicate_shreds_switch_failure() {
     );
 
     info!(
-        "Purging towers and ledgers for: {:?}",
-        duplicate_fork_validator1_pubkey
+        "Purging towers and ledgers for: {duplicate_fork_validator1_pubkey:?}"
     );
     clear_ledger_and_tower(
         &duplicate_fork_validator1_ledger_path,
@@ -5682,8 +5652,7 @@ fn test_duplicate_shreds_switch_failure() {
     );
 
     info!(
-        "Purging towers and ledgers for: {:?}",
-        duplicate_fork_validator2_pubkey
+        "Purging towers and ledgers for: {duplicate_fork_validator2_pubkey:?}"
     );
     // Copy validator 1's ledger to validator 2 so that they have the same version
     // of the duplicate slot

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -81,7 +81,7 @@ impl InfluxDbMetricsWriter {
 
     fn build_write_url() -> Result<String, MetricsError> {
         let config = get_metrics_config().map_err(|err| {
-            info!("metrics disabled: {}", err);
+            info!("metrics disabled: {err}");
             err
         })?;
 
@@ -149,7 +149,7 @@ impl MetricsWriter for InfluxDbMetricsWriter {
             let client = match client {
                 Ok(client) => client,
                 Err(err) => {
-                    warn!("client instantiation failed: {}", err);
+                    warn!("client instantiation failed: {err}");
                     return;
                 }
             };
@@ -161,7 +161,7 @@ impl MetricsWriter for InfluxDbMetricsWriter {
                     let text = resp
                         .text()
                         .unwrap_or_else(|_| "[text body empty]".to_string());
-                    warn!("submit response unsuccessful: {} {}", status, text,);
+                    warn!("submit response unsuccessful: {status} {text}",);
                 }
             } else {
                 warn!("submit error: {}", response.unwrap_err());
@@ -226,13 +226,12 @@ impl MetricsAgent {
         let fit_counters = max_points.saturating_sub(points.len());
         let points_written = cmp::min(num_points, max_points);
 
-        debug!("run: attempting to write {} points", num_points);
+        debug!("run: attempting to write {num_points} points");
 
         if num_points > max_points {
             warn!(
-                "Max submission rate of {} datapoints per second exceeded.  Only the \
-                 first {} of {} points will be submitted.",
-                max_points_per_sec, max_points, num_points
+                "Max submission rate of {max_points_per_sec} datapoints per second exceeded.  Only the \
+                 first {max_points} of {num_points} points will be submitted."
             );
         }
 
@@ -321,11 +320,11 @@ impl MetricsAgent {
                         barrier.wait();
                     }
                     MetricsCommand::Submit(point, level) => {
-                        log!(level, "{}", point);
+                        log!(level, "{point}");
                         points.push(point);
                     }
                     MetricsCommand::SubmitCounter(counter, _level, bucket) => {
-                        debug!("{:?}", counter);
+                        debug!("{counter:?}");
                         let key = (counter.name, bucket);
                         if let Some(value) = counters.get_mut(&key) {
                             value.count += counter.count;
@@ -404,7 +403,7 @@ static HOST_ID: std::sync::LazyLock<RwLock<String>> = std::sync::LazyLock::new(|
 });
 
 pub fn set_host_id(host_id: String) {
-    info!("host id: {}", host_id);
+    info!("host id: {host_id}");
     *HOST_ID.write().unwrap() = host_id;
 }
 

--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -163,7 +163,7 @@ pub(crate) async fn verify_all_reachable_tcp(
             bind_address,
         )
         .await
-        .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+        .map_err(|err| warn!("ip_echo_server request failed: {err}"));
 
         // spawn checker to wait for reply
         // since we do not know if tcp_listeners are nonblocking, we have to run them in native threads.
@@ -173,7 +173,7 @@ pub(crate) async fn verify_all_reachable_tcp(
 
             // Use blocking API since we have no idea if sockets given to us are nonblocking or not
             let thread_handle = tokio::task::spawn_blocking(move || {
-                debug!("Waiting for incoming connection on tcp/{}", port);
+                debug!("Waiting for incoming connection on tcp/{port}");
                 match tcp_listener.incoming().next() {
                     Some(_) => {
                         // ignore errors here since this can only happen if a timeout was detected.
@@ -251,8 +251,7 @@ pub(crate) async fn verify_all_reachable_udp(
         let ports: Vec<u16> = ports_to_socks_map.keys().copied().collect();
 
         info!(
-            "Checking that udp ports {:?} are reachable from bind IP {:?}",
-            ports, bind_ip
+            "Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}"
         );
 
         'outer: for chunk_to_check in ports.chunks(MAX_PORT_COUNT_PER_MESSAGE) {
@@ -275,7 +274,7 @@ pub(crate) async fn verify_all_reachable_udp(
                     bind_ip,
                 )
                 .await
-                .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+                .map_err(|err| warn!("ip_echo_server request failed: {err}"));
 
                 let reachable_ports = Arc::new(RwLock::new(HashSet::new()));
                 // Spawn threads for each socket to check
@@ -301,8 +300,7 @@ pub(crate) async fn verify_all_reachable_udp(
 
                             let recv_result = socket.recv(&mut [0; 1]);
                             debug!(
-                                "Waited for incoming datagram on udp/{}: {:?}",
-                                port, recv_result
+                                "Waited for incoming datagram on udp/{port}: {recv_result:?}"
                             );
 
                             if recv_result.is_ok() {
@@ -327,8 +325,7 @@ pub(crate) async fn verify_all_reachable_udp(
                     .into_inner()
                     .expect("No threads should hold the lock");
                 info!(
-                    "checked udp ports: {:?}, reachable udp ports: {:?}",
-                    ports_to_check, reachable_ports
+                    "checked udp ports: {ports_to_check:?}, reachable udp ports: {reachable_ports:?}"
                 );
                 if reachable_ports.len() == ports_to_check.len() {
                     continue 'outer; // starts checking next chunk of ports, if any
@@ -336,8 +333,7 @@ pub(crate) async fn verify_all_reachable_udp(
             }
 
             error!(
-                "Maximum retry count reached. Some ports for IP {} unreachable.",
-                bind_ip
+                "Maximum retry count reached. Some ports for IP {bind_ip} unreachable."
             );
             return false;
         }

--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -250,9 +250,7 @@ pub(crate) async fn verify_all_reachable_udp(
     for (bind_ip, ports_to_socks_map) in ip_to_ports {
         let ports: Vec<u16> = ports_to_socks_map.keys().copied().collect();
 
-        info!(
-            "Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}"
-        );
+        info!("Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}");
 
         'outer: for chunk_to_check in ports.chunks(MAX_PORT_COUNT_PER_MESSAGE) {
             let ports_to_check = chunk_to_check.to_vec();
@@ -299,9 +297,7 @@ pub(crate) async fn verify_all_reachable_udp(
                             }
 
                             let recv_result = socket.recv(&mut [0; 1]);
-                            debug!(
-                                "Waited for incoming datagram on udp/{port}: {recv_result:?}"
-                            );
+                            debug!("Waited for incoming datagram on udp/{port}: {recv_result:?}");
 
                             if recv_result.is_ok() {
                                 reachable_ports.write().unwrap().insert(port);
@@ -332,9 +328,7 @@ pub(crate) async fn verify_all_reachable_udp(
                 }
             }
 
-            error!(
-                "Maximum retry count reached. Some ports for IP {bind_ip} unreachable."
-            );
+            error!("Maximum retry count reached. Some ports for IP {bind_ip} unreachable.");
             return false;
         }
     }

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -68,7 +68,7 @@ async fn process_connection(
     peer_addr: SocketAddr,
     shred_version: Option<u16>,
 ) -> io::Result<()> {
-    info!("connection from {:?}", peer_addr);
+    info!("connection from {peer_addr:?}");
 
     let mut data = vec![0u8; ip_echo_server_request_length()];
 
@@ -104,7 +104,7 @@ async fn process_connection(
             ))
         })?;
 
-    trace!("request: {:?}", msg);
+    trace!("request: {msg:?}");
 
     // Fire a datagram at each non-zero UDP port
     match bind_to_unspecified() {
@@ -114,21 +114,21 @@ async fn process_connection(
                     let result =
                         udp_socket.send_to(&[0], SocketAddr::from((peer_addr.ip(), *udp_port)));
                     match result {
-                        Ok(_) => debug!("Successful send_to udp/{}", udp_port),
-                        Err(err) => info!("Failed to send_to udp/{}: {}", udp_port, err),
+                        Ok(_) => debug!("Successful send_to udp/{udp_port}"),
+                        Err(err) => info!("Failed to send_to udp/{udp_port}: {err}"),
                     }
                 }
             }
         }
         Err(err) => {
-            warn!("Failed to bind local udp socket: {}", err);
+            warn!("Failed to bind local udp socket: {err}");
         }
     }
 
     // Try to connect to each non-zero TCP port
     for tcp_port in &msg.tcp_ports {
         if *tcp_port != 0 {
-            debug!("Connecting to tcp/{}", tcp_port);
+            debug!("Connecting to tcp/{tcp_port}");
 
             let mut tcp_stream = timeout(
                 IO_TIMEOUT,
@@ -148,7 +148,7 @@ async fn process_connection(
     // conflict with the first four bytes of a valid HTTP response.
     let mut bytes = vec![0u8; IP_ECHO_SERVER_RESPONSE_LENGTH];
     bincode::serialize_into(&mut bytes[HEADER_LENGTH..], &response).unwrap();
-    trace!("response: {:?}", bytes);
+    trace!("response: {bytes:?}");
     writer.write_all(&bytes).await
 }
 
@@ -163,11 +163,11 @@ async fn run_echo_server(tcp_listener: std::net::TcpListener, shred_version: Opt
             Ok((socket, peer_addr)) => {
                 runtime::Handle::current().spawn(async move {
                     if let Err(err) = process_connection(socket, peer_addr, shred_version).await {
-                        info!("session failed: {:?}", err);
+                        info!("session failed: {err:?}");
                     }
                 });
             }
-            Err(err) => warn!("listener accept failed: {:?}", err),
+            Err(err) => warn!("listener accept failed: {err:?}"),
         }
     }
 }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -366,8 +366,7 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({} requested)",
-            num
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
         );
         num = 1;
     }
@@ -582,8 +581,7 @@ pub fn bind_more_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS {
         if num > 1 {
             warn!(
-                "bind_more_with_config() only supports 1 socket on this platform ({} requested)",
-                num
+                "bind_more_with_config() only supports 1 socket on this platform ({num} requested)"
             );
         }
         Ok(vec![socket])

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -217,8 +217,7 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({} requested)",
-            num
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
         );
         num = 1;
     }
@@ -320,8 +319,7 @@ pub fn bind_more_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS {
         if num > 1 {
             warn!(
-                "bind_more_with_config() only supports 1 socket on this platform ({} requested)",
-                num
+                "bind_more_with_config() only supports 1 socket on this platform ({num} requested)"
             );
         }
         Ok(vec![socket])

--- a/notifier/src/lib.rs
+++ b/notifier/src/lib.rs
@@ -143,9 +143,9 @@ impl Notifier {
         if let Ok(log_level) = env::var(format!("{env_prefix}LOG_NOTIFIER_LEVEL")) {
             match Level::from_str(&log_level) {
                 Ok(level) => notifiers.push(NotificationChannel::Log(level)),
-                Err(e) => warn!(
-                    "could not parse specified log notifier level string ({log_level}): {e}"
-                ),
+                Err(e) => {
+                    warn!("could not parse specified log notifier level string ({log_level}): {e}")
+                }
             }
         }
 

--- a/notifier/src/lib.rs
+++ b/notifier/src/lib.rs
@@ -112,7 +112,7 @@ impl Default for Notifier {
 
 impl Notifier {
     pub fn new(env_prefix: &str) -> Self {
-        info!("Initializing {}Notifier", env_prefix);
+        info!("Initializing {env_prefix}Notifier");
 
         let mut notifiers = vec![];
 
@@ -144,8 +144,7 @@ impl Notifier {
             match Level::from_str(&log_level) {
                 Ok(level) => notifiers.push(NotificationChannel::Log(level)),
                 Err(e) => warn!(
-                    "could not parse specified log notifier level string ({}): {}",
-                    log_level, e
+                    "could not parse specified log notifier level string ({log_level}): {e}"
                 ),
             }
         }
@@ -170,14 +169,14 @@ impl Notifier {
                         // Discord rate limiting is aggressive, limit to 1 message a second
                         sleep(Duration::from_millis(1000));
 
-                        info!("Sending {}", line);
+                        info!("Sending {line}");
                         let data = json!({ "content": line });
 
                         loop {
                             let response = self.client.post(webhook).json(&data).send();
 
                             if let Err(err) = response {
-                                warn!("Failed to send Discord message: \"{}\": {:?}", line, err);
+                                warn!("Failed to send Discord message: \"{line}\": {err:?}");
                                 break;
                             } else if let Ok(response) = response {
                                 info!("response status: {}", response.status());
@@ -195,7 +194,7 @@ impl Notifier {
                 NotificationChannel::Slack(webhook) => {
                     let data = json!({ "text": msg });
                     if let Err(err) = self.client.post(webhook).json(&data).send() {
-                        warn!("Failed to send Slack message: {:?}", err);
+                        warn!("Failed to send Slack message: {err:?}");
                     }
                 }
                 NotificationChannel::PagerDuty(routing_key) => {
@@ -212,7 +211,7 @@ impl Notifier {
                     let url = "https://events.pagerduty.com/v2/enqueue";
 
                     if let Err(err) = self.client.post(url).json(&data).send() {
-                        warn!("Failed to send PagerDuty alert: {:?}", err);
+                        warn!("Failed to send PagerDuty alert: {err:?}");
                     }
                 }
 
@@ -221,7 +220,7 @@ impl Notifier {
                     let url = format!("https://api.telegram.org/bot{bot_token}/sendMessage");
 
                     if let Err(err) = self.client.post(url).json(&data).send() {
-                        warn!("Failed to send Telegram message: {:?}", err);
+                        warn!("Failed to send Telegram message: {err:?}");
                     }
                 }
 
@@ -236,11 +235,11 @@ impl Notifier {
                     );
                     let params = [("To", to), ("From", from), ("Body", &msg.to_string())];
                     if let Err(err) = self.client.post(url).form(&params).send() {
-                        warn!("Failed to send Twilio message: {:?}", err);
+                        warn!("Failed to send Twilio message: {err:?}");
                     }
                 }
                 NotificationChannel::Log(level) => {
-                    log!(*level, "{}", msg)
+                    log!(*level, "{msg}")
                 }
             }
         }

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -171,7 +171,7 @@ mod tests {
             let mut batches =
                 to_packet_batches(&(0..1000).map(|_| test_tx()).collect::<Vec<_>>(), 128);
             discard += dedup_packets_and_count_discards(&filter, &mut batches) as usize;
-            trace!("{} {}", i, discard);
+            trace!("{i} {discard}");
             if filter.popcount.load(Ordering::Relaxed) > capacity {
                 break;
             }

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -685,7 +685,7 @@ impl PinnedPacketBatch {
                     // TODO: This should never happen. Instead the caller should
                     // break the payload into smaller messages, and here any errors
                     // should be propagated.
-                    error!("Couldn't write to packet {:?}. Data skipped.", e);
+                    error!("Couldn't write to packet {e:?}. Data skipped.");
                     packet.meta_mut().set_discard(true);
                 }
             } else {

--- a/perf/src/perf_libs.rs
+++ b/perf/src/perf_libs.rs
@@ -84,10 +84,10 @@ pub struct Api<'a> {
 static API: OnceLock<Container<Api>> = OnceLock::new();
 
 fn init(name: &OsStr) {
-    info!("Loading {:?}", name);
+    info!("Loading {name:?}");
     API.get_or_init(|| {
         unsafe { Container::load(name) }.unwrap_or_else(|err| {
-            error!("Unable to load {:?}: {}", name, err);
+            error!("Unable to load {name:?}: {err}");
             std::process::exit(1);
         })
     });
@@ -97,10 +97,10 @@ pub fn locate_perf_libs() -> Option<PathBuf> {
     let exe = env::current_exe().expect("Unable to get executable path");
     let perf_libs = exe.parent().unwrap().join("perf-libs");
     if perf_libs.is_dir() {
-        info!("perf-libs found at {:?}", perf_libs);
+        info!("perf-libs found at {perf_libs:?}");
         return Some(perf_libs);
     }
-    warn!("{:?} does not exist", perf_libs);
+    warn!("{perf_libs:?} does not exist");
     None
 }
 
@@ -108,10 +108,10 @@ fn find_cuda_home(perf_libs_path: &Path) -> Option<PathBuf> {
     if let Ok(cuda_home) = env::var("CUDA_HOME") {
         let path = PathBuf::from(cuda_home);
         if path.is_dir() {
-            info!("Using CUDA_HOME: {:?}", path);
+            info!("Using CUDA_HOME: {path:?}");
             return Some(path);
         }
-        warn!("Ignoring CUDA_HOME, not a path: {:?}", path);
+        warn!("Ignoring CUDA_HOME, not a path: {path:?}");
     }
 
     // Search /usr/local for a `cuda-` directory that matches a perf-libs subdirectory
@@ -130,7 +130,7 @@ fn find_cuda_home(perf_libs_path: &Path) -> Option<PathBuf> {
             continue;
         }
 
-        info!("CUDA installation found at {:?}", cuda_home);
+        info!("CUDA installation found at {cuda_home:?}");
         return Some(cuda_home);
     }
     None
@@ -141,7 +141,7 @@ pub fn append_to_ld_library_path(mut ld_library_path: String) {
         ld_library_path.push(':');
         ld_library_path.push_str(&env_value);
     }
-    info!("setting ld_library_path to: {:?}", ld_library_path);
+    info!("setting ld_library_path to: {ld_library_path:?}");
     env::set_var("LD_LIBRARY_PATH", ld_library_path);
 }
 
@@ -154,7 +154,7 @@ pub fn init_cuda() {
                 // to ensure the correct CUDA version is used
                 append_to_ld_library_path(cuda_lib64_dir.to_str().unwrap_or("").to_string())
             } else {
-                warn!("CUDA lib64 directory does not exist: {:?}", cuda_lib64_dir);
+                warn!("CUDA lib64 directory does not exist: {cuda_lib64_dir:?}");
             }
 
             let libcuda_crypt = perf_libs_path

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -47,7 +47,7 @@ pub struct RecyclerX<T> {
 impl<T: Default> Default for RecyclerX<T> {
     fn default() -> RecyclerX<T> {
         let id = thread_rng().gen_range(0..1000);
-        trace!("new recycler..{}", id);
+        trace!("new recycler..{id}");
         RecyclerX {
             gc: Mutex::default(),
             stats: RecyclerStats::default(),

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -541,9 +541,7 @@ fn invoke_cargo(config: &Config) {
     );
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
-        warn!(
-            "Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.",
-        );
+        warn!("Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.",);
         env::remove_var("RUSTFLAGS")
     }
     let target_rustflags = env::var(&cargo_target).ok();

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -202,8 +202,7 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
     }
     let latest_version = get_latest_platform_tools_version().unwrap_or_else(|err| {
         debug!(
-            "Can't get the latest version of platform-tools: {}. Using built-in version {}.",
-            err, builtin_version,
+            "Can't get the latest version of platform-tools: {err}. Using built-in version {builtin_version}.",
         );
         builtin_version.to_string()
     });
@@ -213,8 +212,7 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
         downloadable_version(requested_version)
     } else {
         warn!(
-            "Version {} is not valid, latest version is {}. Using the built-in version {}",
-            requested_version, latest_version, builtin_version,
+            "Version {requested_version} is not valid, latest version is {latest_version}. Using the built-in version {builtin_version}",
         );
         builtin_version.to_string()
     }
@@ -239,14 +237,14 @@ fn install_if_missing(
 ) -> Result<(), String> {
     if config.force_tools_install {
         if target_path.is_dir() {
-            debug!("Remove directory {:?}", target_path);
+            debug!("Remove directory {target_path:?}");
             fs::remove_dir_all(target_path).map_err(|err| err.to_string())?;
         }
         let source_base = config.sbf_sdk.join("dependencies");
         if source_base.exists() {
             let source_path = source_base.join(package);
             if source_path.exists() {
-                debug!("Remove file {:?}", source_path);
+                debug!("Remove file {source_path:?}");
                 fs::remove_file(source_path).map_err(|err| err.to_string())?;
             }
         }
@@ -262,7 +260,7 @@ fn install_if_missing(
             .next()
             .is_none()
     {
-        debug!("Remove directory {:?}", target_path);
+        debug!("Remove directory {target_path:?}");
         fs::remove_dir(target_path).map_err(|err| err.to_string())?;
     }
 
@@ -275,7 +273,7 @@ fn install_if_missing(
             .unwrap_or(false)
     {
         if target_path.exists() {
-            debug!("Remove file {:?}", target_path);
+            debug!("Remove file {target_path:?}");
             fs::remove_file(target_path).map_err(|err| err.to_string())?;
         }
         fs::create_dir_all(target_path).map_err(|err| err.to_string())?;
@@ -358,7 +356,7 @@ fn link_solana_toolchain(config: &Config) {
         config.generate_child_script_on_failure,
     );
     if config.verbose {
-        debug!("{}", rustup_output);
+        debug!("{rustup_output}");
     }
     let mut do_link = true;
     for line in rustup_output.lines() {
@@ -374,7 +372,7 @@ fn link_solana_toolchain(config: &Config) {
                     config.generate_child_script_on_failure,
                 );
                 if config.verbose {
-                    debug!("{}", output);
+                    debug!("{output}");
                 }
             } else {
                 do_link = false;
@@ -395,7 +393,7 @@ fn link_solana_toolchain(config: &Config) {
             config.generate_child_script_on_failure,
         );
         if config.verbose {
-            debug!("{}", output);
+            debug!("{output}");
         }
     }
 }
@@ -462,7 +460,7 @@ fn install_tools(
                     exit(1);
                 });
             }
-            error!("Failed to install platform-tools: {}", err);
+            error!("Failed to install platform-tools: {err}");
             exit(1);
         });
     }
@@ -500,7 +498,7 @@ fn prepare_environment(
     };
 
     env::set_current_dir(root_dir).unwrap_or_else(|err| {
-        error!("Unable to set current directory to {}: {}", root_dir, err);
+        error!("Unable to set current directory to {root_dir}: {err}");
         exit(1);
     });
 
@@ -544,8 +542,7 @@ fn invoke_cargo(config: &Config) {
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
         warn!(
-            "Removed RUSTFLAGS from cargo environment, because it overrides {}.",
-            cargo_target,
+            "Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.",
         );
         env::remove_var("RUSTFLAGS")
     }
@@ -611,7 +608,7 @@ fn invoke_cargo(config: &Config) {
     );
 
     if config.verbose {
-        debug!("{}", output);
+        debug!("{output}");
     }
 }
 
@@ -621,7 +618,7 @@ fn check_solana_target_installed(target: &str) {
     let rustc = PathBuf::from(rustc);
     let output = spawn(&rustc, ["--print", "target-list"], false);
     if !output.contains(target) {
-        error!("Provided {:?} does not have {} target. The Solana rustc must be available in $PATH or the $RUSTC environment variable for the build to succeed.", rustc, target);
+        error!("Provided {rustc:?} does not have {target} target. The Solana rustc must be available in $PATH or the $RUSTC environment variable for the build to succeed.");
         exit(1);
     }
 }
@@ -677,7 +674,7 @@ fn build_solana(config: Config, manifest_path: Option<PathBuf>) {
     }
 
     let metadata = metadata_command.exec().unwrap_or_else(|err| {
-        error!("Failed to obtain package metadata: {}", err);
+        error!("Failed to obtain package metadata: {err}");
         exit(1);
     });
 
@@ -971,8 +968,8 @@ fn main() {
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {
-        debug!("{:?}", config);
-        debug!("manifest_path: {:?}", manifest_path);
+        debug!("{config:?}");
+        debug!("manifest_path: {manifest_path:?}");
     }
     build_solana(config, manifest_path);
 }

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -85,7 +85,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 config.generate_child_script_on_failure,
             );
             if config.verbose {
-                debug!("{}", output);
+                debug!("{output}");
             }
         }
 
@@ -108,7 +108,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                     config.generate_child_script_on_failure,
                 );
                 if config.verbose {
-                    debug!("{}", output);
+                    debug!("{output}");
                 }
             }
             postprocess_dump(&program_dump);
@@ -130,7 +130,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 config.generate_child_script_on_failure,
             );
             if config.verbose {
-                debug!("{}", output);
+                debug!("{output}");
             }
         }
 
@@ -179,7 +179,7 @@ fn check_undefined_symbols(config: &Config, program: &Path) {
         config.generate_child_script_on_failure,
     );
     if config.verbose {
-        debug!("{}", output);
+        debug!("{output}");
     }
     let mut unresolved_symbols: Vec<String> = Vec::new();
     for line in output.lines() {
@@ -194,8 +194,7 @@ fn check_undefined_symbols(config: &Config, program: &Path) {
     }
     if !unresolved_symbols.is_empty() {
         warn!(
-            "The following functions are undefined and not known syscalls {:?}.",
-            unresolved_symbols
+            "The following functions are undefined and not known syscalls {unresolved_symbols:?}."
         );
         warn!("         Calling them will trigger a run-time error.");
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -22,7 +22,7 @@ where
         .iter()
         .map(|arg| arg.as_ref().to_str().unwrap_or("?"))
         .join(" ");
-    info!("spawn: {:?} {}", program, msg);
+    info!("spawn: {program:?} {msg}");
 
     let child = Command::new(program)
         .args(args)
@@ -49,11 +49,10 @@ where
             writeln!(out, "{key}=\"{value}\" \\").unwrap();
         }
         write!(out, "{}", program.display()).unwrap();
-        writeln!(out, "{}", msg).unwrap();
+        writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
         error!(
-            "To rerun the failed command for debugging use {}",
-            script_name,
+            "To rerun the failed command for debugging use {script_name}",
         );
         exit(1);
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -51,9 +51,7 @@ where
         write!(out, "{}", program.display()).unwrap();
         writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
-        error!(
-            "To rerun the failed command for debugging use {script_name}",
-        );
+        error!("To rerun the failed command for debugging use {script_name}",);
         exit(1);
     }
     output

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -95,9 +95,7 @@ where
         write!(out, "{}", program.display()).unwrap();
         writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
-        error!(
-            "To rerun the failed command for debugging use {script_name}",
-        );
+        error!("To rerun the failed command for debugging use {script_name}",);
         exit(1);
     }
 }

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -67,7 +67,7 @@ where
         .iter()
         .map(|arg| arg.as_ref().to_str().unwrap_or("?"))
         .join(" ");
-    info!("spawn: {}", msg);
+    info!("spawn: {msg}");
 
     let mut child = Command::new(program)
         .args(args)
@@ -93,11 +93,10 @@ where
             writeln!(out, "{key}=\"{value}\" \\").unwrap();
         }
         write!(out, "{}", program.display()).unwrap();
-        writeln!(out, "{}", msg).unwrap();
+        writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
         error!(
-            "To rerun the failed command for debugging use {}",
-            script_name,
+            "To rerun the failed command for debugging use {script_name}",
         );
         exit(1);
     }
@@ -219,7 +218,7 @@ fn test_solana(config: Config, manifest_path: Option<PathBuf>) {
     }
 
     let metadata = metadata_command.exec().unwrap_or_else(|err| {
-        error!("Failed to obtain package metadata: {}", err);
+        error!("Failed to obtain package metadata: {err}");
         exit(1);
     });
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -582,7 +582,7 @@ impl PohRecorder {
             self.clear_bank();
         }
         if send_result.is_err() {
-            info!("WorkingBank::sender disconnected {:?}", send_result);
+            info!("WorkingBank::sender disconnected {send_result:?}");
             // revert the cache, but clear the working bank
             self.clear_bank();
         } else {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -243,8 +243,7 @@ impl ProgramCacheStats {
         let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         let water_level = self.water_level.load(Ordering::Relaxed);
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {}, Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}, Water-Level: {}",
-            hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries, water_level
+            "Loaded Programs Cache Stats -- Hits: {hits}, Misses: {misses}, Evictions: {evictions}, Reloads: {reloads}, Insertions: {insertions}, Lost-Insertions: {lost_insertions}, Replacements: {replacements}, One-Hit-Wonders: {one_hit_wonders}, Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: {empty_entries}, Water-Level: {water_level}"
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
@@ -902,7 +901,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             ) => {}
                             _ => {
                                 // Something is wrong, I can feel it ...
-                                error!("ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
+                                error!("ProgramCache::assign_program() failed key={key:?} existing={slot_versions:?} entry={entry:?}");
                                 debug_assert!(false, "Unexpected replacement of an entry");
                                 self.stats.replacements.fetch_add(1, Ordering::Relaxed);
                                 return true;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -462,7 +462,7 @@ fn default_shared_object_dirs() -> Vec<PathBuf> {
     if let Ok(dir) = std::env::current_dir() {
         search_path.push(dir);
     }
-    trace!("SBF .so search path: {:?}", search_path);
+    trace!("SBF .so search path: {search_path:?}");
     search_path
 }
 
@@ -723,9 +723,8 @@ impl ProgramTest {
             }
 
             warn!(
-                "Possible bogus program name. Ensure the program name ({}) \
+                "Possible bogus program name. Ensure the program name ({program_name}) \
                 matches one of the following recognizable program names:",
-                program_name,
             );
             for name in valid_program_names {
                 warn!(" - {}", name.to_str().unwrap());
@@ -766,7 +765,7 @@ impl ProgramTest {
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
     ) {
-        info!("\"{}\" builtin program", program_name);
+        info!("\"{program_name}\" builtin program");
         self.builtin_programs.push((
             program_id,
             program_name,
@@ -829,16 +828,14 @@ impl ProgramTest {
         for deactivate_feature_pk in &self.deactivate_feature_set {
             if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
                 match genesis_config.accounts.remove(deactivate_feature_pk) {
-                    Some(_) => debug!("Feature for {:?} deactivated", deactivate_feature_pk),
+                    Some(_) => debug!("Feature for {deactivate_feature_pk:?} deactivated"),
                     None => warn!(
-                        "Feature {:?} set for deactivation not found in genesis_config account list, ignored.",
-                        deactivate_feature_pk
+                        "Feature {deactivate_feature_pk:?} set for deactivation not found in genesis_config account list, ignored."
                     ),
                 }
             } else {
                 warn!(
-                    "Feature {:?} set for deactivation is not a known Feature public key",
-                    deactivate_feature_pk
+                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
                 );
             }
         }
@@ -846,7 +843,7 @@ impl ProgramTest {
         let target_tick_duration = Duration::from_micros(100);
         genesis_config.poh_config = PohConfig::new_sleep(target_tick_duration);
         debug!("Payer address: {}", mint_keypair.pubkey());
-        debug!("Genesis config: {}", genesis_config);
+        debug!("Genesis config: {genesis_config}");
 
         let bank = Bank::new_with_paths(
             &genesis_config,
@@ -893,7 +890,7 @@ impl ProgramTest {
 
         for (address, account) in self.accounts.iter() {
             if bank.get_account(address).is_some() {
-                info!("Overriding account at {}", address);
+                info!("Overriding account at {address}");
             }
             bank.store_account(address, account);
         }
@@ -1000,7 +997,7 @@ impl ProgramTestBanksClientExt for BanksClient {
             if new_blockhash != *blockhash {
                 return Ok(new_blockhash);
             }
-            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            debug!("Got same blockhash ({blockhash:?}), will retry...");
 
             tokio::time::sleep(Duration::from_millis(200)).await;
             num_retries += 1;

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -240,7 +240,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         program_test.add_account(stake_pubkey, stake_account);
         to_filter.push(stake_pubkey);
         if i % 100 == 0 {
-            debug!("create stake account {} {}", i, stake_pubkey);
+            debug!("create stake account {i} {stake_pubkey}");
         }
     }
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2288,7 +2288,7 @@ mod tests {
         // zero len
         let good_data = vec![1u8, 2, 3, 4, 5];
         let data: Vec<u8> = vec![];
-        assert_eq!(0x1 as *const u8, data.as_ptr());
+        assert_eq!(std::ptr::dangling::<u8>(), data.as_ptr());
         let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(&good_data, 0x100000000)],
             &config,

--- a/programs/stake-tests/tests/test_move_stake_and_lamports.rs
+++ b/programs/stake-tests/tests/test_move_stake_and_lamports.rs
@@ -271,7 +271,7 @@ async fn process_instruction<T: Signers + ?Sized>(
                 TransactionError::InsufficientFundsForRent { .. } => {
                     Err(ProgramError::InsufficientFunds)
                 }
-                _ => panic!("couldnt convert {:?} to ProgramError", e),
+                _ => panic!("couldnt convert {e:?} to ProgramError"),
             }
         }
     }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -53,7 +53,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
 
-    trace!("process_instruction: {:?}", data);
+    trace!("process_instruction: {data:?}");
 
     let get_stake_account = || {
         let me = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -305,7 +305,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction =
         limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)?;
 
-    trace!("process_instruction: {:?}", instruction);
+    trace!("process_instruction: {instruction:?}");
 
     let signers = instruction_context.get_signers(transaction_context)?;
     match instruction {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -55,7 +55,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
 
-    trace!("process_instruction: {:?}", data);
+    trace!("process_instruction: {data:?}");
 
     let mut me = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
     if *me.get_owner() != id() {

--- a/pubsub-client/src/nonblocking/pubsub_client.rs
+++ b/pubsub-client/src/nonblocking/pubsub_client.rs
@@ -627,7 +627,7 @@ impl PubsubClient {
                                 }
                             }
                         } else {
-                            error!("Unknown request id: {}", id);
+                            error!("Unknown request id: {id}");
                             break;
                         }
                         continue;

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -324,8 +324,7 @@ fn connect_with_retry(
 
                 connection_retries -= 1;
                 debug!(
-                    "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
-                    response, connection_retries, duration
+                    "Too many requests: server responded with {response:?}, {connection_retries} retries left, pausing for {duration:?}"
                 );
 
                 sleep(duration);
@@ -785,7 +784,7 @@ impl PubsubClient {
         let handler = move |message| match sender.send(message) {
             Ok(_) => (),
             Err(err) => {
-                info!("receive error: {:?}", err);
+                info!("receive error: {err:?}");
             }
         };
         Self::cleanup_with_handler(exit, socket, handler);
@@ -810,7 +809,7 @@ impl PubsubClient {
                     // Nothing useful, means we received a ping message
                 }
                 Err(err) => {
-                    info!("receive error: {:?}", err);
+                    info!("receive error: {err:?}");
                     break;
                 }
             }

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -267,7 +267,7 @@ impl LedgerWallet {
         }
         let status =
             ((message[message.len() - 2] as usize) << 8) | (message[message.len() - 1] as usize);
-        trace!("Read status {:x}", status);
+        trace!("Read status {status:x}");
         Self::parse_status(status)?;
         let new_len = message.len() - 2;
         message.truncate(new_len);

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -127,7 +127,7 @@ impl RemoteWalletManager {
                         Ok(info) => {
                             ledger.pretty_path = info.get_pretty_path();
                             let path = device_info.path().to_str().unwrap().to_string();
-                            trace!("Found device: {:?}", info);
+                            trace!("Found device: {info:?}");
                             detected_devices.push(Device {
                                 path,
                                 info,
@@ -135,12 +135,12 @@ impl RemoteWalletManager {
                             })
                         }
                         Err(err) => {
-                            error!("Error connecting to ledger device to read info: {}", err);
+                            error!("Error connecting to ledger device to read info: {err}");
                             errors.push(err)
                         }
                     }
                 }
-                Err(err) => error!("Error connecting to ledger device to read info: {}", err),
+                Err(err) => error!("Error connecting to ledger device to read info: {err}"),
             }
         }
 
@@ -198,7 +198,7 @@ impl RemoteWalletManager {
         while start_time.elapsed() <= *max_polling_duration {
             if let Ok(num_devices) = self.update_devices() {
                 let plural = if num_devices == 1 { "" } else { "s" };
-                trace!("{} Remote Wallet{} found", num_devices, plural);
+                trace!("{num_devices} Remote Wallet{plural} found");
                 return true;
             }
         }

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -174,8 +174,7 @@ impl RpcSender for HttpSender {
 
                     too_many_requests_retries -= 1;
                     debug!(
-                                "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
-                                response, too_many_requests_retries, duration
+                                "Too many requests: server responded with {response:?}, {too_many_requests_retries} retries left, pausing for {duration:?}"
                             );
 
                     sleep(duration).await;
@@ -194,7 +193,7 @@ impl RpcSender for HttpSender {
                                         match serde_json::from_value::<RpcSimulateTransactionResult>(json["error"]["data"].clone()) {
                                             Ok(data) => RpcResponseErrorData::SendTransactionPreflightFailure(data),
                                             Err(err) => {
-                                                debug!("Failed to deserialize RpcSimulateTransactionResult: {:?}", err);
+                                                debug!("Failed to deserialize RpcSimulateTransactionResult: {err:?}");
                                                 RpcResponseErrorData::Empty
                                             }
                                         }

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -989,7 +989,7 @@ impl RpcClient {
                     data,
                 }) = err.kind()
                 {
-                    debug!("{} {}", code, message);
+                    debug!("{code} {message}");
                     if let RpcResponseErrorData::SendTransactionPreflightFailure(
                         RpcSimulateTransactionResult {
                             logs: Some(logs), ..
@@ -2316,8 +2316,7 @@ impl RpcClient {
             }
 
             info!(
-                "Waiting for stake to drop below {} current: {:.1}",
-                max_stake_percent, current_percent
+                "Waiting for stake to drop below {max_stake_percent} current: {current_percent:.1}"
             );
             sleep(Duration::from_secs(5)).await;
         }
@@ -2945,7 +2944,7 @@ impl RpcClient {
                 }
                 let result = serde_json::from_value(result_json)
                     .map_err(|err| ClientError::new_with_request(err.into(), request))?;
-                trace!("Response block timestamp {:?} {:?}", slot, result);
+                trace!("Response block timestamp {slot:?} {result:?}");
                 Ok(result)
             })
             .map_err(|err| err.into_with_request(request))?
@@ -3604,7 +3603,7 @@ impl RpcClient {
                     context,
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                trace!("Response account {pubkey:?} {rpc_account:?}");
                 let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
 
                 Ok(Response {
@@ -3892,9 +3891,7 @@ impl RpcClient {
         let minimum_balance: u64 = serde_json::from_value(minimum_balance_json)
             .map_err(|err| ClientError::new_with_request(err.into(), request))?;
         trace!(
-            "Response minimum balance {:?} {:?}",
-            data_len,
-            minimum_balance
+            "Response minimum balance {data_len:?} {minimum_balance:?}"
         );
         Ok(minimum_balance)
     }
@@ -4227,7 +4224,7 @@ impl RpcClient {
                     context,
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                trace!("Response account {pubkey:?} {rpc_account:?}");
                 let response = {
                     if let Some(rpc_account) = rpc_account {
                         if let UiAccountData::Json(account_data) = rpc_account.data {
@@ -4514,10 +4511,7 @@ impl RpcClient {
                 return balance_result;
             }
             trace!(
-                "wait_for_balance_with_commitment [{}] {:?} {:?}",
-                run,
-                balance_result,
-                expected_balance
+                "wait_for_balance_with_commitment [{run}] {balance_result:?} {expected_balance:?}"
             );
             if let (Some(expected_balance), Ok(balance_result)) = (expected_balance, balance_result)
             {
@@ -4591,7 +4585,7 @@ impl RpcClient {
                     }
                 }
                 Err(err) => {
-                    debug!("check_confirmations request failed: {:?}", err);
+                    debug!("check_confirmations request failed: {err:?}");
                 }
             };
             if now.elapsed().as_secs() > 20 {
@@ -4707,7 +4701,7 @@ impl RpcClient {
                     return Ok(new_blockhash);
                 }
             }
-            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            debug!("Got same blockhash ({blockhash:?}), will retry...");
 
             // Retry ~twice during a slot
             sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2)).await;

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3890,9 +3890,7 @@ impl RpcClient {
 
         let minimum_balance: u64 = serde_json::from_value(minimum_balance_json)
             .map_err(|err| ClientError::new_with_request(err.into(), request))?;
-        trace!(
-            "Response minimum balance {data_len:?} {minimum_balance:?}"
-        );
+        trace!("Response minimum balance {data_len:?} {minimum_balance:?}");
         Ok(minimum_balance)
     }
 

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -83,7 +83,7 @@ fn test_rpc_send_tx() {
         .parse()
         .unwrap();
 
-    info!("blockhash: {:?}", blockhash);
+    info!("blockhash: {blockhash:?}");
     let tx = system_transaction::transfer(
         &alice,
         &bob_pubkey,
@@ -442,7 +442,7 @@ fn test_rpc_subscriptions() {
         sleep(Duration::from_millis(100));
     }
     if mint_balance != expected_mint_balance {
-        error!("mint-check timeout. mint_balance {:?}", mint_balance);
+        error!("mint-check timeout. mint_balance {mint_balance:?}");
     }
 
     // Wait for all signature subscriptions

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -165,9 +165,7 @@ impl OptimisticallyConfirmedBankTracker {
                 match sender.send(notification.clone()) {
                     Ok(_) => {}
                     Err(err) => {
-                        info!(
-                            "Failed to send notification {notification:?}, error: {err:?}"
-                        );
+                        info!("Failed to send notification {notification:?}, error: {err:?}");
                     }
                 }
             }
@@ -249,9 +247,7 @@ impl OptimisticallyConfirmedBankTracker {
             let root = roots[i];
             if root > *newest_root_slot {
                 let parent = roots[i - 1];
-                debug!(
-                    "Doing SlotNotification::Root for root {root}, parent: {parent}"
-                );
+                debug!("Doing SlotNotification::Root for root {root}, parent: {parent}");
                 Self::notify_slot_status(
                     slot_notification_subscribers,
                     SlotNotification::Root((root, parent)),

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -166,8 +166,7 @@ impl OptimisticallyConfirmedBankTracker {
                     Ok(_) => {}
                     Err(err) => {
                         info!(
-                            "Failed to send notification {:?}, error: {:?}",
-                            notification, err
+                            "Failed to send notification {notification:?}, error: {err:?}"
                         );
                     }
                 }
@@ -251,8 +250,7 @@ impl OptimisticallyConfirmedBankTracker {
             if root > *newest_root_slot {
                 let parent = roots[i - 1];
                 debug!(
-                    "Doing SlotNotification::Root for root {}, parent: {}",
-                    root, parent
+                    "Doing SlotNotification::Root for root {root}, parent: {parent}"
                 );
                 Self::notify_slot_status(
                     slot_notification_subscribers,
@@ -276,7 +274,7 @@ impl OptimisticallyConfirmedBankTracker {
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
         prioritization_fee_cache: &PrioritizationFeeCache,
     ) {
-        debug!("received bank notification: {:?}", notification);
+        debug!("received bank notification: {notification:?}");
         match notification {
             BankNotification::OptimisticallyConfirmed(slot) => {
                 let bank = bank_forks.read().unwrap().get(slot);
@@ -344,8 +342,7 @@ impl OptimisticallyConfirmedBankTracker {
 
                 if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
                     debug!(
-                        "Calling notify_gossip_subscribers to send deferred notification {:?}",
-                        frozen_slot
+                        "Calling notify_gossip_subscribers to send deferred notification {frozen_slot:?}"
                     );
 
                     Self::notify_or_defer_confirmed_banks(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3006,9 +3006,7 @@ pub mod rpc_bank {
             data_len: usize,
             commitment: Option<CommitmentConfig>,
         ) -> Result<u64> {
-            debug!(
-                "get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}"
-            );
+            debug!("get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}");
             if data_len as u64 > solana_system_interface::MAX_PERMITTED_DATA_LENGTH {
                 return Err(Error::invalid_request());
             }
@@ -3049,9 +3047,7 @@ pub mod rpc_bank {
             start_slot: Slot,
             limit: u64,
         ) -> Result<Vec<String>> {
-            debug!(
-                "get_slot_leaders rpc request received (start: {start_slot} limit: {limit})"
-            );
+            debug!("get_slot_leaders rpc request received (start: {start_slot} limit: {limit})");
 
             let limit = limit as usize;
             if limit > MAX_GET_SLOT_LEADERS {
@@ -3271,9 +3267,7 @@ pub mod rpc_accounts {
             pubkey_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
-            debug!(
-                "get_token_account_balance rpc request received: {pubkey_str:?}"
-            );
+            debug!("get_token_account_balance rpc request received: {pubkey_str:?}");
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_token_account_balance(&pubkey, commitment)
         }
@@ -3363,9 +3357,7 @@ pub mod rpc_accounts_scan {
             program_id_str: String,
             config: Option<RpcProgramAccountsConfig>,
         ) -> BoxFuture<Result<OptionalContext<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_program_accounts rpc request received: {program_id_str:?}"
-            );
+            debug!("get_program_accounts rpc request received: {program_id_str:?}");
             async move {
                 let program_id = verify_pubkey(&program_id_str)?;
                 let (config, filters, with_context, sort_results) = if let Some(config) = config {
@@ -3409,9 +3401,7 @@ pub mod rpc_accounts_scan {
             mint_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcTokenAccountBalance>>>> {
-            debug!(
-                "get_token_largest_accounts rpc request received: {mint_str:?}"
-            );
+            debug!("get_token_largest_accounts rpc request received: {mint_str:?}");
             async move {
                 let mint = verify_pubkey(&mint_str)?;
                 meta.get_token_largest_accounts(mint, commitment).await
@@ -3426,9 +3416,7 @@ pub mod rpc_accounts_scan {
             token_account_filter: RpcTokenAccountsFilter,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_token_accounts_by_owner rpc request received: {owner_str:?}"
-            );
+            debug!("get_token_accounts_by_owner rpc request received: {owner_str:?}");
             async move {
                 let owner = verify_pubkey(&owner_str)?;
                 let token_account_filter = verify_token_account_filter(token_account_filter)?;
@@ -3445,9 +3433,7 @@ pub mod rpc_accounts_scan {
             token_account_filter: RpcTokenAccountsFilter,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_token_accounts_by_delegate rpc request received: {delegate_str:?}"
-            );
+            debug!("get_token_accounts_by_delegate rpc request received: {delegate_str:?}");
             async move {
                 let delegate = verify_pubkey(&delegate_str)?;
                 let token_account_filter = verify_token_account_filter(token_account_filter)?;
@@ -4100,9 +4086,7 @@ pub mod rpc_full {
         ) -> BoxFuture<Result<Vec<Slot>>> {
             let (end_slot, maybe_config) =
                 wrapper.map(|wrapper| wrapper.unzip()).unwrap_or_default();
-            debug!(
-                "get_blocks rpc request received: {start_slot}-{end_slot:?}"
-            );
+            debug!("get_blocks rpc request received: {start_slot}-{end_slot:?}");
             Box::pin(async move {
                 meta.get_blocks(start_slot, end_slot, config.or(maybe_config))
                     .await
@@ -4116,9 +4100,7 @@ pub mod rpc_full {
             limit: usize,
             config: Option<RpcContextConfig>,
         ) -> BoxFuture<Result<Vec<Slot>>> {
-            debug!(
-                "get_blocks_with_limit rpc request received: {start_slot}-{limit}",
-            );
+            debug!("get_blocks_with_limit rpc request received: {start_slot}-{limit}",);
             Box::pin(async move { meta.get_blocks_with_limit(start_slot, limit, config).await })
         }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -344,7 +344,7 @@ impl JsonRpcRequestProcessor {
 
     #[allow(deprecated)]
     fn bank(&self, commitment: Option<CommitmentConfig>) -> Arc<Bank> {
-        debug!("RPC commitment_config: {:?}", commitment);
+        debug!("RPC commitment_config: {commitment:?}");
 
         let commitment = commitment.unwrap_or_default();
         if commitment.is_confirmed() {
@@ -366,10 +366,10 @@ impl JsonRpcRequestProcessor {
 
         match commitment.commitment {
             CommitmentLevel::Processed => {
-                debug!("RPC using the heaviest slot: {:?}", slot);
+                debug!("RPC using the heaviest slot: {slot:?}");
             }
             CommitmentLevel::Finalized => {
-                debug!("RPC using block: {:?}", slot);
+                debug!("RPC using block: {slot:?}");
             }
             CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
         };
@@ -1016,7 +1016,7 @@ impl JsonRpcRequestProcessor {
                 None => Err(Error::invalid_request()),
             },
             Err(err) => {
-                warn!("slot_meta_iterator failed: {:?}", err);
+                warn!("slot_meta_iterator failed: {err:?}");
                 Err(Error::invalid_request())
             }
         }
@@ -1897,7 +1897,7 @@ impl JsonRpcRequestProcessor {
                             bigtable_before = None;
                         }
                         Err(err) => {
-                            warn!("Failed to query Bigtable: {:?}", err);
+                            warn!("Failed to query Bigtable: {err:?}");
                             return Err(RpcCustomError::LongTermStorageUnreachable.into());
                         }
                         Ok(_) => {}
@@ -1929,7 +1929,7 @@ impl JsonRpcRequestProcessor {
                     }
                     Err(StorageError::SignatureNotFound) => {}
                     Err(err) => {
-                        warn!("Failed to query Bigtable: {:?}", err);
+                        warn!("Failed to query Bigtable: {err:?}");
                         return Err(RpcCustomError::LongTermStorageUnreachable.into());
                     }
                 }
@@ -2591,8 +2591,7 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
     {
         if let Some(incorrect_owner_len) = incorrect_owner_len {
             info!(
-                "Incorrect num bytes ({:?}) provided for spl_token_owner_filter",
-                incorrect_owner_len
+                "Incorrect num bytes ({incorrect_owner_len:?}) provided for spl_token_owner_filter"
             );
         }
         owner_key
@@ -2642,8 +2641,7 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
     {
         if let Some(incorrect_mint_len) = incorrect_mint_len {
             info!(
-                "Incorrect num bytes ({:?}) provided for spl_token_mint_filter",
-                incorrect_mint_len
+                "Incorrect num bytes ({incorrect_mint_len:?}) provided for spl_token_mint_filter"
             );
         }
         mint
@@ -2703,7 +2701,7 @@ fn _send_transaction(
     );
     meta.transaction_sender
         .send(transaction_info)
-        .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {}", err));
+        .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {err}"));
 
     Ok(signature.to_string())
 }
@@ -2792,7 +2790,7 @@ pub mod rpc_minimal {
             pubkey_str: String,
             config: Option<RpcContextConfig>,
         ) -> Result<RpcResponse<u64>> {
-            debug!("get_balance rpc request received: {:?}", pubkey_str);
+            debug!("get_balance rpc request received: {pubkey_str:?}");
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_balance(&pubkey, config.unwrap_or_default())
         }
@@ -2927,7 +2925,7 @@ pub mod rpc_minimal {
             let slot = slot.unwrap_or_else(|| bank.slot());
             let epoch = bank.epoch_schedule().get_epoch(slot);
 
-            debug!("get_leader_schedule rpc request received: {:?}", slot);
+            debug!("get_leader_schedule rpc request received: {slot:?}");
 
             Ok(meta
                 .leader_schedule_cache
@@ -3009,8 +3007,7 @@ pub mod rpc_bank {
             commitment: Option<CommitmentConfig>,
         ) -> Result<u64> {
             debug!(
-                "get_minimum_balance_for_rent_exemption rpc request received: {:?}",
-                data_len
+                "get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}"
             );
             if data_len as u64 > solana_system_interface::MAX_PERMITTED_DATA_LENGTH {
                 return Err(Error::invalid_request());
@@ -3053,8 +3050,7 @@ pub mod rpc_bank {
             limit: u64,
         ) -> Result<Vec<String>> {
             debug!(
-                "get_slot_leaders rpc request received (start: {} limit: {})",
-                start_slot, limit
+                "get_slot_leaders rpc request received (start: {start_slot} limit: {limit})"
             );
 
             let limit = limit as usize;
@@ -3223,7 +3219,7 @@ pub mod rpc_accounts {
             pubkey_str: String,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Option<UiAccount>>>> {
-            debug!("get_account_info rpc request received: {:?}", pubkey_str);
+            debug!("get_account_info rpc request received: {pubkey_str:?}");
             async move {
                 let pubkey = verify_pubkey(&pubkey_str)?;
                 meta.get_account_info(pubkey, config).await
@@ -3276,8 +3272,7 @@ pub mod rpc_accounts {
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
             debug!(
-                "get_token_account_balance rpc request received: {:?}",
-                pubkey_str
+                "get_token_account_balance rpc request received: {pubkey_str:?}"
             );
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_token_account_balance(&pubkey, commitment)
@@ -3289,7 +3284,7 @@ pub mod rpc_accounts {
             mint_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
-            debug!("get_token_supply rpc request received: {:?}", mint_str);
+            debug!("get_token_supply rpc request received: {mint_str:?}");
             let mint = verify_pubkey(&mint_str)?;
             meta.get_token_supply(&mint, commitment)
         }
@@ -3369,8 +3364,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcProgramAccountsConfig>,
         ) -> BoxFuture<Result<OptionalContext<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_program_accounts rpc request received: {:?}",
-                program_id_str
+                "get_program_accounts rpc request received: {program_id_str:?}"
             );
             async move {
                 let program_id = verify_pubkey(&program_id_str)?;
@@ -3416,8 +3410,7 @@ pub mod rpc_accounts_scan {
             commitment: Option<CommitmentConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcTokenAccountBalance>>>> {
             debug!(
-                "get_token_largest_accounts rpc request received: {:?}",
-                mint_str
+                "get_token_largest_accounts rpc request received: {mint_str:?}"
             );
             async move {
                 let mint = verify_pubkey(&mint_str)?;
@@ -3434,8 +3427,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_token_accounts_by_owner rpc request received: {:?}",
-                owner_str
+                "get_token_accounts_by_owner rpc request received: {owner_str:?}"
             );
             async move {
                 let owner = verify_pubkey(&owner_str)?;
@@ -3454,8 +3446,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_token_accounts_by_delegate rpc request received: {:?}",
-                delegate_str
+                "get_token_accounts_by_delegate rpc request received: {delegate_str:?}"
             );
             async move {
                 let delegate = verify_pubkey(&delegate_str)?;
@@ -3653,7 +3644,7 @@ pub mod rpc_full {
                 .blockstore
                 .get_recent_perf_samples(limit)
                 .map_err(|err| {
-                    warn!("get_recent_performance_samples failed: {:?}", err);
+                    warn!("get_recent_performance_samples failed: {err:?}");
                     Error::invalid_request()
                 })?
                 .into_iter()
@@ -3794,13 +3785,13 @@ pub mod rpc_full {
             let transaction =
                 request_airdrop_transaction(&faucet_addr, &pubkey, lamports, blockhash).map_err(
                     |err| {
-                        info!("request_airdrop_transaction failed: {:?}", err);
+                        info!("request_airdrop_transaction failed: {err:?}");
                         Error::internal_error()
                     },
                 )?;
 
             let wire_transaction = serialize(&transaction).map_err(|err| {
-                info!("request_airdrop: serialize error: {:?}", err);
+                info!("request_airdrop: serialize error: {err:?}");
                 Error::internal_error()
             })?;
 
@@ -4096,7 +4087,7 @@ pub mod rpc_full {
             slot: Slot,
             config: Option<RpcEncodingConfigWrapper<RpcBlockConfig>>,
         ) -> BoxFuture<Result<Option<UiConfirmedBlock>>> {
-            debug!("get_block rpc request received: {:?}", slot);
+            debug!("get_block rpc request received: {slot:?}");
             Box::pin(async move { meta.get_block(slot, config).await })
         }
 
@@ -4110,8 +4101,7 @@ pub mod rpc_full {
             let (end_slot, maybe_config) =
                 wrapper.map(|wrapper| wrapper.unzip()).unwrap_or_default();
             debug!(
-                "get_blocks rpc request received: {}-{:?}",
-                start_slot, end_slot
+                "get_blocks rpc request received: {start_slot}-{end_slot:?}"
             );
             Box::pin(async move {
                 meta.get_blocks(start_slot, end_slot, config.or(maybe_config))
@@ -4127,8 +4117,7 @@ pub mod rpc_full {
             config: Option<RpcContextConfig>,
         ) -> BoxFuture<Result<Vec<Slot>>> {
             debug!(
-                "get_blocks_with_limit rpc request received: {}-{}",
-                start_slot, limit,
+                "get_blocks_with_limit rpc request received: {start_slot}-{limit}",
             );
             Box::pin(async move { meta.get_blocks_with_limit(start_slot, limit, config).await })
         }
@@ -4147,7 +4136,7 @@ pub mod rpc_full {
             signature_str: String,
             config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
         ) -> BoxFuture<Result<Option<EncodedConfirmedTransactionWithStatusMeta>>> {
-            debug!("get_transaction rpc request received: {:?}", signature_str);
+            debug!("get_transaction rpc request received: {signature_str:?}");
             let signature = verify_signature(&signature_str);
             if let Err(err) = signature {
                 return Box::pin(future::err(err));
@@ -6468,11 +6457,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({
@@ -6512,11 +6500,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "innerInstructions": false, "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({
@@ -6556,11 +6543,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "innerInstructions": true, "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -87,7 +87,7 @@ impl PubSubService {
         pubsub_addr: SocketAddr,
     ) -> (Trigger, Self) {
         let subscription_control = subscriptions.control().clone();
-        info!("rpc_pubsub bound to {:?}", pubsub_addr);
+        info!("rpc_pubsub bound to {pubsub_addr:?}");
 
         let (trigger, tripwire) = Tripwire::new();
         let thread_hdl = Builder::new()
@@ -448,7 +448,7 @@ async fn listen(
         select! {
             result = listener.accept() => match result {
                 Ok((socket, addr)) => {
-                    debug!("new client ({:?})", addr);
+                    debug!("new client ({addr:?})");
                     let subscription_control = subscription_control.clone();
                     let config = config.clone();
                     let tripwire = tripwire.clone();
@@ -458,13 +458,13 @@ async fn listen(
                             socket, subscription_control, config, tripwire
                         );
                         match handle.await {
-                            Ok(()) => debug!("connection closed ({:?})", addr),
-                            Err(err) => warn!("connection handler error ({:?}): {}", addr, err),
+                            Ok(()) => debug!("connection closed ({addr:?})"),
+                            Err(err) => warn!("connection handler error ({addr:?}): {err}"),
                         }
                         drop(counter_token); // Force moving token into the task.
                     });
                 }
-                Err(e) => error!("couldn't accept connection: {:?}", e),
+                Err(e) => error!("couldn't accept connection: {e:?}"),
             },
             _ = &mut tripwire => return Ok(()),
         }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -272,7 +272,7 @@ impl RpcRequestMiddleware {
             .map(|m| m.len())
             .unwrap_or(0)
             .to_string();
-        info!("get {} -> {:?} ({} bytes)", path, filename, file_length);
+        info!("get {path} -> {filename:?} ({file_length} bytes)");
 
         if cfg!(not(test)) {
             assert!(
@@ -335,7 +335,7 @@ impl RpcRequestMiddleware {
             RpcHealthStatus::Behind { .. } => "behind",
             RpcHealthStatus::Unknown => "unknown",
         };
-        info!("health check: {}", response);
+        info!("health check: {response}");
         response
     }
 }
@@ -716,8 +716,8 @@ impl JsonRpcService {
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         runtime: Arc<TokioRuntime>,
     ) -> Result<Self, String> {
-        info!("rpc bound to {:?}", rpc_addr);
-        info!("rpc configuration: {:?}", config);
+        info!("rpc bound to {rpc_addr:?}");
+        info!("rpc configuration: {config:?}");
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let health = Arc::new(RpcHealth::new(
@@ -778,7 +778,7 @@ impl JsonRpcService {
                         )
                     })
                     .unwrap_or_else(|err| {
-                        error!("Failed to initialize BigTable ledger storage: {:?}", err);
+                        error!("Failed to initialize BigTable ledger storage: {err:?}");
                         (None, None)
                     })
             } else {

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -525,7 +525,7 @@ pub struct RpcSubscriptions {
 impl Drop for RpcSubscriptions {
     fn drop(&mut self) {
         self.shutdown().unwrap_or_else(|err| {
-            warn!("RPC Notification - shutdown error: {:?}", err);
+            warn!("RPC Notification - shutdown error: {err:?}");
         });
     }
 }
@@ -748,8 +748,7 @@ impl RpcSubscriptions {
                 Ok(()) => (),
                 Err(SendError(notification)) => {
                     warn!(
-                        "Dropped RPC Notification - receiver disconnected : {:?}",
-                        notification
+                        "Dropped RPC Notification - receiver disconnected : {notification:?}"
                     );
                 }
             }
@@ -797,7 +796,7 @@ impl RpcSubscriptions {
                                 .node_progress_watchers()
                                 .get(&SubscriptionParams::Slot)
                             {
-                                debug!("slot notify: {:?}", slot_info);
+                                debug!("slot notify: {slot_info:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-slot", 1);
                                 notifier.notify(slot_info, sub, false);
                             }
@@ -826,7 +825,7 @@ impl RpcSubscriptions {
                                     timestamp: vote_info.timestamp(),
                                     signature: signature.to_string(),
                                 };
-                                debug!("vote notify: {:?}", vote_info);
+                                debug!("vote notify: {vote_info:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-vote", 1);
                                 notifier.notify(&rpc_vote, sub, false);
                             }
@@ -836,7 +835,7 @@ impl RpcSubscriptions {
                                 .node_progress_watchers()
                                 .get(&SubscriptionParams::Root)
                             {
-                                debug!("root notify: {:?}", root);
+                                debug!("root notify: {root:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-root", 1);
                                 notifier.notify(root, sub, false);
                             }
@@ -1015,7 +1014,7 @@ impl RpcSubscriptions {
                                 let block_update_result = blockstore
                                     .get_complete_block(s, false)
                                     .map_err(|e| {
-                                        error!("get_complete_block error: {}", e);
+                                        error!("get_complete_block error: {e}");
                                         RpcBlockUpdateError::BlockStoreError
                                     })
                                     .and_then(|block| filter_block_result_txs(block, s, params));

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -747,9 +747,7 @@ impl RpcSubscriptions {
             match notification_sender.send(notification_entry.into()) {
                 Ok(()) => (),
                 Err(SendError(notification)) => {
-                    warn!(
-                        "Dropped RPC Notification - receiver disconnected : {notification:?}"
-                    );
+                    warn!("Dropped RPC Notification - receiver disconnected : {notification:?}");
                 }
             }
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2469,7 +2469,7 @@ impl Bank {
                 },
             )| {
                 if let Err(err) = vote_account.checked_add_lamports(vote_rewards) {
-                    debug!("reward redemption failed for {}: {:?}", vote_pubkey, err);
+                    debug!("reward redemption failed for {vote_pubkey}: {err:?}");
                     return;
                 }
 
@@ -3286,7 +3286,7 @@ impl Bank {
             },
         );
 
-        debug!("simulate_transaction: {:?}", timings);
+        debug!("simulate_transaction: {timings:?}");
 
         let processing_result = processing_results
             .pop()
@@ -3489,7 +3489,7 @@ impl Bank {
                 }
                 Err(err) => {
                     if err_count.0 == 0 {
-                        debug!("tx error: {:?} {:?}", err, tx);
+                        debug!("tx error: {err:?} {tx:?}");
                     }
                     *err_count += 1;
                 }
@@ -4145,18 +4145,14 @@ impl Bank {
                     std::cmp::Ordering::Greater => {
                         let increased = new_account.lamports() - old_account.lamports();
                         trace!(
-                            "store_account_and_update_capitalization: increased: {} {}",
-                            pubkey,
-                            increased
+                            "store_account_and_update_capitalization: increased: {pubkey} {increased}"
                         );
                         self.capitalization.fetch_add(increased, Relaxed);
                     }
                     std::cmp::Ordering::Less => {
                         let decreased = old_account.lamports() - new_account.lamports();
                         trace!(
-                            "store_account_and_update_capitalization: decreased: {} {}",
-                            pubkey,
-                            decreased
+                            "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
                         );
                         self.capitalization.fetch_sub(decreased, Relaxed);
                     }
@@ -5648,9 +5644,9 @@ impl Bank {
     }
 
     pub fn add_precompile(&mut self, program_id: &Pubkey) {
-        debug!("Adding precompiled program {}", program_id);
+        debug!("Adding precompiled program {program_id}");
         self.add_precompiled_account(program_id);
-        debug!("Added precompiled program {:?}", program_id);
+        debug!("Added precompiled program {program_id:?}");
     }
 
     // Call AccountsDb::clean_accounts()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4139,37 +4139,36 @@ impl Bank {
         pubkey: &Pubkey,
         new_account: &AccountSharedData,
     ) {
-        let old_account_data_size = if let Some(old_account) =
-            self.get_account_with_fixed_root_no_cache(pubkey)
-        {
-            match new_account.lamports().cmp(&old_account.lamports()) {
-                std::cmp::Ordering::Greater => {
-                    let increased = new_account.lamports() - old_account.lamports();
-                    trace!(
+        let old_account_data_size =
+            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
+                match new_account.lamports().cmp(&old_account.lamports()) {
+                    std::cmp::Ordering::Greater => {
+                        let increased = new_account.lamports() - old_account.lamports();
+                        trace!(
                         "store_account_and_update_capitalization: increased: {pubkey} {increased}"
                     );
-                    self.capitalization.fetch_add(increased, Relaxed);
-                }
-                std::cmp::Ordering::Less => {
-                    let decreased = old_account.lamports() - new_account.lamports();
-                    trace!(
+                        self.capitalization.fetch_add(increased, Relaxed);
+                    }
+                    std::cmp::Ordering::Less => {
+                        let decreased = old_account.lamports() - new_account.lamports();
+                        trace!(
                         "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
                     );
-                    self.capitalization.fetch_sub(decreased, Relaxed);
+                        self.capitalization.fetch_sub(decreased, Relaxed);
+                    }
+                    std::cmp::Ordering::Equal => {}
                 }
-                std::cmp::Ordering::Equal => {}
-            }
-            old_account.data().len()
-        } else {
-            trace!(
-                "store_account_and_update_capitalization: created: {} {}",
-                pubkey,
-                new_account.lamports()
-            );
-            self.capitalization
-                .fetch_add(new_account.lamports(), Relaxed);
-            0
-        };
+                old_account.data().len()
+            } else {
+                trace!(
+                    "store_account_and_update_capitalization: created: {} {}",
+                    pubkey,
+                    new_account.lamports()
+                );
+                self.capitalization
+                    .fetch_add(new_account.lamports(), Relaxed);
+                0
+            };
 
         self.store_account(pubkey, new_account);
         self.calculate_and_update_accounts_data_size_delta_off_chain(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4139,36 +4139,33 @@ impl Bank {
         pubkey: &Pubkey,
         new_account: &AccountSharedData,
     ) {
-        let old_account_data_size =
-            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
-                match new_account.lamports().cmp(&old_account.lamports()) {
-                    std::cmp::Ordering::Greater => {
-                        let increased = new_account.lamports() - old_account.lamports();
-                        trace!(
-                        "store_account_and_update_capitalization: increased: {pubkey} {increased}"
-                    );
-                        self.capitalization.fetch_add(increased, Relaxed);
-                    }
-                    std::cmp::Ordering::Less => {
-                        let decreased = old_account.lamports() - new_account.lamports();
-                        trace!(
-                        "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
-                    );
-                        self.capitalization.fetch_sub(decreased, Relaxed);
-                    }
-                    std::cmp::Ordering::Equal => {}
+        let old_account_data_size = if let Some(old_account) =
+            self.get_account_with_fixed_root_no_cache(pubkey)
+        {
+            match new_account.lamports().cmp(&old_account.lamports()) {
+                std::cmp::Ordering::Greater => {
+                    let diff = new_account.lamports() - old_account.lamports();
+                    trace!("store_account_and_update_capitalization: increased: {pubkey} {diff}");
+                    self.capitalization.fetch_add(diff, Relaxed);
                 }
-                old_account.data().len()
-            } else {
-                trace!(
-                    "store_account_and_update_capitalization: created: {} {}",
-                    pubkey,
-                    new_account.lamports()
-                );
-                self.capitalization
-                    .fetch_add(new_account.lamports(), Relaxed);
-                0
-            };
+                std::cmp::Ordering::Less => {
+                    let diff = old_account.lamports() - new_account.lamports();
+                    trace!("store_account_and_update_capitalization: decreased: {pubkey} {diff}");
+                    self.capitalization.fetch_sub(diff, Relaxed);
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+            old_account.data().len()
+        } else {
+            trace!(
+                "store_account_and_update_capitalization: created: {} {}",
+                pubkey,
+                new_account.lamports()
+            );
+            self.capitalization
+                .fetch_add(new_account.lamports(), Relaxed);
+            0
+        };
 
         self.store_account(pubkey, new_account);
         self.calculate_and_update_accounts_data_size_delta_off_chain(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -368,8 +368,7 @@ impl Bank {
                             ) && VoteAccount::try_from(account_from_db.clone()).is_ok()
                             {
                                 panic!(
-                                    "Vote account {} not found in cache, but found in db: {:?}",
-                                    vote_pubkey, account_from_db
+                                    "Vote account {vote_pubkey} not found in cache, but found in db: {account_from_db:?}"
                                 );
                             }
                         }
@@ -418,8 +417,7 @@ impl Bank {
                         });
                     } else {
                         debug!(
-                            "redeem_rewards() failed for {}: {:?}",
-                            stake_pubkey, redeemed
+                            "redeem_rewards() failed for {stake_pubkey}: {redeemed:?}"
                         );
                     }
                     None

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -12,7 +12,7 @@ impl Bank {
         if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
             let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
                 from_account(&account).unwrap();
-            info!("{prefix} epoch_rewards sysvar: {:?}", epoch_rewards);
+            info!("{prefix} epoch_rewards sysvar: {epoch_rewards:?}");
         } else {
             info!("{prefix} epoch_rewards sysvar: none");
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3753,7 +3753,7 @@ fn test_banks_leak() {
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
     error!(
-        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {})/$REPLY));done", pid
+        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {pid})/$REPLY));done"
     );
     loop {
         num_banks += 1;
@@ -3777,7 +3777,7 @@ fn test_banks_leak() {
             }
             #[cfg(not(target_os = "linux"))]
             {
-                error!("{} banks, sleeping for 5 sec", num_banks);
+                error!("{num_banks} banks, sleeping for 5 sec");
                 std::thread::sleep(Duration::from_secs(5));
             }
         }
@@ -4226,11 +4226,11 @@ fn test_nonce_authority() {
     let bad_nonce_authority = bad_nonce_authority_keypair.pubkey();
     let custodian_account = bank.get_account(&custodian_pubkey).unwrap();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
-    debug!("cust: {:?}", custodian_account);
+    debug!("cust: {custodian_account:?}");
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
@@ -4247,7 +4247,7 @@ fn test_nonce_authority() {
         &[&custodian_keypair, &bad_nonce_authority_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
     let initial_custodian_balance = custodian_account.lamports();
     assert_eq!(
         bank.process_transaction(&nonce_tx),
@@ -4285,9 +4285,9 @@ fn test_nonce_payer() {
     let custodian_pubkey = custodian_keypair.pubkey();
     let nonce_pubkey = nonce_keypair.pubkey();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
     debug!("cust: {:?}", bank.get_account(&custodian_pubkey));
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
@@ -4306,7 +4306,7 @@ fn test_nonce_payer() {
         &[&custodian_keypair, &nonce_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
     assert_eq!(
         bank.process_transaction(&nonce_tx),
         Err(TransactionError::InstructionError(
@@ -4351,9 +4351,9 @@ fn test_nonce_payer_tx_wide_cap() {
     let custodian_pubkey = custodian_keypair.pubkey();
     let nonce_pubkey = nonce_keypair.pubkey();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
     debug!("cust: {:?}", bank.get_account(&custodian_pubkey));
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
@@ -4372,7 +4372,7 @@ fn test_nonce_payer_tx_wide_cap() {
         &[&custodian_keypair, &nonce_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
 
     assert_eq!(
         bank.process_transaction(&nonce_tx),
@@ -4842,7 +4842,7 @@ fn test_account_ids_after_program_ids() {
     let result = bank.process_transaction(&tx);
     assert_eq!(result, Ok(()));
     let account = bank.get_account(&solana_vote_program::id()).unwrap();
-    info!("account: {:?}", account);
+    info!("account: {account:?}");
     assert!(account.executable());
 }
 
@@ -5177,11 +5177,11 @@ fn test_fuzz_instructions() {
             assert!(account.executable());
             assert_eq!(account.data(), name);
         }
-        info!("result: {:?}", result);
+        info!("result: {result:?}");
         let result_key = format!("{result:?}");
         *results.entry(result_key).or_insert(0) += 1;
     }
-    info!("results: {:?}", results);
+    info!("results: {results:?}");
 }
 
 // DEVELOPERS: This test is intended to ensure that the bank hash remains
@@ -5316,8 +5316,8 @@ fn test_clean_nonrooted() {
     let pubkey0 = Pubkey::from([0; 32]);
     let pubkey1 = Pubkey::from([1; 32]);
 
-    info!("pubkey0: {}", pubkey0);
-    info!("pubkey1: {}", pubkey1);
+    info!("pubkey0: {pubkey0}");
+    info!("pubkey1: {pubkey1}");
 
     // Set root for bank 0, with caching enabled
     let bank0 = Arc::new(Bank::new_with_config_for_tests(
@@ -6858,7 +6858,7 @@ fn min_rent_exempt_balance_for_sysvars(bank: &Bank, sysvar_ids: &[Pubkey]) -> u6
     sysvar_ids
         .iter()
         .map(|sysvar_id| {
-            trace!("min_rent_excempt_balance_for_sysvars: {}", sysvar_id);
+            trace!("min_rent_excempt_balance_for_sysvars: {sysvar_id}");
             bank.get_minimum_balance_for_rent_exemption(
                 bank.get_account(sysvar_id).unwrap().data().len(),
             )
@@ -11528,7 +11528,7 @@ fn test_deploy_last_epoch_slot() {
     let signers = &[&payer_keypair, &upgrade_authority_keypair];
     let transaction = Transaction::new(signers, message.clone(), bank.last_blockhash());
     let ret = bank.process_transaction(&transaction);
-    assert!(ret.is_ok(), "ret: {:?}", ret);
+    assert!(ret.is_ok(), "ret: {ret:?}");
     goto_end_of_slot(bank.clone());
 
     // go to the first slot in the new epoch
@@ -11845,7 +11845,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
         bank.store_account(&programdata_address, &programdata_account);
         bank.store_account(&payer_keypair.pubkey(), &payer_account);
         let result = bank.process_transaction(&transaction);
-        assert!(result.is_ok(), "result: {:?}", result);
+        assert!(result.is_ok(), "result: {result:?}");
 
         goto_end_of_slot(bank.clone());
         let bank =

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -209,7 +209,7 @@ impl BankForks {
     }
 
     pub fn install_scheduler_pool(&mut self, pool: InstalledSchedulerPoolArc) {
-        info!("Installed new scheduler_pool into bank_forks: {:?}", pool);
+        info!("Installed new scheduler_pool into bank_forks: {pool:?}");
         assert!(
             self.scheduler_pool.replace(pool).is_none(),
             "Reinstalling scheduler pool isn't supported"

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -246,8 +246,7 @@ pub fn deactivate_features(
             genesis_config.accounts.remove(deactivate_feature_pk);
         } else {
             warn!(
-                "Feature {:?} set for deactivation is not a known Feature public key",
-                deactivate_feature_pk
+                "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
             );
         }
     }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -743,9 +743,7 @@ impl BankWithSchedulerInner {
             result_with_timings.as_ref().map(|(result, _)| result),
             thread::current(),
         );
-        trace!(
-            "wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",
-        );
+        trace!("wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",);
 
         result_with_timings
     }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -612,7 +612,7 @@ impl BankWithSchedulerInner {
                 // unconditional context construction for verification is okay here.
                 let context = SchedulingContext::for_verification(self.bank.clone());
                 let mut scheduler = self.scheduler.write().unwrap();
-                trace!("with_active_scheduler: {:?}", scheduler);
+                trace!("with_active_scheduler: {scheduler:?}");
                 scheduler.transition_from_stale_to_active(|pool, result_with_timings| {
                     let scheduler = pool.take_resumed_scheduler(context, result_with_timings);
                     info!(
@@ -672,7 +672,7 @@ impl BankWithSchedulerInner {
                 );
                 (pool, result_with_timings)
             });
-            trace!("timeout_listener: {:?}", scheduler);
+            trace!("timeout_listener: {scheduler:?}");
         })
     }
 
@@ -744,8 +744,7 @@ impl BankWithSchedulerInner {
             thread::current(),
         );
         trace!(
-            "wait_for_scheduler_termination(result_with_timings: {:?})",
-            result_with_timings,
+            "wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",
         );
 
         result_with_timings

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -242,8 +242,7 @@ impl PrioritizationFeeCache {
                     })
                     .unwrap_or_else(|err| {
                         warn!(
-                            "prioritization fee cache transaction updates failed: {:?}",
-                            err
+                            "prioritization fee cache transaction updates failed: {err:?}"
                         );
                     });
             }
@@ -260,8 +259,7 @@ impl PrioritizationFeeCache {
             .send(CacheServiceUpdate::BankFinalized { slot, bank_id })
             .unwrap_or_else(|err| {
                 warn!(
-                    "prioritization fee cache signalling bank frozen failed: {:?}",
-                    err
+                    "prioritization fee cache signalling bank frozen failed: {err:?}"
                 )
             });
     }
@@ -325,8 +323,7 @@ impl PrioritizationFeeCache {
             if let Some(prioritization_fee) = &mut prioritization_fee {
                 if let Err(err) = prioritization_fee.mark_block_completed() {
                     error!(
-                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
-                        err
+                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}"
                     );
                 }
                 prioritization_fee.report_metrics(slot);

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -241,9 +241,7 @@ impl PrioritizationFeeCache {
                         writable_accounts,
                     })
                     .unwrap_or_else(|err| {
-                        warn!(
-                            "prioritization fee cache transaction updates failed: {err:?}"
-                        );
+                        warn!("prioritization fee cache transaction updates failed: {err:?}");
                     });
             }
         });
@@ -258,9 +256,7 @@ impl PrioritizationFeeCache {
         self.sender
             .send(CacheServiceUpdate::BankFinalized { slot, bank_id })
             .unwrap_or_else(|err| {
-                warn!(
-                    "prioritization fee cache signalling bank frozen failed: {err:?}"
-                )
+                warn!("prioritization fee cache signalling bank frozen failed: {err:?}")
             });
     }
 
@@ -322,9 +318,7 @@ impl PrioritizationFeeCache {
 
             if let Some(prioritization_fee) = &mut prioritization_fee {
                 if let Err(err) = prioritization_fee.mark_block_completed() {
-                    error!(
-                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}"
-                    );
+                    error!("Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}");
                 }
                 prioritization_fee.report_metrics(slot);
             }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -56,9 +56,7 @@ impl SVMRentCollector for RentCollectorWithMetrics {
         if !solana_sdk_ids::incinerator::check_id(address)
             && !self.transition_allowed(pre_rent_state, post_rent_state)
         {
-            debug!(
-                "Account {address} not rent exempt, state {account_state:?}",
-            );
+            debug!("Account {address} not rent exempt, state {account_state:?}",);
             let account_index = account_index as u8;
             Err(TransactionError::InsufficientFundsForRent { account_index })
         } else {

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -57,8 +57,7 @@ impl SVMRentCollector for RentCollectorWithMetrics {
             && !self.transition_allowed(pre_rent_state, post_rent_state)
         {
             debug!(
-                "Account {} not rent exempt, state {:?}",
-                address, account_state,
+                "Account {address} not rent exempt, state {account_state:?}",
             );
             let account_index = account_index as u8;
             Err(TransactionError::InsufficientFundsForRent { account_index })

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -736,7 +736,7 @@ mod serde_snapshot_tests {
             reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
         accounts.clean_accounts_for_tests();
 
-        info!("pubkey: {}", pubkey1);
+        info!("pubkey: {pubkey1}");
         accounts.print_accounts_stats("pre_clean");
         accounts.assert_load_account(current_slot, pubkey1, zero_lamport);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -239,7 +239,7 @@ pub fn bank_from_snapshot_archives(
         exit,
     )?;
     measure_rebuild.stop();
-    info!("{}", measure_rebuild);
+    info!("{measure_rebuild}");
 
     verify_epoch_stakes(&bank)?;
 
@@ -439,7 +439,7 @@ pub fn bank_from_snapshot_dir(
         )?,
         "rebuild storages from snapshot dir"
     );
-    info!("{}", measure_rebuild_storages);
+    info!("{measure_rebuild_storages}");
 
     let next_append_vec_id =
         Arc::try_unwrap(next_append_vec_id).expect("this is the only strong reference");
@@ -467,7 +467,7 @@ pub fn bank_from_snapshot_dir(
         )?,
         "rebuild bank from snapshot"
     );
-    info!("{}", measure_rebuild_bank);
+    info!("{measure_rebuild_bank}");
 
     verify_epoch_stakes(&bank)?;
 

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -125,12 +125,11 @@ impl SnapshotController {
                         enqueued: Instant::now(),
                     }) {
                         warn!(
-                            "Error sending snapshot request for bank: {}, err: {:?}",
-                            bank_slot, e
+                            "Error sending snapshot request for bank: {bank_slot}, err: {e:?}"
                         );
                     }
                 } else {
-                    info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
+                    info!("Not sending snapshot request for bank: {bank_slot}, startup verification is incomplete");
                 }
                 snapshot_time.stop();
                 total_snapshot_ms += snapshot_time.as_ms();

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -124,9 +124,7 @@ impl SnapshotController {
                         request_kind,
                         enqueued: Instant::now(),
                     }) {
-                        warn!(
-                            "Error sending snapshot request for bank: {bank_slot}, err: {e:?}"
-                        );
+                        warn!("Error sending snapshot request for bank: {bank_slot}, err: {e:?}");
                     }
                 } else {
                     info!("Not sending snapshot request for bank: {bank_slot}, startup verification is incomplete");

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1071,7 +1071,7 @@ fn archive_snapshot(
     // Create the staging directories
     let staging_dir_prefix = TMP_SNAPSHOT_ARCHIVE_PREFIX;
     let staging_dir = tempfile::Builder::new()
-        .prefix(&format!("{}{}-", staging_dir_prefix, snapshot_slot))
+        .prefix(&format!("{staging_dir_prefix}{snapshot_slot}-"))
         .tempdir_in(tar_dir)
         .map_err(|err| E::CreateStagingDir(err, tar_dir.to_path_buf()))?;
     let staging_snapshots_dir = staging_dir.path().join(SNAPSHOTS_DIR);
@@ -1960,7 +1960,7 @@ fn unarchive_snapshot(
                 )?,
                 measure_name
             );
-            info!("{}", measure_untar);
+            info!("{measure_untar}");
             create_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
 
             Ok(UnarchivedSnapshot {

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -152,7 +152,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         let keys: Vec<_> = self.cache.keys().copied().collect();
 
         for blockhash in keys.iter() {
-            trace!("get_status_any_blockhash: trying {}", blockhash);
+            trace!("get_status_any_blockhash: trying {blockhash}");
             let status = self.get_status(&key, blockhash, ancestors);
             if status.is_some() {
                 return status;

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -38,7 +38,7 @@ fn test_bad_bank_hash() {
         let ancestors = Ancestors::from(vec![some_slot]);
 
         if last_print.elapsed().as_millis() > 5000 {
-            info!("i: {}", i);
+            info!("i: {i}");
             last_print = Instant::now();
         }
         let num_accounts = thread_rng().gen_range(0..100);

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -447,7 +447,7 @@ impl SendTransactionService {
                 )
                 .is_some()
             {
-                info!("Transaction is rooted: {}", signature);
+                info!("Transaction is rooted: {signature}");
                 result.rooted += 1;
                 stats.rooted_transactions.fetch_add(1, Ordering::Relaxed);
                 return false;
@@ -467,14 +467,14 @@ impl SendTransactionService {
                 let verify_nonce_account =
                     nonce_account::verify_nonce_account(&nonce_account, &durable_nonce);
                 if verify_nonce_account.is_none() && signature_status.is_none() && expired {
-                    info!("Dropping expired durable-nonce transaction: {}", signature);
+                    info!("Dropping expired durable-nonce transaction: {signature}");
                     result.expired += 1;
                     stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
                     return false;
                 }
             }
             if transaction_info.last_valid_block_height < root_bank.block_height() {
-                info!("Dropping expired transaction: {}", signature);
+                info!("Dropping expired transaction: {signature}");
                 result.expired += 1;
                 stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
                 return false;
@@ -485,7 +485,7 @@ impl SendTransactionService {
 
             if let Some(max_retries) = max_retries {
                 if transaction_info.retries >= max_retries {
-                    info!("Dropping transaction due to max retries: {}", signature);
+                    info!("Dropping transaction due to max retries: {signature}");
                     result.max_retries_elapsed += 1;
                     stats
                         .transactions_exceeding_max_retries
@@ -507,7 +507,7 @@ impl SendTransactionService {
                             // Transaction sent before is unknown to the working bank, it might have been
                             // dropped or landed in another fork. Re-send it.
 
-                            info!("Retrying transaction: {}", signature);
+                            info!("Retrying transaction: {signature}");
                             result.retried += 1;
                             transaction_info.retries += 1;
                         }
@@ -534,7 +534,7 @@ impl SendTransactionService {
                 }
                 Some((_slot, status)) => {
                     if !status {
-                        info!("Dropping failed transaction: {}", signature);
+                        info!("Dropping failed transaction: {signature}");
                         result.failed += 1;
                         stats.failed_transactions.fetch_add(1, Ordering::Relaxed);
                         false

--- a/storage-bigtable/src/access_token.rs
+++ b/storage-bigtable/src/access_token.rs
@@ -86,7 +86,7 @@ impl AccessToken {
         credentials: &Credentials,
         scope: &Scope,
     ) -> Result<(Token, Instant), String> {
-        info!("Requesting token for {:?} scope", scope);
+        info!("Requesting token for {scope:?} scope");
         let claims = JwtClaims::new(
             credentials.iss(),
             scope,
@@ -136,7 +136,7 @@ impl AccessToken {
                         let mut token_w = this.token.write().unwrap();
                         *token_w = new_token;
                     }
-                    Err(err) => error!("Failed to fetch new token: {}", err),
+                    Err(err) => error!("Failed to fetch new token: {err}"),
                 },
                 Err(_timeout) => {
                     warn!("Token refresh timeout")

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -146,7 +146,7 @@ impl BigTableConnection {
     ) -> Result<Self> {
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {
-                info!("Connecting to bigtable emulator at {}", endpoint);
+                info!("Connecting to bigtable emulator at {endpoint}");
                 Self::new_for_emulator(
                     instance_name,
                     app_profile_id,
@@ -259,7 +259,7 @@ impl BigTableConnection {
                                 .insert("authorization", authorization_header);
                         }
                         Err(err) => {
-                            warn!("Failed to set authorization header: {}", err);
+                            warn!("Failed to set authorization header: {err}");
                         }
                     }
                 }
@@ -366,7 +366,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
             for (i, mut chunk) in res.chunks.into_iter().enumerate() {
                 // The comments for `read_rows_response::CellChunk` provide essential details for
                 // understanding how the below decoding works...
-                trace!("chunk {}: {:?}", i, chunk);
+                trace!("chunk {i}: {chunk:?}");
 
                 // Starting a new row?
                 if !chunk.row_key.is_empty() {
@@ -934,7 +934,7 @@ where
 
     let data = decompress(value)?;
     T::decode(&data[..]).map_err(|err| {
-        warn!("Failed to deserialize {}/{}: {}", table, key, err);
+        warn!("Failed to deserialize {table}/{key}: {err}");
         Error::ObjectCorrupt(format!("{table}/{key}"))
     })
 }
@@ -955,7 +955,7 @@ where
 
     let data = decompress(value)?;
     bincode::deserialize(&data).map_err(|err| {
-        warn!("Failed to deserialize {}/{}: {}", table, key, err);
+        warn!("Failed to deserialize {table}/{key}: {err}");
         Error::ObjectCorrupt(format!("{table}/{key}"))
     })
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -529,9 +529,7 @@ impl LedgerStorage {
     /// start_slot: slot to start the search from (inclusive)
     /// limit: stop after this many slots have been found
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
-        trace!(
-            "LedgerStorage::get_confirmed_blocks request received: {start_slot:?} {limit:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_blocks request received: {start_slot:?} {limit:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let blocks = bigtable
@@ -550,9 +548,7 @@ impl LedgerStorage {
         &self,
         slots: &'a [Slot],
     ) -> Result<impl Iterator<Item = (Slot, ConfirmedBlock)> + 'a> {
-        trace!(
-            "LedgerStorage::get_confirmed_blocks_with_data request received: {slots:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_blocks_with_data request received: {slots:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let row_keys = slots.iter().copied().map(slot_to_blocks_key);
@@ -576,9 +572,7 @@ impl LedgerStorage {
 
     /// Fetch the confirmed block from the desired slot
     pub async fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
-        trace!(
-            "LedgerStorage::get_confirmed_block request received: {slot:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_block request received: {slot:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let block_cell_data = bigtable
@@ -601,9 +595,7 @@ impl LedgerStorage {
 
     /// Does the confirmed block exist in the Bigtable
     pub async fn confirmed_block_exists(&self, slot: Slot) -> Result<bool> {
-        trace!(
-            "LedgerStorage::confirmed_block_exists request received: {slot:?}"
-        );
+        trace!("LedgerStorage::confirmed_block_exists request received: {slot:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
 
@@ -616,9 +608,7 @@ impl LedgerStorage {
 
     /// Fetches a vector of block entries via a multirow fetch
     pub async fn get_entries(&self, slot: Slot) -> Result<impl Iterator<Item = EntrySummary>> {
-        trace!(
-            "LedgerStorage::get_block_entries request received: {slot:?}"
-        );
+        trace!("LedgerStorage::get_block_entries request received: {slot:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let entry_cell_data = bigtable
@@ -633,9 +623,7 @@ impl LedgerStorage {
     }
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
-        trace!(
-            "LedgerStorage::get_signature_status request received: {signature:?}"
-        );
+        trace!("LedgerStorage::get_signature_status request received: {signature:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let transaction_info = bigtable
@@ -653,9 +641,7 @@ impl LedgerStorage {
         &self,
         signatures: &[Signature],
     ) -> Result<Vec<ConfirmedTransactionWithStatusMeta>> {
-        trace!(
-            "LedgerStorage::get_confirmed_transactions request received: {signatures:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_transactions request received: {signatures:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
 
@@ -713,9 +699,7 @@ impl LedgerStorage {
         &self,
         signature: &Signature,
     ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
-        trace!(
-            "LedgerStorage::get_confirmed_transaction request received: {signature:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_transaction request received: {signature:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
 
@@ -738,9 +722,7 @@ impl LedgerStorage {
             }
             Some(tx_with_meta) => {
                 if tx_with_meta.transaction_signature() != signature {
-                    warn!(
-                        "Transaction info or confirmed block for {signature} is corrupt"
-                    );
+                    warn!("Transaction info or confirmed block for {signature} is corrupt");
                     Ok(None)
                 } else {
                     Ok(Some(ConfirmedTransactionWithStatusMeta {
@@ -771,9 +753,7 @@ impl LedgerStorage {
             u32, /*slot index*/
         )>,
     > {
-        trace!(
-            "LedgerStorage::get_confirmed_signatures_for_address request received: {address:?}"
-        );
+        trace!("LedgerStorage::get_confirmed_signatures_for_address request received: {address:?}");
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
         let address_prefix = format!("{address}/");
@@ -907,9 +887,7 @@ impl LedgerStorage {
         slot: Slot,
         confirmed_block: VersionedConfirmedBlock,
     ) -> Result<()> {
-        trace!(
-            "LedgerStorage::upload_confirmed_block request received: {slot:?}"
-        );
+        trace!("LedgerStorage::upload_confirmed_block request received: {slot:?}");
         self.upload_confirmed_block_with_entries(
             slot,
             VersionedConfirmedBlockWithEntries {
@@ -925,9 +903,7 @@ impl LedgerStorage {
         slot: Slot,
         confirmed_block: VersionedConfirmedBlockWithEntries,
     ) -> Result<()> {
-        trace!(
-            "LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}"
-        );
+        trace!("LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}");
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
         let VersionedConfirmedBlockWithEntries {
             block: confirmed_block,

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -105,7 +105,7 @@ fn key_to_slot(key: &str) -> Option<Slot> {
         Ok(slot) => Some(slot),
         Err(err) => {
             // bucket data is probably corrupt
-            warn!("Failed to parse object key as a slot: {}: {}", key, err);
+            warn!("Failed to parse object key as a slot: {key}: {err}");
             None
         }
     }
@@ -530,9 +530,7 @@ impl LedgerStorage {
     /// limit: stop after this many slots have been found
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
         trace!(
-            "LedgerStorage::get_confirmed_blocks request received: {:?} {:?}",
-            start_slot,
-            limit
+            "LedgerStorage::get_confirmed_blocks request received: {start_slot:?} {limit:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -553,8 +551,7 @@ impl LedgerStorage {
         slots: &'a [Slot],
     ) -> Result<impl Iterator<Item = (Slot, ConfirmedBlock)> + 'a> {
         trace!(
-            "LedgerStorage::get_confirmed_blocks_with_data request received: {:?}",
-            slots
+            "LedgerStorage::get_confirmed_blocks_with_data request received: {slots:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -580,8 +577,7 @@ impl LedgerStorage {
     /// Fetch the confirmed block from the desired slot
     pub async fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
         trace!(
-            "LedgerStorage::get_confirmed_block request received: {:?}",
-            slot
+            "LedgerStorage::get_confirmed_block request received: {slot:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -606,8 +602,7 @@ impl LedgerStorage {
     /// Does the confirmed block exist in the Bigtable
     pub async fn confirmed_block_exists(&self, slot: Slot) -> Result<bool> {
         trace!(
-            "LedgerStorage::confirmed_block_exists request received: {:?}",
-            slot
+            "LedgerStorage::confirmed_block_exists request received: {slot:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -622,8 +617,7 @@ impl LedgerStorage {
     /// Fetches a vector of block entries via a multirow fetch
     pub async fn get_entries(&self, slot: Slot) -> Result<impl Iterator<Item = EntrySummary>> {
         trace!(
-            "LedgerStorage::get_block_entries request received: {:?}",
-            slot
+            "LedgerStorage::get_block_entries request received: {slot:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -640,8 +634,7 @@ impl LedgerStorage {
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
         trace!(
-            "LedgerStorage::get_signature_status request received: {:?}",
-            signature
+            "LedgerStorage::get_signature_status request received: {signature:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -661,8 +654,7 @@ impl LedgerStorage {
         signatures: &[Signature],
     ) -> Result<Vec<ConfirmedTransactionWithStatusMeta>> {
         trace!(
-            "LedgerStorage::get_confirmed_transactions request received: {:?}",
-            signatures
+            "LedgerStorage::get_confirmed_transactions request received: {signatures:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -700,8 +692,7 @@ impl LedgerStorage {
                         .and_then(|tx_with_meta| {
                             if tx_with_meta.transaction_signature().to_string() != *signature {
                                 warn!(
-                                    "Transaction info or confirmed block for {} is corrupt",
-                                    signature
+                                    "Transaction info or confirmed block for {signature} is corrupt"
                                 );
                                 None
                             } else {
@@ -723,8 +714,7 @@ impl LedgerStorage {
         signature: &Signature,
     ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
         trace!(
-            "LedgerStorage::get_confirmed_transaction request received: {:?}",
-            signature
+            "LedgerStorage::get_confirmed_transaction request received: {signature:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -743,14 +733,13 @@ impl LedgerStorage {
         match block.transactions.into_iter().nth(index as usize) {
             None => {
                 // report this somewhere actionable?
-                warn!("Transaction info for {} is corrupt", signature);
+                warn!("Transaction info for {signature} is corrupt");
                 Ok(None)
             }
             Some(tx_with_meta) => {
                 if tx_with_meta.transaction_signature() != signature {
                     warn!(
-                        "Transaction info or confirmed block for {} is corrupt",
-                        signature
+                        "Transaction info or confirmed block for {signature} is corrupt"
                     );
                     Ok(None)
                 } else {
@@ -783,8 +772,7 @@ impl LedgerStorage {
         )>,
     > {
         trace!(
-            "LedgerStorage::get_confirmed_signatures_for_address request received: {:?}",
-            address
+            "LedgerStorage::get_confirmed_signatures_for_address request received: {address:?}"
         );
         self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
@@ -920,8 +908,7 @@ impl LedgerStorage {
         confirmed_block: VersionedConfirmedBlock,
     ) -> Result<()> {
         trace!(
-            "LedgerStorage::upload_confirmed_block request received: {:?}",
-            slot
+            "LedgerStorage::upload_confirmed_block request received: {slot:?}"
         );
         self.upload_confirmed_block_with_entries(
             slot,
@@ -939,8 +926,7 @@ impl LedgerStorage {
         confirmed_block: VersionedConfirmedBlockWithEntries,
     ) -> Result<()> {
         trace!(
-            "LedgerStorage::upload_confirmed_block_with_entries request received: {:?}",
-            slot
+            "LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}"
         );
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
         let VersionedConfirmedBlockWithEntries {
@@ -1167,12 +1153,11 @@ impl LedgerStorage {
                     }
                     Some(Err(err)) => {
                         warn!(
-                            "skipped tx row {} because the bigtable entry was corrupted: {:?}",
-                            signature, err
+                            "skipped tx row {signature} because the bigtable entry was corrupted: {err:?}"
                         );
                     }
                     None => {
-                        warn!("skipped tx row {} because it was not found", signature);
+                        warn!("skipped tx row {signature} because it was not found");
                     }
                 }
             }

--- a/streamer/src/nonblocking/connection_rate_limiter.rs
+++ b/streamer/src/nonblocking/connection_rate_limiter.rs
@@ -22,10 +22,10 @@ impl ConnectionRateLimiter {
     pub fn is_allowed(&self, ip: &IpAddr) -> bool {
         // Acquire a permit from the rate limiter for the given IP address
         if self.limiter.check_key(ip).is_ok() {
-            debug!("Request from IP {:?} allowed", ip);
+            debug!("Request from IP {ip:?} allowed");
             true // Request allowed
         } else {
-            debug!("Request from IP {:?} blocked", ip);
+            debug!("Request from IP {ip:?} blocked");
             false // Request blocked
         }
     }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -254,8 +254,7 @@ impl ClientConnectionTracker {
         if open_connections >= max_concurrent_connections {
             stats.open_connections.fetch_sub(1, Ordering::Relaxed);
             debug!(
-                "There are too many concurrent connections opened already: open: {}, max: {}",
-                open_connections, max_concurrent_connections
+                "There are too many concurrent connections opened already: open: {open_connections}, max: {max_concurrent_connections}"
             );
             return Err(());
         }
@@ -365,8 +364,7 @@ async fn run_server(
             debug!("Got a connection {remote_address:?}");
             if !rate_limiter.is_allowed(&remote_address.ip()) {
                 debug!(
-                    "Reject connection from {:?} -- rate limiting exceeded",
-                    remote_address
+                    "Reject connection from {remote_address:?} -- rate limiting exceeded"
                 );
                 stats
                     .connection_rate_limited_per_ipaddr
@@ -421,7 +419,7 @@ async fn run_server(
                     ));
                 }
                 Err(err) => {
-                    debug!("Incoming::accept(): error {:?}", err);
+                    debug!("Incoming::accept(): error {err:?}");
                 }
             }
         } else {
@@ -478,8 +476,7 @@ pub fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stak
             // No checked math for f64 type. So let's explicitly check for 0 here
             if total_stake == 0 || peer_stake > total_stake {
                 warn!(
-                    "Invalid stake values: peer_stake: {:?}, total_stake: {:?}",
-                    peer_stake, total_stake,
+                    "Invalid stake values: peer_stake: {peer_stake:?}, total_stake: {total_stake:?}",
                 );
 
                 QUIC_MIN_STAKED_CONCURRENT_STREAMS
@@ -837,7 +834,7 @@ async fn setup_connection(
 }
 
 fn handle_connection_error(e: quinn::ConnectionError, stats: &StreamerStats, from: SocketAddr) {
-    debug!("error: {:?} from: {:?}", e, from);
+    debug!("error: {e:?} from: {from:?}");
     stats.connection_setup_error.fetch_add(1, Ordering::Relaxed);
     match e {
         quinn::ConnectionError::TimedOut => {
@@ -912,7 +909,7 @@ fn packet_batch_sender(
                     stats
                         .total_packet_batch_send_err
                         .fetch_add(1, Ordering::Relaxed);
-                    trace!("Send error: {}", e);
+                    trace!("Send error: {e}");
 
                     // The downstream channel is disconnected, this error is not recoverable.
                     if matches!(e, TrySendError::Disconnected(_)) {
@@ -932,7 +929,7 @@ fn packet_batch_sender(
                         .total_bytes_sent_to_consumer
                         .fetch_add(total_bytes, Ordering::Relaxed);
 
-                    trace!("Sent {} packet batch", len);
+                    trace!("Sent {len} packet batch");
                 }
                 break;
             }
@@ -1060,7 +1057,7 @@ async fn handle_connection(
             stream = connection.accept_uni() => match stream {
                 Ok(stream) => stream,
                 Err(e) => {
-                    debug!("stream error: {:?}", e);
+                    debug!("stream error: {e:?}");
                     break;
                 }
             },
@@ -1079,10 +1076,9 @@ async fn handle_connection(
                 STREAM_THROTTLING_INTERVAL.saturating_sub(throttle_interval_start.elapsed());
 
             if !throttle_duration.is_zero() {
-                debug!("Throttling stream from {remote_addr:?}, peer type: {:?}, total stake: {}, \
+                debug!("Throttling stream from {remote_addr:?}, peer type: {peer_type:?}, total stake: {total_stake}, \
                                     max_streams_per_interval: {max_streams_per_throttling_interval}, read_interval_streams: {streams_read_in_throttle_interval} \
-                                    throttle_duration: {throttle_duration:?}",
-                                    peer_type, total_stake);
+                                    throttle_duration: {throttle_duration:?}");
                 stats.throttled_streams.fetch_add(1, Ordering::Relaxed);
                 match peer_type {
                     ConnectionPeerType::Unstaked => {
@@ -1135,7 +1131,7 @@ async fn handle_connection(
                 Ok(Ok(chunk)) => chunk.unwrap_or(0),
                 // read_chunk returned error
                 Ok(Err(e)) => {
-                    debug!("Received stream error: {:?}", e);
+                    debug!("Received stream error: {e:?}");
                     stats
                         .total_stream_read_errors
                         .fetch_add(1, Ordering::Relaxed);
@@ -1277,7 +1273,7 @@ async fn handle_chunks(
                     .fetch_add(1, Ordering::Relaxed);
             }
         }
-        trace!("packet batch send error {:?}", err);
+        trace!("packet batch send error {err:?}");
     } else {
         stats
             .total_packets_sent_for_batching
@@ -1302,7 +1298,7 @@ async fn handle_chunks(
             }
         }
 
-        trace!("sent {} byte packet for batching", bytes_sent);
+        trace!("sent {bytes_sent} byte packet for batching");
     }
 
     Ok(StreamState::Finished)
@@ -1570,14 +1566,14 @@ pub mod test {
             let mut s1 = conn1.open_uni().await.unwrap();
             s1.write_all(&[0u8]).await.unwrap();
             s1.finish().unwrap();
-            info!("done {}", i);
+            info!("done {i}");
             sleep(Duration::from_millis(1000)).await;
         }
         let mut received = 0;
         loop {
             if let Ok(_x) = receiver.try_recv() {
                 received += 1;
-                info!("got {}", received);
+                info!("got {received}");
             } else {
                 sleep(Duration::from_millis(500)).await;
             }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -363,9 +363,7 @@ async fn run_server(
                 .store(rate_limiter.len(), Ordering::Relaxed);
             debug!("Got a connection {remote_address:?}");
             if !rate_limiter.is_allowed(&remote_address.ip()) {
-                debug!(
-                    "Reject connection from {remote_address:?} -- rate limiting exceeded"
-                );
+                debug!("Reject connection from {remote_address:?} -- rate limiting exceeded");
                 stats
                     .connection_rate_limited_per_ipaddr
                     .fetch_add(1, Ordering::Relaxed);

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -99,7 +99,7 @@ mod tests {
 
         match test_setup_reader_sender("::1:0").await {
             Ok(config) => test_one_iter(config).await,
-            Err(e) => warn!("Failed to configure IPv6: {:?}", e),
+            Err(e) => warn!("Failed to configure IPv6: {e:?}"),
         }
     }
 
@@ -136,7 +136,7 @@ mod tests {
 
         match test_setup_reader_sender("::1:0").await {
             Ok(config) => test_multi_iter(config).await,
-            Err(e) => warn!("Failed to configure IPv6: {:?}", e),
+            Err(e) => warn!("Failed to configure IPv6: {e:?}"),
         }
     }
 

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -102,8 +102,7 @@ impl StakedStreamLoadEMA {
 
         let Ok(updated_load_ema) = u64::try_from(updated_load_ema) else {
             error!(
-                "Failed to convert EMA {} to a u64. Not updating the load EMA",
-                updated_load_ema
+                "Failed to convert EMA {updated_load_ema} to a u64. Not updating the load EMA"
             );
             self.stats
                 .stream_load_ema_overflow
@@ -164,8 +163,7 @@ impl StakedStreamLoadEMA {
                     / u128::from(EMA_WINDOW_MS);
                 let calculated_capacity = u64::try_from(calculated_capacity).unwrap_or_else(|_| {
                     error!(
-                        "Failed to convert stream capacity {} to u64. Using minimum load capacity",
-                        calculated_capacity
+                        "Failed to convert stream capacity {calculated_capacity} to u64. Using minimum load capacity"
                     );
                     self.stats
                         .stream_load_capacity_overflow

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -101,9 +101,7 @@ impl StakedStreamLoadEMA {
         }
 
         let Ok(updated_load_ema) = u64::try_from(updated_load_ema) else {
-            error!(
-                "Failed to convert EMA {updated_load_ema} to a u64. Not updating the load EMA"
-            );
+            error!("Failed to convert EMA {updated_load_ema} to a u64. Not updating the load EMA");
             self.stats
                 .stream_load_ema_overflow
                 .fetch_add(1, Ordering::Relaxed);

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -151,7 +151,7 @@ pub async fn check_multiple_streams(
     let conn2 = Arc::new(make_client_endpoint(&server_address, client_keypair).await);
     let mut num_expected_packets = 0;
     for i in 0..10 {
-        info!("sending: {}", i);
+        info!("sending: {i}");
         let c1 = conn1.clone();
         let c2 = conn2.clone();
         let mut s1 = c1.open_uni().await.unwrap();

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -674,7 +674,7 @@ pub fn spawn_server_multi(
         .name(thread_name.into())
         .spawn(move || {
             if let Err(e) = runtime.block_on(result.thread) {
-                warn!("error from runtime.block_on: {:?}", e);
+                warn!("error from runtime.block_on: {e:?}");
             }
         })
         .unwrap();

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -226,7 +226,7 @@ mod tests {
 
         match test_setup_reader_sender(IpAddr::V6(Ipv6Addr::LOCALHOST)) {
             Ok(config) => test_one_iter(config),
-            Err(e) => warn!("Failed to configure IPv6: {:?}", e),
+            Err(e) => warn!("Failed to configure IPv6: {e:?}"),
         }
     }
 
@@ -262,7 +262,7 @@ mod tests {
 
         match test_setup_reader_sender(IpAddr::V6(Ipv6Addr::LOCALHOST)) {
             Ok(config) => test_multi_iter(config),
-            Err(e) => warn!("Failed to configure IPv6: {:?}", e),
+            Err(e) => warn!("Failed to configure IPv6: {e:?}"),
         }
     }
 

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -397,9 +397,7 @@ impl StreamerSendStats {
             });
             entries.truncate(MAX_REPORT_ENTRIES);
         }
-        info!(
-            "streamer send {name} hosts: count:{num_entries} {entries:?}",
-        );
+        info!("streamer send {name} hosts: count:{num_entries} {entries:?}",);
     }
 
     fn maybe_submit(&mut self, name: &'static str, sender: &Sender<Box<dyn FnOnce() + Send>>) {

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -398,8 +398,7 @@ impl StreamerSendStats {
             entries.truncate(MAX_REPORT_ENTRIES);
         }
         info!(
-            "streamer send {} hosts: count:{} {:?}",
-            name, num_entries, entries,
+            "streamer send {name} hosts: count:{num_entries} {entries:?}",
         );
     }
 
@@ -610,7 +609,7 @@ fn responder_loop<P: SocketProvider>(
         let now = timestamp();
         if now - last_print > 1000 && errors != 0 {
             datapoint_info!(name, ("errors", errors, i64),);
-            info!("{} last-error: {:?} count: {}", name, last_error, errors);
+            info!("{name} last-error: {last_error:?} count: {errors}");
             last_print = now;
             errors = 0;
         }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1088,7 +1088,7 @@ mod tests {
                     TransactionError::ProgramAccountNotFound,
                 );
             }
-            result => panic!("unexpected result: {:?}", result),
+            result => panic!("unexpected result: {result:?}"),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1065,14 +1065,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         name: &str,
         builtin: ProgramCacheEntry,
     ) {
-        debug!("Adding program {} under {:?}", name, program_id);
+        debug!("Adding program {name} under {program_id:?}");
         callbacks.add_builtin_account(name, &program_id);
         self.builtin_program_ids.write().unwrap().insert(program_id);
         self.program_cache
             .write()
             .unwrap()
             .assign_program(program_id, Arc::new(builtin));
-        debug!("Added program {} under {:?}", name, program_id);
+        debug!("Added program {name} under {program_id:?}");
     }
 
     #[cfg(feature = "dev-context-only-utils")]

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -405,14 +405,12 @@ fn execute_fixture_as_instr(
     if output.result == 0 {
         assert!(
             result.is_ok(),
-            "Instruction execution was NOT successful, but should have been: {:?}",
-            filename
+            "Instruction execution was NOT successful, but should have been: {filename:?}"
         );
     } else {
         assert!(
             result.is_err(),
-            "Instruction execution was successful, but should NOT have been: {:?}",
-            filename
+            "Instruction execution was successful, but should NOT have been: {filename:?}"
         );
         return;
     }
@@ -484,8 +482,7 @@ fn verify_accounts_and_data(
     assert_eq!(
         consumed_units,
         cu_avail.saturating_sub(output.cu_avail),
-        "Execution units differs in case: {:?}",
-        filename
+        "Execution units differs in case: {filename:?}"
     );
 
     if return_data.is_empty() {
@@ -508,14 +505,14 @@ fn check_account(
 
     if received.lamports() != expected.lamports {
         return Some(
-            format!("Lamports differ in case: {:?}\n", filename)
+            format!("Lamports differ in case: {filename:?}\n")
                 + format_args!(received.lamports(), expected.lamports),
         );
     }
 
     if received.data() != expected.data.as_slice() {
         return Some(
-            format!("Account data differs in case: {:?}\n", filename)
+            format!("Account data differs in case: {filename:?}\n")
                 + format_args!(received.data(), expected.data.as_slice()),
         );
     }
@@ -523,14 +520,14 @@ fn check_account(
     let expected_owner = Pubkey::new_from_array(expected.owner.clone().try_into().unwrap());
     if received.owner() != &expected_owner {
         return Some(
-            format!("Account owner differs in case: {:?}\n", filename)
+            format!("Account owner differs in case: {filename:?}\n")
                 + format_args!(received.owner(), expected_owner),
         );
     }
 
     if received.executable() != expected.executable {
         return Some(
-            format!("Executable boolean differs in case: {:?}\n", filename)
+            format!("Executable boolean differs in case: {filename:?}\n")
                 + format_args!(received.executable(), expected.executable),
         );
     }
@@ -541,7 +538,7 @@ fn check_account(
         && received.rent_epoch() != expected.rent_epoch
     {
         return Some(
-            format!("Rent epoch differs in case: {:?}\n", filename)
+            format!("Rent epoch differs in case: {filename:?}\n")
                 + format_args!(received.rent_epoch(), expected.rent_epoch),
         );
     }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -213,7 +213,7 @@ impl SvmTestEnvironment<'_> {
                     Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
                         format!("{} (fee-only): {:?}", i, fee_only.load_error)
                     }
-                    Err(e) => format!("{} (discarded): {:?}", i, e),
+                    Err(e) => format!("{i} (discarded): {e:?}"),
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -225,8 +225,7 @@ impl SvmTestEnvironment<'_> {
             assert_eq!(
                 Some(expected_account_data),
                 actual_account_data,
-                "mismatch on account {}",
-                pubkey
+                "mismatch on account {pubkey}"
             );
         }
 
@@ -2236,7 +2235,7 @@ fn simd83_account_reallocate(formalize_loaded_transaction_data_size: bool) -> Ve
         test_entry.transaction_batch[1]
             .asserts
             .logs
-            .push(format!("Program log: account size {}", new_target_size));
+            .push(format!("Program log: account size {new_target_size}"));
 
         test_entry.update_expected_account_data(target, &mk_target(new_target_size));
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -344,7 +344,7 @@ impl TestValidatorGenesis {
     {
         let addresses: Vec<Pubkey> = addresses.into_iter().collect();
         for chunk in addresses.chunks(MAX_MULTIPLE_ACCOUNTS) {
-            info!("Fetching {:?} over RPC...", chunk);
+            info!("Fetching {chunk:?} over RPC...");
             let responses = rpc_client
                 .get_multiple_accounts(chunk)
                 .map_err(|err| format!("Failed to fetch: {err}"))?;
@@ -352,7 +352,7 @@ impl TestValidatorGenesis {
                 if let Some(account) = res {
                     self.add_account(*address, transform(address, account)?);
                 } else if skip_missing {
-                    warn!("Could not find {}, skipping.", address);
+                    warn!("Could not find {address}, skipping.");
                 } else {
                     return Err(format!("Failed to fetch {address}"));
                 }
@@ -396,7 +396,7 @@ impl TestValidatorGenesis {
         let mut alt_entries: Vec<Pubkey> = Vec::new();
 
         for chunk in addresses.chunks(MAX_MULTIPLE_ACCOUNTS) {
-            info!("Fetching {:?} over RPC...", chunk);
+            info!("Fetching {chunk:?} over RPC...");
             let responses = rpc_client
                 .get_multiple_accounts(chunk)
                 .map_err(|err| format!("Failed to fetch: {err}"))?;
@@ -568,7 +568,7 @@ impl TestValidatorGenesis {
             json_files.extend(matched_files);
         }
 
-        debug!("account files found: {:?}", json_files);
+        debug!("account files found: {json_files:?}");
 
         let accounts: Vec<_> = json_files
             .iter()
@@ -871,11 +871,10 @@ impl TestValidator {
         let mut feature_set = FeatureSet::default().inactive().clone();
         for feature in &config.deactivate_feature_set {
             if feature_set.remove(feature) {
-                info!("Feature for {:?} deactivated", feature)
+                info!("Feature for {feature:?} deactivated")
             } else {
                 warn!(
-                    "Feature {:?} set for deactivation is not a known Feature public key",
-                    feature,
+                    "Feature {feature:?} set for deactivation is not a known Feature public key",
                 )
             }
         }
@@ -1201,13 +1200,13 @@ impl TestValidator {
                             }
                         }
                         Err(err) => {
-                            warn!("get_fee_for_message() failed: {:?}", err);
+                            warn!("get_fee_for_message() failed: {err:?}");
                             break;
                         }
                     }
                 }
                 Err(err) => {
-                    warn!("get_latest_blockhash() failed: {:?}", err);
+                    warn!("get_latest_blockhash() failed: {err:?}");
                     break;
                 }
             }
@@ -1250,13 +1249,13 @@ impl TestValidator {
                 match rpc_client.send_transaction(&transaction).await {
                     Ok(_) => *is_deployed = true,
                     Err(e) => {
-                        if format!("{:?}", e).contains("Program is not deployed") {
-                            debug!("{:?} - not deployed", program_id);
+                        if format!("{e:?}").contains("Program is not deployed") {
+                            debug!("{program_id:?} - not deployed");
                         } else {
                             // Assuming all other other errors could only occur *after*
                             // program is deployed for usability.
                             *is_deployed = true;
-                            debug!("{:?} - Unexpected error: {:?}", program_id, e);
+                            debug!("{program_id:?} - Unexpected error: {e:?}");
                         }
                     }
                 }
@@ -1265,7 +1264,7 @@ impl TestValidator {
                 return;
             }
 
-            println!("Waiting for programs to be fully deployed {} ...", attempt);
+            println!("Waiting for programs to be fully deployed {attempt} ...");
             sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT)).await;
         }
         panic!("Timeout waiting for program to become usable");

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -873,9 +873,7 @@ impl TestValidator {
             if feature_set.remove(feature) {
                 info!("Feature for {feature:?} deactivated")
             } else {
-                warn!(
-                    "Feature {feature:?} set for deactivation is not a known Feature public key",
-                )
+                warn!("Feature {feature:?} set for deactivation is not a known Feature public key",)
             }
         }
 

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -89,10 +89,7 @@ impl ClientOptimizer {
                 let times = self.times.read().unwrap();
                 let (min_time, min_index) = min_index(&times);
                 trace!(
-                    "done experimenting min: {} time: {} times: {:?}",
-                    min_index,
-                    min_time,
-                    times
+                    "done experimenting min: {min_index} time: {min_time} times: {times:?}"
                 );
 
                 // Only 1 thread should grab the num_clients-1 index, so this should be ok.

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -88,9 +88,7 @@ impl ClientOptimizer {
             if index == (self.num_clients - 1) || time_ms == u64::MAX {
                 let times = self.times.read().unwrap();
                 let (min_time, min_index) = min_index(&times);
-                trace!(
-                    "done experimenting min: {min_index} time: {min_time} times: {times:?}"
-                );
+                trace!("done experimenting min: {min_index} time: {min_time} times: {times:?}");
 
                 // Only 1 thread should grab the num_clients-1 index, so this should be ok.
                 self.cur_index.store(min_index, Ordering::Relaxed);

--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -220,7 +220,7 @@ mod tests {
                 .read_to_string(&mut buf)
                 .unwrap();
             let cfg: ThreadManagerConfig = toml::from_str(&buf).unwrap();
-            println!("{:?}", cfg);
+            println!("{cfg:?}");
         }
     }
     // Nobody runs Agave on windows, and on Mac we can not set mask affinity without patching external crate

--- a/thread-manager/src/tokio_runtime.rs
+++ b/thread-manager/src/tokio_runtime.rs
@@ -100,7 +100,7 @@ impl TokioRuntime {
             .event_interval(cfg.event_interval)
             .thread_name_fn(move || {
                 let id = atomic_id.fetch_add(1, Ordering::Relaxed);
-                format!("{}-{}", base_name, id)
+                format!("{base_name}-{id}")
             })
             .on_thread_park({
                 let counters = counters.clone();

--- a/tps-client/src/lib.rs
+++ b/tps-client/src/lib.rs
@@ -63,7 +63,7 @@ pub trait TpsClient {
                     return Ok(new_blockhash);
                 }
             }
-            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            debug!("Got same blockhash ({blockhash:?}), will retry...");
 
             // Retry ~twice during a slot
             sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2));

--- a/tps-client/src/utils.rs
+++ b/tps-client/src/utils.rs
@@ -23,7 +23,7 @@ fn find_node_activated_stake(
 ) -> Result<(u64, u64), ()> {
     let vote_accounts = rpc_client.get_vote_accounts();
     if let Err(error) = vote_accounts {
-        error!("Failed to get vote accounts, error: {}", error);
+        error!("Failed to get vote accounts, error: {error}");
         return Err(());
     }
 

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -278,7 +278,7 @@ impl WorkersCache {
         }
         while let Some(res) = tasks.join_next().await {
             if let Err(err) = res {
-                debug!("A shutdown task failed: {}", err);
+                debug!("A shutdown task failed: {err}");
             }
         }
     }

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -222,10 +222,7 @@ async fn test_basic_transactions_sending() {
             let elapsed = now.elapsed();
             assert!(
                 elapsed < TEST_MAX_TIME,
-                "Failed to send {} transaction in {:?}.  Only sent {}",
-                expected_num_txs,
-                elapsed,
-                actual_num_packets,
+                "Failed to send {expected_num_txs} transaction in {elapsed:?}.  Only sent {actual_num_packets}",
             );
         }
 

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -162,7 +162,7 @@ impl LeaderTpuCache {
                     leader_sockets.push(*tpu_socket);
                 } else {
                     // The leader is probably delinquent
-                    trace!("TPU not available for leader {}", leader);
+                    trace!("TPU not available for leader {leader}");
                 }
             } else {
                 // Overran the local leader schedule cache
@@ -227,7 +227,7 @@ impl LeaderTpuCache {
                     cluster_refreshed = true;
                 }
                 Err(err) => {
-                    warn!("Failed to fetch cluster tpu sockets: {}", err);
+                    warn!("Failed to fetch cluster tpu sockets: {err}");
                     has_error = true;
                 }
             }
@@ -247,8 +247,7 @@ impl LeaderTpuCache {
                 }
                 Err(err) => {
                     warn!(
-                        "Failed to fetch slot leaders (current estimated slot: {}): {}",
-                        estimated_current_slot, err
+                        "Failed to fetch slot leaders (current estimated slot: {estimated_current_slot}): {err}"
                     );
                     has_error = true;
                 }
@@ -778,8 +777,7 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed to get slot leaders connecting to: {}, timeout: {:?}. Invalid slot range",
-                websocket_url, tpu_leader_service_creation_timeout
+                "Failed to get slot leaders connecting to: {websocket_url}, timeout: {tpu_leader_service_creation_timeout:?}. Invalid slot range"
             ))
         })??;
 
@@ -800,8 +798,7 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed find any cluster node info for upcoming leaders, timeout: {:?}.",
-                tpu_leader_service_creation_timeout
+                "Failed find any cluster node info for upcoming leaders, timeout: {tpu_leader_service_creation_timeout:?}."
             ))
         })??;
         let leader_tpu_cache = Arc::new(RwLock::new(LeaderTpuCache::new(

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -43,7 +43,7 @@ pub fn airdrop_lamports(
     desired_balance: u64,
 ) -> bool {
     let starting_balance = client.get_balance(&id.pubkey()).unwrap_or(0);
-    info!("starting balance {}", starting_balance);
+    info!("starting balance {starting_balance}");
 
     if starting_balance < desired_balance {
         let airdrop_amount = desired_balance - starting_balance;
@@ -82,7 +82,7 @@ pub fn airdrop_lamports(
         let current_balance = client.get_balance(&id.pubkey()).unwrap_or_else(|e| {
             panic!("airdrop error {e}");
         });
-        info!("current balance {}...", current_balance);
+        info!("current balance {current_balance}...");
 
         if current_balance - starting_balance != airdrop_amount {
             info!(
@@ -159,7 +159,7 @@ fn run_transactions_dos(
         CommitmentConfig::confirmed(),
     ));
 
-    info!("Targeting {}", entrypoint_addr);
+    info!("Targeting {entrypoint_addr}");
 
     let space = maybe_space.unwrap_or(1000);
 
@@ -266,7 +266,7 @@ fn run_transactions_dos(
         .collect();
     let mut last_balance = Instant::now();
 
-    info!("Starting balance(s): {:?}", balances);
+    info!("Starting balance(s): {balances:?}");
 
     let executor = TransactionExecutor::new(entrypoint_addr);
 
@@ -298,8 +298,7 @@ fn run_transactions_dos(
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
                     info!(
-                        "Balance {} is less than needed: {}, doing aidrop...",
-                        balance, lamports
+                        "Balance {balance} is less than needed: {lamports}, doing aidrop..."
                     );
                     if !airdrop_lamports(
                         &client,
@@ -375,7 +374,7 @@ fn run_transactions_dos(
             accounts_created = true;
         } else {
             // Create dos transactions
-            info!("creating new batch of size: {}", batch_size);
+            info!("creating new batch of size: {batch_size}");
             let chunk_size = batch_size / payer_keypairs.len();
             for (i, keypair) in payer_keypairs.iter().enumerate() {
                 let txs: Vec<_> = (0..chunk_size)
@@ -412,8 +411,7 @@ fn run_transactions_dos(
         count += 1;
         if last_log.elapsed().as_secs() > 3 {
             info!(
-                "total_dos_messages_sent: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
-                total_dos_messages_sent, tx_sent_count, count, balances
+                "total_dos_messages_sent: {total_dos_messages_sent} tx_sent_count: {tx_sent_count} loop_count: {count} balance(s): {balances:?}"
             );
             last_log = Instant::now();
         }
@@ -561,7 +559,7 @@ fn main() {
             Some(
                 solana_net_utils::get_cluster_shred_version(&entrypoint_addr).unwrap_or_else(
                     |err| {
-                        eprintln!("Failed to get shred version: {}", err);
+                        eprintln!("Failed to get shred version: {err}");
                         exit(1);
                     },
                 ),
@@ -615,7 +613,7 @@ fn main() {
     let account_keypair_refs: Vec<&Keypair> = account_keypairs.iter().collect();
 
     let rpc_addr = if !skip_gossip {
-        info!("Finding cluster entry: {:?}", entrypoint_addr);
+        info!("Finding cluster entry: {entrypoint_addr:?}");
         let (gossip_nodes, _validators) = discover(
             None, // keypair
             Some(&entrypoint_addr),
@@ -635,7 +633,7 @@ fn main() {
         info!("done found {} nodes", gossip_nodes.len());
         gossip_nodes[0].rpc().unwrap()
     } else {
-        info!("Using {:?} as the RPC address", entrypoint_addr);
+        info!("Using {entrypoint_addr:?} as the RPC address");
         entrypoint_addr
     };
 
@@ -694,7 +692,7 @@ pub mod test {
         let blockhash = solana_hash::Hash::default();
         let tx = Transaction::new(&signers, message, blockhash);
         let size = bincode::serialized_size(&tx).unwrap();
-        info!("size:{}", size);
+        info!("size:{size}");
         assert!(size < PACKET_DATA_SIZE as u64);
     }
 
@@ -758,6 +756,6 @@ pub mod test {
             100,
         );
         start.stop();
-        info!("{}", start);
+        info!("{start}");
     }
 }

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -297,9 +297,7 @@ fn run_transactions_dos(
                 }
                 last_balance = Instant::now();
                 if *balance < lamports * 2 {
-                    info!(
-                        "Balance {balance} is less than needed: {lamports}, doing aidrop..."
-                    );
+                    info!("Balance {balance} is less than needed: {lamports}, doing aidrop...");
                     if !airdrop_lamports(
                         &client,
                         &faucet_addr,

--- a/transaction-view/src/bytes.rs
+++ b/transaction-view/src/bytes.rs
@@ -301,13 +301,12 @@ mod tests {
             let read_value = read_compressed_u16(&buffer, &mut offset);
 
             // Assert that the read value matches the original value
-            assert_eq!(read_value, Ok(value), "Value mismatch for: {}", value);
+            assert_eq!(read_value, Ok(value), "Value mismatch for: {value}");
 
             // Assert that the offset matches the serialized length
             assert_eq!(
                 offset, serialized_len as usize,
-                "Offset mismatch for: {}",
-                value
+                "Offset mismatch for: {value}"
             );
         }
 
@@ -354,13 +353,12 @@ mod tests {
             let read_value = optimized_read_compressed_u16(&buffer, &mut offset);
 
             // Assert that the read value matches the original value
-            assert_eq!(read_value, Ok(value), "Value mismatch for: {}", value);
+            assert_eq!(read_value, Ok(value), "Value mismatch for: {value}");
 
             // Assert that the offset matches the serialized length
             assert_eq!(
                 offset, serialized_len as usize,
-                "Offset mismatch for: {}",
-                value
+                "Offset mismatch for: {value}"
             );
         }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -250,7 +250,7 @@ impl BroadcastStage {
                 | Error::ClusterInfo(ClusterInfoError::NoPeers) => (), // TODO: Why are the unit-tests throwing hundreds of these?
                 _ => {
                     inc_new_counter_error!("streamer-broadcaster-error", 1, 1);
-                    error!("{} broadcaster error: {:?}", name, e);
+                    error!("{name} broadcaster error: {e:?}");
                 }
             }
         }
@@ -745,10 +745,7 @@ pub mod test {
         }
 
         trace!(
-            "[broadcast_ledger] max_tick_height: {}, start_tick_height: {}, ticks_per_slot: {}",
-            max_tick_height,
-            start_tick_height,
-            ticks_per_slot,
+            "[broadcast_ledger] max_tick_height: {max_tick_height}, start_tick_height: {start_tick_height}, ticks_per_slot: {ticks_per_slot}",
         );
 
         let mut entries = vec![];

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -834,7 +834,7 @@ mod test {
         assert!(!coding.is_empty());
 
         let r = bs.entries_to_shreds(&keypair, &entries, 0, false, &mut stats, 10, 10);
-        info!("{:?}", r);
+        info!("{r:?}");
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
     }
 }

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -228,8 +228,7 @@ async fn run_server(
             }
             Err(error) => {
                 debug!(
-                    "Error while accepting incoming connection: {error:?} from {}",
-                    remote_addr
+                    "Error while accepting incoming connection: {error:?} from {remote_addr}"
                 );
             }
         }

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -227,9 +227,7 @@ async fn run_server(
                 ));
             }
             Err(error) => {
-                debug!(
-                    "Error while accepting incoming connection: {error:?} from {remote_addr}"
-                );
+                debug!("Error while accepting incoming connection: {error:?} from {remote_addr}");
             }
         }
     }

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -443,7 +443,7 @@ fn retransmit_shred(
             RetransmitSocket::Socket(socket) => match multi_target_send(socket, shred, &addrs) {
                 Ok(()) => num_addrs,
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
-                    error!("retransmit_to multi_target_send error: {ioerr:?}, {num_failed}/{} packets failed", num_addrs);
+                    error!("retransmit_to multi_target_send error: {ioerr:?}, {num_failed}/{num_addrs} packets failed");
                     num_addrs - num_failed
                 }
             },

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -191,7 +191,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> BlockProductionSchedulerInner<S
     fn take_pooled(&mut self) -> S::Inner {
         let id = {
             let Self::Pooled(inner) = &self else {
-                panic!("cannot take: {:?}", self)
+                panic!("cannot take: {self:?}")
             };
             inner.id()
         };
@@ -586,8 +586,7 @@ where
                 };
 
                 info!(
-                    "Scheduler pool cleaner: dropped {} idle inners, {} trashed inners, triggered {} timeout listeners",
-                    idle_inner_count, trashed_inner_count, triggered_timeout_listener_count,
+                    "Scheduler pool cleaner: dropped {idle_inner_count} idle inners, {trashed_inner_count} trashed inners, triggered {triggered_timeout_listener_count} timeout listeners",
                 );
                 sleepless_testing::at(CheckPoint::IdleSchedulerCleaned(idle_inner_count));
                 sleepless_testing::at(CheckPoint::TrashedSchedulerCleaned(trashed_inner_count));
@@ -2184,10 +2183,10 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                         let current_thread = thread::current();
                         error!("handler thread is panicking: {:?}", current_thread);
                         if sender.send(Err(HandlerPanicked)).is_ok() {
-                            info!("notified a panic from {:?}", current_thread);
+                            info!("notified a panic from {current_thread:?}");
                         } else {
                             // It seems that the scheduler thread has been aborted already...
-                            warn!("failed to notify a panic from {:?}", current_thread);
+                            warn!("failed to notify a panic from {current_thread:?}");
                         }
                     }
                     let mut task = ExecutedTask::new_boxed(task);
@@ -2220,7 +2219,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             .map({
                 |thx| {
                     thread::Builder::new()
-                        .name(format!("solScHandle{mode_char}{:02}", thx))
+                        .name(format!("solScHandle{mode_char}{thx:02}"))
                         .spawn_tracked(handler_main_loop())
                         .unwrap()
                 }
@@ -2251,13 +2250,13 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                     (_, Some(s)) => s,
                     (None, None) => "<No panic info>",
                 };
-                panic!("{} (From: {:?})", panic_message, thread);
+                panic!("{panic_message} (From: {thread:?})");
             })
         }
 
         if let Some(scheduler_thread) = self.scheduler_thread.take() {
             for thread in self.handler_threads.drain(..) {
-                debug!("joining...: {:?}", thread);
+                debug!("joining...: {thread:?}");
                 () = join_with_panic_message(thread).unwrap();
             }
             () = join_with_panic_message(scheduler_thread).unwrap();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -624,9 +624,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         pubkey_str: String,
     ) -> Result<HashMap<RpcAccountIndex, usize>> {
-        debug!(
-            "get_secondary_index_key_size rpc request received: {pubkey_str:?}"
-        );
+        debug!("get_secondary_index_key_size rpc request received: {pubkey_str:?}");
         let index_key = verify_pubkey(&pubkey_str)?;
         meta.with_post_init(|post_init| {
             let bank = post_init.bank_forks.read().unwrap().root_bank();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -529,8 +529,8 @@ impl AdminRpc for AdminRpcImpl {
         let mut write_staked_nodes = meta.staked_nodes_overrides.write().unwrap();
         write_staked_nodes.clear();
         write_staked_nodes.extend(loaded_config);
-        info!("Staked nodes overrides loaded from {}", path);
-        debug!("overrides map: {:?}", write_staked_nodes);
+        info!("Staked nodes overrides loaded from {path}");
+        debug!("overrides map: {write_staked_nodes:?}");
         Ok(())
     }
 
@@ -625,8 +625,7 @@ impl AdminRpc for AdminRpcImpl {
         pubkey_str: String,
     ) -> Result<HashMap<RpcAccountIndex, usize>> {
         debug!(
-            "get_secondary_index_key_size rpc request received: {:?}",
-            pubkey_str
+            "get_secondary_index_key_size rpc request received: {pubkey_str:?}"
         );
         let index_key = verify_pubkey(&pubkey_str)?;
         meta.with_post_init(|post_init| {
@@ -833,7 +832,7 @@ pub fn run(ledger_path: &Path, metadata: AdminRpcRequestMetadata) {
 
             match server {
                 Err(err) => {
-                    warn!("Unable to start admin rpc service: {:?}", err);
+                    warn!("Unable to start admin rpc service: {err:?}");
                 }
                 Ok(server) => {
                     info!("started admin rpc service!");
@@ -920,7 +919,7 @@ where
 pub fn load_staked_nodes_overrides(
     path: &String,
 ) -> std::result::Result<StakedNodesOverrides, Box<dyn error::Error>> {
-    debug!("Loading staked nodes overrides configuration from {}", path);
+    debug!("Loading staked nodes overrides configuration from {path}");
     if Path::new(&path).exists() {
         let file = std::fs::File::open(path)?;
         Ok(serde_yaml::from_reader(file)?)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -165,7 +165,7 @@ pub fn warn_for_deprecated_arguments(matches: &ArgMatches) {
                     msg.push('.');
                 }
             }
-            warn!("{}", msg);
+            warn!("{msg}");
         }
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1397,9 +1397,7 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
             Err(err) => eprintln!("get_cluster_shred_version failed: {entrypoint}, {err}"),
             Ok(0) => eprintln!("entrypoint {entrypoint} returned shred-version zero"),
             Ok(shred_version) => {
-                info!(
-                    "obtained shred-version {shred_version} from {entrypoint}"
-                );
+                info!("obtained shred-version {shred_version} from {entrypoint}");
                 return Some(shred_version);
             }
         }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -156,7 +156,7 @@ pub fn execute(
         match &staked_nodes_overrides_path {
             None => StakedNodesOverrides::default(),
             Some(p) => load_staked_nodes_overrides(p).unwrap_or_else(|err| {
-                error!("Failed to load stake-nodes-overrides from {}: {}", p, err);
+                error!("Failed to load stake-nodes-overrides from {p}: {err}");
                 clap::Error::with_description(
                     "Failed to load configuration of stake-nodes-overrides argument",
                     clap::ErrorKind::InvalidValue,
@@ -985,9 +985,8 @@ pub fn execute(
         let full_snapshot_interval_slots = full_snapshot_interval_slots.get();
         if full_snapshot_interval_slots > DEFAULT_SLOTS_PER_EPOCH {
             warn!(
-                "The full snapshot interval is excessively large: {}! This will negatively \
+                "The full snapshot interval is excessively large: {full_snapshot_interval_slots}! This will negatively \
                 impact the background cleanup tasks in accounts-db. Consider a smaller value.",
-                full_snapshot_interval_slots,
             );
         }
     }
@@ -1108,8 +1107,7 @@ pub fn execute(
             .find_map(|i| {
                 let entrypoint_addr = &entrypoint_addrs[i];
                 info!(
-                    "Contacting {} to determine the validator's public IP address",
-                    entrypoint_addr
+                    "Contacting {entrypoint_addr} to determine the validator's public IP address"
                 );
                 solana_net_utils::get_public_ip_addr_with_binding(
                     entrypoint_addr,
@@ -1400,8 +1398,7 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
             Ok(0) => eprintln!("entrypoint {entrypoint} returned shred-version zero"),
             Ok(shred_version) => {
                 info!(
-                    "obtained shred-version {} from {}",
-                    shred_version, entrypoint
+                    "obtained shred-version {shred_version} from {entrypoint}"
                 );
                 return Some(shred_version);
             }

--- a/version/build.rs
+++ b/version/build.rs
@@ -5,7 +5,7 @@ fn main() {
         if git_output.status.success() {
             if let Ok(git_commit_hash) = String::from_utf8(git_output.stdout) {
                 let trimmed_hash = git_commit_hash.trim().to_string();
-                println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={}", trimmed_hash);
+                println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={trimmed_hash}");
             }
         }
     }

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -57,7 +57,7 @@ fn parse_url_with_scheme(expected_schemes: &'static [&'static str]) -> ValuePars
     ValueParser::from(move |input: &str| {
         // Attempt to parse the input as a URL
         let parsed_url =
-            Url::parse(input).map_err(|e| format!("Invalid URL '{}': {}", input, e))?;
+            Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
 
         // Check the scheme of the URL
         if expected_schemes.contains(&parsed_url.scheme()) {

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -56,8 +56,7 @@ fn get_default_tpu_coalesce_ms() -> &'static str {
 fn parse_url_with_scheme(expected_schemes: &'static [&'static str]) -> ValueParser {
     ValueParser::from(move |input: &str| {
         // Attempt to parse the input as a URL
-        let parsed_url =
-            Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
+        let parsed_url = Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
 
         // Check the scheme of the URL
         if expected_schemes.contains(&parsed_url.scheme()) {

--- a/vortexor/src/sender.rs
+++ b/vortexor/src/sender.rs
@@ -76,7 +76,7 @@ impl PacketBatchSender {
             let destinations = destinations.read().expect("Expected to get destinations");
             match Self::receive_until(packet_batch_receiver.clone(), recv_timeout, batch_size) {
                 Ok((packet_count, packet_batches)) => {
-                    trace!("Received packet counts: {}", packet_count);
+                    trace!("Received packet counts: {packet_count}");
                     // Collect all packets once for all destinations
                     let mut packets: Vec<&[u8]> = Vec::new();
 

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -52,7 +52,7 @@ impl StakeUpdater {
                         &rpc_load_balancer,
                         &refresh_sleep_duration,
                     ) {
-                        warn!("Failed to refresh pubkey to stake map! Error: {:?}", err);
+                        warn!("Failed to refresh pubkey to stake map! Error: {err:?}");
                         sleep(refresh_sleep_duration);
                     }
                 }

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -90,8 +90,8 @@ async fn test_vortexor() {
 fn get_server_urls(validator: &ClusterValidatorInfo) -> (Url, Url) {
     let rpc_addr = validator.info.contact_info.rpc().unwrap();
     let rpc_pubsub_addr = validator.info.contact_info.rpc_pubsub().unwrap();
-    let rpc_url = Url::parse(format!("http://{}", rpc_addr).as_str()).unwrap();
-    let ws_url = Url::parse(format!("ws://{}", rpc_pubsub_addr).as_str()).unwrap();
+    let rpc_url = Url::parse(format!("http://{rpc_addr}").as_str()).unwrap();
+    let ws_url = Url::parse(format!("ws://{rpc_pubsub_addr}").as_str()).unwrap();
     (rpc_url, ws_url)
 }
 
@@ -135,7 +135,7 @@ fn test_stake_update() {
             .recv_timeout(slot_receive_timeout)
             .unwrap_or_else(|_| panic!("Expected a slot within {slot_receive_timeout:?}"));
         i += 1;
-        info!("Received a slot update: {}", slot);
+        info!("Received a slot update: {slot}");
     }
 
     let rpc_load_balancer = Arc::new(rpc_load_balancer);
@@ -154,10 +154,10 @@ fn test_stake_update() {
     loop {
         let stakes = shared_staked_nodes.read().unwrap();
         if let Some(stake) = stakes.get_node_stake(pubkey) {
-            info!("Stake for {}: {}", pubkey, stake);
+            info!("Stake for {pubkey}: {stake}");
             assert_eq!(stake, default_node_stake);
             let total_stake = stakes.total_stake();
-            info!("total_stake: {}", total_stake);
+            info!("total_stake: {total_stake}");
             assert!(total_stake >= default_node_stake);
             break;
         }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -282,8 +282,8 @@ fn query_endpoint(
 
     match get_cluster_info(config, &endpoint.rpc_client) {
         Ok((transaction_count, recent_blockhash, vote_accounts, validator_balances)) => {
-            info!("Current transaction count: {}", transaction_count);
-            info!("Recent blockhash: {}", recent_blockhash);
+            info!("Current transaction count: {transaction_count}");
+            info!("Recent blockhash: {recent_blockhash}");
             info!("Current validator count: {}", vote_accounts.current.len());
             info!(
                 "Delinquent validator count: {}",
@@ -385,12 +385,12 @@ fn query_endpoint(
             if let client_error::ErrorKind::Reqwest(reqwest_err) = err.kind() {
                 if let Some(client_error::reqwest::StatusCode::BAD_GATEWAY) = reqwest_err.status() {
                     if config.ignore_http_bad_gateway {
-                        warn!("Error suppressed: {}", err);
+                        warn!("Error suppressed: {err}");
                         return Ok(None);
                     }
                 }
             }
-            warn!("rpc-error: {}", err);
+            warn!("rpc-error: {err}");
             Err(err)
         }
     }
@@ -413,8 +413,8 @@ fn validate_endpoints(
         let slot = endpoint.rpc_client.get_slot()?;
         let genesis_hash = endpoint.rpc_client.get_genesis_hash()?;
 
-        info!("Genesis hash: {}", genesis_hash);
-        info!("Current slot: {}", slot);
+        info!("Genesis hash: {genesis_hash}");
+        info!("Current slot: {slot}");
 
         max_slot = max_slot.max(slot);
         min_slot = min_slot.min(slot);
@@ -458,7 +458,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .collect();
 
     if let Err(err) = validate_endpoints(&config, &endpoints) {
-        error!("Endpoint validation failed: {}", err);
+        error!("Endpoint validation failed: {err}");
         std::process::exit(1);
     }
 
@@ -550,7 +550,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     "All clear after {}",
                     humantime::format_duration(alarm_duration)
                 );
-                info!("{}", all_clear_msg);
+                info!("{all_clear_msg}");
                 notifier.send(
                     &format!("agave-watchtower{}: {}", config.name_suffix, all_clear_msg),
                     &NotificationType::Resolve { incident },

--- a/wen-restart/src/heaviest_fork_aggregate.rs
+++ b/wen-restart/src/heaviest_fork_aggregate.rs
@@ -110,8 +110,7 @@ impl HeaviestForkAggregate {
         let sender_stake = self.epoch_stakes.node_id_to_stake(from).unwrap_or(0);
         if sender_stake == 0 {
             warn!(
-                "Gossip should not accept zero-stake RestartLastVotedFork from {:?}",
-                from
+                "Gossip should not accept zero-stake RestartLastVotedFork from {from:?}"
             );
             return HeaviestForkAggregateResult::ZeroStakeIgnored;
         }

--- a/wen-restart/src/heaviest_fork_aggregate.rs
+++ b/wen-restart/src/heaviest_fork_aggregate.rs
@@ -109,9 +109,7 @@ impl HeaviestForkAggregate {
         let from = &received_heaviest_fork.from;
         let sender_stake = self.epoch_stakes.node_id_to_stake(from).unwrap_or(0);
         if sender_stake == 0 {
-            warn!(
-                "Gossip should not accept zero-stake RestartLastVotedFork from {from:?}"
-            );
+            warn!("Gossip should not accept zero-stake RestartLastVotedFork from {from:?}");
             return HeaviestForkAggregateResult::ZeroStakeIgnored;
         }
         if from == &self.my_pubkey {

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -430,9 +430,7 @@ pub(crate) fn find_heaviest_fork(
         bank_forks.clone(),
         &exit,
     )?;
-    info!(
-        "Heaviest fork found: slot: {heaviest_fork_slot}, bankhash: {heaviest_fork_bankhash:?}"
-    );
+    info!("Heaviest fork found: slot: {heaviest_fork_slot}, bankhash: {heaviest_fork_bankhash:?}");
     Ok((heaviest_fork_slot, heaviest_fork_bankhash))
 }
 
@@ -959,9 +957,7 @@ pub(crate) fn send_and_receive_heaviest_fork(
         ) {
             Ok(()) => pushfn(coordinator_slot, coordinator_hash),
             Err(e) => {
-                warn!(
-                    "Failed to verify coordinator heaviest fork: {e:?}, exit soon"
-                );
+                warn!("Failed to verify coordinator heaviest fork: {e:?}, exit soon");
                 pushfn(my_heaviest_fork_slot, my_heaviest_fork_hash);
                 // flush_push_queue only flushes the messages to crds, doesn't guarantee
                 // sending them out, so we still need to wait for a while before exiting.
@@ -1048,9 +1044,7 @@ pub fn wait_for_wen_restart(config: WenRestartConfig) -> Result<()> {
                             config.blockstore.clone(),
                             config.exit.clone(),
                         )?;
-                        info!(
-                            "Heaviest fork found: slot: {slot}, bankhash: {bankhash}"
-                        );
+                        info!("Heaviest fork found: slot: {slot}, bankhash: {bankhash}");
                         HeaviestForkRecord {
                             slot,
                             bankhash: bankhash.to_string(),
@@ -1248,9 +1242,7 @@ pub(crate) fn initialize(
         Err(e) => {
             let stdio_err = e.downcast_ref::<std::io::Error>();
             if stdio_err.is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound) {
-                info!(
-                    "wen restart proto file not found at {records_path:?}, write init state"
-                );
+                info!("wen restart proto file not found at {records_path:?}, write init state");
                 let progress = WenRestartProgress {
                     state: RestartState::Init.into(),
                     ..Default::default()

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -102,24 +102,22 @@ impl std::fmt::Display for WenRestartError {
             WenRestartError::BankHashMismatch(slot, expected, actual) => {
                 write!(
                     f,
-                    "Bank hash mismatch for slot: {} expected: {} actual: {}",
-                    slot, expected, actual
+                    "Bank hash mismatch for slot: {slot} expected: {expected} actual: {actual}"
                 )
             }
             WenRestartError::BlockNotFound(slot) => {
-                write!(f, "Block not found: {}", slot)
+                write!(f, "Block not found: {slot}")
             }
             WenRestartError::BlockNotFull(slot) => {
-                write!(f, "Block not full: {}", slot)
+                write!(f, "Block not full: {slot}")
             }
             WenRestartError::BlockNotFrozenAfterReplay(slot, err) => {
-                write!(f, "Block not frozen after replay: {} {:?}", slot, err)
+                write!(f, "Block not frozen after replay: {slot} {err:?}")
             }
             WenRestartError::BlockNotLinkedToExpectedParent(slot, parent, expected_parent) => {
                 write!(
                     f,
-                    "Block {} is not linked to expected parent {} but to {:?}",
-                    slot, expected_parent, parent
+                    "Block {slot} is not linked to expected parent {expected_parent} but to {parent:?}"
                 )
             }
             WenRestartError::ChildStakeLargerThanParent(
@@ -130,8 +128,7 @@ impl std::fmt::Display for WenRestartError {
             ) => {
                 write!(
                     f,
-                    "Block {} has more stake {} than its parent {} with stake {}",
-                    slot, child_stake, parent, parent_stake
+                    "Block {slot} has more stake {child_stake} than its parent {parent} with stake {parent_stake}"
                 )
             }
             WenRestartError::Exiting => write!(f, "Exiting"),
@@ -160,10 +157,10 @@ impl std::fmt::Display for WenRestartError {
                 )
             }
             WenRestartError::MalformedLastVotedForkSlotsProtobuf(record) => {
-                write!(f, "Malformed last voted fork slots protobuf: {:?}", record)
+                write!(f, "Malformed last voted fork slots protobuf: {record:?}")
             }
             WenRestartError::MalformedProgress(state, missing) => {
-                write!(f, "Malformed progress: {:?} missing {}", state, missing)
+                write!(f, "Malformed progress: {state:?} missing {missing}")
             }
             WenRestartError::MissingLastVotedForkSlots => {
                 write!(f, "Missing last voted fork slots")
@@ -174,12 +171,11 @@ impl std::fmt::Display for WenRestartError {
             WenRestartError::NotEnoughStakeAgreeingWithUs(slot, hash, block_stake_map) => {
                 write!(
                     f,
-                    "Not enough stake agreeing with our slot: {} hash: {}\n {:?}",
-                    slot, hash, block_stake_map,
+                    "Not enough stake agreeing with our slot: {slot} hash: {hash}\n {block_stake_map:?}",
                 )
             }
             WenRestartError::UnexpectedState(state) => {
-                write!(f, "Unexpected state: {:?}", state)
+                write!(f, "Unexpected state: {state:?}")
             }
         }
     }
@@ -257,7 +253,7 @@ pub(crate) fn aggregate_restart_last_voted_fork_slots(
             if let Err(e) =
                 last_voted_fork_slots_aggregate.aggregate_from_record(key_string, message)
             {
-                error!("Failed to aggregate from record: {:?}", e);
+                error!("Failed to aggregate from record: {e:?}");
             }
         }
     } else {
@@ -294,8 +290,8 @@ pub(crate) fn aggregate_restart_last_voted_fork_slots(
                     progress.conflict_message.insert(
                         from,
                         ConflictMessage {
-                            old_message: format!("{:?}", old_record),
-                            new_message: format!("{:?}", new_record),
+                            old_message: format!("{old_record:?}"),
+                            new_message: format!("{new_record:?}"),
                         },
                     );
                 }
@@ -405,8 +401,7 @@ pub(crate) fn find_heaviest_fork(
         if let Ok(Some(block_meta)) = blockstore.meta(*slot) {
             if block_meta.parent_slot != Some(expected_parent) {
                 if expected_parent == root_slot {
-                    error!("First block {} in repair list not linked to local root {}, this could mean our root is too old",
-                        slot, root_slot);
+                    error!("First block {slot} in repair list not linked to local root {root_slot}, this could mean our root is too old");
                 } else {
                     error!(
                         "Block {} in blockstore is not linked to expected parent from Wen Restart {} but to Block {:?}",
@@ -436,8 +431,7 @@ pub(crate) fn find_heaviest_fork(
         &exit,
     )?;
     info!(
-        "Heaviest fork found: slot: {}, bankhash: {:?}",
-        heaviest_fork_slot, heaviest_fork_bankhash
+        "Heaviest fork found: slot: {heaviest_fork_slot}, bankhash: {heaviest_fork_bankhash:?}"
     );
     Ok((heaviest_fork_slot, heaviest_fork_bankhash))
 }
@@ -720,7 +714,7 @@ pub(crate) fn aggregate_restart_heaviest_fork(
         for message in &aggregate_record.received {
             if let Err(e) = heaviest_fork_aggregate.aggregate_from_record(message) {
                 // Do not abort wen_restart if we got one malformed message.
-                error!("Failed to aggregate from record: {:?}", e);
+                error!("Failed to aggregate from record: {e:?}");
             }
         }
     } else {
@@ -740,11 +734,11 @@ pub(crate) fn aggregate_restart_heaviest_fork(
         }
         let start = timestamp();
         for new_heaviest_fork in cluster_info.get_restart_heaviest_fork(&mut cursor) {
-            info!("Received new heaviest fork: {:?}", new_heaviest_fork);
+            info!("Received new heaviest fork: {new_heaviest_fork:?}");
             let from = new_heaviest_fork.from.to_string();
             match heaviest_fork_aggregate.aggregate(new_heaviest_fork) {
                 HeaviestForkAggregateResult::Inserted(record) => {
-                    info!("Successfully aggregated new heaviest fork: {:?}", record);
+                    info!("Successfully aggregated new heaviest fork: {record:?}");
                     progress
                         .heaviest_fork_aggregate
                         .as_mut()
@@ -757,8 +751,8 @@ pub(crate) fn aggregate_restart_heaviest_fork(
                     progress.conflict_message.insert(
                         from,
                         ConflictMessage {
-                            old_message: format!("{:?}", old_record),
-                            new_message: format!("{:?}", new_record),
+                            old_message: format!("{old_record:?}"),
+                            new_message: format!("{new_record:?}"),
                         },
                     );
                 }
@@ -820,7 +814,7 @@ pub(crate) fn repair_heaviest_fork(
         } else {
             vec![heaviest_slot]
         };
-        info!("wen_restart repair slots: {:?}", to_repair);
+        info!("wen_restart repair slots: {to_repair:?}");
         if to_repair.is_empty() {
             return Ok(()); // All blocks are full
         }
@@ -918,8 +912,7 @@ pub(crate) fn receive_restart_heaviest_fork(
         for new_heaviest_fork in cluster_info.get_restart_heaviest_fork(&mut cursor) {
             if new_heaviest_fork.from == wen_restart_coordinator {
                 info!(
-                    "Received new heaviest fork from coordinator: {} {:?}",
-                    wen_restart_coordinator, new_heaviest_fork
+                    "Received new heaviest fork from coordinator: {wen_restart_coordinator} {new_heaviest_fork:?}"
                 );
                 let coordinator_heaviest_slot = new_heaviest_fork.last_slot;
                 let coordinator_heaviest_hash = new_heaviest_fork.last_slot_hash;
@@ -967,8 +960,7 @@ pub(crate) fn send_and_receive_heaviest_fork(
             Ok(()) => pushfn(coordinator_slot, coordinator_hash),
             Err(e) => {
                 warn!(
-                    "Failed to verify coordinator heaviest fork: {:?}, exit soon",
-                    e
+                    "Failed to verify coordinator heaviest fork: {e:?}, exit soon"
                 );
                 pushfn(my_heaviest_fork_slot, my_heaviest_fork_hash);
                 // flush_push_queue only flushes the messages to crds, doesn't guarantee
@@ -1057,8 +1049,7 @@ pub fn wait_for_wen_restart(config: WenRestartConfig) -> Result<()> {
                             config.exit.clone(),
                         )?;
                         info!(
-                            "Heaviest fork found: slot: {}, bankhash: {}",
-                            slot, bankhash
+                            "Heaviest fork found: slot: {slot}, bankhash: {bankhash}"
                         );
                         HeaviestForkRecord {
                             slot,
@@ -1128,9 +1119,8 @@ pub fn wait_for_wen_restart(config: WenRestartConfig) -> Result<()> {
             } => {
                 error!(
                     "Wen start finished, please remove --wen_restart and restart with \
-                    --wait-for-supermajority {} --expected-bank-hash {} --expected-shred-version {} \
+                    --wait-for-supermajority {slot} --expected-bank-hash {hash} --expected-shred-version {shred_version} \
                     --no-snapshot-fetch",
-                    slot, hash, shred_version,
                 );
                 if config.cluster_info.id() == config.wen_restart_coordinator {
                     aggregate_restart_heaviest_fork(
@@ -1259,8 +1249,7 @@ pub(crate) fn initialize(
             let stdio_err = e.downcast_ref::<std::io::Error>();
             if stdio_err.is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound) {
                 info!(
-                    "wen restart proto file not found at {:?}, write init state",
-                    records_path
+                    "wen restart proto file not found at {records_path:?}, write init state"
                 );
                 let progress = WenRestartProgress {
                     state: RestartState::Init.into(),
@@ -1408,7 +1397,7 @@ pub(crate) fn initialize(
 fn read_wen_restart_records(records_path: &PathBuf) -> Result<WenRestartProgress> {
     let buffer = read(records_path)?;
     let progress = WenRestartProgress::decode(&mut Cursor::new(buffer))?;
-    info!("read record {:?}", progress);
+    info!("read record {progress:?}");
     Ok(progress)
 }
 
@@ -1418,7 +1407,7 @@ pub(crate) fn write_wen_restart_records(
 ) -> Result<()> {
     // overwrite anything if exists
     let mut file = File::create(records_path)?;
-    info!("writing new record {:?}", new_progress);
+    info!("writing new record {new_progress:?}");
     let mut buf = Vec::with_capacity(new_progress.encoded_len());
     new_progress.encode(&mut buf)?;
     file.write_all(&buf)?;
@@ -2053,7 +2042,7 @@ mod tests {
             None,
             &mut timing,
         ) {
-            panic!("process_single_slot failed: {:?}", e);
+            panic!("process_single_slot failed: {e:?}");
         }
 
         {

--- a/zk-sdk/src/encryption/pod/auth_encryption.rs
+++ b/zk-sdk/src/encryption/pod/auth_encryption.rs
@@ -82,7 +82,7 @@ mod tests {
         let ae_key = AeKey::new_rand();
         let expected_ae_ciphertext: PodAeCiphertext = ae_key.encrypt(0_u64).into();
 
-        let ae_ciphertext_base64_str = format!("{}", expected_ae_ciphertext);
+        let ae_ciphertext_base64_str = format!("{expected_ae_ciphertext}");
         let computed_ae_ciphertext = PodAeCiphertext::from_str(&ae_ciphertext_base64_str).unwrap();
 
         assert_eq!(expected_ae_ciphertext, computed_ae_ciphertext);

--- a/zk-sdk/src/encryption/pod/elgamal.rs
+++ b/zk-sdk/src/encryption/pod/elgamal.rs
@@ -188,7 +188,7 @@ mod tests {
         let elgamal_keypair = ElGamalKeypair::new_rand();
         let expected_elgamal_pubkey: PodElGamalPubkey = (*elgamal_keypair.pubkey()).into();
 
-        let elgamal_pubkey_base64_str = format!("{}", expected_elgamal_pubkey);
+        let elgamal_pubkey_base64_str = format!("{expected_elgamal_pubkey}");
         let computed_elgamal_pubkey =
             PodElGamalPubkey::from_str(&elgamal_pubkey_base64_str).unwrap();
 
@@ -201,7 +201,7 @@ mod tests {
         let expected_elgamal_ciphertext: PodElGamalCiphertext =
             elgamal_keypair.pubkey().encrypt(0_u64).into();
 
-        let elgamal_ciphertext_base64_str = format!("{}", expected_elgamal_ciphertext);
+        let elgamal_ciphertext_base64_str = format!("{expected_elgamal_ciphertext}");
         let computed_elgamal_ciphertext =
             PodElGamalCiphertext::from_str(&elgamal_ciphertext_base64_str).unwrap();
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -75,7 +75,7 @@ mod tests {
         let ae_key = AeKey::new_rand();
         let expected_ae_ciphertext: AeCiphertext = ae_key.encrypt(0_u64).into();
 
-        let ae_ciphertext_base64_str = format!("{}", expected_ae_ciphertext);
+        let ae_ciphertext_base64_str = format!("{expected_ae_ciphertext}");
         let computed_ae_ciphertext = AeCiphertext::from_str(&ae_ciphertext_base64_str).unwrap();
 
         assert_eq!(expected_ae_ciphertext, computed_ae_ciphertext);

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -161,7 +161,7 @@ mod tests {
         let elgamal_keypair = ElGamalKeypair::new_rand();
         let expected_elgamal_pubkey: ElGamalPubkey = (*elgamal_keypair.pubkey()).into();
 
-        let elgamal_pubkey_base64_str = format!("{}", expected_elgamal_pubkey);
+        let elgamal_pubkey_base64_str = format!("{expected_elgamal_pubkey}");
         let computed_elgamal_pubkey = ElGamalPubkey::from_str(&elgamal_pubkey_base64_str).unwrap();
 
         assert_eq!(expected_elgamal_pubkey, computed_elgamal_pubkey);
@@ -173,7 +173,7 @@ mod tests {
         let expected_elgamal_ciphertext: ElGamalCiphertext =
             elgamal_keypair.pubkey().encrypt(0_u64).into();
 
-        let elgamal_ciphertext_base64_str = format!("{}", expected_elgamal_ciphertext);
+        let elgamal_ciphertext_base64_str = format!("{expected_elgamal_ciphertext}");
         let computed_elgamal_ciphertext =
             ElGamalCiphertext::from_str(&elgamal_ciphertext_base64_str).unwrap();
 


### PR DESCRIPTION
#### Problem
Work towards #6850 - it appears that using variables inline in `format!` is now required. Sample error output:
```
error: variables can be used directly in the `format!` string
 --> version/build.rs:8:17
  |
8 |                 println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={}", trimmed_hash);
  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
  = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
  |
8 -                 println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={}", trimmed_hash);
8 +                 println!("cargo:rustc-env=AGAVE_GIT_COMMIT_HASH={trimmed_hash}");
  |
```

#### Summary of Changes
The steps to create this PR:
1. Setting version in `rust-toolchain.toml` to `1.88.0`
2. Run `cargo clippy --fix --allow-dirty`
3. Manually revert several changes that were not `uninlined_format_args` complaints
4. Add all changed files to first commit
5. Run `./cargo nightly fmt` to cleanup strings modified in 1st commit
6. Run `cargo clippy --fix --tests --allow-dirty`
7. Run `cargo nightly fmt` to cleanup strings modified in 3rd commit