### PR TITLE
Tweak open connection limits for unstaked connections

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -2098,6 +2098,7 @@ pub mod test {
             staked_nodes,
             QuicServerParams {
                 max_connections_per_peer: 2,
+                max_unstaked_connections_per_ipaddr: 2,
                 ..QuicServerParams::default_for_tests()
             },
             cancel.clone(),

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -761,7 +761,7 @@ async fn setup_connection(
                 let params = get_connection_stake(&new_connection, &staked_nodes).map_or(
                     NewConnectionHandlerParams::new_unstaked(
                         packet_sender.clone(),
-                        quic_server_params.max_connections_per_peer,
+                        quic_server_params.max_unstaked_connections_per_ipaddr,
                         stats.clone(),
                         quic_server_params.wait_for_chunk_timeout,
                         quic_server_params.max_unstaked_connections,
@@ -774,18 +774,25 @@ async fn setup_connection(
                                 * STREAM_THROTTLING_INTERVAL_MS)
                                 as f64;
                         let stake_ratio = stake as f64 / total_stake as f64;
-                        let peer_type = if stake_ratio < min_stake_ratio {
+                        let (peer_type, max_connections_per_peer) = if stake_ratio < min_stake_ratio
+                        {
                             // If it is a staked connection with ultra low stake ratio, treat it as unstaked.
-                            ConnectionPeerType::Unstaked
+                            (
+                                ConnectionPeerType::Unstaked,
+                                quic_server_params.max_unstaked_connections_per_ipaddr,
+                            )
                         } else {
-                            ConnectionPeerType::Staked(stake)
+                            (
+                                ConnectionPeerType::Staked(stake),
+                                quic_server_params.max_connections_per_peer,
+                            )
                         };
                         NewConnectionHandlerParams {
                             packet_sender,
                             remote_pubkey: Some(pubkey),
                             peer_type,
                             total_stake,
-                            max_connections_per_peer: quic_server_params.max_connections_per_peer,
+                            max_connections_per_peer: max_connections_per_peer,
                             stats: stats.clone(),
                             max_stake,
                             min_stake,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -792,7 +792,7 @@ async fn setup_connection(
                             remote_pubkey: Some(pubkey),
                             peer_type,
                             total_stake,
-                            max_connections_per_peer: max_connections_per_peer,
+                            max_connections_per_peer,
                             stats: stats.clone(),
                             max_stake,
                             min_stake,

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -240,13 +240,13 @@ pub mod test {
             DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             DEFAULT_MAX_STREAMS_PER_MS,
         ));
-        // 50K packets per ms * 20% / 500 max unstaked connections
+        // 500 packets per ms * 50% * 100 (ms) / 2000 max unstaked connections
         assert_eq!(
             load_ema.available_load_capacity_in_throttling_duration(
                 ConnectionPeerType::Unstaked,
                 10000,
             ),
-            20
+            12
         );
     }
 

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -11,7 +11,7 @@ use {
     },
 };
 
-const MAX_UNSTAKED_STREAMS_PERCENT: u64 = 20;
+const MAX_UNSTAKED_STREAMS_PERCENT: u64 = 50;
 pub const STREAM_THROTTLING_INTERVAL_MS: u64 = 100;
 pub const STREAM_THROTTLING_INTERVAL: Duration =
     Duration::from_millis(STREAM_THROTTLING_INTERVAL_MS);

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -848,6 +848,7 @@ mod test {
             staked_nodes,
             QuicServerParams {
                 max_connections_per_peer: 2,
+                max_unstaked_connections_per_ipaddr: 2,
                 ..QuicServerParams::default_for_tests()
             },
             cancel.clone(),

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
 pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 2000;
 
 /// The maximum number of connections that can be opened for unstaked peers.
-pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS_PER_IPADDR: usize = 1;
+pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS_PER_IPADDR: usize = 4;
 
 /// Limit to 500K PPS
 pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 500;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -664,6 +664,7 @@ impl QuicServerParams {
         Self {
             coalesce_channel_size: 100_000,
             num_threads: Self::DEFAULT_NUM_SERVER_THREADS_FOR_TEST,
+            max_unstaked_connections_per_ipaddr: 1,
             ..Self::default()
         }
     }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -36,7 +36,11 @@ pub const DEFAULT_MAX_QUIC_CONNECTIONS_PER_PEER: usize = 8;
 
 pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
 
-pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
+/// The maximum number of connections that can be opened for unstaked peers.
+pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 2000;
+
+/// The maximum number of connections that can be opened for unstaked peers.
+pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS_PER_IPADDR: usize = 1;
 
 /// Limit to 500K PPS
 pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 500;
@@ -622,6 +626,7 @@ pub fn spawn_server_multi(
 #[derive(Clone)]
 pub struct QuicServerParams {
     pub max_connections_per_peer: usize,
+    pub max_unstaked_connections_per_ipaddr: usize,
     pub max_staked_connections: usize,
     pub max_unstaked_connections: usize,
     pub max_streams_per_ms: u64,
@@ -637,6 +642,7 @@ impl Default for QuicServerParams {
         QuicServerParams {
             max_connections_per_peer: 1,
             max_staked_connections: DEFAULT_MAX_STAKED_CONNECTIONS,
+            max_unstaked_connections_per_ipaddr: DEFAULT_MAX_UNSTAKED_CONNECTIONS_PER_IPADDR,
             max_unstaked_connections: DEFAULT_MAX_UNSTAKED_CONNECTIONS,
             max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS,
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,


### PR DESCRIPTION
#### Problem
There are only 500 unstaked connection while we allow per address 8 concurrent connections. This leads to large number of connections from unstaked clients to contend for 500/8 for about 62 slots and cause churning.s

#### Summary of Changes

Reduce the per-connection from unstaked clients to 4 per ip address
Increase total connection count for unstaked connections to 2000.
Classifying eviction metrics between staked vs non-staked.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
