### PR TITLE
serve_repair: refactor repair responder and add malicious variant

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -11,6 +11,7 @@ use {
             serve_repair::{
                 self, AncestorHashesRepairType, AncestorHashesResponse, RepairProtocol, ServeRepair,
             },
+            standard_repair_handler::StandardRepairHandler,
         },
         replay_stage::DUPLICATE_THRESHOLD,
         shred_fetch_stage::receive_quic_datagrams,
@@ -203,7 +204,7 @@ impl AncestorHashesService {
         let t_ancestor_hashes_responses = Self::run_responses_listener(
             ancestor_hashes_request_statuses.clone(),
             response_receiver,
-            blockstore,
+            blockstore.clone(),
             outstanding_requests.clone(),
             exit.clone(),
             repair_info.ancestor_duplicate_slots_sender.clone(),
@@ -214,6 +215,7 @@ impl AncestorHashesService {
 
         // Generate ancestor requests for dead slots that are repairable
         let t_ancestor_requests = Self::run_manage_ancestor_requests(
+            blockstore,
             ancestor_hashes_request_statuses,
             ancestor_hashes_request_socket,
             ancestor_hashes_request_quic_sender,
@@ -591,6 +593,7 @@ impl AncestorHashesService {
     }
 
     fn run_manage_ancestor_requests(
+        blockstore: Arc<Blockstore>,
         ancestor_hashes_request_statuses: Arc<DashMap<Slot, AncestorRequestStatus>>,
         ancestor_hashes_request_socket: Arc<UdpSocket>,
         ancestor_hashes_request_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -600,11 +603,14 @@ impl AncestorHashesService {
         ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
         retryable_slots_receiver: RetryableSlotsReceiver,
     ) -> JoinHandle<()> {
-        let serve_repair = ServeRepair::new(
-            repair_info.cluster_info.clone(),
-            repair_info.bank_forks.clone(),
-            repair_info.repair_whitelist.clone(),
-        );
+        let serve_repair = {
+            ServeRepair::new(
+                repair_info.cluster_info.clone(),
+                repair_info.bank_forks.clone(),
+                repair_info.repair_whitelist.clone(),
+                StandardRepairHandler::new(blockstore),
+            )
+        };
         let mut repair_stats = AncestorRepairRequestsStats::default();
 
         let mut dead_slot_pool = HashSet::new();
@@ -1259,20 +1265,23 @@ mod test {
                 Arc::new(keypair),
                 SocketAddrSpace::Unspecified,
             );
-            let responder_serve_repair = ServeRepair::new(
-                Arc::new(cluster_info),
-                vote_simulator.bank_forks,
-                Arc::<RwLock<HashSet<_>>>::default(), // repair whitelist
-            );
+            // Set up blockstore for responses
+            let ledger_path = get_tmp_ledger_path!();
+            let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
+            let responder_serve_repair = {
+                ServeRepair::new(
+                    Arc::new(cluster_info),
+                    vote_simulator.bank_forks,
+                    Arc::<RwLock<HashSet<_>>>::default(), // repair whitelist
+                    StandardRepairHandler::new(blockstore.clone()),
+                )
+            };
 
             // Set up thread to give us responses
-            let ledger_path = get_tmp_ledger_path!();
             let exit = Arc::new(AtomicBool::new(false));
             let (requests_sender, requests_receiver) = unbounded();
             let (response_sender, response_receiver) = unbounded();
 
-            // Set up blockstore for responses
-            let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
             // Create slots [slot - MAX_ANCESTOR_RESPONSES, slot) with 5 shreds apiece
             let (shreds, _) = make_many_slot_entries(
                 slot_to_query - MAX_ANCESTOR_RESPONSES as Slot + 1,
@@ -1310,7 +1319,6 @@ mod test {
                 .unwrap();
             let (repair_response_quic_sender, _) = tokio::sync::mpsc::channel(/*buffer:*/ 128);
             let t_listen = responder_serve_repair.listen(
-                blockstore,
                 remote_request_receiver,
                 response_sender,
                 repair_response_quic_sender,
@@ -1364,11 +1372,16 @@ mod test {
                 SocketAddrSpace::Unspecified,
             ));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::default()));
-            let requester_serve_repair = ServeRepair::new(
-                requester_cluster_info.clone(),
-                bank_forks.clone(),
-                repair_whitelist.clone(),
-            );
+            let ledger_path = get_tmp_ledger_path!();
+            let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
+            let requester_serve_repair = {
+                ServeRepair::new(
+                    requester_cluster_info.clone(),
+                    bank_forks.clone(),
+                    repair_whitelist.clone(),
+                    StandardRepairHandler::new(blockstore),
+                )
+            };
             let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) = unbounded();
             let repair_info = RepairInfo {
                 bank_forks,

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -608,7 +608,7 @@ impl AncestorHashesService {
                 repair_info.cluster_info.clone(),
                 repair_info.bank_forks.clone(),
                 repair_info.repair_whitelist.clone(),
-                StandardRepairHandler::new(blockstore),
+                Box::new(StandardRepairHandler::new(blockstore)),
             )
         };
         let mut repair_stats = AncestorRepairRequestsStats::default();
@@ -1273,7 +1273,7 @@ mod test {
                     Arc::new(cluster_info),
                     vote_simulator.bank_forks,
                     Arc::<RwLock<HashSet<_>>>::default(), // repair whitelist
-                    StandardRepairHandler::new(blockstore.clone()),
+                    Box::new(StandardRepairHandler::new(blockstore.clone())),
                 )
             };
 
@@ -1379,7 +1379,7 @@ mod test {
                     requester_cluster_info.clone(),
                     bank_forks.clone(),
                     repair_whitelist.clone(),
-                    StandardRepairHandler::new(blockstore),
+                    Box::new(StandardRepairHandler::new(blockstore)),
                 )
             };
             let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) = unbounded();

--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -1,14 +1,11 @@
 use {
-    super::{
-        repair_handler::RepairHandler, repair_response::repair_response_packet_from_bytes,
-        standard_repair_handler::StandardRepairHandler,
-    },
+    super::{repair_handler::RepairHandler, repair_response::repair_response_packet_from_bytes},
     solana_clock::Slot,
     solana_ledger::{
         blockstore::Blockstore,
         shred::{Nonce, SIZE_OF_DATA_SHRED_HEADERS},
     },
-    solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
+    solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler},
     std::{net::SocketAddr, sync::Arc},
 };
 
@@ -19,7 +16,6 @@ pub struct MaliciousRepairConfig {
 
 pub struct MaliciousRepairHandler {
     blockstore: Arc<Blockstore>,
-    standard_handler: StandardRepairHandler,
     config: MaliciousRepairConfig,
 }
 
@@ -27,12 +23,13 @@ impl MaliciousRepairHandler {
     const BAD_DATA_INDEX: usize = SIZE_OF_DATA_SHRED_HEADERS + 5;
 
     pub fn new(blockstore: Arc<Blockstore>, config: MaliciousRepairConfig) -> Self {
-        let standard_handler = StandardRepairHandler::new(blockstore.clone());
-        Self {
-            blockstore,
-            standard_handler,
-            config,
-        }
+        Self { blockstore, config }
+    }
+}
+
+impl RepairHandler for MaliciousRepairHandler {
+    fn blockstore(&self) -> &Blockstore {
+        &self.blockstore
     }
 
     fn repair_response_packet(
@@ -56,73 +53,16 @@ impl MaliciousRepairHandler {
         }
         repair_response_packet_from_bytes(shred, dest, nonce)
     }
-}
-
-impl RepairHandler for MaliciousRepairHandler {
-    fn run_window_request(
-        &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        shred_index: u64,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
-        Some(
-            PinnedPacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_window_request",
-                vec![packet],
-            )
-            .into(),
-        )
-    }
-
-    fn run_highest_window_request(
-        &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        highest_index: u64,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let meta = self.blockstore.meta(slot).ok()??;
-        if meta.received > highest_index {
-            // meta.received must be at least 1 by this point
-            let packet = self.repair_response_packet(slot, meta.received - 1, from_addr, nonce)?;
-            return Some(
-                PinnedPacketBatch::new_unpinned_with_recycler_data(
-                    recycler,
-                    "run_highest_window_request",
-                    vec![packet],
-                )
-                .into(),
-            );
-        }
-        None
-    }
 
     fn run_orphan(
         &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        max_responses: usize,
-        nonce: Nonce,
+        _recycler: &PacketBatchRecycler,
+        _from_addr: &SocketAddr,
+        _slot: Slot,
+        _max_responses: usize,
+        _nonce: Nonce,
     ) -> Option<PacketBatch> {
-        self.standard_handler
-            .run_orphan(recycler, from_addr, slot, max_responses, nonce)
-    }
-
-    fn run_ancestor_hashes(
-        &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        self.standard_handler
-            .run_ancestor_hashes(recycler, from_addr, slot, nonce)
+        // Don't respond to orphan repair
+        None
     }
 }

--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -1,0 +1,128 @@
+use {
+    super::{
+        repair_handler::RepairHandler, repair_response::repair_response_packet_from_bytes,
+        standard_repair_handler::StandardRepairHandler,
+    },
+    solana_clock::Slot,
+    solana_ledger::{
+        blockstore::Blockstore,
+        shred::{Nonce, SIZE_OF_DATA_SHRED_HEADERS},
+    },
+    solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
+    std::{net::SocketAddr, sync::Arc},
+};
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct MaliciousRepairConfig {
+    bad_shred_slot_frequency: Option<Slot>,
+}
+
+pub struct MaliciousRepairHandler {
+    blockstore: Arc<Blockstore>,
+    standard_handler: StandardRepairHandler,
+    config: MaliciousRepairConfig,
+}
+
+impl MaliciousRepairHandler {
+    const BAD_DATA_INDEX: usize = SIZE_OF_DATA_SHRED_HEADERS + 5;
+
+    pub fn new(blockstore: Arc<Blockstore>, config: MaliciousRepairConfig) -> Self {
+        let standard_handler = StandardRepairHandler::new(blockstore.clone());
+        Self {
+            blockstore,
+            standard_handler,
+            config,
+        }
+    }
+
+    fn repair_response_packet(
+        &self,
+        slot: Slot,
+        shred_index: u64,
+        dest: &SocketAddr,
+        nonce: Nonce,
+    ) -> Option<Packet> {
+        let mut shred = self
+            .blockstore
+            .get_data_shred(slot, shred_index)
+            .expect("Blockstore could not get data shred")?;
+        if self
+            .config
+            .bad_shred_slot_frequency
+            .is_some_and(|freq| slot % freq == 0)
+        {
+            // Change some random piece of data
+            shred[Self::BAD_DATA_INDEX] = shred[Self::BAD_DATA_INDEX].wrapping_add(1);
+        }
+        repair_response_packet_from_bytes(shred, dest, nonce)
+    }
+}
+
+impl RepairHandler for MaliciousRepairHandler {
+    fn run_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        shred_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_window_request",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
+
+    fn run_highest_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        highest_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        // Try to find the requested index in one of the slots
+        let meta = self.blockstore.meta(slot).ok()??;
+        if meta.received > highest_index {
+            // meta.received must be at least 1 by this point
+            let packet = self.repair_response_packet(slot, meta.received - 1, from_addr, nonce)?;
+            return Some(
+                PinnedPacketBatch::new_unpinned_with_recycler_data(
+                    recycler,
+                    "run_highest_window_request",
+                    vec![packet],
+                )
+                .into(),
+            );
+        }
+        None
+    }
+
+    fn run_orphan(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        max_responses: usize,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        self.standard_handler
+            .run_orphan(recycler, from_addr, slot, max_responses, nonce)
+    }
+
+    fn run_ancestor_hashes(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        self.standard_handler
+            .run_ancestor_hashes(recycler, from_addr, slot, nonce)
+    }
+}

