### PR TITLE
TPU: deprecate ways to enable UDP in TPU via command-line args.

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -354,7 +354,7 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Do not submit transactions via QUIC; only affects TpuClient (default) sends"),
+                .help("DEPRECATED: Do not submit transactions via QUIC; only affects TpuClient (default) sends"),
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -499,6 +499,7 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
     }
 
     if matches.is_present("tpu_disable_quic") {
+        eprintln!("Warning: TPU over UDP is deprecated");
         args.use_quic = false;
     }
 

--- a/bench-vote/src/main.rs
+++ b/bench-vote/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
                 .value_name("KEYPAIR")
                 .takes_value(true)
                 .validator(is_keypair_or_ask_keyword)
-                .help("Identity keypair for the QUIC endpoint when '--use-quic' is set true. If it is not specified a dynamic key is created."),
+                .help("Identity keypair for the QUIC endpoint. If it is not specified a random key is created."),
         )
         .arg(
             Arg::with_name("num-recv-sockets")
@@ -206,10 +206,12 @@ fn main() -> Result<()> {
     let ip_addr = destination.map_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED), |addr| addr.ip());
 
     let quic_params = vote_use_quic.then(|| {
-        let identity_keypair = keypair_of(&matches, "identity").or_else(|| {
-            println!("--identity is not specified when --use-quic is on. Will generate a key dynamically.");
-            Some(Keypair::new())
-        }).unwrap();
+        let identity_keypair = keypair_of(&matches, "identity")
+            .or_else(|| {
+                println!("--identity is not specified, will generate a key dynamically.");
+                Some(Keypair::new())
+            })
+            .unwrap();
 
         let stake: u64 = 1024;
         let total_stake: u64 = 1024;
@@ -226,7 +228,7 @@ fn main() -> Result<()> {
         QuicParams {
             identity_keypair,
             staked_nodes,
-            connection_pool_size
+            connection_pool_size,
         }
     });
 

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -822,19 +822,19 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(false)
             .hidden(hidden_unless_forced())
             .conflicts_with("tpu_disable_quic")
-            .help("Use QUIC to send transactions."),
+            .help("DEPRECATED (should always be enabled): Use QUIC to send transactions."),
     )
     .arg(
         Arg::with_name("tpu_disable_quic")
             .long("tpu-disable-quic")
             .takes_value(false)
-            .help("Do not use QUIC to send transactions."),
+            .help("DEPRECATED (UDP support will be dropped): Do not use QUIC to send transactions."),
     )
     .arg(
         Arg::with_name("tpu_enable_udp")
             .long("tpu-enable-udp")
             .takes_value(false)
-            .help("Enable UDP for receiving/sending transactions."),
+            .help("DEPRECATED (UDP support will be dropped): Enable UDP for receiving/sending transactions."),
     )
     .arg(
         Arg::with_name("tpu_connection_pool_size")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -817,23 +817,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
     )
     .arg(
-        Arg::with_name("tpu_use_quic")
-            .long("tpu-use-quic")
-            .takes_value(false)
-            .hidden(hidden_unless_forced())
-            .conflicts_with("tpu_disable_quic")
-            .help("DEPRECATED (should always be enabled): Use QUIC to send transactions."),
-    )
-    .arg(
         Arg::with_name("tpu_disable_quic")
             .long("tpu-disable-quic")
             .takes_value(false)
+            .hidden(hidden_unless_forced())
             .help("DEPRECATED (UDP support will be dropped): Do not use QUIC to send transactions."),
     )
     .arg(
         Arg::with_name("tpu_enable_udp")
             .long("tpu-enable-udp")
             .takes_value(false)
+            .hidden(hidden_unless_forced())
             .help("DEPRECATED (UDP support will be dropped): Enable UDP for receiving/sending transactions."),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -322,9 +322,13 @@ pub fn execute(
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = !matches.is_present("tpu_disable_quic");
+    if !tpu_use_quic {
+        warn!("TPU QUIC was disabled via --tpu_disable_quic, this will prevent validator from receiving transactions!");
+    }
     let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
 
     let tpu_enable_udp = if matches.is_present("tpu_enable_udp") {
+        warn!("Submission of TPU transactions via UDP is deprecated.");
         true
     } else {
         DEFAULT_TPU_ENABLE_UDP


### PR DESCRIPTION
#### Problem

- TPU UDP is no longer used in production
- Maintaining the code there is a burden on devs

Working towards https://github.com/anza-xyz/agave/issues/6115

#### Summary of Changes

- Deprecate the relevant command line args in preparation for code removal in 3.0. This is intended to be backported in 2.3 branch.