### PR TITLE
Wire up XDP machinery to broadcast stage

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -822,6 +822,7 @@ impl BankingSimulator {
             bank_forks.clone(),
             shred_version,
             sender,
+            None,
         );
 
         info!("Start banking stage!...");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -59,7 +59,10 @@ use {
         quic::{spawn_server_multi, QuicServerParams, SpawnServerResult},
         streamer::StakedNodes,
     },
-    solana_turbine::broadcast_stage::{BroadcastStage, BroadcastStageType},
+    solana_turbine::{
+        broadcast_stage::{BroadcastStage, BroadcastStageType},
+        xdp::XdpSender,
+    },
     std::{
         collections::HashMap,
         net::{SocketAddr, UdpSocket},
@@ -128,6 +131,7 @@ impl Tpu {
         entry_notification_sender: Option<EntryNotifierSender>,
         blockstore: Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
+        xdp_sender: Option<XdpSender>,
         exit: Arc<AtomicBool>,
         shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
@@ -372,6 +376,7 @@ impl Tpu {
             bank_forks,
             shred_version,
             turbine_quic_endpoint_sender,
+            xdp_sender,
         );
 
         let mut key_notifiers = key_notifiers.write().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -47,7 +47,7 @@ use {
         vote_sender_types::ReplayVoteSender,
     },
     solana_streamer::evicting_sender::EvictingSender,
-    solana_turbine::{retransmit_stage::RetransmitStage, xdp::XdpConfig},
+    solana_turbine::{retransmit_stage::RetransmitStage, xdp::XdpSender},
     std::{
         collections::HashSet,
         net::{SocketAddr, UdpSocket},
@@ -99,7 +99,7 @@ pub struct TvuConfig {
     pub replay_forks_threads: NonZeroUsize,
     pub replay_transactions_threads: NonZeroUsize,
     pub shred_sigverify_threads: NonZeroUsize,
-    pub retransmit_xdp: Option<XdpConfig>,
+    pub xdp_sender: Option<XdpSender>,
 }
 
 impl Default for TvuConfig {
@@ -113,7 +113,7 @@ impl Default for TvuConfig {
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            retransmit_xdp: None,
+            xdp_sender: None,
         }
     }
 }
@@ -226,7 +226,7 @@ impl Tvu {
             max_slots.clone(),
             Some(rpc_subscriptions.clone()),
             slot_status_notifier.clone(),
-            tvu_config.retransmit_xdp.clone(),
+            tvu_config.xdp_sender,
         );
 
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -23,7 +23,8 @@ use {
     solana_time_utils::{timestamp, AtomicInterval},
     solana_turbine::{
         broadcast_stage::{
-            broadcast_metrics::TransmitShredsStats, broadcast_shreds, BroadcastStage,
+            broadcast_metrics::TransmitShredsStats, broadcast_shreds, BroadcastSocket,
+            BroadcastStage,
         },
         cluster_nodes::ClusterNodesCache,
     },
@@ -44,6 +45,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
         SocketAddrSpace::Unspecified,
     );
     let socket = bind_to_unspecified().unwrap();
+    let socket = BroadcastSocket::Udp(&socket);
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank);
@@ -90,8 +92,8 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     bencher.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
-            &socket,
-            &shreds,
+            socket,
+            shreds,
             &cluster_nodes_cache,
             &last_datapoint,
             &mut TransmitShredsStats::default(),

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -298,7 +298,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         &mut self,
         receiver: &TransmitReceiver,
         cluster_info: &ClusterInfo,
-        sock: &UdpSocket,
+        sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
     ) -> Result<()> {
@@ -396,6 +396,12 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             .flatten()
             .collect();
 
+        let sock = match sock {
+            BroadcastSocket::Udp(sock) => sock,
+            BroadcastSocket::Xdp(_) => {
+                panic!("Xdp not supported for duplicate shreds run");
+            }
+        };
         batch_send(sock, packets).map_err(|SendPktsError::IoError(err, _)| Error::Io(err))
     }
 

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -155,10 +155,16 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         &mut self,
         receiver: &TransmitReceiver,
         cluster_info: &ClusterInfo,
