### PR TITLE
ci: fix docs publishing for beta tag

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -19,6 +19,7 @@ echo $?
 # Publish only from merge commits and beta release tags
 if [[ -n $CI ]]; then
   if [[ -z $CI_PULL_REQUEST ]]; then
+    eval "$(../ci/channel-info.sh)"
     if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
       echo "not a beta tag"
       exit 0


### PR DESCRIPTION
#### Problem

We’re currently not running channel-info.sh, so non-beta tags aren’t being filtered. 

v2.3.4: https://github.com/anza-xyz/agave/actions/runs/16229992346/job/45830686697#step:4:160
v2.2.20: https://github.com/anza-xyz/agave/actions/runs/16229986304/job/45830666862#step:4:208

#### Summary of Changes

ensure we get $BETA_CHANNEL before the condition
