### PR TITLE
Do not unref obsolete accounts during clean_stored_dead_slots

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7457,10 +7457,15 @@ impl AccountsDb {
                     .map(|store| {
                         let slot = store.slot();
                         let mut pubkeys = Vec::with_capacity(store.count());
+                        // Obsolete accounts are already unreffed before this point, so do not add
+                        // them to the pubkeys list.
+                        let obsolete_accounts = store.get_obsolete_accounts(None);
                         store
                             .accounts
-                            .scan_pubkeys(|pubkey| {
-                                pubkeys.push((slot, *pubkey));
+                            .scan_accounts_without_data(|offset, account| {
+                                if !obsolete_accounts.contains(&(offset, account.data_len)) {
+                                    pubkeys.push((slot, *account.pubkey));
+                                }
                             })
                             .expect("must scan accounts storage");
                         pubkeys


### PR DESCRIPTION
#### Problem
Handle Reclaims unrefs account when the entire storage is being removed (it does *not* unref when a subset of accounts in the storage are removed). Obsolete accounts have already been unreffed at this point, which leads to a double unref.

Note: With full implementation of obsolete accounts, clean_stored_dead_slots can be skipped, which resolves this issue as well, but that is a future refactor. 

#### Summary of Changes
- Do not unref obsolete accounts during clean_stored_dead_slots
- Add test that creates/injects obsolete accounts and exercises scenario

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