-        sock: &UdpSocket,
+        sock: BroadcastSocket,
         _bank_forks: &RwLock<BankForks>,
         _quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
     ) -> Result<()> {
+        let sock = match sock {
+            BroadcastSocket::Udp(sock) => sock,
+            BroadcastSocket::Xdp(_) => {
+                panic!("Xdp not supported for fake shreds");
+            }
+        };
         for (data_shreds, batch_info) in receiver {
             let fake = batch_info.is_some();
             let peers = cluster_info.tvu_peers(ContactInfo::clone);

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -21,12 +21,15 @@ pub struct TransmitShredsStats {
     pub send_mmsg_elapsed: u64,
     /// microseconds spent sending packets to quic endpoint
     pub send_quic_elapsed: u64,
+    /// microseconds spent sending packets to xdp endpoint
+    pub send_xdp_elapsed: u64,
     /// Time spent figuring out which shreds to send where
     pub shred_select: u64,
     pub num_shreds: usize,
     pub total_packets: usize,
     pub(crate) dropped_packets_udp: usize,
     pub(crate) dropped_packets_quic: usize,
+    pub(crate) dropped_packets_xdp: usize,
 }
 
 impl BroadcastStats for TransmitShredsStats {
@@ -34,11 +37,13 @@ impl BroadcastStats for TransmitShredsStats {
         self.transmit_elapsed += new_stats.transmit_elapsed;
         self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
         self.send_quic_elapsed += new_stats.send_quic_elapsed;
+        self.send_xdp_elapsed += new_stats.send_xdp_elapsed;
         self.num_shreds += new_stats.num_shreds;
         self.shred_select += new_stats.shred_select;
         self.total_packets += new_stats.total_packets;
         self.dropped_packets_udp += new_stats.dropped_packets_udp;
         self.dropped_packets_quic += new_stats.dropped_packets_quic;
+        self.dropped_packets_xdp += new_stats.dropped_packets_xdp;
     }
     fn report_stats(&mut self, slot: Slot, slot_start: Instant, was_interrupted: bool) {
         if was_interrupted {
@@ -48,6 +53,7 @@ impl BroadcastStats for TransmitShredsStats {
                 ("transmit_elapsed", self.transmit_elapsed as i64, i64),
                 ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
                 ("send_quic_elapsed", self.send_quic_elapsed as i64, i64),
+                ("send_xdp_elapsed", self.send_xdp_elapsed as i64, i64),
                 ("num_shreds", self.num_shreds as i64, i64),
                 ("shred_select", self.shred_select as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
@@ -57,6 +63,7 @@ impl BroadcastStats for TransmitShredsStats {
                     self.dropped_packets_quic as i64,
                     i64
                 ),
+                ("dropped_packets_xdp", self.dropped_packets_xdp as i64, i64),
             );
         } else {
             datapoint_info!(
@@ -72,6 +79,7 @@ impl BroadcastStats for TransmitShredsStats {
                 ("transmit_elapsed", self.transmit_elapsed as i64, i64),
                 ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
                 ("send_quic_elapsed", self.send_quic_elapsed as i64, i64),
+                ("send_xdp_elapsed", self.send_xdp_elapsed as i64, i64),
                 ("num_shreds", self.num_shreds as i64, i64),
                 ("shred_select", self.shred_select as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
@@ -81,6 +89,7 @@ impl BroadcastStats for TransmitShredsStats {
                     self.dropped_packets_quic as i64,
                     i64
                 ),
+                ("dropped_packets_xdp", self.dropped_packets_xdp as i64, i64),
             );
         }
     }
@@ -223,11 +232,13 @@ mod test {
                 transmit_elapsed: 1,
                 send_quic_elapsed: 2,
                 send_mmsg_elapsed: 3,
-                shred_select: 4,
-                num_shreds: 5,
-                total_packets: 6,
-                dropped_packets_udp: 7,
-                dropped_packets_quic: 8,
+                send_xdp_elapsed: 4,
+                shred_select: 5,
+                num_shreds: 6,
+                total_packets: 7,
+                dropped_packets_udp: 8,
+                dropped_packets_quic: 9,
+                dropped_packets_xdp: 10,
             },
             &Some(BroadcastShredBatchInfo {
                 slot: 0,
@@ -244,22 +255,26 @@ mod test {
         assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_quic_elapsed, 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 3);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 4);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 5);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.total_packets, 6);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_udp, 7);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_quic, 8);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_xdp_elapsed, 4);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 5);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 6);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.total_packets, 7);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_udp, 8);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_quic, 9);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_xdp, 10);
 
         slot_broadcast_stats.update(
             &TransmitShredsStats {
                 transmit_elapsed: 11,
                 send_quic_elapsed: 12,
                 send_mmsg_elapsed: 13,
-                shred_select: 14,
-                num_shreds: 15,
-                total_packets: 16,
-                dropped_packets_udp: 17,
-                dropped_packets_quic: 18,
+                send_xdp_elapsed: 14,
+                shred_select: 15,
+                num_shreds: 16,
+                total_packets: 17,
+                dropped_packets_udp: 18,
+                dropped_packets_quic: 19,
+                dropped_packets_xdp: 20,
             },
             &None,
         );
