### PR TITLE
Removes AccountsPackageKind::EpochAccountsHash

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -142,51 +142,18 @@ impl AccountsHashVerifier {
                 Some((accounts_package, 1, 0))
             }
             _ => {
-                let num_eah_packages = accounts_packages
-                    .iter()
-                    .filter(|account_package| {
-                        account_package.package_kind == AccountsPackageKind::EpochAccountsHash
-                    })
-                    .count();
-                assert!(
-                    num_eah_packages <= 1,
-                    "Only a single EAH accounts package is allowed at a time! count: \
-                     {num_eah_packages}"
-                );
-
                 // Get the two highest priority requests, `y` and `z`.
                 // By asking for the second-to-last element to be in its final sorted position, we
                 // also ensure that the last element is also sorted.
-                let (_, y, z) = accounts_packages.select_nth_unstable_by(
+                // Note, we no longer need the second-to-last element; this code can be refactored.
+                let (_, _y, z) = accounts_packages.select_nth_unstable_by(
                     accounts_packages_len - 2,
                     snapshot_package::cmp_accounts_packages_by_priority,
                 );
                 assert_eq!(z.len(), 1);
-                let z = z.first().unwrap();
-                let y: &_ = y; // reborrow to remove `mut`
 
-                // If the highest priority request (`z`) is EpochAccountsHash, we need to check if
-                // there's a FullSnapshot request with a lower slot in `y` that is about to be
-                // dropped.  We do not want to drop a FullSnapshot request in this case because it
-                // will cause subsequent IncrementalSnapshot requests to fail.
-                //
-                // So, if `z` is an EpochAccountsHash request, check `y`.  We know there can only
-                // be at most one EpochAccountsHash request, so `y` is the only other request we
-                // need to check.  If `y` is a FullSnapshot request *with a lower slot* than `z`,
-                // then handle `y` first.
-                let accounts_package = if z.package_kind == AccountsPackageKind::EpochAccountsHash
-                    && y.package_kind == AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
-                    && y.slot < z.slot
-                {
-                    // SAFETY: We know the len is > 1, so both `pop`s will return `Some`
-                    let z = accounts_packages.pop().unwrap();
-                    let y = accounts_packages.pop().unwrap();
-                    accounts_packages.push(z);
-                    y
-                } else {
-                    // SAFETY: We know the len is > 1, so `pop` will return `Some`
-                    accounts_packages.pop().unwrap()
-                };
+                // SAFETY: We know the len is > 1, so `pop` will return `Some`
+                let accounts_package = accounts_packages.pop().unwrap();
 
                 let handled_accounts_package_slot = accounts_package.slot;
                 // re-enqueue any remaining accounts packages for slots GREATER-THAN the accounts package
@@ -258,7 +225,6 @@ impl AccountsHashVerifier {
         }
 
         let accounts_hash_calculation_kind = match accounts_package.package_kind {
-            AccountsPackageKind::EpochAccountsHash => unreachable!("EAH is removed"),
             AccountsPackageKind::Snapshot(snapshot_kind) => match snapshot_kind {
                 SnapshotKind::FullSnapshot => CalcAccountsHashKind::Full,
                 SnapshotKind::IncrementalSnapshot(_) => CalcAccountsHashKind::Incremental,
@@ -506,9 +472,6 @@ mod tests {
             ..AccountsPackage::default_for_tests()
         }
     }
-    fn new_eah(slot: Slot) -> AccountsPackage {
-        new(AccountsPackageKind::EpochAccountsHash, slot)
-    }
     fn new_fss(slot: Slot) -> AccountsPackage {
         new(
             AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
@@ -535,13 +498,12 @@ mod tests {
         let mut accounts_packages = [
             new_fss(100), // skipped, since there's another full snapshot with a higher slot
             new_iss(110, 100),
-            new_eah(200), // <-- handle 1st
             new_iss(210, 100),
-            new_fss(300),
+            new_fss(300), // skipped, since there's another full snapshot with a higher slot
             new_iss(310, 300),
-            new_fss(400), // <-- handle 2nd
+            new_fss(400), // <-- handle 1st
             new_iss(410, 400),
-            new_iss(420, 400), // <-- handle 3rd
+            new_iss(420, 400), // <-- handle 2nd
         ];
         // Shuffle the accounts packages to simulate receiving new accounts packages from ABS
         // simultaneously as AHV is processing them.
@@ -550,25 +512,8 @@ mod tests {
             .into_iter()
             .for_each(|accounts_package| accounts_package_sender.send(accounts_package).unwrap());
 
-        // The EAH is handled 1st
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::EpochAccountsHash
-        );
-        assert_eq!(account_package.slot, 200);
-        assert_eq!(num_re_enqueued_accounts_packages, 6);
-
-        // The Full Snapshot from slot 400 is handled 2nd
-        // (the older full snapshot from slot 300 is skipped and dropped)
+        // The Full Snapshot from slot 400 is handled 1st
+        // (the older full snapshots are skipped and dropped)
         let (
             account_package,
             _num_outstanding_accounts_packages,
@@ -601,89 +546,6 @@ mod tests {
             AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(400))
         );
         assert_eq!(account_package.slot, 420);
-        assert_eq!(num_re_enqueued_accounts_packages, 0);
-
-        // And now the accounts package channel is empty!
-        assert!(AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver
-        )
-        .is_none());
-    }
-
-    /// Ensure that unhandled accounts packages are properly re-enqueued or dropped
-    ///
-    /// This test differs from the one above by having an older full snapshot request that must be
-    /// handled before the new epoch accounts hash request.
-    #[test]
-    fn test_get_next_accounts_package2() {
-        let (accounts_package_sender, accounts_package_receiver) = crossbeam_channel::unbounded();
-
-        // Populate the channel so that re-enqueueing and dropping will be tested
-        let mut accounts_packages = [
-            new_fss(100), // <-- handle 1st
-            new_iss(110, 100),
-            new_eah(200), // <-- handle 2nd
-            new_iss(210, 100),
-            new_iss(220, 100), // <-- handle 3rd
-        ];
-        // Shuffle the accounts packages to simulate receiving new accounts packages from ABS
-        // simultaneously as AHV is processing them.
-        accounts_packages.shuffle(&mut rand::thread_rng());
-        accounts_packages
-            .into_iter()
-            .for_each(|accounts_package| accounts_package_sender.send(accounts_package).unwrap());
-
-        // The Full Snapshot is handled 1st
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot)
-        );
-        assert_eq!(account_package.slot, 100);
-        assert_eq!(num_re_enqueued_accounts_packages, 4);
-
-        // The EAH is handled 2nd
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::EpochAccountsHash
-        );
-        assert_eq!(account_package.slot, 200);
-        assert_eq!(num_re_enqueued_accounts_packages, 2);
-
-        // The Incremental Snapshot from slot 220 is handled 3rd
-        // (the older incremental snapshot from slot 210 is skipped and dropped)
-        let (
-            account_package,
-            _num_outstanding_accounts_packages,
-            num_re_enqueued_accounts_packages,
-        ) = AccountsHashVerifier::get_next_accounts_package(
-            &accounts_package_sender,
-            &accounts_package_receiver,
-        )
-        .unwrap();
-        assert_eq!(
-            account_package.package_kind,
-            AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(100))
-        );
-        assert_eq!(account_package.slot, 220);
         assert_eq!(num_re_enqueued_accounts_packages, 0);
 
         // And now the accounts package channel is empty!

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -122,15 +122,10 @@ impl Debug for SnapshotRequest {
 }
 
 /// What kind of request is this?
-///
-/// The snapshot request has been expanded to support more than just snapshots.  This is
-/// confusing, but can be resolved by renaming this type; or better, by creating an enum with
-/// variants that wrap the fields-of-interest for each request.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SnapshotRequestKind {
     FullSnapshot,
     IncrementalSnapshot,
-    EpochAccountsHash,
 }
 
 pub struct SnapshotRequestHandler {
@@ -200,48 +195,16 @@ impl SnapshotRequestHandler {
                 Some((snapshot_request, 1, 0))
             }
             _ => {
-                let num_eah_requests = requests
-                    .iter()
-                    .filter(|request| {
-                        request.request_kind == SnapshotRequestKind::EpochAccountsHash
-                    })
-                    .count();
-                assert!(
-                    num_eah_requests <= 1,
-                    "Only a single EAH request is allowed at a time! count: {num_eah_requests}"
-                );
-
                 // Get the two highest priority requests, `y` and `z`.
                 // By asking for the second-to-last element to be in its final sorted position, we
                 // also ensure that the last element is also sorted.
-                let (_, y, z) =
+                // Note, we no longer need the second-to-last element; this code can be refactored.
+                let (_, _y, z) =
                     requests.select_nth_unstable_by(requests_len - 2, cmp_requests_by_priority);
                 assert_eq!(z.len(), 1);
-                let z = z.first().unwrap();
-                let y: &_ = y; // reborrow to remove `mut`
 
-                // If the highest priority request (`z`) is EpochAccountsHash, we need to check if
-                // there's a FullSnapshot request with a lower slot in `y` that is about to be
-                // dropped.  We do not want to drop a FullSnapshot request in this case because it
-                // will cause subsequent IncrementalSnapshot requests to fail.
-                //
-                // So, if `z` is an EpochAccountsHash request, check `y`.  We know there can only
-                // be at most one EpochAccountsHash request, so `y` is the only other request we
-                // need to check.  If `y` is a FullSnapshot request *with a lower slot* than `z`,
-                // then handle `y` first.
-                let snapshot_request = if z.request_kind == SnapshotRequestKind::EpochAccountsHash
-                    && y.request_kind == SnapshotRequestKind::FullSnapshot
-                    && y.snapshot_root_bank.slot() < z.snapshot_root_bank.slot()
-                {
-                    // SAFETY: We know the len is > 1, so both `pop`s will return `Some`
-                    let z = requests.pop().unwrap();
-                    let y = requests.pop().unwrap();
-                    requests.push(z);
-                    y
-                } else {
-                    // SAFETY: We know the len is > 1, so `pop` will return `Some`
-                    requests.pop().unwrap()
-                };
+                // SAFETY: We know the len is > 1, so `pop` will return `Some`
+                let snapshot_request = requests.pop().unwrap();
 
                 let handled_request_slot = snapshot_request.snapshot_root_bank.slot();
                 // re-enqueue any remaining requests for slots GREATER-THAN the one that will be handled
@@ -335,13 +298,8 @@ impl SnapshotRequestHandler {
                         snapshot_storages,
                         status_cache_slot_deltas,
                     ),
-                    AccountsPackageKind::EpochAccountsHash => panic!(
-                        "Illegal account package type: EpochAccountsHash packages must \
-                         be from an EpochAccountsHash request!"
-                    ),
                 }
             }
