### PR TITLE
runtime: Inline `solana_sha256_hasher::extend_and_hash`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4455,9 +4455,7 @@ impl Bank {
             .unwrap()
             .get_hash_data(slot, self.parent_slot());
         if let Some(buf) = buf {
-            let mut hash_data = hash.as_ref().to_vec();
-            hash_data.extend_from_slice(&buf);
-            let hard_forked_hash = hashv(&[&hash_data]);
+            let hard_forked_hash = hashv(&[hash.as_ref(), &buf]);
             warn!("hard fork at slot {slot} by hashing {buf:?}: {hash} => {hard_forked_hash}");
             hash = hard_forked_hash;
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -127,7 +127,7 @@ use {
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk_ids::{bpf_loader_upgradeable, incinerator, native_loader},
-    solana_sha256_hasher::{extend_and_hash, hashv},
+    solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_slot_hashes::SlotHashes,
     solana_slot_history::{Check, SlotHistory},
@@ -4455,7 +4455,9 @@ impl Bank {
             .unwrap()
             .get_hash_data(slot, self.parent_slot());
         if let Some(buf) = buf {
-            let hard_forked_hash = extend_and_hash(&hash, &buf);
+            let mut hash_data = hash.as_ref().to_vec();
+            hash_data.extend_from_slice(&buf);
+            let hard_forked_hash = hashv(&[&hash_data]);
             warn!("hard fork at slot {slot} by hashing {buf:?}: {hash} => {hard_forked_hash}");
             hash = hard_forked_hash;
         }


### PR DESCRIPTION
#### Problem

`solana_sha256_hasher::extend_and_hash` requires dynamic allocation because of the vec creation, which means adding a `std` feature to the crate.

However, the function is only used in one place, so it would be easier to remove it and simplify the hasher crate.

#### Summary of changes

Inline the usage of `extend_and_hash` so it can be safely removed from the hasher crate.

For reference, here is the current implementation of `extend_and_hash`: https://github.com/anza-xyz/solana-sdk/blob/020e730cdac5806447aafefe5e53afb049c18a3d/sha256-hasher/src/lib.rs#L62-L66