### PR TITLE
clippy: uninlined_format_args (zk-*)

### DIFF
--- a/zk-sdk/src/encryption/pod/auth_encryption.rs
+++ b/zk-sdk/src/encryption/pod/auth_encryption.rs
@@ -82,7 +82,7 @@ mod tests {
         let ae_key = AeKey::new_rand();
         let expected_ae_ciphertext: PodAeCiphertext = ae_key.encrypt(0_u64).into();
 
-        let ae_ciphertext_base64_str = format!("{}", expected_ae_ciphertext);
+        let ae_ciphertext_base64_str = format!("{expected_ae_ciphertext}");
         let computed_ae_ciphertext = PodAeCiphertext::from_str(&ae_ciphertext_base64_str).unwrap();
 
         assert_eq!(expected_ae_ciphertext, computed_ae_ciphertext);

--- a/zk-sdk/src/encryption/pod/elgamal.rs
+++ b/zk-sdk/src/encryption/pod/elgamal.rs
@@ -188,7 +188,7 @@ mod tests {
         let elgamal_keypair = ElGamalKeypair::new_rand();
         let expected_elgamal_pubkey: PodElGamalPubkey = (*elgamal_keypair.pubkey()).into();
 
-        let elgamal_pubkey_base64_str = format!("{}", expected_elgamal_pubkey);
+        let elgamal_pubkey_base64_str = format!("{expected_elgamal_pubkey}");
         let computed_elgamal_pubkey =
             PodElGamalPubkey::from_str(&elgamal_pubkey_base64_str).unwrap();
 
@@ -201,7 +201,7 @@ mod tests {
         let expected_elgamal_ciphertext: PodElGamalCiphertext =
             elgamal_keypair.pubkey().encrypt(0_u64).into();
 
-        let elgamal_ciphertext_base64_str = format!("{}", expected_elgamal_ciphertext);
+        let elgamal_ciphertext_base64_str = format!("{expected_elgamal_ciphertext}");
         let computed_elgamal_ciphertext =
             PodElGamalCiphertext::from_str(&elgamal_ciphertext_base64_str).unwrap();
 

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -75,7 +75,7 @@ mod tests {
         let ae_key = AeKey::new_rand();
         let expected_ae_ciphertext: AeCiphertext = ae_key.encrypt(0_u64).into();
 
-        let ae_ciphertext_base64_str = format!("{}", expected_ae_ciphertext);
+        let ae_ciphertext_base64_str = format!("{expected_ae_ciphertext}");
         let computed_ae_ciphertext = AeCiphertext::from_str(&ae_ciphertext_base64_str).unwrap();
 
         assert_eq!(expected_ae_ciphertext, computed_ae_ciphertext);

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -161,7 +161,7 @@ mod tests {
         let elgamal_keypair = ElGamalKeypair::new_rand();
         let expected_elgamal_pubkey: ElGamalPubkey = (*elgamal_keypair.pubkey()).into();
 
-        let elgamal_pubkey_base64_str = format!("{}", expected_elgamal_pubkey);
+        let elgamal_pubkey_base64_str = format!("{expected_elgamal_pubkey}");
         let computed_elgamal_pubkey = ElGamalPubkey::from_str(&elgamal_pubkey_base64_str).unwrap();
 
         assert_eq!(expected_elgamal_pubkey, computed_elgamal_pubkey);
@@ -173,7 +173,7 @@ mod tests {
         let expected_elgamal_ciphertext: ElGamalCiphertext =
             elgamal_keypair.pubkey().encrypt(0_u64).into();
 
-        let elgamal_ciphertext_base64_str = format!("{}", expected_elgamal_ciphertext);
+        let elgamal_ciphertext_base64_str = format!("{expected_elgamal_ciphertext}");
         let computed_elgamal_ciphertext =
             ElGamalCiphertext::from_str(&elgamal_ciphertext_base64_str).unwrap();
 


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
