### PR TITLE
Remove `index_in_caller` and `index_in_callee` from `InstructionAccount`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -29,7 +29,9 @@ use {
         verifier::RequisiteVerifier,
     },
     solana_sdk_ids::{bpf_loader_upgradeable, sysvar},
-    solana_transaction_context::{IndexOfAccount, InstructionAccount},
+    solana_transaction_context::{
+        IndexOfAccount, InstructionAccountView, InstructionAccountViewVector,
+    },
     std::{
         collections::HashMap,
         fmt::{self, Debug, Formatter},
@@ -398,7 +400,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let bank = load_blockstore(&ledger_path, matches);
     let loader_id = bpf_loader_upgradeable::id();
     let mut transaction_accounts = Vec::new();
-    let mut instruction_accounts = Vec::new();
+    let mut instruction_accounts = InstructionAccountViewVector::new();
     let mut program_id = Pubkey::new_unique();
     let mut cached_account_keys = vec![];
 
@@ -409,7 +411,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 pubkey,
                 AccountSharedData::new(0, allocation_size, &Pubkey::new_unique()),
             ));
-            instruction_accounts.push(InstructionAccount::new(0, 0, 0, false, true));
+            instruction_accounts.push(InstructionAccountView::new(0, 0, 0, false, true));
             vec![]
         }
         Err(_) => {
@@ -424,71 +426,72 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             // Maps a public key to the transaction account index
             let mut txn_acct_indices =
                 HashMap::<Pubkey, usize>::with_capacity(input.accounts.len());
-            instruction_accounts = input
-                .accounts
-                .into_iter()
-                .map(|account_info| {
-                    let pubkey = account_info.key.parse::<Pubkey>().unwrap_or_else(|err| {
-                        eprintln!("Invalid key in input {}, error {}", account_info.key, err);
-                        exit(1);
-                    });
-                    let data = account_info.data.unwrap_or_default();
-                    let space = data.len();
-                    let account = if let Some(account) = bank.get_account_with_fixed_root(&pubkey) {
-                        let owner = *account.owner();
-                        if bpf_loader_upgradeable::check_id(&owner) {
-                            if let Ok(UpgradeableLoaderState::Program {
-                                programdata_address,
-                            }) = account.state()
+            let mut new_instr_accs = InstructionAccountViewVector::new();
+            for account_info in input.accounts.into_iter() {
+                let pubkey = account_info.key.parse::<Pubkey>().unwrap_or_else(|err| {
+                    eprintln!("Invalid key in input {}, error {}", account_info.key, err);
+                    exit(1);
+                });
+                let data = account_info.data.unwrap_or_default();
+                let space = data.len();
+                let account = if let Some(account) = bank.get_account_with_fixed_root(&pubkey) {
+                    let owner = *account.owner();
+                    if bpf_loader_upgradeable::check_id(&owner) {
+                        if let Ok(UpgradeableLoaderState::Program {
+                            programdata_address,
+                        }) = account.state()
+                        {
+                            debug!("Program data address {}", programdata_address);
+                            if bank
+                                .get_account_with_fixed_root(&programdata_address)
+                                .is_some()
                             {
-                                debug!("Program data address {programdata_address}");
-                                if bank
-                                    .get_account_with_fixed_root(&programdata_address)
-                                    .is_some()
-                                {
-                                    cached_account_keys.push(pubkey);
-                                }
+                                cached_account_keys.push(pubkey);
                             }
                         }
-                        // Override account data and lamports from input file if provided
-                        if space > 0 {
-                            let lamports = account_info.lamports.unwrap_or(account.lamports());
-                            let mut account = AccountSharedData::new(lamports, space, &owner);
-                            account.set_data_from_slice(&data);
-                            account
-                        } else {
-                            account
-                        }
-                    } else {
-                        let owner = account_info
-                            .owner
-                            .unwrap_or(Pubkey::new_unique().to_string());
-                        let owner = owner.parse::<Pubkey>().unwrap_or_else(|err| {
-                            eprintln!("Invalid owner key in input {owner}, error {err}");
-                            Pubkey::new_unique()
-                        });
-                        let lamports = account_info.lamports.unwrap_or(0);
+                    }
+                    // Override account data and lamports from input file if provided
+                    if space > 0 {
+                        let lamports = account_info.lamports.unwrap_or(account.lamports());
                         let mut account = AccountSharedData::new(lamports, space, &owner);
                         account.set_data_from_slice(&data);
                         account
-                    };
-                    let txn_acct_index = if let Some(idx) = txn_acct_indices.get(&pubkey) {
-                        *idx
                     } else {
-                        let idx = transaction_accounts.len();
-                        txn_acct_indices.insert(pubkey, idx);
-                        transaction_accounts.push((pubkey, account));
-                        idx
-                    };
-                    InstructionAccount::new(
-                        txn_acct_index as IndexOfAccount,
-                        txn_acct_index as IndexOfAccount,
-                        txn_acct_index as IndexOfAccount,
-                        account_info.is_signer.unwrap_or(false),
-                        account_info.is_writable.unwrap_or(false),
-                    )
-                })
-                .collect();
+                        account
+                    }
+                } else {
+                    let owner = account_info
+                        .owner
+                        .unwrap_or(Pubkey::new_unique().to_string());
+                    let owner = owner.parse::<Pubkey>().unwrap_or_else(|err| {
+                        eprintln!("Invalid owner key in input {owner}, error {err}");
+                        Pubkey::new_unique()
+                    });
+                    let lamports = account_info.lamports.unwrap_or(0);
+                    let mut account = AccountSharedData::new(lamports, space, &owner);
+                    account.set_data_from_slice(&data);
+                    account
+                };
+                let txn_acct_index = if let Some(idx) = txn_acct_indices.get(&pubkey) {
+                    *idx
+                } else {
+                    let idx = transaction_accounts.len();
+                    txn_acct_indices.insert(pubkey, idx);
+                    transaction_accounts.push((pubkey, account));
+                    idx
+                };
+
+                let instr_acc = InstructionAccountView::new(
+                    txn_acct_index as IndexOfAccount,
+                    txn_acct_index as IndexOfAccount,
+                    txn_acct_index as IndexOfAccount,
+                    account_info.is_signer.unwrap_or(false),
+                    account_info.is_writable.unwrap_or(false),
+                );
+                new_instr_accs.push(instr_acc);
+            }
+            instruction_accounts = std::mem::take(&mut new_instr_accs);
+
             input.instruction_data
         }
     };
