### PR TITLE
Fix - Missing resize at loader-v1 deserialization with direct mapping

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -401,12 +401,14 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?;
                 // The redundant check helps to avoid the expensive data comparison if we can
-                match borrowed_account.can_data_be_resized(data.len()) {
+                match borrowed_account.can_data_be_resized(pre_len) {
                     Ok(()) => borrowed_account.set_data_from_slice(data)?,
                     Err(err) if borrowed_account.get_data() != data => return Err(err),
                     _ => {}
                 }
                 start += pre_len; // data
+            } else if borrowed_account.get_data().len() != pre_len {
+                borrowed_account.set_data_length(pre_len)?;
             }
             start += size_of::<Pubkey>() // owner
                 + size_of::<u8>() // executable

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3955,12 +3955,12 @@ fn test_cpi_account_data_updates() {
             let account = bank.get_account(&account_keypair.pubkey()).unwrap();
             // deprecated_callee is incapable of resizing accounts
             assert_eq!(account.data(), b"foobar");
-        } else if deprecated_caller && (deprecated_callee || !direct_mapping) {
+        } else if deprecated_caller {
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(
                     0,
-                    if direct_mapping {
+                    if direct_mapping && deprecated_callee {
                         InstructionError::InvalidRealloc
                     } else {
                         InstructionError::AccountDataSizeChanged


### PR DESCRIPTION
#### Problem

The original direct mapping implementation (https://github.com/solana-labs/solana/pull/28053) forgot to resize accounts at loader-v1 deserialization in the direct mapping enabled branch of the feature gate. Meaning the last CPI callee would be controlling the account size instead.

https://github.com/solana-labs/solana/pull/28053/files#diff-c53636d36ed15b806b0a727e1e5ab040475674798ddf036903133dc1447c45b4R365 is where the `else` branch should have been.

#### Summary of Changes

Adds the missing resize logic and adjusts `test_cpi_account_data_updates`.