### PR TITLE
Capture ability of BufferedReader to provide contiguous min len buffers as a trait

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1090,6 +1090,19 @@ impl AppendVec {
                     } else {
                         // repeat loop with required buffer size holding whole account data
                         min_buf_len = STORE_META_OVERHEAD + data_len;
+
+                        const MAX_CAPACITY: usize =
+                            STORE_META_OVERHEAD + MAX_PERMITTED_DATA_LENGTH as usize;
+                        // 128KiB covers a reasonably large distribution of typical account sizes.
+                        // In a recent sample, 99.98% of accounts' data lengths were less than or equal to 128KiB.
+                        const MIN_CAPACITY: usize = 1024 * 128;
+                        let capacity = data_overflow_buffer.capacity();
+                        if min_buf_len > capacity {
+                            let next_cap = min_buf_len
+                                .next_power_of_two()
+                                .clamp(MIN_CAPACITY, MAX_CAPACITY);
+                            data_overflow_buffer.reserve_exact(next_cap - capacity);
+                        }
                     }
                 }
             }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1672,12 +1672,17 @@ pub mod tests {
 
         let mut test_accounts = Vec::with_capacity(num_accounts);
         let mut file_size = 0;
+        let special_file_interval = num_accounts / 8;
         for i in 0..num_accounts {
             let data_len = match i {
-                // ensure one max size account
-                0 => MAX_PERMITTED_DATA_LENGTH as usize,
-                // ensure one 64KiB account
-                x if x == num_accounts - 1 => 1 << 16,
+                // Create several spread out accounts with varying sizes:
+                // for (x / special_file_interval) in 0..7 range
+                x if x % special_file_interval == 0 => {
+                    // mult increases in 0 to 3 range twice
+                    let mult = (x / special_file_interval) % 4;
+                    // and data_len goes over 0..MAX_PERMITTED_DATA_LENGTH range also twice
+                    mult * (MAX_PERMITTED_DATA_LENGTH as usize) / 3
+                }
                 // Otherwise use a reasonably small account to avoid long test times
                 x => x % 256,
             };

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -10,10 +10,12 @@ pub mod test_utils;
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
+use crate::buffered_reader::ContiguousBufFileRead;
 #[cfg(feature = "dev-context-only-utils")]
 pub use meta::{AccountMeta, StoredMeta};
 #[cfg(not(feature = "dev-context-only-utils"))]
 use meta::{AccountMeta, StoredMeta};
+
 use {
     crate::{
         account_info::Offset,
@@ -1051,16 +1053,14 @@ impl AppendVec {
             AppendVecFileBacking::File(file) => {
                 let self_len = self.len();
                 const BUFFER_SIZE: usize = PAGE_SIZE * 8;
-                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(
-                    self_len,
-                    file,
-                    STORE_META_OVERHEAD,
-                );
+                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self_len, file);
+                reader.set_default_required_fill_buf_len(STORE_META_OVERHEAD);
+                let max_buf_len = reader.max_supported_contiguous_buf_len();
                 // Buffer for account data that doesn't fit within the stack allocated buffer.
                 // This will be re-used for each account that doesn't fit within the stack allocated buffer.
                 let mut data_overflow_buffer = vec![];
                 loop {
-                    let offset = reader.get_offset();
+                    let offset = reader.get_file_offset();
                     let bytes = match reader.fill_buf() {
                         Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
@@ -1087,8 +1087,8 @@ impl AppendVec {
                         };
                         callback(account);
                         reader.consume(stored_size);
-                    } else if STORE_META_OVERHEAD + data_len <= BUFFER_SIZE {
-                        reader.set_required_data_len(STORE_META_OVERHEAD + data_len);
+                    } else if STORE_META_OVERHEAD + data_len <= max_buf_len {
+                        reader.set_next_required_fill_buf_len(STORE_META_OVERHEAD + data_len);
                     } else {
                         const MAX_CAPACITY: usize = MAX_PERMITTED_DATA_LENGTH as usize;
                         // 128KiB covers a reasonably large distribution of typical account sizes.
@@ -1252,13 +1252,12 @@ impl AppendVec {
             AppendVecFileBacking::File(file) => {
                 // Heuristic observed in benchmarking that maintains a reasonable balance between syscalls and data waste
                 const BUFFER_SIZE: usize = PAGE_SIZE * 4;
-                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(
-                    self_len,
-                    file,
+                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self_len, file);
+                reader.set_default_required_fill_buf_len(
                     mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>(),
                 );
                 loop {
-                    let offset = reader.get_offset();
+                    let offset = reader.get_file_offset();
                     let bytes = match reader.fill_buf() {
                         Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1049,17 +1049,17 @@ impl AppendVec {
                 {}
             }
             AppendVecFileBacking::File(file) => {
-                let self_len = self.len();
                 const BUFFER_SIZE: usize = PAGE_SIZE * 8;
-                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self_len, file);
-                reader.set_default_required_fill_buf_len(STORE_META_OVERHEAD);
-                let max_buf_len = reader.max_supported_contiguous_buf_len();
+                let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self.len(), file);
+                let mut min_buf_len = STORE_META_OVERHEAD;
                 // Buffer for account data that doesn't fit within the stack allocated buffer.
                 // This will be re-used for each account that doesn't fit within the stack allocated buffer.
                 let mut data_overflow_buffer = vec![];
                 loop {
                     let offset = reader.get_file_offset();
-                    let bytes = match reader.fill_buf() {
+                    let bytes = match reader
+                        .fill_buf_required_or_overflow(min_buf_len, &mut data_overflow_buffer)
+                    {
                         Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
                         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
@@ -1085,53 +1085,11 @@ impl AppendVec {
                         };
                         callback(account);
                         reader.consume(stored_size);
-                    } else if STORE_META_OVERHEAD + data_len <= max_buf_len {
-                        reader.set_next_required_fill_buf_len(STORE_META_OVERHEAD + data_len);
+                        // restore default required buffer size
+                        min_buf_len = STORE_META_OVERHEAD;
                     } else {
-                        const MAX_CAPACITY: usize = MAX_PERMITTED_DATA_LENGTH as usize;
-                        // 128KiB covers a reasonably large distribution of typical account sizes.
-                        // In a recent sample, 99.98% of accounts' data lengths were less than or equal to 128KiB.
-                        const MIN_CAPACITY: usize = 1024 * 128;
-                        let capacity = data_overflow_buffer.capacity();
-                        if data_len > capacity {
-                            let next_cap = data_len
-                                .next_power_of_two()
-                                .clamp(MIN_CAPACITY, MAX_CAPACITY);
-                            data_overflow_buffer.reserve_exact(next_cap - capacity);
-                            // SAFETY: We only write to the uninitialized portion of the buffer via `copy_from_slice` and `read_into_buffer`.
-                            // Later, we ensure we only read from the initialized portion of the buffer.
-                            unsafe {
-                                data_overflow_buffer.set_len(next_cap);
-                            }
-                        }
-
-                        // Copy already read data to overflow buffer.
-                        data_overflow_buffer[..leftover].copy_from_slice(&bytes.0[next..]);
-
-                        // Read remaining data into overflow buffer.
-                        let Ok(bytes_read) = read_into_buffer(
-                            file,
-                            self_len,
-                            offset + next + leftover,
-                            &mut data_overflow_buffer[leftover..data_len],
-                        ) else {
-                            break;
-                        };
-                        if bytes_read + leftover < data_len {
-                            break;
-                        }
-                        let data = &data_overflow_buffer[..data_len];
-                        let stored_size = aligned_stored_size(data_len);
-                        let account = StoredAccountMeta {
-                            meta,
-                            account_meta,
-                            data,
-                            offset,
-                            stored_size,
-                            hash,
-                        };
-                        callback(account);
-                        reader.consume(stored_size);
+                        // repeat loop with required buffer size holding whole account data
+                        min_buf_len = STORE_META_OVERHEAD + data_len;
                     }
                 }
             }
@@ -1251,12 +1209,11 @@ impl AppendVec {
                 // Heuristic observed in benchmarking that maintains a reasonable balance between syscalls and data waste
                 const BUFFER_SIZE: usize = PAGE_SIZE * 4;
                 let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self_len, file);
-                reader.set_default_required_fill_buf_len(
-                    mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>(),
-                );
+                const REQUIRED_DATA_LEN: usize =
+                    mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>();
                 loop {
                     let offset = reader.get_file_offset();
-                    let bytes = match reader.fill_buf() {
+                    let bytes = match reader.fill_buf_required(REQUIRED_DATA_LEN) {
                         Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
                         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1091,17 +1091,19 @@ impl AppendVec {
                         // repeat loop with required buffer size holding whole account data
                         min_buf_len = STORE_META_OVERHEAD + data_len;
 
-                        const MAX_CAPACITY: usize =
-                            STORE_META_OVERHEAD + MAX_PERMITTED_DATA_LENGTH as usize;
-                        // 128KiB covers a reasonably large distribution of typical account sizes.
-                        // In a recent sample, 99.98% of accounts' data lengths were less than or equal to 128KiB.
-                        const MIN_CAPACITY: usize = 1024 * 128;
-                        let capacity = data_overflow_buffer.capacity();
-                        if min_buf_len > capacity {
-                            let next_cap = min_buf_len
-                                .next_power_of_two()
-                                .clamp(MIN_CAPACITY, MAX_CAPACITY);
-                            data_overflow_buffer.reserve_exact(next_cap - capacity);
+                        if min_buf_len > BUFFER_SIZE {
+                            const MAX_CAPACITY: usize =
+                                STORE_META_OVERHEAD + MAX_PERMITTED_DATA_LENGTH as usize;
+                            // 128KiB covers a reasonably large distribution of typical account sizes.
+                            // In a recent sample, 99.98% of accounts' data lengths were less than or equal to 128KiB.
+                            const MIN_CAPACITY: usize = 1024 * 128;
+                            if min_buf_len > data_overflow_buffer.capacity() {
+                                let next_cap = min_buf_len
+                                    .next_power_of_two()
+                                    .clamp(MIN_CAPACITY, MAX_CAPACITY);
+                                data_overflow_buffer
+                                    .reserve_exact(next_cap - data_overflow_buffer.len());
+                            }
                         }
                     }
                 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1222,11 +1222,11 @@ impl AppendVec {
                 // Heuristic observed in benchmarking that maintains a reasonable balance between syscalls and data waste
                 const BUFFER_SIZE: usize = PAGE_SIZE * 4;
                 let mut reader = BufferedReader::<Stack<BUFFER_SIZE>>::new_stack(self_len, file);
-                const REQUIRED_DATA_LEN: usize =
+                const REQUIRED_READ_LEN: usize =
                     mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>();
                 loop {
                     let offset = reader.get_file_offset();
-                    let bytes = match reader.fill_buf_required(REQUIRED_DATA_LEN) {
+                    let bytes = match reader.fill_buf_required(REQUIRED_READ_LEN) {
                         Ok([]) => break,
                         Ok(bytes) => ValidSlice::new(bytes),
                         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -10,12 +10,10 @@ pub mod test_utils;
 // Used all over the accounts-db crate.  Probably should be minimized.
 pub(crate) use meta::StoredAccountMeta;
 // Some tests/benches use AccountMeta/StoredMeta
-use crate::buffered_reader::ContiguousBufFileRead;
 #[cfg(feature = "dev-context-only-utils")]
 pub use meta::{AccountMeta, StoredMeta};
 #[cfg(not(feature = "dev-context-only-utils"))]
 use meta::{AccountMeta, StoredMeta};
-
 use {
     crate::{
         account_info::Offset,
@@ -25,7 +23,7 @@ use {
             StoredAccountsInfo,
         },
         accounts_hash::AccountHash,
-        buffered_reader::{BufferedReader, Stack},
+        buffered_reader::{BufferedReader, ContiguousBufFileRead, Stack},
         file_io::read_into_buffer,
         is_zero_lamport::IsZeroLamport,
         storable_accounts::StorableAccounts,

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -171,9 +171,8 @@ impl<'a, T: Backing> ContiguousBufFileRead<'a> for BufferedReader<'a, T> {
             return self.fill_buf_required(required_len);
         }
 
-        let capacity = overflow_buffer.capacity();
-        if required_len > capacity {
-            overflow_buffer.reserve(required_len - capacity);
+        if required_len > overflow_buffer.len() {
+            overflow_buffer.reserve_exact(required_len - overflow_buffer.len());
         }
         // SAFETY: We only write to the uninitialized portion of the buffer via `copy_from_slice` and `read_into_buffer`.
         // Later, we ensure we only read from the initialized portion of the buffer.
@@ -187,7 +186,7 @@ impl<'a, T: Backing> ContiguousBufFileRead<'a> for BufferedReader<'a, T> {
         overflow_buffer[..leftover].copy_from_slice(available_valid_data);
 
         // Read remaining data into overflow buffer.
-        let read_dst = &mut overflow_buffer[leftover..required_len];
+        let read_dst = &mut overflow_buffer[leftover..];
         let bytes_read = read_into_buffer(
             self.file,
             self.file_len_valid,

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -204,7 +204,7 @@ impl<'a, T: Backing> ContiguousBufFileRead<'a> for BufferedReader<'a, T> {
     }
 }
 
-impl<'a, T> BufferedReader<'a, T>
+impl<T> BufferedReader<'_, T>
 where
     T: Backing,
 {

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -171,7 +171,7 @@ impl<'a, T: Backing> ContiguousBufFileRead<'a> for BufferedReader<'a, T> {
             return self.fill_buf_required(required_len);
         }
 
-        if required_len > overflow_buffer.len() {
+        if required_len > overflow_buffer.capacity() {
             overflow_buffer.reserve_exact(required_len - overflow_buffer.len());
         }
         // SAFETY: We only write to the uninitialized portion of the buffer via `copy_from_slice` and `read_into_buffer`.

--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -184,11 +184,11 @@ impl<'a, T: Backing> ContiguousBufFileRead<'a> for BufferedReader<'a, T> {
                 .next_power_of_two()
                 .clamp(MIN_CAPACITY, MAX_CAPACITY);
             overflow_buffer.reserve_exact(next_cap - capacity);
-            // SAFETY: We only write to the uninitialized portion of the buffer via `copy_from_slice` and `read_into_buffer`.
-            // Later, we ensure we only read from the initialized portion of the buffer.
-            unsafe {
-                overflow_buffer.set_len(required_len);
-            }
+        }
+        // SAFETY: We only write to the uninitialized portion of the buffer via `copy_from_slice` and `read_into_buffer`.
+        // Later, we ensure we only read from the initialized portion of the buffer.
+        unsafe {
+            overflow_buffer.set_len(required_len);
         }
 
         // Copy already read data to overflow buffer.


### PR DESCRIPTION
#### Problem
As part of a larger change to provide io_uring replacement for BufferedReader I want to capture its functionality and API as a well-defined trait(s).
Some uses of BufferedReader are also mixed-up with extra reads done through `read_into_buffer` to overflow buffers - that could be better encapsulated in BufferedReader impl and trait.

#### Summary of Changes
This PR adds `ContiguousBufFileRead` that addresses the functionalities of:
* reading buffer with default requirement for returned buffer size -> new trait function `fill_buf_required`
* reading buffer with required size potentially exceeding internal buffer, with fallback to overflow buffer -> new trait function `fill_buf_required_or_overflow`
* getting underlying file offset -> trait function `get_file_offset()`
