### PR TITLE
Removes unused on_halt_store_hash_raw_data_for_debug

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -226,8 +226,6 @@ pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -
     let verify_index = arg_matches.is_present("verify_accounts_index");
     let limit_load_slot_count_from_snapshot =
         value_t!(arg_matches, "limit_load_slot_count_from_snapshot", usize).ok();
-    let on_halt_store_hash_raw_data_for_debug =
-        arg_matches.is_present("halt_at_slot_store_hash_raw_data");
     let run_final_accounts_hash_calc = arg_matches.is_present("run_final_hash_calc");
     let debug_keys = pubkeys_of(arg_matches, "debug_key")
         .map(|pubkeys| Arc::new(pubkeys.into_iter().collect::<HashSet<_>>()));
@@ -242,7 +240,6 @@ pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -
         accounts_db_skip_shrink,
         verify_index,
         limit_load_slot_count_from_snapshot,
-        on_halt_store_hash_raw_data_for_debug,
         run_final_accounts_hash_calc,
         debug_keys,
         run_verification,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -24,7 +24,6 @@ use {
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
     solana_accounts_db::accounts_index::{ScanConfig, ScanOrder},
     solana_clap_utils::{
-        hidden_unless_forced,
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
             is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
@@ -836,13 +835,6 @@ fn main() {
     let os_memory_stats_reporting_arg = Arg::with_name("os_memory_stats_reporting")
         .long("os-memory-stats-reporting")
         .help("Enable reporting of OS memory statistics.");
-    let halt_at_slot_store_hash_raw_data = Arg::with_name("halt_at_slot_store_hash_raw_data")
-        .long("halt-at-slot-store-hash-raw-data")
-        .help(
-            "After halting at slot, run an accounts hash calculation and store the raw hash data \
-             for debugging.",
-        )
-        .hidden(hidden_unless_forced());
     let verify_index_arg = Arg::with_name("verify_accounts_index")
         .long("verify-accounts-index")
         .takes_value(false)
@@ -1091,7 +1083,6 @@ fn main() {
                 .arg(&halt_at_slot_arg)
                 .arg(&limit_load_slot_count_from_snapshot_arg)
                 .arg(&verify_index_arg)
-                .arg(&halt_at_slot_store_hash_raw_data)
                 .arg(&hard_forks_arg)
                 .arg(&os_memory_stats_reporting_arg)
                 .arg(&allow_dead_slots_arg)

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -846,7 +846,6 @@ pub struct ProcessOptions {
     pub accounts_db_config: Option<AccountsDbConfig>,
     pub verify_index: bool,
     pub runtime_config: RuntimeConfig,
-    pub on_halt_store_hash_raw_data_for_debug: bool, // will be removed next
     /// true if after processing the contents of the blockstore at startup, we should run an accounts hash calc
     /// This is useful for debugging.
     pub run_final_accounts_hash_calc: bool,
@@ -1846,7 +1845,6 @@ fn load_frozen_forks(
         opts,
     )?;
 
-    let on_halt_store_hash_raw_data_for_debug = opts.on_halt_store_hash_raw_data_for_debug;
     if Some(bank_forks.read().unwrap().root()) != opts.halt_at_slot {
         let recyclers = VerifyRecyclers::default();
         let mut all_banks = HashMap::new();
@@ -2023,7 +2021,7 @@ fn load_frozen_forks(
                 opts,
             )?;
         }
-    } else if on_halt_store_hash_raw_data_for_debug {
+    } else if opts.run_final_accounts_hash_calc {
         bank_forks.read().unwrap().root_bank().run_final_hash_calc();
     }
 


### PR DESCRIPTION
#### Problem

The `on_halt_store_hash_raw_data_for_debug` ledger-tool cli arg is unused and should be removed.


#### Summary of Changes

Removes it and fixes up callers.