@@ -527,7 +530,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         .unwrap()
         .configure(
             &[program_index, program_index.saturating_add(1)],
-            &instruction_accounts,
+            instruction_accounts,
             &instruction_data,
         );
     invoke_context.push().unwrap();

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -411,7 +411,13 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 pubkey,
                 AccountSharedData::new(0, allocation_size, &Pubkey::new_unique()),
             ));
-            instruction_accounts.push(InstructionAccountView::new(0, 0, 0, false, true));
+            instruction_accounts.push(InstructionAccountView {
+                index_in_transaction: 0,
+                index_in_caller: 0,
+                index_in_callee: 0,
+                is_signer: false,
+                is_writable: true,
+            });
             vec![]
         }
         Err(_) => {
@@ -481,13 +487,13 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                     idx
                 };
 
-                let instr_acc = InstructionAccountView::new(
-                    txn_acct_index as IndexOfAccount,
-                    txn_acct_index as IndexOfAccount,
-                    txn_acct_index as IndexOfAccount,
-                    account_info.is_signer.unwrap_or(false),
-                    account_info.is_writable.unwrap_or(false),
-                );
+                let instr_acc = InstructionAccountView {
+                    index_in_transaction: txn_acct_index as IndexOfAccount,
+                    index_in_caller: txn_acct_index as IndexOfAccount,
+                    index_in_callee: txn_acct_index as IndexOfAccount,
+                    is_signer: account_info.is_signer.unwrap_or(false),
+                    is_writable: account_info.is_writable.unwrap_or(false),
+                };
                 new_instr_accs.push(instr_acc);
             }
             instruction_accounts = std::mem::take(&mut new_instr_accs);

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1318,7 +1318,7 @@ mod tests {
             (Pubkey::new_unique(), dummy_account),
             (program_key, program_account),
         ];
