### PR TITLE
Clean up startup accounts verification fns

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2124,7 +2124,7 @@ impl ReplayStage {
 
         assert!(parent.is_frozen());
 
-        if !parent.is_startup_verification_complete() {
+        if !parent.has_initial_accounts_hash_verification_completed() {
             info!("startup verification incomplete, so skipping my leader slot");
             return false;
         }
@@ -2494,7 +2494,7 @@ impl ReplayStage {
         has_new_vote_been_rooted: bool,
         wait_to_vote_slot: Option<Slot>,
     ) -> GenerateVoteTxResult {
-        if !bank.is_startup_verification_complete() {
+        if !bank.has_initial_accounts_hash_verification_completed() {
             info!("startup verification incomplete, so unable to vote");
             return GenerateVoteTxResult::Failed;
         }
@@ -9272,7 +9272,7 @@ pub(crate) mod tests {
         assert!(working_bank.is_complete());
         assert!(working_bank.is_frozen());
         // Mark startup verification as complete to avoid skipping leader slots
-        working_bank.set_startup_verification_complete();
+        working_bank.set_initial_accounts_hash_verification_completed();
 
         // Insert a block two slots greater than current bank. This slot does
         // not have a corresponding Bank in BankForks; this emulates a scenario

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -144,7 +144,7 @@ impl TestEnvironment {
         let bank = bank_forks.read().unwrap().working_bank();
         assert!(epoch_accounts_hash_utils::is_enabled_this_epoch(&bank));
 
-        bank.set_startup_verification_complete();
+        bank.set_initial_accounts_hash_verification_completed();
 
         TestEnvironment {
             bank_forks,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -91,7 +91,7 @@ impl SnapshotTestConfig {
             vec![accounts_dir.clone()],
         );
         bank0.freeze();
-        bank0.set_startup_verification_complete();
+        bank0.set_initial_accounts_hash_verification_completed();
         let bank_forks_arc = BankForks::new_rw_arc(bank0);
 
         let snapshot_config = SnapshotConfig {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -198,7 +198,7 @@ pub fn load_bank_forks(
                 .read()
                 .unwrap()
                 .root_bank()
-                .set_startup_verification_complete();
+                .set_initial_accounts_hash_verification_completed();
 
             (bank_forks, None)
         };

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -178,7 +178,7 @@ pub mod tests {
 
         // Mark startup verification complete - status still unknown as no slots have been
         // optimistically confirmed yet
-        bank0.set_startup_verification_complete();
+        bank0.set_initial_accounts_hash_verification_completed();
         assert_eq!(health.check(), RpcHealthStatus::Unknown);
 
         // Mark slot 15 as being optimistically confirmed in the Blockstore, this could

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -286,7 +286,7 @@ impl SnapshotRequestHandler {
         } = snapshot_request;
 
         // we should not rely on the state of this validator until startup verification is complete
-        assert!(snapshot_root_bank.is_startup_verification_complete());
+        assert!(snapshot_root_bank.has_initial_accounts_hash_verification_completed());
 
         if accounts_package_kind == AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot) {
             // The latest full snapshot slot is what accounts-db uses to properly handle
@@ -605,7 +605,7 @@ impl AccountsBackgroundService {
                         // request handling can both kick off accounts hash calculations in
                         // background threads, and these must not happen concurrently.
                         let snapshot_handle_result = bank
-                            .is_startup_verification_complete()
+                            .has_initial_accounts_hash_verification_completed()
                             .then(|| {
                                 request_handlers.handle_snapshot_requests(
                                     test_hash_calculation,
@@ -627,7 +627,7 @@ impl AccountsBackgroundService {
                                          snapshot request slot: {snapshot_slot}, \
                                          is startup verification complete: {}, \
                                          enqueued snapshot requests: {:?}",
-                                        bank.is_startup_verification_complete(),
+                                        bank.has_initial_accounts_hash_verification_completed(),
                                         request_handlers
                                             .snapshot_request_handler
                                             .snapshot_request_receiver
@@ -947,7 +947,7 @@ mod test {
         genesis_config_info.genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
         let mut bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
-        bank.set_startup_verification_complete();
+        bank.set_initial_accounts_hash_verification_completed();
         // Need to set the EAH to Valid so that `Bank::new_from_parent()` doesn't panic during
         // freeze when parent is in the EAH calculation window.
         bank.rc
@@ -1119,7 +1119,7 @@ mod test {
         };
         let genesis_config_info = create_genesis_config(10);
         let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
-        bank.set_startup_verification_complete();
+        bank.set_initial_accounts_hash_verification_completed();
         bank.rc.accounts.accounts_db.enable_bank_drop_callback();
         bank.set_callback(Some(Box::new(SendDroppedBankCallback::new(
             pruned_banks_sender,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2908,19 +2908,6 @@ impl Bank {
             .verified
     }
 
-    /// return true if bg hash verification is complete
-    /// return false if bg hash verification has not completed yet
-    /// if hash verification failed, a panic will occur
-    pub fn is_startup_verification_complete(&self) -> bool {
-        self.has_initial_accounts_hash_verification_completed()
-    }
-
-    /// This can occur because it completed in the background
-    /// or if the verification was run in the foreground.
-    pub fn set_startup_verification_complete(&self) {
-        self.set_initial_accounts_hash_verification_completed();
-    }
-
     pub fn get_fee_for_message_with_lamports_per_signature(
         &self,
         message: &impl SVMMessage,
@@ -5303,11 +5290,7 @@ impl Bank {
                 verified
             } else {
                 info!("Verifying accounts... Skipped.");
-                self.rc
-                    .accounts
-                    .accounts_db
-                    .verify_accounts_hash_in_bg
-                    .verification_complete();
+                self.set_initial_accounts_hash_verification_completed();
                 true
             }
         });

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -113,7 +113,7 @@ impl SnapshotController {
                 is_root_bank_squashed = bank_slot == root;
 
                 let mut snapshot_time = Measure::start("squash::snapshot_time");
-                if bank.is_startup_verification_complete() {
+                if bank.has_initial_accounts_hash_verification_completed() {
                     // Save off the status cache because these may get pruned if another
                     // `set_root()` is called before the snapshots package can be generated
                     let status_cache_slot_deltas =

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -847,7 +847,7 @@ impl TestValidator {
             .read()
             .unwrap()
             .root_bank()
-            .set_startup_verification_complete();
+            .set_initial_accounts_hash_verification_completed();
     }
 
     /// Initialize the ledger directory


### PR DESCRIPTION
#### Problem

There are multiple ways/fns to query and set if/when startup accounts verification has completed. This is unnecessary.


#### Summary of Changes

Remove the duplicates.