### PR TITLE
agave-validator: add args tests for run (part 4) 

### DIFF
--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -13,7 +13,7 @@ use {
     },
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct AccountSecondaryIndexes {
     pub keys: Option<AccountSecondaryIndexesIncludeExclude>,
     pub indexes: HashSet<AccountIndex>,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -159,7 +159,7 @@ fn is_finalized(
         && (blockstore.is_root(slot) || bank.status_cache_ancestors().contains(&slot))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct JsonRpcConfig {
     pub enable_rpc_transaction_history: bool,
     pub enable_extended_tx_metadata_storage: bool,
@@ -211,7 +211,7 @@ impl JsonRpcConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RpcBigtableConfig {
     pub enable_bigtable_ledger_upload: bool,
     pub bigtable_instance_name: String,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1756,7 +1756,7 @@ mod tests {
                     health_check_slot_distance: 128,
                     max_multiple_accounts: Some(100),
                     rpc_threads: num_cpus::get(),
-                    rpc_blocking_threads: 4,
+                    rpc_blocking_threads: 1.max(num_cpus::get() / 4),
                     ..JsonRpcConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -37,6 +37,7 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
+pub mod account_secondary_indexes;
 pub mod blockstore_options;
 pub mod json_rpc_config;
 pub mod rpc_bigtable_config;

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1756,6 +1756,7 @@ mod tests {
                     health_check_slot_distance: 128,
                     max_multiple_accounts: Some(100),
                     rpc_threads: 16,
+                    rpc_blocking_threads: 4,
                     ..JsonRpcConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1755,7 +1755,7 @@ mod tests {
                 json_rpc_config: JsonRpcConfig {
                     health_check_slot_distance: 128,
                     max_multiple_accounts: Some(100),
-                    rpc_threads: 16,
+                    rpc_threads: num_cpus::get(),
                     rpc_blocking_threads: 4,
                     ..JsonRpcConfig::default()
                 },

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1750,7 +1750,10 @@ mod tests {
                 socket_addr_space: SocketAddrSpace::Global,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
                 blockstore_options: BlockstoreOptions::default(),
-                json_rpc_config: JsonRpcConfig::default(),
+                json_rpc_config: JsonRpcConfig {
+                    health_check_slot_distance: 128,
+                    ..JsonRpcConfig::default()
+                },
             }
         }
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -39,6 +39,7 @@ const INCLUDE_KEY: &str = "account-index-include-key";
 
 pub mod blockstore_options;
 pub mod json_rpc_config;
+pub mod rpc_bigtable_config;
 pub mod rpc_bootstrap_config;
 
 #[derive(Debug, PartialEq)]

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1753,6 +1753,7 @@ mod tests {
                 blockstore_options: BlockstoreOptions::default(),
                 json_rpc_config: JsonRpcConfig {
                     health_check_slot_distance: 128,
+                    max_multiple_accounts: Some(100),
                     ..JsonRpcConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -23,6 +23,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{blockstore_options::BlockstoreOptions, use_snapshot_archives_at_startup},
     solana_pubkey::Pubkey,
+    solana_rpc::rpc::JsonRpcConfig,
     solana_runtime::snapshot_utils::{SnapshotVersion, SUPPORTED_ARCHIVE_COMPRESSION},
     solana_send_transaction_service::send_transaction_service::{
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
@@ -37,6 +38,7 @@ const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
 pub mod blockstore_options;
+pub mod json_rpc_config;
 pub mod rpc_bootstrap_config;
 
 #[derive(Debug, PartialEq)]
@@ -48,6 +50,7 @@ pub struct RunArgs {
     pub socket_addr_space: SocketAddrSpace,
     pub rpc_bootstrap_config: RpcBootstrapConfig,
     pub blockstore_options: BlockstoreOptions,
+    pub json_rpc_config: JsonRpcConfig,
 }
 
 impl FromClapArgMatches for RunArgs {
@@ -95,6 +98,7 @@ impl FromClapArgMatches for RunArgs {
             socket_addr_space,
             rpc_bootstrap_config: RpcBootstrapConfig::from_clap_arg_match(matches)?,
             blockstore_options: BlockstoreOptions::from_clap_arg_match(matches)?,
+            json_rpc_config: JsonRpcConfig::from_clap_arg_match(matches)?,
         })
     }
 }
@@ -1746,6 +1750,7 @@ mod tests {
                 socket_addr_space: SocketAddrSpace::Global,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
                 blockstore_options: BlockstoreOptions::default(),
+                json_rpc_config: JsonRpcConfig::default(),
             }
         }
     }
@@ -1760,6 +1765,7 @@ mod tests {
                 socket_addr_space: self.socket_addr_space,
                 rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
                 blockstore_options: self.blockstore_options.clone(),
+                json_rpc_config: self.json_rpc_config.clone(),
             }
         }
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1755,6 +1755,7 @@ mod tests {
                 json_rpc_config: JsonRpcConfig {
                     health_check_slot_distance: 128,
                     max_multiple_accounts: Some(100),
+                    rpc_threads: 16,
                     ..JsonRpcConfig::default()
                 },
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1735,10 +1735,7 @@ mod tests {
         super::*,
         crate::cli::thread_args::thread_args,
         solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
-        std::{
-            net::{IpAddr, Ipv4Addr},
-            num::NonZeroUsize,
-        },
+        std::net::{IpAddr, Ipv4Addr},
     };
 
     impl Default for RunArgs {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1734,7 +1734,11 @@ mod tests {
     use {
         super::*,
         crate::cli::thread_args::thread_args,
-        std::net::{IpAddr, Ipv4Addr},
+        solana_rpc::rpc::MAX_REQUEST_BODY_SIZE,
+        std::{
+            net::{IpAddr, Ipv4Addr},
+            num::NonZeroUsize,
+        },
     };
 
     impl Default for RunArgs {
@@ -1757,6 +1761,7 @@ mod tests {
                     max_multiple_accounts: Some(100),
                     rpc_threads: num_cpus::get(),
                     rpc_blocking_threads: 1.max(num_cpus::get() / 4),
+                    max_request_body_size: Some(MAX_REQUEST_BODY_SIZE),
                     ..JsonRpcConfig::default()
                 },
             }

--- a/validator/src/commands/run/args/account_secondary_indexes.rs
+++ b/validator/src/commands/run/args/account_secondary_indexes.rs
@@ -1,0 +1,307 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::{values_t, ArgMatches},
+    solana_accounts_db::accounts_index::{
+        AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
+    },
+    solana_pubkey::Pubkey,
+    std::collections::HashSet,
+};
+
+impl FromClapArgMatches for AccountSecondaryIndexes {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let account_indexes: HashSet<AccountIndex> = matches
+            .values_of("account_indexes")
+            .unwrap_or_default()
+            .map(|value| match value {
+                "program-id" => AccountIndex::ProgramId,
+                "spl-token-mint" => AccountIndex::SplTokenMint,
+                "spl-token-owner" => AccountIndex::SplTokenOwner,
+                _ => unreachable!(),
+            })
+            .collect();
+
+        let account_indexes_include_keys: HashSet<Pubkey> =
+            values_t!(matches, "account_index_include_key", Pubkey)
+                .unwrap_or_default()
+                .iter()
+                .cloned()
+                .collect();
+
+        let account_indexes_exclude_keys: HashSet<Pubkey> =
+            values_t!(matches, "account_index_exclude_key", Pubkey)
+                .unwrap_or_default()
+                .iter()
+                .cloned()
+                .collect();
+
+        let exclude_keys = !account_indexes_exclude_keys.is_empty();
+        let include_keys = !account_indexes_include_keys.is_empty();
+
+        let keys = if !account_indexes.is_empty() && (exclude_keys || include_keys) {
+            let account_indexes_keys = AccountSecondaryIndexesIncludeExclude {
+                exclude: exclude_keys,
+                keys: if exclude_keys {
+                    account_indexes_exclude_keys
+                } else {
+                    account_indexes_include_keys
+                },
+            };
+            Some(account_indexes_keys)
+        } else {
+            None
+        };
+
+        Ok(AccountSecondaryIndexes {
+            keys,
+            indexes: account_indexes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+        solana_rpc::rpc::JsonRpcConfig,
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_account_indexes() {
+        // program-id
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: None,
+                        indexes: HashSet::from([AccountIndex::ProgramId]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--account-index", "program-id"],
+                expected_args,
+            );
+        }
+
+        // spl-token-mint
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: None,
+                        indexes: HashSet::from([AccountIndex::SplTokenMint]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--account-index", "spl-token-mint"],
+                expected_args,
+            );
+        }
+
+        // spl-token-owner
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: None,
+                        indexes: HashSet::from([AccountIndex::SplTokenOwner]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--account-index", "spl-token-owner"],
+                expected_args,
+            );
+        }
+
+        // all
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: None,
+                        indexes: HashSet::from([
+                            AccountIndex::ProgramId,
+                            AccountIndex::SplTokenMint,
+                            AccountIndex::SplTokenOwner,
+                        ]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--account-index",
+                    "program-id",
+                    "--account-index",
+                    "spl-token-mint",
+                    "--account-index",
+                    "spl-token-owner",
+                ],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_account_index_include_key() {
+        // single key
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let account_pubkey_1 = Pubkey::new_unique();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: Some(AccountSecondaryIndexesIncludeExclude {
+                            exclude: false,
+                            keys: HashSet::from([account_pubkey_1]),
+                        }),
+                        indexes: HashSet::from([AccountIndex::ProgramId]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--account-index", // required by --account-index-include-key
+                    "program-id",
+                    "--account-index-include-key",
+                    account_pubkey_1.to_string().as_str(),
+                ],
+                expected_args,
+            );
+        }
+
+        // multiple keys
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let account_pubkey_1 = Pubkey::new_unique();
+            let account_pubkey_2 = Pubkey::new_unique();
+            let account_pubkey_3 = Pubkey::new_unique();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: Some(AccountSecondaryIndexesIncludeExclude {
+                            exclude: false,
+                            keys: HashSet::from([
+                                account_pubkey_1,
+                                account_pubkey_2,
+                                account_pubkey_3,
+                            ]),
+                        }),
+                        indexes: HashSet::from([AccountIndex::ProgramId]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--account-index", // required by --account-index-include-key
+                    "program-id",
+                    "--account-index-include-key",
+                    account_pubkey_1.to_string().as_str(),
+                    "--account-index-include-key",
+                    account_pubkey_2.to_string().as_str(),
+                    "--account-index-include-key",
+                    account_pubkey_3.to_string().as_str(),
+                ],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_account_index_exclude_key() {
+        // single key
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let account_pubkey_1 = Pubkey::new_unique();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: Some(AccountSecondaryIndexesIncludeExclude {
+                            exclude: true,
+                            keys: HashSet::from([account_pubkey_1]),
+                        }),
+                        indexes: HashSet::from([AccountIndex::ProgramId]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--account-index", // required by --account-index-exclude-key
+                    "program-id",
+                    "--account-index-exclude-key",
+                    account_pubkey_1.to_string().as_str(),
+                ],
+                expected_args,
+            );
+        }
+
+        // multiple keys
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let account_pubkey_1 = Pubkey::new_unique();
+            let account_pubkey_2 = Pubkey::new_unique();
+            let account_pubkey_3 = Pubkey::new_unique();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    account_indexes: AccountSecondaryIndexes {
+                        keys: Some(AccountSecondaryIndexesIncludeExclude {
+                            exclude: true,
+                            keys: HashSet::from([
+                                account_pubkey_1,
+                                account_pubkey_2,
+                                account_pubkey_3,
+                            ]),
+                        }),
+                        indexes: HashSet::from([AccountIndex::ProgramId]),
+                    },
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--account-index", // required by --account-index-exclude-key
+                    "program-id",
+                    "--account-index-exclude-key",
+                    account_pubkey_1.to_string().as_str(),
+                    "--account-index-exclude-key",
+                    account_pubkey_2.to_string().as_str(),
+                    "--account-index-exclude-key",
+                    account_pubkey_3.to_string().as_str(),
+                ],
+                expected_args,
+            );
+        }
+    }
+}

