### PR TITLE
bump indicatif from 0.17.12 to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "dirs-next",
- "indicatif",
+ "indicatif 0.18.0",
  "nix",
  "reqwest 0.12.22",
  "scopeguard",
@@ -412,7 +412,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indicatif",
+ "indicatif 0.18.0",
  "itertools 0.12.1",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3803,6 +3803,19 @@ name = "indicatif"
 version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",
@@ -7498,7 +7511,7 @@ dependencies = [
  "console 0.16.0",
  "ed25519-dalek",
  "humantime",
- "indicatif",
+ "indicatif 0.18.0",
  "pretty-hex",
  "semver 1.0.26",
  "serde",
@@ -7543,7 +7556,7 @@ dependencies = [
  "futures 0.3.31",
  "futures-util",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "quinn",
  "rayon",
@@ -7783,7 +7796,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -8369,7 +8382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05a9744774fdbd7ae8575e5bd6d5df6946f321fb9b6019410b300a515369a37d"
 dependencies = [
  "console 0.15.11",
- "indicatif",
+ "indicatif 0.17.12",
  "log",
  "reqwest 0.11.27",
 ]
@@ -9907,7 +9920,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "futures 0.3.31",
- "indicatif",
+ "indicatif 0.18.0",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "log",
@@ -11102,7 +11115,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "pickledb",
  "serde",
  "serde_derive",
@@ -11176,7 +11189,7 @@ dependencies = [
  "bincode",
  "futures-util",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "rayon",
  "solana-client-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ hyper = "0.14.32"
 hyper-proxy = "0.9.1"
 im = "15.1.0"
 indexmap = "2.10.0"
-indicatif = "0.17.12"
+indicatif = "0.18.0"
 io-uring = "0.7.8"
 itertools = "0.12.1"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "fd-lock",
- "indicatif",
+ "indicatif 0.18.0",
  "itertools 0.12.1",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -2898,6 +2898,19 @@ name = "indicatif"
 version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",
@@ -5818,7 +5831,7 @@ dependencies = [
  "clap",
  "console 0.16.0",
  "humantime",
- "indicatif",
+ "indicatif 0.18.0",
  "pretty-hex",
  "semver",
  "serde",
@@ -5859,7 +5872,7 @@ dependencies = [
  "futures 0.3.31",
  "futures-util",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "quinn",
  "rayon",
@@ -6493,7 +6506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05a9744774fdbd7ae8575e5bd6d5df6946f321fb9b6019410b300a515369a37d"
 dependencies = [
  "console 0.15.11",
- "indicatif",
+ "indicatif 0.17.12",
  "log",
  "reqwest 0.11.27",
 ]
@@ -7682,7 +7695,7 @@ dependencies = [
  "bincode",
  "bs58",
  "futures 0.3.31",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "reqwest 0.12.22",
  "reqwest-middleware",
@@ -9380,7 +9393,7 @@ dependencies = [
  "bincode",
  "futures-util",
  "indexmap 2.10.0",
- "indicatif",
+ "indicatif 0.18.0",
  "log",
  "rayon",
  "solana-client-traits",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",


### PR DESCRIPTION
#### Problem
Compiling crates that depend on solana-client from the master branch throws an error:

```
error: failed to select a version for the requirement `indicatif = "^0.17.12"`
  version 0.17.12 is yanked
location searched: crates.io index
required by package `solana-client v3.0.0
```

#### Summary of Changes
Bump indicatif to 0.18.0


Fixes #

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
