### PR TITLE
accounts-db: Run cargo fmt with format_strings = true

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -800,10 +800,13 @@ impl LoadedAccountAccessor<'_> {
                 // was still in the storage map. This means even if the storage entry is removed
                 // from the storage map after we grabbed the storage entry, the recycler should not
                 // reset the storage entry until we drop the reference to the storage entry.
-                maybe_storage_entry.accounts.get_account_shared_data(*offset).expect(
-                    "If a storage entry was found in the storage map, it must not have been reset \
-                     yet",
-                )
+                maybe_storage_entry
+                    .accounts
+                    .get_account_shared_data(*offset)
+                    .expect(
+                        "If a storage entry was found in the storage map, it must not have been \
+                         reset yet",
+                    )
             }
             _ => self.check_and_get_loaded_account(|loaded_account| loaded_account.take_account()),
         }
@@ -2098,8 +2101,8 @@ impl AccountsDb {
                 } else {
                     // a pubkey we were planning to remove is not removing all stores that contain the account
                     debug!(
-                        "calc_delete_dependencies(), pubkey: {pubkey}, slot list len: {}, \
-                         ref count: {ref_count}, slot list: {slot_list:?}",
+                        "calc_delete_dependencies(), pubkey: {pubkey}, slot list len: {}, ref \
+                         count: {ref_count}, slot list: {slot_list:?}",
                         slot_list.len(),
                     );
                 }
@@ -3671,9 +3674,9 @@ impl AccountsDb {
                         // entry for `pubkey`. Log a warning for now. In future,
                         // we will panic when this happens.
                         warn!(
-                        "pubkey {pubkey} in slot {slot} was NOT found in accounts index during \
-                         shrink"
-                    );
+                            "pubkey {pubkey} in slot {slot} was NOT found in accounts index \
+                             during shrink"
+                        );
                         datapoint_warn!(
                             "accounts_db-shink_pubkey_missing_from_index",
                             ("store_slot", slot, i64),
@@ -7941,9 +7944,13 @@ impl AccountsDb {
 
             // sanity check that stored_size is not larger than the u64 aligned size of the accounts files.
             // Note that the stored_size is aligned, so it can be larger than the size of the accounts file.
-            assert!(info.stored_size <= u64_align!(storage.accounts.len()),
-                "Stored size ({}) is larger than the size of the accounts file ({}) for store_id: {}",
-                info.stored_size, storage.accounts.len(), store_id
+            assert!(
+                info.stored_size <= u64_align!(storage.accounts.len()),
+                "Stored size ({}) is larger than the size of the accounts file ({}) for store_id: \
+                 {}",
+                info.stored_size,
+                storage.accounts.len(),
+                store_id
             );
         }
         // zero_lamport_pubkeys are candidates for cleaning. So add them to uncleaned_pubkeys

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3297,8 +3297,8 @@ fn run_test_flush_accounts_cache_if_needed(num_roots: usize, num_unrooted: usize
                     db.accounts_cache
                         .slot_cache(unrooted_slot as Slot)
                         .is_some(),
-                    "unrooted_slot: {unrooted_slot}, total_slots: {total_slots}, \
-                     expected_size: {expected_size}"
+                    "unrooted_slot: {unrooted_slot}, total_slots: {total_slots}, expected_size: \
+                     {expected_size}"
                 );
             }
         }
