### PR TITLE
Fix comment on Entry about lock restrictions

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -112,10 +112,10 @@ pub struct Api<'a> {
 /// * For TPU: `solana_core::banking_stage::BankingStage::process_and_record_transactions()`
 /// * For TVU: `solana_core::replay_stage::ReplayStage::replay_blockstore_into_bank()`
 ///
+/// Until SIMD83 is activated:
 /// All transactions in the `transactions` field have to follow the read/write locking restrictions
 /// with regard to the accounts they reference. A single account can be either written by a single
 /// transaction, or read by one or more transactions, but not both.
-///
 /// This enforcement is done via a call to `solana_runtime::accounts::Accounts::lock_accounts()`
 /// with the `txs` argument holding all the `transactions` in the `Entry`.
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]


### PR DESCRIPTION
#### Problem
- This comment on Entry is not true once SIMD83 is activated

#### Summary of Changes
- Add conditional "until simd83 is activated" on the restriction of locks in `Entry` documentation

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
