### PR TITLE
Removes is_accounts_lt_hash_enabled()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -480,8 +480,7 @@ pub struct BankFieldsToSerialize {
     pub is_delta: bool,
     pub accounts_data_len: u64,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
-    // When removing the accounts lt hash featurization code, also remove this Option wrapper
-    pub accounts_lt_hash: Option<AccountsLtHash>,
+    pub accounts_lt_hash: AccountsLtHash,
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
@@ -596,8 +595,7 @@ impl PartialEq for Bank {
             // different Mutexes.
             && (Arc::ptr_eq(hash_overrides, &other.hash_overrides) ||
                 *hash_overrides.lock().unwrap() == *other.hash_overrides.lock().unwrap())
-            && !(self.is_accounts_lt_hash_enabled() && other.is_accounts_lt_hash_enabled()
-                && *accounts_lt_hash.lock().unwrap() != *other.accounts_lt_hash.lock().unwrap())
+            && *accounts_lt_hash.lock().unwrap() == *other.accounts_lt_hash.lock().unwrap()
             && *block_id.read().unwrap() == *other.block_id.read().unwrap()
     }
 }
@@ -637,7 +635,7 @@ impl BankFieldsToSerialize {
             is_delta: bool::default(),
             accounts_data_len: u64::default(),
             versioned_epoch_stakes: HashMap::default(),
-            accounts_lt_hash: Some(AccountsLtHash(LtHash([0x7E57; LtHash::NUM_ELEMENTS]))),
+            accounts_lt_hash: AccountsLtHash(LtHash([0x7E57; LtHash::NUM_ELEMENTS])),
         }
     }
 }
@@ -1405,29 +1403,25 @@ impl Bank {
             .transaction_processor
             .fill_missing_sysvar_cache_entries(&new));
 
-        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) = new
-            .is_accounts_lt_hash_enabled()
-            .then(|| {
-                measure_us!({
-                    // The cache for accounts lt hash needs to be made aware of accounts modified
-                    // before transaction processing begins.  Otherwise we may calculate the wrong
-                    // accounts lt hash due to having the wrong initial state of the account.  The
-                    // lt hash cache's initial state must always be from an ancestor, and cannot be
-                    // an intermediate state within this Bank's slot.  If the lt hash cache has the
-                    // wrong initial account state, we'll mix out the wrong lt hash value, and thus
-                    // have the wrong overall accounts lt hash, and diverge.
-                    let accounts_modified_this_slot =
-                        new.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
-                    let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
-                    for pubkey in accounts_modified_this_slot {
-                        new.cache_for_accounts_lt_hash
-                            .entry(pubkey)
-                            .or_insert(AccountsLtHashCacheValue::BankNew);
-                    }
-                    num_accounts_modified_this_slot
-                })
-            })
-            .unzip();
+        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
+            measure_us!({
+                // The cache for accounts lt hash needs to be made aware of accounts modified
+                // before transaction processing begins.  Otherwise we may calculate the wrong
+                // accounts lt hash due to having the wrong initial state of the account.  The
+                // lt hash cache's initial state must always be from an ancestor, and cannot be
+                // an intermediate state within this Bank's slot.  If the lt hash cache has the
+                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
+                // have the wrong overall accounts lt hash, and diverge.
+                let accounts_modified_this_slot =
+                    new.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
+                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
+                for pubkey in accounts_modified_this_slot {
+                    new.cache_for_accounts_lt_hash
+                        .entry(pubkey)
+                        .or_insert(AccountsLtHashCacheValue::BankNew);
+                }
+                num_accounts_modified_this_slot
+            });
 
         time.stop();
         report_new_bank_metrics(
@@ -1926,9 +1920,7 @@ impl Bank {
             is_delta: self.is_delta.load(Relaxed),
             accounts_data_len: self.load_accounts_data_size(),
             versioned_epoch_stakes: self.epoch_stakes.clone(),
-            accounts_lt_hash: self
-                .is_accounts_lt_hash_enabled()
-                .then(|| self.accounts_lt_hash.lock().unwrap().clone()),
+            accounts_lt_hash: self.accounts_lt_hash.lock().unwrap().clone(),
         }
     }
 
@@ -2538,11 +2530,9 @@ impl Bank {
 
             // freeze is a one-way trip, idempotent
             self.freeze_started.store(true, Relaxed);
-            if self.is_accounts_lt_hash_enabled() {
-                // updating the accounts lt hash must happen *outside* of hash_internal_state() so
-                // that rehash() can be called and *not* modify self.accounts_lt_hash.
-                self.update_accounts_lt_hash();
-            }
+            // updating the accounts lt hash must happen *outside* of hash_internal_state() so
+            // that rehash() can be called and *not* modify self.accounts_lt_hash.
+            self.update_accounts_lt_hash();
             *hash = self.hash_internal_state();
             self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
         }
@@ -5897,9 +5887,7 @@ impl TransactionProcessingCallback for Bank {
     }
 
     fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
