### PR TITLE
[zk-token-sdk] deprecate the crate

### DIFF
--- a/programs/zk-token-proof/benches/verify_proofs.rs
+++ b/programs/zk-token-proof/benches/verify_proofs.rs
@@ -1,4 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
+// Allow deprecated warnings since this crate will be removed along with
+// `solana-zk-token-sdk` will be removed
+#![allow(deprecated)]
 use {
     criterion::{criterion_group, criterion_main, Criterion},
     curve25519_dalek::scalar::Scalar,

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -1,4 +1,7 @@
 #![forbid(unsafe_code)]
+// Allow deprecated warnings since this crate will be removed along with
+// `solana-zk-token-sdk` will be removed
+#![allow(deprecated)]
 
 use {
     bytemuck::Pod,

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use {
     bip39::{Mnemonic, MnemonicType, Seed},
     clap::{crate_description, crate_name, Arg, ArgMatches, Command, PossibleValue},

--- a/zk-token-sdk/README.md
+++ b/zk-token-sdk/README.md
@@ -1,0 +1,7 @@
+# zk-token-sdk (DEPRECATED)
+
+**This crate is deprecated and no longer maintained.**
+
+This crate has been replaced by the [zk-sdk](https://github.com/solana-program/zk-elgamal-proof) crate.
+
+For the latest updates and features, please use the new crate.

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,3 +1,8 @@
+// Deprecate the crate
+#![deprecated]
+// Allow deprecated warnings to be suppressed in the crate
+#![allow(deprecated)]
+
 #![allow(clippy::arithmetic_side_effects, clippy::op_ref)]
 
 // The warning `clippy::op_ref` is disabled to allow efficient operator arithmetic of structs that

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,5 +1,7 @@
 // Deprecate the crate
-#![deprecated]
+#![deprecated(
+    note = "use the `zk-sdk` instead: https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk"
+)]
 // Allow deprecated warnings to be suppressed in the crate
 #![allow(deprecated)]
 #![allow(clippy::arithmetic_side_effects, clippy::op_ref)]

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,6 +1,6 @@
 // Deprecate the crate
 #![deprecated(
-    since = "2.3.8",
+    since = "3.0.0",
     note = "use the `solana-zk-sdk` instead: https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk"
 )]
 // Allow deprecated warnings to be suppressed in the crate

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -2,7 +2,6 @@
 #![deprecated]
 // Allow deprecated warnings to be suppressed in the crate
 #![allow(deprecated)]
-
 #![allow(clippy::arithmetic_side_effects, clippy::op_ref)]
 
 // The warning `clippy::op_ref` is disabled to allow efficient operator arithmetic of structs that

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,6 +1,7 @@
 // Deprecate the crate
 #![deprecated(
-    note = "use the `zk-sdk` instead: https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk"
+    since = "2.3.8",
+    note = "use the `solana-zk-sdk` instead: https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk"
 )]
 // Allow deprecated warnings to be suppressed in the crate
 #![allow(deprecated)]


### PR DESCRIPTION
#### Summary of Changes
This is a little overdue, but let's deprecate the `zk-token-sdk`.
- I added deprecation flag in `zk-token-sdk`
- added README to give a warning that the crate is deprecated and point to `zk-sdk`.
- I added lines to explicitly allow deprecated in `zk-token-proof` and `zk-keygen` crates for now. The `zk-token-proof` will have to be eventually removed and `zk-keygen` should be migrated to the `zk-elgamal-proof` repository. I will address this in a follow-up.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
