### PR TITLE
Refactors Bank::set_capitalization()

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2346,10 +2346,8 @@ fn main() {
                     }
 
                     let pre_capitalization = bank.capitalization();
-
-                    bank.set_capitalization();
-
-                    let post_capitalization = bank.capitalization();
+                    let post_capitalization = bank.calculate_capitalization();
+                    bank.set_capitalization(post_capitalization);
 
                     let capitalization_message = if pre_capitalization != post_capitalization {
                         let amount = if pre_capitalization > post_capitalization {
@@ -2646,8 +2644,10 @@ fn main() {
 
                     if arg_matches.is_present("recalculate_capitalization") {
                         println!("Recalculating capitalization");
-                        let old_capitalization = bank.set_capitalization();
-                        if old_capitalization == bank.capitalization() {
+                        let old_capitalization = bank.capitalization();
+                        let new_capitalization = bank.calculate_capitalization();
+                        bank.set_capitalization(new_capitalization);
+                        if old_capitalization == new_capitalization {
                             eprintln!("Capitalization was identical: {}", Sol(old_capitalization));
                         }
                     }
@@ -2733,8 +2733,9 @@ fn main() {
                             if store_failed_count >= 1 {
                                 // we have no choice; maybe locally created blank cluster with
                                 // not-Development cluster type.
-                                let old_cap = base_bank.set_capitalization();
-                                let new_cap = base_bank.capitalization();
+                                let old_cap = base_bank.capitalization();
+                                let new_cap = base_bank.calculate_capitalization();
+                                base_bank.set_capitalization(new_cap);
                                 warn!(
                                     "Skewing capitalization a bit to enable \
                                          credits_auto_rewind as requested: increasing {} from {} \

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -897,7 +897,7 @@ impl ProgramTest {
             }
             bank.store_account(address, account);
         }
-        bank.set_capitalization();
+        bank.set_capitalization(bank.calculate_capitalization());
         // Advance beyond slot 0 for a slightly more realistic test environment
         let bank = {
             let bank = Arc::new(bank);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5118,22 +5118,12 @@ impl Bank {
             .calculate_capitalization_at_startup_from_index(&self.ancestors, self.slot())
     }
 
-    /// Forcibly overwrites capitalization by recalculating accounts' balances.
+    /// Sets the capitalization.
     ///
-    /// Returns the previous capitalization.
-    ///
-    /// Panics if capitalization overflows a u64.
-    ///
-    /// Note, this is *very* expensive!  It walks the whole accounts index,
-    /// account-by-account, summing each account's balance.
-    ///
-    /// Only intended to be called at startup by ledger-tool or tests.
+    /// Only intended to be called by ledger-tool or tests.
     /// (cannot be made DCOU due to snapshot-minimizer)
-    pub fn set_capitalization(&self) -> u64 {
-        let old = self.capitalization();
-        self.capitalization
-            .store(self.calculate_capitalization(), Relaxed);
-        old
+    pub fn set_capitalization(&self, capitalization: u64) {
+        self.capitalization.store(capitalization, Relaxed);
     }
 
     /// Returns the `AccountsHash` that was calculated for this bank's slot

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -74,7 +74,9 @@ impl<'a> SnapshotMinimizer<'a> {
 
         // Update accounts_cache and capitalization
         minimizer.bank.force_flush_accounts_cache();
-        minimizer.bank.set_capitalization();
+        minimizer
+            .bank
+            .set_capitalization(minimizer.bank.calculate_capitalization());
 
         if minimizer.bank.is_accounts_lt_hash_enabled() {
             // Since the account state has changed, the accounts lt hash must be recalculated


### PR DESCRIPTION
#### Problem

`Bank::set_capitalization()` is strange because it doesn't do what is expected of a `set_xx()` function. It calculates the new capitalization, then updates it. Why?

More context: https://github.com/anza-xyz/agave/pull/6867#discussion_r2191236583


#### Summary of Changes

Have `set_capitalization()` take a capitalization parameter instead.