### PR TITLE
clippy: iter_kv_map

### DIFF
--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -46,7 +46,7 @@ impl From<Vec<Slot>> for Ancestors {
 
 impl From<&HashMap<Slot, usize>> for Ancestors {
     fn from(source: &HashMap<Slot, usize>) -> Ancestors {
-        let vec = source.iter().map(|(slot, _)| *slot).collect::<Vec<_>>();
+        let vec = source.keys().copied().collect::<Vec<_>>();
         Ancestors::from(vec)
     }
 }

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -60,8 +60,8 @@ const fn feature_u64(feature: &Pubkey) -> u64 {
 static INDEXED_FEATURES: std::sync::LazyLock<HashMap<u64, Pubkey>> =
     std::sync::LazyLock::new(|| {
         FEATURE_NAMES
-            .iter()
-            .map(|(pubkey, _)| (feature_u64(pubkey), *pubkey))
+            .keys()
+            .map(|pubkey| (feature_u64(pubkey), *pubkey))
             .collect()
     });
 


### PR DESCRIPTION
#### Problem
Work for upgrading to Rust 1.88.0 - see https://github.com/anza-xyz/agave/issues/6850

#### Summary of Changes
This PR resolves violations of `iter_kv_map` such as below:
https://rust-lang.github.io/rust-clippy/master/#iter_kv_map
```
error: iterating on a map's keys
  --> accounts-db/src/ancestors.rs:49:19
   |
49 |         let vec = source.iter().map(|(slot, _)| *slot).collect::<Vec<_>>();
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `source.keys().map(|slot| *slot)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
   = note: `-D clippy::iter-kv-map` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
```
