### PR TITLE
agave-validator: add args tests for run (part 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "spl-token-2022",
  "symlink",
  "tempfile",
+ "test-case",
  "thiserror 2.0.12",
  "tikv-jemallocator",
  "tokio",

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -7,7 +7,7 @@ use {
 /// The subdirectory under ledger directory where the Blockstore lives
 pub const BLOCKSTORE_DIRECTORY_ROCKS_LEVEL: &str = "rocksdb";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BlockstoreOptions {
     // The access type of blockstore. Default: Primary
     pub access_type: AccessType,
@@ -59,7 +59,7 @@ pub enum AccessType {
     Secondary,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BlockstoreRecoveryMode {
     TolerateCorruptedTailRecords,
     AbsoluteConsistency,
@@ -99,7 +99,7 @@ impl From<BlockstoreRecoveryMode> for DBRecoveryMode {
 /// Options for LedgerColumn.
 /// Each field might also be used as a tag that supports group-by operation when
 /// reporting metrics.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LedgerColumnOptions {
     // Determine the way to compress column families which are eligible for
     // compression.
@@ -122,7 +122,7 @@ impl LedgerColumnOptions {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BlockstoreCompressionType {
     None,
     Snappy,

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -106,3 +106,4 @@ solana-time-utils = { workspace = true }
 spl-generic-token = { workspace = true }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tempfile = { workspace = true }
+test-case = { workspace = true }

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -102,8 +102,6 @@ pub struct NumThreadConfig {
     pub rayon_global_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
-    pub rocksdb_compaction_threads: NonZeroUsize,
-    pub rocksdb_flush_threads: NonZeroUsize,
     pub tpu_transaction_forward_receive_threads: NonZeroUsize,
     pub tpu_transaction_receive_threads: NonZeroUsize,
     pub tpu_vote_transaction_receive_threads: NonZeroUsize,
@@ -146,16 +144,6 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
             ReplayTransactionsThreadsArg::NAME,
             NonZeroUsize
         ),
-        rocksdb_compaction_threads: value_t_or_exit!(
-            matches,
-            RocksdbCompactionThreadsArg::NAME,
-            NonZeroUsize
-        ),
-        rocksdb_flush_threads: value_t_or_exit!(
-            matches,
-            RocksdbFlushThreadsArg::NAME,
-            NonZeroUsize
-        ),
         tpu_transaction_forward_receive_threads: value_t_or_exit!(
             matches,
             TpuTransactionForwardReceiveThreadArgs::NAME,
@@ -186,7 +174,7 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
 }
 
 /// Configuration for CLAP arguments that control the number of threads for various functions
-trait ThreadArg {
+pub trait ThreadArg {
     /// The argument's name
     const NAME: &'static str;
     /// The argument's long name
@@ -314,7 +302,7 @@ impl ThreadArg for ReplayTransactionsThreadsArg {
     }
 }
 
-struct RocksdbCompactionThreadsArg;
+pub struct RocksdbCompactionThreadsArg;
 impl ThreadArg for RocksdbCompactionThreadsArg {
     const NAME: &'static str = "rocksdb_compaction_threads";
     const LONG_NAME: &'static str = "rocksdb-compaction-threads";
@@ -325,7 +313,7 @@ impl ThreadArg for RocksdbCompactionThreadsArg {
     }
 }
 
-struct RocksdbFlushThreadsArg;
+pub struct RocksdbFlushThreadsArg;
 impl ThreadArg for RocksdbFlushThreadsArg {
     const NAME: &'static str = "rocksdb_flush_threads";
     const LONG_NAME: &'static str = "rocksdb-flush-threads";

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1768,10 +1768,7 @@ mod tests {
     use {
         super::*,
         crate::cli::thread_args::thread_args,
-        std::{
-            net::{IpAddr, Ipv4Addr},
-            num::NonZeroUsize,
-        },
+        std::net::{IpAddr, Ipv4Addr},
     };
 
     impl Default for RunArgs {
@@ -2315,46 +2312,6 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--no-incremental-snapshots"],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
-    fn verify_args_struct_by_command_run_with_rocksdb_compaction_threads() {
-        // long arg
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    num_rocksdb_compaction_threads: NonZeroUsize::new(1).unwrap(),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-compaction-threads", "1"],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
-    fn verify_args_struct_by_command_run_with_rocksdb_flush_threads() {
-        // long arg
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    num_rocksdb_flush_threads: NonZeroUsize::new(1).unwrap(),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-flush-threads", "1"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1872,6 +1872,32 @@ mod tests {
         verify_args_struct_by_command(&default_args, args, expected_args);
     }
 
+    pub fn verify_args_struct_by_command_run_is_error_with_identity_setup(
+        default_run_args: RunArgs,
+        args: Vec<&str>,
+    ) {
+        let default_args = DefaultArgs::default();
+
+        // generate a keypair
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file = tmp_dir.path().join("id.json");
+        let keypair = default_run_args.identity_keypair.insecure_clone();
+        solana_keypair::write_keypair_file(&keypair, &file).unwrap();
+
+        let app = add_args(App::new("run_command"), &default_args)
+            .args(&thread_args(&default_args.thread_args));
+
+        crate::commands::tests::verify_args_struct_by_command_is_error::<RunArgs>(
+            app,
+            [
+                &["run_command"],
+                &["--identity", file.to_str().unwrap()][..],
+                &args[..],
+            ]
+            .concat(),
+        );
+    }
+
     #[test]
     fn verify_args_struct_by_command_run_with_log() {
         let default_run_args = RunArgs::default();

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -21,7 +21,7 @@ use {
         validator::{BlockProductionMethod, BlockVerificationMethod, TransactionStructure},
     },
     solana_keypair::Keypair,
-    solana_ledger::use_snapshot_archives_at_startup,
+    solana_ledger::{blockstore_options::BlockstoreOptions, use_snapshot_archives_at_startup},
     solana_pubkey::Pubkey,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
     solana_send_transaction_service::send_transaction_service::{
@@ -35,6 +35,7 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
+pub mod blockstore_options;
 pub mod rpc_bootstrap_config;
 
 #[derive(Debug, PartialEq)]
@@ -44,6 +45,7 @@ pub struct RunArgs {
     pub entrypoints: Vec<SocketAddr>,
     pub known_validators: Option<HashSet<Pubkey>>,
     pub rpc_bootstrap_config: RpcBootstrapConfig,
+    pub blockstore_options: BlockstoreOptions,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -87,6 +89,7 @@ impl FromClapArgMatches for RunArgs {
             entrypoints,
             known_validators,
             rpc_bootstrap_config: RpcBootstrapConfig::from_clap_arg_match(matches)?,
+            blockstore_options: BlockstoreOptions::from_clap_arg_match(matches)?,
         })
     }
 }
@@ -1764,7 +1767,11 @@ fn validators_set(
 mod tests {
     use {
         super::*,
-        std::net::{IpAddr, Ipv4Addr},
+        crate::cli::thread_args::thread_args,
+        std::{
+            net::{IpAddr, Ipv4Addr},
+            num::NonZeroUsize,
+        },
     };
 
     impl Default for RunArgs {
@@ -1780,6 +1787,7 @@ mod tests {
                 entrypoints,
                 known_validators,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
+                blockstore_options: BlockstoreOptions::default(),
             }
         }
     }
@@ -1792,6 +1800,7 @@ mod tests {
                 entrypoints: self.entrypoints.clone(),
                 known_validators: self.known_validators.clone(),
                 rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
+                blockstore_options: self.blockstore_options.clone(),
             }
         }
     }
@@ -1801,8 +1810,11 @@ mod tests {
         args: Vec<&str>,
         expected_args: RunArgs,
     ) {
+        let app = add_args(App::new("run_command"), default_args)
+            .args(&thread_args(&default_args.thread_args));
+
         crate::commands::tests::verify_args_struct_by_command::<RunArgs>(
-            add_args(App::new("run_command"), default_args),
+            app,
             [&["run_command"], &args[..]].concat(),
             expected_args,
         );
@@ -1843,7 +1855,7 @@ mod tests {
         }
     }
 
-    fn verify_args_struct_by_command_run_with_identity_setup(
+    pub fn verify_args_struct_by_command_run_with_identity_setup(
         default_run_args: RunArgs,
         args: Vec<&str>,
         expected_args: RunArgs,
@@ -2277,6 +2289,46 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--no-incremental-snapshots"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_compaction_threads() {
+        // long arg
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    num_rocksdb_compaction_threads: NonZeroUsize::new(1).unwrap(),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-compaction-threads", "1"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_flush_threads() {
+        // long arg
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    num_rocksdb_flush_threads: NonZeroUsize::new(1).unwrap(),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-flush-threads", "1"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -1,0 +1,255 @@
+use {
+    crate::{
+        cli::thread_args::{RocksdbCompactionThreadsArg, RocksdbFlushThreadsArg, ThreadArg},
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{value_t, ArgMatches},
+    solana_ledger::blockstore_options::{
+        AccessType, BlockstoreCompressionType, BlockstoreOptions, BlockstoreRecoveryMode,
+        LedgerColumnOptions,
+    },
+    std::num::NonZeroUsize,
+};
+
+impl FromClapArgMatches for BlockstoreOptions {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let recovery_mode = matches
+            .value_of("wal_recovery_mode")
+            .map(BlockstoreRecoveryMode::from);
+
+        let column_options = LedgerColumnOptions {
+            compression_type: match matches.value_of("rocksdb_ledger_compression") {
+                None => BlockstoreCompressionType::default(),
+                Some(ledger_compression_string) => match ledger_compression_string {
+                    "none" => BlockstoreCompressionType::None,
+                    "snappy" => BlockstoreCompressionType::Snappy,
+                    "lz4" => BlockstoreCompressionType::Lz4,
+                    "zlib" => BlockstoreCompressionType::Zlib,
+                    _ => {
+                        return Err(crate::commands::Error::Dynamic(
+                            Box::<dyn std::error::Error>::from(format!(
+                                "Unsupported ledger_compression: {ledger_compression_string}"
+                            )),
+                        ));
+                    }
+                },
+            },
+            rocks_perf_sample_interval: value_t!(matches, "rocksdb_perf_sample_interval", usize)
+                .map_err(|err| {
+                    Box::<dyn std::error::Error>::from(format!(
+                        "failed to parse rocksdb_perf_sample_interval: {err}"
+                    ))
+                })?,
+        };
+
+        let rocksdb_compaction_threads =
+            value_t!(matches, RocksdbCompactionThreadsArg::NAME, NonZeroUsize).map_err(|err| {
+                Box::<dyn std::error::Error>::from(format!(
+                    "failed to parse rocksdb_compaction_threads: {err}"
+                ))
+            })?;
+
+        let rocksdb_flush_threads = value_t!(matches, RocksdbFlushThreadsArg::NAME, NonZeroUsize)
+            .map_err(|err| {
+            Box::<dyn std::error::Error>::from(format!(
+                "failed to parse rocksdb_flush_threads: {err}"
+            ))
+        })?;
+
+        Ok(BlockstoreOptions {
+            recovery_mode,
+            column_options,
+            // The validator needs to open many files, check that the process has
+            // permission to do so in order to fail quickly and give a direct error
+            enforce_ulimit_nofile: true,
+            // The validator needs primary (read/write)
+            access_type: AccessType::Primary,
+            num_rocksdb_compaction_threads: rocksdb_compaction_threads,
+            num_rocksdb_flush_threads: rocksdb_flush_threads,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_wal_recovery_mode() {
+        // tolerate_corrupted_tail_records
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    recovery_mode: Some(BlockstoreRecoveryMode::TolerateCorruptedTailRecords),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--wal-recovery-mode", "tolerate_corrupted_tail_records"],
+                expected_args,
+            );
+        }
+
+        // absolute_consistency
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    recovery_mode: Some(BlockstoreRecoveryMode::AbsoluteConsistency),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--wal-recovery-mode", "absolute_consistency"],
+                expected_args,
+            );
+        }
+
+        // point_in_time
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    recovery_mode: Some(BlockstoreRecoveryMode::PointInTime),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--wal-recovery-mode", "point_in_time"],
+                expected_args,
+            );
+        }
+
+        // skip_any_corrupted_record
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    recovery_mode: Some(BlockstoreRecoveryMode::SkipAnyCorruptedRecord),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--wal-recovery-mode", "skip_any_corrupted_record"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression() {
+        // none
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    column_options: LedgerColumnOptions {
+                        compression_type: BlockstoreCompressionType::None,
+                        ..default_run_args.blockstore_options.column_options.clone()
+                    },
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-ledger-compression", "none"],
+                expected_args,
+            );
+        }
+
+        // snappy
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    column_options: LedgerColumnOptions {
+                        compression_type: BlockstoreCompressionType::Snappy,
+                        ..default_run_args.blockstore_options.column_options.clone()
+                    },
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-ledger-compression", "snappy"],
+                expected_args,
+            );
+        }
+
+        // lz4
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    column_options: LedgerColumnOptions {
+                        compression_type: BlockstoreCompressionType::Lz4,
+                        ..default_run_args.blockstore_options.column_options.clone()
+                    },
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-ledger-compression", "lz4"],
+                expected_args,
+            );
+        }
+
+        // zlib
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    column_options: LedgerColumnOptions {
+                        compression_type: BlockstoreCompressionType::Zlib,
+                        ..default_run_args.blockstore_options.column_options.clone()
+                    },
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-ledger-compression", "zlib"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_perf_sample_interval() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            blockstore_options: BlockstoreOptions {
+                column_options: LedgerColumnOptions {
+                    rocks_perf_sample_interval: 100,
+                    ..default_run_args.blockstore_options.column_options.clone()
+                },
+                ..default_run_args.blockstore_options.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rocksdb-perf-sample-interval", "100"],
+            expected_args,
+        );
+    }
+}

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -61,7 +61,11 @@ mod tests {
     use {
         super::*,
         crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            tests::{
+                verify_args_struct_by_command_run_is_error_with_identity_setup,
+                verify_args_struct_by_command_run_with_identity_setup,
+            },
+            RunArgs,
         },
     };
 
@@ -215,6 +219,15 @@ mod tests {
                 default_run_args,
                 vec!["--rocksdb-ledger-compression", "zlib"],
                 expected_args,
+            );
+        }
+
+        // invalid
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            verify_args_struct_by_command_run_is_error_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-ledger-compression", "invalid"],
             );
         }
     }

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -100,6 +100,15 @@ mod tests {
     }
 
     #[test]
