### PR TITLE
Resolve Rust 1.88 clippy string lints and format strings (svm + misc)

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -145,7 +145,7 @@ fn prepare_environment(
     };
 
     env::set_current_dir(root_dir).unwrap_or_else(|err| {
-        error!("Unable to set current directory to {}: {}", root_dir, err);
+        error!("Unable to set current directory to {root_dir}: {err}");
         exit(1);
     });
 
@@ -189,8 +189,7 @@ fn invoke_cargo(config: &Config) {
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
         warn!(
-            "Removed RUSTFLAGS from cargo environment, because it overrides {}.",
-            cargo_target,
+            "Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.",
         );
         env::remove_var("RUSTFLAGS")
     }
@@ -256,7 +255,7 @@ fn invoke_cargo(config: &Config) {
     );
 
     if config.verbose {
-        debug!("{}", output);
+        debug!("{output}");
     }
 }
 
@@ -311,7 +310,7 @@ fn build_solana(config: Config, manifest_path: Option<PathBuf>) {
     }
 
     let metadata = metadata_command.exec().unwrap_or_else(|err| {
-        error!("Failed to obtain package metadata: {}", err);
+        error!("Failed to obtain package metadata: {err}");
         exit(1);
     });
 
@@ -605,8 +604,8 @@ fn main() {
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {
-        debug!("{:?}", config);
-        debug!("manifest_path: {:?}", manifest_path);
+        debug!("{config:?}");
+        debug!("manifest_path: {manifest_path:?}");
     }
     build_solana(config, manifest_path);
 }

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -188,9 +188,7 @@ fn invoke_cargo(config: &Config) {
     );
     let rustflags = env::var("RUSTFLAGS").ok().unwrap_or_default();
     if env::var("RUSTFLAGS").is_ok() {
-        warn!(
-            "Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.",
-        );
+        warn!("Removed RUSTFLAGS from cargo environment, because it overrides {cargo_target}.");
         env::remove_var("RUSTFLAGS")
     }
     let target_rustflags = env::var(&cargo_target).ok();

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -88,7 +88,11 @@ pub fn is_version_string(arg: &str) -> Result<(), String> {
     if semver_re.is_match(arg) {
         return Ok(());
     }
-    Err("a version string may start with 'v' and contains major and minor version numbers separated by a dot, e.g. v1.32 or 1.32".to_string())
+    Err(
+        "a version string may start with 'v' and contains major and minor version numbers \
+         separated by a dot, e.g. v1.32 or 1.32"
+            .to_string(),
+    )
 }
 
 fn home_dir() -> PathBuf {
@@ -166,7 +170,7 @@ fn invoke_cargo(config: &Config) {
     if corrupted_toolchain(config) {
         error!(
             "The Solana toolchain is corrupted. Please, run cargo-build-sbf with the \
-        --force-tools-install argument to fix it."
+             --force-tools-install argument to fix it."
         );
         exit(1);
     }
@@ -272,10 +276,13 @@ fn generate_program_name(package: &cargo_metadata::Package) -> Option<String> {
                 };
 
                 if let Some(other_crate) = other_crate_type {
-                    warn!("Package '{}' has two crate types defined: cdylib and {}. \
-                        This setting precludes link-time optimizations (LTO). Use cdylib for programs \
-                        to be deployed and rlib for packages to be imported by other programs as libraries.",
-                        package.name, other_crate);
+                    warn!(
+                        "Package '{}' has two crate types defined: cdylib and {}. This setting \
+                         precludes link-time optimizations (LTO). Use cdylib for programs to be \
+                         deployed and rlib for packages to be imported by other programs as \
+                         libraries.",
+                        package.name, other_crate
+                    );
                 }
 
                 Some(&target.name)
@@ -440,14 +447,21 @@ fn main() {
                 .long("skip-tools-install")
                 .takes_value(false)
                 .conflicts_with("force_tools_install")
-                .help("Skip downloading and installing platform-tools, assuming they are properly mounted"),
-            )
-            .arg(
-                Arg::new("no_rustup_override")
+                .help(
+                    "Skip downloading and installing platform-tools, assuming they are properly \
+                     mounted",
+                ),
+        )
+        .arg(
+            Arg::new("no_rustup_override")
                 .long("no-rustup-override")
                 .takes_value(false)
                 .conflicts_with("force_tools_install")
-                .help("Do not use rustup to manage the toolchain. By default, cargo-build-sbf invokes rustup to find the Solana rustc using a `+solana` toolchain override. This flag disables that behavior."),
+                .help(
+                    "Do not use rustup to manage the toolchain. By default, cargo-build-sbf \
+                     invokes rustup to find the Solana rustc using a `+solana` toolchain \
+                     override. This flag disables that behavior.",
+                ),
         )
         .arg(
             Arg::new("generate_child_script_on_failure")
@@ -518,16 +532,16 @@ fn main() {
             Arg::new("optimize_size")
                 .long("optimize-size")
                 .takes_value(false)
-                .help("Optimize program for size. This option may reduce program size, potentially increasing CU consumption.")
+                .help(
+                    "Optimize program for size. This option may reduce program size, potentially \
+                     increasing CU consumption.",
+                ),
         )
-        .arg(
-            Arg::new("lto")
-                .long("lto")
-                .takes_value(false)
-                .help("Enable Link-Time Optimization (LTO) for all crates being built. \
-                This option may decrease program size and CU consumption. The default option is LTO \
-                disabled, as one may get mixed results with it.")
-        )
+        .arg(Arg::new("lto").long("lto").takes_value(false).help(
+            "Enable Link-Time Optimization (LTO) for all crates being built. This option may \
+             decrease program size and CU consumption. The default option is LTO disabled, as one \
+             may get mixed results with it.",
+        ))
         .get_matches_from(args);
 
     let sbf_sdk: PathBuf = matches.value_of_t_or_exit("sbf_sdk");

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -93,12 +93,17 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
             let dump_script = config.sbf_sdk.join("scripts").join("dump.sh");
             #[cfg(windows)]
             {
-                error!("Using Bash scripts from within a program is not supported on Windows, skipping `--dump`.");
                 error!(
-                    "Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this command to see the processed program dump.",
+                    "Using Bash scripts from within a program is not supported on Windows, \
+                     skipping `--dump`."
+                );
+                error!(
+                    "Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this \
+                     command to see the processed program dump.",
                     &dump_script.display(),
                     &program_unstripped_so.display(),
-                    &program_dump.display());
+                    &program_dump.display()
+                );
             }
             #[cfg(not(windows))]
             {

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -85,7 +85,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 config.generate_child_script_on_failure,
             );
             if config.verbose {
-                debug!("{}", output);
+                debug!("{output}");
             }
         }
 
@@ -108,7 +108,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                     config.generate_child_script_on_failure,
                 );
                 if config.verbose {
-                    debug!("{}", output);
+                    debug!("{output}");
                 }
             }
             postprocess_dump(&program_dump);
