### PR TITLE
Updates index stats at startup w.r.t. duplicates

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1235,14 +1235,59 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let duplicates_put_on_disk = std::mem::take(&mut duplicate_items.duplicates_put_on_disk);
         drop(duplicate_items);
 
-        duplicates_put_on_disk
+        // accumulated stats after inserting pubkeys into the index
+        let mut num_did_not_exist = 0;
+        let mut num_existed_in_mem = 0;
+        let mut num_existed_on_disk = 0;
+
+        let duplicates = duplicates_put_on_disk
             .into_iter()
             .chain(duplicates.into_iter().map(|(slot, key, info)| {
                 let entry = PreAllocatedAccountMapEntry::new(slot, info, &self.storage, true);
-                self.insert_new_entry_if_missing_with_lock(key, entry);
+                match self.insert_new_entry_if_missing_with_lock(key, entry) {
+                    InsertNewEntryResults::DidNotExist => {
+                        num_did_not_exist += 1;
+                    }
+                    InsertNewEntryResults::Existed {
+                        other_slot: _,
+                        location,
+                    } => match location {
+                        ExistedLocation::InMem => {
+                            num_existed_in_mem += 1;
+                        }
+                        ExistedLocation::OnDisk => {
+                            num_existed_on_disk += 1;
+                        }
+                    },
+                };
                 (slot, key)
             }))
-            .collect()
+            .collect();
+
+        let stats = self.stats();
+
+        // stats for inserted entries that previously did *not* exist
+        stats.inc_insert_count(num_did_not_exist);
+        stats.add_mem_count(num_did_not_exist as usize);
+
+        // stats for inserted entries that previous did exist *in-mem*
+        stats
+            .entries_from_mem
+            .fetch_add(num_existed_in_mem, Ordering::Relaxed);
+        stats
+            .updates_in_mem
+            .fetch_add(num_existed_in_mem, Ordering::Relaxed);
+
+        // stats for inserted entries that previously did exist *on-disk*
+        stats.add_mem_count(num_existed_on_disk as usize);
+        stats
+            .entries_missing
+            .fetch_add(num_existed_on_disk, Ordering::Relaxed);
+        stats
+            .updates_in_mem
+            .fetch_add(num_existed_on_disk, Ordering::Relaxed);
+
+        duplicates
     }
 
     pub fn startup_take_duplicates_from_in_memory_only(&self) -> Vec<(Slot, Pubkey)> {


### PR DESCRIPTION
#### Problem

PR #6703 refactored how accounts index stats were updated at startup. This moved updating stats *out* of `insert_new_entry_if_missing_with_lock()` and into its callers.  There are two callers of `insert_new_entry_if_missing_with_lock()` but I only updated one and didn't update `populate_and_retrieve_duplicate_keys_from_startup()`.  So, starting a validator with the disk-index accounts index *enabled* (which is the default), the in-mem index stats will be wrong (undercounted).

Here's an example of *negative* number of entries 😬 
![Screenshot 2025-07-08 at 3 49 13 PM](https://github.com/user-attachments/assets/10984850-6700-4387-9a2f-b150b658eb1f)


#### Summary of Changes

Fix the index stats in `populate_and_retrieve_duplicate_keys_from_startup()`.

Note, since #6703 was backported to v2.3, I also intend to backport this PR, since stats are broken there too.


#### Results

I restarted a dev box with this PR approximately where the cursor is. On the left is the old/wrong number of in-mem index entries. On the right is the new/correct number of in-mem index entries.
![Screenshot 2025-07-09 at 1 36 58 PM](https://github.com/user-attachments/assets/6b1e0e69-8579-4b99-9679-bcf392f40f4c)