+    fn verify_args_struct_by_command_run_with_wal_recovery_mode_invalid() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        verify_args_struct_by_command_run_is_error_with_identity_setup(
+            default_run_args,
+            vec!["--wal-recovery-mode", "invalid"],
+        );
+    }
+
+    #[test]
     fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression() {
         // none
         {

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -34,27 +34,13 @@ impl FromClapArgMatches for BlockstoreOptions {
                     }
                 },
             },
-            rocks_perf_sample_interval: value_t!(matches, "rocksdb_perf_sample_interval", usize)
-                .map_err(|err| {
-                    Box::<dyn std::error::Error>::from(format!(
-                        "failed to parse rocksdb_perf_sample_interval: {err}"
-                    ))
-                })?,
+            rocks_perf_sample_interval: value_t!(matches, "rocksdb_perf_sample_interval", usize)?,
         };
 
         let rocksdb_compaction_threads =
-            value_t!(matches, RocksdbCompactionThreadsArg::NAME, NonZeroUsize).map_err(|err| {
-                Box::<dyn std::error::Error>::from(format!(
-                    "failed to parse rocksdb_compaction_threads: {err}"
-                ))
-            })?;
+            value_t!(matches, RocksdbCompactionThreadsArg::NAME, NonZeroUsize)?;
 