@@ -130,7 +130,7 @@ pub(crate) fn post_process(config: &Config, target_directory: &Path, program_nam
                 config.generate_child_script_on_failure,
             );
             if config.verbose {
-                debug!("{}", output);
+                debug!("{output}");
             }
         }
 
@@ -179,7 +179,7 @@ fn check_undefined_symbols(config: &Config, program: &Path) {
         config.generate_child_script_on_failure,
     );
     if config.verbose {
-        debug!("{}", output);
+        debug!("{output}");
     }
     let mut unresolved_symbols: Vec<String> = Vec::new();
     for line in output.lines() {
@@ -194,8 +194,7 @@ fn check_undefined_symbols(config: &Config, program: &Path) {
     }
     if !unresolved_symbols.is_empty() {
         warn!(
-            "The following functions are undefined and not known syscalls {:?}.",
-            unresolved_symbols
+            "The following functions are undefined and not known syscalls {unresolved_symbols:?}."
         );
         warn!("         Calling them will trigger a run-time error.");
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -73,8 +73,8 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
     }
     let latest_version = get_latest_platform_tools_version().unwrap_or_else(|err| {
         debug!(
-            "Can't get the latest version of platform-tools: {}. Using built-in version {}.",
-            err, builtin_version,
+            "Can't get the latest version of platform-tools: {err}. Using built-in version \
+             {builtin_version}.",
         );
         builtin_version.to_string()
     });
@@ -84,8 +84,8 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
         downloadable_version(requested_version)
     } else {
         warn!(
-            "Version {} is not valid, latest version is {}. Using the built-in version {}",
-            requested_version, latest_version, builtin_version,
+            "Version {requested_version} is not valid, latest version is {latest_version}. Using \
+             the built-in version {builtin_version}",
         );
         builtin_version.to_string()
     }
