### PR TITLE
clippy: manual_abs_diff

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -304,11 +304,7 @@ impl SimulatorLoopLogger {
                     } else {
                         "-"
                     },
-                    if elapsed_simulation_time > elapsed_event_time {
-                        elapsed_simulation_time - elapsed_event_time
-                    } else {
-                        elapsed_event_time - elapsed_simulation_time
-                    },
+                    elapsed_simulation_time.abs_diff(elapsed_event_time),
                     elapsed_simulation_time,
                     elapsed_event_time,
                 );

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2150,11 +2150,7 @@ mod tests {
                 })
                 .sum::<u64>();
 
-            let delta = if total_effective_stake > prev_total_effective_stake {
-                total_effective_stake - prev_total_effective_stake
-            } else {
-                prev_total_effective_stake - total_effective_stake
-            };
+            let delta = total_effective_stake.abs_diff(prev_total_effective_stake);
 
             // uncomment and add ! for fun with graphing
             // eprint("{:8} {:8} {:8} ", epoch, total_effective_stake, delta);


### PR DESCRIPTION
#### Problem
Work for upgrading to Rust 1.88.0 - see https://github.com/anza-xyz/agave/issues/6850

#### Summary of Changes
This PR resolves violations of `manual_abs_diff` which was added in 1.88:
https://rust-lang.github.io/rust-clippy/master/#manual_abs_diff