--- a/core/src/repair/mod.rs
+++ b/core/src/repair/mod.rs
@@ -1,10 +1,12 @@
 pub mod ancestor_hashes_service;
 pub mod cluster_slot_state_verifier;
 pub mod duplicate_repair_status;
+pub mod malicious_repair_handler;
 pub mod outstanding_requests;
 pub mod packet_threshold;
 pub(crate) mod quic_endpoint;
 pub mod repair_generic_traversal;
+pub mod repair_handler;
 pub mod repair_response;
 pub mod repair_service;
 pub mod repair_weight;
@@ -13,3 +15,4 @@ pub mod request_response;
 pub mod result;
 pub mod serve_repair;
 pub mod serve_repair_service;
+pub mod standard_repair_handler;

--- a/core/src/repair/mod.rs
+++ b/core/src/repair/mod.rs
@@ -1,7 +1,7 @@
 pub mod ancestor_hashes_service;
 pub mod cluster_slot_state_verifier;
 pub mod duplicate_repair_status;
-pub mod malicious_repair_handler;
+pub(crate) mod malicious_repair_handler;
 pub mod outstanding_requests;
 pub mod packet_threshold;
 pub(crate) mod quic_endpoint;
@@ -15,4 +15,4 @@ pub mod request_response;
 pub mod result;
 pub mod serve_repair;
 pub mod serve_repair_service;
