### PR TITLE
Clean up hold_range_in_memory from accounts index: part 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,6 +7271,7 @@ dependencies = [
  "num_enum",
  "rand 0.8.5",
  "rayon",
+ "solana-bucket-map",
  "solana-clock",
  "solana-logger",
  "solana-measure",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -14,6 +14,9 @@ edition = { workspace = true }
 crate-type = ["lib"]
 name = "solana_bucket_map"
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true }
@@ -30,6 +33,7 @@ tempfile = { workspace = true }
 [dev-dependencies]
 fs_extra = { workspace = true }
 rayon = { workspace = true }
+solana-bucket-map = { path = ".", features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -1,11 +1,12 @@
+#[cfg(feature = "dev-context-only-utils")]
+use crate::bucket_item::BucketItem;
 use {
     crate::{
-        bucket::Bucket, bucket_item::BucketItem, bucket_map::BucketMapError,
-        bucket_stats::BucketMapStats, restart::RestartableBucket, MaxSearch, RefCount,
+        bucket::Bucket, bucket_map::BucketMapError, bucket_stats::BucketMapStats,
+        restart::RestartableBucket, MaxSearch, RefCount,
     },
     solana_pubkey::Pubkey,
     std::{
-        ops::RangeBounds,
         path::PathBuf,
         sync::{
             atomic::{AtomicU64, Ordering},
@@ -47,15 +48,13 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     }
 
     /// Get the items for bucket
-    pub fn items_in_range<R>(&self, range: &Option<&R>) -> Vec<BucketItem<T>>
-    where
-        R: RangeBounds<Pubkey>,
-    {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn items(&self) -> Vec<BucketItem<T>> {
         self.bucket
             .read()
             .unwrap()
             .as_ref()
-            .map(|bucket| bucket.items_in_range(range))
+            .map(|bucket| bucket.items())
             .unwrap_or_default()
     }
 

--- a/bucket_map/src/bucket_item.rs
+++ b/bucket_map/src/bucket_item.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "dev-context-only-utils")]
 use {crate::RefCount, solana_pubkey::Pubkey};
 
 #[derive(Debug, Default, Clone)]

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -446,10 +446,7 @@ mod tests {
                         assert_eq!(total_entries, expected_count);
                         let mut r = vec![];
                         for bin in 0..map.num_buckets() {
-                            r.append(
-                                &mut map.buckets[bin]
-                                    .items_in_range(&None::<&std::ops::RangeInclusive<Pubkey>>),
-                            );
+                            r.append(&mut map.buckets[bin].items());
                         }
                         r
                     })


### PR DESCRIPTION
#### Problem

hold_range_in_memory was originally introduced to support rent scanning by keeping certain key ranges in memory. However, since we no longer perform range-based rent scanning, this mechanism is now obsolete.

This is part 3 for the clean up:  refactor bucket_api item_in_range. 

#### Summary of Changes

- refactor bucket_api items_in_range to items
- make items fn and BucketItems dev-context-util-only since they are now only used in tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
