### PR TITLE
perf: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -171,7 +171,7 @@ mod tests {
             let mut batches =
                 to_packet_batches(&(0..1000).map(|_| test_tx()).collect::<Vec<_>>(), 128);
             discard += dedup_packets_and_count_discards(&filter, &mut batches) as usize;
-            trace!("{} {}", i, discard);
+            trace!("{i} {discard}");
             if filter.popcount.load(Ordering::Relaxed) > capacity {
                 break;
             }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -68,8 +68,9 @@ pub fn report_target_features() {
                 info!("AVX detected");
             } else {
                 error!(
-                "Incompatible CPU detected: missing AVX support. Please build from source on the target"
-            );
+                    "Incompatible CPU detected: missing AVX support. Please build from source on \
+                     the target"
+                );
                 std::process::abort();
             }
         }
@@ -83,7 +84,8 @@ pub fn report_target_features() {
                 info!("AVX2 detected");
             } else {
                 error!(
-                    "Incompatible CPU detected: missing AVX2 support. Please build from source on the target"
+                    "Incompatible CPU detected: missing AVX2 support. Please build from source on \
+                     the target"
                 );
                 std::process::abort();
             }

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -685,7 +685,7 @@ impl PinnedPacketBatch {
                     // TODO: This should never happen. Instead the caller should
                     // break the payload into smaller messages, and here any errors
                     // should be propagated.
-                    error!("Couldn't write to packet {:?}. Data skipped.", e);
+                    error!("Couldn't write to packet {e:?}. Data skipped.");
                     packet.meta_mut().set_discard(true);
                 }
             } else {

--- a/perf/src/perf_libs.rs
+++ b/perf/src/perf_libs.rs
@@ -84,10 +84,10 @@ pub struct Api<'a> {
 static API: OnceLock<Container<Api>> = OnceLock::new();
 
 fn init(name: &OsStr) {
-    info!("Loading {:?}", name);
+    info!("Loading {name:?}");
     API.get_or_init(|| {
         unsafe { Container::load(name) }.unwrap_or_else(|err| {
-            error!("Unable to load {:?}: {}", name, err);
+            error!("Unable to load {name:?}: {err}");
             std::process::exit(1);
         })
     });
@@ -97,10 +97,10 @@ pub fn locate_perf_libs() -> Option<PathBuf> {
     let exe = env::current_exe().expect("Unable to get executable path");
     let perf_libs = exe.parent().unwrap().join("perf-libs");
     if perf_libs.is_dir() {
-        info!("perf-libs found at {:?}", perf_libs);
+        info!("perf-libs found at {perf_libs:?}");
         return Some(perf_libs);
     }
-    warn!("{:?} does not exist", perf_libs);
+    warn!("{perf_libs:?} does not exist");
     None
 }
 
@@ -108,10 +108,10 @@ fn find_cuda_home(perf_libs_path: &Path) -> Option<PathBuf> {
     if let Ok(cuda_home) = env::var("CUDA_HOME") {
         let path = PathBuf::from(cuda_home);
         if path.is_dir() {
-            info!("Using CUDA_HOME: {:?}", path);
+            info!("Using CUDA_HOME: {path:?}");
             return Some(path);
         }
-        warn!("Ignoring CUDA_HOME, not a path: {:?}", path);
+        warn!("Ignoring CUDA_HOME, not a path: {path:?}");
     }
 
     // Search /usr/local for a `cuda-` directory that matches a perf-libs subdirectory
@@ -130,7 +130,7 @@ fn find_cuda_home(perf_libs_path: &Path) -> Option<PathBuf> {
             continue;
         }
 
-        info!("CUDA installation found at {:?}", cuda_home);
+        info!("CUDA installation found at {cuda_home:?}");
         return Some(cuda_home);
     }
     None
@@ -141,7 +141,7 @@ pub fn append_to_ld_library_path(mut ld_library_path: String) {
         ld_library_path.push(':');
         ld_library_path.push_str(&env_value);
     }
-    info!("setting ld_library_path to: {:?}", ld_library_path);
+    info!("setting ld_library_path to: {ld_library_path:?}");
     env::set_var("LD_LIBRARY_PATH", ld_library_path);
 }
 
@@ -154,7 +154,7 @@ pub fn init_cuda() {
                 // to ensure the correct CUDA version is used
                 append_to_ld_library_path(cuda_lib64_dir.to_str().unwrap_or("").to_string())
             } else {
-                warn!("CUDA lib64 directory does not exist: {:?}", cuda_lib64_dir);
+                warn!("CUDA lib64 directory does not exist: {cuda_lib64_dir:?}");
             }
 
             let libcuda_crypt = perf_libs_path

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -47,7 +47,7 @@ pub struct RecyclerX<T> {
 impl<T: Default> Default for RecyclerX<T> {
     fn default() -> RecyclerX<T> {
         let id = thread_rng().gen_range(0..1000);
-        trace!("new recycler..{}", id);
+        trace!("new recycler..{id}");
         RecyclerX {
             gc: Mutex::default(),
             stats: RecyclerStats::default(),

--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -81,9 +81,8 @@ where
         Ok(())
     } else {
         Err(String::from(
-            "niceness adjustment supported only on Linux; negative adjustment \
-             (priority increase) requires root or CAP_SYS_NICE (see `man 7 capabilities` \
-             for details)",
+            "niceness adjustment supported only on Linux; negative adjustment (priority increase) \
+             requires root or CAP_SYS_NICE (see `man 7 capabilities` for details)",
         ))
     }
 }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`