### PR TITLE
streamer: Remove `NUM_RCVMMSGS`, use `PACKETS_PER_BATCH` consequently

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -60,7 +60,8 @@ use {
 
 /// Sets the upper bound on the number of batches stored in the retransmit
 /// stage ingress channel.
-/// Allows for a max of 16k batches of up to 64 packets each (NUM_RCVMMSGS).
+/// Allows for a max of 16k batches of up to 64 packets each
+/// (PACKETS_PER_BATCH).
 /// This translates to about 1 GB of RAM for packet storage in the worst case.
 /// In reality this means about 200K shreds since most batches are not full.
 const CHANNEL_SIZE_RETRANSMIT_INGRESS: usize = 16 * 1024;

--- a/streamer/src/nonblocking/recvmmsg.rs
+++ b/streamer/src/nonblocking/recvmmsg.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         packet::{Meta, Packet},
-        recvmmsg::NUM_RCVMMSGS,
+        recvmmsg::PACKETS_PER_BATCH,
     },
     std::{cmp, io},
     tokio::net::UdpSocket,
@@ -16,7 +16,7 @@ pub async fn recv_mmsg(
     packets: &mut [Packet],
 ) -> io::Result</*num packets:*/ usize> {
     debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
-    let count = cmp::min(NUM_RCVMMSGS, packets.len());
+    let count = cmp::min(PACKETS_PER_BATCH, packets.len());
     socket.readable().await?;
     let mut i = 0;
     for p in packets.iter_mut().take(count) {

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -37,11 +37,10 @@ pub(crate) fn recv_from(
     batch: &mut PinnedPacketBatch,
     socket: &UdpSocket,
     // If max_wait is None, reads from the socket until either:
-    //   * 64 packets are read (NUM_RCVMMSGS == PACKETS_PER_BATCH == 64), or
+    //   * 64 packets are read (PACKETS_PER_BATCH == 64), or
     //   * There are no more data available to read from the socket.
     max_wait: Option<Duration>,
 ) -> Result<usize> {
-    use crate::recvmmsg::NUM_RCVMMSGS;
     let mut i = 0;
     //DOCUMENTED SIDE-EFFECT
     //Performance out of the IO without poll
@@ -54,10 +53,7 @@ pub(crate) fn recv_from(
     let should_wait = max_wait.is_some();
     let start = should_wait.then(Instant::now);
     loop {
-        batch.resize(
-            std::cmp::min(i + NUM_RCVMMSGS, PACKETS_PER_BATCH),
-            Packet::default(),
-        );
+        batch.resize(PACKETS_PER_BATCH, Packet::default());
         match recv_mmsg(socket, &mut batch[i..]) {
             Err(err) if i > 0 => {
                 if !should_wait && err.kind() == ErrorKind::WouldBlock {


### PR DESCRIPTION
#### Problem

Both of these constans had the same value. Since we aim to receive the whole batch of packets in `recv_mmsg`, distinguising these constants doesn't make much sense.

#### Summary of Changes

Remove `NUM_RCVMMSGS` and use `PACKETS_PER_BATCH` instead.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
