### PR TITLE
remove unused SnapshotMinimizer::ending_slot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -524,7 +524,7 @@ fn minimize_bank_for_snapshot(
     let total_accounts_len = transaction_account_set.len();
     info!("Added {total_accounts_len} accounts from transactions. {transaction_accounts_measure}");
 
-    SnapshotMinimizer::minimize(bank, snapshot_slot, ending_slot, transaction_account_set);
+    SnapshotMinimizer::minimize(bank, snapshot_slot, transaction_account_set);
     possibly_incomplete
 }
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -34,9 +34,6 @@ use {
 pub struct SnapshotMinimizer<'a> {
     bank: &'a Bank,
     starting_slot: Slot,
-    /// Ending slot is not used, but kept for consistency with the function signature
-    /// TODO: Remove this field and CLI argument in the future.
-    _ending_slot: Slot,
     minimized_account_set: DashSet<Pubkey>,
 }
 
@@ -47,16 +44,10 @@ impl<'a> SnapshotMinimizer<'a> {
     ///
     /// This function will modify accounts_db by removing accounts not needed to replay [starting_slot, ending_slot],
     /// and update the bank's capitalization.
-    pub fn minimize(
-        bank: &'a Bank,
-        starting_slot: Slot,
-        ending_slot: Slot,
-        transaction_account_set: DashSet<Pubkey>,
-    ) {
+    pub fn minimize(bank: &'a Bank, starting_slot: Slot, transaction_account_set: DashSet<Pubkey>) {
         let minimizer = SnapshotMinimizer {
             bank,
             starting_slot,
-            _ending_slot: ending_slot,
             minimized_account_set: transaction_account_set,
         };
 
@@ -408,7 +399,6 @@ mod tests {
         let minimizer = SnapshotMinimizer {
             bank: &bank,
             starting_slot: 0,
-            _ending_slot: 0,
             minimized_account_set: DashSet::new(),
         };
         minimizer.get_vote_accounts();
@@ -437,7 +427,6 @@ mod tests {
         let minimizer = SnapshotMinimizer {
             bank: &bank,
             starting_slot: 0,
-            _ending_slot: 0,
             minimized_account_set: DashSet::new(),
         };
         minimizer.get_stake_accounts();
@@ -477,7 +466,6 @@ mod tests {
         let minimizer = SnapshotMinimizer {
             bank: &bank,
             starting_slot: 0,
-            _ending_slot: 0,
             minimized_account_set: owner_accounts,
         };
 
@@ -515,7 +503,6 @@ mod tests {
         let minimizer = SnapshotMinimizer {
             bank: &bank,
             starting_slot: 0,
-            _ending_slot: 0,
             minimized_account_set: programdata_accounts,
         };
         minimizer.get_programdata_accounts();
@@ -573,7 +560,6 @@ mod tests {
         let minimizer = SnapshotMinimizer {
             bank: &bank,
             starting_slot: current_slot,
-            _ending_slot: current_slot,
             minimized_account_set,
         };
         minimizer.minimize_accounts_db();
@@ -636,12 +622,7 @@ mod tests {
         bank.force_flush_accounts_cache();
 
         // do the minimization
-        SnapshotMinimizer::minimize(
-            &bank,
-            bank.slot(),
-            bank.slot(),
-            DashSet::from_iter([pubkey_to_keep]),
-        );
+        SnapshotMinimizer::minimize(&bank, bank.slot(), DashSet::from_iter([pubkey_to_keep]));
 
         // take a snapshot of the minimized bank, then load it
         let snapshot_config = SnapshotConfig::default();


### PR DESCRIPTION
#### Problem

SnapshotMinimizer::ending_slot used to be required for snapshot_minimizer due to rent collection. Now rent collection is disabled.  ending_slot is no longer needed for snapshot_minimizer.


#### Summary of Changes

remove ending_slot from snapshot_minimizer.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
