### PR TITLE
Removes MerkleOrLatticeAccountsHash enum

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1247,15 +1247,6 @@ pub const ZERO_LAMPORT_ACCOUNT_LT_HASH: AccountLtHash = AccountLtHash(LtHash::id
 pub struct AccountsLtHash(pub LtHash);
 
 /// Hash of accounts
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum MerkleOrLatticeAccountsHash {
-    /// Merkle-based hash of accounts
-    Merkle(AccountsHashKind),
-    /// Lattice-based hash of accounts
-    Lattice,
-}
-
-/// Hash of accounts
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AccountsHashKind {
     Full(AccountsHash),

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -3,7 +3,6 @@
 use {
     crate::snapshot_packager_service::PendingSnapshotPackages,
     crossbeam_channel::{Receiver, Sender},
-    solana_accounts_db::accounts_hash::MerkleOrLatticeAccountsHash,
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_measure::measure_us,
     solana_runtime::{
@@ -178,12 +177,7 @@ impl AccountsHashVerifier {
     ) -> io::Result<()> {
         Self::purge_old_accounts_hashes(&accounts_package, snapshot_config);
 
-        Self::submit_for_packaging(
-            accounts_package,
-            pending_snapshot_packages,
-            MerkleOrLatticeAccountsHash::Lattice,
-            None,
-        );
+        Self::submit_for_packaging(accounts_package, pending_snapshot_packages, None);
 
         Ok(())
     }
@@ -222,7 +216,6 @@ impl AccountsHashVerifier {
     fn submit_for_packaging(
         accounts_package: AccountsPackage,
         pending_snapshot_packages: &Mutex<PendingSnapshotPackages>,
-        merkle_or_lattice_accounts_hash: MerkleOrLatticeAccountsHash,
         bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     ) {
         if !matches!(
@@ -232,11 +225,8 @@ impl AccountsHashVerifier {
             return;
         }
 
-        let snapshot_package = SnapshotPackage::new(
-            accounts_package,
-            merkle_or_lattice_accounts_hash,
-            bank_incremental_snapshot_persistence,
-        );
+        let snapshot_package =
+            SnapshotPackage::new(accounts_package, bank_incremental_snapshot_persistence);
         pending_snapshot_packages
             .lock()
             .unwrap()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -80,7 +80,7 @@ use {
         },
         accounts_hash::{
             AccountsHash, AccountsLtHash, CalcAccountsHashConfig, HashStats,
-            IncrementalAccountsHash, MerkleOrLatticeAccountsHash,
+            IncrementalAccountsHash,
         },
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -4809,10 +4809,7 @@ impl Bank {
     ///
     /// This fn is used at startup to verify the bank was rebuilt correctly.
     pub fn get_snapshot_hash(&self) -> SnapshotHash {
-        SnapshotHash::new(
-            &MerkleOrLatticeAccountsHash::Lattice,
-            Some(self.accounts_lt_hash.lock().unwrap().0.checksum()),
-        )
+        SnapshotHash::new(Some(self.accounts_lt_hash.lock().unwrap().0.checksum()))
     }
 
     pub fn load_account_into_read_cache(&self, key: &Pubkey) {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -39,7 +39,6 @@ use {
     log::*,
     solana_accounts_db::{
         accounts_db::{AccountStorageEntry, AccountsDbConfig, AtomicAccountsFileId},
-        accounts_hash::MerkleOrLatticeAccountsHash,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         utils::remove_dir_contents,
     },
@@ -789,7 +788,6 @@ fn bank_to_full_snapshot_archive_with(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
-    let merkle_or_lattice_accounts_hash = MerkleOrLatticeAccountsHash::Lattice;
     let snapshot_storages = bank.get_snapshot_storages(None);
     let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new_for_snapshot(
@@ -798,8 +796,7 @@ fn bank_to_full_snapshot_archive_with(
         snapshot_storages,
         status_cache_slot_deltas,
     );
-    let snapshot_package =
-        SnapshotPackage::new(accounts_package, merkle_or_lattice_accounts_hash, None);
+    let snapshot_package = SnapshotPackage::new(accounts_package, None);
 
     let snapshot_config = SnapshotConfig {
         full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
@@ -849,8 +846,6 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
-    let (merkle_or_lattice_accounts_hash, bank_incremental_snapshot_persistence) =
-        (MerkleOrLatticeAccountsHash::Lattice, None);
     let snapshot_storages = bank.get_snapshot_storages(Some(full_snapshot_slot));
     let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new_for_snapshot(
@@ -859,11 +854,7 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_storages,
         status_cache_slot_deltas,
     );
-    let snapshot_package = SnapshotPackage::new(
-        accounts_package,
-        merkle_or_lattice_accounts_hash,
-        bank_incremental_snapshot_persistence,
-    );
+    let snapshot_package = SnapshotPackage::new(accounts_package, None);
 
     // Note: Since the snapshot_storages above are *only* the incremental storages,
     // this bank snapshot *cannot* be used by fastboot.

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -1,7 +1,7 @@
 //! Helper types and functions for handling and dealing with snapshot hashes.
 use {
-    solana_accounts_db::accounts_hash::MerkleOrLatticeAccountsHash, solana_clock::Slot,
-    solana_hash::Hash, solana_lattice_hash::lt_hash::Checksum as AccountsLtHashChecksum,
+    solana_clock::Slot, solana_hash::Hash,
+    solana_lattice_hash::lt_hash::Checksum as AccountsLtHashChecksum,
 };
 
 /// At startup, when loading from snapshots, the starting snapshot hashes need to be passed to
@@ -32,19 +32,13 @@ impl SnapshotHash {
     /// Make a snapshot hash from accounts hashes
     #[must_use]
     pub fn new(
-        merkle_or_lattice_accounts_hash: &MerkleOrLatticeAccountsHash,
         accounts_lt_hash_checksum: Option<AccountsLtHashChecksum>, // option wrapper will be removed next
     ) -> Self {
-        let accounts_hash = match merkle_or_lattice_accounts_hash {
-            MerkleOrLatticeAccountsHash::Merkle(accounts_hash_kind) => {
-                *accounts_hash_kind.as_hash()
-            }
-            MerkleOrLatticeAccountsHash::Lattice => Hash::new_from_array(
-                accounts_lt_hash_checksum
-                    .expect("lattice kind must have lt hash checksum")
-                    .0,
-            ),
-        };
+        let accounts_hash = Hash::new_from_array(
+            accounts_lt_hash_checksum
+                .expect("lattice kind must have lt hash checksum")
+                .0,
+        );
         Self(accounts_hash)
     }
 }


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

For this PR, remove the unused MerkleOrLatticeAccountsHash enum.
