### PR TITLE
perf: filter zero stakes from leader schedule gen

### DIFF
--- a/ledger/src/leader_schedule/vote_keyed.rs
+++ b/ledger/src/leader_schedule/vote_keyed.rs
@@ -26,6 +26,7 @@ impl LeaderSchedule {
     ) -> Self {
         let keyed_stakes: Vec<_> = vote_accounts_map
             .iter()
+            .filter(|(_pubkey, (stake, _account))| *stake > 0)
             .map(|(vote_pubkey, (stake, _account))| (vote_pubkey, *stake))
             .collect();
         let vote_keyed_slot_leaders = stake_weighted_slot_leaders(keyed_stakes, epoch, len, repeat);


### PR DESCRIPTION
#### Problem
Zero stake entries are not filtered out in the new vote keyed leader schedule generation algorithm. This slows down staked vote account sorting and allocates more memory than needed. Note that zero stake entries do not impact the result of the leader schedule generation algorithm at all. Also note that zero stake entries are filtered out of in the legacy leader schedule generation algorithm.

Thanks to @0x0ece for pointing this out!

#### Summary of Changes
Filter out zero stakes

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
