### PR TITLE
dcou test only code in streamer

### DIFF
--- a/streamer/src/nonblocking/mod.rs
+++ b/streamer/src/nonblocking/mod.rs
@@ -1,5 +1,6 @@
 pub mod connection_rate_limiter;
 pub mod quic;
+#[cfg(feature = "dev-context-only-utils")]
 pub mod recvmmsg;
 pub mod sendmmsg;
 mod stream_throttle;

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 solana-packet = { workspace = true }
+solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }


### PR DESCRIPTION
#### Problem
streamer/src/nonblocking/recvmmsg.rs is not used outside of unittests but is exposed as pub fn.

#### Summary of Changes

- DCOU a module we do not use outside of tests. 