-        let rocksdb_flush_threads = value_t!(matches, RocksdbFlushThreadsArg::NAME, NonZeroUsize)
-            .map_err(|err| {
-            Box::<dyn std::error::Error>::from(format!(
-                "failed to parse rocksdb_flush_threads: {err}"
-            ))
-        })?;
+        let rocksdb_flush_threads = value_t!(matches, RocksdbFlushThreadsArg::NAME, NonZeroUsize)?;
 
         Ok(BlockstoreOptions {
             recovery_mode,

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -108,96 +108,39 @@ mod tests {
         );
     }
 
+    #[test_case("none", BlockstoreCompressionType::None)]
+    #[test_case("snappy", BlockstoreCompressionType::Snappy)]
+    #[test_case("lz4", BlockstoreCompressionType::Lz4)]
+    #[test_case("zlib", BlockstoreCompressionType::Zlib)]
+    fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression(
+        arg_value: &str,
+        expected_compression: BlockstoreCompressionType,
+    ) {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            blockstore_options: BlockstoreOptions {
+                column_options: LedgerColumnOptions {
+                    compression_type: expected_compression,
+                    ..default_run_args.blockstore_options.column_options.clone()
+                },
+                ..default_run_args.blockstore_options.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--rocksdb-ledger-compression", arg_value],
+            expected_args,
+        );
+    }
+
     #[test]
-    fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression() {
-        // none
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    column_options: LedgerColumnOptions {
-                        compression_type: BlockstoreCompressionType::None,
-                        ..default_run_args.blockstore_options.column_options.clone()
-                    },
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-ledger-compression", "none"],
-                expected_args,
-            );
-        }
-
-        // snappy
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    column_options: LedgerColumnOptions {
-                        compression_type: BlockstoreCompressionType::Snappy,
-                        ..default_run_args.blockstore_options.column_options.clone()
-                    },
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-ledger-compression", "snappy"],
-                expected_args,
-            );
-        }
-
-        // lz4
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    column_options: LedgerColumnOptions {
-                        compression_type: BlockstoreCompressionType::Lz4,
-                        ..default_run_args.blockstore_options.column_options.clone()
-                    },
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-ledger-compression", "lz4"],
-                expected_args,
-            );
-        }
-
-        // zlib
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    column_options: LedgerColumnOptions {
-                        compression_type: BlockstoreCompressionType::Zlib,
-                        ..default_run_args.blockstore_options.column_options.clone()
-                    },
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-ledger-compression", "zlib"],
-                expected_args,
-            );
-        }
-
-        // invalid
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            verify_args_struct_by_command_run_is_error_with_identity_setup(
-                default_run_args,
-                vec!["--rocksdb-ledger-compression", "invalid"],
-            );
-        }
+    fn verify_args_struct_by_command_run_with_rocksdb_ledger_compression_invalid() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        verify_args_struct_by_command_run_is_error_with_identity_setup(
+            default_run_args,
+            vec!["--rocksdb-ledger-compression", "invalid"],
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -67,77 +67,36 @@ mod tests {
             },
             RunArgs,
         },
