### PR TITLE
Enable coalesce in shred-fetch streamer::receiver

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -204,10 +204,10 @@ impl ShredFetchStage {
                     packet_sender.clone(),
                     recycler.clone(),
                     receiver_stats.clone(),
-                    None,  // coalesce
-                    true,  // use_pinned_memory
-                    None,  // in_vote_only_mode
-                    false, // is_staked_service
+                    Some(Duration::from_millis(5)), // coalesce
+                    true,                           // use_pinned_memory
+                    None,                           // in_vote_only_mode
+                    false,                          // is_staked_service
                 )
             })
             .collect();


### PR DESCRIPTION
#### Problem

See https://github.com/anza-xyz/agave/pull/6802 for full context.

#### Summary of Changes

Enables 5ms coalesce time for shred-fetch `streamer::receiver` instances.

before:
<img width="439" height="178" alt="image" src="https://github.com/user-attachments/assets/6299d7b4-7dbe-46a4-b505-779084cdb6b8" />

after:
<img width="455" height="217" alt="image" src="https://github.com/user-attachments/assets/855658a5-7412-4ae7-aaa0-8e530037115e" />
