### PR TITLE
remove test_hash_calculation from some structs

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -66,7 +66,6 @@ fn bench_accounts_hash_bank_hash(bencher: &mut Bencher) {
                 total_lamports,
                 VerifyAccountsHashAndLamportsConfig {
                     ancestors: &ancestors,
-                    test_hash_calculation: false,
                     epoch_schedule: &EpochSchedule::default(),
                     epoch: Epoch::default(),
                     ignore_mismatch: false,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -180,8 +180,6 @@ pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
 pub struct VerifyAccountsHashAndLamportsConfig<'a> {
     /// bank ancestors
     pub ancestors: &'a Ancestors,
-    /// true to verify hash calculation
-    pub test_hash_calculation: bool,
     /// epoch_schedule
     pub epoch_schedule: &'a EpochSchedule,
     /// epoch
@@ -8860,7 +8858,6 @@ impl<'a> VerifyAccountsHashAndLamportsConfig<'a> {
     ) -> Self {
         Self {
             ancestors,
-            test_hash_calculation: true,
             epoch_schedule,
             epoch,
             ignore_mismatch: false,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -199,7 +199,6 @@ pub use {partitioned_epoch_rewards::KeyedRewardsAndNumPartitions, solana_reward_
 
 /// params to `verify_accounts_hash`
 struct VerifyAccountsHashConfig {
-    test_hash_calculation: bool,
     ignore_mismatch: bool,
     require_rooted_bank: bool,
     run_in_background: bool,
@@ -4732,7 +4731,6 @@ impl Bank {
         _ = self.verify_accounts_hash(
             None,
             VerifyAccountsHashConfig {
-                test_hash_calculation: false,
                 ignore_mismatch: true,
                 require_rooted_bank: false,
                 run_in_background: false,
@@ -4815,7 +4813,6 @@ impl Bank {
             ancestors: &self.ancestors,
             epoch_schedule: self.epoch_schedule(),
             epoch: self.epoch(),
-            test_hash_calculation: config.test_hash_calculation,
             ignore_mismatch: config.ignore_mismatch,
             store_detailed_debug_info: config.store_hash_raw_data_for_debug,
             use_bg_thread_pool: config.run_in_background,
@@ -5258,7 +5255,7 @@ impl Bank {
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(
         &self,
-        test_hash_calculation: bool,
+        _test_hash_calculation: bool,
         skip_shrink: bool,
         force_clean: bool,
         latest_full_snapshot_slot: Slot,
@@ -5279,7 +5276,6 @@ impl Bank {
                 let verified = self.verify_accounts_hash(
                     base,
                     VerifyAccountsHashConfig {
-                        test_hash_calculation,
                         ignore_mismatch: false,
                         require_rooted_bank: false,
                         run_in_background: true,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -943,7 +943,6 @@ fn test_bank_update_rewards_determinism() {
 impl VerifyAccountsHashConfig {
     fn default_for_test() -> Self {
         Self {
-            test_hash_calculation: true,
             ignore_mismatch: false,
             require_rooted_bank: false,
             run_in_background: false,
@@ -10934,10 +10933,7 @@ fn test_bank_verify_accounts_hash_with_base() {
     // ensure the accounts hash verifies
     assert!(bank.verify_accounts_hash(
         Some((base_slot, base_capitalization)),
-        VerifyAccountsHashConfig {
-            test_hash_calculation: false,
-            ..VerifyAccountsHashConfig::default_for_test()
-        },
+        VerifyAccountsHashConfig::default_for_test(),
         None,
     ));
 }


### PR DESCRIPTION
#### Problem
trying to cleanup lattice hash and legacy hash of all accounts code

#### Summary of Changes
Get rid of `test_hash_calculation` across multiple structs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