--- a/validator/src/commands/run/args/account_secondary_indexes.rs
+++ b/validator/src/commands/run/args/account_secondary_indexes.rs
@@ -67,100 +67,63 @@ mod tests {
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
         solana_rpc::rpc::JsonRpcConfig,
+        test_case::test_case,
     };
 
+    #[test_case("program-id", AccountIndex::ProgramId)]
+    #[test_case("spl-token-mint", AccountIndex::SplTokenMint)]
+    #[test_case("spl-token-owner", AccountIndex::SplTokenOwner)]
+    fn verify_args_struct_by_command_run_with_account_indexes(
+        arg_value: &str,
+        expected_index: AccountIndex,
+    ) {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                account_indexes: AccountSecondaryIndexes {
+                    keys: None,
+                    indexes: HashSet::from([expected_index]),
+                },
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--account-index", arg_value],
+            expected_args,
+        );
+    }
+
     #[test]
-    fn verify_args_struct_by_command_run_with_account_indexes() {
-        // program-id
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: None,
-                        indexes: HashSet::from([AccountIndex::ProgramId]),
-                    },
-                    ..default_run_args.json_rpc_config.clone()
+    fn verify_args_struct_by_command_run_with_account_indexes_multiple() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                account_indexes: AccountSecondaryIndexes {
+                    keys: None,
+                    indexes: HashSet::from([
+                        AccountIndex::ProgramId,
+                        AccountIndex::SplTokenMint,
+                        AccountIndex::SplTokenOwner,
+                    ]),
                 },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--account-index", "program-id"],
