### PR TITLE
[clap-v3-utils] Update dependency from zk-token-sdk to zk-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7404,7 +7404,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-system-interface",
- "solana-zk-token-sdk",
+ "solana-zk-sdk 3.0.0",
  "tempfile",
  "thiserror 2.0.12",
  "tiny-bip39",

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "solana_clap_v3_utils"
 
 [features]
 default = ["elgamal"]
-elgamal = ["solana-zk-sdk"]
+elgamal = ["dep:solana-zk-sdk"]
 
 [dependencies]
 chrono = { workspace = true, features = ["default"] }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "solana_clap_v3_utils"
 
 [features]
-default = ["elgamal"]
+default = []
 elgamal = ["dep:solana-zk-sdk"]
 
 [dependencies]

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -35,7 +35,7 @@ solana-seed-derivable = { workspace = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-zk-token-sdk = { workspace = true }
+solana-zk-sdk = { workspace = true }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 uriparse = { workspace = true }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -15,6 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lib]
 name = "solana_clap_v3_utils"
 
+[features]
+default = ["elgamal"]
+elgamal = ["solana-zk-sdk"]
+
 [dependencies]
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "3.2.23", features = ["cargo"] }
@@ -46,7 +50,3 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
-
-[features]
-default = ["elgamal"]
-elgamal = ["solana-zk-sdk"]

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -35,7 +35,7 @@ solana-seed-derivable = { workspace = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-zk-sdk = { workspace = true }
+solana-zk-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 uriparse = { workspace = true }
@@ -46,3 +46,7 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
+
+[features]
+default = ["elgamal"]
+elgamal = ["solana-zk-sdk"]

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -32,7 +32,6 @@ use {
     solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase,
     solana_signature::Signature,
     solana_signer::{null_signer::NullSigner, EncodableKey, EncodableKeypair, Signer},
-    solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     std::{
         cell::RefCell,
         error,
@@ -42,6 +41,9 @@ use {
         rc::Rc,
     },
 };
+
+#[cfg(feature = "elgamal")]
+use solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair};
 
 pub struct SignOnly {
     pub blockhash: Hash,
@@ -950,6 +952,7 @@ pub fn keypair_from_source(
 /// )?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[cfg(feature = "elgamal")]
 pub fn elgamal_keypair_from_path(
     matches: &ArgMatches,
     path: &str,
@@ -964,6 +967,7 @@ pub fn elgamal_keypair_from_path(
     Ok(elgamal_keypair)
 }
 
+#[cfg(feature = "elgamal")]
 pub fn elgamal_keypair_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
@@ -1020,6 +1024,7 @@ fn confirm_encodable_keypair_pubkey<K: EncodableKeypair>(keypair: &K, pubkey_lab
 /// )?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[cfg(feature = "elgamal")]
 pub fn ae_key_from_path(
     matches: &ArgMatches,
     path: &str,
@@ -1029,6 +1034,7 @@ pub fn ae_key_from_path(
     encodable_key_from_path(path, key_name, skip_validation)
 }
 
+#[cfg(feature = "elgamal")]
 pub fn ae_key_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
@@ -1106,6 +1112,7 @@ pub fn keypair_from_seed_phrase(
 /// derivation.
 ///
 /// Optionally skips validation of seed phrase. Optionally confirms recovered public key.
+#[cfg(feature = "elgamal")]
 pub fn elgamal_keypair_from_seed_phrase(
     elgamal_keypair_name: &str,
     skip_validation: bool,
@@ -1127,6 +1134,7 @@ pub fn elgamal_keypair_from_seed_phrase(
 
 /// Reads user input from stdin to retrieve a seed phrase and passphrase for an authenticated
 /// encryption keypair derivation.
+#[cfg(feature = "elgamal")]
 pub fn ae_key_from_seed_phrase(
     keypair_name: &str,
     skip_validation: bool,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -9,6 +9,8 @@
 //! sources supported by the Solana CLI. Many other functions here are
 //! variations on, or delegate to, `signer_from_path`.
 
+#[cfg(feature = "elgamal")]
+use solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair};
 use {
     crate::{
         input_parsers::signer::{try_pubkeys_sigs_of, SignerSource, SignerSourceKind},
@@ -41,9 +43,6 @@ use {
         rc::Rc,
     },
 };
-
-#[cfg(feature = "elgamal")]
-use solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair};
 
 pub struct SignOnly {
     pub blockhash: Hash,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -32,7 +32,7 @@ use {
     solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase,
     solana_signature::Signature,
     solana_signer::{null_signer::NullSigner, EncodableKey, EncodableKeypair, Signer},
-    solana_zk_token_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
+    solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     std::{
         cell::RefCell,
         error,

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/main.rs"
 bs58 = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "derive"] }
 dirs-next = { workspace = true }
-solana-clap-v3-utils = { workspace = true }
+solana-clap-v3-utils = { workspace = true, features = ["elgamal"] }
 solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-seed-derivable = "=2.2.1"
 solana-signer = "=2.2.1"


### PR DESCRIPTION
#### Problem
The clap-v3-utils still relies on the `zk-token-sdk`, which is deprecated and replaced by `zk-sdk`.

#### Summary of Changes
I updated the dependency from `zk-token-sdk` to `zk-sdk`. I also realized that most consumers of the clap-v3-utils will not be needing the parsing of ElGamal keys, but they need to have a relatively heavy dependency on zk-sdk and curve25519. I ended up making a separate `elgamal` feature that can optionally be excluded.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
