### PR TITLE
clippy: iter_kv_map instance in core

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4457,8 +4457,8 @@ pub(crate) mod tests {
 
         let blockstore = Arc::new(blockstore);
         let validator_node_to_vote_keys: HashMap<Pubkey, Pubkey> = validator_keypairs
-            .iter()
-            .map(|(_, keypairs)| {
+            .values()
+            .map(|keypairs| {
                 (
                     keypairs.node_keypair.pubkey(),
                     keypairs.vote_keypair.pubkey(),


### PR DESCRIPTION
#### Problem
Work for upgrading to Rust 1.88.0 - see https://github.com/anza-xyz/agave/issues/6850. Missed this in https://github.com/anza-xyz/agave/pull/6855