### PR TITLE
Resolve race condition in remove dead accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7245,7 +7245,9 @@ impl AccountsDb {
                     count
                 };
 
-                // Double check just in case, did we remove all accounts?
+                // Check if we have removed all accounts from the storage
+                // This may be different from the check above as this
+                // can be multithreaded
                 if remaining_count == 0 {
                     self.dirty_stores.insert(*slot, store);
                     dead_slots.insert(*slot);


### PR DESCRIPTION
#### Problem
If remove_dead_accounts is called in multiple threads in parallel, the slot may not be marked dead even if all the accounts are removed. 


#### Summary of Changes
- Use the count returned from remove_accounts to determine whether the storage is dead or not

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
