### PR TITLE
net-utils (& others): swap tests to non-overlapping port allocation

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -52,7 +52,7 @@ use {
 
 fn pubsub_addr() -> SocketAddr {
     let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start)
 }
 
 #[test]

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -6,6 +6,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
     solana_native_token::sol_to_lamports,
+    solana_net_utils::sockets::localhost_port_single_for_tests,
     solana_pubkey::Pubkey,
     solana_pubsub_client::{nonblocking, pubsub_client::PubsubClient},
     solana_rpc::{
@@ -51,8 +52,10 @@ use {
 };
 
 fn pubsub_addr() -> SocketAddr {
-    let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start)
+    SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        localhost_port_single_for_tests(),
+    )
 }
 
 #[test]

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -205,10 +205,8 @@ mod tests {
 
     #[test]
     fn test_connection_with_specified_client_endpoint() {
-        let port_range = localhost_port_range_for_tests();
-        let mut port_range = port_range.0..port_range.1;
-        let client_socket =
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.next().unwrap()).unwrap();
+        let mut pr = localhost_port_range_for_tests();
+        let client_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.next().unwrap()).unwrap();
         let connection_cache = ConnectionCache::new_with_client_options(
             "connection_cache_test",
             1,                   // connection_pool_size
@@ -218,13 +216,13 @@ mod tests {
         );
 
         // server port 1:
-        let port1 = port_range.next().unwrap();
+        let port1 = pr.next().unwrap();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port1);
         let conn = connection_cache.get_connection(&addr);
         assert_eq!(conn.server_addr().port(), port1);
 
         // server port 2:
