### PR TITLE
Support shorter connection handshaking timeout in tpu-client-next

### DIFF
--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -4,6 +4,7 @@
 use {
     super::leader_updater::LeaderUpdater,
     crate::{
+        connection_worker::DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
         quic_networking::{
             create_client_config, create_client_endpoint, QuicClientCertificate, QuicError,
         },
@@ -40,7 +41,7 @@ pub struct ConnectionWorkersScheduler {
 }
 
 /// Errors that arise from running [`ConnectionWorkersSchedulerError`].
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum ConnectionWorkersSchedulerError {
     #[error(transparent)]
     QuicError(#[from] QuicError),
@@ -275,6 +276,7 @@ impl ConnectionWorkersScheduler {
                         worker_channel_size,
                         skip_check_transaction_age,
                         max_reconnect_attempts,
+                        DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
                         stats.clone(),
                     );
                     if let Some(pop_worker) = workers.push(peer, worker) {

--- a/tpu-client-next/src/quic_networking.rs
+++ b/tpu-client-next/src/quic_networking.rs
@@ -1,18 +1,15 @@
 //! Utility code to handle quic networking.
 
 use {
-    crate::{
-        connection_worker::DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
-        connection_workers_scheduler::BindTarget,
-    },
+    crate::connection_workers_scheduler::BindTarget,
     quinn::{
         crypto::rustls::QuicClientConfig, default_runtime, ClientConfig, Connection, Endpoint,
         EndpointConfig, IdleTimeout, TransportConfig,
     },
-    solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_SEND_FAIRNESS},
+    solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS},
     solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
     solana_tls_utils::tls_client_config_builder,
-    std::{sync::Arc, time::Duration},
+    std::sync::Arc,
 };
 
 pub mod error;
@@ -35,10 +32,7 @@ pub(crate) fn create_client_config(client_certificate: &QuicClientCertificate) -
     let transport_config = {
         let mut res = TransportConfig::default();
 
-        let timeout = IdleTimeout::try_from(Duration::from_secs(
-            DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT.as_secs(),
-        ))
-        .unwrap();
+        let timeout = IdleTimeout::try_from(QUIC_MAX_TIMEOUT).unwrap();
         res.max_idle_timeout(Some(timeout));
         res.keep_alive_interval(Some(QUIC_KEEP_ALIVE));
         res.send_fairness(QUIC_SEND_FAIRNESS);

--- a/tpu-client-next/src/quic_networking/error.rs
+++ b/tpu-client-next/src/quic_networking/error.rs
@@ -46,4 +46,6 @@ pub enum QuicError {
     Connect(#[from] ConnectError),
     #[error(transparent)]
     Endpoint(#[from] IoErrorWithPartialEq),
+    #[error("Handshake timeout")]
+    HandshakeTimeout,
 }

--- a/tpu-client-next/src/send_transaction_stats.rs
+++ b/tpu-client-next/src/send_transaction_stats.rs
@@ -117,6 +117,11 @@ pub fn record_error(err: QuicError, stats: &SendTransactionStats) {
         // Endpoint is created on the scheduler level and handled separately
         // No counters are used for this case.
         QuicError::Endpoint(_) => (),
+        QuicError::HandshakeTimeout => {
+            stats
+                .connection_error_timed_out
+                .fetch_add(1, Ordering::Relaxed);
+        }
     }
 }
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -583,11 +583,16 @@ async fn test_rate_limiting() {
     scheduler_cancel.cancel();
     let stats = join_scheduler(scheduler_handle).await;
 
-    // We do not expect to see any errors, as the connection is in the pending state still, when we
-    // do the shutdown.  If we increase the time we wait in `count_received_packets_for`, we would
-    // start seeing a `connection_error_timed_out` incremented to 1.  Potentially, we may want to
-    // accept both 0 and 1 as valid values for it.
-    assert_eq!(stats, SendTransactionStatsNonAtomic::default());
+    // Accept both 0 and 1 as valid values for it as we may run into connection handshake timeout
+    // error within the TEST_MAX_TIME.
+    assert!(
+        stats
+            == SendTransactionStatsNonAtomic {
+                connection_error_timed_out: 1,
+                ..Default::default()
+            }
+            || stats == SendTransactionStatsNonAtomic::default()
+    );
 
     // Stop the server.
     exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
When we use longer QUIC connection idle timeout value (60 s), some of the tpu-client-next unit tests are failing due to timeout. The reason is some test is written in a way relying on the connection timeout to happen quickly when no server is replying  as internally Quinn was using the Conneciton idle timeout to timeout new connection handshaking.

#### Summary of Changes

The change explicitly time out the connection handshaking in the application (above Quinn).  The default handshake timeout is set to 2 seconds. This paves way to increase the Conneciton idle timeout.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
