### PR TITLE
Fix turbine to sign last fec set if last entry in slot 

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -838,6 +838,41 @@ pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -
     max_entries_per_n_shred(&ticks[0], num_shreds, shred_data_size)
 }
 
+// created this to use in lieu of `max_entries_per_n_shred`
+// in test_multi_fec_block_coding
+pub fn max_entries_per_n_shred_last_or_not(
+    entry: &Entry,
+    num_shreds: u64,
+    is_last_in_slot: bool,
+) -> u64 {
+    // Default 32:32 erasure batches yields 64 shreds; log2(64) = 6.
+    let merkle_variant_unsigned = Some((
+        /*proof_size:*/ 6, /*chained:*/ true, /*resigned:*/ false,
+    ));
+    let merkle_variant_signed = Some((
+        /*proof_size:*/ 6, /*chained:*/ true, /*resigned:*/ true,
+    ));
+
+    let vec_size = bincode::serialized_size(&vec![entry]).unwrap();
+    let entry_size = bincode::serialized_size(entry).unwrap();
+    let count_size = vec_size - entry_size;
+
+    if !is_last_in_slot {
+        // all shreds are unsigned
+        let shred_data_size = ShredData::capacity(merkle_variant_unsigned).unwrap() as u64;
+        (shred_data_size * num_shreds - count_size) / entry_size
+    } else {
+        // last FEC SET is signed, all others are unsigned
+        let shred_data_size_unsigned = ShredData::capacity(merkle_variant_unsigned).unwrap() as u64;
+        let shred_data_size_signed = ShredData::capacity(merkle_variant_signed).unwrap() as u64;
+        let shreds_per_fec_block = SHREDS_PER_FEC_BLOCK as u64;
+        (shred_data_size_unsigned * (num_shreds - shreds_per_fec_block)
+            + shred_data_size_signed * shreds_per_fec_block
+            - count_size)
+            / entry_size
+    }
+}
+
 pub fn max_entries_per_n_shred(
     entry: &Entry,
     num_shreds: u64,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -838,8 +838,6 @@ pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -
     max_entries_per_n_shred(&ticks[0], num_shreds, shred_data_size)
 }
 
-// created this to use in lieu of `max_entries_per_n_shred`
-// in test_multi_fec_block_coding
 pub fn max_entries_per_n_shred_last_or_not(
     entry: &Entry,
     num_shreds: u64,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -838,6 +838,8 @@ pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -
     max_entries_per_n_shred(&ticks[0], num_shreds, shred_data_size)
 }
 
