### PR TITLE
Log warning on call to do_load_with_populate_read_cache without fixed root and remove invalid test 

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5009,8 +5009,9 @@ impl AccountsDb {
             let ending_max_root = self.accounts_index.max_root_inclusive();
             if starting_max_root != ending_max_root {
                 warn!(
-                    "do_load_with_populate_read_cache() called with fixed max root, but max root
-                    changed from {starting_max_root} to {ending_max_root} during function call"
+                    "do_load_with_populate_read_cache() scanning pubkey {pubkey} called with \
+                    fixed max root, but max root changed from {starting_max_root} to \
+                    {ending_max_root} during function call"
                 );
             }
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4939,7 +4939,7 @@ impl AccountsDb {
         #[cfg(not(test))]
         assert!(max_root.is_none());
 
-        let starting_max_slot = self.accounts_index.max_root_inclusive();
+        let starting_max_root = self.accounts_index.max_root_inclusive();
 
         let (slot, storage_location, _maybe_account_accesor) =
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, max_root, false)?;
@@ -5006,9 +5006,9 @@ impl AccountsDb {
             || load_hint == LoadHint::FixedMaxRootDoNotPopulateReadCache
         {
             // If the load hint is that the max root is fixed, the max root should be fixed.
-            let ending_max_slot = self.accounts_index.max_root_inclusive();
-            if starting_max_slot != ending_max_slot {
-                error!("do_load_with_populate_read_cache() called with fixed max root, but max root changed from {} to {} during function call", starting_max_slot, ending_max_slot);
+            let ending_max_root = self.accounts_index.max_root_inclusive();
+            if starting_max_root != ending_max_root {
+                error!("do_load_with_populate_read_cache() called with fixed max root, but max root changed from {} to {} during function call", starting_max_root, ending_max_root);
             }
         }
         Some((account, slot))

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5008,7 +5008,10 @@ impl AccountsDb {
             // If the load hint is that the max root is fixed, the max root should be fixed.
             let ending_max_root = self.accounts_index.max_root_inclusive();
             if starting_max_root != ending_max_root {
-                error!("do_load_with_populate_read_cache() called with fixed max root, but max root changed from {} to {} during function call", starting_max_root, ending_max_root);
+                warn!(
+                    "do_load_with_populate_read_cache() called with fixed max root, but max root
+                    changed from {starting_max_root} to {ending_max_root} during function call"
+                );
             }
         }
         Some((account, slot))

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4939,6 +4939,8 @@ impl AccountsDb {
         #[cfg(not(test))]
         assert!(max_root.is_none());
 
+        let starting_max_slot = self.accounts_index.max_root_inclusive();
+
         let (slot, storage_location, _maybe_account_accesor) =
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, max_root, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
@@ -4999,6 +5001,15 @@ impl AccountsDb {
             */
             self.read_only_accounts_cache
                 .store(*pubkey, slot, account.clone());
+        }
+        if load_hint == LoadHint::FixedMaxRoot
+            || load_hint == LoadHint::FixedMaxRootDoNotPopulateReadCache
+        {
+            // If the load hint is that the max root is fixed, the max root should be fixed.
+            let ending_max_slot = self.accounts_index.max_root_inclusive();
+            if starting_max_slot != ending_max_slot {
+                error!("do_load_with_populate_read_cache() called with fixed max root, but max root changed from {} to {} during function call", starting_max_slot, ending_max_slot);
+            }
         }
         Some((account, slot))
     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4605,7 +4605,8 @@ fn start_load_thread(
         .unwrap()
 }
 
-fn do_test_load_account_and_cache_flush_race(with_retry: bool) {
+#[test]
+fn test_load_account_and_cache_flush_race() {
     solana_logger::setup();
 
     let mut db = AccountsDb::new_single_for_tests();
@@ -4648,7 +4649,7 @@ fn do_test_load_account_and_cache_flush_race(with_retry: bool) {
     };
 
     let t_do_load = start_load_thread(
-        with_retry,
+        false,
         Ancestors::default(),
         db,
         exit.clone(),
@@ -4660,16 +4661,6 @@ fn do_test_load_account_and_cache_flush_race(with_retry: bool) {
     exit.store(true, Ordering::Relaxed);
     t_flush_accounts_cache.join().unwrap();
     t_do_load.join().map_err(std::panic::resume_unwind).unwrap()
-}
-
-#[test]
-fn test_load_account_and_cache_flush_race_with_retry() {
-    do_test_load_account_and_cache_flush_race(true);
-}
-
-#[test]
-fn test_load_account_and_cache_flush_race_without_retry() {
-    do_test_load_account_and_cache_flush_race(false);
 }
 
 fn do_test_load_account_and_shrink_race(with_retry: bool) {


### PR DESCRIPTION
#### Problem
Calling do_load_with_populate_read_cache while changing roots may lead to a panic. There is an existing test that calls this flow which will panic if delays are added to get_account_accessor. 

#### Summary of Changes
- Add error log when function called with changing roots
- Remove invalid test 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
