### PR TITLE
clippy: manual_dangling_ptr

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2288,7 +2288,7 @@ mod tests {
         // zero len
         let good_data = vec![1u8, 2, 3, 4, 5];
         let data: Vec<u8> = vec![];
-        assert_eq!(0x1 as *const u8, data.as_ptr());
+        assert_eq!(std::ptr::dangling::<u8>(), data.as_ptr());
         let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(&good_data, 0x100000000)],
             &config,


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6910

#### Summary of Changes
Avoid the instance of `manual_dangling_ptr`; this lint was added in Rust `1.88`:
https://rust-lang.github.io/rust-clippy/master/index.html#manual_dangling_ptr
