### PR TITLE
Removes featurization for remove_accounts_delta_hash

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -143,7 +143,7 @@ mod tests {
                 &mut writer,
                 bank_fields,
                 bank2.get_bank_hash_stats(),
-                accounts_db.get_accounts_delta_hash(bank2_slot).unwrap(),
+                AccountsDeltaHash(Hash::default()), // obsolete, will be removed next
                 expected_accounts_hash,
                 &get_storages_to_serialize(&bank2.get_snapshot_storages(None)),
                 ExtraFieldsToSerialize {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -777,7 +777,7 @@ struct SerializableAccountsDb<'a> {
     slot: Slot,
     account_storage_entries: &'a [Vec<Arc<AccountStorageEntry>>],
     bank_hash_stats: BankHashStats,
-    accounts_delta_hash: AccountsDeltaHash,
+    accounts_delta_hash: AccountsDeltaHash, // obsolete, will be removed next
     accounts_hash: AccountsHash,
     write_version: u64,
 }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -4,7 +4,6 @@ use {
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
     },
-    agave_feature_set as feature_set,
     log::*,
     solana_accounts_db::{
         accounts::Accounts,
@@ -72,17 +71,7 @@ impl AccountsPackage {
         let snapshot_info = {
             let accounts_db = &bank.rc.accounts.accounts_db;
             let write_version = accounts_db.write_version.load(Ordering::Acquire);
-            let accounts_delta_hash = if bank
-                .feature_set
-                .is_active(&feature_set::remove_accounts_delta_hash::id())
-            {
-                AccountsDeltaHash(Hash::default())
-            } else {
-                // SAFETY: There *must* be an accounts delta hash for this slot.
-                // Since we only snapshot rooted slots, and we know rooted slots must be frozen,
-                // that guarantees this slot will have an accounts delta hash.
-                accounts_db.get_accounts_delta_hash(slot).unwrap()
-            };
+            let accounts_delta_hash = AccountsDeltaHash(Hash::default());
             let bank_hash_stats = bank.get_bank_hash_stats();
             let bank_fields_to_serialize = bank.get_fields_to_serialize();
             SupplementalSnapshotInfo {
@@ -175,7 +164,7 @@ pub struct SupplementalSnapshotInfo {
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
     pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
-    pub accounts_delta_hash: AccountsDeltaHash,
+    pub accounts_delta_hash: AccountsDeltaHash, // obsolete, will be removed next
     pub write_version: u64,
 }
 
@@ -197,7 +186,7 @@ pub struct SnapshotPackage {
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
     pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
-    pub accounts_delta_hash: AccountsDeltaHash,
+    pub accounts_delta_hash: AccountsDeltaHash, // obsolete, will be removed next
     pub accounts_hash: AccountsHash,
     pub write_version: u64,
     pub bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,


### PR DESCRIPTION
The `remove_accounts_delta_hash` feature (SIMD-223) has been activated on all public clusters, and its featurization code can be removed.

Note, there's lots of additional cleanup to do after this PR too! This one is meant to be the minimum amount of changes to remove uses of `feature_set::remove_accounts_delta_hash`.