### PR TITLE
svm: use load_transaction_account for initial nonce load

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -630,10 +630,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         //
         // Note these checks are *not* obviated by fee-only transactions.
         let nonce_is_valid = account_loader
-            .load_account(nonce_info.address())
-            .and_then(|ref current_nonce_account| {
-                system_program::check_id(current_nonce_account.owner()).then_some(())?;
-                StateMut::<NonceVersions>::state(current_nonce_account).ok()
+            .load_transaction_account(nonce_info.address(), true)
+            .and_then(|ref current_nonce| {
+                system_program::check_id(current_nonce.account.owner()).then_some(())?;
+                StateMut::<NonceVersions>::state(&current_nonce.account).ok()
             })
             .and_then(
                 |current_nonce_versions| match current_nonce_versions.state() {


### PR DESCRIPTION
#### Problem
we use `load_account()` to load the nonce account for validation, but this is potentially confusing because it occurs prior to full transaction loading

#### Summary of Changes
use `load_transaction_account()` instead