### PR TITLE
Use RWLock for shrink map as map should be small, and dashmap is empty checks are expensive

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -3,10 +3,12 @@
 use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
-    std::collections::HashMap,
     solana_clock::Slot,
     solana_nohash_hasher::BuildNoHashHasher,
-    std::sync::{Arc, RwLock},
+    std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+    },
 };
 
 pub mod stored_account_info;
@@ -55,9 +57,11 @@ impl AccountStorage {
 
         lookup_in_map()
             .or_else(|| {
-                self.shrink_in_progress_map.read().unwrap().get(&slot).and_then(|entry| {
-                    (entry.id() == store_id).then(|| Arc::clone(entry))
-                })
+                self.shrink_in_progress_map
+                    .read()
+                    .unwrap()
+                    .get(&slot)
+                    .and_then(|entry| (entry.id() == store_id).then(|| Arc::clone(entry)))
             })
             .or_else(lookup_in_map)
     }
@@ -164,7 +168,9 @@ impl AccountStorage {
 
         // insert 'new_store' into 'shrink_in_progress_map'
         assert!(
-            self.shrink_in_progress_map.write().unwrap()
+            self.shrink_in_progress_map
+                .write()
+                .unwrap()
                 .insert(slot, Arc::clone(&new_store))
                 .is_none(),
             "duplicate call"
@@ -260,7 +266,8 @@ impl Drop for ShrinkInProgress<'_> {
         assert!(self
             .storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .remove(&self.slot)
             .is_some());
     }
@@ -337,7 +344,11 @@ pub(crate) mod tests {
         );
 
         // look in shrink_in_progress_map
-        storage.shrink_in_progress_map.write().unwrap().insert(slot, entry2);
+        storage
+            .shrink_in_progress_map
+            .write()
+            .unwrap()
+            .insert(slot, entry2);
 
         // look in map
         assert_eq!(
@@ -386,7 +397,8 @@ pub(crate) mod tests {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.get_slot_storage_entry(0);
     }
@@ -397,7 +409,8 @@ pub(crate) mod tests {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.all_slots();
     }
@@ -408,18 +421,22 @@ pub(crate) mod tests {
         let mut storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.initialize(AccountStorageMap::default());
     }
 
     #[test]
-    #[should_panic(expected = "shrink_can_be_active || self.shrink_in_progress_map.read().unwrap().is_empty()")]
+    #[should_panic(
+        expected = "shrink_can_be_active || self.shrink_in_progress_map.read().unwrap().is_empty()"
+    )]
     fn test_remove_fail() {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.remove(&0, false);
     }
@@ -430,7 +447,8 @@ pub(crate) mod tests {
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
-            .write().unwrap()
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.iter();
     }
@@ -440,7 +458,11 @@ pub(crate) mod tests {
     fn test_insert_fail() {
         let storage = AccountStorage::default();
         let sample = storage.get_test_storage();
-        storage.shrink_in_progress_map.write().unwrap().insert(0, sample.clone());
+        storage
+            .shrink_in_progress_map
+            .write()
+            .unwrap()
+            .insert(0, sample.clone());
         storage.insert(0, sample);
     }
 
@@ -451,7 +473,11 @@ pub(crate) mod tests {
         let storage = AccountStorage::default();
         let sample = storage.get_test_storage();
         storage.map.insert(0, sample.clone());
-        storage.shrink_in_progress_map.write().unwrap().insert(0, sample.clone());
+        storage
+            .shrink_in_progress_map
+            .write()
+            .unwrap()
+            .insert(0, sample.clone());
         storage.shrinking_in_progress(0, sample);
     }
 
@@ -485,7 +511,8 @@ pub(crate) mod tests {
             (slot, id_shrunk),
             storage
                 .shrink_in_progress_map
-                .read().unwrap()
+                .read()
+                .unwrap()
                 .iter()
                 .next()
                 .map(|r| (*r.0, r.1.id()))
@@ -538,7 +565,9 @@ pub(crate) mod tests {
             .get_account_storage_entry(slot, missing_id)
             .is_none());
         storage
-            .shrink_in_progress_map.write().unwrap()
+            .shrink_in_progress_map
+            .write()
+            .unwrap()
             .insert(slot, Arc::clone(&sample));
         // id is found in map
         assert!(storage
@@ -590,7 +619,9 @@ pub(crate) mod tests {
     fn test_get_if_fail() {
         let storage = AccountStorage::default();
         storage
-            .shrink_in_progress_map.write().unwrap()
+            .shrink_in_progress_map
+            .write()
+            .unwrap()
             .insert(0, storage.get_test_storage());
         storage.get_if(|_, _| true);
     }

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -4,11 +4,8 @@ use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
     solana_clock::Slot,
-    solana_nohash_hasher::BuildNoHashHasher,
-    std::{
-        collections::HashMap,
-        sync::{Arc, RwLock},
-    },
+    solana_nohash_hasher::{BuildNoHashHasher, IntMap},
+    std::sync::{Arc, RwLock},
 };
 
 pub mod stored_account_info;
@@ -22,7 +19,7 @@ pub struct AccountStorage {
     /// while shrink is operating on a slot, there can be 2 append vecs active for that slot
     /// Once the index has been updated to only refer to the new append vec, the single entry for the slot in 'map' can be updated.
     /// Entries in 'shrink_in_progress_map' can be found by 'get_account_storage_entry'
-    shrink_in_progress_map: RwLock<HashMap<Slot, Arc<AccountStorageEntry>>>,
+    shrink_in_progress_map: RwLock<IntMap<Slot, Arc<AccountStorageEntry>>>,
 }
 
 impl AccountStorage {


### PR DESCRIPTION
#### Problem
Empty checks on dashmaps are expensive

#### Summary of Changes
Since shrink map is relatively small, replace with RwLock<HashMap>

Grabbed a quick check of clean timings:
<img width="1607" height="304" alt="image" src="https://github.com/user-attachments/assets/09cebb6f-7342-4d90-9683-65b51147ed7e" />
The line of interest is the blue line. Others are just reference lines. There are three different versions running on the blue line:
1. 1st restart is with the RwLock<HashMap>
2. 2nd restart is with the Base code Dashmap
3 3rd restart is with the RwLock<HashMap> and removing all the asserts 

1 & 3 seem noticeably better. I don't see a real difference between 1 and 3, so I am proposing the RwLock<HashMap> to keep the asserts.  

There are many other paths effected by the empty check, but they have more noise than the clean flow.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