@@ -128,14 +128,14 @@ fn install_if_missing(
 ) -> Result<(), String> {
     if config.force_tools_install {
         if target_path.is_dir() {
-            debug!("Remove directory {:?}", target_path);
+            debug!("Remove directory {target_path:?}");
             fs::remove_dir_all(target_path).map_err(|err| err.to_string())?;
         }
         let source_base = config.sbf_sdk.join("dependencies");
         if source_base.exists() {
             let source_path = source_base.join(package);
             if source_path.exists() {
-                debug!("Remove file {:?}", source_path);
+                debug!("Remove file {source_path:?}");
                 fs::remove_file(source_path).map_err(|err| err.to_string())?;
             }
         }
@@ -151,7 +151,7 @@ fn install_if_missing(
             .next()
             .is_none()
     {
-        debug!("Remove directory {:?}", target_path);
+        debug!("Remove directory {target_path:?}");
         fs::remove_dir(target_path).map_err(|err| err.to_string())?;
     }
 
@@ -164,7 +164,7 @@ fn install_if_missing(
             .unwrap_or(false)
     {
         if target_path.exists() {
-            debug!("Remove file {:?}", target_path);
+            debug!("Remove file {target_path:?}");
             fs::remove_file(target_path).map_err(|err| err.to_string())?;
         }
         fs::create_dir_all(target_path).map_err(|err| err.to_string())?;
@@ -247,7 +247,7 @@ fn link_solana_toolchain(config: &Config) {
         config.generate_child_script_on_failure,
     );
     if config.verbose {
-        debug!("{}", rustup_output);
+        debug!("{rustup_output}");
     }
     let mut do_link = true;
     for line in rustup_output.lines() {
@@ -263,7 +263,7 @@ fn link_solana_toolchain(config: &Config) {
                     config.generate_child_script_on_failure,
                 );
                 if config.verbose {
-                    debug!("{}", output);
+                    debug!("{output}");
                 }
             } else {
                 do_link = false;
@@ -284,7 +284,7 @@ fn link_solana_toolchain(config: &Config) {
             config.generate_child_script_on_failure,
         );
         if config.verbose {
-            debug!("{}", output);
+            debug!("{output}");
         }
     }
 }
@@ -295,15 +295,30 @@ pub(crate) fn install_tools(
     metadata: &cargo_metadata::Metadata,
 ) {
     let platform_tools_version = config.platform_tools_version.unwrap_or_else(|| {
-        let workspace_tools_version = metadata.workspace_metadata.get("solana").and_then(|v| v.get("tools-version")).and_then(|v| v.as_str());
-        let package_tools_version = package.map(|p| p.metadata.get("solana").and_then(|v| v.get("tools-version")).and_then(|v| v.as_str())).unwrap_or(None);
+        let workspace_tools_version = metadata
+            .workspace_metadata
+            .get("solana")
+            .and_then(|v| v.get("tools-version"))
+            .and_then(|v| v.as_str());
+        let package_tools_version = package
+            .map(|p| {
+                p.metadata
+                    .get("solana")
+                    .and_then(|v| v.get("tools-version"))
+                    .and_then(|v| v.as_str())
+            })
+            .unwrap_or(None);
         match (workspace_tools_version, package_tools_version) {
             (Some(workspace_version), Some(package_version)) => {
                 if workspace_version != package_version {
-                    warn!("Workspace and package specify conflicting tools versions, {workspace_version} and {package_version}, using package version {package_version}");
+                    warn!(
+                        "Workspace and package specify conflicting tools versions, \
+                         {workspace_version} and {package_version}, using package version \
+                         {package_version}"
+                    );
                 }
                 package_version
-            },
+            }
             (Some(workspace_version), None) => workspace_version,
             (None, Some(package_version)) => package_version,
             (None, None) => DEFAULT_PLATFORM_TOOLS_VERSION,
@@ -351,7 +366,7 @@ pub(crate) fn install_tools(
                     exit(1);
                 });
             }
-            error!("Failed to install platform-tools: {}", err);
+            error!("Failed to install platform-tools: {err}");
             exit(1);
         });
     }
@@ -367,7 +382,8 @@ pub(crate) fn install_tools(
         // this by removing RUSTC from the child process environment.
         if env::var("RUSTC").is_ok() {
             warn!(
-                "Removed RUSTC from cargo environment, because it overrides +solana cargo command line option."
+                "Removed RUSTC from cargo environment, because it overrides +solana cargo command \
+                 line option."
             );
             env::remove_var("RUSTC")
         }
@@ -380,7 +396,10 @@ fn check_solana_target_installed(target: &str) {
     let rustc = PathBuf::from(rustc);
     let output = spawn(&rustc, ["--print", "target-list"], false);
     if !output.contains(target) {
-        error!("Provided {:?} does not have {} target. The Solana rustc must be available in $PATH or the $RUSTC environment variable for the build to succeed.", rustc, target);
+        error!(
+            "Provided {rustc:?} does not have {target} target. The Solana rustc must be available \
+             in $PATH or the $RUSTC environment variable for the build to succeed."
+        );
         exit(1);
     }
 }

--- a/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/toolchain.rs
@@ -74,7 +74,7 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
     let latest_version = get_latest_platform_tools_version().unwrap_or_else(|err| {
         debug!(
             "Can't get the latest version of platform-tools: {err}. Using built-in version \
-             {builtin_version}.",
+             {builtin_version}."
         );
         builtin_version.to_string()
     });
@@ -85,7 +85,7 @@ fn validate_platform_tools_version(requested_version: &str, builtin_version: &st
     } else {
         warn!(
             "Version {requested_version} is not valid, latest version is {latest_version}. Using \
-             the built-in version {builtin_version}",
+             the built-in version {builtin_version}"
         );
         builtin_version.to_string()
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -22,7 +22,7 @@ where
         .iter()
         .map(|arg| arg.as_ref().to_str().unwrap_or("?"))
         .join(" ");
-    info!("spawn: {:?} {}", program, msg);
+    info!("spawn: {program:?} {msg}");
 
     let child = Command::new(program)
         .args(args)
@@ -49,11 +49,10 @@ where
             writeln!(out, "{key}=\"{value}\" \\").unwrap();
         }
         write!(out, "{}", program.display()).unwrap();
-        writeln!(out, "{}", msg).unwrap();
+        writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
         error!(
-            "To rerun the failed command for debugging use {}",
-            script_name,
+            "To rerun the failed command for debugging use {script_name}",
         );
         exit(1);
     }

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -51,9 +51,7 @@ where
         write!(out, "{}", program.display()).unwrap();
         writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
-        error!(
-            "To rerun the failed command for debugging use {script_name}",
-        );
+        error!("To rerun the failed command for debugging use {script_name}");
         exit(1);
     }
     output

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -95,9 +95,7 @@ where
         write!(out, "{}", program.display()).unwrap();
         writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
-        error!(
-            "To rerun the failed command for debugging use {script_name}",
-        );
+        error!("To rerun the failed command for debugging use {script_name}");
         exit(1);
     }
 }

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -67,7 +67,7 @@ where
         .iter()
         .map(|arg| arg.as_ref().to_str().unwrap_or("?"))
         .join(" ");