-                expected_args,
-            );
-        }
-
-        // spl-token-mint
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: None,
-                        indexes: HashSet::from([AccountIndex::SplTokenMint]),
-                    },
-                    ..default_run_args.json_rpc_config.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--account-index", "spl-token-mint"],
-                expected_args,
-            );
-        }
-
-        // spl-token-owner
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: None,
-                        indexes: HashSet::from([AccountIndex::SplTokenOwner]),
-                    },
-                    ..default_run_args.json_rpc_config.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--account-index", "spl-token-owner"],
-                expected_args,
-            );
-        }
-
-        // all
-        {
-            let default_run_args = crate::commands::run::args::RunArgs::default();
-            let expected_args = RunArgs {
-                json_rpc_config: JsonRpcConfig {
-                    account_indexes: AccountSecondaryIndexes {
-                        keys: None,
-                        indexes: HashSet::from([
-                            AccountIndex::ProgramId,
-                            AccountIndex::SplTokenMint,
-                            AccountIndex::SplTokenOwner,
-                        ]),
-                    },
-                    ..default_run_args.json_rpc_config.clone()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec![
-                    "--account-index",
-                    "program-id",
-                    "--account-index",
-                    "spl-token-mint",
-                    "--account-index",
-                    "spl-token-owner",
-                ],
-                expected_args,
-            );
-        }
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--account-index",
+                "program-id",
+                "--account-index",
+                "spl-token-mint",
+                "--account-index",
+                "spl-token-owner",
+            ],
+            expected_args,
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -21,6 +21,7 @@ impl FromClapArgMatches for JsonRpcConfig {
                 })
                 .transpose()?,
             health_check_slot_distance: value_t!(matches, "health_check_slot_distance", u64)?,
