### PR TITLE
Refactor - Boolean flag consistency in serialization

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -537,8 +537,8 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        true, // copy_account_data
-        true, // for mask_out_rent_epoch_in_vm_serialization
+        false, // direct_mapping
+        true,  // for mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -51,18 +51,18 @@ struct Serializer {
     vaddr: u64,
     region_start: usize,
     aligned: bool,
-    copy_account_data: bool,
+    direct_mapping: bool,
 }
 
 impl Serializer {
-    fn new(size: usize, start_addr: u64, aligned: bool, copy_account_data: bool) -> Serializer {
+    fn new(size: usize, start_addr: u64, aligned: bool, direct_mapping: bool) -> Serializer {
         Serializer {
             buffer: AlignedMemory::with_capacity(size),
             regions: Vec::new(),
             region_start: 0,
             vaddr: start_addr,
             aligned,
-            copy_account_data,
+            direct_mapping,
         }
     }
 
@@ -109,7 +109,7 @@ impl Serializer {
         &mut self,
         account: &mut BorrowedAccount<'_>,
     ) -> Result<u64, InstructionError> {
-        let vm_data_addr = if self.copy_account_data {
+        let vm_data_addr = if !self.direct_mapping {
             let vm_data_addr = self.vaddr.saturating_add(self.buffer.len() as u64);
             self.write_all(account.get_data());
             vm_data_addr
@@ -135,7 +135,7 @@ impl Serializer {
         if self.aligned {
             let align_offset =
                 (account.get_data().len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
-            if self.copy_account_data {
+            if !self.direct_mapping {
                 self.fill_write(MAX_PERMITTED_DATA_INCREASE + align_offset, 0)
                     .map_err(|_| InstructionError::InvalidArgument)?;
             } else {
@@ -186,7 +186,7 @@ impl Serializer {
 pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    copy_account_data: bool,
+    direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -235,7 +235,7 @@ pub fn serialize_parameters(
             accounts,
             instruction_context.get_instruction_data(),
             &program_id,
-            copy_account_data,
+            direct_mapping,
             mask_out_rent_epoch_in_vm_serialization,
         )
     } else {
@@ -243,7 +243,7 @@ pub fn serialize_parameters(
             accounts,
             instruction_context.get_instruction_data(),
             &program_id,
-            copy_account_data,
+            direct_mapping,
             mask_out_rent_epoch_in_vm_serialization,
         )
     }
@@ -252,7 +252,7 @@ pub fn serialize_parameters(
 pub fn deserialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    copy_account_data: bool,
+    direct_mapping: bool,
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
@@ -265,7 +265,7 @@ pub fn deserialize_parameters(
         deserialize_parameters_unaligned(
             transaction_context,
             instruction_context,
-            copy_account_data,
+            direct_mapping,
             buffer,
             account_lengths,
         )
@@ -273,7 +273,7 @@ pub fn deserialize_parameters(
         deserialize_parameters_aligned(
             transaction_context,
             instruction_context,
-            copy_account_data,
+            direct_mapping,
             buffer,
             account_lengths,
         )
@@ -284,7 +284,7 @@ fn serialize_parameters_unaligned(
     accounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
-    copy_account_data: bool,
+    direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -309,7 +309,7 @@ fn serialize_parameters_unaligned(
                 + size_of::<Pubkey>() // owner
                 + size_of::<u8>() // executable
                 + size_of::<u64>(); // rent_epoch
-                if copy_account_data {
+                if !direct_mapping {
                     size += account.get_data().len();
                 }
             }
@@ -319,7 +319,7 @@ fn serialize_parameters_unaligned(
          + instruction_data.len() // instruction data
          + size_of::<Pubkey>(); // program id
 
-    let mut s = Serializer::new(size, MM_INPUT_START, false, copy_account_data);
+    let mut s = Serializer::new(size, MM_INPUT_START, false, direct_mapping);
 
     let mut accounts_metadata: Vec<SerializedAccountMetadata> = Vec::with_capacity(accounts.len());
     s.write::<u64>((accounts.len() as u64).to_le());
@@ -367,7 +367,7 @@ fn serialize_parameters_unaligned(
 fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    copy_account_data: bool,
+    direct_mapping: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -396,7 +396,7 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
             }
             start += size_of::<u64>() // lamports
                 + size_of::<u64>(); // data length
-            if copy_account_data {
+            if !direct_mapping {
                 let data = buffer
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?;
@@ -422,7 +422,7 @@ fn serialize_parameters_aligned(
     accounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
-    copy_account_data: bool,
+    direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -450,7 +450,7 @@ fn serialize_parameters_aligned(
                 + size_of::<u64>()  // lamports
                 + size_of::<u64>()  // data len
                 + size_of::<u64>(); // rent epoch
-                if copy_account_data {
+                if !direct_mapping {
                     size += data_len
                         + MAX_PERMITTED_DATA_INCREASE
                         + (data_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
@@ -464,7 +464,7 @@ fn serialize_parameters_aligned(
     + instruction_data.len()
     + size_of::<Pubkey>(); // program id;
 
-    let mut s = Serializer::new(size, MM_INPUT_START, true, copy_account_data);
+    let mut s = Serializer::new(size, MM_INPUT_START, true, direct_mapping);
 
     // Serialize into the buffer
     s.write::<u64>((accounts.len() as u64).to_le());
@@ -514,7 +514,7 @@ fn serialize_parameters_aligned(
 fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    copy_account_data: bool,
+    direct_mapping: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -562,7 +562,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
             {
                 return Err(InstructionError::InvalidRealloc);
             }
-            if copy_account_data {
+            if !direct_mapping {
                 let data = buffer
                     .get(start..start + post_len)
                     .ok_or(InstructionError::InvalidArgument)?;
@@ -575,7 +575,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
             } else if borrowed_account.get_data().len() != post_len {
                 borrowed_account.set_data_length(post_len)?;
             }
-            start += if copy_account_data {
+            start += if !direct_mapping {
                 let alignment_offset = (pre_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
                 pre_len // data
                     .saturating_add(MAX_PERMITTED_DATA_INCREASE) // realloc padding
@@ -650,7 +650,7 @@ mod tests {
             name: &'static str,
         }
 
-        for copy_account_data in [true] {
+        for direct_mapping in [false] {
             for TestCase {
                 num_ix_accounts,
                 append_dup_account,
@@ -729,7 +729,7 @@ mod tests {
                 let serialization_result = serialize_parameters(
                     invoke_context.transaction_context,
                     instruction_context,
-                    copy_account_data,
+                    direct_mapping,
                     true, // mask_out_rent_epoch_in_vm_serialization
                 );
                 assert_eq!(
@@ -745,7 +745,7 @@ mod tests {
                 let mut serialized_regions = concat_regions(&regions);
                 let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                     deserialize(
-                        if copy_account_data {
+                        if !direct_mapping {
                             serialized.as_slice_mut()
                         } else {
                             serialized_regions.as_slice_mut()
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_serialize_parameters() {
-        for copy_account_data in [false, true] {
+        for direct_mapping in [false, true] {
             let program_id = solana_pubkey::new_rand();
             let transaction_accounts = vec![
                 (
@@ -873,18 +873,18 @@ mod tests {
             let (mut serialized, regions, accounts_metadata) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                copy_account_data,
+                direct_mapping,
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
 
             let mut serialized_regions = concat_regions(&regions);
-            if copy_account_data {
+            if !direct_mapping {
                 assert_eq!(serialized.as_slice(), serialized_regions.as_slice());
             }
             let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                 deserialize(
-                    if copy_account_data {
+                    if !direct_mapping {
                         serialized.as_slice_mut()
                     } else {
                         serialized_regions.as_slice_mut()
@@ -933,7 +933,7 @@ mod tests {
             deserialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                copy_account_data,
+                direct_mapping,
                 serialized.as_slice(),
                 &accounts_metadata,
             )
@@ -966,7 +966,7 @@ mod tests {
             let (mut serialized, regions, account_lengths) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                copy_account_data,
+                direct_mapping,
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -974,7 +974,7 @@ mod tests {
 
             let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                 deserialize_unaligned(
-                    if copy_account_data {
+                    if !direct_mapping {
                         serialized.as_slice_mut()
                     } else {
                         serialized_regions.as_slice_mut()
@@ -1005,7 +1005,7 @@ mod tests {
             deserialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                copy_account_data,
+                direct_mapping,
                 serialized.as_slice(),
                 &account_lengths,
             )

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -134,7 +134,7 @@ pub fn invoke_builtin_function(
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,
-        true, // copy_account_data // There is no VM so direct mapping can not be implemented here
+        false, // direct_mapping // There is no VM so direct mapping can not be implemented here
         mask_out_rent_epoch_in_vm_serialization,
     )?;
 

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -124,7 +124,7 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false,
+                true, // direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -142,8 +142,8 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true,
-                true, // mask_out_rent_epoch_in_vm_serialization
+                false, // direct_mapping
+                true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
         });
@@ -161,7 +161,7 @@ fn bench_serialize_aligned(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false,
+                true, // direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -180,8 +180,8 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true,
-                true, // mask_out_rent_epoch_in_vm_serialization
+                false, // direct_mapping
+                true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
         });
@@ -199,7 +199,7 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false,
+                true, // direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -218,7 +218,7 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false,
+                true, // direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1610,7 +1610,7 @@ fn execute<'a, 'b: 'a>(
     let (parameter_bytes, regions, accounts_metadata) = serialization::serialize_parameters(
         invoke_context.transaction_context,
         instruction_context,
-        !direct_mapping,
+        direct_mapping,
         mask_out_rent_epoch_in_vm_serialization,
     )?;
     serialize_time.stop();
@@ -1769,14 +1769,14 @@ fn execute<'a, 'b: 'a>(
     fn deserialize_parameters(
         invoke_context: &mut InvokeContext,
         parameter_bytes: &[u8],
-        copy_account_data: bool,
+        direct_mapping: bool,
     ) -> Result<(), InstructionError> {
         serialization::deserialize_parameters(
             invoke_context.transaction_context,
             invoke_context
                 .transaction_context
                 .get_current_instruction_context()?,
-            copy_account_data,
+            direct_mapping,
             parameter_bytes,
             &invoke_context.get_syscall_context()?.accounts_metadata,
         )
@@ -1784,7 +1784,7 @@ fn execute<'a, 'b: 'a>(
 
     let mut deserialize_time = Measure::start("deserialize");
     let execute_or_deserialize_result = execution_result.and_then(|_| {
-        deserialize_parameters(invoke_context, parameter_bytes.as_slice(), !direct_mapping)
+        deserialize_parameters(invoke_context, parameter_bytes.as_slice(), direct_mapping)
             .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
     });
     deserialize_time.stop();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -243,8 +243,8 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        !direct_mapping, // copy_account_data
-        true,            // mask_out_rent_epoch_in_vm_serialization
+        direct_mapping,
+        true, // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 
@@ -278,8 +278,8 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        !direct_mapping, // copy_account_data
-        true,            // mask_out_rent_epoch_in_vm_serialization
+        direct_mapping,
+        true, // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 


### PR DESCRIPTION
#### Problem

The fields `aligned` and `copy_account_data` of `Serializer` are quite confusing because they are the opposite of what the rest of the code base uses.

#### Summary of Changes

- Inverts the boolean parameter `copy_account_data` to `direct_mapping`.
- Inverts the boolean parameter `aligned` to `is_loader_v1`.