### PR TITLE
TPU: optimize rate limits

### DIFF
--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -558,11 +558,12 @@ async fn test_rate_limiting() {
         },
     );
 
+    // open a connection to consume the limit
     let connection_to_reach_limit = make_client_endpoint(&server_address, None).await;
     drop(connection_to_reach_limit);
 
-    // Setup sending txs
-    let tx_size = 1;
+    // Setup sending txs which are full packets in size
+    let tx_size = 1024;
     let expected_num_txs: usize = 16;
     let SpawnTxGenerator {
         tx_receiver,
@@ -583,16 +584,16 @@ async fn test_rate_limiting() {
     scheduler_cancel.cancel();
     let stats = join_scheduler(scheduler_handle).await;
 
-    // Accept both 0 and 1 as valid values for it as we may run into connection handshake timeout
-    // error within the TEST_MAX_TIME.
+    dbg!(&stats);
     assert!(
         stats
             == SendTransactionStatsNonAtomic {
-                connection_error_timed_out: 1,
+                successfully_sent: 2,
+                write_error_connection_lost: 2,
                 ..Default::default()
             }
-            || stats == SendTransactionStatsNonAtomic::default()
     );
+    //    drop(connection_to_reach_limit);
 
     // Stop the server.
     exit.store(true, Ordering::Relaxed);

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -584,7 +584,8 @@ async fn test_rate_limiting() {
     scheduler_cancel.cancel();
     let stats = join_scheduler(scheduler_handle).await;
 
-    dbg!(&stats);
+    // we get 2 transactions registered as sent (but not acked) because of how QUIC works
+    // before ratelimiter kicks in.
     assert!(
         stats
             == SendTransactionStatsNonAtomic {
@@ -593,7 +594,6 @@ async fn test_rate_limiting() {
                 ..Default::default()
             }
     );
-    //    drop(connection_to_reach_limit);
 
     // Stop the server.
     exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

- TPU handshake timeout is coupled with SDK which is not appropriate
- TPU rate limit handling could be done more efficiently


#### Summary of Changes

- Decouple the constant from SDK
- Optimize the rate limit performance