### PR TITLE
Generate toolchain name inside condition

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -227,11 +227,12 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
 
     let cargo_build = PathBuf::from("cargo");
     let mut cargo_build_args = vec![];
-    let toolchain_name = generate_toolchain_name(validated_toolchain_version.as_str());
-    let toolchain_argument = format!("+{toolchain_name}");
 
+    let mut toolchain_name: String;
     if !config.no_rustup_override {
-        cargo_build_args.push(toolchain_argument.as_str());
+        toolchain_name = generate_toolchain_name(validated_toolchain_version.as_str());
+        toolchain_name = format!("+{toolchain_name}");
+        cargo_build_args.push(toolchain_name.as_str());
     };
 
     cargo_build_args.append(&mut vec!["build", "--release", "--target", &target_triple]);


### PR DESCRIPTION
#### Problem

Rustup may not be available in nix-environments, so we cannot rely on it for generating the toolchain name. See the comment in https://github.com/anza-xyz/agave/pull/6981#discussion_r2211647579.

#### Summary of Changes

Only generate the toolchain name if we are not overriding rustup.