-pub mod standard_repair_handler;
+pub(crate) mod standard_repair_handler;

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -1,0 +1,87 @@
+use {
+    super::{
+        malicious_repair_handler::{MaliciousRepairConfig, MaliciousRepairHandler},
+        serve_repair::ServeRepair,
+        standard_repair_handler::StandardRepairHandler,
+    },
+    solana_clock::Slot,
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_ledger::{blockstore::Blockstore, shred::Nonce},
+    solana_perf::packet::{PacketBatch, PacketBatchRecycler},
+    solana_pubkey::Pubkey,
+    solana_runtime::bank_forks::BankForks,
+    std::{
+        collections::HashSet,
+        net::SocketAddr,
+        sync::{Arc, RwLock},
+    },
+};
+
+pub trait RepairHandler {
+    fn run_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        shred_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch>;
+
+    fn run_highest_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        highest_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch>;
+
+    fn run_orphan(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        max_responses: usize,
+        nonce: Nonce,
+    ) -> Option<PacketBatch>;
+
+    fn run_ancestor_hashes(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        nonce: Nonce,
+    ) -> Option<PacketBatch>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum RepairHandlerType {
+    #[default]
+    Standard,
+    Malicious(MaliciousRepairConfig),
+}
+
+impl RepairHandlerType {
+    pub fn create_serve_repair(
+        &self,
+        blockstore: Arc<Blockstore>,
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        serve_repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+    ) -> ServeRepair {
+        match self {
+            RepairHandlerType::Standard => ServeRepair::new(
+                cluster_info,
+                bank_forks,
+                serve_repair_whitelist,
+                StandardRepairHandler::new(blockstore),
+            ),
+            RepairHandlerType::Malicious(config) => ServeRepair::new(
+                cluster_info,
+                bank_forks,
+                serve_repair_whitelist,
+                MaliciousRepairHandler::new(blockstore, *config),
+            ),
+        }
+    }
+}

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -4,10 +4,19 @@ use {
         serve_repair::ServeRepair,
         standard_repair_handler::StandardRepairHandler,
     },
+    crate::repair::{
+        repair_response,
+        serve_repair::{AncestorHashesResponse, MAX_ANCESTOR_RESPONSES},
+    },
+    bincode::serialize,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_ledger::{blockstore::Blockstore, shred::Nonce},
-    solana_perf::packet::{PacketBatch, PacketBatchRecycler},
+    solana_ledger::{
+        ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
+        blockstore::Blockstore,
+        shred::Nonce,
+    },
+    solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     std::{
@@ -18,6 +27,16 @@ use {
 };
 
 pub trait RepairHandler {
+    fn blockstore(&self) -> &Blockstore;
+
+    fn repair_response_packet(
+        &self,
+        slot: Slot,
+        shred_index: u64,
+        dest: &SocketAddr,
+        nonce: Nonce,
+    ) -> Option<Packet>;
+
     fn run_window_request(
         &self,
         recycler: &PacketBatchRecycler,
@@ -25,7 +44,18 @@ pub trait RepairHandler {
         slot: Slot,
         shred_index: u64,
         nonce: Nonce,
-    ) -> Option<PacketBatch>;
+    ) -> Option<PacketBatch> {
+        // Try to find the requested index in one of the slots
+        let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_window_request",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
 
     fn run_highest_window_request(
         &self,
@@ -34,7 +64,23 @@ pub trait RepairHandler {
         slot: Slot,
         highest_index: u64,
         nonce: Nonce,
-    ) -> Option<PacketBatch>;
+    ) -> Option<PacketBatch> {
+        // Try to find the requested index in one of the slots
+        let meta = self.blockstore().meta(slot).ok()??;
+        if meta.received > highest_index {
+            // meta.received must be at least 1 by this point
+            let packet = self.repair_response_packet(slot, meta.received - 1, from_addr, nonce)?;
+            return Some(
+                PinnedPacketBatch::new_unpinned_with_recycler_data(
+                    recycler,
+                    "run_highest_window_request",
+                    vec![packet],
+                )
+                .into(),
+            );
+        }
+        None
+    }
 
     fn run_orphan(
         &self,
@@ -51,7 +97,36 @@ pub trait RepairHandler {
         from_addr: &SocketAddr,
         slot: Slot,
         nonce: Nonce,
-    ) -> Option<PacketBatch>;
+    ) -> Option<PacketBatch> {
+        let ancestor_slot_hashes = if self.blockstore().is_duplicate_confirmed(slot) {
+            let ancestor_iterator = AncestorIteratorWithHash::from(
+                AncestorIterator::new_inclusive(slot, self.blockstore()),
+            );
+            ancestor_iterator.take(MAX_ANCESTOR_RESPONSES).collect()
+        } else {
+            // If this slot is not duplicate confirmed, return nothing
+            vec![]
+        };
+        let response = AncestorHashesResponse::Hashes(ancestor_slot_hashes);
+        let serialized_response = serialize(&response).ok()?;
+
+        // Could probably directly write response into packet via `serialize_into()`
+        // instead of incurring extra copy in `repair_response_packet_from_bytes`, but
+        // serialize_into doesn't return the written size...
+        let packet = repair_response::repair_response_packet_from_bytes(
+            serialized_response,
+            from_addr,
+            nonce,
+        )?;
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_ancestor_hashes",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1,11 +1,7 @@
 //! The `repair_service` module implements the tools necessary to generate a thread which
 //! regularly finds missing shreds in the ledger and sends repair requests for those shreds
-#[cfg(test)]
 use {
-    crate::repair::duplicate_repair_status::DuplicateSlotRepairStatus,
-    solana_clock::DEFAULT_MS_PER_SLOT, solana_keypair::Keypair,
-};
-use {
+    super::standard_repair_handler::StandardRepairHandler,
     crate::{
         cluster_info_vote_listener::VerifiedVoteReceiver,
         cluster_slots_service::cluster_slots::ClusterSlots,
@@ -52,6 +48,11 @@ use {
         time::{Duration, Instant},
     },
     tokio::sync::mpsc::Sender as AsyncSender,
+};
+#[cfg(test)]
+use {
+    crate::repair::duplicate_repair_status::DuplicateSlotRepairStatus,
+    solana_clock::DEFAULT_MS_PER_SLOT, solana_keypair::Keypair,
 };
 
 // Time to defer repair requests to allow for turbine propagation
@@ -449,7 +450,7 @@ impl RepairService {
                 .name("solRepairSvc".to_string())
                 .spawn(move || {
                     Self::run(
-                        &blockstore,
+                        blockstore,
                         &exit,
                         &repair_socket,
                         repair_service_channels.repair_channels,
@@ -741,7 +742,7 @@ impl RepairService {
     }
 
     fn run(
-        blockstore: &Blockstore,
+        blockstore: Arc<Blockstore>,
         exit: &AtomicBool,
         repair_socket: &UdpSocket,
         repair_channels: RepairChannels,
@@ -753,11 +754,14 @@ impl RepairService {
         let mut repair_tracker = RepairTracker {
             root_bank_cache,
             repair_weight: RepairWeight::new(root_bank_slot),
-            serve_repair: ServeRepair::new(
-                repair_info.cluster_info.clone(),
-                repair_info.bank_forks.clone(),
-                repair_info.repair_whitelist.clone(),
-            ),
+            serve_repair: {
+                ServeRepair::new(
+                    repair_info.cluster_info.clone(),
+                    repair_info.bank_forks.clone(),
+                    repair_info.repair_whitelist.clone(),
+                    StandardRepairHandler::new(blockstore.clone()),
+                )
+            },
             repair_metrics: RepairMetrics::default(),
             peers_cache: LruCache::new(REPAIR_PEERS_CACHE_CAPACITY),
             popular_pruned_forks_requests: HashSet::new(),
@@ -766,7 +770,7 @@ impl RepairService {
 
         while !exit.load(Ordering::Relaxed) {
             Self::run_repair_iteration(
-                blockstore,
+                blockstore.as_ref(),
                 &repair_channels,
                 &repair_info,
                 &mut repair_tracker,
@@ -1637,15 +1641,18 @@ mod test {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
         let identity_keypair = cluster_info.keypair().clone();
-        let serve_repair = ServeRepair::new(
-            cluster_info,
-            bank_forks,
-            Arc::new(RwLock::new(HashSet::default())),
-        );
+        let serve_repair = {
+            ServeRepair::new(
+                cluster_info,
+                bank_forks,
+                Arc::new(RwLock::new(HashSet::default())),
+                StandardRepairHandler::new(blockstore.clone()),
+            )
+        };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
         let receive_socket = &bind_to_unspecified().unwrap();
@@ -1740,11 +1747,16 @@ mod test {
             bind_to_unspecified().unwrap().local_addr().unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info());
-        let serve_repair = ServeRepair::new(
-            cluster_info.clone(),
-            bank_forks,
-            Arc::new(RwLock::new(HashSet::default())),
-        );
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let serve_repair = {
+            ServeRepair::new(
+                cluster_info.clone(),
+                bank_forks,
+                Arc::new(RwLock::new(HashSet::default())),
+                StandardRepairHandler::new(blockstore),
+            )
+        };
         let valid_repair_peer = Node::new_localhost().info;
 
         // Signal that this peer has confirmed the dead slot, and is thus

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -759,7 +759,7 @@ impl RepairService {
                     repair_info.cluster_info.clone(),
                     repair_info.bank_forks.clone(),
                     repair_info.repair_whitelist.clone(),
-                    StandardRepairHandler::new(blockstore.clone()),
+                    Box::new(StandardRepairHandler::new(blockstore.clone())),
                 )
             },
             repair_metrics: RepairMetrics::default(),
@@ -1650,7 +1650,7 @@ mod test {
                 cluster_info,
                 bank_forks,
                 Arc::new(RwLock::new(HashSet::default())),
-                StandardRepairHandler::new(blockstore.clone()),
+                Box::new(StandardRepairHandler::new(blockstore.clone())),
             )
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
@@ -1754,7 +1754,7 @@ mod test {
                 cluster_info.clone(),
                 bank_forks,
                 Arc::new(RwLock::new(HashSet::default())),
-                StandardRepairHandler::new(blockstore),
+                Box::new(StandardRepairHandler::new(blockstore)),
             )
         };
         let valid_repair_peer = Node::new_localhost().info;

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -402,13 +402,13 @@ impl ServeRepair {
         cluster_info: Arc<ClusterInfo>,
         bank_forks: Arc<RwLock<BankForks>>,
         repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
-        repair_handler: impl RepairHandler + Send + Sync + 'static,
+        repair_handler: Box<dyn RepairHandler + Send + Sync>,
     ) -> Self {
         Self {
             cluster_info,
             root_bank_cache: RootBankCache::new(bank_forks),
             repair_whitelist,
-            repair_handler: Box::new(repair_handler),
+            repair_handler,
         }
     }
 
@@ -420,7 +420,7 @@ impl ServeRepair {
     ) -> Self {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let repair_handler = StandardRepairHandler::new(blockstore);
+        let repair_handler = Box::new(StandardRepairHandler::new(blockstore));
         Self::new(cluster_info, bank_forks, repair_whitelist, repair_handler)
     }
 

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1,10 +1,15 @@
+#[cfg(test)]
+use {
+    crate::repair::standard_repair_handler::StandardRepairHandler,
+    solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
+};
 use {
     crate::{
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{
             duplicate_repair_status::get_ancestor_hash_repair_sample_size,
             quic_endpoint::RemoteRequest,
-            repair_response,
+            repair_handler::RepairHandler,
             repair_service::{OutstandingShredRepairs, RepairStats, REPAIR_MS},
             request_response::RequestResponse,
             result::{Error, RepairVerifyError, Result},
@@ -28,11 +33,7 @@ use {
     },
     solana_hash::{Hash, HASH_BYTES},
     solana_keypair::{signable::Signable, Keypair},
-    solana_ledger::{
-        ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
-        blockstore::Blockstore,
-        shred::{self, Nonce, ShredFetchStats, SIZE_OF_NONCE},
-    },
+    solana_ledger::shred::{self, Nonce, ShredFetchStats, SIZE_OF_NONCE},
     solana_packet::PACKET_DATA_SIZE,
     solana_perf::{
         data_budget::DataBudget,
@@ -338,6 +339,7 @@ pub struct ServeRepair {
     cluster_info: Arc<ClusterInfo>,
     root_bank_cache: RootBankCache,
     repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+    repair_handler: Box<dyn RepairHandler + Send + Sync>,
 }
 
 // Cache entry for repair peers for a slot.
@@ -400,12 +402,26 @@ impl ServeRepair {
         cluster_info: Arc<ClusterInfo>,
         bank_forks: Arc<RwLock<BankForks>>,
         repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+        repair_handler: impl RepairHandler + Send + Sync + 'static,
     ) -> Self {
         Self {
             cluster_info,
             root_bank_cache: RootBankCache::new(bank_forks),
             repair_whitelist,
+            repair_handler: Box::new(repair_handler),
         }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test(
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+    ) -> Self {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let repair_handler = StandardRepairHandler::new(blockstore);
+        Self::new(cluster_info, bank_forks, repair_whitelist, repair_handler)
     }
 
     pub(crate) fn my_id(&self) -> Pubkey {
@@ -413,9 +429,9 @@ impl ServeRepair {
     }
 
     fn handle_repair(
+        &self,
         recycler: &PacketBatchRecycler,
         from_addr: &SocketAddr,
-        blockstore: &Blockstore,
         request: RepairProtocol,
         stats: &mut ServeRepairStats,
         ping_cache: &mut PingCache,
@@ -429,10 +445,9 @@ impl ServeRepair {
                     shred_index,
                 } => {
                     stats.window_index += 1;
-                    let batch = Self::run_window_request(
+                    let batch = self.repair_handler.run_window_request(
                         recycler,
                         from_addr,
-                        blockstore,
                         *slot,
                         *shred_index,
                         *nonce,
@@ -449,10 +464,9 @@ impl ServeRepair {
                 } => {
                     stats.highest_window_index += 1;
                     (
-                        Self::run_highest_window_request(
+                        self.repair_handler.run_highest_window_request(
                             recycler,
                             from_addr,
-                            blockstore,
                             *slot,
                             *highest_index,
                             *nonce,
@@ -466,10 +480,9 @@ impl ServeRepair {
                 } => {
                     stats.orphan += 1;
                     (
-                        Self::run_orphan(
+                        self.repair_handler.run_orphan(
                             recycler,
                             from_addr,
-                            blockstore,
                             *slot,
                             MAX_ORPHAN_REPAIR_RESPONSES,
                             *nonce,
@@ -483,7 +496,8 @@ impl ServeRepair {
                 } => {
                     stats.ancestor_hashes += 1;
                     (
-                        Self::run_ancestor_hashes(recycler, from_addr, blockstore, *slot, *nonce),
+                        self.repair_handler
+                            .run_ancestor_hashes(recycler, from_addr, *slot, *nonce),
                         "AncestorHashes",
                     )
                 }
@@ -630,7 +644,6 @@ impl ServeRepair {
         &mut self,
         ping_cache: &mut PingCache,
         recycler: &PacketBatchRecycler,
-        blockstore: &Blockstore,
         requests_receiver: &Receiver<RemoteRequest>,
         response_sender: &PacketBatchSender,
         repair_response_quic_sender: &AsyncSender<(SocketAddr, Bytes)>,
@@ -705,7 +718,6 @@ impl ServeRepair {
         self.handle_requests(
             ping_cache,
             recycler,
-            blockstore,
             decoded_requests,
             response_sender,
             repair_response_quic_sender,
@@ -807,7 +819,6 @@ impl ServeRepair {
 
     pub(crate) fn listen(
         mut self,
-        blockstore: Arc<Blockstore>,
         requests_receiver: Receiver<RemoteRequest>,
         response_sender: PacketBatchSender,
         repair_response_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
@@ -839,7 +850,6 @@ impl ServeRepair {
                     let result = self.run_listen(
                         &mut ping_cache,
                         &recycler,
-                        &blockstore,
                         &requests_receiver,
                         &response_sender,
                         &repair_response_quic_sender,
@@ -973,7 +983,6 @@ impl ServeRepair {
         &self,
         ping_cache: &mut PingCache,
         recycler: &PacketBatchRecycler,
-        blockstore: &Blockstore,
         requests: Vec<RepairRequestWithMeta>,
         packet_batch_sender: &PacketBatchSender,
         repair_response_quic_sender: &AsyncSender<(SocketAddr, Bytes)>,
@@ -1008,8 +1017,7 @@ impl ServeRepair {
                 }
             }
             stats.processed += 1;
-            let Some(rsp) =
-                Self::handle_repair(recycler, &from_addr, blockstore, request, stats, ping_cache)
+            let Some(rsp) = self.handle_repair(recycler, &from_addr, request, stats, ping_cache)
             else {
                 continue;
             };
@@ -1284,128 +1292,6 @@ impl ServeRepair {
             self.cluster_info.repair_peers(slot)
         }
     }
-
-    fn run_window_request(
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        blockstore: &Blockstore,
-        slot: Slot,
-        shred_index: u64,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let packet = repair_response::repair_response_packet(
-            blockstore,
-            slot,
-            shred_index,
-            from_addr,
-            nonce,
-        )?;
-        Some(
-            PinnedPacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_window_request",
-                vec![packet],
-            )
-            .into(),
-        )
-    }
-
-    fn run_highest_window_request(
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        blockstore: &Blockstore,
-        slot: Slot,
-        highest_index: u64,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let meta = blockstore.meta(slot).ok()??;
-        if meta.received > highest_index {
-            // meta.received must be at least 1 by this point
-            let packet = repair_response::repair_response_packet(
-                blockstore,
-                slot,
-                meta.received - 1,
-                from_addr,
-                nonce,
-            )?;
-            return Some(
-                PinnedPacketBatch::new_unpinned_with_recycler_data(
-                    recycler,
-                    "run_highest_window_request",
-                    vec![packet],
-                )
-                .into(),
-            );
-        }
-        None
-    }
-
-    fn run_orphan(
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        blockstore: &Blockstore,
-        slot: Slot,
-        max_responses: usize,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        let mut res =
-            PinnedPacketBatch::new_unpinned_with_recycler(recycler, max_responses, "run_orphan");
-        // Try to find the next "n" parent slots of the input slot
-        let packets = std::iter::successors(blockstore.meta(slot).ok()?, |meta| {
-            blockstore.meta(meta.parent_slot?).ok()?
-        })
-        .map_while(|meta| {
-            repair_response::repair_response_packet(
-                blockstore,
-                meta.slot,
-                meta.received.checked_sub(1u64)?,
-                from_addr,
-                nonce,
-            )
-        });
-        for packet in packets.take(max_responses) {
-            res.push(packet);
-        }
-        (!res.is_empty()).then_some(res.into())
-    }
-
-    fn run_ancestor_hashes(
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        blockstore: &Blockstore,
-        slot: Slot,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        let ancestor_slot_hashes = if blockstore.is_duplicate_confirmed(slot) {
-            let ancestor_iterator =
-                AncestorIteratorWithHash::from(AncestorIterator::new_inclusive(slot, blockstore));
-            ancestor_iterator.take(MAX_ANCESTOR_RESPONSES).collect()
-        } else {
-            // If this slot is not duplicate confirmed, return nothing
-            vec![]
-        };
-        let response = AncestorHashesResponse::Hashes(ancestor_slot_hashes);
-        let serialized_response = serialize(&response).ok()?;
-
-        // Could probably directly write response into packet via `serialize_into()`
-        // instead of incurring extra copy in `repair_response_packet_from_bytes`, but
-        // serialize_into doesn't return the written size...
-        let packet = repair_response::repair_response_packet_from_bytes(
-            serialized_response,
-            from_addr,
-            nonce,
-        )?;
-        Some(
-            PinnedPacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_ancestor_hashes",
-                vec![packet],
-            )
-            .into(),
-        )
-    }
 }
 
 #[inline]
@@ -1455,7 +1341,7 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore::make_many_slot_entries,
+            blockstore::{make_many_slot_entries, Blockstore},
             blockstore_processor::fill_blockstore_slot_with_ticks,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path_auto_delete,
@@ -1598,7 +1484,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
-        let serve_repair = ServeRepair::new(
+        let serve_repair = ServeRepair::new_for_test(
             cluster_info.clone(),
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
@@ -1647,7 +1533,7 @@ mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.feature_set = Arc::new(FeatureSet::all_enabled());
         let bank_forks = BankForks::new_rw_arc(bank);
-        let serve_repair = ServeRepair::new(
+        let serve_repair = ServeRepair::new_for_test(
             cluster_info,
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
@@ -1684,7 +1570,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
-        let serve_repair = ServeRepair::new(
+        let serve_repair = ServeRepair::new_for_test(
             cluster_info.clone(),
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
@@ -1885,19 +1771,13 @@ mod tests {
     }
 
     /// test run_window_request responds with the right shred, and do not overrun
-    fn run_highest_window_request(slot: Slot, num_slots: u64, nonce: Nonce) {
+    pub fn run_highest_window_request(slot: Slot, num_slots: u64, nonce: Nonce) {
         let recycler = PacketBatchRecycler::default();
         solana_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let rv = ServeRepair::run_highest_window_request(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            0,
-            0,
-            nonce,
-        );
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let rv = handler.run_highest_window_request(&recycler, &socketaddr_any!(), 0, 0, nonce);
         assert!(rv.is_none());
 
         let _ = fill_blockstore_slot_with_ticks(
@@ -1909,15 +1789,9 @@ mod tests {
         );
 
         let index = 1;
-        let mut rv = ServeRepair::run_highest_window_request(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot,
-            index,
-            nonce,
-        )
-        .expect("packets");
+        let mut rv = handler
+            .run_highest_window_request(&recycler, &socketaddr_any!(), slot, index, nonce)
+            .expect("packets");
         let request = ShredRepairType::HighestShred(slot, index);
         verify_responses(&request, rv.iter());
 
@@ -1936,10 +1810,9 @@ mod tests {
         assert_eq!(rv[0].index(), index as u32);
         assert_eq!(rv[0].slot(), slot);
 
-        let rv = ServeRepair::run_highest_window_request(
+        let rv = handler.run_highest_window_request(
             &recycler,
             &socketaddr_any!(),
-            &blockstore,
             slot,
             index + 1,
             nonce,
@@ -1953,19 +1826,13 @@ mod tests {
     }
 
     /// test window requests respond with the right shred, and do not overrun
-    fn run_window_request(slot: Slot, nonce: Nonce) {
+    pub fn run_window_request(slot: Slot, nonce: Nonce) {
         let recycler = PacketBatchRecycler::default();
         solana_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let rv = ServeRepair::run_window_request(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot,
-            0,
-            nonce,
-        );
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let rv = handler.run_window_request(&recycler, &socketaddr_any!(), slot, 0, nonce);
         assert!(rv.is_none());
         let shred = Shred::new_from_data(slot, 1, 1, &[], ShredFlags::empty(), 0, 2, 0);
 
@@ -1974,15 +1841,9 @@ mod tests {
             .expect("Expect successful ledger write");
 
         let index = 1;
-        let mut rv = ServeRepair::run_window_request(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot,
-            index,
-            nonce,
-        )
-        .expect("packets");
+        let mut rv = handler
+            .run_window_request(&recycler, &socketaddr_any!(), slot, index, nonce)
+            .expect("packets");
         let request = ShredRepairType::Shred(slot, index);
         verify_responses(&request, rv.iter());
         let rv: Vec<Shred> = rv
@@ -2013,7 +1874,7 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
-        let serve_repair = ServeRepair::new(
+        let serve_repair = ServeRepair::new_for_test(
             cluster_info.clone(),
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
@@ -2120,13 +1981,13 @@ mod tests {
         run_orphan(2, 3, 9);
     }
 
-    fn run_orphan(slot: Slot, num_slots: u64, nonce: Nonce) {
+    pub fn run_orphan(slot: Slot, num_slots: u64, nonce: Nonce) {
         solana_logger::setup();
         let recycler = PacketBatchRecycler::default();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let rv =
-            ServeRepair::run_orphan(&recycler, &socketaddr_any!(), &blockstore, slot, 5, nonce);
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let rv = handler.run_orphan(&recycler, &socketaddr_any!(), slot, 5, nonce);
         assert!(rv.is_none());
 
         // Create slots [slot, slot + num_slots) with 5 shreds apiece
@@ -2137,27 +1998,20 @@ mod tests {
             .expect("Expect successful ledger write");
 
         // We don't have slot `slot + num_slots`, so we don't know how to service this request
-        let rv = ServeRepair::run_orphan(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot + num_slots,
-            5,
-            nonce,
-        );
+        let rv = handler.run_orphan(&recycler, &socketaddr_any!(), slot + num_slots, 5, nonce);
         assert!(rv.is_none());
 
         // For a orphan request for `slot + num_slots - 1`, we should return the highest shreds
         // from slots in the range [slot, slot + num_slots - 1]
-        let rv = ServeRepair::run_orphan(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot + num_slots - 1,
-            5,
-            nonce,
-        )
-        .expect("run_orphan packets");
+        let rv = handler
+            .run_orphan(
+                &recycler,
+                &socketaddr_any!(),
+                slot + num_slots - 1,
+                5,
+                nonce,
+            )
+            .expect("run_orphan packets");
 
         // Verify responses
         let request = ShredRepairType::Orphan(slot + num_slots - 1);
@@ -2212,7 +2066,9 @@ mod tests {
         // Orphan request for slot 2 should only return slot 1 since
         // calling `repair_response_packet` on slot 1's shred will
         // be corrupted
-        let rv = ServeRepair::run_orphan(&recycler, &socketaddr_any!(), &blockstore, 2, 5, nonce)
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let rv = handler
+            .run_orphan(&recycler, &socketaddr_any!(), 2, 5, nonce)
             .expect("run_orphan packets");
 
         // Verify responses
@@ -2254,14 +2110,10 @@ mod tests {
             .expect("Expect successful ledger write");
 
         // We don't have slot `slot + num_slots`, so we return empty
-        let rv = ServeRepair::run_ancestor_hashes(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot + num_slots,
-            nonce,
-        )
-        .expect("run_ancestor_hashes packets");
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let rv = handler
+            .run_ancestor_hashes(&recycler, &socketaddr_any!(), slot + num_slots, nonce)
+            .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
         let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
@@ -2276,14 +2128,9 @@ mod tests {
 
         // `slot + num_slots - 1` is not marked duplicate confirmed so nothing should return
         // empty
-        let rv = ServeRepair::run_ancestor_hashes(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot + num_slots - 1,
-            nonce,
-        )
-        .expect("run_ancestor_hashes packets");
+        let rv = handler
+            .run_ancestor_hashes(&recycler, &socketaddr_any!(), slot + num_slots - 1, nonce)
+            .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
         let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
@@ -2305,14 +2152,9 @@ mod tests {
                 (duplicate_confirmed_slot, frozen_hash);
             blockstore.insert_bank_hash(duplicate_confirmed_slot, frozen_hash, true);
         }
-        let rv = ServeRepair::run_ancestor_hashes(
-            &recycler,
-            &socketaddr_any!(),
-            &blockstore,
-            slot + num_slots - 1,
-            nonce,
-        )
-        .expect("run_ancestor_hashes packets");
+        let rv = handler
+            .run_ancestor_hashes(&recycler, &socketaddr_any!(), slot + num_slots - 1, nonce)
+            .expect("run_ancestor_hashes packets");
         assert_eq!(rv.len(), 1);
         let packet = rv.first().unwrap();
         let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
@@ -2341,7 +2183,7 @@ mod tests {
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
         let identity_keypair = cluster_info.keypair().clone();
-        let serve_repair = ServeRepair::new(
+        let serve_repair = ServeRepair::new_for_test(
             cluster_info,
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -2,7 +2,6 @@ use {
     crate::repair::{quic_endpoint::RemoteRequest, serve_repair::ServeRepair},
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver, Sender},
-    solana_ledger::blockstore::Blockstore,
     solana_perf::{packet::PacketBatch, recycler::Recycler},
     solana_streamer::{
         socket::SocketAddrSpace,
@@ -27,7 +26,6 @@ impl ServeRepairService {
         remote_request_sender: Sender<RemoteRequest>,
         remote_request_receiver: Receiver<RemoteRequest>,
         repair_response_quic_sender: AsyncSender<(SocketAddr, Bytes)>,
-        blockstore: Arc<Blockstore>,
         serve_repair_socket: UdpSocket,
         socket_addr_space: SocketAddrSpace,
         stats_reporter_sender: Sender<Box<dyn FnOnce() + Send>>,
@@ -65,7 +63,6 @@ impl ServeRepairService {
             Some(stats_reporter_sender),
         );
         let t_listen = serve_repair.listen(
-            blockstore,
             remote_request_receiver,
             response_sender,
             repair_response_quic_sender,

--- a/core/src/repair/standard_repair_handler.rs
+++ b/core/src/repair/standard_repair_handler.rs
@@ -1,0 +1,151 @@
+use {
+    super::{
+        repair_handler::RepairHandler,
+        repair_response,
+        serve_repair::{AncestorHashesResponse, MAX_ANCESTOR_RESPONSES},
+    },
+    bincode::serialize,
+    solana_clock::Slot,
+    solana_ledger::{
+        ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
+        blockstore::Blockstore,
+        shred::Nonce,
+    },
+    solana_perf::packet::{PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
+    std::{net::SocketAddr, sync::Arc},
+};
+
+pub(crate) struct StandardRepairHandler {
+    blockstore: Arc<Blockstore>,
+}
+
+impl StandardRepairHandler {
+    pub(crate) fn new(blockstore: Arc<Blockstore>) -> Self {
+        Self { blockstore }
+    }
+}
+
+impl RepairHandler for StandardRepairHandler {
+    fn run_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        shred_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        // Try to find the requested index in one of the slots
+        let packet = repair_response::repair_response_packet(
+            self.blockstore.as_ref(),
+            slot,
+            shred_index,
+            from_addr,
+            nonce,
+        )?;
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_window_request",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
+
+    fn run_highest_window_request(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        highest_index: u64,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        // Try to find the requested index in one of the slots
+        let meta = self.blockstore.meta(slot).ok()??;
+        if meta.received > highest_index {
+            // meta.received must be at least 1 by this point
+            let packet = repair_response::repair_response_packet(
+                self.blockstore.as_ref(),
+                slot,
+                meta.received - 1,
+                from_addr,
+                nonce,
+            )?;
+            return Some(
+                PinnedPacketBatch::new_unpinned_with_recycler_data(
+                    recycler,
+                    "run_highest_window_request",
+                    vec![packet],
+                )
+                .into(),
+            );
+        }
+        None
+    }
+
+    fn run_orphan(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        max_responses: usize,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let mut res =
+            PinnedPacketBatch::new_unpinned_with_recycler(recycler, max_responses, "run_orphan");
+        // Try to find the next "n" parent slots of the input slot
+        let packets = std::iter::successors(self.blockstore.meta(slot).ok()?, |meta| {
+            self.blockstore.meta(meta.parent_slot?).ok()?
+        })
+        .map_while(|meta| {
+            repair_response::repair_response_packet(
+                self.blockstore.as_ref(),
+                meta.slot,
+                meta.received.checked_sub(1u64)?,
+                from_addr,
+                nonce,
+            )
+        });
+        for packet in packets.take(max_responses) {
+            res.push(packet);
+        }
+        (!res.is_empty()).then_some(res.into())
+    }
+
+    fn run_ancestor_hashes(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let ancestor_slot_hashes = if self.blockstore.is_duplicate_confirmed(slot) {
+            let ancestor_iterator = AncestorIteratorWithHash::from(
+                AncestorIterator::new_inclusive(slot, self.blockstore.as_ref()),
+            );
+            ancestor_iterator.take(MAX_ANCESTOR_RESPONSES).collect()
+        } else {
+            // If this slot is not duplicate confirmed, return nothing
+            vec![]
+        };
+        let response = AncestorHashesResponse::Hashes(ancestor_slot_hashes);
+        let serialized_response = serialize(&response).ok()?;
+
+        // Could probably directly write response into packet via `serialize_into()`
+        // instead of incurring extra copy in `repair_response_packet_from_bytes`, but
+        // serialize_into doesn't return the written size...
+        let packet = repair_response::repair_response_packet_from_bytes(
+            serialized_response,
+            from_addr,
+            nonce,
+        )?;
+        Some(
+            PinnedPacketBatch::new_unpinned_with_recycler_data(
+                recycler,
+                "run_ancestor_hashes",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
+}

--- a/core/src/repair/standard_repair_handler.rs
+++ b/core/src/repair/standard_repair_handler.rs
@@ -1,17 +1,8 @@
 use {
-    super::{
-        repair_handler::RepairHandler,
-        repair_response,
-        serve_repair::{AncestorHashesResponse, MAX_ANCESTOR_RESPONSES},
-    },
-    bincode::serialize,
+    super::{repair_handler::RepairHandler, repair_response},
     solana_clock::Slot,
-    solana_ledger::{
-        ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
-        blockstore::Blockstore,
-        shred::Nonce,
-    },
-    solana_perf::packet::{PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
+    solana_ledger::{blockstore::Blockstore, shred::Nonce},
+    solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     std::{net::SocketAddr, sync::Arc},
 };
 
@@ -26,61 +17,24 @@ impl StandardRepairHandler {
 }
 
 impl RepairHandler for StandardRepairHandler {
-    fn run_window_request(
+    fn blockstore(&self) -> &Blockstore {
+        &self.blockstore
+    }
+
+    fn repair_response_packet(
         &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
         slot: Slot,
         shred_index: u64,
+        dest: &SocketAddr,
         nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let packet = repair_response::repair_response_packet(
+    ) -> Option<Packet> {
+        repair_response::repair_response_packet(
             self.blockstore.as_ref(),
             slot,
             shred_index,
-            from_addr,
+            dest,
             nonce,
-        )?;
-        Some(
-            PinnedPacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_window_request",
-                vec![packet],
-            )
-            .into(),
         )
-    }
-
-    fn run_highest_window_request(
-        &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        highest_index: u64,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let meta = self.blockstore.meta(slot).ok()??;
-        if meta.received > highest_index {
-            // meta.received must be at least 1 by this point
-            let packet = repair_response::repair_response_packet(
-                self.blockstore.as_ref(),
-                slot,
-                meta.received - 1,
-                from_addr,
-                nonce,
-            )?;
-            return Some(
-                PinnedPacketBatch::new_unpinned_with_recycler_data(
-                    recycler,
-                    "run_highest_window_request",
-                    vec![packet],
-                )
-                .into(),
-            );
-        }
-        None
     }
 
     fn run_orphan(
@@ -110,42 +64,5 @@ impl RepairHandler for StandardRepairHandler {
             res.push(packet);
         }
         (!res.is_empty()).then_some(res.into())
-    }
-
-    fn run_ancestor_hashes(
-        &self,
-        recycler: &PacketBatchRecycler,
-        from_addr: &SocketAddr,
-        slot: Slot,
-        nonce: Nonce,
-    ) -> Option<PacketBatch> {
-        let ancestor_slot_hashes = if self.blockstore.is_duplicate_confirmed(slot) {
-            let ancestor_iterator = AncestorIteratorWithHash::from(
-                AncestorIterator::new_inclusive(slot, self.blockstore.as_ref()),
-            );
-            ancestor_iterator.take(MAX_ANCESTOR_RESPONSES).collect()
-        } else {
-            // If this slot is not duplicate confirmed, return nothing
-            vec![]
-        };
-        let response = AncestorHashesResponse::Hashes(ancestor_slot_hashes);
-        let serialized_response = serialize(&response).ok()?;
-
-        // Could probably directly write response into packet via `serialize_into()`
-        // instead of incurring extra copy in `repair_response_packet_from_bytes`, but
-        // serialize_into doesn't return the written size...
-        let packet = repair_response::repair_response_packet_from_bytes(
-            serialized_response,
-            from_addr,
-            nonce,
-        )?;
-        Some(
-            PinnedPacketBatch::new_unpinned_with_recycler_data(
-                recycler,
-                "run_ancestor_hashes",
-                vec![packet],
-            )
-            .into(),
-        )
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -16,7 +16,7 @@ use {
         repair::{
             self,
             quic_endpoint::{RepairQuicAsyncSenders, RepairQuicSenders, RepairQuicSockets},
-            serve_repair::ServeRepair,
+            repair_handler::RepairHandlerType,
             serve_repair_service::ServeRepairService,
         },
         sample_performance_service::SamplePerformanceService,
@@ -293,6 +293,7 @@ pub struct ValidatorConfig {
     pub delay_leader_block_for_pending_fork: bool,
     pub use_tpu_client_next: bool,
     pub retransmit_xdp: Option<XdpConfig>,
+    pub repair_handler_type: RepairHandlerType,
 }
 
 impl Default for ValidatorConfig {
@@ -368,6 +369,7 @@ impl Default for ValidatorConfig {
             delay_leader_block_for_pending_fork: false,
             use_tpu_client_next: true,
             retransmit_xdp: None,
+            repair_handler_type: RepairHandlerType::default(),
         }
     }
 }
@@ -1326,7 +1328,8 @@ impl Validator {
             Some(stats_reporter_sender.clone()),
             exit.clone(),
         );
-        let serve_repair = ServeRepair::new(
+        let serve_repair = config.repair_handler_type.create_serve_repair(
+            blockstore.clone(),
             cluster_info.clone(),
             bank_forks.clone(),
             config.repair_whitelist.clone(),
@@ -1455,7 +1458,6 @@ impl Validator {
             repair_request_quic_sender,
             repair_request_quic_receiver,
             repair_quic_async_senders.repair_response_quic_sender,
-            blockstore.clone(),
             node.sockets.serve_repair,
             socket_addr_space,
             stats_reporter_sender,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -111,7 +111,7 @@ pub const SIZE_OF_NONCE: usize = std::mem::size_of::<Nonce>();
 /// The following constants are computed by hand, and hardcoded.
 /// `test_shred_constants` ensures that the values are correct.
 const SIZE_OF_COMMON_SHRED_HEADER: usize = 83;
-const SIZE_OF_DATA_SHRED_HEADERS: usize = 88;
+pub const SIZE_OF_DATA_SHRED_HEADERS: usize = 88;
 const SIZE_OF_CODING_SHRED_HEADERS: usize = 89;
 const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -80,6 +80,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
         use_tpu_client_next: config.use_tpu_client_next,
         retransmit_xdp: config.retransmit_xdp.clone(),
+        repair_handler_type: config.repair_handler_type.clone(),
     }
 }
 


### PR DESCRIPTION
#### Problem

Responding to repair requests is entangled in `serve_repair` which makes it difficult to mock for testing. We wish to enable testing of more intricate duplicate block and catchup cases in Alpenglow.

#### Summary of Changes

Similar to the encapsulation in `broadcast_stage`, separate the response logic into a separate `RepairHandler` trait object.
Additionally create a malicious variant for use in local cluster and invalidator testing later.

This PR should not change any behavior, just a refactor. Also open to naming suggestions.