### PR TITLE
measure: Update Rust edition to 2024

### DIFF
--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -8,7 +8,7 @@ authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/measure/src/macros.rs
+++ b/measure/src/macros.rs
@@ -73,20 +73,20 @@
 /// ```
 #[macro_export]
 macro_rules! measure_time {
-    ($val:expr, $name:tt $(,)?) => {{
+    ($val:expr_2021, $name:tt $(,)?) => {{
         let mut measure = $crate::measure::Measure::start($name);
         let result = $val;
         measure.stop();
         (result, measure)
     }};
-    ($val:expr) => {
+    ($val:expr_2021) => {
         measure_time!($val, "")
     };
 }
 
 #[macro_export]
 macro_rules! measure_us {
-    ($expr:expr) => {{
+    ($expr:expr_2021) => {{
         let (result, duration) = $crate::meas_dur!($expr);
         (result, duration.as_micros() as u64)
     }};
@@ -107,7 +107,7 @@ macro_rules! measure_us {
 // When said aloud, the pronunciation is close to "measure".
 #[macro_export]
 macro_rules! meas_dur {
-    ($expr:expr) => {{
+    ($expr:expr_2021) => {{
         let start = std::time::Instant::now();
         let result = $expr;
         (result, start.elapsed())

--- a/measure/src/macros.rs
+++ b/measure/src/macros.rs
@@ -73,20 +73,20 @@
 /// ```
 #[macro_export]
 macro_rules! measure_time {
-    ($val:expr_2021, $name:tt $(,)?) => {{
+    ($val:expr, $name:tt $(,)?) => {{
         let mut measure = $crate::measure::Measure::start($name);
         let result = $val;
         measure.stop();
         (result, measure)
     }};
-    ($val:expr_2021) => {
+    ($val:expr) => {
         measure_time!($val, "")
     };
 }
 
 #[macro_export]
 macro_rules! measure_us {
-    ($expr:expr_2021) => {{
+    ($expr:expr) => {{
         let (result, duration) = $crate::meas_dur!($expr);
         (result, duration.as_micros() as u64)
     }};
@@ -107,7 +107,7 @@ macro_rules! measure_us {
 // When said aloud, the pronunciation is close to "measure".
 #[macro_export]
 macro_rules! meas_dur {
-    ($expr:expr_2021) => {{
+    ($expr:expr) => {{
         let start = std::time::Instant::now();
         let result = $expr;
         (result, start.elapsed())


### PR DESCRIPTION
#### Problem
We want to update our Rust edition to `2024` per https://github.com/anza-xyz/agave/issues/6203

#### Summary of Changes
Update the Rust edition to 2024 for `solana-measure`

Per [1], the changes that `cargo fix` applied are unnecessary since we do match `const` or `_` in these macros. Reviewing commit by commit should tell the story here. Also, `cargo fix --edition` did not detect anything else that required attention, so there was no log output to upload to justify any other changes.

[1] https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html

