### PR TITLE
Subscription requests now take priority over notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Release channels have their own copy of this changelog:
 <a name="edge-channel"></a>
 ## 3.0.0 - Unreleased
 
+### RPC
+
+#### Changes
+* The subscription server now prioritizes processing received messages before sending out responses. This ensures that new subscription requests and time-sensitive messages like `PING` opcodes take priority over notifications.
+
 ### Validator
 
 #### Breaking

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -401,6 +401,12 @@ async fn handle_connection(
             pin!(receive_future);
             loop {
                 select! {
+                    biased; // See [prioritization] note below.
+
+                    // [prioritization]
+                    // This block must come FIRST in the `select!` macro. This prioritizes
+                    // processing received messages over sending messages. This ensures the timely
+                    // processing of new subscriptions and time-sensitive opcodes like `PING`.
                     result = &mut receive_future => match result {
                         Ok(_) => break,
                         Err(soketto::connection::Error::Closed) => return Ok(()),


### PR DESCRIPTION
#### Problem

When there are a ton of notifications ready to send out over the RPC subscriptions server, they can end up starving the _request_ processor. This means that time-sensitive requests like `PING` and new subscription requests don't get through.

#### Summary of Changes

_Always_ process waiting requests before sending out ready notifications.

#### Test plan

Add a sleep to let a ton of notifications pile up in the broadcast sender.

```diff
  select! {
      result = &mut receive_future => match result {
          Ok(_) => {
              break;
          },
          Err(soketto::connection::Error::Closed) => return Ok(()),
          Err(err) => return Err(err.into()),
      },
      result = broadcast_receiver.recv() => {
          // In both possible error cases (closed or lagged) we disconnect the client.
          if let Some(json) = broadcast_handler.handle(result?)? {
              sender.send_text(&*json).await?;
          }
+         sleep(Duration::from_secs(6)).await;
      },
      _ = &mut tripwire => {
          warn!("disconnecting websocket client: shutting down");
          return Ok(())
      },
  }
```

Send pings from the client.
```ts
import ws from "ws";

const w = new ws("ws://127.0.0.1:8900");

w.on("message", function (message) {
  console.log("<<<", new TextDecoder().decode(message));
});

// When connected, send a PING
w.on("open", function open() {
  console.log("Connected to WebSocket server.");
  w.send('{"id":1,"jsonrpc":"2.0","method":"blockSubscribe","params":["all"]}');
  console.log("Subscribed to blocks");
  setInterval(() => {
    w.ping();
    console.log("Sent PING.");
  }, 5000);
});

// Optional: Listen for PONG responses from the server
w.on("pong", function () {
  console.log("PONG received.");
});
```

Observe that they _always_ get processed before the next notification gets sent.

Fixes #7022