### PR TITLE
Run rustfmt with format_strings = true (1 / N)

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -243,8 +243,21 @@ impl ProgramCacheStats {
         let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         let water_level = self.water_level.load(Ordering::Relaxed);
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, Insertions: {}, Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}, Water-Level: {}",
-            hits, misses, evictions, reloads, insertions, lost_insertions, replacements, one_hit_wonders, prunes_orphan, prunes_environment, empty_entries, water_level
+            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, \
+             Insertions: {}, Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, \
+             Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}, Water-Level: {}",
+            hits,
+            misses,
+            evictions,
+            reloads,
+            insertions,
+            lost_insertions,
+            replacements,
+            one_hit_wonders,
+            prunes_orphan,
+            prunes_environment,
+            empty_entries,
+            water_level
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
@@ -902,7 +915,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             ) => {}
                             _ => {
                                 // Something is wrong, I can feel it ...
-                                error!("ProgramCache::assign_program() failed key={:?} existing={:?} entry={:?}", key, slot_versions, entry);
+                                error!(
+                                    "ProgramCache::assign_program() failed key={:?} existing={:?} \
+                                     entry={:?}",
+                                    key, slot_versions, entry
+                                );
                                 debug_assert!(false, "Unexpected replacement of an entry");
                                 self.stats.replacements.fetch_add(1, Ordering::Relaxed);
                                 return true;

--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -44,7 +44,8 @@ pub trait TransactionProcessingCallback: InvokeContextCallback {
 
     #[deprecated(
         since = "2.3.0",
-        note = "Use `get_epoch_stake_for_vote_account` on the `InvokeContextCallback` trait instead"
+        note = "Use `get_epoch_stake_for_vote_account` on the `InvokeContextCallback` trait \
+                instead"
     )]
     fn get_current_epoch_vote_account_stake(&self, vote_address: &Pubkey) -> u64 {
         Self::get_epoch_stake_for_vote_account(self, vote_address)

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -895,7 +895,10 @@ fn encode_account<T: ReadableAccount>(
             .unwrap_or(account.data().len())
             > MAX_BASE58_BYTES
     {
-        let message = format!("Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please use Base64 encoding.");
+        let message = format!(
+            "Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please \
+             use Base64 encoding."
+        );
         Err(error::Error {
             code: error::ErrorCode::InvalidRequest,
             message,

--- a/svm/examples/json-rpc/server/src/rpc_service.rs
+++ b/svm/examples/json-rpc/server/src/rpc_service.rs
@@ -69,8 +69,8 @@ impl JsonRpcService {
 
                 if let Err(e) = server {
                     warn!(
-                        "JSON RPC service unavailable error: {:?}. \n\
-                           Also, check that port {} is not already in use by another application",
+                        "JSON RPC service unavailable error: {:?}. \nAlso, check that port {} is \
+                         not already in use by another application",
                         e,
                         rpc_addr.port()
                     );

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2062,8 +2062,8 @@ mod tests {
         let starting_balance = transaction_fee + priority_fee;
         assert!(
             starting_balance > min_balance,
-            "we're testing that a rent exempt fee payer can be fully drained, \
-                so ensure that the starting balance is more than the min balance"
+            "we're testing that a rent exempt fee payer can be fully drained, so ensure that the \
+             starting balance is more than the min balance"
         );
 
         let fee_payer_rent_epoch = current_epoch;


### PR DESCRIPTION
#### Problem
Long string literals have previously been observed to cause issues for `cargo fmt`

#### Summary of Changes
Run `cargo fmt` on the crates that have `svm` as codeowners