-        let instruction_accounts = InstructionAccountViewVector::from_view_vector(vec![
+        let instruction_accounts = InstructionAccountViewVector::from_vector(vec![
             InstructionAccountView::new(0, 0, 0, false, true),
             InstructionAccountView::new(1, 1, 1, false, false),
         ]);

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -628,13 +628,13 @@ mod tests {
                 .iter()
                 .position(|account_index| account_index == index_in_transaction)
                 .unwrap_or(index_in_instruction);
-            instr_accounts.push(InstructionAccountView::new(
-                *index_in_transaction,
-                *index_in_transaction,
-                index_in_callee as IndexOfAccount,
-                false,
-                is_writable(index_in_instruction),
-            ));
+            instr_accounts.push(InstructionAccountView {
+                index_in_transaction: *index_in_transaction,
+                index_in_caller: *index_in_transaction,
+                index_in_callee: index_in_callee as IndexOfAccount,
+                is_signer: false,
+                is_writable: is_writable(index_in_instruction),
+            });
         }
 
         instr_accounts

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -704,9 +704,8 @@ mod tests {
                 let mut instruction_accounts =
                     deduplicated_instruction_accounts(&transaction_accounts_indexes, |_| false);
                 if append_dup_account {
-                    let last_idx = instruction_accounts.len().saturating_sub(1);
-                    instruction_accounts
-                        .push_raw(instruction_accounts.get_raw_cloned(last_idx).unwrap());
+                    let last = instruction_accounts.iter().next_back().unwrap();
+                    instruction_accounts.push(last);
                 }
                 let program_indices = [0];
                 let instruction_data = vec![];

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -320,7 +320,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
                     .set_owner(account_info.owner.as_ref())
                     .unwrap();
             }
-            if instruction_account.is_writable() {
+            if instruction_account.is_writable {
                 account_indices.push((instruction_account.index_in_caller, account_info_index));
             }
         }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -329,7 +329,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
         invoke_context
             .process_instruction(
                 &instruction.data,
-                &instruction_accounts,
+                instruction_accounts,
                 &program_indices,
                 &mut compute_units_consumed,
                 &mut ExecuteTimings::default(),

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -95,13 +95,13 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
             .iter()
             .position(|account| account.index_in_transaction == index_in_transaction)
             .unwrap_or(instruction_account_index) as IndexOfAccount;
-        instruction_accounts.push(InstructionAccountView::new(
-            instruction_account_index as IndexOfAccount,
+        instruction_accounts.push(InstructionAccountView {
+            index_in_caller: instruction_account_index as IndexOfAccount,
             index_in_transaction,
             index_in_callee,
-            false,
-            instruction_account_index >= 4,
-        ));
+            is_signer: false,
+            is_writable: instruction_account_index >= 4,
+        });
     }
 
     let mut transaction_context =

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -5,7 +5,9 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated},
-    solana_transaction_context::{IndexOfAccount, InstructionAccount, TransactionContext},
+    solana_transaction_context::{
+        IndexOfAccount, InstructionAccountView, InstructionAccountViewVector, TransactionContext,
+    },
 };
 
 fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionContext {
@@ -82,7 +84,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
             }),
         ),
     ];
-    let mut instruction_accounts: Vec<InstructionAccount> = Vec::new();
+    let mut instruction_accounts = InstructionAccountViewVector::new();
     for (instruction_account_index, index_in_transaction) in [1, 1, 2, 3, 4, 4, 5, 6]
         .into_iter()
         .cycle()
@@ -93,7 +95,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
             .iter()
             .position(|account| account.index_in_transaction == index_in_transaction)
             .unwrap_or(instruction_account_index) as IndexOfAccount;
