### PR TITLE
Removes data_source param from Bank::warp_from_parent()

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2320,7 +2320,6 @@ fn maybe_warp_slot(
             root_bank,
             &Pubkey::default(),
             warp_slot,
-            solana_accounts_db::accounts_db::CalcAccountsHashDataSource::Storages,
         ));
         bank_forks
             .set_root(warp_slot, Some(snapshot_controller), Some(warp_slot))

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -22,10 +22,7 @@ use {
     log::*,
     serde_derive::Serialize,
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount, WritableAccount},
-    solana_accounts_db::{
-        accounts_db::CalcAccountsHashDataSource,
-        accounts_index::{ScanConfig, ScanOrder},
-    },
+    solana_accounts_db::accounts_index::{ScanConfig, ScanOrder},
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
@@ -2381,7 +2378,6 @@ fn main() {
                             bank.clone(),
                             bank.collector_id(),
                             warp_slot,
-                            CalcAccountsHashDataSource::Storages,
                         ))
                     } else {
                         bank

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1159,8 +1159,6 @@ impl ProgramTestContext {
                     bank,
                     &Pubkey::default(),
                     pre_warp_slot,
-                    // some warping tests cannot use the append vecs because of the sequence of adding roots and flushing
-                    solana_accounts_db::accounts_db::CalcAccountsHashDataSource::IndexForTests,
                 ))
                 .clone_without_scheduler()
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1689,12 +1689,7 @@ impl Bank {
     ///   in the past
     /// * Adjusts the new bank's tick height to avoid having to run PoH for millions of slots
     /// * Freezes the new bank, assuming that the user will `Bank::new_from_parent` from this bank
-    pub fn warp_from_parent(
-        parent: Arc<Bank>,
-        collector_id: &Pubkey,
-        slot: Slot,
-        _data_source: CalcAccountsHashDataSource, // will be removed next
-    ) -> Self {
+    pub fn warp_from_parent(parent: Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
         parent.freeze();
         let parent_timestamp = parent.clock().unix_timestamp;
         let mut new = Bank::new_from_parent(parent, collector_id, slot);


### PR DESCRIPTION
#### Problem

The `data_source` param for `Bank::warp_from_parent()` is unused and should be removed.


#### Summary of Changes

Remove it and update callers.