-        let port2 = port_range.next().unwrap();
+        let port2 = pr.next().unwrap();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port2);
         let conn = connection_cache.get_connection(&addr);
         assert_eq!(conn.server_addr().port(), port2);

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1358,7 +1358,7 @@ mod test {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
             let ancestor_hashes_request_socket =
-                Arc::new(bind_to_unique_localhost_for_tests().expect("should bind"));
+                Arc::new(bind_to_unique_localhost().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::sockets::bind_to_unique_unspecified,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1358,7 +1358,7 @@ mod test {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
             let ancestor_hashes_request_socket =
-                Arc::new(bind_to_unique_unspecified().expect("should bind"));
+                Arc::new(bind_to_unique_localhost().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -928,10 +928,7 @@ mod test {
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
-        std::{
-            collections::HashMap,
-            net::{IpAddr, Ipv4Addr},
-        },
+        std::collections::HashMap,
         trees::tr,
     };
 
@@ -1361,7 +1358,7 @@ mod test {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
             let ancestor_hashes_request_socket =
-                Arc::new(bind_to_unique_unspecified.expect("should bind"));
+                Arc::new(bind_to_unique_unspecified().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1358,7 +1358,7 @@ mod test {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
             let ancestor_hashes_request_socket =
-                Arc::new(bind_to_unique_localhost().expect("should bind"));
+                Arc::new(bind_to_unique_localhost_for_tests().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+        solana_net_utils::sockets::bind_to_unique_unspecified,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1360,13 +1360,8 @@ mod test {
     impl ManageAncestorHashesState {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
-            let ancestor_hashes_request_socket = Arc::new(
-                bind_to(
-                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                    localhost_port_range_for_tests().0,
-                )
-                .expect("should bind"),
-            );
+            let ancestor_hashes_request_socket =
+                Arc::new(bind_to_unique_unspecified.expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,12 +923,15 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::bind_to_unspecified,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
-        std::collections::HashMap,
+        std::{
+            collections::HashMap,
+            net::{IpAddr, Ipv4Addr},
+        },
         trees::tr,
     };
 
@@ -1357,7 +1360,13 @@ mod test {
     impl ManageAncestorHashesState {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
-            let ancestor_hashes_request_socket = Arc::new(bind_to_unspecified().unwrap());
+            let ancestor_hashes_request_socket = Arc::new(
+                bind_to(
+                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                    localhost_port_range_for_tests().0,
+                )
+                .expect("should bind"),
+            );
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1358,7 +1358,7 @@ mod test {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
             let ancestor_hashes_request_socket =
-                Arc::new(bind_to_unique_localhost().expect("should bind"));
+                Arc::new(bind_to_localhost_unique().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -1038,9 +1038,8 @@ mod tests {
             .build()
             .unwrap();
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
-        let port_range = localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let sockets: Vec<UdpSocket> = port_range
+        let sockets: Vec<UdpSocket> = localhost_port_range_for_tests()
             .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)
             .collect();

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -1039,8 +1039,8 @@ mod tests {
             .unwrap();
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
         let port_range = localhost_port_range_for_tests();
-        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let sockets: Vec<UdpSocket> = (port_range.0..port_range.1)
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST); // TODO: maybe switch to new api
+        let sockets: Vec<UdpSocket> = port_range
             .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)
             .collect();

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -1039,7 +1039,7 @@ mod tests {
             .unwrap();
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
         let port_range = localhost_port_range_for_tests();
-        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST); // TODO: maybe switch to new api
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let sockets: Vec<UdpSocket> = port_range
             .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1277,7 +1277,7 @@ mod test {
             shred::max_ticks_per_n_shreds,
         },
         solana_net_utils::sockets::{
-            bind_to, bind_to_unique_unspecified, localhost_port_range_for_tests,
+            bind_to, bind_to_unique_localhost, localhost_port_range_for_tests,
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -1661,7 +1661,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unique_unspecified().expect("should bind");
+        let receive_socket = &bind_to_unique_localhost().expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1690,7 +1690,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_unspecified().expect("should bind"),
+            &bind_to_unique_localhost().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1716,7 +1716,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_unspecified().expect("should bind"),
+            &bind_to_unique_localhost().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1754,7 +1754,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unique_unspecified()
+            bind_to_unique_localhost()
                 .expect("should bind")
                 .local_addr()
                 .unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,17 +1276,12 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::sockets::{
-            bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
-        },
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
         solana_time_utils::timestamp,
-        std::{
-            collections::HashSet,
-            net::{IpAddr, Ipv4Addr},
-        },
+        std::collections::HashSet,
     };
 
     fn new_test_cluster_info() -> ClusterInfo {
@@ -1302,11 +1297,9 @@ mod test {
         let pubkey = cluster_info.id();
         let slot = 100;
         let shred_index = 50;
-        let port_range = localhost_port_range_for_tests();
-        let reader =
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start).expect("should bind");
+        let reader = bind_to_localhost_unique().expect("should bind");
         let address = reader.local_addr().unwrap();
-        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.end).expect("should bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
         let outstanding_repair_requests = Arc::new(RwLock::new(OutstandingShredRepairs::default()));
 
         // Send a repair request

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1303,9 +1303,10 @@ mod test {
         let slot = 100;
         let shred_index = 50;
         let port_range = localhost_port_range_for_tests();
-        let reader = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind");
+        let reader =
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start).expect("should bind"); // TODO: maybe switch to new api
         let address = reader.local_addr().unwrap();
-        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.1).expect("should bind");
+        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.end).expect("should bind"); // TODO: maybe switch to new api
         let outstanding_repair_requests = Arc::new(RwLock::new(OutstandingShredRepairs::default()));
 
         // Send a repair request

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1277,7 +1277,7 @@ mod test {
             shred::max_ticks_per_n_shreds,
         },
         solana_net_utils::sockets::{
-            bind_to, bind_to_unique_localhost, localhost_port_range_for_tests,
+            bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -1661,7 +1661,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unique_localhost().expect("should bind");
+        let receive_socket = &bind_to_localhost_unique().expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1690,7 +1690,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost().expect("should bind"),
+            &bind_to_localhost_unique().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1716,7 +1716,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost().expect("should bind"),
+            &bind_to_localhost_unique().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1754,7 +1754,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unique_localhost()
+            bind_to_localhost_unique()
                 .expect("should bind")
                 .local_addr()
                 .unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1277,7 +1277,7 @@ mod test {
             shred::max_ticks_per_n_shreds,
         },
         solana_net_utils::sockets::{
-            bind_to, bind_to_unique_localhost_for_tests, localhost_port_range_for_tests,
+            bind_to, bind_to_unique_localhost, localhost_port_range_for_tests,
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -1661,7 +1661,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unique_localhost_for_tests().expect("should bind");
+        let receive_socket = &bind_to_unique_localhost().expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1690,7 +1690,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost_for_tests().expect("should bind"),
+            &bind_to_unique_localhost().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1716,7 +1716,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost_for_tests().expect("should bind"),
+            &bind_to_unique_localhost().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1754,7 +1754,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unique_localhost_for_tests()
+            bind_to_unique_localhost()
                 .expect("should bind")
                 .local_addr()
                 .unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1304,9 +1304,9 @@ mod test {
         let shred_index = 50;
         let port_range = localhost_port_range_for_tests();
         let reader =
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start).expect("should bind"); // TODO: maybe switch to new api
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.start).expect("should bind");
         let address = reader.local_addr().unwrap();
-        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.end).expect("should bind"); // TODO: maybe switch to new api
+        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.end).expect("should bind");
         let outstanding_repair_requests = Arc::new(RwLock::new(OutstandingShredRepairs::default()));
 
         // Send a repair request

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1277,7 +1277,7 @@ mod test {
             shred::max_ticks_per_n_shreds,
         },
         solana_net_utils::sockets::{
-            bind_to, bind_to_unique_localhost, localhost_port_range_for_tests,
+            bind_to, bind_to_unique_localhost_for_tests, localhost_port_range_for_tests,
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -1661,7 +1661,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unique_localhost().expect("should bind");
+        let receive_socket = &bind_to_unique_localhost_for_tests().expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1690,7 +1690,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost().expect("should bind"),
+            &bind_to_unique_localhost_for_tests().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1716,7 +1716,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_localhost().expect("should bind"),
+            &bind_to_unique_localhost_for_tests().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1754,7 +1754,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unique_localhost()
+            bind_to_unique_localhost_for_tests()
                 .expect("should bind")
                 .local_addr()
                 .unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,7 +1276,9 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::sockets::bind_to_unique_unspecified,
+        solana_net_utils::sockets::{
+            bind_to, bind_to_unique_unspecified, localhost_port_range_for_tests,
+        },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -1659,7 +1661,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unique_unspecified.expect("should bind");
+        let receive_socket = &bind_to_unique_unspecified().expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1688,7 +1690,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_unspecified.expect("should bind"),
+            &bind_to_unique_unspecified().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1714,7 +1716,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unique_unspecified.expect("should bind"),
+            &bind_to_unique_unspecified().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1752,7 +1754,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unique_unspecified
+            bind_to_unique_unspecified()
                 .expect("should bind")
                 .local_addr()
                 .unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,10 +1276,7 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::{
-            bind_to_unspecified,
-            sockets::{bind_to, localhost_port_range_for_tests},
-        },
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -1662,7 +1659,11 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unspecified().unwrap();
+        let receive_socket = &bind_to(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1691,7 +1692,11 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to(
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                localhost_port_range_for_tests().0,
+            )
+            .expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1717,7 +1722,11 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to(
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                localhost_port_range_for_tests().0,
+            )
+            .expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1736,7 +1745,11 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to(
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                localhost_port_range_for_tests().0,
+            )
+            .expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1751,7 +1764,13 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unspecified().unwrap().local_addr().unwrap(),
+            bind_to(
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                localhost_port_range_for_tests().0,
+            )
+            .expect("should bind")
+            .local_addr()
+            .unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info());
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,7 +1276,7 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+        solana_net_utils::sockets::bind_to_unique_unspecified,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -1659,11 +1659,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .expect("should bind");
+        let receive_socket = &bind_to_unique_unspecified.expect("should bind");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1692,11 +1688,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                localhost_port_range_for_tests().0,
-            )
-            .expect("should bind"),
+            &bind_to_unique_unspecified.expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1722,11 +1714,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                localhost_port_range_for_tests().0,
-            )
-            .expect("should bind"),
+            &bind_to_unique_unspecified.expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1764,13 +1752,10 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                localhost_port_range_for_tests().0,
-            )
-            .expect("should bind")
-            .local_addr()
-            .unwrap(),
+            bind_to_unique_unspecified
+                .expect("should bind")
+                .local_addr()
+                .unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info());
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,9 +1276,7 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::sockets::{
-            bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
-        },
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -1735,11 +1733,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                localhost_port_range_for_tests().0,
-            )
-            .expect("should bind"),
+            &bind_to_localhost_unique().expect("should bind"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1276,7 +1276,9 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::sockets::bind_to_localhost_unique,
+        solana_net_utils::sockets::{
+            bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
+        },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -59,7 +59,7 @@ use {
             localhost_port_range_for_tests, multi_bind_in_range_with_config,
             SocketConfiguration as SocketConfig,
         },
-        PortRange, VALIDATOR_PORT_RANGE,
+        PortRange, RangeExt, VALIDATOR_PORT_RANGE,
     },
     solana_perf::{
         data_budget::DataBudget,
@@ -2440,8 +2440,8 @@ impl Node {
             bind_ip_addrs: BindIpAddrs {
                 addrs: vec![bind_ip_addr],
             },
-            gossip_port: port_range.0,
-            port_range,
+            gossip_port: port_range.start,
+            port_range: port_range.as_tuple(),
             advertised_ip: bind_ip_addr,
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
@@ -2452,7 +2452,8 @@ impl Node {
             vortexor_receiver_addr: None,
         };
         let mut node = Self::new_with_external_ip(pubkey, config);
-        let rpc_ports: [u16; 2] = find_available_ports_in_range(bind_ip_addr, port_range).unwrap();
+        let rpc_ports: [u16; 2] =
+            find_available_ports_in_range(bind_ip_addr, port_range.as_tuple()).unwrap();
         let rpc_addr = SocketAddr::new(bind_ip_addr, rpc_ports[0]);
         let rpc_pubsub_addr = SocketAddr::new(bind_ip_addr, rpc_ports[1]);
         node.info.set_rpc(rpc_addr).unwrap();
@@ -3142,7 +3143,7 @@ mod tests {
         let config = NodeConfig {
             advertised_ip: IpAddr::V4(ip),
             gossip_port: 0,
-            port_range,
+            port_range: port_range.as_tuple(),
             bind_ip_addrs: BindIpAddrs::new(vec![IpAddr::V4(ip)]).unwrap(),
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
@@ -3154,7 +3155,7 @@ mod tests {
 
         let node = Node::new_with_external_ip(&solana_pubkey::new_rand(), config);
 
-        check_node_sockets(&node, IpAddr::V4(ip), port_range);
+        check_node_sockets(&node, IpAddr::V4(ip), port_range.as_tuple());
     }
 
     #[test]
@@ -3163,11 +3164,11 @@ mod tests {
         // port returned by `bind_in_range()` might be snatched up before `Node::new_with_external_ip()` runs
         let port_range = localhost_port_range_for_tests();
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port = port_range.0;
+        let port = port_range.start;
         let config = NodeConfig {
             advertised_ip: ip,
             gossip_port: port,
-            port_range,
+            port_range: port_range.as_tuple(),
             bind_ip_addrs: BindIpAddrs::new(vec![ip]).unwrap(),
             public_tpu_addr: None,
             public_tpu_forwards_addr: None,
@@ -3179,7 +3180,7 @@ mod tests {
 
         let node = Node::new_with_external_ip(&solana_pubkey::new_rand(), config);
 
-        check_node_sockets(&node, ip, port_range);
+        check_node_sockets(&node, ip, port_range.as_tuple());
 
         assert_eq!(node.sockets.gossip.local_addr().unwrap().port(), port);
     }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -723,7 +723,7 @@ mod tests {
     fn test_bind() {
         let pr = sockets::localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let s = bind_in_range(ip_addr, (pr.start, pr.end)).unwrap();
+        let s = bind_in_range(ip_addr, pr.as_tuple()).unwrap();
         assert_eq!(
             s.0, pr.start,
             "bind_in_range should use first available port"
@@ -773,7 +773,7 @@ mod tests {
             find_available_port_in_range(ip_addr, (pr.start, pr.start + 1)).unwrap(),
             pr.start
         );
-        let port = find_available_port_in_range(ip_addr, (pr.start, pr.end)).unwrap();
+        let port = find_available_port_in_range(ip_addr, pr.as_tuple()).unwrap();
         assert!(pr.contains(&port));
 
         let _socket = bind_to(ip_addr, port, false).unwrap();
@@ -844,7 +844,7 @@ mod tests {
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
             bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
         let (_client_port, (client_udp_socket, client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (pr.start, pr.end), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
@@ -1008,9 +1008,12 @@ mod tests {
         let ip_a = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let ip_b = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let pr = sockets::localhost_port_range_for_tests();
-        let (_srv_udp_port, (srv_udp_sock, srv_tcp_listener)) =
-            bind_common_in_range_with_config(ip_a, pr.as_tuple(), config).unwrap();
+        let (_srv_udp_port, (srv_udp_sock, srv_tcp_listener)) = bind_common_in_range_with_config(
+            ip_a,
+            localhost_port_range_for_tests().as_tuple(),
+            config,
+        )
+        .unwrap();
 
         let ip_echo_server_addr = srv_udp_sock.local_addr().unwrap();
         let _runtime = ip_echo_server(

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -406,6 +406,11 @@ pub fn bind_to_localhost() -> io::Result<UdpSocket> {
     sockets::bind_to_with_config(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, config)
 }
 
+#[deprecated(
+    since = "3.0.0",
+    note = "Please avoid this function in favor of sockets::bind_to_localhost_unique"
+)]
+#[allow(deprecated)]
 pub fn bind_to_unspecified() -> io::Result<UdpSocket> {
     let config = sockets::SocketConfiguration::default();
     sockets::bind_to_with_config(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, config)
@@ -724,13 +729,13 @@ mod tests {
     #[test]
     fn test_bind() {
         let pr = sockets::localhost_port_range_for_tests();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let s = bind_in_range(ip_addr, pr.as_tuple()).unwrap();
         assert_eq!(
             s.0, pr.start,
             "bind_in_range should use first available port"
         );
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfig::default().reuseport(true);
         let x = bind_to_with_config(ip_addr, pr.start + 1, config).unwrap();
         let y = bind_to_with_config(ip_addr, pr.start + 1, config).unwrap();
@@ -750,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_bind_with_any_port() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfig::default();
         let x = bind_with_any_port_with_config(ip_addr, config).unwrap();
         let y = bind_with_any_port_with_config(ip_addr, config).unwrap();
@@ -762,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_bind_in_range_nil() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         bind_in_range(ip_addr, (2000, 2000)).unwrap_err();
         bind_in_range(ip_addr, (2000, 1999)).unwrap_err();
     }
@@ -829,11 +834,8 @@ mod tests {
 
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
         assert_eq!(
-            get_public_ip_addr_with_binding(
-                &server_ip_echo_addr,
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-            )
-            .unwrap(),
+            get_public_ip_addr_with_binding(&server_ip_echo_addr, IpAddr::V4(Ipv4Addr::LOCALHOST))
+                .unwrap(),
             parse_host("127.0.0.1").unwrap(),
         );
         assert_eq!(get_cluster_shred_version(&server_ip_echo_addr).unwrap(), 42);
@@ -959,11 +961,8 @@ mod tests {
         );
 
         assert_eq!(
-            get_public_ip_addr_with_binding(
-                &ip_echo_server_addr,
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-            )
-            .unwrap(),
+            get_public_ip_addr_with_binding(&ip_echo_server_addr, IpAddr::V4(Ipv4Addr::LOCALHOST))
+                .unwrap(),
             parse_host("127.0.0.1").unwrap(),
         );
 
@@ -978,7 +977,7 @@ mod tests {
     #[test]
     fn test_bind_two_in_range_with_offset() {
         solana_logger::setup();
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let offset = 6;
         if let Ok(((port1, _), (port2, _))) =
             bind_two_in_range_with_offset(ip_addr, (1024, 65535), offset)

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -406,11 +406,6 @@ pub fn bind_to_localhost() -> io::Result<UdpSocket> {
     sockets::bind_to_with_config(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, config)
 }
 
-#[deprecated(
-    since = "3.0.0",
-    note = "Please avoid this function in favor of sockets::bind_to_localhost_unique"
-)]
-#[allow(deprecated)]
 pub fn bind_to_unspecified() -> io::Result<UdpSocket> {
     let config = sockets::SocketConfiguration::default();
     sockets::bind_to_with_config(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, config)

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -35,6 +35,8 @@ use {
     },
     url::Url,
 };
+
+/// Helper for code that still expects port ranges as `(u16, u16)`
 pub trait RangeExt {
     fn as_tuple(&self) -> (u16, u16);
 }
@@ -810,10 +812,14 @@ mod tests {
     fn test_get_public_ip_addr_none() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let pr = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(
+                ip_addr,
+                localhost_port_range_for_tests().as_tuple(),
+                config,
+            )
+            .expect("should bind");
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
@@ -839,12 +845,12 @@ mod tests {
     fn test_get_public_ip_addr_reachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let pr = sockets::localhost_port_range_for_tests();
+        let pr = sockets::localhost_port_range_for_tests().as_tuple();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
         let (_client_port, (client_udp_socket, client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
 
         let _runtime = ip_echo_server(
             server_tcp_listener,
@@ -879,16 +885,16 @@ mod tests {
     fn test_verify_ports_tcp_unreachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let pr = sockets::localhost_port_range_for_tests();
+        let pr = sockets::localhost_port_range_for_tests().as_tuple();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
 
         // make the socket unreachable by not running the ip echo server!
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
 
         let (_, (_client_udp_socket, client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
 
         let rt = runtime();
         assert!(!rt.block_on(ip_echo_client::verify_all_reachable_tcp(
@@ -902,16 +908,16 @@ mod tests {
     fn test_verify_ports_udp_unreachable() {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let pr = sockets::localhost_port_range_for_tests();
+        let pr = sockets::localhost_port_range_for_tests().as_tuple();
         let config = SocketConfig::default();
         let (_server_port, (server_udp_socket, _server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
 
         // make the socket unreachable by not running the ip echo server!
         let server_ip_echo_addr = server_udp_socket.local_addr().unwrap();
 
         let (_correct_client_port, (client_udp_socket, _client_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, pr, config).unwrap();
 
         let rt = runtime();
         assert!(!rt.block_on(ip_echo_client::verify_all_reachable_udp(
@@ -1013,7 +1019,7 @@ mod tests {
             localhost_port_range_for_tests().as_tuple(),
             config,
         )
-        .unwrap();
+        .expect("should bind");
 
         let ip_echo_server_addr = srv_udp_sock.local_addr().unwrap();
         let _runtime = ip_echo_server(

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -35,8 +35,6 @@ use {
     },
     url::Url,
 };
-
-/// Helper for less verbose tests transition to the new API.
 pub trait RangeExt {
     fn as_tuple(&self) -> (u16, u16);
 }
@@ -54,7 +52,6 @@ pub struct UdpSocketPair {
     pub sender: UdpSocket,   // Locally bound socket to send via public address
 }
 
-// TODO: maybe replace Tuple by Range<u16>?
 pub type PortRange = (u16, u16);
 
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
@@ -777,7 +774,7 @@ mod tests {
             pr.start
         );
         let port = find_available_port_in_range(ip_addr, (pr.start, pr.end)).unwrap();
-        assert!(pr.contains(&port)); // TODO: doublecheck
+        assert!(pr.contains(&port));
 
         let _socket = bind_to(ip_addr, port, false).unwrap();
         find_available_port_in_range(ip_addr, (port, port + 1)).unwrap_err();
@@ -804,7 +801,7 @@ mod tests {
         let config = SocketConfig::default();
         let (port, _sockets) =
             bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
-        assert!((pr.start..pr.end).contains(&port));
+        assert!(pr.contains(&port));
 
         bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
     }

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -43,28 +43,33 @@ pub fn unique_port_range_for_tests(size: u16) -> (u16, u16) {
 }
 
 /// Retrieve a free 20-port slice for unit tests
-#[inline]
 pub fn localhost_port_range_for_tests() -> (u16, u16) {
     unique_port_range_for_tests(20)
 }
 
 /// Retrieve a single free port for unit tests
-#[inline]
 pub fn localhost_unique_port_for_tests() -> u16 {
     unique_port_range_for_tests(1).0
 }
 
-/// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address.
-/// Port collisions are managed at `unique_port_range_for_tests` level.
-#[inline]
+/// Bind a `UdpSocket` to a unique, localhost test-safe port on the given IPv4 address.
 pub fn bind_to_unique_port(addr: Ipv4Addr) -> io::Result<UdpSocket> {
     bind_to(IpAddr::V4(addr), localhost_unique_port_for_tests())
 }
 
-/// Bind a `UdpSocket` to a unique port at every interface - Test-safe.
-#[inline]
+/// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address / async.
+pub async fn bind_to_unique_port_async(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
+    bind_to_async(IpAddr::V4(addr), localhost_unique_port_for_tests()).await
+}
+
+/// Bind a `UdpSocket` to a unique port at every interface.
 pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
     bind_to_unique_port(Ipv4Addr::UNSPECIFIED)
+}
+
+/// Bind a `UdpSocket` to a unique port at every interface / async.
+pub async fn bind_to_unique_unspecified_async() -> io::Result<TokioUdpSocket> {
+    bind_to_unique_port_async(Ipv4Addr::UNSPECIFIED).await
 }
 
 pub fn bind_gossip_port_in_range(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -59,7 +59,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 pub fn bind_to_localhost_unique() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        localhost_port_range_for_tests().0,
+        unique_port_range_for_tests(1).0,
     )
 }
 

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -56,7 +56,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface.
-pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
+pub fn bind_to_localhost_unique() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         localhost_port_range_for_tests().0,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -56,21 +56,11 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface.
-pub fn bind_to_unique_localhost_for_tests() -> io::Result<UdpSocket> {
+pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         localhost_port_range_for_tests().0,
     )
-}
-
-/// Bind a `UdpSocket` to a unique port at every interface / async.
-#[cfg(feature = "dev-context-only-utils")]
-pub async fn bind_to_unique_localhost_for_tests_async() -> io::Result<TokioUdpSocket> {
-    bind_to_async(
-        IpAddr::V4(Ipv4Addr::LOCALHOST),
-        localhost_port_range_for_tests().0,
-    )
-    .await
 }
 
 pub fn bind_gossip_port_in_range(
@@ -275,7 +265,11 @@ pub async fn bind_to_async(ip_addr: IpAddr, port: u16) -> io::Result<TokioUdpSoc
 
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
-    bind_to_async(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).await
+    bind_to_async(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        localhost_port_range_for_tests().0,
+    )
+    .await
 }
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -43,6 +43,14 @@ pub fn unique_port_range_for_tests(size: u16) -> (u16, u16) {
 }
 
 /// Retrieve a free 20-port slice for unit tests
+///
+/// When running under nextest, this will try to provide
+/// a unique slice of port numbers (assuming no other nextest processes
+/// are running on the same host) based on NEXTEST_TEST_GLOBAL_SLOT variable
+/// The port ranges will be reused following nextest logic.
+///
+/// When running without nextest, this will only bump an atomic and eventually
+/// panic when it runs out of port numbers to assign.
 pub fn localhost_port_range_for_tests() -> (u16, u16) {
     unique_port_range_for_tests(20)
 }
@@ -53,25 +61,25 @@ pub fn localhost_unique_port_for_tests() -> u16 {
 }
 
 /// Bind a `UdpSocket` to a unique, localhost test-safe port on the given IPv4 address.
-pub fn bind_to_unique_port(addr: Ipv4Addr) -> io::Result<UdpSocket> {
+pub fn bind_to_unique_port_for_tests(addr: Ipv4Addr) -> io::Result<UdpSocket> {
     bind_to(IpAddr::V4(addr), localhost_unique_port_for_tests())
 }
 
 /// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address / async.
 #[cfg(feature = "dev-context-only-utils")]
-pub async fn bind_to_unique_port_async(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
+pub async fn bind_to_unique_port_async_for_tests(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
     bind_to_async(IpAddr::V4(addr), localhost_unique_port_for_tests()).await
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface.
 pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
-    bind_to_unique_port(Ipv4Addr::UNSPECIFIED)
+    bind_to_unique_port_for_tests(Ipv4Addr::UNSPECIFIED)
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface / async.
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_unique_unspecified_async() -> io::Result<TokioUdpSocket> {
-    bind_to_unique_port_async(Ipv4Addr::UNSPECIFIED).await
+    bind_to_unique_port_async_for_tests(Ipv4Addr::UNSPECIFIED).await
 }
 
 pub fn bind_gossip_port_in_range(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -1,15 +1,15 @@
+#[cfg(feature = "dev-context-only-utils")]
+use tokio::net::UdpSocket as TokioUdpSocket;
 use {
     crate::PortRange,
     log::warn,
     socket2::{Domain, SockAddr, Socket, Type},
     std::{
         io,
-        net::{IpAddr, SocketAddr, TcpListener, UdpSocket},
+        net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
         sync::atomic::{AtomicU16, Ordering},
     },
 };
-#[cfg(feature = "dev-context-only-utils")]
-use {std::net::Ipv4Addr, tokio::net::UdpSocket as TokioUdpSocket};
 // base port for deconflicted allocations
 const BASE_PORT: u16 = 5000;
 // how much to allocate per individual process.

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -376,7 +376,7 @@ mod tests {
         let pr = localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let config = SocketConfiguration::default();
-        let s = bind_in_range(ip_addr, (pr.start, pr.end)).unwrap();
+        let s = bind_in_range(ip_addr, pr.as_tuple()).unwrap();
         assert_eq!(
             s.0, pr.start,
             "bind_in_range should use first available port"

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -56,28 +56,34 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 }
 
 /// Retrieve a single free port for unit tests
+///
+/// When running under nextest, this will try to provide
+/// a unique slice of port numbers (assuming no other nextest processes
+/// are running on the same host) based on NEXTEST_TEST_GLOBAL_SLOT variable
+/// The port ranges will be reused following nextest logic.
+///
+/// When running without nextest, this will only bump an atomic and eventually
+/// panic when it runs out of port numbers to assign.
 pub fn localhost_unique_port_for_tests() -> u16 {
     unique_port_range_for_tests(1).0
 }
 
-/// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address / async.
-#[cfg(feature = "dev-context-only-utils")]
-pub async fn bind_to_unique_port_async_for_tests(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
-    bind_to_async(IpAddr::V4(addr), localhost_unique_port_for_tests()).await
-}
-
 /// Bind a `UdpSocket` to a unique port at every interface.
-pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
+pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
     bind_to(
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
         localhost_unique_port_for_tests(),
     )
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface / async.
 #[cfg(feature = "dev-context-only-utils")]
-pub async fn bind_to_unique_unspecified_async() -> io::Result<TokioUdpSocket> {
-    bind_to_unique_port_async_for_tests(Ipv4Addr::UNSPECIFIED).await
+pub async fn bind_to_unique_localhost_async() -> io::Result<TokioUdpSocket> {
+    bind_to_async(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        localhost_unique_port_for_tests(),
+    )
+    .await
 }
 
 pub fn bind_gossip_port_in_range(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -7,9 +7,11 @@ use {
     std::{
         io,
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
+        ops::Range,
         sync::atomic::{AtomicU16, Ordering},
     },
 };
+
 // base port for deconflicted allocations
 const BASE_PORT: u16 = 5000;
 // how much to allocate per individual process.
@@ -23,7 +25,7 @@ const SLICE_PER_PROCESS: u16 = (u16::MAX - BASE_PORT) / 64;
 /// When running without nextest, this will only bump an atomic and eventually
 /// panic when it runs out of port numbers to assign.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn unique_port_range_for_tests(size: u16) -> (u16, u16) {
+pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
     static SLICE: AtomicU16 = AtomicU16::new(0);
     let offset = SLICE.fetch_add(size, Ordering::Relaxed);
     let start = offset
@@ -38,8 +40,8 @@ pub fn unique_port_range_for_tests(size: u16) -> (u16, u16) {
             }
             Err(_) => BASE_PORT,
         };
-    assert!(start < u16::MAX - size, "ran out of port numbers!");
-    (start, start + size)
+    assert!(start < u16::MAX - size, "Ran out of port numbers!");
+    start..start + size
 }
 
 /// Retrieve a free 20-port slice for unit tests
@@ -51,7 +53,7 @@ pub fn unique_port_range_for_tests(size: u16) -> (u16, u16) {
 ///
 /// When running without nextest, this will only bump an atomic and eventually
 /// panic when it runs out of port numbers to assign.
-pub fn localhost_port_range_for_tests() -> (u16, u16) {
+pub fn localhost_port_range_for_tests() -> Range<u16> {
     unique_port_range_for_tests(20)
 }
 
@@ -59,7 +61,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 pub fn bind_to_localhost_unique() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        unique_port_range_for_tests(1).0,
+        unique_port_range_for_tests(1).start,
     )
 }
 
@@ -267,7 +269,7 @@ pub async fn bind_to_async(ip_addr: IpAddr, port: u16) -> io::Result<TokioUdpSoc
 pub async fn bind_to_localhost_async() -> io::Result<TokioUdpSocket> {
     bind_to_async(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        localhost_port_range_for_tests().0,
+        localhost_port_range_for_tests().start,
     )
     .await
 }
@@ -365,29 +367,32 @@ pub fn bind_more_with_config(
 mod tests {
     use {
         super::*,
-        crate::{bind_in_range, sockets::localhost_port_range_for_tests},
+        crate::{bind_in_range, sockets::localhost_port_range_for_tests, RangeExt},
         std::net::Ipv4Addr,
     };
 
     #[test]
     fn test_bind() {
-        let (pr_s, pr_e) = localhost_port_range_for_tests();
+        let pr = localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let config = SocketConfiguration::default();
-        let s = bind_in_range(ip_addr, (pr_s, pr_e)).unwrap();
-        assert_eq!(s.0, pr_s, "bind_in_range should use first available port");
+        let s = bind_in_range(ip_addr, (pr.start, pr.end)).unwrap();
+        assert_eq!(
+            s.0, pr.start,
+            "bind_in_range should use first available port"
+        );
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let x = bind_to_with_config(ip_addr, pr_s + 1, config).unwrap();
+        let x = bind_to_with_config(ip_addr, pr.start + 1, config).unwrap();
         let y = bind_more_with_config(x, 2, config).unwrap();
         assert_eq!(
             y[0].local_addr().unwrap().port(),
             y[1].local_addr().unwrap().port()
         );
-        bind_to_with_config(ip_addr, pr_s, SocketConfiguration::default()).unwrap_err();
-        bind_in_range(ip_addr, (pr_s, pr_s + 2)).unwrap_err();
+        bind_to_with_config(ip_addr, pr.start, SocketConfiguration::default()).unwrap_err();
+        bind_in_range(ip_addr, (pr.start, pr.start + 2)).unwrap_err();
 
         let (port, v) =
-            multi_bind_in_range_with_config(ip_addr, (pr_s + 5, pr_e), config, 10).unwrap();
+            multi_bind_in_range_with_config(ip_addr, (pr.start + 5, pr.end), config, 10).unwrap();
         for sock in &v {
             assert_eq!(port, sock.local_addr().unwrap().port());
         }
@@ -416,21 +421,21 @@ mod tests {
     fn test_bind_on_top() {
         let config = SocketConfiguration::default();
         let localhost = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port_range = localhost_port_range_for_tests();
-        let (_p, s) = bind_in_range_with_config(localhost, port_range, config).unwrap();
+        let pr = localhost_port_range_for_tests();
+        let (_p, s) = bind_in_range_with_config(localhost, pr.as_tuple(), config).unwrap();
         let _socks = bind_more_with_config(s, 8, config).unwrap();
 
-        let _socks2 = multi_bind_in_range_with_config(localhost, port_range, config, 8).unwrap();
+        let _socks2 = multi_bind_in_range_with_config(localhost, pr.as_tuple(), config, 8).unwrap();
     }
 
     #[test]
     fn test_bind_common_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let (pr_s, pr_e) = localhost_port_range_for_tests();
+        let pr = localhost_port_range_for_tests();
         let config = SocketConfiguration::default();
         let (port, _sockets) =
-            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
-        assert!((pr_s..pr_e).contains(&port));
+            bind_common_in_range_with_config(ip_addr, pr.as_tuple(), config).unwrap();
+        assert!(pr.contains(&port));
 
         bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
     }

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -60,11 +60,6 @@ pub fn localhost_unique_port_for_tests() -> u16 {
     unique_port_range_for_tests(1).0
 }
 
-/// Bind a `UdpSocket` to a unique, localhost test-safe port on the given IPv4 address.
-pub fn bind_to_unique_port_for_tests(addr: Ipv4Addr) -> io::Result<UdpSocket> {
-    bind_to(IpAddr::V4(addr), localhost_unique_port_for_tests())
-}
-
 /// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address / async.
 #[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_unique_port_async_for_tests(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
@@ -73,7 +68,10 @@ pub async fn bind_to_unique_port_async_for_tests(addr: Ipv4Addr) -> io::Result<T
 
 /// Bind a `UdpSocket` to a unique port at every interface.
 pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
-    bind_to_unique_port_for_tests(Ipv4Addr::UNSPECIFIED)
+    bind_to(
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        localhost_unique_port_for_tests(),
+    )
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface / async.

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -56,7 +56,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface.
-pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
+pub fn bind_to_unique_localhost_for_tests() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         localhost_port_range_for_tests().0,
@@ -65,7 +65,7 @@ pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
 
 /// Bind a `UdpSocket` to a unique port at every interface / async.
 #[cfg(feature = "dev-context-only-utils")]
-pub async fn bind_to_unique_localhost_async() -> io::Result<TokioUdpSocket> {
+pub async fn bind_to_unique_localhost_for_tests_async() -> io::Result<TokioUdpSocket> {
     bind_to_async(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         localhost_port_range_for_tests().0,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -55,24 +55,11 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
     unique_port_range_for_tests(20)
 }
 
-/// Retrieve a single free port for unit tests
-///
-/// When running under nextest, this will try to provide
-/// a unique slice of port numbers (assuming no other nextest processes
-/// are running on the same host) based on NEXTEST_TEST_GLOBAL_SLOT variable
-/// The port ranges will be reused following nextest logic.
-///
-/// When running without nextest, this will only bump an atomic and eventually
-/// panic when it runs out of port numbers to assign.
-pub fn localhost_unique_port_for_tests() -> u16 {
-    unique_port_range_for_tests(1).0
-}
-
 /// Bind a `UdpSocket` to a unique port at every interface.
 pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        localhost_unique_port_for_tests(),
+        localhost_port_range_for_tests().0,
     )
 }
 
@@ -81,7 +68,7 @@ pub fn bind_to_unique_localhost() -> io::Result<UdpSocket> {
 pub async fn bind_to_unique_localhost_async() -> io::Result<TokioUdpSocket> {
     bind_to_async(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        localhost_unique_port_for_tests(),
+        localhost_port_range_for_tests().0,
     )
     .await
 }

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -63,7 +63,7 @@ pub fn bind_to_unique_port(addr: Ipv4Addr) -> io::Result<UdpSocket> {
 
 /// Bind a `UdpSocket` to a unique port at every interface - Test-safe.
 #[inline]
-pub fn bing_to_unique_unspecified() -> io::Result<UdpSocket> {
+pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
     bind_to_unique_port(Ipv4Addr::UNSPECIFIED)
 }
 

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -58,6 +58,7 @@ pub fn bind_to_unique_port(addr: Ipv4Addr) -> io::Result<UdpSocket> {
 }
 
 /// Bind a `UdpSocket` to a unique, test-safe port on the given IPv4 address / async.
+#[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_unique_port_async(addr: Ipv4Addr) -> io::Result<TokioUdpSocket> {
     bind_to_async(IpAddr::V4(addr), localhost_unique_port_for_tests()).await
 }
@@ -68,6 +69,7 @@ pub fn bind_to_unique_unspecified() -> io::Result<UdpSocket> {
 }
 
 /// Bind a `UdpSocket` to a unique port at every interface / async.
+#[cfg(feature = "dev-context-only-utils")]
 pub async fn bind_to_unique_unspecified_async() -> io::Result<TokioUdpSocket> {
     bind_to_unique_port_async(Ipv4Addr::UNSPECIFIED).await
 }

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -55,7 +55,7 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
     unique_port_range_for_tests(20)
 }
 
-/// Bind a `UdpSocket` to a unique port at every interface.
+/// Bind a `UdpSocket` to a unique port.
 pub fn bind_to_localhost_unique() -> io::Result<UdpSocket> {
     bind_to(
         IpAddr::V4(Ipv4Addr::LOCALHOST),

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -5,7 +5,7 @@ mod tests {
         log::*,
         solana_connection_cache::connection_cache_stats::ConnectionCacheStats,
         solana_keypair::Keypair,
-        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_packet::PACKET_DATA_SIZE,
         solana_perf::packet::PacketBatch,
         solana_quic_client::nonblocking::quic_client::QuicLazyInitializedEndpoint,
@@ -15,7 +15,7 @@ mod tests {
         },
         solana_tls_utils::{new_dummy_x509_certificate, QuicClientCertificate},
         std::{
-            net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
+            net::{SocketAddr, UdpSocket},
             sync::{
                 atomic::{AtomicBool, Ordering},
                 Arc, RwLock,
@@ -51,9 +51,8 @@ mod tests {
     }
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair) {
-        let pr = localhost_port_range_for_tests();
         (
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.start).expect("should bind"),
+            bind_to_localhost_unique().expect("should bind"),
             Arc::new(AtomicBool::new(false)),
             Keypair::new(),
         )

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -51,9 +51,9 @@ mod tests {
     }
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair) {
-        let port_range = localhost_port_range_for_tests();
+        let pr = localhost_port_range_for_tests();
         (
-            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind"),
+            bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.start).expect("should bind"),
             Arc::new(AtomicBool::new(false)),
             Keypair::new(),
         )

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
+    solana_net_utils::sockets::bind_to_unique_localhost,
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -290,7 +290,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unique_localhost_for_tests().expect("should bind");
+    let transactions_socket = bind_to_unique_localhost().expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+    solana_net_utils::sockets::bind_to_unique_unspecified,
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -291,11 +291,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to(
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        localhost_port_range_for_tests().0,
-    )
-    .expect("should bind");
+    let transactions_socket = bind_to_unique_unspecified.expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::sockets::bind_to_unique_localhost,
+    solana_net_utils::sockets::bind_to_localhost_unique,
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -290,7 +290,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unique_localhost().expect("should bind");
+    let transactions_socket = bind_to_localhost_unique().expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::sockets::bind_to_unique_unspecified,
+    solana_net_utils::sockets::bind_to_unique_localhost,
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -290,7 +290,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unique_unspecified().expect("should bind");
+    let transactions_socket = bind_to_unique_localhost().expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -31,7 +31,6 @@ use {
     solana_transaction_status::TransactionStatus,
     std::{
         collections::HashSet,
-        net::{IpAddr, Ipv4Addr},
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
@@ -291,7 +290,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unique_unspecified.expect("should bind");
+    let transactions_socket = bind_to_unique_unspecified().expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::sockets::bind_to_unique_localhost,
+    solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -290,7 +290,7 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unique_localhost().expect("should bind");
+    let transactions_socket = bind_to_unique_localhost_for_tests().expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -10,7 +10,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_net_utils::bind_to_unspecified,
+    solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
     solana_pubkey::Pubkey,
     solana_pubsub_client::nonblocking::pubsub_client::PubsubClient,
     solana_rent::Rent,
@@ -31,6 +31,7 @@ use {
     solana_transaction_status::TransactionStatus,
     std::{
         collections::HashSet,
+        net::{IpAddr, Ipv4Addr},
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
@@ -290,7 +291,11 @@ fn test_rpc_subscriptions() {
     let test_validator =
         TestValidator::with_no_fees_udp(alice.pubkey(), None, SocketAddrSpace::Unspecified);
 
-    let transactions_socket = bind_to_unspecified().unwrap();
+    let transactions_socket = bind_to(
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        localhost_port_range_for_tests().0,
+    )
+    .expect("should bind");
     transactions_socket.connect(test_validator.tpu()).unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -962,6 +962,9 @@ mod tests {
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path_auto_delete,
         },
+        solana_net_utils::{
+            find_available_port_in_range, sockets::localhost_port_range_for_tests, RangeExt,
+        },
         solana_rpc_client_api::config::RpcContextConfig,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -984,10 +987,10 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let cluster_info = Arc::new(new_test_cluster_info());
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
+        let pr = localhost_port_range_for_tests();
         let rpc_addr = SocketAddr::new(
             ip_addr,
-            solana_net_utils::find_available_port_in_range(ip_addr, port_range).unwrap(),
+            find_available_port_in_range(ip_addr, pr.as_tuple()).unwrap(),
         );
         let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -986,11 +986,11 @@ mod tests {
         let validator_exit = create_validator_exit(exit.clone());
         let bank = Bank::new_for_tests(&genesis_config);
         let cluster_info = Arc::new(new_test_cluster_info());
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let pr = localhost_port_range_for_tests();
+        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let rpc_addr = SocketAddr::new(
             ip_addr,
-            find_available_port_in_range(ip_addr, pr.as_tuple()).unwrap(),
+            find_available_port_in_range(ip_addr, localhost_port_range_for_tests().as_tuple())
+                .unwrap(),
         );
         let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -9,13 +9,8 @@ use {
         },
     },
     solana_client::connection_cache::ConnectionCache,
-    solana_net_utils::sockets::{
-        bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
-    },
-    std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
-        sync::Arc,
-    },
+    solana_net_utils::sockets::bind_to_localhost_unique,
+    std::{net::SocketAddr, sync::Arc},
     tokio::runtime::Handle,
     tokio_util::sync::CancellationToken,
 };

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -57,8 +57,8 @@ impl CreateClient for TpuClientNextClient {
     ) -> Self {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
-        let port_range = localhost_port_range_for_tests();
-        let bind_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
+        let pr = localhost_port_range_for_tests();
+        let bind_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.start)
             .expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -9,7 +9,9 @@ use {
         },
     },
     solana_client::connection_cache::ConnectionCache,
-    solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+    solana_net_utils::sockets::{
+        bind_to, bind_to_localhost_unique, localhost_port_range_for_tests,
+    },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::Arc,
@@ -57,9 +59,8 @@ impl CreateClient for TpuClientNextClient {
     ) -> Self {
         let runtime_handle =
             maybe_runtime.expect("Runtime should be provided for the TpuClientNextClient.");
-        let pr = localhost_port_range_for_tests();
-        let bind_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.start)
-            .expect("Should be able to open UdpSocket for tests.");
+        let bind_socket =
+            bind_to_localhost_unique().expect("Should be able to open UdpSocket for tests.");
         Self::new::<NullTpuInfo>(
             runtime_handle,
             my_tpu_address,

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -62,7 +62,8 @@ mod tests {
         },
         assert_matches::assert_matches,
         solana_net_utils::sockets::{
-            bind_to_async, bind_to_localhost_async, localhost_port_range_for_tests,
+            bind_to_localhost_async, bind_to_unique_port_async, bind_to_unique_unspecified_async,
+            localhost_port_range_for_tests,
         },
         solana_packet::PACKET_DATA_SIZE,
         std::{
@@ -179,12 +180,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_async(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .await
-        .expect("should bind");
+        let sender = bind_to_unique_unspecified_async.expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -196,12 +192,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_async(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .await
-        .expect("should bind");
+        let sender = bind_to_unique_unspecified_async.expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,7 +61,9 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unspecified_async},
+        solana_net_utils::sockets::{
+            bind_to_async, bind_to_localhost_async, localhost_port_range_for_tests,
+        },
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -177,7 +179,12 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unspecified_async().await.expect("bind");
+        let sender = bind_to_async(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .await
+        .expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -189,7 +196,12 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unspecified_async().await.expect("bind");
+        let sender = bind_to_async(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .await
+        .expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,7 +61,9 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unique_localhost_async},
+        solana_net_utils::sockets::{
+            bind_to_localhost_async, bind_to_unique_localhost_for_tests_async,
+        },
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -177,7 +179,9 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_localhost_async().await.expect("should bind");
+        let sender = bind_to_unique_localhost_for_tests_async()
+            .await
+            .expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -189,7 +193,9 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_localhost_async().await.expect("should bind");
+        let sender = bind_to_unique_localhost_for_tests_async()
+            .await
+            .expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,10 +61,7 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::sockets::{
-            bind_to_localhost_async, bind_to_unique_port_async, bind_to_unique_unspecified_async,
-            localhost_port_range_for_tests,
-        },
+        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unique_unspecified_async},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -180,7 +177,9 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_unspecified_async.expect("should bind");
+        let sender = bind_to_unique_unspecified_async()
+            .await
+            .expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -192,7 +191,9 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_unspecified_async.expect("should bind");
+        let sender = bind_to_unique_unspecified_async()
+            .await
+            .expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,7 +61,7 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unique_unspecified_async},
+        solana_net_utils::sockets::{bind_to_localhost_async, bind_to_unique_localhost_async},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -177,9 +177,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_unspecified_async()
-            .await
-            .expect("should bind");
+        let sender = bind_to_unique_localhost_async().await.expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -191,9 +189,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_unspecified_async()
-            .await
-            .expect("should bind");
+        let sender = bind_to_unique_localhost_async().await.expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -61,9 +61,7 @@ mod tests {
             sendmmsg::SendPktsError,
         },
         assert_matches::assert_matches,
-        solana_net_utils::sockets::{
-            bind_to_localhost_async, bind_to_unique_localhost_for_tests_async,
-        },
+        solana_net_utils::sockets::bind_to_localhost_async,
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -179,9 +177,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_localhost_for_tests_async()
-            .await
-            .expect("should bind");
+        let sender = bind_to_localhost_async().await.expect("should bind");
         let res = batch_send(&sender, &packet_refs[..]).await;
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs).await;
@@ -193,9 +189,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_localhost_for_tests_async()
-            .await
-            .expect("should bind");
+        let sender = bind_to_localhost_async().await.expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -17,6 +17,7 @@ use {
             localhost_port_range_for_tests, multi_bind_in_range_with_config,
             SocketConfiguration as SocketConfig,
         },
+        RangeExt,
     },
     solana_perf::packet::PacketBatch,
     solana_quic_definitions::{QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS},
@@ -68,7 +69,7 @@ pub fn create_quic_server_sockets() -> Vec<UdpSocket> {
     let port_range = localhost_port_range_for_tests();
     multi_bind_in_range_with_config(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        port_range,
+        port_range.as_tuple(),
         SocketConfig::default(),
         num,
     )

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -66,10 +66,9 @@ pub fn create_quic_server_sockets() -> Vec<UdpSocket> {
     } else {
         1
     };
-    let port_range = localhost_port_range_for_tests();
     multi_bind_in_range_with_config(
         IpAddr::V4(Ipv4Addr::LOCALHOST),
-        port_range.as_tuple(),
+        localhost_port_range_for_tests().as_tuple(),
         SocketConfig::default(),
         num,
     )

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -199,9 +199,9 @@ mod tests {
 
     fn test_setup_reader_sender(ip: IpAddr) -> io::Result<TestConfig> {
         let pr = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, (pr.start, pr.end), SocketConfig::default())?.1;
+        let reader = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())?.1;
         let reader_addr = reader.local_addr()?;
-        let sender = bind_in_range_with_config(ip, (pr.start, pr.end), SocketConfig::default())?.1;
+        let sender = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())?.1;
         let sender_addr = sender.local_addr()?;
         Ok((reader, reader_addr, sender, sender_addr))
     }

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -198,10 +198,10 @@ mod tests {
     type TestConfig = (UdpSocket, SocketAddr, UdpSocket, SocketAddr);
 
     fn test_setup_reader_sender(ip: IpAddr) -> io::Result<TestConfig> {
-        let pr = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())?.1;
+        let pr = localhost_port_range_for_tests().as_tuple();
+        let reader = bind_in_range_with_config(ip, pr, SocketConfig::default())?.1;
         let reader_addr = reader.local_addr()?;
-        let sender = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())?.1;
+        let sender = bind_in_range_with_config(ip, pr, SocketConfig::default())?.1;
         let sender_addr = sender.local_addr()?;
         Ok((reader, reader_addr, sender, sender_addr))
     }
@@ -301,18 +301,18 @@ mod tests {
     #[test]
     pub fn test_recv_mmsg_multi_addrs() {
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let pr = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
+        let pr = localhost_port_range_for_tests().as_tuple();
+        let reader = bind_in_range_with_config(ip, pr, SocketConfig::default())
             .unwrap()
             .1;
         let reader_addr = reader.local_addr().unwrap();
-        let sender1 = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
+        let sender1 = bind_in_range_with_config(ip, pr, SocketConfig::default())
             .unwrap()
             .1;
         let sender1_addr = sender1.local_addr().unwrap();
         let sent1 = TEST_NUM_MSGS - 1;
 
-        let sender2 = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
+        let sender2 = bind_in_range_with_config(ip, pr, SocketConfig::default())
             .unwrap()
             .1;
         let sender_addr = sender2.local_addr().unwrap();

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -182,9 +182,12 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
 mod tests {
     use {
         crate::{packet::PACKET_DATA_SIZE, recvmmsg::*},
-        solana_net_utils::sockets::{
-            bind_in_range_with_config, localhost_port_range_for_tests,
-            SocketConfiguration as SocketConfig,
+        solana_net_utils::{
+            sockets::{
+                bind_in_range_with_config, localhost_port_range_for_tests,
+                SocketConfiguration as SocketConfig,
+            },
+            RangeExt,
         },
         std::{
             net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
@@ -195,10 +198,10 @@ mod tests {
     type TestConfig = (UdpSocket, SocketAddr, UdpSocket, SocketAddr);
 
     fn test_setup_reader_sender(ip: IpAddr) -> io::Result<TestConfig> {
-        let port_range = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, port_range, SocketConfig::default())?.1;
+        let pr = localhost_port_range_for_tests();
+        let reader = bind_in_range_with_config(ip, (pr.start, pr.end), SocketConfig::default())?.1;
         let reader_addr = reader.local_addr()?;
-        let sender = bind_in_range_with_config(ip, port_range, SocketConfig::default())?.1;
+        let sender = bind_in_range_with_config(ip, (pr.start, pr.end), SocketConfig::default())?.1;
         let sender_addr = sender.local_addr()?;
         Ok((reader, reader_addr, sender, sender_addr))
     }
@@ -298,18 +301,18 @@ mod tests {
     #[test]
     pub fn test_recv_mmsg_multi_addrs() {
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port_range = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, port_range, SocketConfig::default())
+        let pr = localhost_port_range_for_tests();
+        let reader = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
             .unwrap()
             .1;
         let reader_addr = reader.local_addr().unwrap();
-        let sender1 = bind_in_range_with_config(ip, port_range, SocketConfig::default())
+        let sender1 = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
             .unwrap()
             .1;
         let sender1_addr = sender1.local_addr().unwrap();
         let sent1 = TEST_NUM_MSGS - 1;
 
-        let sender2 = bind_in_range_with_config(ip, port_range, SocketConfig::default())
+        let sender2 = bind_in_range_with_config(ip, pr.as_tuple(), SocketConfig::default())
             .unwrap()
             .1;
         let sender_addr = sender2.local_addr().unwrap();

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_unspecified},
+        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -362,7 +362,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_unspecified().expect("should bind");
+        let sender = bind_to_unique_localhost().expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);
@@ -374,7 +374,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_unspecified().expect("should bind");
+        let sender = bind_to_unique_localhost().expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,10 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, bind_to_unspecified},
+        solana_net_utils::{
+            bind_to_localhost,
+            sockets::{bind_to, localhost_port_range_for_tests},
+        },
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -362,7 +365,11 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unspecified().expect("bind");
+        let sender = bind_to(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);
@@ -374,7 +381,11 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unspecified().expect("bind");
+        let sender = bind_to(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -374,11 +374,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .expect("should bind");
+        let sender = bind_to_unique_unspecified().expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, sockets::bind_to_localhost_unique},
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -257,9 +257,9 @@ mod tests {
 
     #[test]
     pub fn test_send_mmsg_one_dest() {
-        let reader = bind_to_localhost().expect("bind");
+        let reader = bind_to_localhost_unique().expect("should bind");
         let addr = reader.local_addr().unwrap();
-        let sender = bind_to_localhost().expect("bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
 
         let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &addr)).collect();
@@ -274,13 +274,13 @@ mod tests {
 
     #[test]
     pub fn test_send_mmsg_multi_dest() {
-        let reader = bind_to_localhost().expect("bind");
+        let reader = bind_to_localhost_unique().expect("should bind");
         let addr = reader.local_addr().unwrap();
 
-        let reader2 = bind_to_localhost().expect("bind");
+        let reader2 = bind_to_localhost_unique().expect("should bind");
         let addr2 = reader2.local_addr().unwrap();
 
-        let sender = bind_to_localhost().expect("bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
 
         let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets
@@ -309,19 +309,19 @@ mod tests {
 
     #[test]
     pub fn test_multicast_msg() {
-        let reader = bind_to_localhost().expect("bind");
+        let reader = bind_to_localhost_unique().expect("should bind");
         let addr = reader.local_addr().unwrap();
 
-        let reader2 = bind_to_localhost().expect("bind");
+        let reader2 = bind_to_localhost_unique().expect("should bind");
         let addr2 = reader2.local_addr().unwrap();
 
-        let reader3 = bind_to_localhost().expect("bind");
+        let reader3 = bind_to_localhost_unique().expect("should bind");
         let addr3 = reader3.local_addr().unwrap();
 
-        let reader4 = bind_to_localhost().expect("bind");
+        let reader4 = bind_to_localhost_unique().expect("should bind");
         let addr4 = reader4.local_addr().unwrap();
 
-        let sender = bind_to_localhost().expect("bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
 
         let packet = Packet::default();
 

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost},
+        solana_net_utils::{bind_to_localhost, sockets::bind_to_localhost_unique},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -362,7 +362,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_localhost().expect("should bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);
@@ -374,7 +374,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_localhost().expect("should bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost},
+        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost_for_tests},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -362,7 +362,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_localhost().expect("should bind");
+        let sender = bind_to_unique_localhost_for_tests().expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);
@@ -374,7 +374,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_localhost().expect("should bind");
+        let sender = bind_to_unique_localhost_for_tests().expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,10 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{
-            bind_to_localhost,
-            sockets::{bind_to, localhost_port_range_for_tests},
-        },
+        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_unspecified},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -365,11 +362,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .expect("should bind");
+        let sender = bind_to_unique_unspecified().expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -247,7 +247,7 @@ mod tests {
             sendmmsg::{batch_send, multi_target_send, SendPktsError},
         },
         assert_matches::assert_matches,
-        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost_for_tests},
+        solana_net_utils::{bind_to_localhost, sockets::bind_to_unique_localhost},
         solana_packet::PACKET_DATA_SIZE,
         std::{
             io::ErrorKind,
@@ -362,7 +362,7 @@ mod tests {
         ];
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
-        let sender = bind_to_unique_localhost_for_tests().expect("should bind");
+        let sender = bind_to_unique_localhost().expect("should bind");
         let res = batch_send(&sender, packet_refs);
         assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
         let res = multi_target_send(&sender, &packets[0], &dest_refs);
@@ -374,7 +374,7 @@ mod tests {
         let packets: Vec<_> = (0..5).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let ipv4local = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
-        let sender = bind_to_unique_localhost_for_tests().expect("should bind");
+        let sender = bind_to_unique_localhost().expect("should bind");
 
         // test intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -38,7 +38,9 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,
     solana_native_token::sol_to_lamports,
-    solana_net_utils::{find_available_ports_in_range, PortRange, RangeExt},
+    solana_net_utils::{
+        find_available_ports_in_range, sockets::localhost_port_range_for_tests, PortRange, RangeExt,
+    },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
@@ -100,7 +102,7 @@ impl Default for TestValidatorNodeConfig {
         #[cfg(not(debug_assertions))]
         let port_range = solana_net_utils::VALIDATOR_PORT_RANGE;
         #[cfg(debug_assertions)]
-        let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
+        let port_range = localhost_port_range_for_tests();
         Self {
             gossip_addr: SocketAddr::new(bind_ip_addr, port_range.start),
             port_range: port_range.as_tuple(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -38,7 +38,7 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,
     solana_native_token::sol_to_lamports,
-    solana_net_utils::{find_available_ports_in_range, PortRange},
+    solana_net_utils::{find_available_ports_in_range, PortRange, RangeExt},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
@@ -102,8 +102,8 @@ impl Default for TestValidatorNodeConfig {
         #[cfg(debug_assertions)]
         let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
         Self {
-            gossip_addr: SocketAddr::new(bind_ip_addr, port_range.0),
-            port_range,
+            gossip_addr: SocketAddr::new(bind_ip_addr, port_range.start),
+            port_range: port_range.as_tuple(),
             bind_ip_addr,
         }
     }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -327,7 +327,11 @@ mod tests {
             SendTransactionStats,
         },
         quinn::Endpoint,
-        solana_net_utils::{bind_in_range, sockets::localhost_port_range_for_tests, RangeExt},
+        solana_net_utils::{
+            bind_in_range,
+            sockets::{localhost_port_range_for_tests, localhost_port_single_for_tests},
+            RangeExt,
+        },
         solana_tls_utils::QuicClientCertificate,
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -342,10 +346,12 @@ mod tests {
     const TEST_MAX_TIME: Duration = Duration::from_secs(5);
 
     fn create_test_endpoint() -> Endpoint {
-        let pr = localhost_port_range_for_tests();
-        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.as_tuple())
-            .unwrap()
-            .1;
+        let socket = bind_in_range(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            localhost_port_range_for_tests().as_tuple(),
+        )
+        .expect("should bind")
+        .1;
         let client_config = create_client_config(&QuicClientCertificate::new(None));
         create_client_endpoint(BindTarget::Socket(socket), client_config).unwrap()
     }
@@ -356,7 +362,7 @@ mod tests {
 
         let peer: SocketAddr = SocketAddr::new(
             Ipv4Addr::LOCALHOST.into(),
-            localhost_port_range_for_tests().start,
+            localhost_port_single_for_tests(),
         );
 
         let worker_channel_size = 1;
@@ -392,7 +398,7 @@ mod tests {
 
         let peer: SocketAddr = SocketAddr::new(
             Ipv4Addr::LOCALHOST.into(),
-            localhost_port_range_for_tests().start,
+            localhost_port_single_for_tests(),
         );
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -426,7 +432,7 @@ mod tests {
 
         let peer: SocketAddr = SocketAddr::new(
             Ipv4Addr::LOCALHOST.into(),
-            localhost_port_range_for_tests().start,
+            localhost_port_single_for_tests(),
         );
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -354,8 +354,10 @@ mod tests {
     async fn test_worker_stopped_after_failed_connect() {
         let endpoint = create_test_endpoint();
 
-        let pr = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
+        let peer: SocketAddr = SocketAddr::new(
+            Ipv4Addr::LOCALHOST.into(),
+            localhost_port_range_for_tests().start,
+        );
 
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -388,9 +390,10 @@ mod tests {
     async fn test_worker_shutdown() {
         let endpoint = create_test_endpoint();
 
-        let pr = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
-
+        let peer: SocketAddr = SocketAddr::new(
+            Ipv4Addr::LOCALHOST.into(),
+            localhost_port_range_for_tests().start,
+        );
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;
@@ -421,8 +424,10 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut cache = WorkersCache::new(10, cancel.clone());
 
-        let pr = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
+        let peer: SocketAddr = SocketAddr::new(
+            Ipv4Addr::LOCALHOST.into(),
+            localhost_port_range_for_tests().start,
+        );
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -327,7 +327,7 @@ mod tests {
             SendTransactionStats,
         },
         quinn::Endpoint,
-        solana_net_utils::{bind_in_range, sockets::localhost_port_range_for_tests},
+        solana_net_utils::{bind_in_range, sockets::localhost_port_range_for_tests, RangeExt},
         solana_tls_utils::QuicClientCertificate,
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -343,7 +343,7 @@ mod tests {
 
     fn create_test_endpoint() -> Endpoint {
         let pr = localhost_port_range_for_tests();
-        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), (pr.start, pr.end))
+        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), pr.as_tuple())
             .unwrap()
             .1;
         let client_config = create_client_config(&QuicClientCertificate::new(None));

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -342,8 +342,8 @@ mod tests {
     const TEST_MAX_TIME: Duration = Duration::from_secs(5);
 
     fn create_test_endpoint() -> Endpoint {
-        let port_range = localhost_port_range_for_tests();
-        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range)
+        let pr = localhost_port_range_for_tests();
+        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), (pr.start, pr.end))
             .unwrap()
             .1;
         let client_config = create_client_config(&QuicClientCertificate::new(None));
@@ -354,8 +354,8 @@ mod tests {
     async fn test_worker_stopped_after_failed_connect() {
         let endpoint = create_test_endpoint();
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let pr = localhost_port_range_for_tests();
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
 
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -388,8 +388,8 @@ mod tests {
     async fn test_worker_shutdown() {
         let endpoint = create_test_endpoint();
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let pr = localhost_port_range_for_tests();
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
 
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -421,8 +421,8 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut cache = WorkersCache::new(10, cancel.clone());
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let pr = localhost_port_range_for_tests();
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pr.start);
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,7 +499,7 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
+        solana_net_utils::sockets::bind_to_unique_unspecified,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -536,11 +536,7 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to(
-            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            localhost_port_range_for_tests().0,
-        )
-        .expect("should bind");
+        let socket = bind_to_unique_unspecified().expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,7 +499,7 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -531,7 +531,7 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to_unique_localhost().expect("should bind");
+        let socket = bind_to_unique_localhost_for_tests().expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,7 +499,7 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::sockets::bind_to_unique_unspecified,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -531,7 +531,7 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to_unique_unspecified().expect("should bind");
+        let socket = bind_to_unique_localhost().expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -503,12 +503,7 @@ mod test {
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
-        std::{
-            net::{IpAddr, Ipv4Addr},
-            ops::Deref,
-            sync::Arc,
-            time::Duration,
-        },
+        std::{ops::Deref, sync::Arc, time::Duration},
     };
 
     #[allow(clippy::type_complexity)]

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,11 +499,16 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::bind_to_unspecified,
+        solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
-        std::{ops::Deref, sync::Arc, time::Duration},
+        std::{
+            net::{IpAddr, Ipv4Addr},
+            ops::Deref,
+            sync::Arc,
+            time::Duration,
+        },
     };
 
     #[allow(clippy::type_complexity)]
@@ -531,7 +536,11 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to_unspecified().unwrap();
+        let socket = bind_to(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            localhost_port_range_for_tests().0,
+        )
+        .expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,7 +499,7 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -531,7 +531,7 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to_unique_localhost_for_tests().expect("should bind");
+        let socket = bind_to_unique_localhost().expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -499,7 +499,7 @@ mod test {
             get_tmp_ledger_path,
             shred::{max_ticks_per_n_shreds, DATA_SHREDS_PER_FEC_BLOCK},
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -531,7 +531,7 @@ mod test {
             leader_keypair.clone(),
             SocketAddrSpace::Unspecified,
         ));
-        let socket = bind_to_unique_localhost().expect("should bind");
+        let socket = bind_to_localhost_unique().expect("should bind");
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -845,7 +845,7 @@ mod tests {
         let keypairs: Vec<Keypair> = repeat_with(Keypair::new).take(NUM_ENDPOINTS).collect();
         let port_range = localhost_port_range_for_tests();
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let sockets: Vec<UdpSocket> = (port_range.0..port_range.1)
+        let sockets: Vec<UdpSocket> = port_range
             .map(|port| bind_to(ip_addr, port).unwrap())
             .take(NUM_ENDPOINTS)
             .collect();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -975,7 +975,7 @@ mod tests {
         solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         spl_generic_token::token,
         spl_token_2022::state::{Account as TokenAccount, AccountState as TokenAccountState, Mint},
-        std::{collections::HashSet, fs::remove_dir_all, net::Ipv4Addr, sync::atomic::AtomicBool},
+        std::{collections::HashSet, fs::remove_dir_all, sync::atomic::AtomicBool},
     };
 
     #[derive(Default)]

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::sockets::localhost_port_range_for_tests,
+        solana_net_utils::sockets::bind_to_unique_unspecified,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -1030,13 +1030,7 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(
-                        bind_to(
-                            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                            localhost_port_range_for_tests().0,
-                        )
-                        .expect("should bind"),
-                    ),
+                    repair_socket: Arc::new(bind_to_unique_unspecified().expect("should bind")),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -1030,7 +1030,9 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(bind_to_unique_localhost().expect("should bind")),
+                    repair_socket: Arc::new(
+                        bind_to_unique_localhost_for_tests().expect("should bind"),
+                    ),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1016,11 +1016,6 @@ mod tests {
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
-            let repair_socket = bind_to(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                localhost_port_range_for_tests().0,
-            )
-            .expect("should bind");
             let meta = AdminRpcRequestMetadata {
                 rpc_addr: None,
                 start_time: SystemTime::now(),
@@ -1035,7 +1030,13 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(repair_socket),
+                    repair_socket: Arc::new(
+                        bind_to(
+                            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                            localhost_port_range_for_tests().0,
+                        )
+                        .expect("should bind"),
+                    ),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::sockets::bind_to_unique_unspecified,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -1030,7 +1030,7 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(bind_to_unique_unspecified().expect("should bind")),
+                    repair_socket: Arc::new(bind_to_unique_localhost().expect("should bind")),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::sockets::bind_to_unique_localhost_for_tests,
+        solana_net_utils::sockets::bind_to_unique_localhost,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -1030,9 +1030,7 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(
-                        bind_to_unique_localhost_for_tests().expect("should bind"),
-                    ),
+                    repair_socket: Arc::new(bind_to_unique_localhost().expect("should bind")),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::bind_to_unspecified,
+        solana_net_utils::sockets::localhost_port_range_for_tests,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -975,7 +975,7 @@ mod tests {
         solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         spl_generic_token::token,
         spl_token_2022::state::{Account as TokenAccount, AccountState as TokenAccountState, Mint},
-        std::{collections::HashSet, fs::remove_dir_all, sync::atomic::AtomicBool},
+        std::{collections::HashSet, fs::remove_dir_all, net::Ipv4Addr, sync::atomic::AtomicBool},
     };
 
     #[derive(Default)]
@@ -1016,6 +1016,11 @@ mod tests {
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
+            let repair_socket = bind_to(
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                localhost_port_range_for_tests().0,
+            )
+            .expect("should bind");
             let meta = AdminRpcRequestMetadata {
                 rpc_addr: None,
                 start_time: SystemTime::now(),
@@ -1030,7 +1035,7 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(bind_to_unspecified().unwrap()),
+                    repair_socket: Arc::new(repair_socket),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -961,7 +961,7 @@ mod tests {
                 create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
             },
         },
-        solana_net_utils::sockets::bind_to_unique_localhost,
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_program_option::COption,
         solana_program_pack::Pack,
         solana_pubkey::Pubkey,
@@ -1030,7 +1030,7 @@ mod tests {
                     vote_account,
                     repair_whitelist,
                     notifies: Arc::new(RwLock::new(KeyUpdaters::default())),
-                    repair_socket: Arc::new(bind_to_unique_localhost().expect("should bind")),
+                    repair_socket: Arc::new(bind_to_localhost_unique().expect("should bind")),
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),


### PR DESCRIPTION
#### Problem
A bunch of tests still relies on either hardcoded ports or bind_to_localhost and bind_to_unspecified. This creates flaky tests in cases where unique port ranges are needed.

Related to https://github.com/anza-xyz/agave/pull/6886 

#### Summary of Changes
- Swapped tests to non-overlapping port allocation.
- Added helper function to convert Range<u16> to (u16, u16) as still some functions expect the tuple.
- Added helper functions to allocate unique ports for localhost, range and single scenarios.
- Reduced amount of imports and lines / less verbose overall.
- Swapped `UNSPECIFIED` to `LOCALHOST` at many points.
