### PR TITLE
refactor: `Bank::process_transaction`

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -397,7 +397,7 @@ fn main() {
                 // Ignore any pesky duplicate signature errors in the case we are using single-payer
                 let sig: [u8; 64] = std::array::from_fn(|_| thread_rng().gen::<u8>());
                 fund.signatures = vec![Signature::from(sig)];
-                bank.process_transaction(&fund).unwrap();
+                bank.process_transaction(fund).unwrap();
             });
     });
 
@@ -408,6 +408,7 @@ fn main() {
             packets_for_single_iteration
                 .transactions
                 .iter()
+                .cloned()
                 .for_each(|tx| {
                     let res = bank.process_transaction(tx);
                     assert!(res.is_ok(), "sanity test transactions error: {res:?}");
@@ -418,8 +419,9 @@ fn main() {
         if write_lock_contention == WriteLockContention::None {
             all_packets.iter().for_each(|packets_for_single_iteration| {
                 //sanity check, make sure all the transactions can execute in parallel
-                let res =
-                    bank.process_transactions(packets_for_single_iteration.transactions.iter());
+                let res = bank.process_transactions(
+                    packets_for_single_iteration.transactions.iter().cloned(),
+                );
                 for r in res {
                     assert!(r.is_ok(), "sanity parallel execution error: {r:?}");
                 }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -167,7 +167,7 @@ fn test_account_subscription() {
         .unwrap()
         .get(1)
         .unwrap()
-        .process_transaction(&tx)
+        .process_transaction(tx)
         .unwrap();
     let commitment_slots = CommitmentSlots {
         slot: 1,
@@ -368,7 +368,7 @@ fn test_program_subscription() {
         .unwrap()
         .get(1)
         .unwrap()
-        .process_transaction(&tx)
+        .process_transaction(tx)
         .unwrap();
     let commitment_slots = CommitmentSlots {
         slot: 1,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -204,17 +204,17 @@ fn bench_banking(
             mint_total / txes as u64,
             genesis_config.hash(),
         );
-        let x = bank.process_transaction(&fund);
+        let x = bank.process_transaction(fund);
         x.unwrap();
     });
     //sanity check, make sure all the transactions can execute sequentially
-    transactions.iter().for_each(|tx| {
+    transactions.iter().cloned().for_each(|tx| {
         let res = bank.process_transaction(tx);
         assert!(res.is_ok(), "sanity test transactions");
     });
     bank.clear_signatures();
     //sanity check, make sure all the transactions can execute in parallel
-    let res = bank.process_transactions(transactions.iter());
+    let res = bank.process_transactions(transactions.iter().cloned());
     for r in res {
         assert!(r.is_ok(), "sanity parallel execution");
     }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -908,7 +908,7 @@ mod tests {
         // fund another account so we can send 2 good transactions in a single batch.
         let keypair = Keypair::new();
         let fund_tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, start_hash);
-        bank.process_transaction(&fund_tx).unwrap();
+        bank.process_transaction(fund_tx.clone()).unwrap();
 
         // good tx, but no verify
         let to = solana_pubkey::new_rand();
@@ -950,7 +950,7 @@ mod tests {
 
         let mut blockhash = start_hash;
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        bank.process_transaction(&fund_tx).unwrap();
+        bank.process_transaction(fund_tx).unwrap();
         //receive entries + ticks
         loop {
             let entries: Vec<Entry> = entry_receiver
@@ -1252,7 +1252,7 @@ mod tests {
         let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
         let vote_keypairs = (0..100).map(|_| Keypair::new()).collect_vec();
         for keypair in keypairs.iter() {
-            bank.process_transaction(&system_transaction::transfer(
+            bank.process_transaction(system_transaction::transfer(
                 &mint_keypair,
                 &keypair.pubkey(),
                 20,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1176,7 +1176,7 @@ mod tests {
 
         // Fund the keypairs.
         for tx in &txs {
-            bank.process_transaction(&system_transaction::transfer(
+            bank.process_transaction(system_transaction::transfer(
                 mint_keypair,
                 &tx.account_keys()[0],
                 2,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -476,7 +476,7 @@ mod tests {
                 500_000, // just some amount that will always be enough
                 bank.last_blockhash(),
             );
-            bank.process_transaction(&transfer).unwrap();
+            bank.process_transaction(transfer).unwrap();
         }
 
         let transfer = system_instruction::transfer(&from_keypair.pubkey(), to_pubkey, lamports);

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -573,7 +573,7 @@ mod tests {
                 &validator_vote_keypairs.vote_keypair,
                 None,
             );
-            bank.process_transaction(&vote).unwrap();
+            bank.process_transaction(vote).unwrap();
         }
 
         let working_bank = bank_forks.read().unwrap().working_bank();
@@ -602,7 +602,7 @@ mod tests {
             &validator_vote_keypairs.vote_keypair,
             None,
         );
-        bank34.process_transaction(&vote33).unwrap();
+        bank34.process_transaction(vote33).unwrap();
 
         let working_bank = bank_forks.read().unwrap().working_bank();
         let vote_state = get_vote_state(vote_pubkey, &working_bank);
@@ -684,7 +684,7 @@ mod tests {
                 &validator_vote_keypairs.vote_keypair,
                 None,
             );
-            bank.process_transaction(&vote).unwrap();
+            bank.process_transaction(vote).unwrap();
         }
 
         let working_bank = bank_forks.read().unwrap().working_bank();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5432,7 +5432,7 @@ pub(crate) mod tests {
             &my_node_pubkey,
             1,
         );
-        bank1.process_transaction(&vote_tx).unwrap();
+        bank1.process_transaction(vote_tx).unwrap();
         bank1.freeze();
 
         // Insert the bank that contains a vote for slot 0, which confirms slot 0
@@ -6319,7 +6319,7 @@ pub(crate) mod tests {
             &validator0_keypairs.vote_keypair,
             None,
         );
-        bank7.process_transaction(&vote_tx).unwrap();
+        bank7.process_transaction(vote_tx.clone()).unwrap();
         assert!(bank7.get_signature_status(&vote_tx.signatures[0]).is_some());
 
         // Both signatures should exist in status cache
@@ -7684,9 +7684,9 @@ pub(crate) mod tests {
         );
 
         let mut cursor = Cursor::default();
-        let votes = cluster_info.get_votes(&mut cursor);
+        let mut votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
-        let vote_tx = &votes[0];
+        let vote_tx = votes.pop().unwrap();
         assert_eq!(vote_tx.message.recent_blockhash, bank0.last_blockhash());
         assert_eq!(
             tower.last_vote_tx_blockhash(),
@@ -7917,9 +7917,9 @@ pub(crate) mod tests {
         );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
-        let votes = cluster_info.get_votes(&mut cursor);
+        let mut votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
-        let vote_tx = &votes[0];
+        let vote_tx = votes.pop().unwrap();
         assert_eq!(
             vote_tx.message.recent_blockhash,
             expired_bank.last_blockhash()
@@ -7938,7 +7938,9 @@ pub(crate) mod tests {
             &Pubkey::default(),
             expired_bank_child_slot,
         );
-        expired_bank_child.process_transaction(vote_tx).unwrap();
+        expired_bank_child
+            .process_transaction(vote_tx.clone())
+            .unwrap();
         let vote_account = expired_bank_child
             .get_vote_account(&my_vote_pubkey)
             .unwrap();
@@ -8058,9 +8060,9 @@ pub(crate) mod tests {
             Arc::new(connection_cache),
         );
 
-        let votes = cluster_info.get_votes(cursor);
+        let mut votes = cluster_info.get_votes(cursor);
         assert_eq!(votes.len(), 1);
-        let vote_tx = &votes[0];
+        let vote_tx = votes.pop().unwrap();
         assert_eq!(
             vote_tx.message.recent_blockhash,
             parent_bank.last_blockhash()

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -130,7 +130,7 @@ impl VoteSimulator {
                         None,
                     );
                     info!("voting {} {}", parent_bank.slot(), parent_bank.hash());
-                    new_bank.process_transaction(&vote_tx).unwrap();
+                    new_bank.process_transaction(vote_tx).unwrap();
 
                     // Check the vote landed
                     let vote_account = new_bank

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -285,7 +285,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
                 1,
                 bank.last_blockhash(),
             );
-            bank.process_transaction(&transaction).unwrap();
+            bank.process_transaction(transaction).unwrap();
             bank.fill_bank_with_ticks_for_tests();
 
             bank
@@ -398,7 +398,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
                 1,
                 bank.last_blockhash(),
             );
-            bank.process_transaction(&transaction).unwrap();
+            bank.process_transaction(transaction).unwrap();
             bank.fill_bank_with_ticks_for_tests();
 
             bank
@@ -517,7 +517,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
                 1,
                 bank.last_blockhash(),
             );
-            bank.process_transaction(&transaction).unwrap();
+            bank.process_transaction(transaction).unwrap();
             bank.fill_bank_with_ticks_for_tests();
 
             bank

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -253,11 +253,11 @@ fn test_bank_forks_snapshot() {
         |bank, mint_keypair| {
             let key1 = Keypair::new().pubkey();
             let tx = system_transaction::transfer(mint_keypair, &key1, 1, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
 
             let key2 = Keypair::new().pubkey();
             let tx = system_transaction::transfer(mint_keypair, &key2, 0, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
         },
         1,
     );
@@ -370,14 +370,14 @@ fn test_bank_forks_status_cache_snapshot() {
                     1,
                     bank.parent().unwrap().last_blockhash(),
                 );
-                assert_eq!(bank.process_transaction(&tx), Ok(()));
+                assert_eq!(bank.process_transaction(tx), Ok(()));
                 let tx = system_transaction::transfer(
                     mint_keypair,
                     &key2,
                     1,
                     bank.parent().unwrap().last_blockhash(),
                 );
-                assert_eq!(bank.process_transaction(&tx), Ok(()));
+                assert_eq!(bank.process_transaction(tx), Ok(()));
                 goto_end_of_slot(bank);
             },
             *set_root_interval,
@@ -452,11 +452,11 @@ fn test_bank_forks_incremental_snapshot() {
 
             let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
 
             let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
 
             bank.fill_bank_with_ticks_for_tests();
 
@@ -733,11 +733,11 @@ fn test_snapshots_with_background_services(
 
             let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 1, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
 
             let key = solana_pubkey::new_rand();
             let tx = system_transaction::transfer(mint_keypair, &key, 0, bank.last_blockhash());
-            assert_eq!(bank.process_transaction(&tx), Ok(()));
+            assert_eq!(bank.process_transaction(tx), Ok(()));
 
             bank.fill_bank_with_ticks_for_tests();
         }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3100,13 +3100,13 @@ pub mod tests {
 
         // First, ensure the TX is rejected because of the unregistered last ID
         assert_eq!(
-            bank.process_transaction(&tx),
+            bank.process_transaction(tx.clone()),
             Err(TransactionError::BlockhashNotFound)
         );
 
         // Now ensure the TX is accepted despite pointing to the ID of an empty entry.
         process_entries_for_tests_without_scheduler(&bank, slot_entries).unwrap();
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(bank.process_transaction(tx), Ok(()));
     }
 
     #[test]
@@ -3805,14 +3805,14 @@ pub mod tests {
             1,
             bank.last_blockhash(),
         );
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(bank.process_transaction(tx), Ok(()));
         let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
             bank.last_blockhash(),
         );
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(bank.process_transaction(tx), Ok(()));
 
         // ensure bank can process 2 entries that do not have a common account and no tick is registered
         let blockhash = bank.last_blockhash();
@@ -3917,7 +3917,7 @@ pub mod tests {
                 0,
                 bank.last_blockhash(),
             );
-            assert_eq!(bank.process_transaction(&create_account_tx), Ok(()));
+            assert_eq!(bank.process_transaction(create_account_tx), Ok(()));
             assert_matches!(
                 bank.transfer(initial_lamports, &mint_keypair, &keypair.pubkey()),
                 Ok(_)
@@ -3985,14 +3985,14 @@ pub mod tests {
             1,
             bank.last_blockhash(),
         );
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(bank.process_transaction(tx), Ok(()));
         let tx = system_transaction::transfer(
             &mint_keypair,
             &keypair2.pubkey(),
             1,
             bank.last_blockhash(),
         );
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(bank.process_transaction(tx), Ok(()));
 
         let blockhash = bank.last_blockhash();
         while blockhash == bank.last_blockhash() {
@@ -4066,12 +4066,12 @@ pub mod tests {
         );
         // First process attempt will fail but still update status cache
         assert_eq!(
-            bank.process_transaction(&tx),
+            bank.process_transaction(tx.clone()),
             Err(TransactionError::ProgramAccountNotFound)
         );
         // Second attempt will be rejected since tx was already in status cache
         assert_eq!(
-            bank.process_transaction(&tx),
+            bank.process_transaction(tx),
             Err(TransactionError::AlreadyProcessed)
         );
 
@@ -4081,13 +4081,13 @@ pub mod tests {
 
         // Should fail with blockhash not found
         assert_eq!(
-            bank.process_transaction(&tx).map(|_| signature),
+            bank.process_transaction(tx.clone()).map(|_| signature),
             Err(TransactionError::BlockhashNotFound)
         );
 
         // Should fail again with blockhash not found
         assert_eq!(
-            bank.process_transaction(&tx).map(|_| signature),
+            bank.process_transaction(tx).map(|_| signature),
             Err(TransactionError::BlockhashNotFound)
         );
     }
@@ -4141,7 +4141,7 @@ pub mod tests {
 
         // fails with simd83 as already processed, succeeds otherwise
         assert_eq!(
-            bank.process_transaction(&test_tx),
+            bank.process_transaction(test_tx),
             if relax_intrabatch_account_locks {
                 Err(TransactionError::AlreadyProcessed)
             } else {

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -36,7 +36,7 @@ pub(crate) mod tests {
                 keypairs,
                 bank.last_blockhash(),
             );
-            bank.process_transaction(&tx).unwrap();
+            bank.process_transaction(tx).unwrap();
         }
 
         process_instructions(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5376,7 +5376,7 @@ pub mod tests {
         // make a non-circulating account one of the largest accounts
         let non_circulating_key = &non_circulating_accounts()[0];
         let bank = rpc.working_bank();
-        bank.process_transaction(&system_transaction::transfer(
+        bank.process_transaction(system_transaction::transfer(
             &rpc.mint_keypair,
             non_circulating_key,
             500_000,
@@ -7658,7 +7658,7 @@ pub mod tests {
                 bank.last_blockhash(),
             );
 
-            bank.process_transaction(&transaction)
+            bank.process_transaction(transaction)
                 .expect("process transaction");
         };
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1394,7 +1394,7 @@ pub(crate) mod tests {
                 .unwrap()
                 .get(1)
                 .unwrap()
-                .process_transaction(&tx)
+                .process_transaction(tx)
                 .unwrap();
             let commitment_slots = CommitmentSlots {
                 slot: 1,
@@ -1796,7 +1796,7 @@ pub(crate) mod tests {
             .unwrap()
             .get(0)
             .unwrap()
-            .process_transaction(&tx)
+            .process_transaction(tx)
             .unwrap();
 
         let exit = Arc::new(AtomicBool::new(false));
@@ -1908,7 +1908,7 @@ pub(crate) mod tests {
             &stake::program::id(),
         );
 
-        bank1.process_transaction(&tx).unwrap();
+        bank1.process_transaction(tx).unwrap();
 
         let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
@@ -1925,7 +1925,7 @@ pub(crate) mod tests {
         );
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
-        bank2.process_transaction(&tx).unwrap();
+        bank2.process_transaction(tx).unwrap();
 
         let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
@@ -1942,7 +1942,7 @@ pub(crate) mod tests {
         );
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
 
-        bank3.process_transaction(&tx).unwrap();
+        bank3.process_transaction(tx).unwrap();
 
         // now add programSubscribe at the "confirmed" commitment level
         let exit = Arc::new(AtomicBool::new(false));
@@ -2100,7 +2100,7 @@ pub(crate) mod tests {
             &stake::program::id(),
         );
 
-        bank1.process_transaction(&tx).unwrap();
+        bank1.process_transaction(tx).unwrap();
 
         let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
@@ -2117,7 +2117,7 @@ pub(crate) mod tests {
         );
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
-        bank2.process_transaction(&tx).unwrap();
+        bank2.process_transaction(tx).unwrap();
 
         // now add programSubscribe at the "confirmed" commitment level
         let exit = Arc::new(AtomicBool::new(false));
@@ -2213,7 +2213,7 @@ pub(crate) mod tests {
             &stake::program::id(),
         );
 
-        bank1.process_transaction(&tx).unwrap();
+        bank1.process_transaction(tx).unwrap();
 
         let bank2 = Bank::new_from_parent(bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
@@ -2230,7 +2230,7 @@ pub(crate) mod tests {
         );
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
-        bank2.process_transaction(&tx).unwrap();
+        bank2.process_transaction(tx).unwrap();
 
         // now add programSubscribe at the "confirmed" commitment level
         let exit = Arc::new(AtomicBool::new(false));
@@ -2331,7 +2331,7 @@ pub(crate) mod tests {
         );
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
 
-        bank3.process_transaction(&tx).unwrap();
+        bank3.process_transaction(tx).unwrap();
         bank3.freeze();
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::Frozen(bank3),
@@ -2394,7 +2394,7 @@ pub(crate) mod tests {
             .unwrap()
             .get(0)
             .unwrap()
-            .process_transaction(&past_bank_tx)
+            .process_transaction(past_bank_tx.clone())
             .unwrap();
 
         let next_bank = Bank::new_from_parent(
@@ -2409,7 +2409,7 @@ pub(crate) mod tests {
             .unwrap()
             .get(1)
             .unwrap()
-            .process_transaction(&processed_tx)
+            .process_transaction(processed_tx.clone())
             .unwrap();
         let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
 
@@ -2747,7 +2747,7 @@ pub(crate) mod tests {
 
         // Add the transaction to the 1st bank and then freeze the bank
         let bank1 = bank_forks.write().unwrap().get(1).unwrap();
-        bank1.process_transaction(&tx).unwrap();
+        bank1.process_transaction(tx.clone()).unwrap();
         bank1.freeze();
 
         // Add the same transaction to the unfrozen 2nd bank
@@ -2756,7 +2756,7 @@ pub(crate) mod tests {
             .unwrap()
             .get(2)
             .unwrap()
-            .process_transaction(&tx)
+            .process_transaction(tx)
             .unwrap();
 
         // First, notify the unfrozen bank first to queue pending notification

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -84,7 +84,7 @@ pub fn create_native_loader_transactions(
 }
 
 fn sync_bencher(bank: &Bank, _bank_client: &BankClient, transactions: &[(Transaction, Hash)]) {
-    let results = bank.process_transactions(transactions.iter().map(|(tx, _)| tx));
+    let results = bank.process_transactions(transactions.iter().map(|(tx, _)| tx).cloned());
     assert!(results.iter().all(Result::is_ok));
 }
 
@@ -135,7 +135,7 @@ fn do_bench_transactions(
     let transactions = create_transactions(&bank_client, &mint_keypair);
 
     // Do once to fund accounts, load modules, etc...
-    let results = bank.process_transactions(transactions.iter().map(|(tx, _)| tx));
+    let results = bank.process_transactions(transactions.iter().map(|(tx, _)| tx).cloned());
     assert!(results.iter().all(Result::is_ok));
 
     bencher.iter(|| {

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -237,7 +237,7 @@ mod tests_core_bpf_migration {
             new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), next_slot);
 
         // Successfully invoke the new BPF builtin program.
-        bank.process_transaction(&Transaction::new(
+        bank.process_transaction(Transaction::new(
             &vec![&mint_keypair],
             Message::new(
                 &[Instruction::new_with_bytes(*builtin_id, &[], Vec::new())],
@@ -248,7 +248,7 @@ mod tests_core_bpf_migration {
         .unwrap();
 
         // Successfully invoke the new BPF builtin program via CPI.
-        bank.process_transaction(&Transaction::new(
+        bank.process_transaction(Transaction::new(
             &vec![&mint_keypair],
             Message::new(
                 &[Instruction::new_with_bytes(
@@ -277,7 +277,7 @@ mod tests_core_bpf_migration {
         test_context.run_program_checks(&bank, migration_slot);
 
         // Again, successfully invoke the new BPF builtin program.
-        bank.process_transaction(&Transaction::new(
+        bank.process_transaction(Transaction::new(
             &vec![&mint_keypair],
             Message::new(
                 &[Instruction::new_with_bytes(*builtin_id, &[], Vec::new())],
@@ -288,7 +288,7 @@ mod tests_core_bpf_migration {
         .unwrap();
 
         // Again, successfully invoke the new BPF builtin program via CPI.
-        bank.process_transaction(&Transaction::new(
+        bank.process_transaction(Transaction::new(
             &vec![&mint_keypair],
             Message::new(
                 &[Instruction::new_with_bytes(

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -879,7 +879,7 @@ mod tests {
                 &validator_vote_keypairs.vote_keypair,
                 None,
             );
-            bank.process_transaction(&vote).unwrap();
+            bank.process_transaction(vote).unwrap();
 
             // Insert a transfer transaction from the mint to new stake account
             let system_tx = system_transaction::transfer(
@@ -888,7 +888,7 @@ mod tests {
                 transfer_amount,
                 bank.last_blockhash(),
             );
-            let system_result = bank.process_transaction(&system_tx);
+            let system_result = bank.process_transaction(system_tx);
 
             // Credits should always succeed
             assert!(system_result.is_ok());
@@ -907,7 +907,7 @@ mod tests {
                 &[&mint_keypair, &new_stake_signer],
                 bank.last_blockhash(),
             );
-            let stake_result = bank.process_transaction(&stake_tx);
+            let stake_result = bank.process_transaction(stake_tx);
 
             if slot == num_slots_in_epoch {
                 // When the bank is at the beginning of the new epoch, i.e. slot

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -61,8 +61,9 @@ impl SyncClient for BankClient {
     ) -> Result<Signature> {
         let blockhash = self.bank.last_blockhash();
         let transaction = Transaction::new(keypairs, message, blockhash);
-        self.bank.process_transaction(&transaction)?;
-        Ok(transaction.signatures.first().cloned().unwrap_or_default())
+        let signature = transaction.signatures.first().cloned().unwrap_or_default();
+        self.bank.process_transaction(transaction)?;
+        Ok(signature)
     }
 
     /// Create and process a transaction from a single instruction.

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1672,7 +1672,7 @@ mod tests {
             lamports_to_transfer - fee,
             blockhash,
         );
-        bank2.process_transaction(&tx).unwrap();
+        bank2.process_transaction(tx).unwrap();
         assert_eq!(
             bank2.get_balance(&key1.pubkey()),
             0,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -714,7 +714,7 @@ mod test {
                 1,
                 root_bank.last_blockhash(),
             );
-            root_bank.process_transaction(&transaction).unwrap();
+            root_bank.process_transaction(transaction.clone()).unwrap();
             let signature = transaction.signatures[0];
             (transaction, signature)
         };
@@ -736,7 +736,9 @@ mod test {
                 2,
                 working_bank.last_blockhash(),
             );
-            working_bank.process_transaction(&transaction).unwrap();
+            working_bank
+                .process_transaction(transaction.clone())
+                .unwrap();
             let signature = transaction.signatures[0];
             (transaction, signature)
         };
@@ -748,7 +750,9 @@ mod test {
                 1,
                 working_bank.last_blockhash(),
             );
-            working_bank.process_transaction(&transaction).unwrap_err();
+            working_bank
+                .process_transaction(transaction.clone())
+                .unwrap_err();
             let signature = transaction.signatures[0];
             (transaction, signature)
         };
@@ -1005,7 +1009,7 @@ mod test {
                 1,
                 root_bank.last_blockhash(),
             );
-            root_bank.process_transaction(&transaction).unwrap();
+            root_bank.process_transaction(transaction.clone()).unwrap();
             let signature = transaction.signatures[0];
             (transaction, signature)
         };
@@ -1037,7 +1041,9 @@ mod test {
                 working_bank.last_blockhash(),
             );
             let signature = transaction.signatures[0];
-            working_bank.process_transaction(&transaction).unwrap();
+            working_bank
+                .process_transaction(transaction.clone())
+                .unwrap();
             (transaction, signature)
         };
 
@@ -1048,7 +1054,9 @@ mod test {
             let transaction =
                 system_transaction::transfer(&mint_keypair, &Pubkey::default(), 1, blockhash);
             let signature = transaction.signatures[0];
-            working_bank.process_transaction(&transaction).unwrap_err();
+            working_bank
+                .process_transaction(transaction.clone())
+                .unwrap_err();
             (transaction, signature)
         };
 


### PR DESCRIPTION
#### Problem
`Bank::process_transaction` takes a `&Transaction` only to clone and convert to a `VersionedTransaction`. And there's no equivalent convenience method for processing a single versioned transaction.

#### Summary of Changes
- Updated `Bank::process_transaction` to accept a transaction of type `Into<VersionedTransaction>`
- Updated the less commonly used `Bank::try_process_transactions` and `Bank::process_transactions` to also accept transactions of type `Into<VersionedTransaction>`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
