### PR TITLE
clippy: uninlined_format_args (ledger-tool)

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -71,13 +71,13 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .long("accounts-db-skip-shrink")
             .help(
                 "Enables faster starting of ledger-tool by skipping shrink. This option is for \
-                use during testing.",
+                 use during testing.",
             ),
         Arg::with_name("accounts_db_verify_refcounts")
             .long("accounts-db-verify-refcounts")
             .help(
                 "Debug option to scan all AppendVecs and verify account index refcounts prior to \
-                clean",
+                 clean",
             )
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_scan_filter_for_shrinking")
@@ -86,12 +86,13 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .possible_values(&["all", "only-abnormal", "only-abnormal-with-verify"])
             .help(
                 "Debug option to use different type of filtering for accounts index scan in \
-                shrinking. \"all\" will scan both in-memory and on-disk accounts index, which is the default. \
-                \"only-abnormal\" will scan in-memory accounts index only for abnormal entries and \
-                skip scanning on-disk accounts index by assuming that on-disk accounts index contains \
-                only normal accounts index entry. \"only-abnormal-with-verify\" is similar to \
-                \"only-abnormal\", which will scan in-memory index for abnormal entries, but will also \
-                verify that on-disk account entries are indeed normal.",
+                 shrinking. \"all\" will scan both in-memory and on-disk accounts index, which is \
+                 the default. \"only-abnormal\" will scan in-memory accounts index only for \
+                 abnormal entries and skip scanning on-disk accounts index by assuming that \
+                 on-disk accounts index contains only normal accounts index entry. \
+                 \"only-abnormal-with-verify\" is similar to \"only-abnormal\", which will scan \
+                 in-memory index for abnormal entries, but will also verify that on-disk account \
+                 entries are indeed normal.",
             )
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_db_skip_initial_hash_calculation")

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -773,32 +773,32 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             }
                         };
                     } else {
-                        let confirmed_block =
-                            match source_bigtable_clone.get_confirmed_block(slot).await {
-                                Ok(block) => match VersionedConfirmedBlock::try_from(block) {
-                                    Ok(block) => block,
-                                    Err(err) => {
-                                        error!(
-                                            "failed to convert confirmed block to versioned \
-                                             confirmed block, slot: {slot}, err: {err}"
-                                        );
-                                        failed_slots_clone.lock().unwrap().push(slot);
-                                        continue;
-                                    }
-                                },
-                                Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
-                                    debug!("block not found, slot: {slot}");
-                                    block_not_found_slots_clone.lock().unwrap().push(slot);
-                                    continue;
-                                }
+                        let confirmed_block = match source_bigtable_clone
+                            .get_confirmed_block(slot)
+                            .await
+                        {
+                            Ok(block) => match VersionedConfirmedBlock::try_from(block) {
+                                Ok(block) => block,
                                 Err(err) => {
                                     error!(
-                                        "failed to get confirmed block, slot: {slot}, err: {err}"
+                                        "failed to convert confirmed block to versioned \
+                                             confirmed block, slot: {slot}, err: {err}"
                                     );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
-                            };
+                            },
+                            Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
+                                debug!("block not found, slot: {slot}");
+                                block_not_found_slots_clone.lock().unwrap().push(slot);
+                                continue;
+                            }
+                            Err(err) => {
+                                error!("failed to get confirmed block, slot: {slot}, err: {err}");
+                                failed_slots_clone.lock().unwrap().push(slot);
+                                continue;
+                            }
+                        };
 
                         match destination_bigtable_clone
                             .upload_confirmed_block(slot, confirmed_block)

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -220,17 +220,17 @@ fn get_shred_config_from_ledger(
         let ending_epoch = epoch_schedule.get_epoch(ending_slot);
         if starting_epoch != ending_epoch {
             eprintln!(
-                "The specified --starting-slot and --ending-slot must be in the\
-                same epoch. --starting-slot {starting_slot} is in epoch {starting_epoch},\
-                but --ending-slot {ending_slot} is in epoch {ending_epoch}."
+                "The specified --starting-slot and --ending-slot must be in the same epoch. \
+                 --starting-slot {starting_slot} is in epoch {starting_epoch}, but --ending-slot \
+                 {ending_slot} is in epoch {ending_epoch}."
             );
             exit(1);
         }
         if starting_epoch != working_bank_epoch {
             eprintln!(
-                "The range of slots between --starting-slot and --ending-slot are in a \
-                different epoch than the working bank. The specified range is in epoch \
-                {starting_epoch}, but the working bank is in {working_bank_epoch}."
+                "The range of slots between --starting-slot and --ending-slot are in a different \
+                 epoch than the working bank. The specified range is in epoch {starting_epoch}, \
+                 but the working bank is in {working_bank_epoch}."
             );
             exit(1);
         }
@@ -781,8 +781,8 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                                 Ok(block) => block,
                                 Err(err) => {
                                     error!(
-                                        "failed to convert confirmed block to versioned \
-                                             confirmed block, slot: {slot}, err: {err}"
+                                        "failed to convert confirmed block to versioned confirmed \
+                                         block, slot: {slot}, err: {err}"
                                     );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
@@ -1088,9 +1088,9 @@ impl BigTableSubCommand for App<'_, '_> {
                 .subcommand(
                     SubCommand::with_name("shreds")
                         .about(
-                            "Get confirmed blocks from BigTable, reassemble the transactions \
-                            and entries, shred the block and then insert the shredded blocks into \
-                            the local Blockstore",
+                            "Get confirmed blocks from BigTable, reassemble the transactions and \
+                             entries, shred the block and then insert the shredded blocks into \
+                             the local Blockstore",
                         )
                         .arg(load_genesis_arg())
                         .args(&snapshot_args())
@@ -1118,9 +1118,9 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(false)
                                 .help(
                                     "For slots where PoH entries are unavailable, allow the \
-                                    generation of mock PoH entries. The mock PoH entries enable \
-                                    the shredded block(s) to be replayable if PoH verification is \
-                                    disabled.",
+                                     generation of mock PoH entries. The mock PoH entries enable \
+                                     the shredded block(s) to be replayable if PoH verification \
+                                     is disabled.",
                                 ),
                         )
                         .arg(
@@ -1131,7 +1131,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .conflicts_with("allow_mock_poh")
                                 .help(
                                     "The version to encode in created shreds. Specifying this \
-                                    value will avoid determining the value from a rebuilt Bank.",
+                                     value will avoid determining the value from a rebuilt Bank.",
                                 ),
                         ),
                 )
@@ -1435,7 +1435,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             if starting_slot > ending_slot {
                 eprintln!(
                     "The specified --starting-slot {starting_slot} must be less than or equal to \
-                    the specified --ending-slot {ending_slot}."
+                     the specified --ending-slot {ending_slot}."
                 );
                 exit(1);
             }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -93,7 +93,7 @@ async fn upload(
             Arc::new(AtomicBool::new(false)),
         )
         .await?;
-        info!("last slot checked: {}", last_slot_checked);
+        info!("last slot checked: {last_slot_checked}");
         starting_slot = last_slot_checked.saturating_add(1);
     }
     info!("No more blocks to upload.");
@@ -676,7 +676,7 @@ impl CopyArgs {
 async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     let from_slot = args.from_slot;
     let to_slot = args.to_slot.unwrap_or(from_slot);
-    debug!("from_slot: {}, to_slot: {}", from_slot, to_slot);
+    debug!("from_slot: {from_slot}, to_slot: {to_slot}");
 
     if from_slot > to_slot {
         return Err("starting slot should be less than or equal to ending slot")?;
@@ -708,7 +708,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let workers = min(to_slot - from_slot + 1, num_cpus::get().try_into().unwrap());
-    debug!("worker num: {}", workers);
+    debug!("worker num: {workers}");
 
     let success_slots = Arc::new(Mutex::new(vec![]));
     let skip_slots = Arc::new(Mutex::new(vec![]));
@@ -727,7 +727,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
             let failed_slots_clone = Arc::clone(&failed_slots);
             tokio::spawn(async move {
                 while let Ok(slot) = r.try_recv() {
-                    debug!("worker {}: received slot {}", i, slot);
+                    debug!("worker {i}: received slot {slot}");
 
                     if !args.force {
                         match destination_bigtable_clone
@@ -743,8 +743,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             Err(err) => {
                                 error!(
                                     "confirmed_block_exists() failed from the destination \
-                                     Bigtable, slot: {}, err: {}",
-                                    slot, err
+                                     Bigtable, slot: {slot}, err: {err}"
                                 );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
@@ -756,10 +755,10 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                         match source_bigtable_clone.confirmed_block_exists(slot).await {
                             Ok(exist) => {
                                 if exist {
-                                    debug!("will write block: {}", slot);
+                                    debug!("will write block: {slot}");
                                     success_slots_clone.lock().unwrap().push(slot);
                                 } else {
-                                    debug!("block not found, slot: {}", slot);
+                                    debug!("block not found, slot: {slot}");
                                     block_not_found_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
@@ -767,8 +766,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             Err(err) => {
                                 error!(
                                     "failed to get a confirmed block from the source Bigtable, \
-                                     slot: {}, err: {}",
-                                    slot, err
+                                     slot: {slot}, err: {err}"
                                 );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
@@ -782,22 +780,20 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                                     Err(err) => {
                                         error!(
                                             "failed to convert confirmed block to versioned \
-                                             confirmed block, slot: {}, err: {}",
-                                            slot, err
+                                             confirmed block, slot: {slot}, err: {err}"
                                         );
                                         failed_slots_clone.lock().unwrap().push(slot);
                                         continue;
                                     }
                                 },
                                 Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
-                                    debug!("block not found, slot: {}", slot);
+                                    debug!("block not found, slot: {slot}");
                                     block_not_found_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
                                 Err(err) => {
                                     error!(
-                                        "failed to get confirmed block, slot: {}, err: {}",
-                                        slot, err
+                                        "failed to get confirmed block, slot: {slot}, err: {err}"
                                     );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
@@ -809,11 +805,11 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                             .await
                         {
                             Ok(()) => {
-                                debug!("wrote block: {}", slot);
+                                debug!("wrote block: {slot}");
                                 success_slots_clone.lock().unwrap().push(slot);
                             }
                             Err(err) => {
-                                error!("write failed, slot: {}, err: {}", slot, err);
+                                error!("write failed, slot: {slot}, err: {err}");
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
                             }
@@ -821,7 +817,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                debug!("worker {}: exit", i);
+                debug!("worker {i}: exit");
             })
         })
         .collect::<FuturesUnordered<_>>();
@@ -837,10 +833,10 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut failed_slots = failed_slots.lock().unwrap();
     failed_slots.sort();
 
-    debug!("success slots: {:?}", success_slots);
-    debug!("skip slots: {:?}", skip_slots);
-    debug!("blocks not found slots: {:?}", block_not_found_slots);
-    debug!("failed slots: {:?}", failed_slots);
+    debug!("success slots: {success_slots:?}");
+    debug!("skip slots: {skip_slots:?}");
+    debug!("blocks not found slots: {block_not_found_slots:?}");
+    debug!("failed slots: {failed_slots:?}");
 
     println!(
         "success: {}, skip: {}, block not found: {}, failed: {}",

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -305,8 +305,7 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
     vec![
         SubCommand::with_name("analyze-storage")
             .about(
-                "Output statistics in JSON format about all column families in the ledger \
-                rocksdb",
+                "Output statistics in JSON format about all column families in the ledger rocksdb",
             )
             .settings(&hidden),
         SubCommand::with_name("bounds")
@@ -344,8 +343,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
             .arg(&starting_slot_arg),
         SubCommand::with_name("latest-optimistic-slots")
             .about(
-                "Output up to the most recent <num-slots> optimistic slots with their hashes \
-                 and timestamps.",
+                "Output up to the most recent <num-slots> optimistic slots with their hashes and \
+                 timestamps.",
             )
             // This command is important in cluster restart scenarios, so do not hide it ever
             // such that the subcommand will be visible as the top level of agave-ledger-tool
@@ -391,8 +390,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .required(false)
                     .takes_value(true)
                     .help(
-                        "The location of the output YAML file. A list of rollback slot \
-                         heights and hashes will be written to the file",
+                        "The location of the output YAML file. A list of rollback slot heights \
+                         and hashes will be written to the file",
                     ),
             )
             .arg(
@@ -451,8 +450,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .takes_value(true)
                     .value_name("SST_FILE_NAME")
                     .help(
-                        "The ledger file name (e.g. 011080.sst.) If no file name is \
-                         specified, it will print the metadata of all ledger files.",
+                        "The ledger file name (e.g. 011080.sst.) If no file name is specified, it \
+                         will print the metadata of all ledger files.",
                     ),
             ),
         SubCommand::with_name("purge")
@@ -467,8 +466,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .help("Start slot to purge from (inclusive)"),
             )
             .arg(Arg::with_name("end_slot").index(2).value_name("SLOT").help(
-                "Ending slot to stop purging (inclusive) \
-                [default: the highest slot in the ledger]",
+                "Ending slot to stop purging (inclusive). \
+                 [default: the highest slot in the ledger]",
             ))
             .arg(
                 Arg::with_name("batch_size")
@@ -484,8 +483,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .required(false)
                     .takes_value(false)
                     .help(
-                        "--no-compaction is deprecated, ledger compaction after purge is \
-                         disabled by default",
+                        "--no-compaction is deprecated, ledger compaction after purge is disabled \
+                         by default",
                     )
                     .conflicts_with("enable_compaction")
                     .hidden(hidden_unless_forced()),
@@ -496,8 +495,8 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .required(false)
                     .takes_value(false)
                     .help(
-                        "Perform ledger compaction after purge. Compaction will optimize \
-                         storage space, but may take a long time to complete.",
+                        "Perform ledger compaction after purge. Compaction will optimize storage \
+                         space, but may take a long time to complete.",
                     )
                     .conflicts_with("no_compaction"),
             )
@@ -877,14 +876,14 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             };
             if end_slot < start_slot {
                 return Err(LedgerToolError::BadArgument(format!(
-                    "starting slot {start_slot} should be less than or equal to \
-                    ending slot {end_slot}"
+                    "starting slot {start_slot} should be less than or equal to ending slot \
+                     {end_slot}"
                 )));
             }
 
             info!(
-                "Purging data from slots {} to {} ({} slots) (do compaction: {}) \
-                (dead slot only: {})",
+                "Purging data from slots {} to {} ({} slots) (do compaction: {}) (dead slot only: \
+                 {})",
                 start_slot,
                 end_slot,
                 end_slot - start_slot,
@@ -956,7 +955,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             if arg_matches.is_present("end_root") && num_slots > max_slots {
                 return Err(LedgerToolError::BadArgument(format!(
                     "Requested range {num_slots} too large, max {max_slots}. Either adjust \
-                    `--until` value, or pass a larger `--repair-limit` to override the limit",
+                     `--until` value, or pass a larger `--repair-limit` to override the limit",
                 )));
             }
 

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -676,7 +676,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
                 if target.insert_cow_shreds(shreds, None, true).is_err() {
-                    warn!("error inserting shreds for slot {}", slot);
+                    warn!("error inserting shreds for slot {slot}");
                 }
             }
         }
@@ -920,7 +920,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                     .dead_slots_iterator(start_slot)?
                     .take_while(|s| *s <= end_slot);
                 for dead_slot in dead_slots_iter {
-                    info!("Purging dead slot {}", dead_slot);
+                    info!("Purging dead slot {dead_slot}");
                     purge_from_blockstore(dead_slot, dead_slot);
                 }
             }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -236,8 +236,7 @@ pub fn load_and_process_ledger(
             .join(LEDGER_TOOL_DIRECTORY)
             .join("accounts");
         info!(
-            "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
-            non_primary_accounts_path
+            "Default accounts path is switched aligning with Blockstore's secondary access: {non_primary_accounts_path:?}"
         );
         vec![non_primary_accounts_path]
     };
@@ -347,8 +346,7 @@ pub fn load_and_process_ledger(
         BlockVerificationMethod
     );
     info!(
-        "Using: block-verification-method: {}",
-        block_verification_method,
+        "Using: block-verification-method: {block_verification_method}",
     );
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
@@ -499,8 +497,7 @@ pub fn open_blockstore(
             )
             .unwrap_or_else(|err| {
                 eprintln!(
-                    "Failed to open blockstore (with --force-update-to-open) at {:?}: {:?}",
-                    ledger_path, err
+                    "Failed to open blockstore (with --force-update-to-open) at {ledger_path:?}: {err:?}"
                 );
                 exit(1);
             })
@@ -536,8 +533,7 @@ fn open_blockstore_with_temporary_primary_access(
     }
     // Now, attempt to open the blockstore with original AccessType
     info!(
-        "Blockstore forced open succeeded, retrying with original access: {:?}",
-        original_access_type
+        "Blockstore forced open succeeded, retrying with original access: {original_access_type:?}"
     );
     Blockstore::open_with_options(
         ledger_path,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -345,9 +345,7 @@ pub fn load_and_process_ledger(
         "block_verification_method",
         BlockVerificationMethod
     );
-    info!(
-        "Using: block-verification-method: {block_verification_method}",
-    );
+    info!("Using: block-verification-method: {block_verification_method}");
     let unified_scheduler_handler_threads =
         value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
     match block_verification_method {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -68,9 +68,9 @@ pub struct LoadAndProcessLedgerOutput {
 
 const PROCESS_SLOTS_HELP_STRING: &str =
     "The starting slot is either the latest found snapshot slot, or genesis (slot 0) if the \
-     --no-snapshot flag was specified or if no snapshots were found. \
-     The ending slot is the snapshot creation slot for create-snapshot, the value for \
-     --halt-at-slot if specified, or the highest slot in the blockstore.";
+     --no-snapshot flag was specified or if no snapshots were found. The ending slot is the \
+     snapshot creation slot for create-snapshot, the value for --halt-at-slot if specified, or \
+     the highest slot in the blockstore.";
 
 #[derive(Error, Debug)]
 pub(crate) enum LoadAndProcessLedgerError {
@@ -236,7 +236,8 @@ pub fn load_and_process_ledger(
             .join(LEDGER_TOOL_DIRECTORY)
             .join("accounts");
         info!(
-            "Default accounts path is switched aligning with Blockstore's secondary access: {non_primary_accounts_path:?}"
+            "Default accounts path is switched aligning with Blockstore's secondary access: \
+             {non_primary_accounts_path:?}"
         );
         vec![non_primary_accounts_path]
     };
@@ -495,7 +496,8 @@ pub fn open_blockstore(
             )
             .unwrap_or_else(|err| {
                 eprintln!(
-                    "Failed to open blockstore (with --force-update-to-open) at {ledger_path:?}: {err:?}"
+                    "Failed to open blockstore (with --force-update-to-open) at {ledger_path:?}: \
+                     {err:?}"
                 );
                 exit(1);
             })

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -622,7 +622,7 @@ fn setup_slot_recording(
             // So open-code the conflicts_with() here
             eprintln!(
                 "error: The argument '--verify-slots <FILENAME>' cannot be used with \
-                '--record-slots <FILENAME>'"
+                 '--record-slots <FILENAME>'"
             );
             exit(1);
         }
@@ -721,8 +721,12 @@ fn setup_slot_recording(
                         ..
                     } = slots.lock().unwrap().remove(0);
                     if bank.slot() != expected_slot || bank.hash().to_string() != expected_hash {
-                        error!("Expected slot: {expected_slot} hash: {expected_hash} got slot: {} hash: {}",
-                                    bank.slot(), bank.hash());
+                        error!(
+                            "Expected slot: {expected_slot} hash: {expected_hash} got slot: {} \
+                             hash: {}",
+                            bank.slot(),
+                            bank.hash()
+                        );
                     } else {
                         info!("Expected slot: {expected_slot} hash: {expected_hash} correct");
                     }
@@ -1046,7 +1050,7 @@ fn main() {
         .subcommand(
             SubCommand::with_name("genesis-hash")
                 .about("Prints the ledger's genesis hash")
-                .arg(&load_genesis_config_arg)
+                .arg(&load_genesis_config_arg),
         )
         .subcommand(
             SubCommand::with_name("modify-genesis")
@@ -1074,7 +1078,7 @@ fn main() {
                 .arg(&load_genesis_config_arg)
                 .args(&accounts_db_config_args)
                 .args(&snapshot_config_args)
-                .arg(&hard_forks_arg)
+                .arg(&hard_forks_arg),
         )
         .subcommand(
             SubCommand::with_name("bank-hash")
@@ -1082,7 +1086,7 @@ fn main() {
                 .arg(&load_genesis_config_arg)
                 .args(&accounts_db_config_args)
                 .args(&snapshot_config_args)
-                .arg(&halt_at_slot_arg)
+                .arg(&halt_at_slot_arg),
         )
         .subcommand(
             SubCommand::with_name("verify")
@@ -1128,8 +1132,8 @@ fn main() {
                         .requires("enable_rpc_transaction_history")
                         .takes_value(false)
                         .help(
-                            "Include CPI inner instructions, logs, and return data in the historical \
-                             transaction info stored",
+                            "Include CPI inner instructions, logs, and return data in the \
+                             historical transaction info stored",
                         ),
                 )
                 .arg(
@@ -1155,9 +1159,7 @@ fn main() {
                     Arg::with_name("print_bank_hash")
                         .long("print-bank-hash")
                         .takes_value(false)
-                        .help(
-                            "After verifying the ledger, print the working bank's hash"
-                        ),
+                        .help("After verifying the ledger, print the working bank's hash"),
                 )
                 .arg(
                     Arg::with_name("write_bank_file")
@@ -1194,7 +1196,10 @@ fn main() {
                             "enable_rpc_transaction_history",
                             "geyser_plugin_config",
                         ])
-                        .help("In addition to the bank hash, optionally include accounts and/or transactions details for the slot"),
+                        .help(
+                            "In addition to the bank hash, optionally include accounts and/or \
+                             transactions details for the slot",
+                        ),
                 )
                 .arg(
                     Arg::with_name("abort_on_invalid_block")
@@ -1216,8 +1221,8 @@ fn main() {
                         .takes_value(false)
                         .help(
                             "Enable override of blockhashes and bank hashes from banking trace \
-                             event files to correctly verify blocks produced by \
-                             the simulate-block-production subcommand",
+                             event files to correctly verify blocks produced by the \
+                             simulate-block-production subcommand",
                         ),
                 ),
         )
@@ -1292,7 +1297,7 @@ fn main() {
                         .takes_value(true)
                         .help(
                             "Output directory for the snapshot \
-                            [default: --snapshot-archive-path if present else --ledger directory]",
+                             [default: --snapshot-archive-path if present else --ledger directory]",
                         ),
                 )
                 .arg(
@@ -1462,10 +1467,10 @@ fn main() {
                         .takes_value(true)
                         .help("The compression level to use when archiving with zstd")
                         .long_help(
-                            "The compression level to use when archiving with zstd. \
-                             Higher compression levels generally produce higher \
-                             compression ratio at the expense of speed and memory. \
-                             See the zstd manpage for more information."
+                            "The compression level to use when archiving with zstd. Higher \
+                             compression levels generally produce higher compression ratio at the \
+                             expense of speed and memory. See the zstd manpage for more \
+                             information.",
                         ),
                 )
                 .arg(
@@ -1506,7 +1511,7 @@ fn main() {
                         .validator(is_slot)
                         .takes_value(true)
                         .required(true)
-                        .help("Start simulation at the given slot")
+                        .help("Start simulation at the given slot"),
                 )
                 .arg(
                     Arg::with_name("no_block_cost_limits")
@@ -1556,7 +1561,7 @@ fn main() {
                         .multiple(true)
                         .help(
                             "Limit output to accounts corresponding to the specified pubkey(s), \
-                            may be specified multiple times",
+                             may be specified multiple times",
                         ),
                 )
                 .arg(
@@ -1779,8 +1784,8 @@ fn main() {
                 }
                 ("bank-hash", Some(_)) => {
                     eprintln!(
-                        "The bank-hash command has been deprecated, use \
-                        agave-ledger-tool verify --print-bank-hash ... instead"
+                        "The bank-hash command has been deprecated, use agave-ledger-tool verify \
+                         --print-bank-hash ... instead"
                     );
                 }
                 ("verify", Some(arg_matches)) => {
@@ -1980,9 +1985,9 @@ fn main() {
                     let minimum_stake_lamports = rent.minimum_balance(StakeStateV2::size_of());
                     if bootstrap_validator_stake_lamports < minimum_stake_lamports {
                         eprintln!(
-                        "Error: insufficient --bootstrap-validator-stake-lamports. Minimum amount \
-                         is {minimum_stake_lamports}"
-                    );
+                            "Error: insufficient --bootstrap-validator-stake-lamports. Minimum \
+                             amount is {minimum_stake_lamports}"
+                        );
                         exit(1);
                     }
                     let bootstrap_validator_pubkeys =
@@ -2049,9 +2054,9 @@ fn main() {
                         .is_none()
                     {
                         eprintln!(
-                        "Error: snapshot slot {snapshot_slot} does not exist in blockstore or is \
-                         not full.",
-                    );
+                            "Error: snapshot slot {snapshot_slot} does not exist in blockstore or \
+                             is not full.",
+                        );
                         exit(1);
                     }
                     process_options.halt_at_slot = Some(snapshot_slot);
@@ -2061,7 +2066,7 @@ fn main() {
                         if ending_slot <= snapshot_slot {
                             eprintln!(
                                 "Error: ending_slot ({ending_slot}) must be greater than \
-                             snapshot_slot ({snapshot_slot})"
+                                 snapshot_slot ({snapshot_slot})"
                             );
                             exit(1);
                         }
@@ -2330,8 +2335,7 @@ fn main() {
                         if let Some(warp_slot) = warp_slot {
                             if warp_slot < minimum_warp_slot {
                                 eprintln!(
-                                    "Error: --warp-slot too close.  Must be >= \
-                                         {minimum_warp_slot}"
+                                    "Error: --warp-slot too close.  Must be >= {minimum_warp_slot}"
                                 );
                                 exit(1);
                             }
@@ -2409,15 +2413,15 @@ fn main() {
                         if starting_snapshot_hashes.is_none() {
                             eprintln!(
                                 "Unable to create incremental snapshot without a base full \
-                                     snapshot"
+                                 snapshot"
                             );
                             exit(1);
                         }
                         let full_snapshot_slot = starting_snapshot_hashes.unwrap().full.0 .0;
                         if bank.slot() <= full_snapshot_slot {
                             eprintln!(
-                                "Unable to create incremental snapshot: Slot must be greater \
-                                     than full snapshot slot. slot: {}, full snapshot slot: {}",
+                                "Unable to create incremental snapshot: Slot must be greater than \
+                                 full snapshot slot. slot: {}, full snapshot slot: {}",
                                 bank.slot(),
                                 full_snapshot_slot,
                             );
@@ -2440,8 +2444,8 @@ fn main() {
                             });
 
                         println!(
-                            "Successfully created incremental snapshot for slot {}, hash {}, \
-                                 base slot: {}: {}",
+                            "Successfully created incremental snapshot for slot {}, hash {}, base \
+                             slot: {}: {}",
                             bank.slot(),
                             bank.hash(),
                             full_snapshot_slot,
@@ -2475,9 +2479,9 @@ fn main() {
                                 bank.epoch_schedule().get_epoch(ending_slot.unwrap());
                             if starting_epoch != ending_epoch {
                                 warn!(
-                                    "Minimized snapshot range crosses epoch boundary ({} to \
-                                         {}). Bank hashes after {} will not match replays from a \
-                                         full snapshot",
+                                    "Minimized snapshot range crosses epoch boundary ({} to {}). \
+                                     Bank hashes after {} will not match replays from a full \
+                                     snapshot",
                                     starting_epoch,
                                     ending_epoch,
                                     bank.epoch_schedule().get_last_slot_in_epoch(starting_epoch)
@@ -2486,9 +2490,9 @@ fn main() {
 
                             if minimize_snapshot_possibly_incomplete {
                                 warn!(
-                                    "Minimized snapshot may be incomplete due to missing \
-                                         accounts from CPI'd address lookup table extensions. \
-                                         This may lead to mismatched bank hashes while replaying."
+                                    "Minimized snapshot may be incomplete due to missing accounts \
+                                     from CPI'd address lookup table extensions. This may lead to \
+                                     mismatched bank hashes while replaying."
                                 );
                             }
                         }
@@ -2518,8 +2522,8 @@ fn main() {
                     let simulator = BankingSimulator::new(banking_trace_events, slot);
                     let Some(parent_slot) = simulator.parent_slot() else {
                         eprintln!(
-                            "Couldn't determine parent_slot of first_simulated_slot: {slot} \
-                             due to missing banking_trace_event data."
+                            "Couldn't determine parent_slot of first_simulated_slot: {slot} due \
+                             to missing banking_trace_event data."
                         );
                         exit(1);
                     };
@@ -2550,7 +2554,10 @@ fn main() {
                     let transaction_struct =
                         value_t_or_exit!(arg_matches, "transaction_struct", TransactionStructure);
 
-                    info!("Using: block-production-method: {block_production_method} transaction-structure: {transaction_struct}");
+                    info!(
+                        "Using: block-production-method: {block_production_method} \
+                         transaction-structure: {transaction_struct}"
+                    );
 
                     match simulator.start(
                         genesis_config,
@@ -2737,9 +2744,9 @@ fn main() {
                                 let new_cap = base_bank.calculate_capitalization_for_tests();
                                 base_bank.set_capitalization_for_tests(new_cap);
                                 warn!(
-                                    "Skewing capitalization a bit to enable \
-                                         credits_auto_rewind as requested: increasing {feature_account_balance} from {old_cap} \
-                                         to {new_cap}",
+                                    "Skewing capitalization a bit to enable credits_auto_rewind \
+                                     as requested: increasing {feature_account_balance} from \
+                                     {old_cap} to {new_cap}",
                                 );
                                 assert_eq!(
                                     old_cap + feature_account_balance * store_failed_count,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -476,7 +476,7 @@ fn compute_slot_cost(
                     &reserved_account_keys.active,
                 )
                 .map_err(|err| {
-                    warn!("Failed to compute cost of transaction: {:?}", err);
+                    warn!("Failed to compute cost of transaction: {err:?}");
                 })
                 .ok()
             })
@@ -2336,7 +2336,7 @@ fn main() {
                                 exit(1);
                             }
                         } else {
-                            warn!("Warping to slot {}", minimum_warp_slot);
+                            warn!("Warping to slot {minimum_warp_slot}");
                             warp_slot = Some(minimum_warp_slot);
                         }
                     }
@@ -2738,9 +2738,8 @@ fn main() {
                                 base_bank.set_capitalization_for_tests(new_cap);
                                 warn!(
                                     "Skewing capitalization a bit to enable \
-                                         credits_auto_rewind as requested: increasing {} from {} \
-                                         to {}",
-                                    feature_account_balance, old_cap, new_cap,
+                                         credits_auto_rewind as requested: increasing {feature_account_balance} from {old_cap} \
+                                         to {new_cap}",
                                 );
                                 assert_eq!(
                                     old_cap + feature_account_balance * store_failed_count,
@@ -3100,7 +3099,7 @@ fn main() {
                                 }
                                 overall_delta += delta;
                             } else {
-                                error!("new account!?: {}", pubkey);
+                                error!("new account!?: {pubkey}");
                             }
                         }
                         if overall_delta > 0 {
@@ -3150,5 +3149,5 @@ fn main() {
         }
     };
     measure_total_execution_time.stop();
-    info!("{}", measure_total_execution_time);
+    info!("{measure_total_execution_time}");
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -320,7 +320,7 @@ impl VerboseDisplay for CliDuplicateSlotProof {
         write!(w, "    Shred2 ")?;
         VerboseDisplay::write_str(&self.shred2, w)?;
         if let Some(erasure_consistency) = self.erasure_consistency {
-            writeln!(w, "    Erasure consistency {}", erasure_consistency)?;
+            writeln!(w, "    Erasure consistency {erasure_consistency}")?;
         }
         Ok(())
     }
@@ -331,7 +331,7 @@ impl fmt::Display for CliDuplicateSlotProof {
         write!(f, "    Shred1 {}", self.shred1)?;
         write!(f, "    Shred2 {}", self.shred2)?;
         if let Some(erasure_consistency) = self.erasure_consistency {
-            writeln!(f, "    Erasure consistency {}", erasure_consistency)?;
+            writeln!(f, "    Erasure consistency {erasure_consistency}")?;
         }
         Ok(())
     }
@@ -440,8 +440,7 @@ impl EncodedConfirmedBlockWithEntries {
                 .transactions
                 .get(entry.starting_transaction_index..ending_transaction_index)
                 .ok_or(LedgerToolError::Generic(format!(
-                    "Mismatched entry data and transactions: entry {:?}",
-                    i
+                    "Mismatched entry data and transactions: entry {i:?}"
                 )))?;
             entries.push(CliPopulatedEntry {
                 num_hashes: entry.num_hashes,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -127,7 +127,8 @@ impl Display for SlotBankHash {
 fn writeln_entry(f: &mut dyn fmt::Write, i: usize, entry: &CliEntry, prefix: &str) -> fmt::Result {
     writeln!(
         f,
-        "{prefix}Entry {} - num_hashes: {}, hash: {}, transactions: {}, starting_transaction_index: {}",
+        "{prefix}Entry {} - num_hashes: {}, hash: {}, transactions: {}, \
+         starting_transaction_index: {}",
         i, entry.num_hashes, entry.hash, entry.num_transactions, entry.starting_transaction_index,
     )
 }
@@ -371,8 +372,8 @@ impl CliDuplicateShred {
     fn write_common(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
         writeln!(
             w,
-            "fec_set_index {}, index {}, shred_type {:?}\n       \
-             version {}, merkle_root {:?}, chained_merkle_root {:?}, last_in_slot {}",
+            "fec_set_index {}, index {}, shred_type {:?}\n       version {}, merkle_root {:?}, \
+             chained_merkle_root {:?}, last_in_slot {}",
             self.fec_set_index,
             self.index,
             self.shred_type,
@@ -630,8 +631,8 @@ pub fn output_slot(
             // Given that Blockstore::get_complete_block_with_entries() returned Ok(_), we know
             // that we have a full block so meta.consumed is the number of shreds in the block
             println!(
-                "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, \
-                 is_full: {}",
+                "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, is_full: \
+                 {}",
                 meta.consumed,
                 meta.parent_slot,
                 meta.next_slots,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -447,7 +447,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                                 programdata_address,
                             }) = account.state()
                             {
-                                debug!("Program data address {}", programdata_address);
+                                debug!("Program data address {programdata_address}");
                                 if bank
                                     .get_account_with_fixed_root(&programdata_address)
                                     .is_some()
@@ -523,7 +523,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             bank.load_program(&key, false, bank.epoch())
                 .expect("Couldn't find program account"),
         );
-        debug!("Loaded program {}", key);
+        debug!("Loaded program {key}");
     }
     invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
Fix `uninlined_format_args` warnings in ledger-tool + format strings to ensure any changes remain compliant with 100 character line width limit

The string formatting was previously done with below PR, but clearly not having that setting persisted in our config allowed more stuff to creep in:
https://github.com/solana-labs/solana/pull/34284
