### PR TITLE
Invert Index in caller and index in transaction in the serialization benchmark

### DIFF
--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -94,8 +94,8 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
             .position(|account| account.index_in_transaction == index_in_transaction)
             .unwrap_or(instruction_account_index) as IndexOfAccount;
         instruction_accounts.push(InstructionAccount::new(
-            instruction_account_index as IndexOfAccount,
             index_in_transaction,
+            instruction_account_index as IndexOfAccount,
             index_in_callee,
             false,
             instruction_account_index >= 4,


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/pull/6829, I refactored `InstructionAccount` and created a constructor for it. As a consequence, we don't have named fields anymore during initialization and we must pass the arguments to the constructor in the correct order.

In my refactor, I did not pay attention to one case where the initialization of the struct members did not follow the same order of the constructor parameters. See https://github.com/anza-xyz/agave/pull/6829/files#diff-4d03f27ca1e78f3acca722a473b99537c734ec252882d32681cb88a29e727365R95-R102.

#### Summary of Changes

Invert the indexes for the correct usage.
