### PR TITLE
print approximate slot time in solana leader-schedule

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1840,6 +1840,8 @@ impl fmt::Display for CliBlockTime {
 pub struct CliLeaderSchedule {
     pub epoch: Epoch,
     pub leader_schedule_entries: Vec<CliLeaderScheduleEntry>,
+    pub show_times: bool,
+    pub local_time: bool,
 }
 
 impl QuietDisplay for CliLeaderSchedule {}
@@ -1848,8 +1850,19 @@ impl VerboseDisplay for CliLeaderSchedule {}
 impl fmt::Display for CliLeaderSchedule {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for entry in &self.leader_schedule_entries {
-            let time_str = if let Some(timestamp) = entry.approximate_slot_time {
-                format!(" ({})", unix_timestamp_to_string(timestamp))
+            let time_str = if self.show_times {
+                if let Some(timestamp) = entry.approximate_slot_time {
+                    if self.local_time {
+                        let dt = chrono::Local.timestamp_opt(timestamp, 0).unwrap();
+                        format!(" ({} local)", dt.format("%Y-%m-%d %H:%M:%S.%f"))
+                    } else {
+                        // UTC
+                        let dt = chrono::Utc.timestamp_opt(timestamp, 0).unwrap();
+                        format!(" ({} UTC)", dt.format("%Y-%m-%d %H:%M:%S.%f"))
+                    }
+                } else {
+                    String::new()
+                }
             } else {
                 String::new()
             };

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1848,7 +1848,12 @@ impl VerboseDisplay for CliLeaderSchedule {}
 impl fmt::Display for CliLeaderSchedule {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for entry in &self.leader_schedule_entries {
-            writeln!(f, "  {:<15} {:<44}", entry.slot, entry.leader)?;
+            let time_str = if let Some(timestamp) = entry.approximate_slot_time {
+                format!(" ({})", unix_timestamp_to_string(timestamp))
+            } else {
+                String::new()
+            };
+            writeln!(f, "  {:<15} {:<44}{}", entry.slot, entry.leader, time_str)?;
         }
         Ok(())
     }
@@ -1859,6 +1864,8 @@ impl fmt::Display for CliLeaderSchedule {
 pub struct CliLeaderScheduleEntry {
     pub slot: Slot,
     pub leader: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approximate_slot_time: Option<UnixTimestamp>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -90,6 +90,8 @@ pub enum CliCommand {
     },
     LeaderSchedule {
         epoch: Option<Epoch>,
+        show_times: bool,
+        local_time: bool,
     },
     LiveSlots,
     Logs {
@@ -929,8 +931,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Inflation(inflation_subcommand) => {
             process_inflation_subcommand(&rpc_client, config, inflation_subcommand)
         }
-        CliCommand::LeaderSchedule { epoch } => {
-            process_leader_schedule(&rpc_client, config, *epoch)
+        CliCommand::LeaderSchedule { epoch, show_times, local_time } => {
+            process_leader_schedule(&rpc_client, config, *epoch, *show_times, *local_time)
         }
         CliCommand::LiveSlots => process_live_slots(config),
         CliCommand::Logs { filter } => process_logs(config, filter),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -195,6 +195,18 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .value_name("EPOCH")
                         .validator(is_epoch)
                         .help("Epoch to show leader schedule for [default: current]"),
+                )
+                .arg(
+                    Arg::with_name("show_times")
+                        .long("show-times")
+                        .takes_value(false)
+                        .help("Show approximate slot times for each entry"),
+                )
+                .arg(
+                    Arg::with_name("local_time")
+                        .long("local-time")
+                        .takes_value(false)
+                        .help("Show times in local time instead of UTC (requires --show-times)"),
                 ),
         )
         .subcommand(
@@ -974,8 +986,10 @@ pub fn process_first_available_block(rpc_client: &RpcClient) -> ProcessResult {
 
 pub fn parse_leader_schedule(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let epoch = value_of(matches, "epoch");
+    let show_times = matches.is_present("show_times");
+    let local_time = matches.is_present("local_time");
     Ok(CliCommandInfo::without_signers(
-        CliCommand::LeaderSchedule { epoch },
+        CliCommand::LeaderSchedule { epoch, show_times, local_time },
     ))
 }
 
@@ -983,6 +997,8 @@ pub fn process_leader_schedule(
     rpc_client: &RpcClient,
     config: &CliConfig,
     epoch: Option<Epoch>,
+    show_times: bool,
+    local_time: bool,
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
     let epoch = epoch.unwrap_or(epoch_info.epoch);
@@ -1011,67 +1027,56 @@ pub fn process_leader_schedule(
         }
     }
 
-    // Calculate average slot time from recent performance samples.
-    let avg_slot_time_ms = rpc_client
-        .get_recent_performance_samples(Some(60))
-        .ok()
-        .and_then(|samples| {
-            if samples.is_empty() {
-                return None;
-            }
-            
-            let (total_slots, total_secs) = samples.iter().fold(
-                (0u64, 0u64),
-                |(slots, secs), sample| {
-                    (
-                        slots.saturating_add(sample.num_slots),
-                        secs.saturating_add(sample.sample_period_secs as u64),
-                    )
-                },
-            );
-            
-            if total_slots == 0 {
-                return None;
-            }
-            
-            // Convert to milliseconds per slot.
-            total_secs.saturating_mul(1000).checked_div(total_slots)
-        })
-        .unwrap_or(clock::DEFAULT_MS_PER_SLOT);
-
-    // Try to get epoch start time - first try exact time, then estimate.
-    let epoch_start_time = rpc_client
-        .get_block_time(first_slot_in_epoch)
-        .ok()
-        .or_else(|| {
-            // Estimate from current slot if exact time unavailable.
-            let current_slot = rpc_client.get_slot().ok()?;
-            let current_time = rpc_client.get_block_time(current_slot).ok()?;
-            
-            let slot_distance = first_slot_in_epoch.abs_diff(current_slot);
-            let time_offset_ms = slot_distance.saturating_mul(avg_slot_time_ms);
-            let time_offset_secs = time_offset_ms / 1000;
-            
-            if current_slot >= first_slot_in_epoch {
-                current_time.checked_sub(time_offset_secs as i64)
-            } else {
-                current_time.checked_add(time_offset_secs as i64)
-            }
-        });
+    let (avg_slot_time_ms, epoch_start_time) = if show_times {
+        let avg_slot_time_ms = rpc_client
+            .get_recent_performance_samples(Some(60))
+            .ok()
+            .and_then(|samples| {
+                let (slots, secs) = samples.iter().fold(
+                    (0, 0u64),
+                    |(slots, secs): (u64, u64),
+                    RpcPerfSample {
+                        num_slots,
+                        sample_period_secs,
+                        ..
+                    }| {
+                        (
+                            slots.saturating_add(*num_slots),
+                            secs.saturating_add((*sample_period_secs).into()),
+                        )
+                    },
+                );
+                secs.saturating_mul(1000).checked_div(slots)
+            })
+            .unwrap_or(clock::DEFAULT_MS_PER_SLOT);
+        let epoch_start_time = rpc_client
+            .get_block_time(first_slot_in_epoch)
+            .ok()
+            .map(|time| {
+                time.saturating_sub(
+                    first_slot_in_epoch
+                        .saturating_sub(first_slot_in_epoch)
+                        .saturating_mul(avg_slot_time_ms)
+                        .saturating_div(1000) as i64,
+                )
+            });
+        (Some(avg_slot_time_ms), epoch_start_time)
+    } else {
+        (None, None)
+    };
 
     let mut leader_schedule_entries = vec![];
-    
-    
     for (slot_index, leader) in leader_per_slot_index.iter().enumerate() {
         let slot = first_slot_in_epoch.saturating_add(slot_index as u64);
-        
-        // Calculate approximate slot time if we have epoch start time.
-        let approximate_slot_time = epoch_start_time.and_then(|start_time| {
-            let time_offset_ms = slot_index as u64 * avg_slot_time_ms;
-            let time_offset_secs = time_offset_ms / 1000;
-            start_time.checked_add(time_offset_secs as i64)
-        });
-        
+        let approximate_slot_time = if show_times {
+            epoch_start_time.and_then(|start_time| {
+                let avg_slot_time_ms = avg_slot_time_ms.unwrap_or(clock::DEFAULT_MS_PER_SLOT) as f64;
+                let time_offset_secs = (slot_index as f64) * (avg_slot_time_ms / 1000.0);
+                start_time.checked_add(time_offset_secs.round() as i64)
+            })
+        } else {
+            None
+        };
         leader_schedule_entries.push(CliLeaderScheduleEntry {
             slot,
             leader: leader.to_string(),
@@ -1082,6 +1087,8 @@ pub fn process_leader_schedule(
     Ok(config.output_format.formatted_string(&CliLeaderSchedule {
         epoch,
         leader_schedule_entries,
+        show_times,
+        local_time,
     }))
 }
 


### PR DESCRIPTION
#### Problem
`solana leader-schedule` does not print approximate slot times.

#### Summary of Changes
- Add approximate_slot_time: Option<UnixTimestamp> field to CliLeaderScheduleEntry struct
- Calculate and display approximate slot time


