### PR TITLE
remove block_min_prioritization_fee metrics reporting

### DIFF
--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -242,25 +242,6 @@ impl PrioritizationFee {
 
     pub fn report_metrics(&self, slot: Slot) {
         self.metrics.report(slot);
-
-        // report this slot's min_transaction_fee and top 10 min_writable_account_fees
-        let min_transaction_fee = self.get_min_transaction_fee().unwrap_or(0);
-        let mut accounts_fees: Vec<_> = self.get_writable_account_fees().collect();
-        accounts_fees.sort_by(|lh, rh| rh.1.cmp(lh.1));
-        datapoint_info!(
-            "block_min_prioritization_fee",
-            ("slot", slot as i64, i64),
-            ("entity", "block", String),
-            ("min_prioritization_fee", min_transaction_fee as i64, i64),
-        );
-        for (account_key, fee) in accounts_fees.iter().take(10) {
-            datapoint_trace!(
-                "block_min_prioritization_fee",
-                ("slot", slot as i64, i64),
-                ("entity", account_key.to_string(), String),
-                ("min_prioritization_fee", **fee as i64, i64),
-            );
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem
`block_min_prioritization_fee` is obsoleted, most usful information about block prioritization fee are available in `block_prioritization_fee` datapoints.

#### Summary of Changes
- remove `block_min_prioritization_fee` datapoint

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
