### PR TITLE
Marks AccountsFile::new_from_file() as DCOU

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -79,6 +79,7 @@ impl AccountsFile {
     ///
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn new_from_file(
         path: impl Into<PathBuf>,
         current_len: usize,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -423,6 +423,7 @@ impl AppendVec {
         self.file_size
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn new_from_file(
         path: impl Into<PathBuf>,
         current_len: usize,


### PR DESCRIPTION
#### Problem

AccountsFile::new_from_file() is only used by tests, but is not marked as such.

Also see https://github.com/anza-xyz/agave/pull/6552#discussion_r2151039071.


#### Summary of Changes

Mark as DCOU.