### PR TITLE
Downgrade Rust to 1.86.0

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-03-29
+  nightly_version=2025-02-16
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.86.0"


### PR DESCRIPTION
#### Problem
A performance regression in PohService was observed, and bisect revealed the degradation to start from when we upgraded to Rust 1.87.0

#### Summary of Changes
This reverts commit 2361c7d4beb1d1fe49787dfa1eb60735772d3994 (https://github.com/anza-xyz/agave/pull/6800)

#### Degradation
The performance regression is visible in `poh-service.total_hash_time_us`. Below is a graph of our MNB canaries; these nodes restart on different days of the week with the latest tip-of-master. As we can see, each restart after July 4th shows the degradation.
<img width="2471" height="783" alt="image" src="https://github.com/user-attachments/assets/ecd91377-a22c-4b2f-ab6c-1943c99c2d8a" />

I also confirmed that I saw the degradation when toggling between e92e9a1b860bdfe191c844f172dd72b5dd0be7a3 and 2361c7d4beb1d1fe49787dfa1eb60735772d3994 on my dev node:
<img width="1007" height="783" alt="image" src="https://github.com/user-attachments/assets/5c6dcd94-6878-4f41-b60e-c3a79cca80e9" />

