### PR TITLE
vote-interface: explicitly use v3 everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11702,9 +11702,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f08746f154458f28b98330c0d55cb431e2de64ee4b8efc98dcbe292e0672b"
+checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -556,7 +556,7 @@ solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=3
 solana-validator-exit = "2.2.1"
 solana-version = { path = "version", version = "=3.0.0" }
 solana-vote = { path = "vote", version = "=3.0.0" }
-solana-vote-interface = "2.2.5"
+solana-vote-interface = "2.2.6"
 solana-vote-program = { path = "programs/vote", version = "=3.0.0", default-features = false }
 solana-wen-restart = { path = "wen-restart", version = "=3.0.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.0.0" }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -59,7 +59,7 @@ use {
     solana_transaction_status::{
         EncodableWithMeta, EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding,
     },
-    solana_vote_program::vote_state::VoteState,
+    solana_vote_program::vote_state::VoteStateV3,
     std::{
         collections::{BTreeMap, HashMap, HashSet, VecDeque},
         fmt,
@@ -2262,7 +2262,7 @@ impl RentLengthValue {
             Self::Nonce => NonceState::size(),
             Self::Stake => StakeStateV2::size_of(),
             Self::System => 0,
-            Self::Vote => VoteState::size_of(),
+            Self::Vote => VoteStateV3::size_of(),
             Self::Bytes(l) => *l,
         }
     }

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -15,7 +15,7 @@ use {
     solana_signer::{null_signer::NullSigner, Signer},
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
-    solana_vote_program::vote_state::{VoteAuthorize, VoteState, VoteStateVersions},
+    solana_vote_program::vote_state::{VoteAuthorize, VoteStateV3, VoteStateVersions},
     test_case::test_case,
 };
 
@@ -67,7 +67,7 @@ fn test_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;
     assert_eq!(authorized_withdrawer, config.signers[0].pubkey());
     let expected_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(VoteState::size_of())
+        .get_minimum_balance_for_rent_exemption(VoteStateV3::size_of())
         .unwrap()
         .max(1);
     check_balance!(expected_balance, &rpc_client, &vote_account_pubkey);
@@ -295,7 +295,7 @@ fn test_offline_vote_authorize_and_withdraw(compute_unit_price: Option<u64>) {
     let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;
     assert_eq!(authorized_withdrawer, offline_keypair.pubkey());
     let expected_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(VoteState::size_of())
+        .get_minimum_balance_for_rent_exemption(VoteStateV3::size_of())
         .unwrap()
         .max(1);
     check_balance!(expected_balance, &rpc_client, &vote_account_pubkey);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -336,11 +336,11 @@ impl Tower {
 
     #[cfg(test)]
     pub fn new_random(node_pubkey: Pubkey) -> Self {
-        use {rand::Rng, solana_vote_program::vote_state::VoteState};
+        use {rand::Rng, solana_vote_program::vote_state::VoteStateV3};
 
         let mut rng = rand::thread_rng();
         let root_slot = rng.gen();
-        let vote_state = VoteState::new_rand_for_tests(node_pubkey, root_slot);
+        let vote_state = VoteStateV3::new_rand_for_tests(node_pubkey, root_slot);
         let last_vote = TowerSync::from(
             vote_state
                 .votes

--- a/core/src/consensus/tower_vote_state.rs
+++ b/core/src/consensus/tower_vote_state.rs
@@ -1,7 +1,9 @@
 use {
     solana_clock::Slot,
     solana_vote::vote_state_view::VoteStateView,
-    solana_vote_program::vote_state::{Lockout, VoteState, VoteState1_14_11, MAX_LOCKOUT_HISTORY},
+    solana_vote_program::vote_state::{
+        Lockout, VoteState1_14_11, VoteStateV3, MAX_LOCKOUT_HISTORY,
+    },
     std::collections::VecDeque,
 };
 
@@ -82,9 +84,9 @@ impl TowerVoteState {
     }
 }
 
-impl From<VoteState> for TowerVoteState {
-    fn from(vote_state: VoteState) -> Self {
-        let VoteState {
+impl From<VoteStateV3> for TowerVoteState {
+    fn from(vote_state: VoteStateV3) -> Self {
+        let VoteStateV3 {
             votes, root_slot, ..
         } = vote_state;
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -42,7 +42,7 @@ use {
     solana_signer::Signer,
     solana_stake_interface::state::StakeStateV2,
     solana_stake_program::stake_state,
-    solana_vote_program::vote_state::{self, VoteState},
+    solana_vote_program::vote_state::{self, VoteStateV3},
     std::{
         collections::HashMap,
         error,
@@ -253,7 +253,7 @@ fn add_validator_accounts(
             identity_pubkey,
             identity_pubkey,
             commission,
-            VoteState::get_rent_exempt_reserve(rent).max(1),
+            VoteStateV3::get_rent_exempt_reserve(rent).max(1),
         );
 
         genesis_config.add_account(
@@ -314,7 +314,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     // vote account
     let default_bootstrap_validator_lamports = &sol_to_lamports(500.0)
-        .max(VoteState::get_rent_exempt_reserve(&rent))
+        .max(VoteStateV3::get_rent_exempt_reserve(&rent))
         .to_string();
     // stake account
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
@@ -1306,7 +1306,7 @@ mod tests {
                 // check vote account
                 let vote_pk = b64_account.vote_account.parse().unwrap();
                 let vote_data = genesis_config.accounts[&vote_pk].data.clone();
-                let vote_state = VoteState::deserialize(&vote_data).unwrap();
+                let vote_state = VoteStateV3::deserialize(&vote_data).unwrap();
                 assert_eq!(vote_state.node_pubkey, identity_pk);
                 assert_eq!(vote_state.authorized_withdrawer, identity_pk);
                 let authorized_voters = vote_state.authorized_voters();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -84,7 +84,7 @@ use {
     solana_vote::vote_state_view::VoteStateView,
     solana_vote_program::{
         self,
-        vote_state::{self, VoteState},
+        vote_state::{self, VoteStateV3},
     },
     std::{
         collections::{HashMap, HashSet},
@@ -917,7 +917,7 @@ fn main() {
 
     let rent = Rent::default();
     let default_bootstrap_validator_lamports = &sol_to_lamports(500.0)
-        .max(VoteState::get_rent_exempt_reserve(&rent))
+        .max(VoteStateV3::get_rent_exempt_reserve(&rent))
         .to_string();
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
         .max(rent.minimum_balance(StakeStateV2::size_of()))
@@ -2303,7 +2303,7 @@ fn main() {
                                 identity_pubkey,
                                 identity_pubkey,
                                 100,
-                                VoteState::get_rent_exempt_reserve(&rent).max(1),
+                                VoteStateV3::get_rent_exempt_reserve(&rent).max(1),
                             );
 
                             bank.store_account(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2358,7 +2358,7 @@ pub mod tests {
         solana_vote::{vote_account::VoteAccount, vote_transaction},
         solana_vote_program::{
             self,
-            vote_state::{TowerSync, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY},
+            vote_state::{TowerSync, VoteStateV3, VoteStateVersions, MAX_LOCKOUT_HISTORY},
         },
         std::{collections::BTreeSet, slice, sync::RwLock},
         test_case::{test_case, test_matrix},
@@ -4804,12 +4804,15 @@ pub mod tests {
             roots_stakes
                 .into_iter()
                 .map(|(root, stake)| {
-                    let mut vote_state = VoteState::default();
+                    let mut vote_state = VoteStateV3::default();
                     vote_state.root_slot = Some(root);
-                    let mut vote_account =
-                        AccountSharedData::new(1, VoteState::size_of(), &solana_vote_program::id());
+                    let mut vote_account = AccountSharedData::new(
+                        1,
+                        VoteStateV3::size_of(),
+                        &solana_vote_program::id(),
+                    );
                     let versioned = VoteStateVersions::new_current(vote_state);
-                    VoteState::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
+                    VoteStateV3::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
                     (
                         solana_pubkey::new_rand(),
                         (stake, VoteAccount::try_from(vote_account).unwrap()),

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -17,7 +17,7 @@ pub(crate) mod tests {
         solana_vote::vote_account::{VoteAccount, VoteAccounts},
         solana_vote_program::{
             vote_instruction,
-            vote_state::{VoteInit, VoteState, VoteStateVersions},
+            vote_state::{VoteInit, VoteStateV3, VoteStateVersions},
         },
     };
 
@@ -85,7 +85,7 @@ pub(crate) mod tests {
         for i in 0..3 {
             stakes.push((
                 i,
-                VoteState::new(
+                VoteStateV3::new(
                     &VoteInit {
                         node_pubkey: node1,
                         ..VoteInit::default()
@@ -100,7 +100,7 @@ pub(crate) mod tests {
 
         stakes.push((
             5,
-            VoteState::new(
+            VoteStateV3::new(
                 &VoteInit {
                     node_pubkey: node2,
                     ..VoteInit::default()

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -50,7 +50,7 @@ use {
     solana_sysvar::Sysvar,
     solana_sysvar_id::SysvarId,
     solana_timings::ExecuteTimings,
-    solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
+    solana_vote_program::vote_state::{self, VoteStateV3, VoteStateVersions},
     std::{
         cell::RefCell,
         collections::{HashMap, HashSet},
@@ -806,7 +806,7 @@ impl ProgramTest {
         };
         let bootstrap_validator_pubkey = Pubkey::new_unique();
         let bootstrap_validator_stake_lamports =
-            rent.minimum_balance(VoteState::size_of()) + sol_to_lamports(1_000_000.0);
+            rent.minimum_balance(VoteStateV3::size_of()) + sol_to_lamports(1_000_000.0);
 
         let mint_keypair = Keypair::new();
         let voting_keypair = Keypair::new();

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -12,7 +12,7 @@ use {
     solana_transaction::Transaction,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{self, VoteInit, VoteState},
+        vote_state::{self, VoteInit, VoteStateV3},
     },
 };
 
@@ -54,7 +54,7 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         0,
         &system_program::id(),
     ));
-    let vote_lamports = Rent::default().minimum_balance(VoteState::size_of());
+    let vote_lamports = Rent::default().minimum_balance(VoteStateV3::size_of());
     let vote_keypair = Keypair::new();
     let user_keypair = Keypair::new();
     instructions.append(&mut vote_instruction::create_account_with_config(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9742,9 +9742,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f08746f154458f28b98330c0d55cb431e2de64ee4b8efc98dcbe292e0672b"
+checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
  "bincode",
  "num-derive",

--- a/programs/stake-tests/tests/test_move_stake_and_lamports.rs
+++ b/programs/stake-tests/tests/test_move_stake_and_lamports.rs
@@ -26,7 +26,7 @@ use {
     solana_transaction_error::TransactionError,
     solana_vote_program::{
         self, vote_instruction,
-        vote_state::{VoteInit, VoteState, VoteStateVersions},
+        vote_state::{VoteInit, VoteStateV3, VoteStateVersions},
     },
     test_case::test_matrix,
 };
@@ -89,7 +89,7 @@ async fn create_vote(
     vote_account: &Keypair,
 ) {
     let rent = context.banks_client.get_rent().await.unwrap();
-    let rent_voter = rent.minimum_balance(VoteState::size_of());
+    let rent_voter = rent.minimum_balance(VoteStateV3::size_of());
 
     let mut instructions = vec![system_instruction::create_account(
         &context.payer.pubkey(),

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1777,14 +1777,14 @@ mod tests {
             },
             101,
             CreateVoteAccountConfig {
-                space: vote_state::VoteState::size_of() as u64,
+                space: vote_state::VoteStateV3::size_of() as u64,
                 ..CreateVoteAccountConfig::default()
             },
         );
         // grab the `space` value from SystemInstruction::CreateAccount by directly indexing, for
         // expediency
         let space = usize::from_le_bytes(instructions[0].data[12..20].try_into().unwrap());
-        assert_eq!(space, vote_state::VoteState::size_of());
+        assert_eq!(space, vote_state::VoteStateV3::size_of());
         let empty_vote_account = AccountSharedData::new(101, space, &id());
 
         let transaction_accounts = vec![

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -257,13 +257,13 @@ mod tests {
     use {
         self::points::null_tracer, super::*, solana_native_token::sol_to_lamports,
         solana_pubkey::Pubkey, solana_stake_interface::state::Delegation,
-        solana_vote_program::vote_state::VoteState, test_case::test_case,
+        solana_vote_program::vote_state::VoteStateV3, test_case::test_case,
     };
 
     fn new_stake(
         stake: u64,
         voter_pubkey: &Pubkey,
-        vote_state: &VoteState,
+        vote_state: &VoteStateV3,
         activation_epoch: Epoch,
     ) -> Stake {
         Stake {
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_redeem_rewards() {
-        let mut vote_state = VoteState::default();
+        let mut vote_state = VoteStateV3::default();
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
         let stake_lamports = 1;
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_rewards() {
-        let mut vote_state = VoteState::default();
+        let mut vote_state = VoteStateV3::default();
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
         let mut stake = new_stake(1, &Pubkey::default(), &vote_state, u64::MAX);
@@ -652,7 +652,7 @@ mod tests {
     #[test_case(u64::MAX, 1_000, u64::MAX => panics "Rewards intermediate calculation should fit within u128")]
     #[test_case(1, u64::MAX, u64::MAX => panics "Rewards should fit within u64")]
     fn calculate_rewards_tests(stake: u64, rewards: u64, credits: u64) {
-        let mut vote_state = VoteState::default();
+        let mut vote_state = VoteStateV3::default();
 
         let stake = new_stake(stake, &Pubkey::default(), &vote_state, u64::MAX);
 
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_points_with_typical_values() {
-        let vote_state = VoteState::default();
+        let vote_state = VoteStateV3::default();
 
         // bootstrap means fully-vested stake at epoch 0 with
         //  10_000_000 SOL is a big but not unreasaonable stake

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -207,13 +207,14 @@ pub(crate) fn calculate_stake_points_and_credits(
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_native_token::sol_to_lamports, solana_vote_program::vote_state::VoteState,
+        super::*, solana_native_token::sol_to_lamports,
+        solana_vote_program::vote_state::VoteStateV3,
     };
 
     fn new_stake(
         stake: u64,
         voter_pubkey: &Pubkey,
-        vote_state: &VoteState,
+        vote_state: &VoteStateV3,
         activation_epoch: Epoch,
     ) -> Stake {
         Stake {
@@ -224,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_points_with_typical_values() {
-        let mut vote_state = VoteState::default();
+        let mut vote_state = VoteStateV3::default();
 
         // bootstrap means fully-vested stake at epoch 0 with
         //  10_000_000 SOL is a big but not unreasonable stake

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -26,7 +26,7 @@ use {
     solana_sysvar::{self as sysvar, stake_history::StakeHistory},
     solana_vote_program::{
         vote_instruction,
-        vote_state::{TowerSync, VoteInit, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY},
+        vote_state::{TowerSync, VoteInit, VoteStateV3, VoteStateVersions, MAX_LOCKOUT_HISTORY},
     },
     std::sync::{Arc, RwLock},
 };
@@ -322,7 +322,7 @@ fn test_stake_account_lifetime() {
     let (vote_balance, stake_rent_exempt_reserve, stake_minimum_delegation) = {
         let rent = &bank.rent_collector().rent;
         (
-            rent.minimum_balance(VoteState::size_of()),
+            rent.minimum_balance(VoteStateV3::size_of()),
             rent.minimum_balance(StakeStateV2::size_of()),
             solana_stake_program::get_minimum_delegation(
                 bank.feature_set
@@ -430,7 +430,7 @@ fn test_stake_account_lifetime() {
 
     // Test that votes and credits are there
     let account = bank.get_account(&vote_pubkey).expect("account not found");
-    let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&account)
+    let vote_state: VoteStateV3 = StateMut::<VoteStateVersions>::state(&account)
         .expect("couldn't unpack account data")
         .convert_to_current();
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8826,9 +8826,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f08746f154458f28b98330c0d55cb431e2de64ee4b8efc98dcbe292e0672b"
+checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
  "bincode",
  "num-derive",


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/solana-sdk/pull/221, the `solana-vote-interface` crate now explicitly names `vote_state_v3::VoteState` to `vote_state_v3::VoteStateV3`. In preparation for the upcoming vote state v4, we should go through the monorepo and update all callsites to use `VoteStateV3` explicitly.

#### Summary of Changes
Update all callsites to use `VoteStateV3` explicitly.