### PR TITLE
vortexor: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -57,7 +57,7 @@ fn parse_url_with_scheme(expected_schemes: &'static [&'static str]) -> ValuePars
     ValueParser::from(move |input: &str| {
         // Attempt to parse the input as a URL
         let parsed_url =
-            Url::parse(input).map_err(|e| format!("Invalid URL '{}': {}", input, e))?;
+            Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
 
         // Check the scheme of the URL
         if expected_schemes.contains(&parsed_url.scheme()) {

--- a/vortexor/src/cli.rs
+++ b/vortexor/src/cli.rs
@@ -56,8 +56,7 @@ fn get_default_tpu_coalesce_ms() -> &'static str {
 fn parse_url_with_scheme(expected_schemes: &'static [&'static str]) -> ValueParser {
     ValueParser::from(move |input: &str| {
         // Attempt to parse the input as a URL
-        let parsed_url =
-            Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
+        let parsed_url = Url::parse(input).map_err(|e| format!("Invalid URL '{input}': {e}"))?;
 
         // Check the scheme of the URL
         if expected_schemes.contains(&parsed_url.scheme()) {

--- a/vortexor/src/main.rs
+++ b/vortexor/src/main.rs
@@ -124,8 +124,11 @@ pub fn main() {
         .zip(websocket_servers)
         .collect::<Vec<_>>();
 
-    info!("Creating the PacketBatchSender: at address: {:?} for the following initial destinations: {destinations:?}",
-        sender_socket.1.local_addr());
+    info!(
+        "Creating the PacketBatchSender: at address: {:?} for the following initial destinations: \
+         {destinations:?}",
+        sender_socket.1.local_addr()
+    );
 
     let destinations = Arc::new(RwLock::new(destinations));
     let packet_sender = PacketBatchSender::new(
@@ -178,11 +181,10 @@ pub fn main() {
 
     for destination in destinations.read().unwrap().iter() {
         info!(
-            "To pair the validator with receiver address {destination} with this \
-             vortexor, add the following arguments in the validator's start command: \
-              --tpu-vortexor-receiver-address {destination} \
-              --public-tpu-address {tpu_public_address} \
-              --public-tpu-forwards-address {tpu_fwd_public_address}",
+            "To pair the validator with receiver address {destination} with this vortexor, add \
+             the following arguments in the validator's start command: \
+             --tpu-vortexor-receiver-address {destination} --public-tpu-address \
+             {tpu_public_address} --public-tpu-forwards-address {tpu_fwd_public_address}",
         );
     }
 

--- a/vortexor/src/sender.rs
+++ b/vortexor/src/sender.rs
@@ -76,7 +76,7 @@ impl PacketBatchSender {
             let destinations = destinations.read().expect("Expected to get destinations");
             match Self::receive_until(packet_batch_receiver.clone(), recv_timeout, batch_size) {
                 Ok((packet_count, packet_batches)) => {
-                    trace!("Received packet counts: {}", packet_count);
+                    trace!("Received packet counts: {packet_count}");
                     // Collect all packets once for all destinations
                     let mut packets: Vec<&[u8]> = Vec::new();
 

--- a/vortexor/src/stake_updater.rs
+++ b/vortexor/src/stake_updater.rs
@@ -52,7 +52,7 @@ impl StakeUpdater {
                         &rpc_load_balancer,
                         &refresh_sleep_duration,
                     ) {
-                        warn!("Failed to refresh pubkey to stake map! Error: {:?}", err);
+                        warn!("Failed to refresh pubkey to stake map! Error: {err:?}");
                         sleep(refresh_sleep_duration);
                     }
                 }

--- a/vortexor/tests/vortexor.rs
+++ b/vortexor/tests/vortexor.rs
@@ -90,8 +90,8 @@ async fn test_vortexor() {
 fn get_server_urls(validator: &ClusterValidatorInfo) -> (Url, Url) {
     let rpc_addr = validator.info.contact_info.rpc().unwrap();
     let rpc_pubsub_addr = validator.info.contact_info.rpc_pubsub().unwrap();
-    let rpc_url = Url::parse(format!("http://{}", rpc_addr).as_str()).unwrap();
-    let ws_url = Url::parse(format!("ws://{}", rpc_pubsub_addr).as_str()).unwrap();
+    let rpc_url = Url::parse(format!("http://{rpc_addr}").as_str()).unwrap();
+    let ws_url = Url::parse(format!("ws://{rpc_pubsub_addr}").as_str()).unwrap();
     (rpc_url, ws_url)
 }
 
@@ -135,7 +135,7 @@ fn test_stake_update() {
             .recv_timeout(slot_receive_timeout)
             .unwrap_or_else(|_| panic!("Expected a slot within {slot_receive_timeout:?}"));
         i += 1;
-        info!("Received a slot update: {}", slot);
+        info!("Received a slot update: {slot}");
     }
 
     let rpc_load_balancer = Arc::new(rpc_load_balancer);
@@ -154,10 +154,10 @@ fn test_stake_update() {
     loop {
         let stakes = shared_staked_nodes.read().unwrap();
         if let Some(stake) = stakes.get_node_stake(pubkey) {
-            info!("Stake for {}: {}", pubkey, stake);
+            info!("Stake for {pubkey}: {stake}");
             assert_eq!(stake, default_node_stake);
             let total_stake = stakes.total_stake();
-            info!("total_stake: {}", total_stake);
+            info!("total_stake: {total_stake}");
             assert!(total_stake >= default_node_stake);
             break;
         }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`