### PR TITLE
Updates docs for Bank::set_capitalization()

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -529,7 +529,7 @@ fn minimize_bank_for_snapshot(
 }
 
 fn assert_capitalization(bank: &Bank) {
-    let calculated = bank.calculate_capitalization();
+    let calculated = bank.calculate_capitalization_for_tests();
     let expected = bank.capitalization();
     assert_eq!(
         calculated, expected,
@@ -2346,8 +2346,8 @@ fn main() {
                     }
 
                     let pre_capitalization = bank.capitalization();
-                    let post_capitalization = bank.calculate_capitalization();
-                    bank.set_capitalization(post_capitalization);
+                    let post_capitalization = bank.calculate_capitalization_for_tests();
+                    bank.set_capitalization_for_tests(post_capitalization);
 
                     let capitalization_message = if pre_capitalization != post_capitalization {
                         let amount = if pre_capitalization > post_capitalization {
@@ -2645,8 +2645,8 @@ fn main() {
                     if arg_matches.is_present("recalculate_capitalization") {
                         println!("Recalculating capitalization");
                         let old_capitalization = bank.capitalization();
-                        let new_capitalization = bank.calculate_capitalization();
-                        bank.set_capitalization(new_capitalization);
+                        let new_capitalization = bank.calculate_capitalization_for_tests();
+                        bank.set_capitalization_for_tests(new_capitalization);
                         if old_capitalization == new_capitalization {
                             eprintln!("Capitalization was identical: {}", Sol(old_capitalization));
                         }
@@ -2734,8 +2734,8 @@ fn main() {
                                 // we have no choice; maybe locally created blank cluster with
                                 // not-Development cluster type.
                                 let old_cap = base_bank.capitalization();
-                                let new_cap = base_bank.calculate_capitalization();
-                                base_bank.set_capitalization(new_cap);
+                                let new_cap = base_bank.calculate_capitalization_for_tests();
+                                base_bank.set_capitalization_for_tests(new_cap);
                                 warn!(
                                     "Skewing capitalization a bit to enable \
                                          credits_auto_rewind as requested: increasing {} from {} \

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -897,7 +897,7 @@ impl ProgramTest {
             }
             bank.store_account(address, account);
         }
-        bank.set_capitalization(bank.calculate_capitalization());
+        bank.set_capitalization_for_tests(bank.calculate_capitalization_for_tests());
         // Advance beyond slot 0 for a slightly more realistic test environment
         let bank = {
             let bank = Arc::new(bank);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5085,8 +5085,8 @@ impl Bank {
     /// account-by-account, summing each account's balance.
     ///
     /// Only intended to be called at startup by ledger-tool or tests.
-    /// (cannot be made DCOU due to snapshot-minimizer)
-    pub fn calculate_capitalization(&self) -> u64 {
+    /// (cannot be made DCOU due to solana-program-test)
+    pub fn calculate_capitalization_for_tests(&self) -> u64 {
         self.rc
             .accounts
             .accounts_db
@@ -5101,8 +5101,8 @@ impl Bank {
     /// Sets the capitalization.
     ///
     /// Only intended to be called by ledger-tool or tests.
-    /// (cannot be made DCOU due to snapshot-minimizer)
-    pub fn set_capitalization(&self, capitalization: u64) {
+    /// (cannot be made DCOU due to solana-program-test)
+    pub fn set_capitalization_for_tests(&self, capitalization: u64) {
         self.capitalization.store(capitalization, Relaxed);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -468,7 +468,10 @@ fn assert_capitalization_diff(
     let new = bank.capitalization();
     if asserter(old, new) {
         add_root_and_flush_write_cache(bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+        assert_eq!(
+            bank.capitalization(),
+            bank.calculate_capitalization_for_tests()
+        );
     }
 }
 
@@ -823,7 +826,10 @@ where
     add_root_and_flush_write_cache(&bank0);
     add_root_and_flush_write_cache(&bank1);
     add_root_and_flush_write_cache(&bank2);
-    assert_eq!(bank2.capitalization(), bank2.calculate_capitalization());
+    assert_eq!(
+        bank2.capitalization(),
+        bank2.calculate_capitalization_for_tests()
+    );
 }
 
 fn do_test_bank_update_rewards_determinism() -> u64 {
@@ -896,7 +902,10 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     bank1.freeze();
     add_root_and_flush_write_cache(&bank);
     add_root_and_flush_write_cache(&bank1);
-    assert_eq!(bank1.capitalization(), bank1.calculate_capitalization());
+    assert_eq!(
+        bank1.capitalization(),
+        bank1.calculate_capitalization_for_tests()
+    );
 
     // verify voting and staking rewards are recorded
     let rewards = bank1.rewards.read().unwrap();
@@ -2694,7 +2703,10 @@ fn test_bank_update_sysvar_account() {
         let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
         if pass == 0 {
             add_root_and_flush_write_cache(&bank1);
-            assert_eq!(bank1.calculate_capitalization(), bank1.capitalization());
+            assert_eq!(
+                bank1.calculate_capitalization_for_tests(),
+                bank1.capitalization()
+            );
             continue;
         }
 
@@ -3587,7 +3599,10 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
+            assert_eq!(
+                bank.calculate_capitalization_for_tests(),
+                bank.capitalization()
+            );
             continue;
         }
 
@@ -3604,7 +3619,10 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(!bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
+            assert_eq!(
+                bank.calculate_capitalization_for_tests(),
+                bank.capitalization()
+            );
             continue;
         }
 
@@ -3627,7 +3645,10 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.calculate_capitalization(), bank.capitalization());
+            assert_eq!(
+                bank.calculate_capitalization_for_tests(),
+                bank.capitalization()
+            );
             continue;
         }
         assert_eq!(
@@ -3653,7 +3674,10 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
             assert!(stakes.vote_accounts().as_ref().is_empty());
         }
         assert!(bank.stakes_cache.stakes().stake_delegations().is_empty());
-        assert_eq!(bank.calculate_capitalization(), bank.capitalization());
+        assert_eq!(
+            bank.calculate_capitalization_for_tests(),
+            bank.capitalization()
+        );
         assert_eq!(
             "mock_program1",
             String::from_utf8_lossy(bank.get_account(&vote_id).unwrap_or_default().data())
@@ -5584,7 +5608,10 @@ fn test_add_builtin_account_inherited_cap_while_replacing() {
         bank.add_builtin_account("mock_program", &program_id);
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
@@ -5592,19 +5619,28 @@ fn test_add_builtin_account_inherited_cap_while_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
+            assert_ne!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
         bank.add_builtin_account("mock_program v2", &program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+        assert_eq!(
+            bank.capitalization(),
+            bank.calculate_capitalization_for_tests()
+        );
     }
 }
 
@@ -5619,19 +5655,28 @@ fn test_add_builtin_account_squatted_while_not_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
+            assert_ne!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
         bank.add_builtin_account("mock_program", &program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+        assert_eq!(
+            bank.capitalization(),
+            bank.calculate_capitalization_for_tests()
+        );
     }
 }
 
@@ -5710,7 +5755,10 @@ fn test_add_precompiled_account_inherited_cap_while_replacing() {
         bank.add_precompiled_account(&program_id);
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
@@ -5718,19 +5766,28 @@ fn test_add_precompiled_account_inherited_cap_while_replacing() {
         bank.withdraw(&mint_keypair.pubkey(), 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
+            assert_ne!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 2 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
         bank.add_precompiled_account(&program_id);
         add_root_and_flush_write_cache(&bank);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+        assert_eq!(
+            bank.capitalization(),
+            bank.calculate_capitalization_for_tests()
+        );
     }
 }
 
@@ -5746,20 +5803,29 @@ fn test_add_precompiled_account_squatted_while_not_replacing() {
         if pass == 0 {
             add_root_and_flush_write_cache(&bank);
 
-            assert_ne!(bank.capitalization(), bank.calculate_capitalization());
+            assert_ne!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
         test_utils::deposit(&bank, &program_id, 10).unwrap();
         if pass == 1 {
             add_root_and_flush_write_cache(&bank);
-            assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+            assert_eq!(
+                bank.capitalization(),
+                bank.calculate_capitalization_for_tests()
+            );
             continue;
         }
 
         bank.add_precompiled_account(&program_id);
         add_root_and_flush_write_cache(&bank);
 
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
+        assert_eq!(
+            bank.capitalization(),
+            bank.calculate_capitalization_for_tests()
+        );
     }
 }
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -77,7 +77,7 @@ impl<'a> SnapshotMinimizer<'a> {
         minimizer.bank.force_flush_accounts_cache();
         minimizer
             .bank
-            .set_capitalization(minimizer.bank.calculate_capitalization());
+            .set_capitalization_for_tests(minimizer.bank.calculate_capitalization_for_tests());
 
         if minimizer.bank.is_accounts_lt_hash_enabled() {
             // Since the account state has changed, the accounts lt hash must be recalculated


### PR DESCRIPTION
#### Problem

Bank::set_capitalization() and Bank::calculate_capitalization() *should* be DCOU, but solana-program-test currently prevents that.  The doc comments should indicate as such, and we can rename the fns to make that clear.


#### Summary of Changes

Update the docs and rename the fns so it is clear they should only be called by tests/dcou.