### PR TITLE
Removes test_hash_calculation from AccountsBackgroundService handle_snapshot_requests()

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -379,10 +379,6 @@ impl AccountsHashVerifier {
             );
         }
 
-        if let Some(expected_hash) = accounts_package.accounts_hash_for_testing {
-            assert_eq!(expected_hash, accounts_hash);
-        };
-
         datapoint_info!(
             "accounts_hash_verifier",
             ("calculate_hash", measure_hash_us, i64),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -210,7 +210,7 @@ where
                 .unwrap()
                 .set_root(bank.slot(), Some(&snapshot_controller), None)
                 .unwrap();
-            snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
+            snapshot_request_handler.handle_snapshot_requests(0, &AtomicBool::new(false));
         }
     }
 
@@ -450,7 +450,7 @@ fn test_bank_forks_incremental_snapshot() {
                 .unwrap()
                 .set_root(bank.slot(), Some(&snapshot_controller), None)
                 .unwrap();
-            snapshot_request_handler.handle_snapshot_requests(false, 0, &AtomicBool::new(false));
+            snapshot_request_handler.handle_snapshot_requests(0, &AtomicBool::new(false));
         }
 
         // Since AccountsBackgroundService isn't running, manually make a full snapshot archive

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -861,7 +861,6 @@ fn bank_to_full_snapshot_archive_with(
         bank,
         snapshot_storages,
         status_cache_slot_deltas,
-        None,
     );
     let snapshot_package =
         SnapshotPackage::new(accounts_package, merkle_or_lattice_accounts_hash, None);
@@ -956,7 +955,6 @@ pub fn bank_to_incremental_snapshot_archive(
         bank,
         snapshot_storages,
         status_cache_slot_deltas,
-        None,
     );
     let snapshot_package = SnapshotPackage::new(
         accounts_package,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -33,7 +33,6 @@ pub struct AccountsPackage {
     pub block_height: Slot,
     pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     pub expected_capitalization: u64,
-    pub accounts_hash_for_testing: Option<AccountsHash>,
     pub accounts: Arc<Accounts>,
     pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
@@ -54,7 +53,6 @@ impl AccountsPackage {
         bank: &Bank,
         snapshot_storages: Vec<Arc<AccountStorageEntry>>,
         status_cache_slot_deltas: Vec<BankSlotDelta>,
-        accounts_hash_for_testing: Option<AccountsHash>,
     ) -> Self {
         let slot = bank.slot();
         if let AccountsPackageKind::Snapshot(snapshot_kind) = package_kind {
@@ -107,7 +105,6 @@ impl AccountsPackage {
             package_kind,
             bank,
             snapshot_storages,
-            accounts_hash_for_testing,
             accounts_hash_algorithm,
             Some(snapshot_info),
         )
@@ -117,7 +114,6 @@ impl AccountsPackage {
         package_kind: AccountsPackageKind,
         bank: &Bank,
         snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-        accounts_hash_for_testing: Option<AccountsHash>,
         accounts_hash_algorithm: AccountsHashAlgorithm,
         snapshot_info: Option<SupplementalSnapshotInfo>,
     ) -> Self {
@@ -127,7 +123,6 @@ impl AccountsPackage {
             block_height: bank.block_height(),
             snapshot_storages,
             expected_capitalization: bank.capitalization(),
-            accounts_hash_for_testing,
             accounts: bank.accounts(),
             epoch_schedule: bank.epoch_schedule().clone(),
             rent_collector: bank.rent_collector().clone(),
@@ -150,7 +145,6 @@ impl AccountsPackage {
             block_height: Slot::default(),
             snapshot_storages: Vec::default(),
             expected_capitalization: u64::default(),
-            accounts_hash_for_testing: Option::default(),
             accounts: Arc::new(accounts),
             epoch_schedule: EpochSchedule::default(),
             rent_collector: RentCollector::default(),


### PR DESCRIPTION
#### Problem

The `test_hash_calculation` parameter to AccountsBackgroundService's `handle_snapshot_requests()` is unused and should be removed.


#### Summary of Changes

Remove the param, then update all the callers.