@@ -271,11 +286,13 @@ mod test {
         assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_quic_elapsed, 2);
         assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 3);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 4);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 5);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.total_packets, 6);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_udp, 7);
-        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_quic, 8);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_xdp_elapsed, 4);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.shred_select, 5);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 6);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.total_packets, 7);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_udp, 8);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_quic, 9);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.dropped_packets_xdp, 10);
 
         // If another batch is given, then total number of batches == num_expected_batches == 2,
         // so the batch should be purged from the HashMap
@@ -284,11 +301,13 @@ mod test {
                 transmit_elapsed: 1,
                 send_quic_elapsed: 1,
                 send_mmsg_elapsed: 1,
+                send_xdp_elapsed: 1,
                 shred_select: 1,
                 num_shreds: 1,
                 total_packets: 1,
                 dropped_packets_udp: 1,
                 dropped_packets_quic: 1,
+                dropped_packets_xdp: 1,
             },
             &Some(BroadcastShredBatchInfo {
                 slot: 0,

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -182,14 +182,14 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         &mut self,
         receiver: &TransmitReceiver,
         cluster_info: &ClusterInfo,
-        sock: &UdpSocket,
+        sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
         quic_endpoint_sender: &AsyncSender<(SocketAddr, Bytes)>,
     ) -> Result<()> {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
             sock,
-            &shreds,
+            shreds,
             &self.cluster_nodes_cache,
             &AtomicInterval::default(),
             &mut TransmitShredsStats::default(),

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         addr_cache::AddrCache,
         cluster_nodes::{self, ClusterNodes, ClusterNodesCache, Error, MAX_NUM_TURBINE_HOPS},
-        xdp::{XdpConfig, XdpRetransmitter, XdpSender},
+        xdp::{XdpSender, XdpShredPayload},
     },
     bytes::Bytes,
     crossbeam_channel::{Receiver, RecvError, TryRecvError},
@@ -430,7 +430,11 @@ fn retransmit_shred(
             RetransmitSocket::Xdp(sender) => {
                 let mut sent = num_addrs;
                 if num_addrs > 0 {
-                    if let Err(e) = sender.try_send(key.index(), addrs.to_vec(), shred) {
+                    if let Err(e) = sender.try_send(
+                        key.index() as usize,
+                        addrs.to_vec(),
+                        XdpShredPayload::Owned(shred),
+                    ) {
                         log::warn!("xdp channel full: {e:?}");
                         stats
                             .num_shreds_dropped_xdp_full
@@ -562,7 +566,6 @@ fn cache_retransmit_addrs(
 /// Service to retransmit messages received from other peers in turbine.
 pub struct RetransmitStage {
     retransmit_thread_handle: JoinHandle<()>,
-    xdp_retransmitter: Option<XdpRetransmitter>,
 }
 
 impl RetransmitStage {
@@ -586,7 +589,7 @@ impl RetransmitStage {
         max_slots: Arc<MaxSlots>,
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
-        xdp_config: Option<XdpConfig>,
+        xdp_sender: Option<XdpSender>,
     ) -> Self {
         let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
             CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
@@ -604,18 +607,6 @@ impl RetransmitStage {
                 .thread_name(|i| format!("solRetransmit{i:02}"))
                 .build()
                 .unwrap()
-        };
-
-        let (xdp_retransmitter, xdp_sender) = if let Some(xdp_config) = xdp_config {
-            let src_port = retransmit_sockets[0]
-                .local_addr()
-                .expect("failed to get local address")
-                .port();
-            let (rtx, sender) = XdpRetransmitter::new(xdp_config, src_port)
-                .expect("failed to create xdp retransmitter");
-            (Some(rtx), Some(sender))
-        } else {
-            (None, None)
         };
 
         let retransmit_thread_handle = Builder::new()
@@ -649,14 +640,10 @@ impl RetransmitStage {
 
         Self {
             retransmit_thread_handle,
-            xdp_retransmitter,
         }
     }
 
     pub fn join(self) -> thread::Result<()> {
-        if let Some(rtx) = self.xdp_retransmitter {
-            rtx.join()?;
-        }
         self.retransmit_thread_handle.join()
     }
 }

--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -8,12 +8,12 @@ use {
         tx_loop::tx_loop,
     },
     crossbeam_channel::TryRecvError,
-    std::{sync::Arc, thread::Builder, time::Duration},
+    std::{thread::Builder, time::Duration},
 };
 use {
     crossbeam_channel::{Sender, TrySendError},
     solana_ledger::shred,
-    std::{error::Error, net::SocketAddr, thread},
+    std::{error::Error, net::SocketAddr, sync::Arc, thread},
 };
 
 #[derive(Clone, Debug)]

--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -53,40 +53,67 @@ impl XdpConfig {
     }
 }
 
-pub(crate) struct XdpSender {
-    senders: Vec<Sender<(Vec<SocketAddr>, shred::Payload)>>,
+/// The shred payload variants of the Xdp channel.
+///
+/// This is currently meant to capture the constraints of both the retransmit
+/// and broadcast stages.
+pub(crate) enum XdpShredPayload {
+    /// The shreds, and thus their payloads, are owned by the caller.
+    ///
+    /// For example, retransmit has its own [`Vec`] of [`shred::Shred`], and can simply
+    /// pass along the payloads to the XDP thread(s) via the Xdp channel.
+    Owned(shred::Payload),
+    /// The shreds, and thus their payloads, are shared between disparate components in the validator.
+    ///
+    /// For example, broadcast deals with an `Arc<Vec<shred::Shred>>` due to those shreds being
+    /// shared with the blockstore (see [`StandardBroadcastRun::process_receive_results`](crate::broadcast_stage::standard_broadcast_run::StandardBroadcastRun::process_receive_results)).
+    /// To avoid cloning the payloads, we pass along the `Arc` reference and the index of the shred
+    /// in the `Vec` to the XDP thread(s).
+    Shared {
+        ptr: Arc<Vec<shred::Shred>>,
+        index: usize,
+    },
+}
+
+impl AsRef<[u8]> for XdpShredPayload {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            XdpShredPayload::Owned(payload) => payload.as_ref(),
+            XdpShredPayload::Shared { ptr, index } => ptr[*index].payload().as_ref(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct XdpSender {
+    senders: Vec<Sender<(Vec<SocketAddr>, XdpShredPayload)>>,
 }
 
 impl XdpSender {
     #[inline]
     pub(crate) fn try_send(
         &self,
-        sender_index: u32,
+        sender_index: usize,
         addr: Vec<SocketAddr>,
-        payload: shred::Payload,
-    ) -> Result<(), TrySendError<(Vec<SocketAddr>, shred::Payload)>> {
-        self.senders[sender_index as usize % self.senders.len()].try_send((addr.clone(), payload))
+        payload: XdpShredPayload,
+    ) -> Result<(), TrySendError<(Vec<SocketAddr>, XdpShredPayload)>> {
+        self.senders[sender_index % self.senders.len()].try_send((addr, payload))
     }
 }
 
-pub(crate) struct XdpRetransmitter {
+pub struct XdpRetransmitter {
     threads: Vec<thread::JoinHandle<()>>,
 }
 
 impl XdpRetransmitter {
     #[cfg(not(target_os = "linux"))]
-    pub(crate) fn new(
-        _config: XdpConfig,
-        _src_port: u16,
-    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+    pub fn new(_config: XdpConfig, _src_port: u16) -> Result<(Self, XdpSender), Box<dyn Error>> {
         Err("XDP is only supported on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    pub(crate) fn new(
-        config: XdpConfig,
-        src_port: u16,
-    ) -> Result<(Self, XdpSender), Box<dyn Error>> {
+    pub fn new(config: XdpConfig, src_port: u16) -> Result<(Self, XdpSender), Box<dyn Error>> {
         use caps::{
             CapSet,
             Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW},


### PR DESCRIPTION
#### Problem
The retransmit XDP code is implemented in a way that is general enough to be utilized by both retransmit and broadcast stages, but it is not yet wired up to broadcast. Retransmit and broadcast stages are effectively mutually exclusive, so they can share the same XDP processing loop.

#### Summary of Changes

This moves the instantiation of the XDP processing loop higher up from the retransmit stage into the validator construction stage. The XDP sender is then plumbed through both the broadcast and retransmit stages so that they utilize the same XDP process. A slight adjustment is made to the turbine XDP code to handle the fact that broadcast stage must deal with shared references to `Shred`s rather than owned copies (like in the retransmit case). Broadcast stage is also updated to conditionally use XDP if it has been configured in the validator configuration, similar to how it's done in the retransmit stage.
