### PR TITLE
perf: move benchmarks to bencher 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9321,6 +9321,7 @@ version = "3.0.0"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
+ "bencher",
  "bincode",
  "bv",
  "bytes",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -77,6 +77,7 @@ nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+bencher = { workspace = true }
 rand_chacha = { workspace = true }
 solana-logger = { workspace = true }
 solana-perf = { path = ".", features = ["dev-context-only-utils"] }
@@ -86,10 +87,28 @@ test-case = { workspace = true }
 jemallocator = { workspace = true }
 
 [[bench]]
+name = "dedup"
+harness = false
+
+[[bench]]
+name = "recycler"
+harness = false
+
+[[bench]]
+name = "reset"
+harness = false
+
+[[bench]]
+name = "shrink"
+harness = false
+
+[[bench]]
 name = "sigverify"
+harness = false
 
 [[bench]]
 name = "discard"
+harness = false
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/perf/benches/discard.rs
+++ b/perf/benches/discard.rs
@@ -1,10 +1,6 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
+    bencher::{benchmark_group, benchmark_main, Bencher},
     solana_perf::{discard::discard_batches_randomly, packet::to_packet_batches, test_tx::test_tx},
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -13,8 +9,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 const NUM: usize = 1000;
 
-#[bench]
-fn bench_discard(bencher: &mut Bencher) {
+fn bench_discard(b: &mut Bencher) {
     solana_logger::setup();
     let tx = test_tx();
     let num_packets = NUM;
@@ -25,9 +20,12 @@ fn bench_discard(bencher: &mut Bencher) {
         10,
     );
 
-    bencher.iter(|| {
+    b.iter(|| {
         let mut discarded = batches.clone();
         discard_batches_randomly(&mut discarded, 100, NUM);
         assert_eq!(discarded.len(), 10);
     })
 }
+
+benchmark_group!(benches, bench_discard);
+benchmark_main!(benches);

--- a/perf/benches/recycler.rs
+++ b/perf/benches/recycler.rs
@@ -1,14 +1,9 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
+    bencher::{benchmark_group, benchmark_main, Bencher},
     solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
-    test::Bencher,
 };
 
-#[bench]
-fn bench_recycler(bencher: &mut Bencher) {
+fn bench_recycler(b: &mut Bencher) {
     solana_logger::setup();
 
     let recycler: PacketBatchRecycler = Recycler::default();
@@ -17,7 +12,10 @@ fn bench_recycler(bencher: &mut Bencher) {
         let _packet = recycler.allocate("");
     }
 
-    bencher.iter(move || {
+    b.iter(move || {
         let _packet = recycler.allocate("");
     });
 }
+
+benchmark_group!(benches, bench_recycler);
+benchmark_main!(benches);

--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -1,10 +1,9 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
-    std::sync::atomic::{AtomicU64, Ordering},
-    test::Bencher,
+    bencher::{benchmark_group, benchmark_main, Bencher},
+    std::{
+        hint::black_box,
+        sync::atomic::{AtomicU64, Ordering},
+    },
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -16,15 +15,14 @@ const N: usize = 1_000_000;
 // test bench_reset1 ... bench:     436,240 ns/iter (+/- 176,714)
 // test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
 
-#[bench]
-fn bench_reset1(bencher: &mut Bencher) {
+fn bench_reset1(b: &mut Bencher) {
     solana_logger::setup();
 
     let mut v = Vec::with_capacity(N);
     v.resize_with(N, AtomicU64::default);
 
-    bencher.iter(|| {
-        test::black_box({
+    b.iter(|| {
+        black_box({
             for i in &v {
                 i.store(0, Ordering::Relaxed);
             }
@@ -33,18 +31,20 @@ fn bench_reset1(bencher: &mut Bencher) {
     });
 }
 
-#[bench]
-fn bench_reset2(bencher: &mut Bencher) {
+fn bench_reset2(b: &mut Bencher) {
     solana_logger::setup();
 
     let mut v = Vec::with_capacity(N);
     v.resize_with(N, AtomicU64::default);
 
-    bencher.iter(|| {
-        test::black_box({
+    b.iter(|| {
+        black_box({
             v.clear();
             v.resize_with(N, AtomicU64::default);
             0
         });
     });
 }
+
+benchmark_group!(benches, bench_reset2, bench_reset1);
+benchmark_main!(benches);


### PR DESCRIPTION
#### Problem
Our benchmarking setup relies on nightly compiler which is not what we use for actual builds of agave. Using the same compiler (stable) for releases and benches would be preferable #5931

#### Summary of Changes
Moved benchmarks to  bencher 0.1.5.