### PR TITLE
cargo-registry: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/cargo-registry/src/client.rs
+++ b/cargo-registry/src/client.rs
@@ -204,7 +204,7 @@ impl Client {
         let port = value_t_or_exit!(matches, "port", u16);
 
         let server_url =
-            value_t!(matches, "server_url", String).unwrap_or(format!("http://0.0.0.0:{}", port));
+            value_t!(matches, "server_url", String).unwrap_or(format!("http://0.0.0.0:{port}"));
 
         let skip_preflight = matches.is_present("skip_preflight");
 

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -297,11 +297,10 @@ impl UnpackedCrate {
 
         let lib_name = UnpackedCrate::program_library_name(&tempdir, &meta)?;
 
-        let program_path =
-            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
-                .into_os_string()
-                .into_string()
-                .map_err(|_| "Failed to get program file path")?;
+        let program_path = UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "Failed to get program file path")?;
 
         let keypair = Keypair::read_from_file(UnpackedCrate::make_path(
             &tempdir,

--- a/cargo-registry/src/crate_handler.rs
+++ b/cargo-registry/src/crate_handler.rs
@@ -137,8 +137,8 @@ impl Program {
             None..None,
         )
         .map_err(|e| {
-            error!("Failed to deploy the program: {}", e);
-            format!("Failed to deploy the program: {}", e)
+            error!("Failed to deploy the program: {e}");
+            format!("Failed to deploy the program: {e}")
         })?;
 
         Ok(())
@@ -154,8 +154,8 @@ impl Program {
             &self.path,
         )
         .map_err(|e| {
-            error!("Failed to fetch the program: {}", e);
-            format!("Failed to fetch the program: {}", e)
+            error!("Failed to fetch the program: {e}");
+            format!("Failed to fetch the program: {e}")
         })?;
 
         if APPEND_CRATE_TO_ELF {
@@ -298,7 +298,7 @@ impl UnpackedCrate {
         let lib_name = UnpackedCrate::program_library_name(&tempdir, &meta)?;
 
         let program_path =
-            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{}.so", lib_name))
+            UnpackedCrate::make_path(&tempdir, &meta, format!("out/{lib_name}.so"))
                 .into_os_string()
                 .into_string()
                 .map_err(|_| "Failed to get program file path")?;
@@ -306,9 +306,9 @@ impl UnpackedCrate {
         let keypair = Keypair::read_from_file(UnpackedCrate::make_path(
             &tempdir,
             &meta,
-            format!("out/{}-keypair.json", lib_name),
+            format!("out/{lib_name}-keypair.json"),
         ))
-        .map_err(|e| format!("Failed to get keypair from the file: {}", e))?;
+        .map_err(|e| format!("Failed to get keypair from the file: {e}"))?;
 
         Ok(UnpackedCrate {
             meta,
@@ -406,7 +406,7 @@ impl UnpackedCrate {
         fs::create_dir_all(base_path)
             .map_err(|_| "Failed to create the base directory for output")?;
 
-        let program_path = Self::make_path(&tempdir, &meta, format!("out/{}.so", id))
+        let program_path = Self::make_path(&tempdir, &meta, format!("out/{id}.so"))
             .into_os_string()
             .into_string()
             .map_err(|_| "Failed to get program file path")?;

--- a/cargo-registry/src/main.rs
+++ b/cargo-registry/src/main.rs
@@ -55,12 +55,12 @@ impl CargoRegistryService {
                 };
 
                 if result.is_ok() {
-                    info!("Published the crate successfully. {:?}", result);
+                    info!("Published the crate successfully. {result:?}");
                     response_builder::success_response()
                 } else {
                     response_builder::error_response(
                         hyper::StatusCode::BAD_REQUEST,
-                        format!("Failed to publish the crate. {:?}", result).as_str(),
+                        format!("Failed to publish the crate. {result:?}").as_str(),
                     )
                 }
             }
@@ -283,7 +283,7 @@ async fn main() {
     });
 
     let server = Server::bind(&bind_addr).serve(registry_service);
-    info!("Server running on http://{}", bind_addr);
+    info!("Server running on http://{bind_addr}");
 
     let _ = server.await;
 }

--- a/cargo-registry/src/response_builder.rs
+++ b/cargo-registry/src/response_builder.rs
@@ -1,7 +1,7 @@
 use log::error;
 
 pub(crate) fn error_response(status: hyper::StatusCode, msg: &str) -> hyper::Response<hyper::Body> {
-    error!("{}", msg);
+    error!("{msg}");
     hyper::Response::builder()
         .status(status)
         .body(hyper::Body::from(

--- a/cargo-registry/src/sparse_index.rs
+++ b/cargo-registry/src/sparse_index.rs
@@ -81,13 +81,13 @@ impl From<PackageMetaData> for IndexEntry {
 impl RegistryIndex {
     pub(crate) fn new(root: &str, server_url: &str) -> Self {
         let registry_config = RegistryConfig {
-            dl: format!("{}/api/v1/crates", server_url),
+            dl: format!("{server_url}/api/v1/crates"),
             api: Some(server_url.to_string()),
         };
         let config =
             serde_json::to_string(&registry_config).expect("Failed to create registry config");
 
-        info!("Registry index is available at {}{}/", server_url, root);
+        info!("Registry index is available at {server_url}{root}/");
         Self {
             index_root: root.to_string(),
             config,
@@ -127,7 +127,7 @@ impl RegistryIndex {
         let mut write_index = self
             .index
             .write()
-            .map_err(|e| format!("Failed to lock the index for writing: {}", e))?;
+            .map_err(|e| format!("Failed to lock the index for writing: {e}"))?;
         info!("Inserting {}-{} in registry index", entry.name, entry.vers);
         write_index.insert(entry.name.clone(), entry);
         Ok(())
@@ -144,12 +144,12 @@ impl RegistryIndex {
             2 => path == "/2",
             3 => {
                 let first_char = crate_name.chars().next()?;
-                path == format!("/3/{}", first_char)
+                path == format!("/3/{first_char}")
             }
             _ => {
                 let (first_two_char, rest) = crate_name.split_at(2);
                 let (next_two_char, _) = rest.split_at(2);
-                path == format!("/{}/{}", first_two_char, next_two_char)
+                path == format!("/{first_two_char}/{next_two_char}")
             }
         }
         .then_some(crate_name)
@@ -167,7 +167,7 @@ impl RegistryIndex {
             );
         };
 
-        info!("Looking up index for {:?}", crate_name);
+        info!("Looking up index for {crate_name:?}");
 
         let Ok(read_index) = self.index.read() else {
             return response_builder::error_response(


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`