+            skip_preflight_health_check: matches.is_present("skip_preflight_health_check"),
             ..Default::default()
         })
     }
@@ -111,6 +112,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--health-check-slot-distance", "100"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_skip_preflight_health_check() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    skip_preflight_health_check: true,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--skip-preflight-health-check"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -10,6 +10,16 @@ impl FromClapArgMatches for JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
             enable_extended_tx_metadata_storage: matches
                 .is_present("enable_extended_tx_metadata_storage"),
+            faucet_addr: matches
+                .value_of("rpc_faucet_addr")
+                .map(|address| {
+                    solana_net_utils::parse_host_port(address).map_err(|err| {
+                        crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(
+                            format!("failed to parse rpc_faucet_addr: {err}"),
+                        ))
+                    })
+                })
+                .transpose()?,
             ..Default::default()
         })
     }
@@ -22,6 +32,7 @@ mod tests {
         crate::commands::run::args::{
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
+        std::net::{Ipv4Addr, SocketAddr},
     };
 
     #[test]
@@ -61,6 +72,25 @@ mod tests {
                     "--enable-rpc-transaction-history", // required by enable_extended_tx_metadata_storage
                     "--enable-extended-tx-metadata-storage",
                 ],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_faucet_addr() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    faucet_addr: Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 8000))),
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-faucet-address", "127.0.0.1:8000"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,11 +1,19 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
     clap::{value_t, ArgMatches},
-    solana_rpc::rpc::JsonRpcConfig,
+    solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
 };
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
+            || matches.is_present("enable_bigtable_ledger_upload")
+        {
+            Some(RpcBigtableConfig::from_clap_arg_match(matches)?)
+        } else {
+            None
+        };
+
         Ok(JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
             enable_extended_tx_metadata_storage: matches
@@ -22,6 +30,7 @@ impl FromClapArgMatches for JsonRpcConfig {
                 .transpose()?,
             health_check_slot_distance: value_t!(matches, "health_check_slot_distance", u64)?,
             skip_preflight_health_check: matches.is_present("skip_preflight_health_check"),
+            rpc_bigtable_config,
             ..Default::default()
         })
     }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -50,7 +50,11 @@ mod tests {
     use {
         super::*,
         crate::commands::run::args::{
-            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+            tests::{
+                verify_args_struct_by_command_run_is_error_with_identity_setup,
+                verify_args_struct_by_command_run_with_identity_setup,
+            },
+            RunArgs,
         },
         std::net::{Ipv4Addr, SocketAddr},
     };
@@ -229,6 +233,15 @@ mod tests {
                 expected_args,
             );
         }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_niceness_adj() {
+        verify_args_struct_by_command_run_is_error_with_identity_setup(
+            crate::commands::run::args::RunArgs::default(),
+            vec!["--rpc-niceness-adjustment", "10"],
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -40,7 +40,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             full_api: matches.is_present("full_rpc_api"),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             max_request_body_size: Some(value_t!(matches, "rpc_max_request_body_size", usize)?),
-            ..Default::default()
+            disable_health_check: false,
         })
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -47,14 +47,12 @@ impl FromClapArgMatches for JsonRpcConfig {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_os = "linux"))]
+    use crate::commands::run::args::tests::verify_args_struct_by_command_run_is_error_with_identity_setup;
     use {
         super::*,
         crate::commands::run::args::{
-            tests::{
-                verify_args_struct_by_command_run_is_error_with_identity_setup,
-                verify_args_struct_by_command_run_with_identity_setup,
-            },
-            RunArgs,
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
         std::net::{Ipv4Addr, SocketAddr},
     };

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -35,6 +35,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             max_multiple_accounts: Some(value_t!(matches, "rpc_max_multiple_accounts", usize)?),
             account_indexes: AccountSecondaryIndexes::from_clap_arg_match(matches)?,
             rpc_threads: value_t!(matches, "rpc_threads", usize)?,
+            rpc_blocking_threads: value_t!(matches, "rpc_blocking_threads", usize)?,
             ..Default::default()
         })
     }
@@ -182,6 +183,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--rpc-threads", "10"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_blocking_threads() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    rpc_blocking_threads: 999,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-blocking-threads", "999"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -31,6 +31,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             health_check_slot_distance: value_t!(matches, "health_check_slot_distance", u64)?,
             skip_preflight_health_check: matches.is_present("skip_preflight_health_check"),
             rpc_bigtable_config,
