### PR TITLE
Support closing connections when QUIC connection drop

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -245,12 +245,6 @@ impl QuicClient {
                 CONNECTION_CLOSE_CODE_APPLICATION_CLOSE.into(),
                 CONNECTION_CLOSE_REASON_APPLICATION_CLOSE,
             );
-            let result = conn.connection.closed().await;
-            trace!(
-                "Closed connection to {} connection_id: {:?} result: {result:?}",
-                self.addr,
-                conn.connection
-            );
         }
     }
 }

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -245,7 +245,12 @@ impl QuicClient {
                 CONNECTION_CLOSE_CODE_APPLICATION_CLOSE.into(),
                 CONNECTION_CLOSE_REASON_APPLICATION_CLOSE,
             );
-            conn.connection.closed().await;
+            let result = conn.connection.closed().await;
+            trace!(
+                "Closed connection to {} connection_id: {:?} result: {result:?}",
+                self.addr,
+                conn.connection
+            );
         }
     }
 }

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -229,6 +229,27 @@ pub struct QuicClient {
     stats: Arc<ClientStats>,
 }
 
+const CONNECTION_CLOSE_CODE_APPLICATION_CLOSE: u32 = 0u32;
+const CONNECTION_CLOSE_REASON_APPLICATION_CLOSE: &[u8] = b"dropped";
+
+impl QuicClient {
+    /// Explicitly close the connection. Must be called manually if cleanup is needed.
+    pub async fn close(&self) {
+        let mut conn_guard = self.connection.lock().await;
+        if let Some(conn) = conn_guard.take() {
+            debug!(
+                "Closing connection to {} connection_id: {:?}",
+                self.addr, conn.connection
+            );
+            conn.connection.close(
+                CONNECTION_CLOSE_CODE_APPLICATION_CLOSE.into(),
+                CONNECTION_CLOSE_REASON_APPLICATION_CLOSE,
+            );
+            conn.connection.closed().await;
+        }
+    }
+}
+
 impl QuicClient {
     pub fn new(endpoint: Arc<QuicLazyInitializedEndpoint>, addr: SocketAddr) -> Self {
         Self {

--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -180,3 +180,9 @@ impl ClientConnection for QuicClientConnection {
         Ok(())
     }
 }
+
+pub(crate) fn close_quic_connection(connection: Arc<QuicClient>) {
+    // Close the connection and release resources
+    trace!("Closing QUIC connection to {}", connection.server_addr());
+    RUNTIME.block_on(connection.close());
+}


### PR DESCRIPTION
#### Problem
When we increase connection idle time out, the connections opened in earlier connection cache instance will take longer time to reach timeout and close. This cause problems for applications recreating connection cache in lower level APIs. As their new connection attempt are blocked by connection limit per peer.

#### Summary of Changes
This support gracefully closing the client connections when the connection cache is dropped.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