-        instruction_accounts.push(InstructionAccount::new(
+        instruction_accounts.push(InstructionAccountView::new(
             instruction_account_index as IndexOfAccount,
             index_in_transaction,
             index_in_callee,
@@ -108,7 +110,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
     transaction_context
         .get_next_instruction_context()
         .unwrap()
-        .configure(&[0], &instruction_accounts, &instruction_data);
+        .configure(&[0], instruction_accounts, &instruction_data);
     transaction_context.push().unwrap();
     transaction_context
 }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1877,7 +1877,7 @@ mod tests {
 
         mock_create_vm!(_vm, Vec::new(), vec![account_metadata], &mut invoke_context);
 
-        let instruction_accounts = InstructionAccountViewVector::from_view_vector(vec![
+        let instruction_accounts = InstructionAccountViewVector::from_vector(vec![
             InstructionAccountView::new(1, 0, 0, false, true),
             InstructionAccountView::new(1, 0, 0, false, true),
         ]);

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4442,7 +4442,7 @@ mod tests {
                     .transaction_context
                     .get_instruction_context_stack_height()
             {
-                let instruction_accounts = InstructionAccountViewVector::from_view_vector(vec![
+                let instruction_accounts = InstructionAccountViewVector::from_vector(vec![
                     InstructionAccountView::new(
                         index_in_trace.saturating_add(1) as IndexOfAccount,
                         0, // This is incorrect / inconsistent but not required

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4443,13 +4443,13 @@ mod tests {
                     .get_instruction_context_stack_height()
             {
                 let instruction_accounts =
-                    InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
-                        index_in_trace.saturating_add(1) as IndexOfAccount,
-                        0, // This is incorrect / inconsistent but not required
-                        0,
-                        false,
-                        false,
-                    )]);
+                    InstructionAccountViewVector::from_vector(vec![InstructionAccountView {
+                        index_in_transaction: index_in_trace.saturating_add(1) as IndexOfAccount,
+                        index_in_caller: 0, // This is incorrect / inconsistent but not required
+                        index_in_callee: 0,
+                        is_signer: false,
+                        is_writable: false,
+                    }]);
                 invoke_context
                     .transaction_context
                     .get_next_instruction_context()

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -4442,15 +4442,14 @@ mod tests {
                     .transaction_context
                     .get_instruction_context_stack_height()
             {
-                let instruction_accounts = InstructionAccountViewVector::from_vector(vec![
-                    InstructionAccountView::new(
+                let instruction_accounts =
+                    InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
                         index_in_trace.saturating_add(1) as IndexOfAccount,
                         0, // This is incorrect / inconsistent but not required
                         0,
                         false,
                         false,
-                    ),
-                ]);
+                    )]);
                 invoke_context
                     .transaction_context
                     .get_next_instruction_context()

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -38,7 +38,7 @@ use {
     solana_sdk_ids::{bpf_loader, native_loader},
     solana_signer::Signer,
     solana_svm_feature_set::SVMFeatureSet,
-    solana_transaction_context::InstructionAccount,
+    solana_transaction_context::{InstructionAccountView, InstructionAccountViewVector},
     std::{mem, sync::Arc},
     test::Bencher,
 };
@@ -70,7 +70,7 @@ macro_rules! with_mock_invoke_context {
             .transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&[0, 1], &instruction_accounts, &[]);
+            .configure(&[0, 1], instruction_accounts, &[]);
         $invoke_context.push().unwrap();
     };
 }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -60,7 +60,10 @@ macro_rules! with_mock_invoke_context {
                 AccountSharedData::new(2, $account_size, &program_key),
             ),
         ];
-        let instruction_accounts = vec![InstructionAccount::new(2, 2, 0, false, true)];
+        let instruction_accounts =
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
+                2, 2, 0, false, true,
+            )]);
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,
             transaction_context,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -61,9 +61,13 @@ macro_rules! with_mock_invoke_context {
             ),
         ];
         let instruction_accounts =
-            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
-                2, 2, 0, false, true,
-            )]);
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView {
+                index_in_transaction: 2,
+                index_in_caller: 2,
+                index_in_callee: 0,
+                is_signer: false,
+                is_writable: true,
+            }]);
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,
             transaction_context,

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -48,6 +48,7 @@ solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["bincode", "dev-context-only-utils"]}
 
 [[bench]]
 name = "system"

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -48,7 +48,7 @@ solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["bincode", "dev-context-only-utils"]}
+solana-transaction-context = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
 
 [[bench]]
 name = "system"

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -294,8 +294,20 @@ mod test {
                 (system_program::id(), AccountSharedData::default()),
             ];
             let $instruction_accounts = InstructionAccountViewVector::from_vector(vec![
-                InstructionAccountView::new(0, 0, 0, true, true),
-                InstructionAccountView::new(1, 1, 1, false, true),
+                InstructionAccountView {
+                    index_in_transaction: 0,
+                    index_in_caller: 0,
+                    index_in_callee: 0,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                InstructionAccountView {
+                    index_in_transaction: 1,
+                    index_in_caller: 1,
+                    index_in_callee: 1,
+                    is_signer: false,
+                    is_writable: true,
+                },
             ]);
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
         };

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -257,7 +257,7 @@ mod test {
         solana_program_runtime::with_mock_invoke_context,
         solana_sdk_ids::system_program,
         solana_sha256_hasher::hash,
-        solana_transaction_context::InstructionAccount,
+        solana_transaction_context::{InstructionAccountView, InstructionAccountViewVector},
     };
 
     pub const NONCE_ACCOUNT_INDEX: IndexOfAccount = 0;