-            SnapshotRequestKind::EpochAccountsHash => unreachable!("EAH has been removed"),
         };
         let send_result = self.accounts_package_sender.send(accounts_package);
         if let Err(err) = send_result {
@@ -729,7 +687,6 @@ impl AbsStatus {
 #[must_use]
 fn new_accounts_package_kind(snapshot_request: &SnapshotRequest) -> Option<AccountsPackageKind> {
     match snapshot_request.request_kind {
-        SnapshotRequestKind::EpochAccountsHash => unreachable!("EAH has been removed"),
         SnapshotRequestKind::FullSnapshot => {
             Some(AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot))
         }
@@ -775,7 +732,6 @@ fn cmp_requests_by_priority(a: &SnapshotRequest, b: &SnapshotRequest) -> cmp::Or
 /// Compare snapshot request kinds by priority
 ///
 /// Priority, from highest to lowest:
-/// - Epoch Accounts Hash
 /// - Full Snapshot
 /// - Incremental Snapshot
 #[must_use]
@@ -788,12 +744,6 @@ fn cmp_snapshot_request_kinds_by_priority(
         SnapshotRequestKind as Kind,
     };
     match (a, b) {
-        // Epoch Accounts Hash packages
-        (Kind::EpochAccountsHash, Kind::EpochAccountsHash) => Equal,
-        (Kind::EpochAccountsHash, _) => Greater,
-        (_, Kind::EpochAccountsHash) => Less,
-
-        // Snapshot packages
         (Kind::FullSnapshot, Kind::FullSnapshot) => Equal,
         (Kind::FullSnapshot, Kind::IncrementalSnapshot) => Greater,
         (Kind::IncrementalSnapshot, Kind::FullSnapshot) => Less,
@@ -845,16 +795,10 @@ mod test {
     ///
     /// The snapshot request handler should be flexible and handle re-queueing unhandled snapshot
     /// requests, if those unhandled requests are for slots GREATER-THAN the last request handled.
-    /// This is needed if, for example, an Epoch Accounts Hash for slot X and a Full Snapshot for
-    /// slot X+1 are both in the request channel.  The EAH needs to be handled first, but the full
-    /// snapshot should also be handled afterwards, since future incremental snapshots will depend
-    /// on it.
     #[test]
     fn test_get_next_snapshot_request() {
         // These constants were picked to ensure the desired snapshot requests were sent to the
-        // channel.  With 400 slots per Epoch, the EAH start will be at slot 100.  Ensure there are
-        // other requests before this slot, and then 2+ requests of each type afterwards (to
-        // further test the prioritization logic).
+        // channel.  Ensure there are multiple requests of each kind.
         const SLOTS_PER_EPOCH: Slot = 400;
         const FULL_SNAPSHOT_INTERVAL: Slot = 80;
         const INCREMENTAL_SNAPSHOT_INTERVAL: Slot = 30;
@@ -917,15 +861,14 @@ mod test {
         //
         // fss  80
         // iss  90
-        // eah 100 <-- handled 1st
         // iss 120
         // iss 150
         // fss 160
         // iss 180
         // iss 210
-        // fss 240 <-- handled 2nd
+        // fss 240 <-- handled 1st
         // iss 270
-        // iss 300 <-- handled 3rd
+        // iss 300 <-- handled 2nd
         //
         // Also, incremental snapshots before slot 240 (the first full snapshot handled), will
         // actually be skipped since the latest full snapshot slot will be `None`.
@@ -940,13 +883,7 @@ mod test {
 
                 // Since we're not using `BankForks::set_root()`, we have to handle sending the
                 // correct snapshot requests ourself.
-                // Also, manually set the EAH slot for now; will be entirely removed soon.
-                if bank.slot() == 100 || bank.slot() == 500 {
-                    send_snapshot_request(
-                        Arc::clone(&bank),
-                        SnapshotRequestKind::EpochAccountsHash,
-                    );
-                } else if bank.block_height() % FULL_SNAPSHOT_INTERVAL == 0 {
+                if bank.block_height() % FULL_SNAPSHOT_INTERVAL == 0 {
                     send_snapshot_request(Arc::clone(&bank), SnapshotRequestKind::FullSnapshot);
                 } else if bank.block_height() % INCREMENTAL_SNAPSHOT_INTERVAL == 0 {
                     send_snapshot_request(
@@ -958,18 +895,7 @@ mod test {
         };
         make_banks(303);
 
-        // Ensure the EAH is handled 1st
-        assert_eq!(latest_full_snapshot_slot(&bank0), None);
-        let (snapshot_request, ..) = snapshot_request_handler
-            .get_next_snapshot_request()
-            .unwrap();
-        assert_eq!(
-            snapshot_request.request_kind,
-            SnapshotRequestKind::EpochAccountsHash
-        );
-        assert_eq!(snapshot_request.snapshot_root_bank.slot(), 100);
-
-        // Ensure the full snapshot from slot 240 is handled 2nd
+        // Ensure the full snapshot from slot 240 is handled 1st
         // (the older full snapshots are skipped and dropped)
         assert_eq!(latest_full_snapshot_slot(&bank0), None);
         let (snapshot_request, ..) = snapshot_request_handler
@@ -982,7 +908,7 @@ mod test {
         assert_eq!(snapshot_request.snapshot_root_bank.slot(), 240);
         set_latest_full_snapshot_slot(&bank0, 240);
 
-        // Ensure the incremental snapshot from slot 300 is handled 3rd
+        // Ensure the incremental snapshot from slot 300 is handled 2nd
         // (the older incremental snapshots are skipped and dropped)
         assert_eq!(latest_full_snapshot_slot(&bank0), Some(240));
         let (snapshot_request, ..) = snapshot_request_handler
@@ -996,58 +922,6 @@ mod test {
 
         // And now ensure the snapshot request channel is empty!
         assert_eq!(latest_full_snapshot_slot(&bank0), Some(240));
-        assert!(snapshot_request_handler
-            .get_next_snapshot_request()
-            .is_none());
-
-        // Create more banks and send snapshot requests so that the following requests will be in
-        // the channel before handling the requests:
-        //
-        // fss 480 <-- handled 1st
-        // eah 500 <-- handled 2nd
-        // iss 510
-        // iss 540 <-- handled 3rd
-        //
-        // This test differs from the one above by having an older full snapshot request that must
-        // be handled before the new epoch accounts hash request.
-        make_banks(240);
-
-        // Ensure the full snapshot is handled 1st
-        assert_eq!(latest_full_snapshot_slot(&bank0), Some(240));
-        let (snapshot_request, ..) = snapshot_request_handler
-            .get_next_snapshot_request()
-            .unwrap();
-        assert_eq!(
-            snapshot_request.request_kind,
-            SnapshotRequestKind::FullSnapshot
-        );
-        assert_eq!(snapshot_request.snapshot_root_bank.slot(), 480);
-        set_latest_full_snapshot_slot(&bank0, 480);
-
-        // Ensure the EAH is handled 2nd
-        assert_eq!(latest_full_snapshot_slot(&bank0), Some(480));
-        let (snapshot_request, ..) = snapshot_request_handler
-            .get_next_snapshot_request()
-            .unwrap();
-        assert_eq!(
-            snapshot_request.request_kind,
-            SnapshotRequestKind::EpochAccountsHash
-        );
-        assert_eq!(snapshot_request.snapshot_root_bank.slot(), 500);
-
-        // Ensure the incremental snapshot is handled 3rd
-        assert_eq!(latest_full_snapshot_slot(&bank0), Some(480));
-        let (snapshot_request, ..) = snapshot_request_handler
-            .get_next_snapshot_request()
-            .unwrap();
-        assert_eq!(
-            snapshot_request.request_kind,
-            SnapshotRequestKind::IncrementalSnapshot
-        );
-        assert_eq!(snapshot_request.snapshot_root_bank.slot(), 540);
-
-        // And now ensure the snapshot request channel is empty!
-        assert_eq!(latest_full_snapshot_slot(&bank0), Some(480));
         assert!(snapshot_request_handler
             .get_next_snapshot_request()
             .is_none());
@@ -1122,26 +996,6 @@ mod test {
         use cmp::Ordering::{Equal, Greater, Less};
         for (snapshot_request_kind_a, snapshot_request_kind_b, expected_result) in [
             (
-                SnapshotRequestKind::EpochAccountsHash,
-                SnapshotRequestKind::EpochAccountsHash,
-                Equal,
-            ),
-            (
-                SnapshotRequestKind::EpochAccountsHash,
-                SnapshotRequestKind::FullSnapshot,
-                Greater,
-            ),
-            (
-                SnapshotRequestKind::EpochAccountsHash,
-                SnapshotRequestKind::IncrementalSnapshot,
-                Greater,
-            ),
-            (
-                SnapshotRequestKind::FullSnapshot,
-                SnapshotRequestKind::EpochAccountsHash,
-                Less,
-            ),
-            (
                 SnapshotRequestKind::FullSnapshot,
                 SnapshotRequestKind::FullSnapshot,
                 Equal,
@@ -1150,11 +1004,6 @@ mod test {
                 SnapshotRequestKind::FullSnapshot,
                 SnapshotRequestKind::IncrementalSnapshot,
                 Greater,
-            ),
-            (
-                SnapshotRequestKind::IncrementalSnapshot,
-                SnapshotRequestKind::EpochAccountsHash,
-                Less,
             ),
             (
                 SnapshotRequestKind::IncrementalSnapshot,

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -19,7 +19,6 @@ pub fn cmp_accounts_packages_by_priority(a: &AccountsPackage, b: &AccountsPackag
 /// Compare accounts package kinds by priority
 ///
 /// Priority, from highest to lowest:
-/// - Epoch Accounts Hash
 /// - Full Snapshot
 /// - Incremental Snapshot
 ///
@@ -31,12 +30,6 @@ pub fn cmp_accounts_package_kinds_by_priority(
 ) -> Ordering {
     use AccountsPackageKind as Kind;
     match (a, b) {
-        // Epoch Accounts Hash packages
-        (Kind::EpochAccountsHash, Kind::EpochAccountsHash) => Equal,
-        (Kind::EpochAccountsHash, _) => Greater,
-        (_, Kind::EpochAccountsHash) => Less,
-
-        // Snapshot packages
         (Kind::Snapshot(snapshot_kind_a), Kind::Snapshot(snapshot_kind_b)) => {
             cmp_snapshot_kinds_by_priority(snapshot_kind_a, snapshot_kind_b)
         }
@@ -146,45 +139,6 @@ mod tests {
 
         for (accounts_package_a, accounts_package_b, expected_result) in [
             (
-                new(AccountsPackageKind::EpochAccountsHash, 11),
-                new(AccountsPackageKind::EpochAccountsHash, 22),
-                Less,
-            ),
-            (
-                new(AccountsPackageKind::EpochAccountsHash, 22),
-                new(AccountsPackageKind::EpochAccountsHash, 22),
-                Equal,
-            ),
-            (
-                new(AccountsPackageKind::EpochAccountsHash, 33),
-                new(AccountsPackageKind::EpochAccountsHash, 22),
-                Greater,
-            ),
-            (
-                new(AccountsPackageKind::EpochAccountsHash, 123),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                Greater,
-            ),
-            (
-                new(AccountsPackageKind::EpochAccountsHash, 123),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                new(AccountsPackageKind::EpochAccountsHash, 123),
-                Less,
-            ),
-            (
                 new(
                     AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                     11,
@@ -227,14 +181,6 @@ mod tests {
                     123,
                 ),
                 Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(AccountsPackageKind::EpochAccountsHash, 123),
-                Less,
             ),
             (
                 new(
@@ -313,26 +259,6 @@ mod tests {
     fn test_cmp_accounts_package_kinds_by_priority() {
         for (accounts_package_kind_a, accounts_package_kind_b, expected_result) in [
             (
-                AccountsPackageKind::EpochAccountsHash,
-                AccountsPackageKind::EpochAccountsHash,
-                Equal,
-            ),
-            (
-                AccountsPackageKind::EpochAccountsHash,
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                Greater,
-            ),
-            (
-                AccountsPackageKind::EpochAccountsHash,
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                Greater,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageKind::EpochAccountsHash,
-                Less,
-            ),
-            (
                 AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 Equal,
@@ -341,11 +267,6 @@ mod tests {
                 AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
                 Greater,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::EpochAccountsHash,
-                Less,
             ),
             (
                 AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),


### PR DESCRIPTION
#### Problem

The epoch accounts hash has been removed, so there are no more snapshot requests to calculate the EAH. The EAH request kind for AccountsBackgroundService and AccountsHashVerifier can be removed.


#### Summary of Changes

Removes SnapshotRequestKind::EpochAccountsHash and AccountsPackageKind::EpochAccountsHash.