+        test_case::test_case,
     };
 
-    #[test]
-    fn verify_args_struct_by_command_run_with_wal_recovery_mode() {
-        // tolerate_corrupted_tail_records
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    recovery_mode: Some(BlockstoreRecoveryMode::TolerateCorruptedTailRecords),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--wal-recovery-mode", "tolerate_corrupted_tail_records"],
-                expected_args,
-            );
-        }
-
-        // absolute_consistency
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    recovery_mode: Some(BlockstoreRecoveryMode::AbsoluteConsistency),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--wal-recovery-mode", "absolute_consistency"],
-                expected_args,
-            );
-        }
-
-        // point_in_time
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    recovery_mode: Some(BlockstoreRecoveryMode::PointInTime),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--wal-recovery-mode", "point_in_time"],
-                expected_args,
-            );
-        }
-
-        // skip_any_corrupted_record
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                blockstore_options: BlockstoreOptions {
-                    recovery_mode: Some(BlockstoreRecoveryMode::SkipAnyCorruptedRecord),
-                    ..default_run_args.blockstore_options.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--wal-recovery-mode", "skip_any_corrupted_record"],
-                expected_args,
-            );
-        }
+    #[test_case(
+        "tolerate_corrupted_tail_records",
+        BlockstoreRecoveryMode::TolerateCorruptedTailRecords
+    )]
+    #[test_case("absolute_consistency", BlockstoreRecoveryMode::AbsoluteConsistency)]
+    #[test_case("point_in_time", BlockstoreRecoveryMode::PointInTime)]
+    #[test_case(
+        "skip_any_corrupted_record",
+        BlockstoreRecoveryMode::SkipAnyCorruptedRecord
+    )]
+    fn verify_args_struct_by_command_run_with_wal_recovery_mode_valid(
+        arg_value: &str,
+        expected_mode: BlockstoreRecoveryMode,
+    ) {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            blockstore_options: BlockstoreOptions {
+                recovery_mode: Some(expected_mode),
+                ..default_run_args.blockstore_options.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--wal-recovery-mode", arg_value],
+            expected_args,
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -251,4 +251,44 @@ mod tests {
             expected_args,
         );
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_compaction_threads() {
+        // long arg
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    num_rocksdb_compaction_threads: NonZeroUsize::new(1).unwrap(),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-compaction-threads", "1"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rocksdb_flush_threads() {
+        // long arg
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                blockstore_options: BlockstoreOptions {
+                    num_rocksdb_flush_threads: NonZeroUsize::new(1).unwrap(),
+                    ..default_run_args.blockstore_options.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rocksdb-flush-threads", "1"],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -45,10 +45,6 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         blockstore_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
-        blockstore_options::{
-            AccessType, BlockstoreCompressionType, BlockstoreOptions, BlockstoreRecoveryMode,
-            LedgerColumnOptions,
-        },
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     solana_logger::redirect_stderr_to_file,
@@ -111,8 +107,6 @@ pub fn execute(
         rayon_global_threads,
         replay_forks_threads,
         replay_transactions_threads,
-        rocksdb_compaction_threads,
-        rocksdb_flush_threads,
         tpu_transaction_forward_receive_threads,
         tpu_transaction_receive_threads,
         tpu_vote_transaction_receive_threads,
@@ -183,10 +177,6 @@ pub fn execute(
         )
     })?;
 
-    let recovery_mode = matches
-        .value_of("wal_recovery_mode")
-        .map(BlockstoreRecoveryMode::from);
-
     let max_ledger_shreds = if matches.is_present("limit_ledger_size") {
         let limit_ledger_size = match matches.value_of("limit_ledger_size") {
             Some(_) => value_t_or_exit!(matches, "limit_ledger_size", u64),
@@ -203,35 +193,7 @@ pub fn execute(
         None
     };
 
-    let column_options = LedgerColumnOptions {
-        compression_type: match matches.value_of("rocksdb_ledger_compression") {
-            None => BlockstoreCompressionType::default(),
-            Some(ledger_compression_string) => match ledger_compression_string {
-                "none" => BlockstoreCompressionType::None,
-                "snappy" => BlockstoreCompressionType::Snappy,
-                "lz4" => BlockstoreCompressionType::Lz4,
-                "zlib" => BlockstoreCompressionType::Zlib,
-                _ => panic!("Unsupported ledger_compression: {ledger_compression_string}"),
-            },
-        },
-        rocks_perf_sample_interval: value_t_or_exit!(
-            matches,
-            "rocksdb_perf_sample_interval",
-            usize
-        ),
-    };
-
-    let blockstore_options = BlockstoreOptions {
-        recovery_mode,
-        column_options,
-        // The validator needs to open many files, check that the process has
-        // permission to do so in order to fail quickly and give a direct error
-        enforce_ulimit_nofile: true,
-        // The validator needs primary (read/write)
-        access_type: AccessType::Primary,
-        num_rocksdb_compaction_threads: rocksdb_compaction_threads,
-        num_rocksdb_flush_threads: rocksdb_flush_threads,
-    };
+    let blockstore_options = run_args.blockstore_options;
 
     let accounts_hash_cache_path = matches
         .value_of("accounts_hash_cache_path")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -193,8 +193,6 @@ pub fn execute(
         None
     };
 
-    let blockstore_options = run_args.blockstore_options;
-
     let accounts_hash_cache_path = matches
         .value_of("accounts_hash_cache_path")
         .map(Into::into)
@@ -619,7 +617,7 @@ pub fn execute(
         repair_whitelist,
         gossip_validators,
         max_ledger_shreds,
-        blockstore_options,
+        blockstore_options: run_args.blockstore_options,
         run_verification: !matches.is_present("skip_startup_ledger_verification"),
         debug_keys,
         contact_debug_interval,


### PR DESCRIPTION
### Problem

https://github.com/anza-xyz/agave/issues/4082

### Summary of Changes

#### - impl `FromClapArgMatches` for `BlockstoreOptions` and derive PartialEq for some structs

in the part 2 PR, we decided to use the same struct for both user input and core logic.

#### - stop parsing `rocksdb_compaction_threads` and `rocksdb_flush_threads` in the thread_args

this one is a bit tricky. I noticed we have a struct that includes all threads-related args. however, if we wanna use the same struct, the thread args will go back to the component level. in this PR, I only moved the parsing logic. the args definitions and default values are still in the original file