@@ -6369,12 +6369,11 @@ fn test_shrink_collect_simple() {
                             }
                             debug!(
                                 "space: {space}, lamports: {lamports}, alive: {alive}, \
-                                 account_count: {account_count}, \
-                                 append_opposite_alive_account: \
+                                 account_count: {account_count}, append_opposite_alive_account: \
                                  {append_opposite_alive_account}, \
                                  append_opposite_zero_lamport_account: \
-                                 {append_opposite_zero_lamport_account}, \
-                                 normal_account_count: {normal_account_count}"
+                                 {append_opposite_zero_lamport_account}, normal_account_count: \
+                                 {normal_account_count}"
                             );
                             let db = AccountsDb::new_single_for_tests();
                             let slot5 = 5;

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1736,51 +1736,197 @@ mod tests {
             .collect();
 
         type ExpectedType = (String, bool, u64, String);
-        let expected:Vec<ExpectedType> = vec![
+        let expected: Vec<ExpectedType> = vec![
             // ("key/lamports key2/lamports ...",
             // is_last_slice
             // result lamports
             // result hashes)
             // "a5" = key_a, 5 lamports
             ("a1", false, 1, "[11111111111111111111111111111111]"),
-            ("a1b2", false, 3, "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("a1b2b3", false, 4, "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("a1b2b3b4", false, 5, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("a1b2b3b4c5", false, 10, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b2", false, 2, "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("b2b3", false, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b2b3b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b2b3b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b3", false, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b3b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b3b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("c5", false, 5, "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
+            (
+                "a1b2",
+                false,
+                3,
+                "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "a1b2b3",
+                false,
+                4,
+                "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "a1b2b3b4",
+                false,
+                5,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "a1b2b3b4c5",
+                false,
+                10,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b2",
+                false,
+                2,
+                "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "b2b3",
+                false,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b2b3b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b2b3b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b3",
+                false,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b3b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b3b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "c5",
+                false,
+                5,
+                "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
             ("a1", true, 1, "[11111111111111111111111111111111]"),
-            ("a1b2", true, 3, "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("a1b2b3", true, 4, "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("a1b2b3b4", true, 5, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("a1b2b3b4c5", true, 10, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b2", true, 2, "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("b2b3", true, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b2b3b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b2b3b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b3", true, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b3b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b3b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("c5", true, 5, "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ].into_iter().map(|item| {
-                let result: ExpectedType = (
-                    item.0.to_string(),
-                    item.1,
-                    item.2,
-                    item.3.to_string(),
-                );
-                result
-            }).collect();
+            (
+                "a1b2",
+                true,
+                3,
+                "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "a1b2b3",
+                true,
+                4,
+                "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "a1b2b3b4",
+                true,
+                5,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "a1b2b3b4c5",
+                true,
+                10,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b2",
+                true,
+                2,
+                "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "b2b3",
+                true,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b2b3b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b2b3b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b3",
+                true,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b3b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b3b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "c5",
+                true,
+                5,
+                "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+        ]
+        .into_iter()
+        .map(|item| {
+            let result: ExpectedType = (item.0.to_string(), item.1, item.2, item.3.to_string());
+            result
+        })
+        .collect();
 
         let dir_for_temp_cache_files = tempdir().unwrap();
         let hash = AccountsHasher::new(dir_for_temp_cache_files.path().to_path_buf());

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2121,21 +2121,24 @@ mod tests {
                     }
                     assert_eq!(
                         expected_result, result,
-                        "return value different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "return value different. other: {other_slot:?}, {expected:?}, \
+                         {slot_list:?}, original: {original:?}"
                     );
                     // sort for easy comparison
                     expected_reclaims.sort_unstable();
                     reclaims.sort_unstable();
                     assert_eq!(
                         expected_reclaims, reclaims,
-                        "reclaims different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "reclaims different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
                     );
                     // sort for easy comparison
                     slot_list.sort_unstable();
                     expected.sort_unstable();
                     assert_eq!(
                         slot_list, expected,
-                        "slot_list different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "slot_list different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
                     );
                 }
             }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1333,7 +1333,11 @@ pub mod tests {
                     NonZeroU64::new(ideal_size).unwrap(),
                 );
                 let storages_needed = result.len();
-                assert_eq!(storages_needed, expected_storages, "num_slots: {num_slots}, expected_storages: {expected_storages}, storages_needed: {storages_needed}, ideal_size: {ideal_size}");
+                assert_eq!(
+                    storages_needed, expected_storages,
+                    "num_slots: {num_slots}, expected_storages: {expected_storages}, \
+                     storages_needed: {storages_needed}, ideal_size: {ideal_size}"
+                );
                 compare_all_accounts(
                     &packed_to_compare(&result, &db)[..],
                     &original_results_all_accounts,
@@ -1454,13 +1458,17 @@ pub mod tests {
                             largest_account_size
                         );
                     }
+                    assert!(packed.bytes > 0, "packed size of zero");
                     assert!(
-                        packed.bytes > 0,
-                        "packed size of zero"
-                    );
-                    assert!(
-                        packed.bytes <= ideal_size || packed.accounts.iter().map(|(_slot, accounts)| accounts.len()).sum::<usize>() == 1,
-                        "packed size too large: bytes: {}, ideal_size: {}, data_size: {}, num_slots: {}, # accounts: {}",
+                        packed.bytes <= ideal_size
+                            || packed
+                                .accounts
+                                .iter()
+                                .map(|(_slot, accounts)| accounts.len())
+                                .sum::<usize>()
+                                == 1,
+                        "packed size too large: bytes: {}, ideal_size: {}, data_size: {}, \
+                         num_slots: {}, # accounts: {}",
                         packed.bytes,
                         ideal_size,
                         data_size,
@@ -1687,13 +1695,20 @@ pub mod tests {
                                 assert!(slots[i] < slots[i + 1]);
                             });
 
-                        log::debug!("output slots: {:?}, num_slots: {num_slots}, two_refs: {two_refs}, many_refs: {many_ref_slots:?}, expected accounts to combine: {expected_accounts_to_combine}, target slots: {:?}, accounts_to_combine: {}", accounts_to_combine.target_slots_sorted,
-                        accounts_to_combine.target_slots_sorted,
-                        accounts_to_combine.accounts_to_combine.len(),);
+                        log::debug!(
+                            "output slots: {:?}, num_slots: {num_slots}, two_refs: {two_refs}, \
+                             many_refs: {many_ref_slots:?}, expected accounts to combine: \
+                             {expected_accounts_to_combine}, target slots: {:?}, \
+                             accounts_to_combine: {}",
+                            accounts_to_combine.target_slots_sorted,
+                            accounts_to_combine.target_slots_sorted,
+                            accounts_to_combine.accounts_to_combine.len(),
+                        );
                         assert_eq!(
                             accounts_to_combine.accounts_to_combine.len(),
                             expected_accounts_to_combine,
-                            "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: {many_ref_slots:?}"
+                            "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
+                             {many_ref_slots:?}"
                         );
                     }
                 }
@@ -1807,7 +1822,8 @@ pub mod tests {
                                 assert_eq!(
                                     accounts_to_combine.accounts_to_combine.len(),
                                     expected_number_accounts_to_combine,
-                                    "method: {method:?}, num_slots: {num_slots}, two_refs: {two_refs}, many_refs: {many_ref_slots:?}"
+                                    "method: {method:?}, num_slots: {num_slots}, two_refs: \
+                                     {two_refs}, many_refs: {many_ref_slots:?}"
                                 );
 
                                 if add_dead_account {
@@ -3289,8 +3305,13 @@ pub mod tests {
                     assert_eq!(
                         expected_infos,
                         count,
-                        "percent_of_alive_shrunk_data: {percent_of_alive_shrunk_data}, infos: {expected_infos}, method: {method:?}, swap: {swap}, data: {:?}",
-                        infos.all_infos.iter().map(|info| (info.slot, info.capacity, info.alive_bytes)).collect::<Vec<_>>()
+                        "percent_of_alive_shrunk_data: {percent_of_alive_shrunk_data}, infos: \
+                         {expected_infos}, method: {method:?}, swap: {swap}, data: {:?}",
+                        infos
+                            .all_infos
+                            .iter()
+                            .map(|info| (info.slot, info.capacity, info.alive_bytes))
+                            .collect::<Vec<_>>()
                     );
                 }
             }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -294,8 +294,8 @@ impl AppendVec {
         let mmap = unsafe { MmapMut::map_mut(&data) };
         let mmap = mmap.unwrap_or_else(|err| {
             panic!(
-                "Failed to map the data file (size: {size}): {err}. \
-                 Please increase sysctl vm.max_map_count or equivalent for your platform.",
+                "Failed to map the data file (size: {size}): {err}. Please increase sysctl \
+                 vm.max_map_count or equivalent for your platform.",
             );
         });
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
@@ -463,8 +463,7 @@ impl AppendVec {
             // fallback to the old/slow impl that does the full sanitization.
             // [^1]: https://github.com/anza-xyz/agave/issues/6797
             info!(
-                "Could not optimistically create new AppendVec, \
-                 falling back to pessimistic impl: \
+                "Could not optimistically create new AppendVec, falling back to pessimistic impl: \
                  file size ({}) and current length ({}) do not match for '{}'",
                 new.file_size,
                 current_len,
@@ -516,7 +515,11 @@ impl AppendVec {
             let result = MmapMut::map_mut(&data);
             if result.is_err() {
                 // for vm.max_map_count, error is: {code: 12, kind: Other, message: "Cannot allocate memory"}
-                info!("memory map error: {:?}. This may be because vm.max_map_count is not set correctly.", result);
+                info!(
+                    "memory map error: {:?}. This may be because vm.max_map_count is not set \
+                     correctly.",
+                    result
+                );
             }
             result?
         };

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -89,8 +89,11 @@ impl CacheHashDataFileReference {
         }
         cache_file.capacity = capacity;
         assert_eq!(
-            capacity, file_len,
-            "expected: {capacity}, len on disk: {file_len} {}, entries: {entries}, cell_size: {cell_size}", self.path.display(),
+            capacity,
+            file_len,
+            "expected: {capacity}, len on disk: {file_len} {}, entries: {entries}, cell_size: \
+             {cell_size}",
+            self.path.display(),
         );
 
         self.stats
@@ -546,7 +549,8 @@ mod tests {
                         }
                         assert_eq!(
                             accum, data_this_pass,
-                            "bins: {bins}, start_bin_this_pass: {start_bin_this_pass}, pass: {pass}, flatten: {flatten_data}, passes: {passes}"
+                            "bins: {bins}, start_bin_this_pass: {start_bin_this_pass}, pass: \
+                             {pass}, flatten: {flatten_data}, passes: {passes}"
                         );
                     }
                 }

--- a/accounts-db/src/epoch_accounts_hash/manager.rs
+++ b/accounts-db/src/epoch_accounts_hash/manager.rs
@@ -51,9 +51,9 @@ impl Manager {
         let mut state = self.state.lock().unwrap();
         if let State::Valid(old_epoch_accounts_hash, old_slot) = &*state {
             panic!(
-                "The epoch accounts hash is already valid! \
-                \nold slot: {old_slot}, epoch accounts hash: {old_epoch_accounts_hash:?} \
-                \nnew slot: {slot}, epoch accounts hash: {epoch_accounts_hash:?}"
+                "The epoch accounts hash is already valid! \nold slot: {old_slot}, epoch accounts \
+                 hash: {old_epoch_accounts_hash:?} \nnew slot: {slot}, epoch accounts hash: \
+                 {epoch_accounts_hash:?}"
             );
         }
         *state = State::Valid(epoch_accounts_hash, slot);

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -677,8 +677,8 @@ pub fn open_genesis_config(
         Ok(genesis_config) => Ok(genesis_config),
         Err(load_err) => {
             warn!(
-                "Failed to load genesis_config at {ledger_path:?}: {load_err}. \
-                Will attempt to unpack genesis archive and then retry loading."
+                "Failed to load genesis_config at {ledger_path:?}: {load_err}. Will attempt to \
+                 unpack genesis archive and then retry loading."
             );
 
             let genesis_package = ledger_path.join(DEFAULT_GENESIS_ARCHIVE);

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -1060,22 +1060,54 @@ pub mod tests {
     #[test]
     fn test_debug_formatter() {
         let mut bitfield = RollingBitField::new(1);
-        assert_eq!("RollingBitField { max_width: 1, min: 0, max_exclusive: 0, count: 0, bits: \"[false]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 1, min: 0, max_exclusive: 0, count: 0, bits: \
+             \"[false]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         bitfield.insert(0);
-        assert_eq!("RollingBitField { max_width: 1, min: 0, max_exclusive: 1, count: 1, bits: \"[true]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 1, min: 0, max_exclusive: 1, count: 1, bits: \
+             \"[true]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         let mut bitfield = RollingBitField::new(2);
-        assert_eq!("RollingBitField { max_width: 2, min: 0, max_exclusive: 0, count: 0, bits: \"[false;2]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 2, min: 0, max_exclusive: 0, count: 0, bits: \
+             \"[false;2]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         bitfield.insert(0);
-        assert_eq!("RollingBitField { max_width: 2, min: 0, max_exclusive: 1, count: 1, bits: \"[true, false]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 2, min: 0, max_exclusive: 1, count: 1, bits: \"[true, \
+             false]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         bitfield.insert(1);
-        assert_eq!("RollingBitField { max_width: 2, min: 0, max_exclusive: 2, count: 2, bits: \"[true;2]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 2, min: 0, max_exclusive: 2, count: 2, bits: \
+             \"[true;2]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         let mut bitfield = RollingBitField::new(4096);
-        assert_eq!("RollingBitField { max_width: 4096, min: 0, max_exclusive: 0, count: 0, bits: \"[false;4096]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 4096, min: 0, max_exclusive: 0, count: 0, bits: \
+             \"[false;4096]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         bitfield.insert(4095);
-        assert_eq!("RollingBitField { max_width: 4096, min: 4095, max_exclusive: 4096, count: 1, bits: \"[false;4095, true]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 4096, min: 4095, max_exclusive: 4096, count: 1, bits: \
+             \"[false;4095, true]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
         bitfield.clear();
         bitfield.insert(2);
         bitfield.insert(3);
-        assert_eq!("RollingBitField { max_width: 4096, min: 2, max_exclusive: 4, count: 2, bits: \"[false;2, true;2, false;4092]\", excess: {} }", format!("{bitfield:?}"));
+        assert_eq!(
+            "RollingBitField { max_width: 4096, min: 2, max_exclusive: 4, count: 2, bits: \
+             \"[false;2, true;2, false;4092]\", excess: {} }",
+            format!("{bitfield:?}")
+        );
     }
 }


### PR DESCRIPTION
#### Problem
Attempting to fix some clippy lints in another PR (https://github.com/anza-xyz/agave/pull/6854) revealed that there are some format issues.

#### Summary of Changes
Run `cargo fmt` with below line temporarily added to `rustfmt.toml`:
```
format_strings = true
```