### PR TITLE
TransactionStructure::View as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Release channels have their own copy of this changelog:
 
 #### Changes
 * Reading snapshot archives requires increased `memlock` limits - recommended setting is `LimitMEMLOCK=2000000000` in systemd service configuration. Lack of sufficient limit will result slower startup times.
+* `--transaction-structure view` is now the default.
 
 ## 2.3.0
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -197,8 +197,8 @@ impl BlockProductionMethod {
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum TransactionStructure {
-    #[default]
     Sdk,
+    #[default]
     View,
 }
 


### PR DESCRIPTION
#### Problem
- `view` is more efficient option but not the default

#### Summary of Changes
- make `TransactionStructure::View` the default option

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
