### PR TITLE
Make BufferedReader usable on all platforms to support read of append_vec always through File

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -118,7 +118,7 @@ impl<'a> ValidSlice<'a> {
     }
 
     #[inline(always)]
-    #[cfg(all(unix, test))]
+    #[cfg(test)]
     pub(crate) fn slice(&self) -> &[u8] {
         self.0
     }

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -237,7 +237,7 @@ pub fn large_file_buf_reader(
     Ok(Box::new(BufReader::with_capacity(buf_size, file)))
 }
 
-#[cfg(all(unix, test))]
+#[cfg(test)]
 mod tests {
     use {
         super::*, crate::append_vec::ValidSlice, std::io::Write, tempfile::tempfile,

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -112,7 +112,7 @@ pub fn read_into_buffer(
     Ok(total_bytes_read)
 }
 
-#[cfg(all(test))]
+#[cfg(test)]
 mod tests {
 
     use {super::*, std::io::Write, tempfile::tempfile};

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -1,8 +1,4 @@
 //! File i/o helper functions.
-#[cfg(unix)]
-use std::os::unix::prelude::FileExt;
-#[cfg(not(unix))]
-use std::os::windows::fs::FileExt;
 use std::{fs::File, ops::Range};
 
 /// `buffer` contains `valid_bytes` of data at its end.
@@ -34,6 +30,19 @@ pub fn read_more_buffer(
 }
 
 #[cfg(unix)]
+fn arch_read_at(file: &File, buffer: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    use std::os::unix::prelude::FileExt;
+    file.read_at(buffer, offset)
+}
+
+#[cfg(windows)]
+fn arch_read_at(file: &File, buffer: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+    // Note: as opposed to unix `read_at` this call will update the internal file offset,
+    // so all callers should consistently use the file only through this module
+    file.seek_read(buffer, offset)
+}
+
 /// Read, starting at `start_offset`, until `buffer` is full or we read past `valid_file_len`/eof.
 /// `valid_file_len` is # of valid bytes in the file. This may be <= file length.
 /// return # bytes read
@@ -51,45 +60,7 @@ pub fn read_into_buffer(
     }
 
     while buffer_offset < buffer.len() {
-        match file.read_at(&mut buffer[buffer_offset..], offset as u64) {
-            Err(err) => {
-                if err.kind() == std::io::ErrorKind::Interrupted {
-                    continue;
-                }
-                return Err(err);
-            }
-            Ok(bytes_read_this_time) => {
-                total_bytes_read += bytes_read_this_time;
-                if total_bytes_read + start_offset >= valid_file_len {
-                    total_bytes_read -= (total_bytes_read + start_offset) - valid_file_len;
-                    // we've read all there is in the file
-                    break;
-                }
-                // There is possibly more to read. `read_at` may have returned partial results, so prepare to loop and read again.
-                buffer_offset += bytes_read_this_time;
-                offset += bytes_read_this_time;
-            }
-        }
-    }
-    Ok(total_bytes_read)
-}
-
-#[cfg(not(unix))]
-pub fn read_into_buffer(
-    file: &File,
-    valid_file_len: usize,
-    start_offset: usize,
-    buffer: &mut [u8],
-) -> std::io::Result<usize> {
-    let mut offset = start_offset;
-    let mut buffer_offset = 0;
-    let mut total_bytes_read = 0;
-    if start_offset >= valid_file_len {
-        return Ok(0);
-    }
-
-    while buffer_offset < buffer.len() {
-        match file.seek_read(&mut buffer[buffer_offset..], offset as u64) {
+        match arch_read_at(file, &mut buffer[buffer_offset..], offset as u64) {
             Err(err) => {
                 if err.kind() == std::io::ErrorKind::Interrupted {
                     continue;


### PR DESCRIPTION
#### Problem
`BufferedReader` is excluded from use on non-unix because `read_at` is a `os::unix` API, however there is similar API also available on windows, so we could extend its usage.

#### Summary of Changes
Narrow down platform-specific function call to read at offset and provide unix and windows implementation of it.

Notes:
* not-unix and not-windows implementation is not provided - a stub that panics could be provided, but the goal is to make `BufferedReader` universally available and catch any other platform at compile time
* windows implementation updates the internal file cursor, so file_io shouldn't be used when regular reads from file assume starting at 0 or last used offset