+// This is used in the integration tests for shredding.
+#[cfg(feature = "dev-context-only-utils")]
 pub fn max_entries_per_n_shred_last_or_not(
     entry: &Entry,
     num_shreds: u64,

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1026,7 +1026,7 @@ pub(crate) fn make_shreds_from_data(
     keypair: &Keypair,
     // The Merkle root of the previous erasure batch if chained.
     chained_merkle_root: Option<Hash>,
-    mut data: &[u8], // Serialized &[Entry]
+    data: &[u8], // Serialized &[Entry]
     slot: Slot,
     parent_slot: Slot,
     shred_version: u16,
@@ -1039,9 +1039,9 @@ pub(crate) fn make_shreds_from_data(
 ) -> Result<Vec<Shred>, Error> {
     let now = Instant::now();
     let chained = chained_merkle_root.is_some();
-    // let resigned = chained && is_last_in_slot;
-    // only sign if last batch in slot and is chained
-    let sign_last_batch = chained && is_last_in_slot;
+
+    // only sign if last fec set in slot and is chained
+    let sign_last_fec_set = chained && is_last_in_slot;
     let proof_size = PROOF_ENTRIES_FOR_32_32_BATCH;
 
     // unsigned data_buffer size
@@ -1049,12 +1049,13 @@ pub(crate) fn make_shreds_from_data(
     let data_buffer_total_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size;
 
     // signed data_buffer size
-    let data_buffer_per_shred_size_signed = if sign_last_batch {
+    let data_buffer_per_shred_size_signed = if sign_last_fec_set {
         ShredData::capacity(proof_size, chained, true)?
     } else {
         0
     };
-    let data_buffer_total_size_signed = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size_signed;
+    let data_buffer_total_size_signed =
+        DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size_signed;
 
     // Common header for the data shreds.
     let mut common_header_data = ShredCommonHeader {
@@ -1095,38 +1096,31 @@ pub(crate) fn make_shreds_from_data(
         }
     };
 
-    // Pre-allocate shreds to avoid reallocations.
-    let mut sig_data: &[u8] = &[];
-    let mut shreds = {
-        let number_of_batches = if sign_last_batch {
-            if data.len() > data_buffer_total_size_signed {
-                let remainder_to_be_signed = data.len() % data_buffer_total_size;
-                if remainder_to_be_signed <= data_buffer_total_size_signed {
-                    (data, sig_data) = data.split_at(data.len() - remainder_to_be_signed);
-                }
-                else {
-                    (data, sig_data) = data.split_at(data.len());
-                    assert_eq!(sig_data.len(), 0);
-                }
-                data.len().div_ceil(data_buffer_total_size) + 1
-            } else {
-                sig_data = data;
-                data = &[];
-                1
-            }
+    let (mut unsigned_data, signed_data) = if sign_last_fec_set {
+        // Reserve at least one signed batch (may be empty) at the end.
+        if data.len() > data_buffer_total_size_signed {
+            let split_at = data.len() - data_buffer_total_size_signed; // sign everything except the last batch
+            data.split_at(split_at)
         } else {
-            data.len().div_ceil(data_buffer_total_size)
-        };
-        let total_num_shreds = SHREDS_PER_FEC_BLOCK * number_of_batches;
-        Vec::<Shred>::with_capacity(total_num_shreds)
+            (&[][..], data) // only enough data for one fec set, sign the whole thing
+        }
+    } else {
+        (data, &[][..]) // not last fec set, so don't sign
     };
-    stats.data_bytes += data.len();
+    stats.data_bytes += unsigned_data.len() + signed_data.len();
 
+    let unsigned_sets = unsigned_data.len().div_ceil(data_buffer_total_size);
+    let number_of_fec_sets = if sign_last_fec_set {
+        unsigned_sets + 1
+    } else {
+        unsigned_sets
+    };
+    let mut shreds = Vec::<Shred>::with_capacity(SHREDS_PER_FEC_BLOCK * number_of_fec_sets);
 
     // Split the data into full erasure batches and initialize data and coding
     // shreds for each batch.
-    while data.len() >= data_buffer_total_size {
-        let (current_batch_data_chunk, rest) = data.split_at(data_buffer_total_size);
+    while unsigned_data.len() >= data_buffer_total_size {
+        let (current_batch_data_chunk, rest) = unsigned_data.split_at(data_buffer_total_size);
         debug_assert_eq!(
             current_batch_data_chunk.len(),
             DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size
@@ -1142,7 +1136,7 @@ pub(crate) fn make_shreds_from_data(
             .map(Shred::ShredData),
         );
         shreds.extend(make_shreds_code_header_only(&mut common_header_code).map(Shred::ShredCode));
-        data = rest;
+        unsigned_data = rest;
     }
 
     // Two possibilities for taking this conditional:
@@ -1152,54 +1146,33 @@ pub(crate) fn make_shreds_from_data(
     // 2.) Shreds is_empty, which only happens when we entered w/ zero data.
     //
     // In either case, we want to generate empty data shreds.
-    if !data.is_empty() || (shreds.is_empty() && !sign_last_batch) {
-        stats.padding_bytes += data_buffer_total_size - data.len();
-        common_header_data.shred_variant = ShredVariant::MerkleData {
+    if !unsigned_data.is_empty() || (shreds.is_empty() && !sign_last_fec_set) {
+        stats.padding_bytes += data_buffer_total_size - unsigned_data.len();
+        shred_leftover_data(
             proof_size,
             chained,
-            resigned: false,
-        };
-        common_header_code.shred_variant = ShredVariant::MerkleCode {
-            proof_size,
-            chained,
-            resigned: false,
-        };
-        common_header_data.fec_set_index = common_header_data.index;
-        common_header_code.fec_set_index = common_header_data.fec_set_index;
-        shreds.extend({
-            // Create data chunks out of remaining data + padding.
-            let chunks = data
-                .chunks(data_buffer_per_shred_size)
-                .chain(std::iter::repeat(&[][..])) // possible padding
-                .take(DATA_SHREDS_PER_FEC_BLOCK);
-            make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
-        });
-        shreds.extend(make_shreds_code_header_only(&mut common_header_code).map(Shred::ShredCode));
+            false,
+            unsigned_data,
+            data_buffer_per_shred_size,
+            &mut common_header_data,
+            &mut common_header_code,
+            data_header,
+            &mut shreds,
+        );
     }
-    if !sig_data.is_empty() || (shreds.is_empty() && sign_last_batch) {
-        // send signed last batch
-        stats.padding_bytes += data_buffer_total_size_signed - sig_data.len();
-        common_header_data.shred_variant = ShredVariant::MerkleData {
+    if !signed_data.is_empty() || (shreds.is_empty() && sign_last_fec_set) {
+        stats.padding_bytes += data_buffer_total_size_signed - signed_data.len();
+        shred_leftover_data(
             proof_size,
             chained,
-            resigned: true,
-        };
-        common_header_code.shred_variant = ShredVariant::MerkleCode {
-            proof_size,
-            chained,
-            resigned: true,
-        };
-        common_header_data.fec_set_index = common_header_data.index;
-        common_header_code.fec_set_index = common_header_data.fec_set_index;
-        shreds.extend({
-            // Create data chunks out of remaining data + padding.
-            let chunks = sig_data
-                .chunks(data_buffer_per_shred_size_signed)
-                .chain(std::iter::repeat(&[][..])) // possible padding
-                .take(DATA_SHREDS_PER_FEC_BLOCK);
-            make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
-        });
-        shreds.extend(make_shreds_code_header_only(&mut common_header_code).map(Shred::ShredCode));
+            true,
+            signed_data,
+            data_buffer_per_shred_size_signed,
+            &mut common_header_data,
+            &mut common_header_code,
+            data_header,
+            &mut shreds,
+        );
     }
 
     // Adjust flags for the very last data shred.
@@ -1267,6 +1240,41 @@ pub(crate) fn make_shreds_from_data(
     }
     stats.gen_coding_elapsed += now.elapsed().as_micros() as u64;
     Ok(shreds)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn shred_leftover_data(
+    proof_size: u8,
+    chained: bool,
+    resigned: bool,
+    data: &[u8],
+    data_buffer_per_shred_size: usize,
+    common_header_data: &mut ShredCommonHeader,
+    common_header_code: &mut ShredCommonHeader,
+    data_header: DataShredHeader,
+    shreds: &mut Vec<Shred>,
+) {
+    common_header_data.shred_variant = ShredVariant::MerkleData {
+        proof_size,
+        chained,
+        resigned,
+    };
+    common_header_code.shred_variant = ShredVariant::MerkleCode {
+        proof_size,
+        chained,
+        resigned,
+    };
+    common_header_data.fec_set_index = common_header_data.index;
+    common_header_code.fec_set_index = common_header_data.fec_set_index;
+    shreds.extend({
+        // Create data chunks out of remaining data + padding.
+        let chunks = data
+            .chunks(data_buffer_per_shred_size)
+            .chain(std::iter::repeat(&[][..])) // possible padding
+            .take(DATA_SHREDS_PER_FEC_BLOCK);
+        make_shreds_data(common_header_data, data_header, chunks).map(Shred::ShredData)
+    });
+    shreds.extend(make_shreds_code_header_only(common_header_code).map(Shred::ShredCode));
 }
 
 // Given shreds of the same erasure batch:
@@ -1747,7 +1755,7 @@ mod test {
 
         // only sign last batch if it is chained and is the last in slot
         // let resigned = chained && is_last_in_slot;
-        let sign_last_batch = chained && is_last_in_slot;
+        let sign_last_fec_set = chained && is_last_in_slot;
 
         let slot = 149_745_689;
         let parent_slot = slot - rng.gen_range(1..65536);
@@ -1786,10 +1794,7 @@ mod test {
             .flat_map(|shred| shred.data().unwrap())
             .copied()
             .collect::<Vec<_>>();
-        assert_eq!(
-            data,
-            data2
-        );
+        assert_eq!(data, data2);
         // Assert that shreds sanitize and verify.
         let pubkey = keypair.pubkey();
         for shred in &shreds {
@@ -1839,7 +1844,7 @@ mod test {
         let mut num_coding_shreds = 0;
         for (index, shred) in shreds.iter().enumerate() {
             let common_header = shred.common_header();
-            let resigned = sign_last_batch && index >= shreds.len() - 64;
+            let resigned = sign_last_fec_set && index >= shreds.len() - 64;
 
             assert_eq!(common_header.slot, slot);
             assert_eq!(common_header.version, shred_version);

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1099,13 +1099,16 @@ pub(crate) fn make_shreds_from_data(
     let (mut unsigned_data, signed_data) = if sign_last_fec_set {
         // Reserve at least one signed batch (may be empty) at the end.
         if data.len() > data_buffer_total_size_signed {
-            let split_at = data.len() - data_buffer_total_size_signed; // sign everything except the last batch
+            // sign everything except the last batch
+            let split_at = data.len() - data_buffer_total_size_signed;
             data.split_at(split_at)
         } else {
-            (&[][..], data) // only enough data for one fec set, sign the whole thing
+            // only enough data for one fec set, sign the whole thing
+            (&[][..], data)
         }
     } else {
-        (data, &[][..]) // not last fec set, so don't sign
+        // not last fec set, so don't sign
+        (data, &[][..])
     };
     stats.data_bytes += unsigned_data.len() + signed_data.len();
 

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1100,7 +1100,14 @@ pub(crate) fn make_shreds_from_data(
     let mut shreds = {
         let number_of_batches = if sign_last_batch {
             if data.len() > data_buffer_total_size_signed {
-                (data, sig_data) = data.split_at(data.len() - data_buffer_total_size_signed);
+                let remainder_to_be_signed = data.len() % data_buffer_total_size;
+                if remainder_to_be_signed <= data_buffer_total_size_signed {
+                    (data, sig_data) = data.split_at(data.len() - remainder_to_be_signed);
+                }
+                else {
+                    (data, sig_data) = data.split_at(data.len());
+                    assert_eq!(sig_data.len(), 0);
+                }
                 data.len().div_ceil(data_buffer_total_size) + 1
             } else {
                 sig_data = data;

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1039,10 +1039,22 @@ pub(crate) fn make_shreds_from_data(
 ) -> Result<Vec<Shred>, Error> {
     let now = Instant::now();
     let chained = chained_merkle_root.is_some();
-    let resigned = chained && is_last_in_slot;
+    // let resigned = chained && is_last_in_slot;
+    // only sign if last batch in slot and is chained
+    let sign_last_batch = chained && is_last_in_slot;
     let proof_size = PROOF_ENTRIES_FOR_32_32_BATCH;
-    let data_buffer_per_shred_size = ShredData::capacity(proof_size, chained, resigned)?;
+
+    // unsigned data_buffer size
+    let data_buffer_per_shred_size = ShredData::capacity(proof_size, chained, false)?;
     let data_buffer_total_size = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size;
+
+    // signed data_buffer size
+    let data_buffer_per_shred_size_signed = if sign_last_batch {
+        ShredData::capacity(proof_size, chained, true)?
+    } else {
+        0
+    };
+    let data_buffer_total_size_signed = DATA_SHREDS_PER_FEC_BLOCK * data_buffer_per_shred_size_signed;
 
     // Common header for the data shreds.
     let mut common_header_data = ShredCommonHeader {
@@ -1050,7 +1062,7 @@ pub(crate) fn make_shreds_from_data(
         shred_variant: ShredVariant::MerkleData {
             proof_size,
             chained,
-            resigned,
+            resigned: false,
         },
         slot,
         index: next_shred_index,
@@ -1063,7 +1075,7 @@ pub(crate) fn make_shreds_from_data(
         shred_variant: ShredVariant::MerkleCode {
             proof_size,
             chained,
-            resigned,
+            resigned: false,
         },
         index: next_code_index,
         ..common_header_data
@@ -1084,12 +1096,25 @@ pub(crate) fn make_shreds_from_data(
     };
 
     // Pre-allocate shreds to avoid reallocations.
+    let mut sig_data: &[u8] = &[];
     let mut shreds = {
-        let number_of_batches = data.len().div_ceil(data_buffer_total_size);
+        let number_of_batches = if sign_last_batch {
+            if data.len() > data_buffer_total_size_signed {
+                (data, sig_data) = data.split_at(data.len() - data_buffer_total_size_signed);
+                data.len().div_ceil(data_buffer_total_size) + 1
+            } else {
+                sig_data = data;
+                data = &[];
+                1
+            }
+        } else {
+            data.len().div_ceil(data_buffer_total_size)
+        };
         let total_num_shreds = SHREDS_PER_FEC_BLOCK * number_of_batches;
         Vec::<Shred>::with_capacity(total_num_shreds)
     };
     stats.data_bytes += data.len();
+
 
     // Split the data into full erasure batches and initialize data and coding
     // shreds for each batch.
@@ -1120,17 +1145,17 @@ pub(crate) fn make_shreds_from_data(
     // 2.) Shreds is_empty, which only happens when we entered w/ zero data.
     //
     // In either case, we want to generate empty data shreds.
-    if !data.is_empty() || shreds.is_empty() {
+    if !data.is_empty() || (shreds.is_empty() && !sign_last_batch) {
         stats.padding_bytes += data_buffer_total_size - data.len();
         common_header_data.shred_variant = ShredVariant::MerkleData {
             proof_size,
             chained,
-            resigned,
+            resigned: false,
         };
         common_header_code.shred_variant = ShredVariant::MerkleCode {
             proof_size,
             chained,
-            resigned,
+            resigned: false,
         };
         common_header_data.fec_set_index = common_header_data.index;
         common_header_code.fec_set_index = common_header_data.fec_set_index;
@@ -1138,6 +1163,31 @@ pub(crate) fn make_shreds_from_data(
             // Create data chunks out of remaining data + padding.
             let chunks = data
                 .chunks(data_buffer_per_shred_size)
+                .chain(std::iter::repeat(&[][..])) // possible padding
+                .take(DATA_SHREDS_PER_FEC_BLOCK);
+            make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
+        });
+        shreds.extend(make_shreds_code_header_only(&mut common_header_code).map(Shred::ShredCode));
+    }
+    if !sig_data.is_empty() || (shreds.is_empty() && sign_last_batch) {
+        // send signed last batch
+        stats.padding_bytes += data_buffer_total_size_signed - sig_data.len();
+        common_header_data.shred_variant = ShredVariant::MerkleData {
+            proof_size,
+            chained,
+            resigned: true,
+        };
+        common_header_code.shred_variant = ShredVariant::MerkleCode {
+            proof_size,
+            chained,
+            resigned: true,
+        };
+        common_header_data.fec_set_index = common_header_data.index;
+        common_header_code.fec_set_index = common_header_data.fec_set_index;
+        shreds.extend({
+            // Create data chunks out of remaining data + padding.
+            let chunks = sig_data
+                .chunks(data_buffer_per_shred_size_signed)
                 .chain(std::iter::repeat(&[][..])) // possible padding
                 .take(DATA_SHREDS_PER_FEC_BLOCK);
             make_shreds_data(&mut common_header_data, data_header, chunks).map(Shred::ShredData)
@@ -1687,7 +1737,11 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
         let keypair = Keypair::new();
         let chained_merkle_root = chained.then(|| Hash::new_from_array(rng.gen()));
-        let resigned = chained && is_last_in_slot;
+
+        // only sign last batch if it is chained and is the last in slot
+        // let resigned = chained && is_last_in_slot;
+        let sign_last_batch = chained && is_last_in_slot;
+
         let slot = 149_745_689;
         let parent_slot = slot - rng.gen_range(1..65536);
         let shred_version = rng.gen();
@@ -1720,13 +1774,14 @@ mod test {
             })
             .collect();
         // Assert that the input data can be recovered from data shreds.
+        let data2 = data_shreds
+            .iter()
+            .flat_map(|shred| shred.data().unwrap())
+            .copied()
+            .collect::<Vec<_>>();
         assert_eq!(
             data,
-            data_shreds
-                .iter()
-                .flat_map(|shred| shred.data().unwrap())
-                .copied()
-                .collect::<Vec<_>>()
+            data2
         );
         // Assert that shreds sanitize and verify.
         let pubkey = keypair.pubkey();
@@ -1775,8 +1830,10 @@ mod test {
         // Verify common, data and coding headers.
         let mut num_data_shreds = 0;
         let mut num_coding_shreds = 0;
-        for shred in &shreds {
+        for (index, shred) in shreds.iter().enumerate() {
             let common_header = shred.common_header();
+            let resigned = sign_last_batch && index >= shreds.len() - 64;
+
             assert_eq!(common_header.slot, slot);
             assert_eq!(common_header.version, shred_version);
             let proof_size = shred.proof_size().unwrap();

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -500,9 +500,11 @@ mod tests {
         let mut shreds =
             make_merkle_shreds_for_tests(&mut rng, slot, data_size, chained, is_last_in_slot)
                 .unwrap();
-        for shred in &mut shreds {
+        let shreds_len = shreds.len();
+        for (index, shred) in shreds.iter_mut().enumerate() {
             let signature = make_dummy_signature(&mut rng);
-            if chained && is_last_in_slot {
+            let is_last_batch = index >= shreds_len - 64;
+            if chained && is_last_in_slot && is_last_batch {
                 shred.set_retransmitter_signature(&signature).unwrap();
             } else {
                 assert_matches!(
@@ -511,9 +513,16 @@ mod tests {
                 );
             }
         }
+<<<<<<< HEAD
         for shred in &shreds {
             let nonce = repaired.then(|| rng.gen::<Nonce>());
             let mut packet = shred.payload().to_packet(nonce);
+=======
+
+        for (index, shred) in shreds.iter().enumerate() {
+            let is_last_batch = index >= shreds_len - 64;
+            let mut packet = Packet::default();
+>>>>>>> 9c70346375 (unit tests pass. local validator not working yet)
             if repaired {
                 packet.meta_mut().flags |= PacketFlags::REPAIR;
             }
@@ -571,9 +580,9 @@ mod tests {
             }
             assert_eq!(
                 is_retransmitter_signed_variant(bytes).unwrap(),
-                chained && is_last_in_slot
+                chained && is_last_in_slot && is_last_batch,
             );
-            if chained && is_last_in_slot {
+            if chained && is_last_in_slot && is_last_batch{
                 assert_eq!(
                     get_retransmitter_signature_offset(bytes).unwrap(),
                     shred.retransmitter_signature_offset().unwrap(),

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -582,7 +582,7 @@ mod tests {
                 is_retransmitter_signed_variant(bytes).unwrap(),
                 chained && is_last_in_slot && is_last_batch,
             );
-            if chained && is_last_in_slot && is_last_batch{
+            if chained && is_last_in_slot && is_last_batch {
                 assert_eq!(
                     get_retransmitter_signature_offset(bytes).unwrap(),
                     shred.retransmitter_signature_offset().unwrap(),


### PR DESCRIPTION
#### Problem
Addressing issue https://github.com/anza-xyz/agave/issues/6698
Turbine creates more resigned shreds than necessary

#### Summary of Changes
Changed make_shreds_from_data to have only last fec_set signed if last in slot. Updated unit tests to only check fec_set when last in slot.

Ran Agave on test-net with and without my changes. Inspected several metrics (gen_data_time, gen_coding_time, data_bytes, padding_bytes, num_coding_shreds, num_data_shreds, num_merkle_data_shreds, num_merkle_coding_shreds) to ensure there was no performance degradation. Inspected num_repaired on another Anza validator to ensure that there were no unusual repair requests around the times the validator with my changes was leader. 


