### PR TITLE
Use `Instruction` instead of `StableInstruction` across runtime

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -42,7 +42,6 @@ use {
         runtime_config::RuntimeConfig,
     },
     solana_signer::Signer,
-    solana_stable_layout::stable_instruction::StableInstruction,
     solana_sysvar::Sysvar,
     solana_sysvar_id::SysvarId,
     solana_timings::ExecuteTimings,
@@ -250,7 +249,6 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
         account_infos: &[AccountInfo],
         signers_seeds: &[&[&[u8]]],
     ) -> ProgramResult {
-        let instruction = StableInstruction::from(instruction.clone());
         let invoke_context = get_invoke_context();
         let log_collector = invoke_context.get_log_collector();
         let transaction_context = &invoke_context.transaction_context;
@@ -273,7 +271,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .collect::<Vec<_>>();
 
         let (instruction_accounts, program_indices) = invoke_context
-            .prepare_instruction(&instruction, &signers)
+            .prepare_instruction(instruction, &signers)
             .unwrap();
 
         // Copy caller's account_info modifications into invoke_context accounts

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -659,7 +659,7 @@ fn process_loader_upgradeable_instruction(
                 .iter()
                 .map(|seeds| Pubkey::create_program_address(seeds, caller_program_id))
                 .collect::<Result<Vec<Pubkey>, solana_pubkey::PubkeyError>>()?;
-            invoke_context.native_invoke(instruction.into(), signers.as_slice())?;
+            invoke_context.native_invoke(instruction, signers.as_slice())?;
 
             // Load and verify the program bits
             let transaction_context = &invoke_context.transaction_context;
@@ -1291,8 +1291,7 @@ fn process_loader_upgradeable_instruction(
                         &provided_authority_address,
                         program_len as u32,
                         &program_address,
-                    )
-                    .into(),
+                    ),
                     &[],
                 )?;
 
@@ -1304,8 +1303,7 @@ fn process_loader_upgradeable_instruction(
                         0,
                         0,
                         program_len as u32,
-                    )
-                    .into(),
+                    ),
                     &[],
                 )?;
 
@@ -1313,8 +1311,7 @@ fn process_loader_upgradeable_instruction(
                     solana_loader_v4_interface::instruction::deploy(
                         &program_address,
                         &provided_authority_address,
-                    )
-                    .into(),
+                    ),
                     &[],
                 )?;
 
@@ -1324,8 +1321,7 @@ fn process_loader_upgradeable_instruction(
                             &program_address,
                             &provided_authority_address,
                             &program_address,
-                        )
-                        .into(),
+                        ),
                         &[],
                     )?;
                 } else if migration_authority::check_id(&provided_authority_address) {
@@ -1334,8 +1330,7 @@ fn process_loader_upgradeable_instruction(
                             &program_address,
                             &provided_authority_address,
                             &upgrade_authority_address.unwrap(),
-                        )
-                        .into(),
+                        ),
                         &[],
                     )?;
                 }
@@ -1496,7 +1491,7 @@ fn common_extend_program(
         )?;
 
         invoke_context.native_invoke(
-            system_instruction::transfer(&payer_key, &programdata_key, required_payment).into(),
+            system_instruction::transfer(&payer_key, &programdata_key, required_payment),
             &[],
         )?;
     }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     crate::{translate_inner, translate_slice_inner, translate_type_inner},
+    solana_instruction::Instruction,
     solana_loader_v3_interface::instruction as bpf_loader_upgradeable,
     solana_measure::measure::Measure,
     solana_program_runtime::{
@@ -326,7 +327,7 @@ trait SyscallInvokeSigned {
         addr: u64,
         memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Error>;
+    ) -> Result<Instruction, Error>;
     fn translate_accounts<'a>(
         instruction_accounts: &[InstructionAccount],
         account_infos_addr: u64,
@@ -373,7 +374,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         addr: u64,
         memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Error> {
+    ) -> Result<Instruction, Error> {
         let ix = translate_type::<StableInstruction>(
             memory_mapping,
             addr,
@@ -419,9 +420,9 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
             accounts.push(account_meta.clone());
         }
 
-        Ok(StableInstruction {
-            accounts: accounts.into(),
-            data: data.into(),
+        Ok(Instruction {
+            accounts,
+            data,
             program_id: ix.program_id,
         })
     }
@@ -580,7 +581,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         addr: u64,
         memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-    ) -> Result<StableInstruction, Error> {
+    ) -> Result<Instruction, Error> {
         let ix_c = translate_type::<SolInstruction>(
             memory_mapping,
             addr,
@@ -641,9 +642,9 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
             });
         }
 
-        Ok(StableInstruction {
-            accounts: accounts.into(),
-            data: data.into(),
+        Ok(Instruction {
+            accounts,
+            data,
             program_id: *program_id,
         })
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4695,8 +4695,7 @@ pub mod tests {
                 lamports,
                 space,
                 &owner_pubkey,
-            )
-            .into(),
+            ),
             &[],
         )?;
 

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -108,7 +108,7 @@ mod tests_core_bpf_migration {
 
             let instruction = Instruction::new_with_bytes(*target_program_id, &[], Vec::new());
 
-            invoke_context.native_invoke(instruction.into(), &[])
+            invoke_context.native_invoke(instruction, &[])
         });
     }
 


### PR DESCRIPTION
#### Problem

The runtime code is very complex, containing multiple sites with similar code doing the same thing, many data structures to represent the same underlying data and too many conversions between them.

That conundrum hinders proper refactors for ABIv2 and the simplification of our runtime code.

#### Summary of Changes

This PR replaces `StableIntruction` by `Instruction` across runtime, except in address translation, where the switch is not possible.

That reduces the conversion overhead and will allow us to further simplify our code in future PRs.

