### PR TITLE
programs: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -110,7 +110,10 @@ pub enum SyscallError {
         num_accounts: u64,
         max_accounts: u64,
     },
-    #[error("Invoked an instruction with too many account info's ({num_account_infos} > {max_account_infos})")]
+    #[error(
+        "Invoked an instruction with too many account info's ({num_account_infos} > \
+         {max_account_infos})"
+    )]
     MaxInstructionAccountInfosExceeded {
         num_account_infos: u64,
         max_account_infos: u64,

--- a/programs/stake-tests/tests/test_move_stake_and_lamports.rs
+++ b/programs/stake-tests/tests/test_move_stake_and_lamports.rs
@@ -271,7 +271,7 @@ async fn process_instruction<T: Signers + ?Sized>(
                 TransactionError::InsufficientFundsForRent { .. } => {
                     Err(ProgramError::InsufficientFunds)
                 }
-                _ => panic!("couldnt convert {:?} to ProgramError", e),
+                _ => panic!("couldnt convert {e:?} to ProgramError"),
             }
         }
     }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -4489,7 +4489,10 @@ mod tests {
                     );
                     assert!(destination_stake.delegation.stake >= minimum_delegation,);
                 } else {
-                    panic!("destination state must be StakeStake::Stake after successful split when source is also StakeStateV2::Stake!");
+                    panic!(
+                        "destination state must be StakeStake::Stake after successful split when \
+                         source is also StakeStateV2::Stake!"
+                    );
                 }
             }
         }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -53,7 +53,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
 
-    trace!("process_instruction: {:?}", data);
+    trace!("process_instruction: {data:?}");
 
     let get_stake_account = || {
         let me = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -305,7 +305,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction =
         limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)?;
 
-    trace!("process_instruction: {:?}", instruction);
+    trace!("process_instruction: {instruction:?}");
 
     let signers = instruction_context.get_signers(transaction_context)?;
     match instruction {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -55,7 +55,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let data = instruction_context.get_instruction_data();
 
-    trace!("process_instruction: {:?}", data);
+    trace!("process_instruction: {data:?}");
 
     let mut me = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
     if *me.get_owner() != id() {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -190,7 +190,8 @@ fn check_and_filter_proposed_vote_state(
                         root_to_check = None;
                     } else {
                         proposed_lockouts_index = proposed_lockouts_index.checked_add(1).expect(
-                            "`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when `proposed_vote_slot` is too old to be in SlotHashes history",
+                            "`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when \
+                             `proposed_vote_slot` is too old to be in SlotHashes history",
                         );
                     }
                     continue;
@@ -207,9 +208,10 @@ fn check_and_filter_proposed_vote_state(
             }
             Ordering::Greater => {
                 // Decrement `slot_hashes_index` to find newer slots in the SlotHashes history
-                slot_hashes_index = slot_hashes_index
-                    .checked_sub(1)
-                    .expect("`slot_hashes_index` is positive when finding newer slots in SlotHashes history");
+                slot_hashes_index = slot_hashes_index.checked_sub(1).expect(
+                    "`slot_hashes_index` is positive when finding newer slots in SlotHashes \
+                     history",
+                );
                 continue;
             }
             Ordering::Equal => {
@@ -219,9 +221,10 @@ fn check_and_filter_proposed_vote_state(
                 if root_to_check.is_some() {
                     root_to_check = None;
                 } else {
-                    proposed_lockouts_index = proposed_lockouts_index
-                        .checked_add(1)
-                        .expect("`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when match is found in SlotHashes history");
+                    proposed_lockouts_index = proposed_lockouts_index.checked_add(1).expect(
+                        "`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when match \
+                         is found in SlotHashes history",
+                    );
                     slot_hashes_index = slot_hashes_index.checked_sub(1).expect(
                         "`slot_hashes_index` is positive when match is found in SlotHashes history",
                     );
@@ -290,9 +293,10 @@ fn check_and_filter_proposed_vote_state(
             true
         };
 
-        proposed_lockouts_index = proposed_lockouts_index
-            .checked_add(1)
-            .expect("`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when filtering out irrelevant votes");
+        proposed_lockouts_index = proposed_lockouts_index.checked_add(1).expect(
+            "`proposed_lockouts_index` is bounded by `MAX_LOCKOUT_HISTORY` when filtering out \
+             irrelevant votes",
+        );
         should_retain
     });
 
@@ -499,9 +503,10 @@ pub fn process_new_vote_state(
                 earned_credits = earned_credits
                     .checked_add(vote_state.credits_for_vote_at_index(current_vote_state_index))
                     .expect("`earned_credits` does not overflow");
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when processing new root");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when \
+                     processing new root",
+                );
                 continue;
             }
 
@@ -542,9 +547,10 @@ pub fn process_new_vote_state(
                 if current_vote.lockout.last_locked_out_slot() >= new_vote.slot() {
                     return Err(VoteError::LockoutConflict);
                 }
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is less than proposed");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     less than proposed",
+                );
             }
             Ordering::Equal => {
                 // The new vote state should never have less lockout than
@@ -556,17 +562,20 @@ pub fn process_new_vote_state(
                 // Copy the vote slot latency in from the current state to the new state
                 new_vote.latency = vote_state.votes[current_vote_state_index].latency;
 
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is equal to proposed");
-                new_vote_state_index = new_vote_state_index
-                    .checked_add(1)
-                    .expect("`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is equal to proposed");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     equal to proposed",
+                );
+                new_vote_state_index = new_vote_state_index.checked_add(1).expect(
+                    "`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     equal to proposed",
+                );
             }
             Ordering::Greater => {
-                new_vote_state_index = new_vote_state_index
-                    .checked_add(1)
-                    .expect("`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is greater than proposed");
+                new_vote_state_index = new_vote_state_index.checked_add(1).expect(
+                    "`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     greater than proposed",
+                );
             }
         }
     }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6910

#### Summary of Changes
For the `programs` directory:
- Run` cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`
