### PR TITLE
increase max ingest

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -37,8 +37,8 @@ pub const DEFAULT_MAX_STAKED_CONNECTIONS: usize = 2000;
 
 pub const DEFAULT_MAX_UNSTAKED_CONNECTIONS: usize = 500;
 
-/// Limit to 250K PPS
-pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 250;
+/// Limit to 500K PPS
+pub const DEFAULT_MAX_STREAMS_PER_MS: u64 = 500;
 
 /// The new connections per minute from a particular IP address.
 /// Heuristically set to the default maximum concurrent connections


### PR DESCRIPTION
#### Problem
We are over-throttling tx ingest and could potentially land more, higher value txs.

QUIC fetch and overall TPU pipeline has been IBRL'ed and can handle significantly more traffic. Old value was set based on ability to ingest/allocate for 250k pps. In testing, we have observed handling more than 2x this (was seeing sustained 600k pps in 10-node cluster testing) with latest code.

Even when we are not hitting the global cap, many individual connections are having their traffic throttled by the EMA throttling window. It is also extremely unlikely that all connections are using their full quota all the time, so this upper bound probably shouldn't be overly pessimistic.

#### Summary of Changes
Double the current global limit from 250k pps to 500k. This value then gets used for managing individual connection limits.

Note:

- We can likely increase this even more. Doubling is conservative.
- Longer term, we would like a more sophisticated connection heuristic. But this stopgap should provide some nice relief.