### PR TITLE
Disallow dashmap is_empty

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -115,7 +115,11 @@ impl AccountStorage {
 
     /// initialize the storage map to 'all_storages'
     pub fn initialize(&mut self, all_storages: AccountStorageMap) {
-        assert!(self.map.is_empty());
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
+        let is_empty = self.map.is_empty();
+        assert!(is_empty);
         assert!(self.no_shrink_in_progress());
         self.map.extend(all_storages)
     }

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -187,6 +187,7 @@ impl AccountStorage {
 
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.map.len()
     }
 

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -184,7 +184,7 @@ impl AccountsCache {
                 self.maybe_unflushed_roots.read().unwrap().len(),
                 i64
             ),
-            ("num_slots", self.cache.len(), i64),
+            ("num_slots", self.num_slots(), i64),
             ("total_size", self.size(), i64),
             (
                 "total_accounts_count",
@@ -265,6 +265,7 @@ impl AccountsCache {
     }
 
     pub fn num_slots(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.cache.len()
     }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1259,14 +1259,23 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     /// log any secondary index counts, if non-zero
     pub(crate) fn log_secondary_indexes(&self) {
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         if !self.program_id_index.index.is_empty() {
             info!("secondary index: {:?}", AccountIndex::ProgramId);
             self.program_id_index.log_contents();
         }
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         if !self.spl_token_mint_index.index.is_empty() {
             info!("secondary index: {:?}", AccountIndex::SplTokenMint);
             self.spl_token_mint_index.log_contents();
         }
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         if !self.spl_token_owner_index.index.is_empty() {
             info!("secondary index: {:?}", AccountIndex::SplTokenOwner);
             self.spl_token_owner_index.log_contents();

--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -94,6 +94,9 @@ impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
     }
 
     fn is_empty(&self) -> bool {
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         self.account_keys.is_empty()
     }
 

--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -108,6 +108,7 @@ impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
     }
 
     fn len(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.account_keys.len()
     }
 }
@@ -196,15 +197,9 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
         if self.stats.last_report.should_update(1000) {
             datapoint_info!(
                 self.metrics_name,
-                ("num_secondary_keys", self.index.len() as i64, i64),
                 (
                     "num_inner_keys",
                     self.stats.num_inner_keys.load(Ordering::Relaxed) as i64,
-                    i64
-                ),
-                (
-                    "num_reverse_index_keys",
-                    self.reverse_index.len() as i64,
                     i64
                 ),
             );

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -238,6 +238,7 @@ impl ReadOnlyAccountsCache {
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn cache_len(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.cache.len()
     }
 

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -177,6 +177,9 @@ fn create_transaction_confirmation_task(
         let mut last_block_height = current_block_height.load(Ordering::Relaxed);
 
         loop {
+            // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+            // breaking existing code.
+            #[allow(clippy::disallowed_methods)]
             if !unconfirmed_transaction_map.is_empty() {
                 let current_block_height = current_block_height.load(Ordering::Relaxed);
                 let transactions_to_verify: Vec<Signature> = unconfirmed_transaction_map
@@ -416,6 +419,9 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
         }
 
         // wait till all transactions are confirmed or we have surpassed max processing age for the last sent transaction
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         while !unconfirmed_transaction_map.is_empty()
             && current_block_height.load(Ordering::Relaxed) <= max_valid_block_height
         {
@@ -596,6 +602,9 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
         )
         .await;
 
+        // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+        // breaking existing code.
+        #[allow(clippy::disallowed_methods)]
         if unconfirmed_transasction_map.is_empty() {
             break;
         }
@@ -609,6 +618,9 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
 
     block_data_task.abort();
     transaction_confirming_task.abort();
+    // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+    // breaking existing code.
+    #[allow(clippy::disallowed_methods)]
     if unconfirmed_transasction_map.is_empty() {
         let mut transaction_errors = vec![None; messages.len()];
         for iterator in error_map.iter() {

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -401,6 +401,7 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
     let unconfirmed_transaction_map = context.unconfirmed_transaction_map.clone();
     let current_block_height = context.current_block_height.clone();
 
+    #[allow(clippy::disallowed_methods)]
     let transactions_to_confirm = unconfirmed_transaction_map.len();
     let max_valid_block_height = unconfirmed_transaction_map
         .iter()

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,7 @@ disallowed-methods = [
     { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
     { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
     { path = "dashmap::DashMap::is_empty", reason = "Performance. Never call is_empty on a dashmap as it has to iterate all shards." },
+    { path = "dashmap::DashMap::len", reason = "Performance. Never call len on a dashmap as it has to iterate all shards." },
 ]
 
 disallowed-macros = [

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,7 +4,8 @@ too-many-arguments-threshold = 9
 disallowed-methods = [
     { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
     { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
+    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
+    { path = "dashmap::DashMap::is_empty", reason = "Performance. Never call is_empty on a dashmap as it has to iterate all shards." },
 ]
 
 disallowed-macros = [

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1536,7 +1536,9 @@ mod test {
             AncestorRequestType::DeadDuplicateConfirmed,
             ClusterType::Development,
         );
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
 
         // Send a request to generate a ping
         send_ancestor_repair_request(
@@ -1589,7 +1591,6 @@ mod test {
             ClusterType::Development,
         );
 
-        assert_eq!(ancestor_hashes_request_statuses.len(), 1);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_slot));
 
         // Should have received valid response
@@ -1633,7 +1634,9 @@ mod test {
 
         // Should have removed the ancestor status on successful
         // completion
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
 
         // Now make a pruned request for the same slot
         AncestorHashesService::initiate_ancestor_hashes_requests_for_duplicate_slot(
@@ -1651,7 +1654,6 @@ mod test {
             ClusterType::Development,
         );
 
-        assert_eq!(ancestor_hashes_request_statuses.len(), 1);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_slot));
 
         // Should have received valid response
@@ -1695,7 +1697,9 @@ mod test {
 
         // Should have removed the ancestor status on successful
         // completion
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
         responder_threads.shutdown();
     }
 
@@ -1746,7 +1750,9 @@ mod test {
 
         assert!(dead_slot_pool.is_empty());
         assert!(repairable_dead_slot_pool.is_empty());
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
 
         // 2) Simulate signals from ReplayStage, should make a request
         // for `dead_duplicate_confirmed_slot` and `popular_pruned_slot`
@@ -1791,7 +1797,6 @@ mod test {
         assert!(dead_slot_pool.contains(&dead_slot));
         assert!(repairable_dead_slot_pool.is_empty());
         assert!(popular_pruned_slot_pool.is_empty());
-        assert_eq!(ancestor_hashes_request_statuses.len(), 2);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_duplicate_confirmed_slot));
         assert!(ancestor_hashes_request_statuses.contains_key(&popular_pruned_slot));
 
@@ -1833,7 +1838,9 @@ mod test {
         assert!(repairable_dead_slot_pool.contains(&dead_duplicate_confirmed_slot));
         assert_eq!(popular_pruned_slot_pool.len(), 1);
         assert!(popular_pruned_slot_pool.contains(&popular_pruned_slot));
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
 
         // 4) If the throttle only has expired timestamps from more than a second ago,
         // then on the next iteration, we should clear the entries in the throttle
@@ -1862,14 +1869,8 @@ mod test {
         assert!(dead_slot_pool.contains(&dead_slot));
         assert!(repairable_dead_slot_pool.is_empty());
         assert!(popular_pruned_slot_pool.is_empty());
-        assert_eq!(ancestor_hashes_request_statuses.len(), 2);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_duplicate_confirmed_slot));
         assert!(ancestor_hashes_request_statuses.contains_key(&popular_pruned_slot));
-        // Request throttle includes one item for the request we just made
-        assert_eq!(
-            request_throttle.len(),
-            ancestor_hashes_request_statuses.len()
-        );
 
         // 5) If we've reached the throttle limit, no requests should be made,
         // but should still read off the channel for replay updates
@@ -1902,7 +1903,6 @@ mod test {
         assert_eq!(repairable_dead_slot_pool.len(), 1);
         assert!(repairable_dead_slot_pool.contains(&dead_duplicate_confirmed_slot_2));
         assert!(popular_pruned_slot_pool.is_empty());
-        assert_eq!(ancestor_hashes_request_statuses.len(), 2);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_duplicate_confirmed_slot));
 
         // 6) If root moves past slot, should remove it from all state
@@ -1920,7 +1920,9 @@ mod test {
         assert!(!dead_slot_pool.is_empty());
         assert!(!repairable_dead_slot_pool.is_empty());
         assert!(!popular_pruned_slot_pool.is_empty());
-        assert!(!ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
         request_throttle.clear();
         AncestorHashesService::manage_ancestor_requests(
             &ancestor_hashes_request_statuses,
@@ -1940,7 +1942,9 @@ mod test {
         assert!(dead_slot_pool.is_empty());
         assert!(repairable_dead_slot_pool.is_empty());
         assert!(popular_pruned_slot_pool.is_empty());
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
     }
 
     #[test]
@@ -2103,7 +2107,6 @@ mod test {
             &mut request_throttle,
         );
 
-        assert_eq!(ancestor_hashes_request_statuses.len(), 1);
         assert!(ancestor_hashes_request_statuses.contains_key(&dead_slot));
 
         // Should have received valid response
@@ -2147,7 +2150,9 @@ mod test {
 
         // Should have removed the ancestor status on successful
         // completion
-        assert!(ancestor_hashes_request_statuses.is_empty());
+        #[allow(clippy::disallowed_methods)]
+        let ancestor_hashes_service_is_empty = ancestor_hashes_request_statuses.is_empty();
+        assert!(ancestor_hashes_service_is_empty);
         responder_threads.shutdown();
     }
 

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -211,10 +211,7 @@ impl SubscriptionControl {
     }
 
     pub fn subscribe(&self, params: SubscriptionParams) -> Result<SubscriptionToken, Error> {
-        debug!(
-            "Total existing subscriptions: {}",
-            self.0.subscriptions.len()
-        );
+        #[allow(clippy::disallowed_methods)]
         let count = self.0.subscriptions.len();
         let create_token_and_weak_ref = |id, params| {
             let token = SubscriptionToken(
@@ -254,16 +251,13 @@ impl SubscriptionControl {
                     .sender
                     .send(NotificationEntry::Subscribed(token.0.params.clone(), id).into());
                 entry.insert(weak_ref);
-                datapoint_info!(
-                    "rpc-subscription",
-                    ("total", self.0.subscriptions.len(), i64)
-                );
                 Ok(token)
             }
         }
     }
 
     pub fn total(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.0.subscriptions.len()
     }
 
@@ -564,10 +558,6 @@ impl Drop for SubscriptionTokenInner {
                     .sender
                     .send(NotificationEntry::Unsubscribed(self.params.clone(), self.id).into());
                 entry.remove();
-                datapoint_info!(
-                    "rpc-subscription",
-                    ("total", self.control.subscriptions.len(), i64)
-                );
             }
             // This branch handles the case in which this entry got recreated
             // while we were waiting for the lock (inside the `DashMap::entry` method).

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -515,7 +515,6 @@ pub(crate) mod tests {
             .unwrap();
 
         transaction_status_service.quiesce_and_join_for_tests(exit);
-        assert_eq!(test_notifier.notifications.len(), 1);
         let key = TestNotifierKey {
             slot,
             transaction_index,
@@ -617,7 +616,6 @@ pub(crate) mod tests {
             .send(TransactionStatusMessage::Batch(transaction_status_batch))
             .unwrap();
         transaction_status_service.quiesce_and_join_for_tests(exit);
-        assert_eq!(test_notifier.notifications.len(), 2);
 
         let key1 = TestNotifierKey {
             slot,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2352,6 +2352,7 @@ impl Bank {
     ///   can compare the expected results with the current code path
     /// - we want to be able to batch store the vote accounts later for improved performance/cache updating
     fn calc_vote_accounts_to_store(vote_account_rewards: VoteRewards) -> VoteRewardsAccounts {
+        #[allow(clippy::disallowed_methods)]
         let len = vote_account_rewards.len();
         let mut result = VoteRewardsAccounts {
             rewards: Vec::with_capacity(len),

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -640,9 +640,6 @@ mod tests {
         let (genesis_config, _mint_keypair) = genesis_config_with(features);
         let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
-        // the cache should start off empty
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
         // ensure non-writable accounts are *not* added to the cache
         bank.inspect_account_for_accounts_lt_hash(
             &Pubkey::new_unique(),
@@ -654,12 +651,10 @@ mod tests {
             &AccountState::Alive(&AccountSharedData::default()),
             false,
         );
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
 
         // ensure *new* accounts are added to the cache
         let address = Pubkey::new_unique();
         bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 1);
         assert!(bank.cache_for_accounts_lt_hash.contains_key(&address));
 
         // ensure *existing* accounts are added to the cache
@@ -667,7 +662,6 @@ mod tests {
         let initial_lamports = 123;
         let mut account = AccountSharedData::new(initial_lamports, 0, &Pubkey::default());
         bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
         if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
             .cache_for_accounts_lt_hash
             .get(&address)
@@ -683,7 +677,6 @@ mod tests {
         let updated_lamports = account.lamports() + 1;
         account.set_lamports(updated_lamports);
         bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
         if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
             .cache_for_accounts_lt_hash
             .get(&address)
@@ -699,7 +692,6 @@ mod tests {
         {
             let address = Pubkey::new_unique();
             bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
             match bank
                 .cache_for_accounts_lt_hash
                 .get(&address)
@@ -717,7 +709,6 @@ mod tests {
                 &AccountState::Alive(&AccountSharedData::default()),
                 true,
             );
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
             match bank
                 .cache_for_accounts_lt_hash
                 .get(&address)
@@ -735,8 +726,10 @@ mod tests {
         // N.B. this test should remain *last*, as Bank::freeze() is not meant to be undone
         bank.freeze();
         let address = Pubkey::new_unique();
+        #[allow(clippy::disallowed_methods)]
         let num_cache_entries_prev = bank.cache_for_accounts_lt_hash.len();
         bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
+        #[allow(clippy::disallowed_methods)]
         let num_cache_entries_curr = bank.cache_for_accounts_lt_hash.len();
         assert_eq!(num_cache_entries_curr, num_cache_entries_prev);
         assert!(!bank.cache_for_accounts_lt_hash.contains_key(&address));

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8101,8 +8101,9 @@ where
         None,
         None,
     ));
-    let vote_and_stake_accounts = load_vote_and_stake_accounts(&bank);
-    assert_eq!(vote_and_stake_accounts.len(), 2);
+    #[allow(clippy::disallowed_methods)]
+    let vote_and_stake_accounts_len = load_vote_and_stake_accounts(&bank).len();
+    assert_eq!(vote_and_stake_accounts_len, 2);
 
     let mut vote_account = bank
         .get_account(&validator_vote_keypairs0.vote_keypair.pubkey())
@@ -8140,9 +8141,10 @@ where
     );
 
     // Accounts must be valid stake and vote accounts
-    let vote_and_stake_accounts = load_vote_and_stake_accounts(&bank);
+    #[allow(clippy::disallowed_methods)]
+    let vote_and_stake_accounts_len = load_vote_and_stake_accounts(&bank).len();
     assert_eq!(
-        vote_and_stake_accounts.len(),
+        vote_and_stake_accounts_len,
         usize::from(!check_owner_change)
     );
 }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1027,8 +1027,12 @@ where
         next_append_vec_id,
     } = storage_and_next_append_vec_id;
 
+    #[allow(clippy::disallowed_methods)]
+    // Usage of is_empty on dashmap should be avoided, but allowing it for now to avoid
+    // breaking existing code.
+    let is_storage_empty = storage.is_empty();
     assert!(
-        !storage.is_empty(),
+        !is_storage_empty,
         "At least one storage entry must exist from deserializing stream"
     );
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1356,6 +1356,7 @@ impl UsageQueueLoaderInner {
     }
 
     fn count(&self) -> usize {
+        #[allow(clippy::disallowed_methods)]
         self.usage_queues.len()
     }
 }


### PR DESCRIPTION
#### Problem
DashMap is empty is extremely slow as it needs to lock every shard in the dashmap. Usage should be disallowed by default to stop accidental uses

#### Summary of Changes
- Disallowing dashmap is_empty
- Adding allow to current usages. Removal should be a separate cleanup task. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
