### PR TITLE
double default max_incoming

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -71,6 +71,8 @@ pub struct SpawnServerResult {
 /// Controls the the channel size for the PacketBatch coalesce
 pub(crate) const DEFAULT_MAX_COALESCE_CHANNEL_SIZE: usize = 250_000;
 
+const MAX_INCOMING_CONNECTIONS: usize = 1 << 17; // 128K
+
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
@@ -90,6 +92,7 @@ pub(crate) fn configure_server(
     let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));
+    server_config.max_incoming(MAX_INCOMING_CONNECTIONS);
     let config = Arc::get_mut(&mut server_config.transport).unwrap();
 
     // QUIC_MAX_CONCURRENT_STREAMS doubled, which was found to improve reliability


### PR DESCRIPTION
#### Problem
Quinn uses 64K as the default max incoming connections. It can be insufficient during occasional bursty use cases.

#### Summary of Changes

increase the max incoming to 128K.
impact: for worst case scenario double the memory for incomings from 100MB to 200MB

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
