### PR TITLE
runtime: Avoid locking during stake vote rewards calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10681,9 +10681,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,7 +515,7 @@ solana-signer = "3.0.0"
 solana-slot-hashes = "3.0.0"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.0"
-solana-stake-interface = { version = "2.0.0" }
+solana-stake-interface = { version = "2.0.1" }
 solana-stake-program = { path = "programs/stake", version = "=3.1.0" }
 solana-storage-bigtable = { path = "storage-bigtable", version = "=3.1.0" }
 solana-storage-proto = { path = "storage-proto", version = "=3.1.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,7 @@ solana-sdk-ids = "=3.0.0"
 solana-signature = { version = "=3.1.0", default-features = false }
 solana-signer = "=3.0.0"
 solana-slot-history = "=3.0.0"
-solana-stake-interface = "=2.0.0"
+solana-stake-interface = "=2.0.1"
 solana-streamer = { workspace = true }
 solana-system-interface = { version = "=2.0", features = ["bincode"] }
 solana-sysvar = "=3.0.0"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -54,7 +54,7 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk-ids = "=3.0.0"
 solana-signer = "=3.0.0"
-solana-stake-interface = { version = "=2.0.0", features = ["borsh"] }
+solana-stake-interface = { version = "=2.0.1", features = ["borsh"] }
 solana-stake-program = { workspace = true }
 solana-time-utils = "3.0.0"
 solana-version = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9126,9 +9126,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd582fe900e43db96651a5b43956b8ebfab1944d091b391d89140635900ef46"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -157,7 +157,7 @@ solana-sbpf = "=0.12.2"
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-sha256-hasher = { version = "=3.0.0", features = ["sha2"] }
-solana-stake-interface = { version = "=2.0.0", features = ["bincode"] }
+solana-stake-interface = { version = "=2.0.1", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=3.1.0" }
 solana-svm-callback = { path = "../../svm-callback", version = "=3.1.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=3.1.0" }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1825,7 +1825,18 @@ impl Bank {
         bank.transaction_processor =
             TransactionBatchProcessor::new_uninitialized(bank.slot, bank.epoch);
 
-        bank.recalculate_partitioned_rewards(null_tracer());
+        // TODO: Only create the thread pool if we need to recalculate rewards,
+        // i.e. epoch_reward_status is active. Currently, this thread pool is
+        // always created and used for recalculate_partitioned_rewards and
+        // lt_hash calculation. Once lt_hash feature is active, lt_hash won't
+        // need the thread pool. Thereby, after lt_hash feature activation, we
+        // can change to create the thread pool only when we need to recalculate
+        // rewards.
+        let thread_pool = ThreadPoolBuilder::new()
+            .thread_name(|i| format!("solBnkNewFlds{i:02}"))
+            .build()
+            .expect("new rayon threadpool");
+        bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
 
         bank.finish_init(
             genesis_config,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -432,7 +432,7 @@ impl Bank {
                                 (None, None)
                             }
                         } else {
-                            debug!("could not find vote accout {vote_pubkey} in cache");
+                            debug!("could not find vote account {vote_pubkey} in cache");
                             (None, None)
                         };
                         stake_reward_ref.write(stake_reward);
@@ -523,7 +523,6 @@ impl Bank {
             stake_history,
             stake_delegations,
             cached_vote_accounts,
-            ..
         } = reward_calculate_params;
 
         let solana_vote_program: Pubkey = solana_vote_program::id();
@@ -567,7 +566,7 @@ impl Bank {
         let epoch_rewards_sysvar = self.get_epoch_rewards_sysvar();
         if epoch_rewards_sysvar.active {
             let thread_pool = ThreadPoolBuilder::new()
-                .thread_name(|i| format!("solBnkNewFlds{i:02}"))
+                .thread_name(|i| format!("solRecalcRwrds{i:02}"))
                 .build()
                 .expect("new rayon threadpool");
             let (stake_rewards, partition_indices) = self.recalculate_stake_rewards(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -9,7 +9,7 @@ use {
     crate::{
         bank::{
             PrevEpochInflationRewards, RewardCalcTracer, RewardCalculationEvent, RewardsMetrics,
-            VoteReward, VoteRewards,
+            VoteReward,
         },
         inflation_rewards::{
             points::{calculate_points, PointValue},
@@ -18,24 +18,25 @@ use {
         stake_account::StakeAccount,
         stakes::Stakes,
     },
-    ahash::random_state::RandomState as AHashRandomState,
-    dashmap::DashMap,
     log::{debug, info},
     rayon::{
-        iter::{IntoParallelRefIterator, ParallelIterator},
-        ThreadPool,
+        iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
+        ThreadPool, ThreadPoolBuilder,
     },
     solana_account::ReadableAccount,
     solana_clock::{Epoch, Slot},
     solana_measure::measure_us,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_stake_interface::state::Delegation,
     solana_sysvar::epoch_rewards::EpochRewards,
     solana_vote::vote_account::VoteAccount,
     solana_vote_program::vote_state::VoteStateVersions,
-    std::sync::{
-        atomic::{AtomicU64, Ordering::Relaxed},
-        Arc,
+    std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicU64, Ordering::Relaxed},
+            Arc,
+        },
     },
 };
 
@@ -343,93 +344,145 @@ impl Bank {
         } = reward_calculate_params;
 
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
-        let estimated_num_vote_accounts = cached_vote_accounts.len();
-        let vote_account_rewards: VoteRewards = DashMap::with_capacity_and_hasher_and_shard_amount(
-            estimated_num_vote_accounts,
-            AHashRandomState::default(),
-            1024, // shard amount
-        );
 
         let total_stake_rewards = AtomicU64::default();
         const ASSERT_STAKE_CACHE: bool = false; // Turn this on to assert that all vote accounts are in the cache
-        let (stake_rewards, measure_stake_rewards_us) = measure_us!(thread_pool.install(|| {
-            stake_delegations
-                .par_iter()
-                .filter_map(|(stake_pubkey, stake_account)| {
-                    // curry closure to add the contextual stake_pubkey
-                    let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
-                        // inner
-                        move |inner_event: &_| {
-                            outer(&RewardCalculationEvent::Staking(stake_pubkey, inner_event))
-                        }
-                    });
+        let ((stake_rewards, vote_account_rewards), measure_stake_rewards_us) =
+            measure_us!(thread_pool.install(|| {
+                stake_delegations
+                    .par_iter()
+                    .with_min_len(10_000)
+                    .filter_map(|(stake_pubkey, stake_account)| {
+                        // curry closure to add the contextual stake_pubkey
+                        let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
+                            // inner
+                            move |inner_event: &_| {
+                                outer(&RewardCalculationEvent::Staking(stake_pubkey, inner_event))
+                            }
+                        });
 
-                    let stake_pubkey = **stake_pubkey;
-                    let vote_pubkey = stake_account.delegation().voter_pubkey;
-                    let vote_account_from_cache = cached_vote_accounts.get(&vote_pubkey);
-                    if ASSERT_STAKE_CACHE && vote_account_from_cache.is_none() {
-                        let account_from_db = self.get_account_with_fixed_root(&vote_pubkey);
-                        if let Some(account_from_db) = account_from_db {
-                            if VoteStateVersions::is_correct_size_and_initialized(
-                                account_from_db.data(),
-                            ) && VoteAccount::try_from(account_from_db.clone()).is_ok()
-                            {
-                                panic!(
-                                    "Vote account {vote_pubkey} not found in cache, but found in \
-                                     db: {account_from_db:?}"
-                                );
+                        let stake_pubkey = **stake_pubkey;
+                        let vote_pubkey = stake_account.delegation().voter_pubkey;
+                        let vote_account_from_cache = cached_vote_accounts.get(&vote_pubkey);
+                        if ASSERT_STAKE_CACHE && vote_account_from_cache.is_none() {
+                            let account_from_db = self.get_account_with_fixed_root(&vote_pubkey);
+                            if let Some(account_from_db) = account_from_db {
+                                if VoteStateVersions::is_correct_size_and_initialized(
+                                    account_from_db.data(),
+                                ) && VoteAccount::try_from(account_from_db.clone()).is_ok()
+                                {
+                                    panic!(
+                                        "Vote account {} not found in cache, but found in db: {:?}",
+                                        vote_pubkey, account_from_db
+                                    );
+                                }
                             }
                         }
-                    }
-                    let vote_account = vote_account_from_cache?;
-                    let vote_state_view = vote_account.vote_state_view();
-                    let mut stake_state = *stake_account.stake_state();
+                        let vote_account = vote_account_from_cache?;
+                        let vote_state_view = vote_account.vote_state_view();
+                        let mut stake_state = *stake_account.stake_state();
 
-                    let redeemed = redeem_rewards(
-                        rewarded_epoch,
-                        &mut stake_state,
-                        vote_state_view,
-                        &point_value,
-                        stake_history,
-                        reward_calc_tracer.as_ref(),
-                        new_warmup_cooldown_rate_epoch,
-                    );
+                        let redeemed = redeem_rewards(
+                            rewarded_epoch,
+                            &mut stake_state,
+                            vote_state_view,
+                            &point_value,
+                            stake_history,
+                            reward_calc_tracer.as_ref(),
+                            new_warmup_cooldown_rate_epoch,
+                        );
 
-                    if let Ok((stakers_reward, voters_reward)) = redeemed {
-                        let commission = vote_state_view.commission();
+                        if let Ok((stakers_reward, voters_reward)) = redeemed {
+                            let commission = vote_state_view.commission();
 
-                        // track voter rewards
-                        let mut voters_reward_entry = vote_account_rewards
-                            .entry(vote_pubkey)
-                            .or_insert(VoteReward {
-                                commission,
-                                vote_account: vote_account.into(),
-                                vote_rewards: 0,
-                            });
+                            total_stake_rewards.fetch_add(stakers_reward, Relaxed);
 
-                        voters_reward_entry.vote_rewards = voters_reward_entry
-                            .vote_rewards
-                            .saturating_add(voters_reward);
+                            // Safe to unwrap because all stake_delegations are type
+                            // StakeAccount<Delegation>, which will always only wrap
+                            // a `StakeStateV2::Stake` variant.
+                            let stake = stake_state.stake().unwrap();
 
-                        total_stake_rewards.fetch_add(stakers_reward, Relaxed);
+                            Some((
+                                PartitionedStakeReward {
+                                    stake_pubkey,
+                                    stake_reward: stakers_reward,
+                                    stake,
+                                    commission,
+                                },
+                                (
+                                    vote_pubkey,
+                                    VoteReward {
+                                        commission,
+                                        vote_account: vote_account.into(),
+                                        vote_rewards: voters_reward,
+                                    },
+                                ),
+                            ))
+                        } else {
+                            debug!(
+                                "redeem_rewards() failed for {}: {:?}",
+                                stake_pubkey, redeemed
+                            );
+                            None
+                        }
+                    })
+                    .fold(
+                        || {
+                            (
+                                Vec::new(),
+                                HashMap::with_hasher(PubkeyHasherBuilder::default()),
+                            )
+                        },
+                        |(mut stake_rewards, mut vote_rewards),
+                         (stake_reward, (vote_pubkey, vote_reward))| {
+                            stake_rewards.push(stake_reward);
+                            vote_rewards
+                                .entry(vote_pubkey)
+                                .and_modify(|dst_vote_reward: &mut VoteReward| {
+                                    dst_vote_reward.vote_rewards = dst_vote_reward
+                                        .vote_rewards
+                                        .saturating_add(vote_reward.vote_rewards)
+                                })
+                                .or_insert(vote_reward);
+                            (stake_rewards, vote_rewards)
+                        },
+                    )
+                    .reduce(
+                        || {
+                            (
+                                Vec::new(),
+                                HashMap::with_hasher(PubkeyHasherBuilder::default()),
+                            )
+                        },
+                        |(stake_rewards_a, vote_rewards_a), (stake_rewards_b, vote_rewards_b)| {
+                            let (mut dst_stake_rewards, src_stake_rewards) =
+                                if stake_rewards_a.len() >= stake_rewards_b.len() {
+                                    (stake_rewards_a, stake_rewards_b)
+                                } else {
+                                    (stake_rewards_b, stake_rewards_a)
+                                };
+                            dst_stake_rewards.extend(src_stake_rewards);
 
-                        // Safe to unwrap because all stake_delegations are type
-                        // StakeAccount<Delegation>, which will always only wrap
-                        // a `StakeStateV2::Stake` variant.
-                        let stake = stake_state.stake().unwrap();
-                        return Some(PartitionedStakeReward {
-                            stake_pubkey,
-                            stake_reward: stakers_reward,
-                            stake,
-                            commission,
-                        });
-                    } else {
-                        debug!("redeem_rewards() failed for {stake_pubkey}: {redeemed:?}");
-                    }
-                    None
-                })
-                .collect()
-        }));
+                            let (mut dst_vote_rewards, src_vote_rewards) =
+                                if vote_rewards_a.len() >= vote_rewards_b.len() {
+                                    (vote_rewards_a, vote_rewards_b)
+                                } else {
+                                    (vote_rewards_b, vote_rewards_a)
+                                };
+                            for (vote_pubkey, vote_reward) in src_vote_rewards {
+                                dst_vote_rewards
+                                    .entry(vote_pubkey)
+                                    .and_modify(|dst_vote_reward: &mut VoteReward| {
+                                        dst_vote_reward.vote_rewards = dst_vote_reward
+                                            .vote_rewards
+                                            .saturating_add(vote_reward.vote_rewards)
+                                    })
+                                    .or_insert(vote_reward);
+                            }
+                            (dst_stake_rewards, dst_vote_rewards)
+                        },
+                    )
+            }));
         let (vote_rewards, measure_vote_rewards_us) =
             measure_us!(Self::calc_vote_accounts_to_store(vote_account_rewards));
 
@@ -457,6 +510,7 @@ impl Bank {
             stake_history,
             stake_delegations,
             cached_vote_accounts,
+            ..
         } = reward_calculate_params;
 
         let solana_vote_program: Pubkey = solana_vote_program::id();
@@ -496,14 +550,17 @@ impl Bank {
     pub(in crate::bank) fn recalculate_partitioned_rewards(
         &mut self,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
-        thread_pool: &ThreadPool,
     ) {
         let epoch_rewards_sysvar = self.get_epoch_rewards_sysvar();
         if epoch_rewards_sysvar.active {
+            let thread_pool = ThreadPoolBuilder::new()
+                .thread_name(|i| format!("solBnkNewFlds{i:02}"))
+                .build()
+                .expect("new rayon threadpool");
             let (stake_rewards, partition_indices) = self.recalculate_stake_rewards(
                 &epoch_rewards_sysvar,
                 reward_calc_tracer,
-                thread_pool,
+                &thread_pool,
             );
             self.set_epoch_reward_status_distribution(
                 epoch_rewards_sysvar.distribution_starting_block_height,
@@ -1045,7 +1102,7 @@ mod tests {
             &mut rewards_metrics,
         );
 
-        bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
+        bank.recalculate_partitioned_rewards(null_tracer());
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(
             StartBlockHeightAndPartitionedRewards {
                 distribution_starting_block_height,
@@ -1083,7 +1140,7 @@ mod tests {
         let mut bank =
             Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), SLOTS_PER_EPOCH + 1);
 
-        bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
+        bank.recalculate_partitioned_rewards(null_tracer());
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(
             StartBlockHeightAndPartitionedRewards {
                 distribution_starting_block_height,
@@ -1126,7 +1183,7 @@ mod tests {
         let mut bank =
             Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), SLOTS_PER_EPOCH + 2);
 
-        bank.recalculate_partitioned_rewards(null_tracer(), &thread_pool);
+        bank.recalculate_partitioned_rewards(null_tracer());
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
     }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -271,6 +271,10 @@ impl Bank {
                         "partition reward out of bound: {index} >= {}",
                         partition_rewards.all_stake_rewards.len()
                     )
+                })
+                .as_ref()
+                .unwrap_or_else(|| {
+                    panic!("partition reward {index} is empty");
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
@@ -339,7 +343,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<Vec<_>>();
 
         let partition_indices =
@@ -363,7 +367,7 @@ mod tests {
         let expected_num = 1;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<Vec<_>>();
 
         let partition_indices = hash_rewards_into_partitions(
@@ -749,7 +753,11 @@ mod tests {
 
         let expected_total = converted_rewards
             .iter()
-            .map(|stake_reward| stake_reward.stake_reward)
+            .filter_map(|stake_reward| {
+                stake_reward
+                    .as_ref()
+                    .map(|stake_reward| stake_reward.stake_reward)
+            })
             .sum::<u64>();
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -1,10 +1,10 @@
 use {
-    crate::bank::partitioned_epoch_rewards::PartitionedStakeReward, itertools::enumerate,
+    crate::bank::partitioned_epoch_rewards::PartitionedStakeRewards, itertools::enumerate,
     solana_epoch_rewards_hasher::EpochRewardsHasher, solana_hash::Hash,
 };
 
 pub(in crate::bank::partitioned_epoch_rewards) fn hash_rewards_into_partitions(
-    stake_rewards: &[PartitionedStakeReward],
+    stake_rewards: &PartitionedStakeRewards,
     parent_blockhash: &Hash,
     num_partitions: usize,
 ) -> Vec<Vec<usize>> {
@@ -12,13 +12,15 @@ pub(in crate::bank::partitioned_epoch_rewards) fn hash_rewards_into_partitions(
     let mut indices = vec![vec![]; num_partitions];
 
     for (i, reward) in enumerate(stake_rewards) {
-        // clone here so the hasher's state is re-used on each call to `hash_address_to_partition`.
-        // This prevents us from re-hashing the seed each time.
-        // The clone is explicit (as opposed to an implicit copy) so it is clear this is intended.
-        let partition_index = hasher
-            .clone()
-            .hash_address_to_partition(&reward.stake_pubkey);
-        indices[partition_index].push(i);
+        if let Some(ref reward) = reward {
+            // clone here so the hasher's state is re-used on each call to `hash_address_to_partition`.
+            // This prevents us from re-hashing the seed each time.
+            // The clone is explicit (as opposed to an implicit copy) so it is clear this is intended.
+            let partition_index = hasher
+                .clone()
+                .hash_address_to_partition(&reward.stake_pubkey);
+            indices[partition_index].push(i);
+        }
     }
     indices
 }
@@ -43,7 +45,7 @@ mod tests {
         let expected_num = 12345;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<Vec<_>>();
 
         let partition_indices = hash_rewards_into_partitions(&stake_rewards, &Hash::default(), 5);
@@ -79,7 +81,7 @@ mod tests {
         // simulate 40K - 1 rewards, the expected num of credit blocks should be 10.
         let expected_num = 40959;
         let stake_rewards = (0..expected_num)
-            .map(|_| PartitionedStakeReward::new_random())
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<Vec<_>>();
 
         let partition_indices =

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11363,7 +11363,7 @@ fn test_system_instruction_unsigned_transaction() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_empty() {
-    let vote_account_rewards = DashMap::default();
+    let vote_account_rewards = HashMap::default();
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
     assert_eq!(
         result.accounts_with_rewards.len(),
@@ -11374,7 +11374,7 @@ fn test_calc_vote_accounts_to_store_empty() {
 
 #[test]
 fn test_calc_vote_accounts_to_store_overflow() {
-    let vote_account_rewards = DashMap::default();
+    let mut vote_account_rewards = HashMap::default();
     let pubkey = solana_pubkey::new_rand();
     let mut vote_account = AccountSharedData::default();
     vote_account.set_lamports(u64::MAX);
@@ -11399,7 +11399,7 @@ fn test_calc_vote_accounts_to_store_normal() {
     let pubkey = solana_pubkey::new_rand();
     for commission in 0..2 {
         for vote_rewards in 0..2 {
-            let vote_account_rewards = DashMap::default();
+            let mut vote_account_rewards = HashMap::default();
             let mut vote_account = AccountSharedData::default();
             vote_account.set_lamports(1);
             vote_account_rewards.insert(


### PR DESCRIPTION
#### Problem

`calculate_stake_vote_rewards` was storing accumulated rewards per vote account in a `DashMap`, which then was used in a parallel iterator over all stake delegations.

There are over 1,000,000 stake delegations and around 1,000 validators. Each thread processed one of the stake delegations and tried to acquire a lock on a `DashMap` shard corresponding to a validator. Given that the number of validators is disproportionally small and they have thousands of delegations, such solution resulted in high contention, with some threads spending the most of their time on waiting for lock.

The time spent on these calculations was ~232.21ms:

```
redeem_rewards_us=232210i
```

Threads spent 65% of their time on waiting for locks:

<img width="1905" height="481" alt="reward-calculation-before-1" src="https://github.com/user-attachments/assets/01373b52-80de-477a-be47-ac21e85de553" />

#### Summary of Changes

Fix that by:

* Removing the `DashMap` and instead using `fold` and `reduce` operations to build a regular `HashMap`.
* Pre-allocating the `stake_rewards` vector and passing `&mut [MaybeUninit<PartitionedStakeReward>]` to the thread pool.
* Pulling the optimization of `StakeHistory::get` in `solana-stake-interface` solana-program/stake#81

The time spent on reward calculations goes down to ~48.78ms:

```
redeem_rewards_us=48781i
```

Threads spend the most of time doing actual calculations:

<img width="3824" height="1929" alt="epoch-rewards-final" src="https://github.com/user-attachments/assets/0041375f-08a3-481f-a89a-aceab09ca07e" />

Fixes #6899
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