@@ -269,7 +269,7 @@ mod test {
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(&[2], &$instruction_accounts, &[]);
+                .configure(&[2], $instruction_accounts, &[]);
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context
@@ -293,10 +293,10 @@ mod test {
                 (Pubkey::new_unique(), create_account(42).into_inner()),
                 (system_program::id(), AccountSharedData::default()),
             ];
-            let $instruction_accounts = vec![
-                InstructionAccount::new(0, 0, 0, true, true),
-                InstructionAccount::new(1, 1, 1, false, true),
-            ];
+            let $instruction_accounts = InstructionAccountViewVector::from_view_vector(vec![
+                InstructionAccountView::new(0, 0, 0, true, true),
+                InstructionAccountView::new(1, 1, 1, false, true),
+            ]);
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
         };
     }

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -293,7 +293,7 @@ mod test {
                 (Pubkey::new_unique(), create_account(42).into_inner()),
                 (system_program::id(), AccountSharedData::default()),
             ];
-            let $instruction_accounts = InstructionAccountViewVector::from_view_vector(vec![
+            let $instruction_accounts = InstructionAccountViewVector::from_vector(vec![
                 InstructionAccountView::new(0, 0, 0, true, true),
                 InstructionAccountView::new(1, 1, 1, false, true),
             ]);

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -73,6 +73,7 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-transaction-context = { workspace = true, features = ['bincode', 'dev-context-only-utils']}
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -73,7 +73,7 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-transaction-context = { workspace = true, features = ['bincode', 'dev-context-only-utils']}
+solana-transaction-context = { workspace = true, features = ['bincode', 'dev-context-only-utils'] }
 test-case = { workspace = true }
 
 [[bench]]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1072,7 +1072,7 @@ mod tests {
         solana_account::{state_traits::StateMut, AccountSharedData},
         solana_clock::DEFAULT_SLOTS_PER_EPOCH,
         solana_sha256_hasher::hash,
-        solana_transaction_context::InstructionAccount,
+        solana_transaction_context::{InstructionAccountView, InstructionAccountViewVector},
         std::cell::RefCell,
         test_case::test_case,
     };
@@ -1167,7 +1167,11 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
+        let instruction_accounts =
+            InstructionAccountViewVector::from_view_vector(vec![InstructionAccountView::new(
+                1, 1, 0, false, true,
+            )]);
+        instruction_context.configure(&[0], instruction_accounts, &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state
@@ -1312,7 +1316,11 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
+        let instruction_accounts =
+            InstructionAccountViewVector::from_view_vector(vec![InstructionAccountView::new(
+                1, 1, 0, false, true,
+            )]);
+        instruction_context.configure(&[0], instruction_accounts, &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1168,7 +1168,7 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         let instruction_accounts =
-            InstructionAccountViewVector::from_view_vector(vec![InstructionAccountView::new(
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
                 1, 1, 0, false, true,
             )]);
         instruction_context.configure(&[0], instruction_accounts, &[]);
@@ -1317,7 +1317,7 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         let instruction_accounts =
-            InstructionAccountViewVector::from_view_vector(vec![InstructionAccountView::new(
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
                 1, 1, 0, false, true,
             )]);
         instruction_context.configure(&[0], instruction_accounts, &[]);

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1168,9 +1168,13 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         let instruction_accounts =
-            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
-                1, 1, 0, false, true,
-            )]);
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView {
+                index_in_transaction: 1,
+                index_in_caller: 1,
+                index_in_callee: 0,
+                is_signer: false,
+                is_writable: true,
+            }]);
         instruction_context.configure(&[0], instruction_accounts, &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
@@ -1317,9 +1321,13 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         let instruction_accounts =
-            InstructionAccountViewVector::from_vector(vec![InstructionAccountView::new(
-                1, 1, 0, false, true,
-            )]);
+            InstructionAccountViewVector::from_vector(vec![InstructionAccountView {
+                index_in_transaction: 1,
+                index_in_caller: 1,
+                index_in_callee: 0,
+                is_signer: false,
+                is_writable: true,
+            }]);
         instruction_context.configure(&[0], instruction_accounts, &[]);
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -41,13 +41,13 @@ pub(crate) fn process_message(
                 .unwrap_or(instruction_account_index)
                 as IndexOfAccount;
             let index_in_transaction = *index_in_transaction as usize;
-            instruction_accounts.push(InstructionAccountView::new(
-                index_in_transaction as IndexOfAccount,
-                index_in_transaction as IndexOfAccount,
+            instruction_accounts.push(InstructionAccountView {
+                index_in_transaction: index_in_transaction as IndexOfAccount,
+                index_in_caller: index_in_transaction as IndexOfAccount,
                 index_in_callee,
-                message.is_signer(index_in_transaction),
-                message.is_writable(index_in_transaction),
-            ));
+                is_signer: message.is_signer(index_in_transaction),
+                is_writable: message.is_writable(index_in_transaction),
+            });
         }
 
         let mut compute_units_consumed = 0;

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1119,7 +1119,7 @@ mod tests {
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
-        solana_transaction_context::TransactionContext,
+        solana_transaction_context::{InstructionAccountViewVector, TransactionContext},
         solana_transaction_error::{TransactionError, TransactionError::DuplicateInstruction},
         test_case::test_case,
     };
@@ -1294,7 +1294,11 @@ mod tests {
                 transaction_context
                     .get_next_instruction_context()
                     .unwrap()
-                    .configure(&[], &[], &[index_in_trace as u8]);
+                    .configure(
+                        &[],
+                        InstructionAccountViewVector::new(),
+                        &[index_in_trace as u8],
+                    );
                 transaction_context.push().unwrap();
             }
         }

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -28,7 +28,8 @@ use {
     solana_sysvar_id::SysvarId,
     solana_timings::ExecuteTimings,
     solana_transaction_context::{
-        ExecutionRecord, IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
+        ExecutionRecord, IndexOfAccount, InstructionAccountView, InstructionAccountViewVector,
+        TransactionAccount, TransactionContext,
     },
     std::{
         collections::{hash_map::Entry, HashMap},
@@ -367,8 +368,9 @@ fn execute_fixture_as_instr(
         SVMTransactionExecutionCost::default(),
     );
 
-    let mut instruction_accounts: Vec<InstructionAccount> =
-        Vec::with_capacity(sanitized_message.instructions()[0].accounts.len());
+    let mut instruction_accounts = InstructionAccountViewVector::with_capacity(
+        sanitized_message.instructions()[0].accounts.len(),
+    );
 
     for (instruction_acct_idx, index_txn) in sanitized_message.instructions()[0]
         .accounts
@@ -383,7 +385,7 @@ fn execute_fixture_as_instr(
             .position(|idx| *idx == *index_txn)
             .unwrap_or(instruction_acct_idx);
 
-        instruction_accounts.push(InstructionAccount::new(
+        instruction_accounts.push(InstructionAccountView::new(
             *index_txn as IndexOfAccount,
             *index_txn as IndexOfAccount,
             index_in_callee as IndexOfAccount,
@@ -396,7 +398,7 @@ fn execute_fixture_as_instr(
     let mut timings = ExecuteTimings::default();
     let result = invoke_context.process_instruction(
         &sanitized_message.instructions()[0].data,
-        &instruction_accounts,
+        instruction_accounts,
         &[program_idx as IndexOfAccount],
         &mut compute_units_consumed,
         &mut timings,

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -385,13 +385,13 @@ fn execute_fixture_as_instr(
             .position(|idx| *idx == *index_txn)
             .unwrap_or(instruction_acct_idx);
 
-        instruction_accounts.push(InstructionAccountView::new(
-            *index_txn as IndexOfAccount,
-            *index_txn as IndexOfAccount,
-            index_in_callee as IndexOfAccount,
-            sanitized_message.is_signer(*index_txn as usize),
-            sanitized_message.is_writable(*index_txn as usize),
-        ));
+        instruction_accounts.push(InstructionAccountView {
+            index_in_transaction: *index_txn as IndexOfAccount,
+            index_in_caller: *index_txn as IndexOfAccount,
+            index_in_callee: index_in_callee as IndexOfAccount,
+            is_signer: sanitized_message.is_signer(*index_txn as usize),
+            is_writable: sanitized_message.is_writable(*index_txn as usize),
+        });
     }
 
     let mut compute_units_consumed = 0u64;

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -88,7 +88,7 @@ impl InstructionAccountViewVector {
         });
     }
 
-    pub fn from_view_vector(vector: Vec<InstructionAccountView>) -> InstructionAccountViewVector {
+    pub fn from_vector(vector: Vec<InstructionAccountView>) -> InstructionAccountViewVector {
         let mut view_owner = Self::with_capacity(vector.len());
         for item in vector {
             view_owner.push(item);

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -112,11 +112,6 @@ impl InstructionAccountViewVector {
             })
     }
 
-    /// Retrieve only an element of the `InstructionAccount` vector as mutable.
-    pub fn get_metadata_mut(&mut self, idx: usize) -> Option<&mut InstructionAccount> {
-        self.metadata.get_mut(idx)
-    }
-
     /// Retrieve a range of the `InstructionAccount` vector as immutable.
     pub fn get_metadata(&self, range: Range<usize>) -> Option<&[InstructionAccount]> {
         self.metadata.get(range)
@@ -131,30 +126,18 @@ impl InstructionAccountViewVector {
         debug_assert_eq!(self.metadata.len(), self.indexes.len());
         self.metadata.is_empty()
     }
-
-    pub fn get_raw_cloned(&self, idx: usize) -> Option<(InstructionAccount, AccountCallIndexes)> {
-        Some((
-            self.metadata.get(idx)?.clone(),
-            self.indexes.get(idx)?.clone(),
-        ))
-    }
-
-    pub fn push_raw(&mut self, elements: (InstructionAccount, AccountCallIndexes)) {
-        self.metadata.push(elements.0.clone());
-        self.indexes.push(elements.1.clone());
-    }
 }
-
 
 /// `InstructionAccountView` is a view struct that merges `InstructionAccount` and
 /// `AccountCallIndexes` for easier handling outside of runtime.
+#[derive(Clone)]
 pub struct InstructionAccountView {
     /// Points to the account and its key in the `TransactionContext`
     pub index_in_transaction: IndexOfAccount,
     /// Is this account supposed to sign
-    is_signer: bool,
+    pub is_signer: bool,
     /// Is this account allowed to become writable
-    is_writable: bool,
+    pub is_writable: bool,
     /// Points to the first occurrence in the parent `InstructionContext`
     ///
     /// This excludes the program accounts.
@@ -188,6 +171,14 @@ impl InstructionAccountView {
 
     pub fn is_writable(&self) -> bool {
         self.is_writable
+    }
+
+    pub fn set_is_signer(&mut self, value: bool) {
+        self.is_signer = value;
+    }
+
+    pub fn set_is_writable(&mut self, value: bool) {
+        self.is_writable = value;
     }
 }
 
@@ -243,14 +234,6 @@ impl InstructionAccount {
 
     pub fn is_writable(&self) -> bool {
         self.is_writable != 0
-    }
-
-    pub fn set_is_signer(&mut self, value: bool) {
-        self.is_signer = value as u8;
-    }
-
-    pub fn set_is_writable(&mut self, value: bool) {
-        self.is_writable = value as u8;
     }
 }
 

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -90,6 +90,7 @@ impl InstructionAccountViewVector {
         });
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn from_vector(vector: Vec<InstructionAccountView>) -> InstructionAccountViewVector {
         let mut view_owner = Self::with_capacity(vector.len());
         for item in vector {
@@ -113,7 +114,7 @@ impl InstructionAccountViewVector {
     }
 
     /// Retrieve a range of the `InstructionAccount` vector as immutable.
-    pub fn get_metadata(&self, range: Range<usize>) -> Option<&[InstructionAccount]> {
+    pub fn get_metadata_for_test(&self, range: Range<usize>) -> Option<&[InstructionAccount]> {
         self.metadata.get(range)
     }
 
@@ -127,6 +128,9 @@ impl InstructionAccountViewVector {
         self.metadata.is_empty()
     }
 }
+
+/// Index of an account inside the TransactionContext or an InstructionContext.
+pub type IndexOfAccount = u16;
 
 /// `InstructionAccountView` is a view struct that merges `InstructionAccount` and
 /// `AccountCallIndexes` for easier handling outside of runtime.
@@ -147,43 +151,6 @@ pub struct InstructionAccountView {
     /// This excludes the program accounts.
     pub index_in_callee: IndexOfAccount,
 }
-
-impl InstructionAccountView {
-    pub fn new(
-        index_in_transaction: IndexOfAccount,
-        index_in_caller: IndexOfAccount,
-        index_in_callee: IndexOfAccount,
-        is_signer: bool,
-        is_writable: bool,
-    ) -> InstructionAccountView {
-        InstructionAccountView {
-            index_in_transaction,
-            index_in_caller,
-            index_in_callee,
-            is_writable,
-            is_signer,
-        }
-    }
-
-    pub fn is_signer(&self) -> bool {
-        self.is_signer
-    }
-
-    pub fn is_writable(&self) -> bool {
-        self.is_writable
-    }
-
-    pub fn set_is_signer(&mut self, value: bool) {
-        self.is_signer = value;
-    }
-
-    pub fn set_is_writable(&mut self, value: bool) {
-        self.is_writable = value;
-    }
-}
-
-/// Index of an account inside the TransactionContext or an InstructionContext.
-pub type IndexOfAccount = u16;
 
 /// `AccountCallIndexes` saves indexes of the account relative to the caller and callee.
 /// These values are only used by the runtime and are not accessible to programs.


### PR DESCRIPTION
#### Problem

In [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we propose sharing the `struct InstructionAccount` with programs. That struct contains the fields `index_in_caller` and `index_in_callee`, which are only used in runtime, not necessary for programs, and are only relevant to ABIv1.

#### Summary of Changes

1. Create a `struct InstructionAccountCallIndexes` to hold those two fields.
2. Remove them from `struct InstructionAccount`.
3. Create a `struct InstructionAccountView`, which is a a copy of the old `InstructionAccount` with all the fields, aiming to  facilitate field accesses before program execution.
4. Create a `struct InstructionAccountViewVector` that exposes `InstructionAccountView`s, but manages internally `InstructionAccount` and `InstructionAccountCallIndexes`.