### PR TITLE
[mergify] add notification for ZK directory changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -217,6 +217,20 @@ pull_request_rules:
           If this PR represents a change to a native program implementation (not
           tests), please include a reviewer from the Firedancer team. And please
           keep refactors to a minimum.
+  - name: Notify about future move of zk-keygen, zk-sdk, and zk-token-sdk
+    conditions:
+      - or:
+        - files~=^zk-keygen/
+        - files~=^zk-sdk/
+        - files~=^zk-token-sdk/
+    actions:
+      comment:
+        message: |
+          For your information, the `zk-keygen` and `zk-sdk` directories are
+          scheduled to be relocated to `solana-program/zk-elgamal-proof` in a
+          separate repository. Additionally, the `zk-token-sdk` directory will
+          be removed. Please take these upcoming changes into account when
+          making modifications.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.


### PR DESCRIPTION
#### Problem
As per discussion in https://discord.com/channels/428295358100013066/560503042458517505/1392793665583185970, the zk-sdk, zk-token-sdk, and the zk-keygen cli is going to be either deleted or moved to `solana-program/zk-elgamal-proof` repository.

The `zk-sdk` is now added to `solana-program/zk-elgamal-proof`, but cleaning things up and publishing the zk-sdk crate could take a couple of days. Moving and deleting `zk-keygen` and `zk-token-sdk` could also take some time.

#### Summary of Changes
Update mergify to provide a notification regarding the move on PRs that make changes to any of these directories.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
