### PR TITLE
core, send-tx-service, quic-client: switch tests to use non-overlapping socket bind api

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -802,12 +802,8 @@ impl BankingSimulator {
         // Broadcast stage is needed to save the simulated blocks for post-run analysis by
         // inserting produced shreds into the blockstore.
         let port_range = localhost_port_range_for_tests();
-        let mut port_range = port_range.0..port_range.1;
         let broadcast_stage = BroadcastStageType::Standard.new_broadcast_stage(
-            vec![
-                bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.next().unwrap())
-                    .expect("should bind"),
-            ],
+            vec![bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind")],
             cluster_info_for_broadcast.clone(),
             entry_receiver,
             retransmit_slots_receiver,

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -27,7 +27,7 @@ use {
         blockstore::{Blockstore, PurgeType},
         leader_schedule_cache::LeaderScheduleCache,
     },
-    solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+    solana_net_utils::sockets::{bind_in_range_with_config, SocketConfiguration},
     solana_poh::{
         poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
         poh_service::{PohService, DEFAULT_HASHES_PER_BATCH, DEFAULT_PINNED_CPU_CORE},
@@ -801,9 +801,14 @@ impl BankingSimulator {
         ));
         // Broadcast stage is needed to save the simulated blocks for post-run analysis by
         // inserting produced shreds into the blockstore.
-        let port_range = localhost_port_range_for_tests();
+        let (_, socket) = bind_in_range_with_config(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            (1024, u16::MAX),
+            SocketConfiguration::default(),
+        )
+        .expect("should bind");
         let broadcast_stage = BroadcastStageType::Standard.new_broadcast_stage(
-            vec![bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind")],
+            vec![socket],
             cluster_info_for_broadcast.clone(),
             entry_receiver,
             retransmit_slots_receiver,

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1272,12 +1272,18 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::{bind_to_localhost, bind_to_unspecified},
-        solana_runtime::bank::Bank,
-        solana_signer::Signer,
-        solana_streamer::socket::SocketAddrSpace,
-        solana_time_utils::timestamp,
-        std::collections::HashSet,
+        solana_net_utils::{
+            bind_to_unspecified,
+            sockets::{bind_to, localhost_port_range_for_tests},
+            solana_runtime::bank::Bank,
+            solana_signer::Signer,
+            solana_streamer::socket::SocketAddrSpace,
+            solana_time_utils::timestamp,
+            std::{
+                collections::HashSet,
+                net::{IpAddr, Ipv4Addr},
+            },
+        },
     };
 
     fn new_test_cluster_info() -> ClusterInfo {
@@ -1293,9 +1299,10 @@ mod test {
         let pubkey = cluster_info.id();
         let slot = 100;
         let shred_index = 50;
-        let reader = bind_to_localhost().expect("bind");
+        let port_range = localhost_port_range_for_tests();
+        let reader = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind");
         let address = reader.local_addr().unwrap();
-        let sender = bind_to_localhost().expect("bind");
+        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.1).expect("should bind");
         let outstanding_repair_requests = Arc::new(RwLock::new(OutstandingShredRepairs::default()));
 
         // Send a repair request

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1275,14 +1275,14 @@ mod test {
         solana_net_utils::{
             bind_to_unspecified,
             sockets::{bind_to, localhost_port_range_for_tests},
-            solana_runtime::bank::Bank,
-            solana_signer::Signer,
-            solana_streamer::socket::SocketAddrSpace,
-            solana_time_utils::timestamp,
-            std::{
-                collections::HashSet,
-                net::{IpAddr, Ipv4Addr},
-            },
+        },
+        solana_runtime::bank::Bank,
+        solana_signer::Signer,
+        solana_streamer::socket::SocketAddrSpace,
+        solana_time_utils::timestamp,
+        std::{
+            collections::HashSet,
+            net::{IpAddr, Ipv4Addr},
         },
     };
 

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -52,10 +52,8 @@ mod tests {
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair) {
         let port_range = localhost_port_range_for_tests();
-        let mut port_range = port_range.0..port_range.1;
         (
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.next().unwrap())
-                .expect("should bind"),
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind"),
             Arc::new(AtomicBool::new(false)),
             Keypair::new(),
         )

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -5,7 +5,7 @@ mod tests {
         log::*,
         solana_connection_cache::connection_cache_stats::ConnectionCacheStats,
         solana_keypair::Keypair,
-        solana_net_utils::bind_to_localhost,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_packet::PACKET_DATA_SIZE,
         solana_perf::packet::PacketBatch,
         solana_quic_client::nonblocking::quic_client::QuicLazyInitializedEndpoint,
@@ -15,7 +15,7 @@ mod tests {
         },
         solana_tls_utils::{new_dummy_x509_certificate, QuicClientCertificate},
         std::{
-            net::{SocketAddr, UdpSocket},
+            net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
             sync::{
                 atomic::{AtomicBool, Ordering},
                 Arc, RwLock,
@@ -51,8 +51,11 @@ mod tests {
     }
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair) {
+        let port_range = localhost_port_range_for_tests();
+        let mut port_range = port_range.0..port_range.1;
         (
-            bind_to_localhost().unwrap(),
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.next().unwrap())
+                .expect("should bind"),
             Arc::new(AtomicBool::new(false)),
             Keypair::new(),
         )

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -9,7 +9,11 @@ use {
         },
     },
     solana_client::connection_cache::ConnectionCache,
-    std::{net::SocketAddr, sync::Arc},
+    solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+    std::{
+        net::{Ipv4Addr, SocketAddr},
+        sync::Arc,
+    },
     tokio::runtime::Handle,
     tokio_util::sync::CancellationToken,
 };
@@ -53,8 +57,13 @@ impl CreateClient for TpuClientNextClient {
     ) -> Self {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
-        let bind_socket = solana_net_utils::bind_to_localhost()
-            .expect("Should be able to open UdpSocket for tests.");
+        let port_range = localhost_port_range_for_tests();
+        let mut port_range = port_range.0..port_range.1;
+        let bind_socket = bind_to(
+            std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port_range.next().unwrap(),
+        )
+        .expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,
             my_tpu_address,

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -58,12 +58,8 @@ impl CreateClient for TpuClientNextClient {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
         let port_range = localhost_port_range_for_tests();
-        let mut port_range = port_range.0..port_range.1;
-        let bind_socket = bind_to(
-            std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
-            port_range.next().unwrap(),
-        )
-        .expect("Should be able to open UdpSocket for tests.");
+        let bind_socket = bind_to(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
+            .expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,
             my_tpu_address,

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -11,7 +11,7 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
     std::{
-        net::{Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::Arc,
     },
     tokio::runtime::Handle,
@@ -58,7 +58,7 @@ impl CreateClient for TpuClientNextClient {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
         let port_range = localhost_port_range_for_tests();
-        let bind_socket = bind_to(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
+        let bind_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
             .expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,


### PR DESCRIPTION
#### Problem
A bunch of tests still relies on either hardcoded ports or bind_to_localhost and bind_to_unspecified. This creates flaky tests in cases where unique port ranges are needed.

Related to https://github.com/anza-xyz/agave/pull/6886 and https://github.com/anza-xyz/agave/pull/6895

#### Summary of Changes
This PR should close the topic of migration to non-overlapping bindings.
