### PR TITLE
TPU: drop default number of workers in QUIC servers to reasonable amounts

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -51,15 +51,15 @@ pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;
 pub const DEFAULT_TPU_COALESCE: Duration = Duration::from_millis(5);
 
 pub fn default_num_tpu_transaction_forward_receive_threads() -> usize {
-    num_cpus::get()
+    num_cpus::get().min(16)
 }
 
 pub fn default_num_tpu_transaction_receive_threads() -> usize {
-    num_cpus::get()
+    num_cpus::get().min(8)
 }
 
 pub fn default_num_tpu_vote_transaction_receive_threads() -> usize {
-    num_cpus::get()
+    num_cpus::get().min(8)
 }
 
 pub struct SpawnServerResult {


### PR DESCRIPTION
#### Problem

- We clearly never need 64 threads for unstaked TPU
- Defaults should be sane

#### Summary of Changes

- Drop default number of TPU server workers to reasonable numbers: 8 for vote, 8 for unstaked TPU, 12 for staked TPU.