### PR TITLE
Do not hash accounts when calculating capitalization

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6278,6 +6278,55 @@ impl AccountsDb {
         AccountsLtHash(lt_hash)
     }
 
+    /// Calculates the capitalization
+    ///
+    /// Note, this is *very* expensive!  It walks the whole accounts index,
+    /// account-by-account, summing each account's balance.
+    ///
+    /// Only intended to be called at startup by ledger-tool or tests.
+    pub fn calculate_capitalization_at_startup_from_index(
+        &self,
+        ancestors: &Ancestors,
+        startup_slot: Slot,
+    ) -> u64 {
+        self.accounts_index
+            .account_maps
+            .par_iter()
+            .map(|accounts_index_bin| {
+                accounts_index_bin
+                    .keys()
+                    .into_iter()
+                    .map(|pubkey| {
+                        self.accounts_index
+                            .get_with_and_then(
+                                &pubkey,
+                                Some(ancestors),
+                                Some(startup_slot),
+                                false,
+                                |(slot, account_info)| {
+                                    (!account_info.is_zero_lamport()).then(|| {
+                                        self.get_account_accessor(
+                                            slot,
+                                            &pubkey,
+                                            &account_info.storage_location(),
+                                        )
+                                        .get_loaded_account(|loaded_account| {
+                                            loaded_account.lamports()
+                                        })
+                                        // SAFETY: The index said this pubkey exists, so
+                                        // there must be an account to load.
+                                        .unwrap()
+                                    })
+                                },
+                            )
+                            .flatten()
+                            .unwrap_or(0)
+                    })
+                    .sum::<u64>()
+            })
+            .sum()
+    }
+
     /// This is only valid to call from tests.
     /// run the accounts hash calculation and store the results
     pub fn update_accounts_hash_for_tests(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6280,6 +6280,8 @@ impl AccountsDb {
 
     /// Calculates the capitalization
     ///
+    /// Panics if capitalization overflows a u64.
+    ///
     /// Note, this is *very* expensive!  It walks the whole accounts index,
     /// account-by-account, summing each account's balance.
     ///
@@ -6322,9 +6324,10 @@ impl AccountsDb {
                             .flatten()
                             .unwrap_or(0)
                     })
-                    .sum::<u64>()
+                    .try_fold(0, u64::checked_add)
             })