-        if self.is_accounts_lt_hash_enabled() {
-            self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
-        }
+        self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
     }
 }
 

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -43,7 +43,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
-    pub(crate) populate_cache_for_accounts_lt_hash_us: Option<u64>,
+    pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
 pub(crate) fn report_new_epoch_metrics(
@@ -98,7 +98,7 @@ pub(crate) fn report_new_bank_metrics(
     slot: Slot,
     parent_slot: Slot,
     block_height: u64,
-    num_accounts_modified_this_slot: Option<usize>,
+    num_accounts_modified_this_slot: usize,
     timings: NewBankTimings,
 ) {
     datapoint_info!(
@@ -151,12 +151,12 @@ pub(crate) fn report_new_bank_metrics(
         (
             "num_accounts_modified_this_slot",
             num_accounts_modified_this_slot,
-            Option<i64>
+            i64
         ),
         (
             "populate_cache_for_accounts_lt_hash_us",
             timings.populate_cache_for_accounts_lt_hash_us,
-            Option<i64>
+            i64
         ),
     );
 }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -138,7 +138,7 @@ mod tests {
         {
             let mut bank_fields = bank2.get_fields_to_serialize();
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
-            let accounts_lt_hash = bank_fields.accounts_lt_hash.clone().map(Into::into);
+            let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
             serde_snapshot::serialize_bank_snapshot_into(
                 &mut writer,
                 bank_fields,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -702,7 +702,7 @@ impl Serialize for SerializableBankAndStorage<'_> {
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         let lamports_per_signature = bank_fields.fee_rate_governor.lamports_per_signature;
         let versioned_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
-        let accounts_lt_hash = bank_fields.accounts_lt_hash.clone().map(Into::into);
+        let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
         let bank_fields_to_serialize = (
             SerializableVersionedBank::from(bank_fields),
             SerializableAccountsDb::<'_> {

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -33,7 +33,7 @@ impl SnapshotHash {
     #[must_use]
     pub fn new(
         merkle_or_lattice_accounts_hash: &MerkleOrLatticeAccountsHash,
-        accounts_lt_hash_checksum: Option<AccountsLtHashChecksum>,
+        accounts_lt_hash_checksum: Option<AccountsLtHashChecksum>, // option wrapper will be removed next
     ) -> Self {
         let accounts_hash = match merkle_or_lattice_accounts_hash {
             MerkleOrLatticeAccountsHash::Merkle(accounts_hash_kind) => {

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -70,16 +70,14 @@ impl<'a> SnapshotMinimizer<'a> {
             .bank
             .set_capitalization_for_tests(minimizer.bank.calculate_capitalization_for_tests());
 
-        if minimizer.bank.is_accounts_lt_hash_enabled() {
-            // Since the account state has changed, the accounts lt hash must be recalculated
-            let new_accounts_lt_hash = minimizer
-                .accounts_db()
-                .calculate_accounts_lt_hash_at_startup_from_index(
-                    &minimizer.bank.ancestors,
-                    minimizer.bank.slot(),
-                );
-            bank.set_accounts_lt_hash_for_snapshot_minimizer(new_accounts_lt_hash);
-        }
+        // Since the account state has changed, the accounts lt hash must be recalculated
+        let new_accounts_lt_hash = minimizer
+            .accounts_db()
+            .calculate_accounts_lt_hash_at_startup_from_index(
+                &minimizer.bank.ancestors,
+                minimizer.bank.slot(),
+            );
+        bank.set_accounts_lt_hash_for_snapshot_minimizer(new_accounts_lt_hash);
     }
 
     /// Helper function to measure time and number of accounts added
@@ -593,10 +591,6 @@ mod tests {
         let genesis_config_info = genesis_utils::create_genesis_config(123_456_789_000_000_000);
         let (bank, bank_forks) =
             Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config);
-
-        // ensure the accounts lt hash is enabled, otherwise minimization
-        // doesn't need to recalculate it
-        assert!(bank.is_accounts_lt_hash_enabled());
 
         // write to multiple accounts and keep track of one, for minimization later
         let pubkey_to_keep = Pubkey::new_unique();

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -248,11 +248,13 @@ impl SnapshotPackage {
             block_height: accounts_package.block_height,
             hash: SnapshotHash::new(
                 &merkle_or_lattice_accounts_hash,
-                snapshot_info
-                    .bank_fields_to_serialize
-                    .accounts_lt_hash
-                    .as_ref()
-                    .map(|accounts_lt_hash| accounts_lt_hash.0.checksum()),
+                Some(
+                    snapshot_info
+                        .bank_fields_to_serialize
+                        .accounts_lt_hash
+                        .0
+                        .checksum(),
+                ),
             ),
             snapshot_storages: accounts_package.snapshot_storages,
             status_cache_slot_deltas: snapshot_info.status_cache_slot_deltas,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -963,7 +963,7 @@ fn serialize_snapshot(
                 incremental_snapshot_persistence: bank_incremental_snapshot_persistence,
                 obsolete_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
-                accounts_lt_hash: bank_fields.accounts_lt_hash.clone().map(Into::into),
+                accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),
             };
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,


### PR DESCRIPTION
#### Problem

The fn `Bank::is_accounts_lt_hash_enabled()` always returns `true`. It can be removed and have its callers cleaned up.

#### Summary of Changes

Remove it and clean up callers.