### PR TITLE
tpu-client-next: make some functions and structs public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11342,6 +11342,7 @@ dependencies = [
  "futures 0.3.31",
  "log",
  "lru",
+ "qualifier_attr",
  "quinn",
  "rustls 0.23.31",
  "solana-cli-config",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9669,7 +9669,6 @@ dependencies = [
  "async-trait",
  "log",
  "lru",
- "qualifier_attr",
  "quinn",
  "rustls 0.23.31",
  "solana-clock",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9669,6 +9669,7 @@ dependencies = [
  "async-trait",
  "log",
  "lru",
+ "qualifier_attr",
  "quinn",
  "rustls 0.23.31",
  "solana-clock",

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -12,15 +12,17 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+agave-unstable-api = []
 default = ["log"]
 log = ["dep:log"]
-tracing = ["dep:tracing"]
 metrics = ["dep:solana-metrics"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 async-trait = { workspace = true }
 log = { workspace = true, optional = true }
 lru = { workspace = true }
+qualifier_attr = { workspace = true }
 quinn = { workspace = true }
 rustls = { workspace = true }
 solana-clock = { workspace = true }

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-agave-unstable-api = []
+agave-unstable-api = ["dep:qualifier_attr"]
 default = ["log"]
 log = ["dep:log"]
 metrics = ["dep:solana-metrics"]
@@ -22,7 +22,7 @@ tracing = ["dep:tracing"]
 async-trait = { workspace = true }
 log = { workspace = true, optional = true }
 lru = { workspace = true }
-qualifier_attr = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 quinn = { workspace = true }
 rustls = { workspace = true }
 solana-clock = { workspace = true }

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -1,6 +1,8 @@
 //! This module defines [`ConnectionWorkersScheduler`] which sends transactions
 //! to the upcoming leaders.
 
+#[cfg(feature = "agave-unstable-api")]
+use qualifier_attr::qualifiers;
 use {
     super::leader_updater::LeaderUpdater,
     crate::{
@@ -62,6 +64,7 @@ pub enum ConnectionWorkersSchedulerError {
 /// The idea of having a separate `connect` parameter is to create a set of
 /// nodes to connect to in advance in order to hide the latency of opening new
 /// connection. Hence, `connect` must be greater or equal to `send`
+#[derive(Debug, Clone)]
 pub struct Fanout {
     /// The number of leaders to target for sending transactions.
     pub send: usize,
@@ -305,7 +308,8 @@ impl ConnectionWorkersScheduler {
 }
 
 /// Sets up the QUIC endpoint for the scheduler to handle connections.
-pub fn setup_endpoint(
+#[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
+fn setup_endpoint(
     bind: BindTarget,
     stake_identity: Option<StakeIdentity>,
 ) -> Result<Endpoint, ConnectionWorkersSchedulerError> {
@@ -367,6 +371,7 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
 ///
 /// This function selects up to `send_fanout` addresses from the `leaders` list, ensuring that
 /// only unique addresses are included while maintaining their original order.
+#[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
 pub fn extract_send_leaders(leaders: &[SocketAddr], send_fanout: usize) -> Vec<SocketAddr> {
     let send_count = send_fanout.min(leaders.len());
     remove_duplicates(&leaders[..send_count])

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -305,7 +305,7 @@ impl ConnectionWorkersScheduler {
 }
 
 /// Sets up the QUIC endpoint for the scheduler to handle connections.
-fn setup_endpoint(
+pub fn setup_endpoint(
     bind: BindTarget,
     stake_identity: Option<StakeIdentity>,
 ) -> Result<Endpoint, ConnectionWorkersSchedulerError> {
@@ -367,7 +367,7 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
 ///
 /// This function selects up to `send_fanout` addresses from the `leaders` list, ensuring that
 /// only unique addresses are included while maintaining their original order.
-fn extract_send_leaders(leaders: &[SocketAddr], send_fanout: usize) -> Vec<SocketAddr> {
+pub fn extract_send_leaders(leaders: &[SocketAddr], send_fanout: usize) -> Vec<SocketAddr> {
     let send_count = send_fanout.min(leaders.len());
     remove_duplicates(&leaders[..send_count])
 }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -140,11 +140,7 @@ impl WorkersCache {
         self.workers.contains(peer)
     }
 
-    pub fn push(
-        &mut self,
-        leader: SocketAddr,
-        peer_worker: WorkerInfo,
-    ) -> Option<ShutdownWorker> {
+    pub fn push(&mut self, leader: SocketAddr, peer_worker: WorkerInfo) -> Option<ShutdownWorker> {
         if let Some((leader, popped_worker)) = self.workers.push(leader, peer_worker) {
             return Some(ShutdownWorker {
                 leader,

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -2,6 +2,8 @@
 //! structures provide mechanisms for caching workers, sending transaction
 //! batches, and gathering send transaction statistics.
 
+#[cfg(feature = "agave-unstable-api")]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         connection_worker::ConnectionWorker, logging::debug, transaction_batch::TransactionBatch,
@@ -71,7 +73,8 @@ impl WorkerInfo {
 }
 
 /// Spawns a worker to handle communication with a given peer.
-pub fn spawn_worker(
+#[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
+pub(crate) fn spawn_worker(
     endpoint: &Endpoint,
     peer: &SocketAddr,
     worker_channel_size: usize,
@@ -127,7 +130,8 @@ pub enum WorkersCacheError {
 }
 
 impl WorkersCache {
-    pub fn new(capacity: usize, cancel: CancellationToken) -> Self {
+    #[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
+    pub(crate) fn new(capacity: usize, cancel: CancellationToken) -> Self {
         Self {
             workers: LruCache::new(capacity),
             cancel,
@@ -140,7 +144,12 @@ impl WorkersCache {
         self.workers.contains(peer)
     }
 
-    pub fn push(&mut self, leader: SocketAddr, peer_worker: WorkerInfo) -> Option<ShutdownWorker> {
+    #[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
+    pub(crate) fn push(
+        &mut self,
+        leader: SocketAddr,
+        peer_worker: WorkerInfo,
+    ) -> Option<ShutdownWorker> {
         if let Some((leader, popped_worker)) = self.workers.push(leader, peer_worker) {
             return Some(ShutdownWorker {
                 leader,
@@ -262,7 +271,8 @@ impl WorkersCache {
     ///
     /// The method awaits the completion of all shutdown tasks, ensuring that
     /// each worker is properly terminated.
-    pub async fn shutdown(&mut self) {
+    #[cfg_attr(feature = "agave-unstable-api", qualifiers(pub))]
+    pub(crate) async fn shutdown(&mut self) {
         // Interrupt any outstanding `send_transactions()` calls.
         self.cancel.cancel();
 

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -71,7 +71,7 @@ impl WorkerInfo {
 }
 
 /// Spawns a worker to handle communication with a given peer.
-pub(crate) fn spawn_worker(
+pub fn spawn_worker(
     endpoint: &Endpoint,
     peer: &SocketAddr,
     worker_channel_size: usize,
@@ -127,7 +127,7 @@ pub enum WorkersCacheError {
 }
 
 impl WorkersCache {
-    pub(crate) fn new(capacity: usize, cancel: CancellationToken) -> Self {
+    pub fn new(capacity: usize, cancel: CancellationToken) -> Self {
         Self {
             workers: LruCache::new(capacity),
             cancel,
@@ -140,7 +140,7 @@ impl WorkersCache {
         self.workers.contains(peer)
     }
 
-    pub(crate) fn push(
+    pub fn push(
         &mut self,
         leader: SocketAddr,
         peer_worker: WorkerInfo,
@@ -266,7 +266,7 @@ impl WorkersCache {
     ///
     /// The method awaits the completion of all shutdown tasks, ensuring that
     /// each worker is properly terminated.
-    pub(crate) async fn shutdown(&mut self) {
+    pub async fn shutdown(&mut self) {
         // Interrupt any outstanding `send_transactions()` calls.
         self.cancel.cancel();
 


### PR DESCRIPTION
#### Problem

Currently, user cannot create a custom scheduler implementation using provided components (`Worker`, `WorkerCache`, etc) because part of the functionality is private. I need it for the development of tool to measure tx landing latency. When this tool will be finalized, make it non draft.

#### Summary of Changes
