### PR TITLE
allow RpcClient::send to send params that are Json object

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4726,7 +4726,7 @@ impl RpcClient {
     where
         T: serde::de::DeserializeOwned,
     {
-        assert!(params.is_array() || params.is_null());
+        assert!(params.is_array() || params.is_null() || params.is_object());
 
         let response = self
             .sender


### PR DESCRIPTION
#### Problem

I'm currently experimenting with a server that exposes custom RPC methods, and these methods might not necessarily require `params` to be an array. The JSON-RPC specifies `params` as "A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted." and defines "Structured" as either Object or Array, so this is valid from the JSON-RPC standpoint.

However I can see that the Solana RPC convention is to use array as the top level `params` structure. I'm not sure if this has deeper implications or is simply a convention. So my question is: Would you be okay with allowing `RpcClient::send` to send object `params`? Effectively, this would allow me to use code like this:
```rs
let res = client.send::<MyResponseType>(
    RpcRequest::Custom {
        method: "myCustomMethod"
    },
    json!({
        "foo": 1,
        "bar": 2
    })
);
```

Also, since this is a one line change I'm sending this as a PR.

The assertion was originally added in this commit fcda972cec8b3ca3b08cc88666391d8e1ce2a5b7 in 2019 as far as I can see.

#### Summary of Changes

Adds `params.is_object()` to the allowed JSON type in `RpcClient::send` assertion.