-            .sum()
+            .try_reduce(|| 0, u64::checked_add)
+            .expect("capitalization cannot overflow")
     }
 
     /// This is only valid to call from tests.

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -529,8 +529,12 @@ fn minimize_bank_for_snapshot(
 }
 
 fn assert_capitalization(bank: &Bank) {
-    let debug_verify = true;
-    assert!(bank.calculate_and_verify_capitalization(debug_verify));
+    let calculated = bank.calculate_capitalization();
+    let expected = bank.capitalization();
+    assert_eq!(
+        calculated, expected,
+        "Capitalization mismatch: calculated: {calculated} != expected: {expected}",
+    );
 }
 
 fn load_banking_trace_events_or_exit(ledger_path: &Path) -> BankingTraceEvents {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5514,6 +5514,8 @@ impl Bank {
 
     /// Calculates and returns the capitalization.
     ///
+    /// Panics if capitalization overflows a u64.
+    ///
     /// Note, this is *very* expensive!  It walks the whole accounts index,
     /// account-by-account, summing each account's balance.
     ///
@@ -5534,6 +5536,8 @@ impl Bank {
     /// Forcibly overwrites capitalization by recalculating accounts' balances.
     ///
     /// Returns the previous capitalization.
+    ///
+    /// Panics if capitalization overflows a u64.
     ///
     /// Note, this is *very* expensive!  It walks the whole accounts index,
     /// account-by-account, summing each account's balance.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5512,9 +5512,14 @@ impl Bank {
         Ok(())
     }
 
-    /// only called from ledger-tool or tests
-    fn calculate_capitalization(&self, debug_verify: bool) -> u64 {
-        let is_startup = true;
+    /// Calculates and returns the capitalization.
+    ///
+    /// Note, this is *very* expensive!  It walks the whole accounts index,
+    /// account-by-account, summing each account's balance.
+    ///
+    /// Only intended to be called at startup by ledger-tool or tests.
+    /// (cannot be made DCOU due to snapshot-minimizer)
+    pub fn calculate_capitalization(&self) -> u64 {
         self.rc
             .accounts
             .accounts_db
@@ -5523,44 +5528,22 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .update_accounts_hash_with_verify_from(
-                // we have to use the index since the slot could be in the write cache still
-                CalcAccountsHashDataSource::IndexForTests,
-                debug_verify,
-                self.slot(),
-                &self.ancestors,
-                None,
-                self.epoch_schedule(),
-                is_startup,
-            )
-            .1
+            .calculate_capitalization_at_startup_from_index(&self.ancestors, self.slot())
     }
 
-    /// only called from tests or ledger tool
-    pub fn calculate_and_verify_capitalization(&self, debug_verify: bool) -> bool {
-        let calculated = self.calculate_capitalization(debug_verify);
-        let expected = self.capitalization();
-        if calculated == expected {
-            true
-        } else {
-            warn!(
-                "Capitalization mismatch: calculated: {} != expected: {}",
-                calculated, expected
-            );
-            false
-        }
-    }
-
-    /// Forcibly overwrites current capitalization by actually recalculating accounts' balances.
-    /// This should only be used for developing purposes.
+    /// Forcibly overwrites capitalization by recalculating accounts' balances.
+    ///
+    /// Returns the previous capitalization.
+    ///
+    /// Note, this is *very* expensive!  It walks the whole accounts index,
+    /// account-by-account, summing each account's balance.
+    ///
+    /// Only intended to be called at startup by ledger-tool or tests.
+    /// (cannot be made DCOU due to snapshot-minimizer)
     pub fn set_capitalization(&self) -> u64 {
         let old = self.capitalization();
-        // We cannot debug verify the hash calculation here because calculate_capitalization will use the index calculation due to callers using the write cache.
-        // debug_verify only exists as an extra debugging step under the assumption that this code path is only used for tests. But, this is used by ledger-tool create-snapshot
-        // for example.
-        let debug_verify = false;
         self.capitalization
-            .store(self.calculate_capitalization(debug_verify), Relaxed);
+            .store(self.calculate_capitalization(), Relaxed);
         old
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -469,7 +469,7 @@ fn assert_capitalization_diff(
     let new = bank.capitalization();
     if asserter(old, new) {
         add_root_and_flush_write_cache(bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 }
 
@@ -1374,7 +1374,7 @@ where
     add_root_and_flush_write_cache(&bank0);
     add_root_and_flush_write_cache(&bank1);
     add_root_and_flush_write_cache(&bank2);
-    assert!(bank2.calculate_and_verify_capitalization(true));
+    assert_eq!(bank2.capitalization(), bank2.calculate_capitalization());
 }
 
 fn do_test_bank_update_rewards_determinism() -> u64 {
@@ -1451,7 +1451,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     bank1.freeze();
     add_root_and_flush_write_cache(&bank);
     add_root_and_flush_write_cache(&bank1);
-    assert!(bank1.calculate_and_verify_capitalization(true));
+    assert_eq!(bank1.capitalization(), bank1.calculate_capitalization());
 
     // verify voting and staking rewards are recorded
     let rewards = bank1.rewards.read().unwrap();
@@ -3253,7 +3253,7 @@ fn test_bank_update_sysvar_account() {
         let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
         if pass == 0 {
             add_root_and_flush_write_cache(&bank1);
-            assert_eq!(bank1.calculate_capitalization(true), bank1.capitalization());
+            assert_eq!(bank1.calculate_capitalization(), bank1.capitalization());
             continue;
         }
 
@@ -4147,7 +4147,7 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
+            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
             continue;
         }
 
@@ -4164,7 +4164,7 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(!bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
+            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
             continue;
         }
 
@@ -4187,7 +4187,7 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
+            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
             continue;
         }
         assert_eq!(
@@ -4213,7 +4213,7 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
             assert!(stakes.vote_accounts().as_ref().is_empty());
         }
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
-        assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
+        assert_eq!(bank.calculate_capitalization(), bank.capitalization());
         assert_eq!(
             "mock_program1",
             String::from_utf8_lossy(bank.get_account(&vote_id).unwrap_or_default().data())
@@ -6150,7 +6150,7 @@ fn test_add_builtin_account_inherited_cap_while_replacing() {
         bank.add_builtin_account("mock_program", &program_id);
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
@@ -6158,19 +6158,19 @@ fn test_add_builtin_account_inherited_cap_while_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
         bank.add_builtin_account("mock_program v2", &program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 }
 
@@ -6185,19 +6185,19 @@ fn test_add_builtin_account_squatted_while_not_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
         bank.add_builtin_account("mock_program", &program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 }
 
@@ -6276,7 +6276,7 @@ fn test_add_precompiled_account_inherited_cap_while_replacing() {
         bank.add_precompiled_account(&program_id);
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
@@ -6284,19 +6284,19 @@ fn test_add_precompiled_account_inherited_cap_while_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
         bank.add_precompiled_account(&program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 }
 
@@ -6312,20 +6312,20 @@ fn test_add_precompiled_account_squatted_while_not_replacing() {
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
 
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
             continue;
         }
 
         bank.add_precompiled_account(&program_id);
         add_root_and_flush_write_cache(&bank);
 
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization(true));
+        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 }
 


### PR DESCRIPTION
#### Problem

When creating a snapshot with ledger-tool, we (re)calculate the capitalization. Under the hood this uses the merkle-based accounts hash calculation. This has the following problems:

1. It's slow. We don't need to hash each account, nor load account data from disk, nor build the merkle tree, nor compute the merkle root.

2. Once all the lattice hash features are enabled, there will be no more merkle-based accounts hash calculations. At that time we'd like to remove the old code. We cannot remove the code yet, since calculating capitalization uses it.


#### Summary of Changes

Reimplement `calculate_capitalization()` to not use any of the merkle-based accounts hash calculation code.

##### Results

I ran `ledger-tool capitalization` against a mnb snapshot to time how long it took to calculate the capitalization with this pr vs master:

| | runtime (s) | 🏁 |
|---------|------|---|
| master  | 540 | 🐢 |
| this pr | 110 | 🏎️ |
