### PR TITLE
Refactor Accounts Index and AccountsIndexIterator

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -8527,12 +8527,9 @@ impl AccountsDb {
         let full_pubkey_range = Pubkey::from([0; 32])..=Pubkey::from([0xff; 32]);
 
         self.accounts_index.account_maps.iter().for_each(|map| {
-            for (pubkey, account_entry) in map.items(&full_pubkey_range) {
-                info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
-                info!(
-                    "      slots: {:?}",
-                    *account_entry.slot_list.read().unwrap()
-                );
+            for (pubkey, slot_list) in map.items(&full_pubkey_range) {
+                info!("  key: {}", pubkey);
+                info!("      slots: {:?}", slot_list);
             }
         });
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -730,21 +730,27 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         for pubkey_list in self.iter(range.as_ref(), returns_items) {
             iterator_timer.stop();
             iterator_elapsed += iterator_timer.as_us();
-            for (pubkey, list) in pubkey_list {
+            for pubkey in pubkey_list {
                 num_keys_iterated += 1;
-                let mut read_lock_timer = Measure::start("read_lock");
-                let list_r = &list.slot_list.read().unwrap();
-                read_lock_timer.stop();
-                read_lock_elapsed += read_lock_timer.as_us();
-                let mut latest_slot_timer = Measure::start("latest_slot");
-                if let Some(index) = self.latest_slot(Some(ancestors), list_r, max_root) {
-                    latest_slot_timer.stop();
-                    latest_slot_elapsed += latest_slot_timer.as_us();
-                    let mut load_account_timer = Measure::start("load_account");
-                    func(&pubkey, (&list_r[index].1, list_r[index].0));
-                    load_account_timer.stop();
-                    load_account_elapsed += load_account_timer.as_us();
-                }
+                self.get_and_then(&pubkey, |entry| {
+                    if let Some(list) = entry {
+                        let mut read_lock_timer = Measure::start("read_lock");
+                        let list_r = &list.slot_list.read().unwrap();
+                        read_lock_timer.stop();
+                        read_lock_elapsed += read_lock_timer.as_us();
+                        let mut latest_slot_timer = Measure::start("latest_slot");
+                        if let Some(index) = self.latest_slot(Some(ancestors), list_r, max_root) {
+                            latest_slot_timer.stop();
+                            latest_slot_elapsed += latest_slot_timer.as_us();
+                            let mut load_account_timer = Measure::start("load_account");
+                            func(&pubkey, (&list_r[index].1, list_r[index].0));
+                            load_account_timer.stop();
+                            load_account_elapsed += load_account_timer.as_us();
+                        }
+                    }
+                    let add_to_in_mem_cache = false;
+                    (add_to_in_mem_cache, ())
+                });
                 if config.is_aborted() {
                     return;
                 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -727,10 +727,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut iterator_elapsed = 0;
         let mut iterator_timer = Measure::start("iterator_elapsed");
 
-        for pubkey_list in self.iter(range.as_ref(), returns_items) {
+        for pubkeys in self.iter(range.as_ref(), returns_items) {
             iterator_timer.stop();
             iterator_elapsed += iterator_timer.as_us();
-            for pubkey in pubkey_list {
+            for pubkey in pubkeys {
                 num_keys_iterated += 1;
                 self.get_and_then(&pubkey, |entry| {
                     if let Some(list) = entry {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -250,52 +250,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
-    pub fn items<R>(&self, range: &R) -> Vec<(Pubkey, SlotList<T>)>
-    where
-        R: RangeBounds<Pubkey> + std::fmt::Debug,
-    {
-        let start = match range.start_bound() {
-            Bound::Included(bound) | Bound::Excluded(bound) => bound,
-            Bound::Unbounded => &Pubkey::from([0; 32]),
-        };
-
-        let end = match range.end_bound() {
-            Bound::Included(bound) | Bound::Excluded(bound) => bound,
-            Bound::Unbounded => &Pubkey::from([0xff; 32]),
-        };
-
-        if start > &self.highest_pubkey || end < &self.lowest_pubkey {
-            // range does not contain any of the keys in this bin. No need to
-            // load and scan the map.
-            // Example:
-            //    |-------------------|  |-------------------|  |-------------------|
-            //       start          end  low               high  start              end
-            return vec![];
-        }
-
-        let m = Measure::start("items");
-
-        // For simplicity, we check the range for every pubkey in the map. This
-        // can be further optimized for case, such as the range contains lowest
-        // and highest pubkey for this bin. In such case, we can return all
-        // items in the map without range check on item's pubkey. Since the
-        // check is cheap when compared with the cost of reading from disk, we
-        // are not optimizing it for now.
-        self.hold_range_in_memory(range, true);
-        let result = self
-            .map_internal
-            .read()
-            .unwrap()
-            .iter()
-            .filter(|&(k, _v)| range.contains(k))
-            .map(|(k, v)| (*k, v.slot_list.read().unwrap().clone()))
-            .collect();
-        self.hold_range_in_memory(range, false);
-        Self::update_stat(&self.stats().items, 1);
-        Self::update_time_stat(&self.stats().items_us, m);
-        result
-    }
-
     /// return all keys in this bin
     pub fn keys(&self) -> Vec<Pubkey> {
         Self::update_stat(&self.stats().keys, 1);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -250,7 +250,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
-    pub fn items<R>(&self, range: &R) -> Vec<(Pubkey, Arc<AccountMapEntry<T>>)>
+    pub fn items<R>(&self, range: &R) -> Vec<(Pubkey, SlotList<T>)>
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
@@ -288,7 +288,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             .unwrap()
             .iter()
             .filter(|&(k, _v)| range.contains(k))
-            .map(|(k, v)| (*k, Arc::clone(v)))
+            .map(|(k, v)| (*k, v.slot_list.read().unwrap().clone()))
             .collect();
         self.hold_range_in_memory(range, false);
         Self::update_stat(&self.stats().items, 1);
@@ -296,7 +296,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         result
     }
 
-    // only called in debug code paths
+    /// return all keys in this bin
     pub fn keys(&self) -> Vec<Pubkey> {
         Self::update_stat(&self.stats().keys, 1);
         // easiest implementation is to load everything from disk into cache and return the keys

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -169,7 +169,6 @@ enum AppendVecFileBacking {
     /// A file-backed block of memory that is used to store the data for each appended item.
     Mmap(MmapMut),
     /// This was opened as a read only file
-    #[cfg_attr(not(unix), allow(dead_code))]
     File(File),
 }
 
@@ -368,13 +367,7 @@ impl AppendVec {
 
     /// when we can use file i/o as opposed to mmap, this is the trigger to tell us
     /// that no more appending will occur and we can close the initial mmap.
-    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
-        #[cfg(not(unix))]
-        // must open as mmmap on non-unix
-        return None;
-
-        #[cfg(unix)]
         match &self.backing {
             AppendVecFileBacking::File(_file) => {
                 // already a file, so already read-only
@@ -477,7 +470,6 @@ impl AppendVec {
     }
 
     /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts
-    #[cfg_attr(not(unix), allow(unused_variables))]
     pub fn new_from_file_unchecked(
         path: impl Into<PathBuf>,
         current_len: usize,
@@ -493,8 +485,6 @@ impl AppendVec {
             .create(false)
             .open(&path)?;
 
-        #[cfg(unix)]
-        // we must use mmap on non-linux
         if storage_access == StorageAccess::File {
             APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -169,6 +169,7 @@ enum AppendVecFileBacking {
     /// A file-backed block of memory that is used to store the data for each appended item.
     Mmap(MmapMut),
     /// This was opened as a read only file
+    #[cfg_attr(not(unix), allow(dead_code))]
     File(File),
 }
 
@@ -367,7 +368,13 @@ impl AppendVec {
 
     /// when we can use file i/o as opposed to mmap, this is the trigger to tell us
     /// that no more appending will occur and we can close the initial mmap.
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
+        #[cfg(not(unix))]
+        // must open as mmmap on non-unix
+        return None;
+
+        #[cfg(unix)]
         match &self.backing {
             AppendVecFileBacking::File(_file) => {
                 // already a file, so already read-only
@@ -470,6 +477,7 @@ impl AppendVec {
     }
 
     /// Creates an appendvec from file without performing sanitize checks or counting the number of accounts
+    #[cfg_attr(not(unix), allow(unused_variables))]
     pub fn new_from_file_unchecked(
         path: impl Into<PathBuf>,
         current_len: usize,
@@ -485,6 +493,8 @@ impl AppendVec {
             .create(false)
             .open(&path)?;
 
+        #[cfg(unix)]
+        // we must use mmap on non-linux
         if storage_access == StorageAccess::File {
             APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
#### Problem
With the removal of rent scanning, we can cleanup, remove, and then simplify flushing and holding ranges. To facilitate that, we can refactor how scan iterates throug the accounts. Scanning accounts are deprecated behavior, but still possible to call.

From API's perspective, we should *not* provide APIs which holds Arc<AccountMapEntry<T>> for an entry that is in the accounts-index. That could lead to race conditions with other accounts-db task, such as flush, clean, shrink etc. To mitigate this, we refactor the account index iterator to avoid returning internal data structures directly and instead return lightweight identifiers (i.e., pubkeys).




#### Summary of Changes
1. remove items api
2. change account index iterator to return just pubkeys
3. update print_index and scan to take pubkey and lookup the accounts again.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
