### PR TITLE
Reimplement keys to not depend on put_range_in_cache

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -259,7 +259,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // Next, collect keys from the disk.
         if let Some(disk) = self.bucket.as_ref() {
-            for key in disk.keys() {
+            let disk_keys = disk.keys();
+            keys.reserve(disk_keys.len());
+            for key in disk_keys {
                 keys.insert(key);
             }
         }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -265,7 +265,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 keys.insert(key);
             }
         }
-        keys.into_iter().collect::<Vec<_>>()
+        keys.into_iter().collect()
     }
 
     fn load_from_disk(&self, pubkey: &Pubkey) -> Option<(SlotList<U>, RefCount)> {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -255,19 +255,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         Self::update_stat(&self.stats().keys, 1);
 
         // Collect keys from the in-memory map first.
-        // We hold a read lock to the in-memory map to ensure that no other thread is modifying it while we are reading.
-        let map = self.map_internal.read().unwrap();
-        let mut keys: HashSet<_> = map.keys().cloned().collect();
+        let mut keys: HashSet<_> = self.map_internal.read().unwrap().keys().cloned().collect();
 
-        // Next, collect keys from the disk if they are not already in-memory.
+        // Next, collect keys from the disk.
         if let Some(disk) = self.bucket.as_ref() {
             for key in disk.keys() {
-                if !map.contains_key(&key) {
-                    keys.insert(key);
-                }
+                keys.insert(key);
             }
         }
-        drop(map);
         keys.into_iter().collect::<Vec<_>>()
     }
 


### PR DESCRIPTION
#### Problem

put_range_in_cache was originally introduced to support rent scanning by keeping certain key ranges in memory. However, since we no longer perform range-based rent scanning, this mechanism is now obsolete.

This PR refactors the keys() to stop relying on put_range_in_cache. With this change, there are no remaining dependencies on put_range_in_cache in the index scan path.

This lays the groundwork for a future PR (#6920) to fully remove hold_range_in_memory from the codebase.

Summary of Changes
reimplement keys to not use put_range_in_cache.


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
