### PR TITLE
remove accounts_db_test_hash_calculation

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -265,7 +265,6 @@ pub struct ValidatorConfig {
     pub process_ledger_before_services: bool,
     pub accounts_db_config: Option<AccountsDbConfig>,
     pub warp_slot: Option<Slot>,
-    pub accounts_db_test_hash_calculation: bool,
     pub accounts_db_skip_shrink: bool,
     pub accounts_db_force_initial_clean: bool,
     pub tpu_coalesce: Duration,
@@ -340,7 +339,6 @@ impl Default for ValidatorConfig {
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
             process_ledger_before_services: false,
             warp_slot: None,
-            accounts_db_test_hash_calculation: false,
             accounts_db_skip_shrink: false,
             accounts_db_force_initial_clean: false,
             tpu_coalesce: DEFAULT_TPU_COALESCE,
@@ -921,7 +919,6 @@ impl Validator {
                 snapshot_request_handler,
                 pruned_banks_request_handler,
             },
-            config.accounts_db_test_hash_calculation,
         );
         info!(
             "Using: block-verification-method: {}, block-production-method: {}, transaction-structure: {}",
@@ -2084,7 +2081,6 @@ fn load_blockstore(
         new_hard_forks: config.new_hard_forks.clone(),
         debug_keys: config.debug_keys.clone(),
         accounts_db_config: config.accounts_db_config.clone(),
-        accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
         accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         accounts_db_force_initial_clean: config.accounts_db_force_initial_clean,
         runtime_config: config.runtime_config.clone(),

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -221,7 +221,6 @@ impl BackgroundServices {
                 snapshot_request_handler,
                 pruned_banks_request_handler,
             },
-            false,
         );
 
         info!("Starting background services... DONE");

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -707,11 +707,8 @@ fn test_snapshots_with_background_services(
         snapshot_controller.clone(),
     );
 
-    let accounts_background_service = AccountsBackgroundService::new(
-        bank_forks.clone(),
-        exit.clone(),
-        abs_request_handler,
-    );
+    let accounts_background_service =
+        AccountsBackgroundService::new(bank_forks.clone(), exit.clone(), abs_request_handler);
 
     let mut latest_full_snapshot_slot = None;
     let mut latest_incremental_snapshot_slot = None;

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -711,7 +711,6 @@ fn test_snapshots_with_background_services(
         bank_forks.clone(),
         exit.clone(),
         abs_request_handler,
-        false,
     );
 
     let mut latest_full_snapshot_slot = None;

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -231,8 +231,6 @@ pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -
         UseSnapshotArchivesAtStartup
     );
     let accounts_db_skip_shrink = arg_matches.is_present("accounts_db_skip_shrink");
-    let accounts_db_test_hash_calculation =
-        arg_matches.is_present("accounts_db_test_hash_calculation");
     let verify_index = arg_matches.is_present("verify_accounts_index");
     let limit_load_slot_count_from_snapshot =
         value_t!(arg_matches, "limit_load_slot_count_from_snapshot", usize).ok();
@@ -250,7 +248,6 @@ pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -
         runtime_config,
         accounts_db_config,
         accounts_db_skip_shrink,
-        accounts_db_test_hash_calculation,
         verify_index,
         limit_load_slot_count_from_snapshot,
         on_halt_store_hash_raw_data_for_debug,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -404,11 +404,8 @@ pub fn load_and_process_ledger(
         snapshot_request_handler,
         pruned_banks_request_handler,
     };
-    let accounts_background_service = AccountsBackgroundService::new(
-        bank_forks.clone(),
-        exit.clone(),
-        abs_request_handler,
-    );
+    let accounts_background_service =
+        AccountsBackgroundService::new(bank_forks.clone(), exit.clone(), abs_request_handler);
 
     let result = blockstore_processor::process_blockstore_from_root(
         blockstore.as_ref(),

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -408,7 +408,6 @@ pub fn load_and_process_ledger(
         bank_forks.clone(),
         exit.clone(),
         abs_request_handler,
-        process_options.accounts_db_test_hash_calculation,
     );
 
     let result = blockstore_processor::process_blockstore_from_root(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -832,7 +832,7 @@ fn main() {
 
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")
-        .help("Enable hash calculation test");
+        .help("DEPRECATED");
     let halt_at_slot_arg = Arg::with_name("halt_at_slot")
         .long("halt-at-slot")
         .value_name("SLOT")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -830,9 +830,6 @@ fn main() {
     let accounts_db_config_args = accounts_db_args();
     let snapshot_config_args = snapshot_args();
 
-    let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
-        .long("accounts-db-test-hash-calculation")
-        .help("DEPRECATED");
     let halt_at_slot_arg = Arg::with_name("halt_at_slot")
         .long("halt-at-slot")
         .value_name("SLOT")
@@ -1099,7 +1096,6 @@ fn main() {
                 .arg(&verify_index_arg)
                 .arg(&halt_at_slot_store_hash_raw_data)
                 .arg(&hard_forks_arg)
-                .arg(&accounts_db_test_hash_calculation_arg)
                 .arg(&os_memory_stats_reporting_arg)
                 .arg(&allow_dead_slots_arg)
                 .arg(&debug_key_arg)

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -311,10 +311,10 @@ fn bank_forks_from_snapshot(
             process_options.debug_keys.clone(),
             None,
             process_options.limit_load_slot_count_from_snapshot,
-            process_options.accounts_db_test_hash_calculation,
             process_options.accounts_db_skip_shrink,
             process_options.accounts_db_force_initial_clean,
             process_options.verify_index,
+            false, // verify_index. This will be removed separately.
             process_options.accounts_db_config.clone(),
             accounts_update_notifier,
             exit,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -849,7 +849,6 @@ pub struct ProcessOptions {
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
     pub limit_load_slot_count_from_snapshot: Option<usize>,
     pub allow_dead_slots: bool,
-    pub accounts_db_test_hash_calculation: bool,
     pub accounts_db_skip_shrink: bool,
     pub accounts_db_force_initial_clean: bool,
     pub accounts_db_config: Option<AccountsDbConfig>,
@@ -2581,7 +2580,6 @@ pub mod tests {
 
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -2646,7 +2644,6 @@ pub mod tests {
 
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -2664,7 +2661,6 @@ pub mod tests {
         */
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 3, 0, blockhash);
@@ -2733,7 +2729,6 @@ pub mod tests {
 
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -2813,7 +2808,6 @@ pub mod tests {
 
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -3027,7 +3021,6 @@ pub mod tests {
         // Check that we can properly restart the ledger / leader scheduler doesn't fail
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -3172,7 +3165,6 @@ pub mod tests {
             .unwrap();
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -3203,7 +3195,6 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -3223,7 +3214,6 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let opts = ProcessOptions {
             full_leader_cache: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (_bank_forks, leader_schedule) =
@@ -4171,7 +4161,6 @@ pub mod tests {
         let opts = ProcessOptions {
             run_verification: true,
             halt_at_slot: Some(0),
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let (bank_forks, ..) =
@@ -4224,7 +4213,6 @@ pub mod tests {
         let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
         let recyclers = VerifyRecyclers::default();
@@ -4685,7 +4673,6 @@ pub mod tests {
 
         let opts = ProcessOptions {
             run_verification: true,
-            accounts_db_test_hash_calculation: true,
             ..ProcessOptions::default()
         };
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -45,7 +45,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         no_os_disk_stats_reporting: config.no_os_disk_stats_reporting,
         poh_pinned_cpu_core: config.poh_pinned_cpu_core,
         warp_slot: config.warp_slot,
-        accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
         accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         accounts_db_force_initial_clean: config.accounts_db_force_initial_clean,
         tpu_coalesce: config.tpu_coalesce,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -536,7 +536,6 @@ impl AccountsBackgroundService {
         bank_forks: Arc<RwLock<BankForks>>,
         exit: Arc<AtomicBool>,
         request_handlers: AbsRequestHandlers,
-        test_hash_calculation: bool,
     ) -> Self {
         let is_running = Arc::new(AtomicBool::new(true));
         let stop = Arc::new(AtomicBool::new(false));
@@ -608,7 +607,7 @@ impl AccountsBackgroundService {
                             .has_initial_accounts_hash_verification_completed()
                             .then(|| {
                                 request_handlers.handle_snapshot_requests(
-                                    test_hash_calculation,
+                                    false, // test_hash_calculation. Will be removed soon.
                                     non_snapshot_time,
                                     &exit,
                                 )

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1527,8 +1527,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("accounts_db_test_hash_calculation")
             .long("accounts-db-test-hash-calculation")
             .help(
-                "Enables testing of hash calculation using stores in AccountsHashVerifier. \
-                 This has a computational cost.",
+                "DEPRECATED",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1524,13 +1524,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("accounts_db_test_hash_calculation")
-            .long("accounts-db-test-hash-calculation")
-            .help(
-                "DEPRECATED",
-            ),
-    )
-    .arg(
         Arg::with_name("accounts_shrink_optimize_total_space")
             .long("accounts-shrink-optimize-total-space")
             .takes_value(true)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -694,7 +694,6 @@ pub fn execute(
         poh_hashes_per_batch: value_of(matches, "poh_hashes_per_batch")
             .unwrap_or(poh_service::DEFAULT_HASHES_PER_BATCH),
         process_ledger_before_services: matches.is_present("process_ledger_before_services"),
-        accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         accounts_db_config,
         accounts_db_skip_shrink: true,
         accounts_db_force_initial_clean: matches.is_present("no_skip_initial_accounts_db_clean"),

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -1616,7 +1616,6 @@ mod tests {
             &blockstore,
             &ProcessOptions {
                 run_verification: true,
-                accounts_db_test_hash_calculation: true,
                 ..ProcessOptions::default()
             },
             Arc::default(),


### PR DESCRIPTION
#### Problem
Trying to remove legacy hash of all accounts.

#### Summary of Changes
remove cli argument for testing legacy hash calculation.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
