### PR TITLE
Removes unused param from Bank::run_final_hash_calc()

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -846,7 +846,7 @@ pub struct ProcessOptions {
     pub accounts_db_config: Option<AccountsDbConfig>,
     pub verify_index: bool,
     pub runtime_config: RuntimeConfig,
-    pub on_halt_store_hash_raw_data_for_debug: bool,
+    pub on_halt_store_hash_raw_data_for_debug: bool, // will be removed next
     /// true if after processing the contents of the blockstore at startup, we should run an accounts hash calc
     /// This is useful for debugging.
     pub run_final_accounts_hash_calc: bool,
@@ -2009,7 +2009,7 @@ fn load_frozen_forks(
                 .unwrap_or(false);
             if done_processing {
                 if opts.run_final_accounts_hash_calc {
-                    bank.run_final_hash_calc(on_halt_store_hash_raw_data_for_debug);
+                    bank.run_final_hash_calc();
                 }
                 break;
             }
@@ -2024,11 +2024,7 @@ fn load_frozen_forks(
             )?;
         }
     } else if on_halt_store_hash_raw_data_for_debug {
-        bank_forks
-            .read()
-            .unwrap()
-            .root_bank()
-            .run_final_hash_calc(on_halt_store_hash_raw_data_for_debug);
+        bank_forks.read().unwrap().root_bank().run_final_hash_calc();
     }
 
     Ok((total_slots_processed, total_rooted_slots))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4578,10 +4578,7 @@ impl Bank {
 
     /// Used by ledger tool to run a final hash calculation once all ledger replay has completed.
     /// This should not be called by validator code.
-    pub fn run_final_hash_calc(
-        &self,
-        _on_halt_store_hash_raw_data_for_debug: bool, // will be removed next
-    ) {
+    pub fn run_final_hash_calc(&self) {
         self.force_flush_accounts_cache();
         // note that this slot may not be a root
         _ = self.verify_accounts_hash(


### PR DESCRIPTION
#### Problem

The `on_halt_store_hash_raw_data_for_debug` param for `Bank::run_final_hash_calc()` is unused and should be removed.


#### Summary of Changes

Remove it and update callers.