-    info!("spawn: {}", msg);
+    info!("spawn: {msg}");
 
     let mut child = Command::new(program)
         .args(args)
@@ -93,11 +93,10 @@ where
             writeln!(out, "{key}=\"{value}\" \\").unwrap();
         }
         write!(out, "{}", program.display()).unwrap();
-        writeln!(out, "{}", msg).unwrap();
+        writeln!(out, "{msg}").unwrap();
         out.flush().unwrap();
         error!(
-            "To rerun the failed command for debugging use {}",
-            script_name,
+            "To rerun the failed command for debugging use {script_name}",
         );
         exit(1);
     }
@@ -219,7 +218,7 @@ fn test_solana(config: Config, manifest_path: Option<PathBuf>) {
     }
 
     let metadata = metadata_command.exec().unwrap_or_else(|err| {
-        error!("Failed to obtain package metadata: {}", err);
+        error!("Failed to obtain package metadata: {err}");
         exit(1);
     });
 

--- a/platform-tools-sdk/cargo-test-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-test-sbf/src/main.rs
@@ -105,7 +105,11 @@ pub fn is_version_string(arg: &str) -> Result<(), String> {
     if semver_re.is_match(arg) {
         return Ok(());
     }
-    Err("a version string may start with 'v' and contains major and minor version numbers separated by a dot, e.g. v1.32 or 1.32".to_string())
+    Err(
+        "a version string may start with 'v' and contains major and minor version numbers \
+         separated by a dot, e.g. v1.32 or 1.32"
+            .to_string(),
+    )
 }
 
 fn test_solana_package(

--- a/platform-tools-sdk/gen-headers/src/main.rs
+++ b/platform-tools-sdk/gen-headers/src/main.rs
@@ -82,7 +82,11 @@ fn transform(inc: &PathBuf) {
         let ty = &caps[1].to_string();
         let func = &caps[2].to_string();
         let args = &caps[3].to_string();
-        let warn = format!("/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE {} AND RUN `cargo run --bin gen-headers` */", inc.display());
+        let warn = format!(
+            "/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE {} AND RUN `cargo run --bin \
+             gen-headers` */",
+            inc.display()
+        );
         let ifndef = format!("#ifndef SOL_SBPFV3\n{ty} {func}({args});");
         let hash = sys_hash(func);
         let typedef_statement = format!("typedef {ty}(*{func}_pointer_type)({args});");
@@ -99,9 +103,8 @@ fn transform(inc: &PathBuf) {
             arg_list = format!("{arg_list} arg{arg}");
         }
         let function_signature = format!("static {ty} {func}({arg_list})");
-        let pointer_assignment = format!(
-            "{func}_pointer_type {func}_pointer = ({func}_pointer_type) {hash};"
-        );
+        let pointer_assignment =
+            format!("{func}_pointer_type {func}_pointer = ({func}_pointer_type) {hash};");
         if !args.is_empty() {
             arg_list = "arg1".to_string();
             for a in 2..arg + 1 {
@@ -114,7 +117,8 @@ fn transform(inc: &PathBuf) {
             format!("return {func}_pointer({arg_list});")
         };
         format!(
-            "{warn}\n{ifndef}\n#else\n{typedef_statement}\n{function_signature} {{\n  {pointer_assignment}\n  {return_statement}\n}}\n#endif",
+            "{warn}\n{ifndef}\n#else\n{typedef_statement}\n{function_signature} {{\n  \
+             {pointer_assignment}\n  {return_statement}\n}}\n#endif",
         )
     });
     write!(output_writer, "{output_content}").unwrap();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -243,9 +243,11 @@ impl ProgramCacheStats {
         let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         let water_level = self.water_level.load(Ordering::Relaxed);
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {hits}, Misses: {misses}, Evictions: {evictions}, Reloads: {reloads}, \
-             Insertions: {insertions}, Lost-Insertions: {lost_insertions}, Replacements: {replacements}, One-Hit-Wonders: {one_hit_wonders}, \
-             Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: {empty_entries}, Water-Level: {water_level}"
+            "Loaded Programs Cache Stats -- Hits: {hits}, Misses: {misses}, Evictions: \
+             {evictions}, Reloads: {reloads}, Insertions: {insertions}, Lost-Insertions: \
+             {lost_insertions}, Replacements: {replacements}, One-Hit-Wonders: {one_hit_wonders}, \
+             Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: \
+             {empty_entries}, Water-Level: {water_level}"
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
@@ -904,8 +906,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             _ => {
                                 // Something is wrong, I can feel it ...
                                 error!(
-                                    "ProgramCache::assign_program() failed key={key:?} existing={slot_versions:?} \
-                                     entry={entry:?}"
+                                    "ProgramCache::assign_program() failed key={key:?} \
+                                     existing={slot_versions:?} entry={entry:?}"
                                 );
                                 debug_assert!(false, "Unexpected replacement of an entry");
                                 self.stats.replacements.fetch_add(1, Ordering::Relaxed);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -243,21 +243,9 @@ impl ProgramCacheStats {
         let empty_entries = self.empty_entries.load(Ordering::Relaxed);
         let water_level = self.water_level.load(Ordering::Relaxed);
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Reloads: {}, \
-             Insertions: {}, Lost-Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, \
-             Prunes-Orphan: {}, Prunes-Environment: {}, Empty: {}, Water-Level: {}",
-            hits,
-            misses,
-            evictions,
-            reloads,
-            insertions,
-            lost_insertions,
-            replacements,
-            one_hit_wonders,
-            prunes_orphan,
-            prunes_environment,
-            empty_entries,
-            water_level
+            "Loaded Programs Cache Stats -- Hits: {hits}, Misses: {misses}, Evictions: {evictions}, Reloads: {reloads}, \
+             Insertions: {insertions}, Lost-Insertions: {lost_insertions}, Replacements: {replacements}, One-Hit-Wonders: {one_hit_wonders}, \
+             Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: {empty_entries}, Water-Level: {water_level}"
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();
@@ -916,9 +904,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             _ => {
                                 // Something is wrong, I can feel it ...
                                 error!(
-                                    "ProgramCache::assign_program() failed key={:?} existing={:?} \
-                                     entry={:?}",
-                                    key, slot_versions, entry
+                                    "ProgramCache::assign_program() failed key={key:?} existing={slot_versions:?} \
+                                     entry={entry:?}"
                                 );
                                 debug_assert!(false, "Unexpected replacement of an entry");
                                 self.stats.replacements.fetch_add(1, Ordering::Relaxed);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -458,7 +458,7 @@ fn default_shared_object_dirs() -> Vec<PathBuf> {
     if let Ok(dir) = std::env::current_dir() {
         search_path.push(dir);
     }
-    trace!("SBF .so search path: {:?}", search_path);
+    trace!("SBF .so search path: {search_path:?}");
     search_path
 }
 
@@ -719,9 +719,8 @@ impl ProgramTest {
             }
 
             warn!(
-                "Possible bogus program name. Ensure the program name ({}) \
+                "Possible bogus program name. Ensure the program name ({program_name}) \
                 matches one of the following recognizable program names:",
-                program_name,
             );
             for name in valid_program_names {
                 warn!(" - {}", name.to_str().unwrap());
@@ -762,7 +761,7 @@ impl ProgramTest {
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
     ) {
-        info!("\"{}\" builtin program", program_name);
+        info!("\"{program_name}\" builtin program");
         self.builtin_programs.push((
             program_id,
             program_name,
@@ -825,16 +824,14 @@ impl ProgramTest {
         for deactivate_feature_pk in &self.deactivate_feature_set {
             if FEATURE_NAMES.contains_key(deactivate_feature_pk) {
                 match genesis_config.accounts.remove(deactivate_feature_pk) {
-                    Some(_) => debug!("Feature for {:?} deactivated", deactivate_feature_pk),
+                    Some(_) => debug!("Feature for {deactivate_feature_pk:?} deactivated"),
                     None => warn!(
-                        "Feature {:?} set for deactivation not found in genesis_config account list, ignored.",
-                        deactivate_feature_pk
+                        "Feature {deactivate_feature_pk:?} set for deactivation not found in genesis_config account list, ignored."
                     ),
                 }
             } else {
                 warn!(
-                    "Feature {:?} set for deactivation is not a known Feature public key",
-                    deactivate_feature_pk
+                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
                 );
             }
         }
@@ -842,7 +839,7 @@ impl ProgramTest {
         let target_tick_duration = Duration::from_micros(100);
         genesis_config.poh_config = PohConfig::new_sleep(target_tick_duration);
         debug!("Payer address: {}", mint_keypair.pubkey());
-        debug!("Genesis config: {}", genesis_config);
+        debug!("Genesis config: {genesis_config}");
 
         let bank = Bank::new_with_paths(
             &genesis_config,
@@ -889,7 +886,7 @@ impl ProgramTest {
 
         for (address, account) in self.accounts.iter() {
             if bank.get_account(address).is_some() {
-                info!("Overriding account at {}", address);
+                info!("Overriding account at {address}");
             }
             bank.store_account(address, account);
         }
@@ -996,7 +993,7 @@ impl ProgramTestBanksClientExt for BanksClient {
             if new_blockhash != *blockhash {
                 return Ok(new_blockhash);
             }
-            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            debug!("Got same blockhash ({blockhash:?}), will retry...");
 
             tokio::time::sleep(Duration::from_millis(200)).await;
             num_retries += 1;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -498,10 +498,8 @@ impl Default for ProgramTest {
     ///
     fn default() -> Self {
         solana_logger::setup_with_default(
-            "solana_sbpf::vm=debug,\
-             solana_runtime::message_processor=debug,\
-             solana_runtime::system_instruction_processor=trace,\
-             solana_program_test=info",
+            "solana_sbpf::vm=debug,solana_runtime::message_processor=debug,\
+             solana_runtime::system_instruction_processor=trace,solana_program_test=info",
         );
         let prefer_bpf =
             std::env::var("BPF_OUT_DIR").is_ok() || std::env::var("SBF_OUT_DIR").is_ok();
@@ -719,8 +717,8 @@ impl ProgramTest {
             }
 
             warn!(
-                "Possible bogus program name. Ensure the program name ({program_name}) \
-                matches one of the following recognizable program names:",
+                "Possible bogus program name. Ensure the program name ({program_name}) matches \
+                 one of the following recognizable program names:",
             );
             for name in valid_program_names {
                 warn!(" - {}", name.to_str().unwrap());
@@ -826,12 +824,14 @@ impl ProgramTest {
                 match genesis_config.accounts.remove(deactivate_feature_pk) {
                     Some(_) => debug!("Feature for {deactivate_feature_pk:?} deactivated"),
                     None => warn!(
-                        "Feature {deactivate_feature_pk:?} set for deactivation not found in genesis_config account list, ignored."
+                        "Feature {deactivate_feature_pk:?} set for deactivation not found in \
+                         genesis_config account list, ignored."
                     ),
                 }
             } else {
                 warn!(
-                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
+                    "Feature {deactivate_feature_pk:?} set for deactivation is not a known \
+                     Feature public key"
                 );
             }
         }

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -240,7 +240,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         program_test.add_account(stake_pubkey, stake_account);
         to_filter.push(stake_pubkey);
         if i % 100 == 0 {
-            debug!("create stake account {} {}", i, stake_pubkey);
+            debug!("create stake account {i} {stake_pubkey}");
         }
     }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1088,7 +1088,7 @@ mod tests {
                     TransactionError::ProgramAccountNotFound,
                 );
             }
-            result => panic!("unexpected result: {:?}", result),
+            result => panic!("unexpected result: {result:?}"),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1065,14 +1065,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         name: &str,
         builtin: ProgramCacheEntry,
     ) {
-        debug!("Adding program {} under {:?}", name, program_id);
+        debug!("Adding program {name} under {program_id:?}");
         callbacks.add_builtin_account(name, &program_id);
         self.builtin_program_ids.write().unwrap().insert(program_id);
         self.program_cache
             .write()
             .unwrap()
             .assign_program(program_id, Arc::new(builtin));
-        debug!("Added program {} under {:?}", name, program_id);
+        debug!("Added program {name} under {program_id:?}");
     }
 
     #[cfg(feature = "dev-context-only-utils")]

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -405,14 +405,12 @@ fn execute_fixture_as_instr(
     if output.result == 0 {
         assert!(
             result.is_ok(),
-            "Instruction execution was NOT successful, but should have been: {:?}",
-            filename
+            "Instruction execution was NOT successful, but should have been: {filename:?}"
         );
     } else {
         assert!(
             result.is_err(),
-            "Instruction execution was successful, but should NOT have been: {:?}",
-            filename
+            "Instruction execution was successful, but should NOT have been: {filename:?}"
         );
         return;
     }
@@ -484,8 +482,7 @@ fn verify_accounts_and_data(
     assert_eq!(
         consumed_units,
         cu_avail.saturating_sub(output.cu_avail),
-        "Execution units differs in case: {:?}",
-        filename
+        "Execution units differs in case: {filename:?}"
     );
 
     if return_data.is_empty() {
@@ -508,14 +505,14 @@ fn check_account(
 
     if received.lamports() != expected.lamports {
         return Some(
-            format!("Lamports differ in case: {:?}\n", filename)
+            format!("Lamports differ in case: {filename:?}\n")
                 + format_args!(received.lamports(), expected.lamports),
         );
     }
 
     if received.data() != expected.data.as_slice() {
         return Some(
-            format!("Account data differs in case: {:?}\n", filename)
+            format!("Account data differs in case: {filename:?}\n")
                 + format_args!(received.data(), expected.data.as_slice()),
         );
     }
@@ -523,14 +520,14 @@ fn check_account(
     let expected_owner = Pubkey::new_from_array(expected.owner.clone().try_into().unwrap());
     if received.owner() != &expected_owner {
         return Some(
-            format!("Account owner differs in case: {:?}\n", filename)
+            format!("Account owner differs in case: {filename:?}\n")
                 + format_args!(received.owner(), expected_owner),
         );
     }
 
     if received.executable() != expected.executable {
         return Some(
-            format!("Executable boolean differs in case: {:?}\n", filename)
+            format!("Executable boolean differs in case: {filename:?}\n")
                 + format_args!(received.executable(), expected.executable),
         );
     }
@@ -541,7 +538,7 @@ fn check_account(
         && received.rent_epoch() != expected.rent_epoch
     {
         return Some(
-            format!("Rent epoch differs in case: {:?}\n", filename)
+            format!("Rent epoch differs in case: {filename:?}\n")
                 + format_args!(received.rent_epoch(), expected.rent_epoch),
         );
     }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -213,7 +213,7 @@ impl SvmTestEnvironment<'_> {
                     Ok(ProcessedTransaction::FeesOnly(fee_only)) => {
                         format!("{} (fee-only): {:?}", i, fee_only.load_error)
                     }
-                    Err(e) => format!("{} (discarded): {:?}", i, e),
+                    Err(e) => format!("{i} (discarded): {e:?}"),
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -225,8 +225,7 @@ impl SvmTestEnvironment<'_> {
             assert_eq!(
                 Some(expected_account_data),
                 actual_account_data,
-                "mismatch on account {}",
-                pubkey
+                "mismatch on account {pubkey}"
             );
         }
 
@@ -2236,7 +2235,7 @@ fn simd83_account_reallocate(formalize_loaded_transaction_data_size: bool) -> Ve
         test_entry.transaction_batch[1]
             .asserts
             .logs
-            .push(format!("Program log: account size {}", new_target_size));
+            .push(format!("Program log: account size {new_target_size}"));
 
         test_entry.update_expected_account_data(target, &mk_target(new_target_size));
 


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
1. Set the Rust version to 1.88.0 (only temporarily, reverted after)
https://github.com/anza-xyz/agave/blob/96bef97b8077a97dc994f8a8a95d2dd27cd3eef9/rust-toolchain.toml#L2
2. Run `cargo clippy --fix --tests`
3. Some manual cleanup on modified files