### PR TITLE
cli-tests: Reuse rpc client

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -42,6 +42,7 @@ use {
         io::{Read, Seek, SeekFrom},
         path::{Path, PathBuf},
         str::FromStr,
+        sync::Arc,
     },
     test_case::test_case,
 };
@@ -99,8 +100,15 @@ fn test_cli_program_deploy_non_upgradeable() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -114,9 +122,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -304,8 +310,15 @@ fn test_cli_program_deploy_no_authority() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -321,9 +334,7 @@ fn test_cli_program_deploy_no_authority() {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
@@ -414,8 +425,15 @@ fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(program_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -431,9 +449,7 @@ fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
@@ -539,8 +555,15 @@ fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let blockhash = rpc_client.get_latest_blockhash().unwrap();
 
@@ -554,8 +577,6 @@ fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
-    config.json_rpc_url = test_validator.rpc_url();
     config.send_transaction_config.skip_preflight = false;
 
     let online_signer = Keypair::new();
@@ -687,8 +708,15 @@ fn test_cli_program_deploy_with_authority() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -704,9 +732,7 @@ fn test_cli_program_deploy_with_authority() {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -1089,8 +1115,15 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1112,9 +1145,7 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -1251,8 +1282,15 @@ fn test_cli_program_close_program() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1268,9 +1306,7 @@ fn test_cli_program_close_program() {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -1370,8 +1406,15 @@ fn test_cli_program_extend_program() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1387,9 +1430,7 @@ fn test_cli_program_extend_program() {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -1542,8 +1583,15 @@ fn test_cli_program_migrate_program() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1559,9 +1607,7 @@ fn test_cli_program_migrate_program() {
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -1627,8 +1673,15 @@ fn test_cli_program_write_buffer() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1645,9 +1698,7 @@ fn test_cli_program_write_buffer() {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -2017,8 +2068,15 @@ fn test_cli_program_write_buffer_feature(enable_feature: bool) {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(program_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2030,9 +2088,7 @@ fn test_cli_program_write_buffer_feature(enable_feature: bool) {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -2104,8 +2160,15 @@ fn test_cli_program_set_buffer_authority() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2117,9 +2180,7 @@ fn test_cli_program_set_buffer_authority() {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -2276,8 +2337,15 @@ fn test_cli_program_mismatch_buffer_authority() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2289,9 +2357,7 @@ fn test_cli_program_mismatch_buffer_authority() {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -2402,8 +2468,15 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let blockhash = rpc_client.get_latest_blockhash().unwrap();
 
@@ -2416,9 +2489,6 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
             max_program_data_len,
         ))
         .unwrap();
-
-    let mut config = CliConfig::recent_for_tests();
-    config.json_rpc_url = test_validator.rpc_url();
 
     let online_signer = Keypair::new();
     let online_signer_identity = NullSigner::new(&online_signer.pubkey());
@@ -2595,8 +2665,15 @@ fn test_cli_program_show() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2608,9 +2685,7 @@ fn test_cli_program_show() {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.output_format = OutputFormat::Json;
 
     // Airdrop
@@ -2792,8 +2867,15 @@ fn test_cli_program_dump() {
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2805,9 +2887,7 @@ fn test_cli_program_dump() {
         ))
         .unwrap();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.output_format = OutputFormat::Json;
 
     // Airdrop
@@ -2936,8 +3016,15 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2953,9 +3040,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
         .unwrap();
     let upgrade_authority = Keypair::new();
 
-    let mut config = CliConfig::recent_for_tests();
     let keypair = Keypair::new();
-    config.json_rpc_url = test_validator.rpc_url();
     config.signers = vec![&keypair];
     config.command = CliCommand::Airdrop {
         pubkey: None,
@@ -3097,21 +3182,27 @@ fn test_cli_program_v4() {
     let test_validator = test_validator_genesis(mint_keypair)
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
-    let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+
+    let mut config = CliConfig::recent_for_tests();
+    config.json_rpc_url = test_validator.rpc_url();
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
 
     let payer_keypair = Keypair::new();
     let upgrade_authority = Keypair::new();
     let program_keypair = Keypair::new();
     let buffer_keypair = Keypair::new();
-    let mut config = CliConfig::recent_for_tests();
     config.signers = vec![
         &payer_keypair,
         &upgrade_authority,
         &program_keypair,
         &buffer_keypair,
     ];
-    config.json_rpc_url = test_validator.rpc_url();
     config.command = CliCommand::Airdrop {
         pubkey: None,
         lamports: 10000000,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -60,6 +60,17 @@ fn test_validator_genesis(mint_keypair: Keypair) -> TestValidatorGenesis {
     genesis
 }
 
+fn setup_rpc_client(config: &mut CliConfig) -> Arc<RpcClient> {
+    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
+        config.json_rpc_url.to_string(),
+        config.rpc_timeout,
+        config.commitment,
+        config.confirm_transaction_initial_timeout,
+    ));
+    config.rpc_client = Some(rpc_client.clone());
+    rpc_client
+}
+
 #[track_caller]
 fn expect_command_failure(config: &CliConfig, should_fail_because: &str, error_expected: &str) {
     let error_actual = process_command(config).expect_err(should_fail_because);
@@ -102,13 +113,7 @@ fn test_cli_program_deploy_non_upgradeable() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -312,13 +317,7 @@ fn test_cli_program_deploy_no_authority() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -427,13 +426,7 @@ fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(program_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -557,13 +550,7 @@ fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let blockhash = rpc_client.get_latest_blockhash().unwrap();
 
@@ -710,13 +697,7 @@ fn test_cli_program_deploy_with_authority() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1117,13 +1098,7 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1284,13 +1259,7 @@ fn test_cli_program_close_program() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1408,13 +1377,7 @@ fn test_cli_program_extend_program() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1585,13 +1548,7 @@ fn test_cli_program_migrate_program() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -1675,13 +1632,7 @@ fn test_cli_program_write_buffer() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2070,13 +2021,7 @@ fn test_cli_program_write_buffer_feature(enable_feature: bool) {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(program_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2162,13 +2107,7 @@ fn test_cli_program_set_buffer_authority() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2339,13 +2278,7 @@ fn test_cli_program_mismatch_buffer_authority() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2470,13 +2403,7 @@ fn test_cli_program_deploy_with_offline_signing(use_offline_signer_as_fee_payer:
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let blockhash = rpc_client.get_latest_blockhash().unwrap();
 
@@ -2667,13 +2594,7 @@ fn test_cli_program_show() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -2869,13 +2790,7 @@ fn test_cli_program_dump() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -3018,13 +2933,7 @@ fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_rpc: b
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let mut file = File::open(noop_path.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -3185,13 +3094,7 @@ fn test_cli_program_v4() {
 
     let mut config = CliConfig::recent_for_tests();
     config.json_rpc_url = test_validator.rpc_url();
-    let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
-        config.json_rpc_url.to_string(),
-        config.rpc_timeout,
-        config.commitment,
-        config.confirm_transaction_initial_timeout,
-    ));
-    config.rpc_client = Some(rpc_client.clone());
+    let rpc_client = setup_rpc_client(&mut config);
 
     let payer_keypair = Keypair::new();
     let upgrade_authority = Keypair::new();


### PR DESCRIPTION
#### Problem

As noted in #6820, there's too much creation and destruction of tokio runtimes during the CLI tests.

#### Summary of changes

Create just one rpc client for each test, and share it for the duration of the test.

This is similar to #6820, but only creates one rpc-client / tokio runtime instead of two.

Closes #6820