### PR TITLE
Sets accounts verification completed when verifying with lattice in foreground

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4950,6 +4950,7 @@ impl Bank {
                              match, expected: {expected}, calculated: {calculated}",
                         );
                     }
+                    self.set_initial_accounts_hash_verification_completed();
                     is_ok
                 }
                 VerifyKind::Merkle => {


### PR DESCRIPTION
#### Problem

If verifying accounts at startup is using lattice _and_ in the foreground (which only happens for tests), we don't currently set the verification as completed.


#### Summary of Changes

Set it complete.