+            max_multiple_accounts: Some(value_t!(matches, "rpc_max_multiple_accounts", usize)?),
             ..Default::default()
         })
     }
@@ -140,6 +141,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--skip-preflight-health-check"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_max_multiple_accounts() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    max_multiple_accounts: Some(9999),
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-max-multiple-accounts", "9999"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -8,6 +8,8 @@ impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
+            enable_extended_tx_metadata_storage: matches
+                .is_present("enable_extended_tx_metadata_storage"),
             ..Default::default()
         })
     }
@@ -36,6 +38,29 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--enable-rpc-transaction-history"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_enable_extended_tx_metadata_storage() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    enable_rpc_transaction_history: true,
+                    enable_extended_tx_metadata_storage: true,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--enable-rpc-transaction-history", // required by enable_extended_tx_metadata_storage
+                    "--enable-extended-tx-metadata-storage",
+                ],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -34,6 +34,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             rpc_bigtable_config,
             max_multiple_accounts: Some(value_t!(matches, "rpc_max_multiple_accounts", usize)?),
             account_indexes: AccountSecondaryIndexes::from_clap_arg_match(matches)?,
+            rpc_threads: value_t!(matches, "rpc_threads", usize)?,
             ..Default::default()
         })
     }
@@ -162,6 +163,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--rpc-max-multiple-accounts", "9999"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_threads() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    rpc_threads: 10,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-threads", "10"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -38,6 +38,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             rpc_blocking_threads: value_t!(matches, "rpc_blocking_threads", usize)?,
             rpc_niceness_adj: value_t!(matches, "rpc_niceness_adj", i8)?,
             full_api: matches.is_present("full_rpc_api"),
+            rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             ..Default::default()
         })
     }
@@ -243,6 +244,29 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--full-rpc-api"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_scan_and_fix_roots() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    enable_rpc_transaction_history: true,
+                    rpc_scan_and_fix_roots: true,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    "--enable-rpc-transaction-history", // required by --rpc-scan-and-fix-roots
+                    "--rpc-scan-and-fix-roots",
+                ],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -36,6 +36,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             account_indexes: AccountSecondaryIndexes::from_clap_arg_match(matches)?,
             rpc_threads: value_t!(matches, "rpc_threads", usize)?,
             rpc_blocking_threads: value_t!(matches, "rpc_blocking_threads", usize)?,
+            rpc_niceness_adj: value_t!(matches, "rpc_niceness_adj", i8)?,
             ..Default::default()
         })
     }
@@ -202,6 +203,26 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--rpc-blocking-threads", "999"],
+                expected_args,
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_niceness_adj() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    rpc_niceness_adj: 10,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-niceness-adjustment", "10"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -20,6 +20,7 @@ impl FromClapArgMatches for JsonRpcConfig {
                     })
                 })
                 .transpose()?,
+            health_check_slot_distance: value_t!(matches, "health_check_slot_distance", u64)?,
             ..Default::default()
         })
     }
@@ -91,6 +92,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--rpc-faucet-address", "127.0.0.1:8000"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_health_check_slot_distance() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    health_check_slot_distance: 100,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--health-check-slot-distance", "100"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -37,6 +37,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             rpc_threads: value_t!(matches, "rpc_threads", usize)?,
             rpc_blocking_threads: value_t!(matches, "rpc_blocking_threads", usize)?,
             rpc_niceness_adj: value_t!(matches, "rpc_niceness_adj", i8)?,
+            full_api: matches.is_present("full_rpc_api"),
             ..Default::default()
         })
     }
@@ -223,6 +224,25 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec!["--rpc-niceness-adjustment", "10"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_full_api() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    full_api: true,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--full-rpc-api"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,6 +1,7 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
     clap::{value_t, ArgMatches},
+    solana_accounts_db::accounts_index::AccountSecondaryIndexes,
     solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
 };
 
@@ -32,6 +33,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             skip_preflight_health_check: matches.is_present("skip_preflight_health_check"),
             rpc_bigtable_config,
             max_multiple_accounts: Some(value_t!(matches, "rpc_max_multiple_accounts", usize)?),
+            account_indexes: AccountSecondaryIndexes::from_clap_arg_match(matches)?,
             ..Default::default()
         })
     }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -39,6 +39,7 @@ impl FromClapArgMatches for JsonRpcConfig {
             rpc_niceness_adj: value_t!(matches, "rpc_niceness_adj", i8)?,
             full_api: matches.is_present("full_rpc_api"),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            max_request_body_size: Some(value_t!(matches, "rpc_max_request_body_size", usize)?),
             ..Default::default()
         })
     }
