### PR TITLE
GCE: fix gce.sh startup

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -189,9 +189,8 @@ annotateBlockexplorerUrl() {
 }
 
 build() {
-  supported=("22.04")
   declare MAYBE_DOCKER=
-  if [[ $(uname) != Linux || ! " ${supported[*]} " =~ $(lsb_release -sr) ]]; then
+  if [[ $(uname) != Linux ]]; then
     # shellcheck source=ci/docker/env.sh
     source "$SOLANA_ROOT"/ci/docker/env.sh
     MAYBE_DOCKER="ci/docker-run.sh ${CI_DOCKER_IMAGE:?}"

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -170,7 +170,6 @@ cloud_CreateInstances() {
   declare optionalBootDiskType="${10:-pd-ssd}"
   declare optionalAdditionalDiskSize="${11}"
   declare optionalPreemptible="${12}"
-  #declare sshPrivateKey="${13}"  # unused
 
   if $enableGpu; then
     # Custom Ubuntu 20.04 LTS image with CUDA 10.2 installed
@@ -185,7 +184,7 @@ cloud_CreateInstances() {
     echo "Error: Not supported" >&2
     exit 1
   else
-    imageName="ubuntu-2204-jammy-v20241119 --image-project ubuntu-os-cloud"
+    imageName="ubuntu-2404-noble-amd64-v20250709 --image-project ubuntu-os-cloud"
   fi
 
   declare -a nodes

--- a/net/scripts/install-earlyoom.sh
+++ b/net/scripts/install-earlyoom.sh
@@ -15,8 +15,7 @@ echo kernel.sysrq=1 >> /etc/sysctl.conf
 if command -v earlyoom; then
   systemctl status earlyoom
 else
-  wget  -r -l1 -np http://ftp.us.debian.org/debian/pool/main/e/earlyoom/ -A 'earlyoom_1.2-*_amd64.deb' -e robots=off -nd
-  apt install --quiet --yes ./earlyoom_1.2-*_amd64.deb
+  apt-get install --quiet --yes earlyoom
 
   cat > earlyoom <<OOM
   # trigger at 20% available RAM,

--- a/net/scripts/network-config.sh
+++ b/net/scripts/network-config.sh
@@ -15,5 +15,4 @@ sudo sysctl -w vm.max_map_count=1000000
 echo "* - nofile 1000000" | sudo tee -a /etc/security/limits.conf
 
 echo "MaxAuthTries 60" | sudo tee -a /etc/ssh/sshd_config
-sudo service sshd restart
-sudo systemctl restart sshd
+sudo systemctl restart ssh


### PR DESCRIPTION
#### Problem

- gce was fetching a broken deb from some random FTP rather than using apt => did not work
- gce would deploy older version of ubuntu on the target hosts
- that caused it to use docker to build everything on the client which is generally slow and cumbersome
- updating to recent ubuntu release also breaks SSH startup

#### Summary of Changes

- replace random deb with apt-get install
- update to use 24.04 ubuntu image
- remove docker requirement for any host not running 22.04
- fix the SSH startup script