### PR TITLE
Tests: use the non-overlapping socket bind API

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -199,13 +199,16 @@ mod tests {
     use {
         super::*,
         crate::connection_cache::ConnectionCache,
-        solana_net_utils::bind_to_localhost,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         std::net::{IpAddr, Ipv4Addr, SocketAddr},
     };
 
     #[test]
     fn test_connection_with_specified_client_endpoint() {
-        let client_socket = bind_to_localhost().unwrap();
+        let port_range = localhost_port_range_for_tests();
+        let mut port_range = port_range.0..port_range.1;
+        let client_socket =
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.next().unwrap()).unwrap();
         let connection_cache = ConnectionCache::new_with_client_options(
             "connection_cache_test",
             1,                   // connection_pool_size
@@ -215,13 +218,13 @@ mod tests {
         );
 
         // server port 1:
-        let port1 = 9001;
+        let port1 = port_range.next().unwrap();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port1);
         let conn = connection_cache.get_connection(&addr);
         assert_eq!(conn.server_addr().port(), port1);
 
         // server port 2:
-        let port2 = 9002;
+        let port2 = port_range.next().unwrap();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port2);
         let conn = connection_cache.get_connection(&addr);
         assert_eq!(conn.server_addr().port(), port2);

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -1018,10 +1018,14 @@ mod tests {
         super::*,
         itertools::{izip, multiunzip},
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        solana_net_utils::bind_to_localhost,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_runtime::bank::Bank,
         solana_signer::Signer,
-        std::{iter::repeat_with, time::Duration},
+        std::{
+            iter::repeat_with,
+            net::{IpAddr, Ipv4Addr},
+            time::Duration,
+        },
     };
 
     #[test]
@@ -1034,10 +1038,12 @@ mod tests {
             .build()
             .unwrap();
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
-        let sockets: Vec<UdpSocket> = repeat_with(bind_to_localhost)
+        let port_range = localhost_port_range_for_tests();
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let sockets: Vec<UdpSocket> = (port_range.0..port_range.1)
+            .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)
-            .collect::<Result<_, _>>()
-            .unwrap();
+            .collect();
         let addresses: Vec<SocketAddr> = sockets
             .iter()
             .map(UdpSocket::local_addr)

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -984,9 +984,10 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let cluster_info = Arc::new(new_test_cluster_info());
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
         let rpc_addr = SocketAddr::new(
             ip_addr,
-            solana_net_utils::find_available_port_in_range(ip_addr, (10000, 65535)).unwrap(),
+            solana_net_utils::find_available_port_in_range(ip_addr, port_range).unwrap(),
         );
         let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -823,10 +823,14 @@ mod tests {
         super::*,
         itertools::{izip, multiunzip},
         solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        solana_net_utils::bind_to_localhost,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_runtime::bank::Bank,
         solana_signer::Signer,
-        std::{iter::repeat_with, time::Duration},
+        std::{
+            iter::repeat_with,
+            net::{IpAddr, Ipv4Addr},
+            time::Duration,
+        },
     };
 
     #[test]
@@ -839,10 +843,12 @@ mod tests {
             .build()
             .unwrap();
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
-        let sockets: Vec<UdpSocket> = repeat_with(bind_to_localhost)
+        let port_range = localhost_port_range_for_tests();
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let sockets: Vec<UdpSocket> = (port_range.0..port_range.1)
+            .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)
-            .collect::<Result<_, _>>()
-            .unwrap();
+            .collect();
         let addresses: Vec<SocketAddr> = sockets
             .iter()
             .map(UdpSocket::local_addr)


### PR DESCRIPTION
#### Problem

- A bunch of tests still relies on either hardcoded ports or `bind_to_localhost` and `bind_to_unspecified`. This creates flaky tests in cases where unique port ranges are needed.
- This is especially noticable in tests such as `gossip_ring` flaking in CI, as they allocate a lot of ports in a fixed pattern.

#### Summary of Changes

- change to use `localhost_port_range_for_tests` in some of the places. 
- More PRs like this to follow.