@@ -267,6 +268,26 @@ mod tests {
                     "--enable-rpc-transaction-history", // required by --rpc-scan-and-fix-roots
                     "--rpc-scan-and-fix-roots",
                 ],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_max_request_body_size() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    max_request_body_size: Some(999),
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--rpc-max-request-body-size", "999"],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -7,7 +7,37 @@ use {
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         Ok(JsonRpcConfig {
+            enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
             ..Default::default()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_enable_rpc_transaction_history() {
+        {
+            let default_run_args = crate::commands::run::args::RunArgs::default();
+            let expected_args = RunArgs {
+                json_rpc_config: JsonRpcConfig {
+                    enable_rpc_transaction_history: true,
+                    ..default_run_args.json_rpc_config.clone()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--enable-rpc-transaction-history"],
+                expected_args,
+            );
+        }
     }
 }

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,0 +1,13 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::{value_t, ArgMatches},
+    solana_rpc::rpc::JsonRpcConfig,
+};
+
+impl FromClapArgMatches for JsonRpcConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(JsonRpcConfig {
+            ..Default::default()
+        })
+    }
+}

--- a/validator/src/commands/run/args/rpc_bigtable_config.rs
+++ b/validator/src/commands/run/args/rpc_bigtable_config.rs
@@ -1,0 +1,193 @@
+use {
+    crate::commands::{FromClapArgMatches, Result},
+    clap::{value_t, ArgMatches},
+    solana_rpc::rpc::RpcBigtableConfig,
+    std::time::Duration,
+};
+
+impl FromClapArgMatches for RpcBigtableConfig {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(RpcBigtableConfig {
+            enable_bigtable_ledger_upload: matches.is_present("enable_bigtable_ledger_upload"),
+            bigtable_instance_name: value_t!(matches, "rpc_bigtable_instance_name", String)?,
+            bigtable_app_profile_id: value_t!(matches, "rpc_bigtable_app_profile_id", String)?,
+            timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
+                .ok()
+                .map(Duration::from_secs),
+            max_message_size: value_t!(matches, "rpc_bigtable_max_message_size", usize)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+        solana_rpc::rpc::JsonRpcConfig,
+    };
+
+    fn default_rpc_bigtable_config() -> RpcBigtableConfig {
+        RpcBigtableConfig {
+            timeout: Some(Duration::from_secs(30)),
+            ..RpcBigtableConfig::default()
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_enable_rpc_bigtable_ledger_storage() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-rpc-bigtable-ledger-storage
+                "--enable-rpc-bigtable-ledger-storage",
+            ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_enable_bigtable_ledger_upload() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    enable_bigtable_ledger_upload: true,
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
+                "--enable-bigtable-ledger-upload",
+            ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_bigtable_instance_name() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    enable_bigtable_ledger_upload: true,
+                    bigtable_instance_name: "my-custom-instance-name".to_string(),
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
+                "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
+                "--rpc-bigtable-instance-name",
+                "my-custom-instance-name",
+            ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_bigtable_app_profile_id() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    enable_bigtable_ledger_upload: true,
+                    bigtable_app_profile_id: "my-custom-app-profile-id".to_string(),
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
+                "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
+                "--rpc-bigtable-app-profile-id",
+                "my-custom-app-profile-id",
+            ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_bigtable_timeout() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    enable_bigtable_ledger_upload: true,
+                    timeout: Some(Duration::from_secs(99999)),
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
+                "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
+                "--rpc-bigtable-timeout",
+                "99999",
+            ],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_rpc_bigtable_max_message_size() {
+        let default_run_args = crate::commands::run::args::RunArgs::default();
+        let expected_args = RunArgs {
+            json_rpc_config: JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                rpc_bigtable_config: Some(RpcBigtableConfig {
+                    enable_bigtable_ledger_upload: true,
+                    max_message_size: 99999,
+                    ..default_rpc_bigtable_config()
+                }),
+                ..default_run_args.json_rpc_config.clone()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--enable-rpc-transaction-history", // required by enable-bigtable-ledger-upload
+                "--enable-bigtable-ledger-upload",  // required by all rpc_bigtable_config
+                "--rpc-bigtable-max-message-size",
+                "99999",
+            ],
+            expected_args,
+        );
+    }
+}

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -51,7 +51,7 @@ use {
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_pubkey::Pubkey,
-    solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
+    solana_rpc::rpc_pubsub_service::PubSubConfig,
     solana_runtime::{
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
@@ -532,25 +532,7 @@ pub fn execute(
             .map(|s| Hash::from_str(s).unwrap()),
         expected_shred_version,
         new_hard_forks: hardforks_of(matches, "hard_forks"),
-        rpc_config: JsonRpcConfig {
-            enable_rpc_transaction_history: run_args.json_rpc_config.enable_rpc_transaction_history,
-            enable_extended_tx_metadata_storage: run_args
-                .json_rpc_config
-                .enable_extended_tx_metadata_storage,
-            rpc_bigtable_config: run_args.json_rpc_config.rpc_bigtable_config,
-            faucet_addr: run_args.json_rpc_config.faucet_addr,
-            full_api: run_args.json_rpc_config.full_api,
-            max_multiple_accounts: run_args.json_rpc_config.max_multiple_accounts,
-            health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
-            disable_health_check: run_args.json_rpc_config.disable_health_check,
-            rpc_threads: run_args.json_rpc_config.rpc_threads,
-            rpc_blocking_threads: run_args.json_rpc_config.rpc_blocking_threads,
-            rpc_niceness_adj: run_args.json_rpc_config.rpc_niceness_adj,
-            account_indexes: run_args.json_rpc_config.account_indexes,
-            rpc_scan_and_fix_roots: run_args.json_rpc_config.rpc_scan_and_fix_roots,
-            max_request_body_size: run_args.json_rpc_config.max_request_body_size,
-            skip_preflight_health_check: run_args.json_rpc_config.skip_preflight_health_check,
-        },
+        rpc_config: run_args.json_rpc_config,
         on_start_geyser_plugin_config_files,
         geyser_plugin_always_enabled: matches.is_present("geyser_plugin_always_enabled"),
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -472,8 +472,6 @@ pub fn execute(
             value_t_or_exit!(matches, "rpc_send_transaction_leader_forward_count", u64)
         };
 
-    let full_api = matches.is_present("full_rpc_api");
-
     let xdp_interface = matches.value_of("retransmit_xdp_interface");
     let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
     let retransmit_xdp = matches.value_of("retransmit_xdp_cpu_cores").map(|cpus| {
@@ -541,7 +539,7 @@ pub fn execute(
                 .enable_extended_tx_metadata_storage,
             rpc_bigtable_config: run_args.json_rpc_config.rpc_bigtable_config,
             faucet_addr: run_args.json_rpc_config.faucet_addr,
-            full_api,
+            full_api: run_args.json_rpc_config.full_api,
             max_multiple_accounts: run_args.json_rpc_config.max_multiple_accounts,
             health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
             disable_health_check: false,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -545,11 +545,7 @@ pub fn execute(
             rpc_bigtable_config: run_args.json_rpc_config.rpc_bigtable_config,
             faucet_addr: run_args.json_rpc_config.faucet_addr,
             full_api,
-            max_multiple_accounts: Some(value_t_or_exit!(
-                matches,
-                "rpc_max_multiple_accounts",
-                usize
-            )),
+            max_multiple_accounts: run_args.json_rpc_config.max_multiple_accounts,
             health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
             disable_health_check: false,
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -547,7 +547,7 @@ pub fn execute(
             rpc_blocking_threads: run_args.json_rpc_config.rpc_blocking_threads,
             rpc_niceness_adj: run_args.json_rpc_config.rpc_niceness_adj,
             account_indexes: run_args.json_rpc_config.account_indexes,
-            rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            rpc_scan_and_fix_roots: run_args.json_rpc_config.rpc_scan_and_fix_roots,
             max_request_body_size: Some(value_t_or_exit!(
                 matches,
                 "rpc_max_request_body_size",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -546,7 +546,7 @@ pub fn execute(
             health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
             disable_health_check: false,
             rpc_threads: run_args.json_rpc_config.rpc_threads,
-            rpc_blocking_threads: value_t_or_exit!(matches, "rpc_blocking_threads", usize),
+            rpc_blocking_threads: run_args.json_rpc_config.rpc_blocking_threads,
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: run_args.json_rpc_config.account_indexes,
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -542,7 +542,7 @@ pub fn execute(
             full_api: run_args.json_rpc_config.full_api,
             max_multiple_accounts: run_args.json_rpc_config.max_multiple_accounts,
             health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
-            disable_health_check: false,
+            disable_health_check: run_args.json_rpc_config.disable_health_check,
             rpc_threads: run_args.json_rpc_config.rpc_threads,
             rpc_blocking_threads: run_args.json_rpc_config.rpc_blocking_threads,
             rpc_niceness_adj: run_args.json_rpc_config.rpc_niceness_adj,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -562,8 +562,7 @@ pub fn execute(
         new_hard_forks: hardforks_of(matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_rpc_transaction_history: run_args.json_rpc_config.enable_rpc_transaction_history,
-            enable_extended_tx_metadata_storage: matches
-                .is_present("enable_extended_tx_metadata_storage"),
+            enable_extended_tx_metadata_storage: run_args.json_rpc_config.enable_extended_tx_metadata_storage,
             rpc_bigtable_config,
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -561,7 +561,7 @@ pub fn execute(
         expected_shred_version,
         new_hard_forks: hardforks_of(matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
-            enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
+            enable_rpc_transaction_history: run_args.json_rpc_config.enable_rpc_transaction_history,
             enable_extended_tx_metadata_storage: matches
                 .is_present("enable_extended_tx_metadata_storage"),
             rpc_bigtable_config,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -548,11 +548,7 @@ pub fn execute(
             rpc_niceness_adj: run_args.json_rpc_config.rpc_niceness_adj,
             account_indexes: run_args.json_rpc_config.account_indexes,
             rpc_scan_and_fix_roots: run_args.json_rpc_config.rpc_scan_and_fix_roots,
-            max_request_body_size: Some(value_t_or_exit!(
-                matches,
-                "rpc_max_request_body_size",
-                usize
-            )),
+            max_request_body_size: run_args.json_rpc_config.max_request_body_size,
             skip_preflight_health_check: run_args.json_rpc_config.skip_preflight_health_check,
         },
         on_start_geyser_plugin_config_files,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -545,7 +545,7 @@ pub fn execute(
             max_multiple_accounts: run_args.json_rpc_config.max_multiple_accounts,
             health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
             disable_health_check: false,
-            rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
+            rpc_threads: run_args.json_rpc_config.rpc_threads,
             rpc_blocking_threads: value_t_or_exit!(matches, "rpc_blocking_threads", usize),
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: run_args.json_rpc_config.account_indexes,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -547,7 +547,7 @@ pub fn execute(
             disable_health_check: false,
             rpc_threads: run_args.json_rpc_config.rpc_threads,
             rpc_blocking_threads: run_args.json_rpc_config.rpc_blocking_threads,
-            rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
+            rpc_niceness_adj: run_args.json_rpc_config.rpc_niceness_adj,
             account_indexes: run_args.json_rpc_config.account_indexes,
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             max_request_body_size: Some(value_t_or_exit!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -564,9 +564,7 @@ pub fn execute(
             enable_rpc_transaction_history: run_args.json_rpc_config.enable_rpc_transaction_history,
             enable_extended_tx_metadata_storage: run_args.json_rpc_config.enable_extended_tx_metadata_storage,
             rpc_bigtable_config,
-            faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
-                solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
-            }),
+            faucet_addr: run_args.json_rpc_config.faucet_addr,
             full_api,
             max_multiple_accounts: Some(value_t_or_exit!(
                 matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -54,10 +54,7 @@ use {
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_pubkey::Pubkey,
-    solana_rpc::{
-        rpc::{JsonRpcConfig, RpcBigtableConfig},
-        rpc_pubsub_service::PubSubConfig,
-    },
+    solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
@@ -436,26 +433,6 @@ pub fn execute(
     let starting_with_geyser_plugins: bool = on_start_geyser_plugin_config_files.is_some()
         || matches.is_present("geyser_plugin_always_enabled");
 
-    let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
-        || matches.is_present("enable_bigtable_ledger_upload")
-    {
-        Some(RpcBigtableConfig {
-            enable_bigtable_ledger_upload: matches.is_present("enable_bigtable_ledger_upload"),
-            bigtable_instance_name: value_t_or_exit!(matches, "rpc_bigtable_instance_name", String),
-            bigtable_app_profile_id: value_t_or_exit!(
-                matches,
-                "rpc_bigtable_app_profile_id",
-                String
-            ),
-            timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
-                .ok()
-                .map(Duration::from_secs),
-            max_message_size: value_t_or_exit!(matches, "rpc_bigtable_max_message_size", usize),
-        })
-    } else {
-        None
-    };
-
     let rpc_send_retry_rate_ms = value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64);
     let rpc_send_batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
     let rpc_send_batch_send_rate_ms =
@@ -562,8 +539,10 @@ pub fn execute(
         new_hard_forks: hardforks_of(matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_rpc_transaction_history: run_args.json_rpc_config.enable_rpc_transaction_history,
-            enable_extended_tx_metadata_storage: run_args.json_rpc_config.enable_extended_tx_metadata_storage,
-            rpc_bigtable_config,
+            enable_extended_tx_metadata_storage: run_args
+                .json_rpc_config
+                .enable_extended_tx_metadata_storage,
+            rpc_bigtable_config: run_args.json_rpc_config.rpc_bigtable_config,
             faucet_addr: run_args.json_rpc_config.faucet_addr,
             full_api,
             max_multiple_accounts: Some(value_t_or_exit!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -571,11 +571,7 @@ pub fn execute(
                 "rpc_max_multiple_accounts",
                 usize
             )),
-            health_check_slot_distance: value_t_or_exit!(
-                matches,
-                "health_check_slot_distance",
-                u64
-            ),
+            health_check_slot_distance: run_args.json_rpc_config.health_check_slot_distance,
             disable_health_check: false,
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
             rpc_blocking_threads: value_t_or_exit!(matches, "rpc_blocking_threads", usize),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -583,7 +583,7 @@ pub fn execute(
                 "rpc_max_request_body_size",
                 usize
             )),
-            skip_preflight_health_check: matches.is_present("skip_preflight_health_check"),
+            skip_preflight_health_check: run_args.json_rpc_config.skip_preflight_health_check,
         },
         on_start_geyser_plugin_config_files,
         geyser_plugin_always_enabled: matches.is_present("geyser_plugin_always_enabled"),


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/issues/4082

the main goal is to extracting `JsonRpcConfig`. however, since it depends on `RpcBigtableConfig` and `AccountSecondaryIndexes`, I also need to impl FromClapArgMatches for them

#### Summary of Changes

impl FromClapArgMatches for `JsonRpcConfig`, `RpcBigtableConfig` and `AccountSecondaryIndexes`