### PR TITLE
net-utils: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -163,7 +163,7 @@ pub(crate) async fn verify_all_reachable_tcp(
             bind_address,
         )
         .await
-        .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+        .map_err(|err| warn!("ip_echo_server request failed: {err}"));
 
         // spawn checker to wait for reply
         // since we do not know if tcp_listeners are nonblocking, we have to run them in native threads.
@@ -173,7 +173,7 @@ pub(crate) async fn verify_all_reachable_tcp(
 
             // Use blocking API since we have no idea if sockets given to us are nonblocking or not
             let thread_handle = tokio::task::spawn_blocking(move || {
-                debug!("Waiting for incoming connection on tcp/{}", port);
+                debug!("Waiting for incoming connection on tcp/{port}");
                 match tcp_listener.incoming().next() {
                     Some(_) => {
                         // ignore errors here since this can only happen if a timeout was detected.
@@ -251,8 +251,7 @@ pub(crate) async fn verify_all_reachable_udp(
         let ports: Vec<u16> = ports_to_socks_map.keys().copied().collect();
 
         info!(
-            "Checking that udp ports {:?} are reachable from bind IP {:?}",
-            ports, bind_ip
+            "Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}"
         );
 
         'outer: for chunk_to_check in ports.chunks(MAX_PORT_COUNT_PER_MESSAGE) {
@@ -275,7 +274,7 @@ pub(crate) async fn verify_all_reachable_udp(
                     bind_ip,
                 )
                 .await
-                .map_err(|err| warn!("ip_echo_server request failed: {}", err));
+                .map_err(|err| warn!("ip_echo_server request failed: {err}"));
 
                 let reachable_ports = Arc::new(RwLock::new(HashSet::new()));
                 // Spawn threads for each socket to check
@@ -301,8 +300,7 @@ pub(crate) async fn verify_all_reachable_udp(
 
                             let recv_result = socket.recv(&mut [0; 1]);
                             debug!(
-                                "Waited for incoming datagram on udp/{}: {:?}",
-                                port, recv_result
+                                "Waited for incoming datagram on udp/{port}: {recv_result:?}"
                             );
 
                             if recv_result.is_ok() {
@@ -327,8 +325,7 @@ pub(crate) async fn verify_all_reachable_udp(
                     .into_inner()
                     .expect("No threads should hold the lock");
                 info!(
-                    "checked udp ports: {:?}, reachable udp ports: {:?}",
-                    ports_to_check, reachable_ports
+                    "checked udp ports: {ports_to_check:?}, reachable udp ports: {reachable_ports:?}"
                 );
                 if reachable_ports.len() == ports_to_check.len() {
                     continue 'outer; // starts checking next chunk of ports, if any
@@ -336,8 +333,7 @@ pub(crate) async fn verify_all_reachable_udp(
             }
 
             error!(
-                "Maximum retry count reached. Some ports for IP {} unreachable.",
-                bind_ip
+                "Maximum retry count reached. Some ports for IP {bind_ip} unreachable."
             );
             return false;
         }

--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -98,12 +98,20 @@ fn parse_response(
         [b'H', b'T', b'T', b'P'] => {
             let http_response = std::str::from_utf8(body);
             match http_response {
-                Ok(r) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port replying with {r}"),
-                Err(_) => bail!("Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port."),
+                Ok(r) => bail!(
+                    "Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port \
+                     replying with {r}"
+                ),
+                Err(_) => bail!(
+                    "Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port."
+                ),
             }
         }
         _ => {
-            bail!("Invalid gossip entrypoint. {ip_echo_server_addr} provided unexpected header bytes {response_header:?} ");
+            bail!(
+                "Invalid gossip entrypoint. {ip_echo_server_addr} provided unexpected header \
+                 bytes {response_header:?} "
+            );
         }
     };
     Ok(payload)
@@ -250,9 +258,7 @@ pub(crate) async fn verify_all_reachable_udp(
     for (bind_ip, ports_to_socks_map) in ip_to_ports {
         let ports: Vec<u16> = ports_to_socks_map.keys().copied().collect();
 
-        info!(
-            "Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}"
-        );
+        info!("Checking that udp ports {ports:?} are reachable from bind IP {bind_ip:?}");
 
         'outer: for chunk_to_check in ports.chunks(MAX_PORT_COUNT_PER_MESSAGE) {
             let ports_to_check = chunk_to_check.to_vec();
@@ -299,9 +305,7 @@ pub(crate) async fn verify_all_reachable_udp(
                             }
 
                             let recv_result = socket.recv(&mut [0; 1]);
-                            debug!(
-                                "Waited for incoming datagram on udp/{port}: {recv_result:?}"
-                            );
+                            debug!("Waited for incoming datagram on udp/{port}: {recv_result:?}");
 
                             if recv_result.is_ok() {
                                 reachable_ports.write().unwrap().insert(port);
@@ -325,16 +329,15 @@ pub(crate) async fn verify_all_reachable_udp(
                     .into_inner()
                     .expect("No threads should hold the lock");
                 info!(
-                    "checked udp ports: {ports_to_check:?}, reachable udp ports: {reachable_ports:?}"
+                    "checked udp ports: {ports_to_check:?}, reachable udp ports: \
+                     {reachable_ports:?}"
                 );
                 if reachable_ports.len() == ports_to_check.len() {
                     continue 'outer; // starts checking next chunk of ports, if any
                 }
             }
 
-            error!(
-                "Maximum retry count reached. Some ports for IP {bind_ip} unreachable."
-            );
+            error!("Maximum retry count reached. Some ports for IP {bind_ip} unreachable.");
             return false;
         }
     }

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -68,7 +68,7 @@ async fn process_connection(
     peer_addr: SocketAddr,
     shred_version: Option<u16>,
 ) -> io::Result<()> {
-    info!("connection from {:?}", peer_addr);
+    info!("connection from {peer_addr:?}");
 
     let mut data = vec![0u8; ip_echo_server_request_length()];
 
@@ -104,7 +104,7 @@ async fn process_connection(
             ))
         })?;
 
-    trace!("request: {:?}", msg);
+    trace!("request: {msg:?}");
 
     // Fire a datagram at each non-zero UDP port
     match bind_to_unspecified() {
@@ -114,21 +114,21 @@ async fn process_connection(
                     let result =
                         udp_socket.send_to(&[0], SocketAddr::from((peer_addr.ip(), *udp_port)));
                     match result {
-                        Ok(_) => debug!("Successful send_to udp/{}", udp_port),
-                        Err(err) => info!("Failed to send_to udp/{}: {}", udp_port, err),
+                        Ok(_) => debug!("Successful send_to udp/{udp_port}"),
+                        Err(err) => info!("Failed to send_to udp/{udp_port}: {err}"),
                     }
                 }
             }
         }
         Err(err) => {
-            warn!("Failed to bind local udp socket: {}", err);
+            warn!("Failed to bind local udp socket: {err}");
         }
     }
 
     // Try to connect to each non-zero TCP port
     for tcp_port in &msg.tcp_ports {
         if *tcp_port != 0 {
-            debug!("Connecting to tcp/{}", tcp_port);
+            debug!("Connecting to tcp/{tcp_port}");
 
             let mut tcp_stream = timeout(
                 IO_TIMEOUT,
@@ -148,7 +148,7 @@ async fn process_connection(
     // conflict with the first four bytes of a valid HTTP response.
     let mut bytes = vec![0u8; IP_ECHO_SERVER_RESPONSE_LENGTH];
     bincode::serialize_into(&mut bytes[HEADER_LENGTH..], &response).unwrap();
-    trace!("response: {:?}", bytes);
+    trace!("response: {bytes:?}");
     writer.write_all(&bytes).await
 }
 
@@ -163,11 +163,11 @@ async fn run_echo_server(tcp_listener: std::net::TcpListener, shred_version: Opt
             Ok((socket, peer_addr)) => {
                 runtime::Handle::current().spawn(async move {
                     if let Err(err) = process_connection(socket, peer_addr, shred_version).await {
-                        info!("session failed: {:?}", err);
+                        info!("session failed: {err:?}");
                     }
                 });
             }
-            Err(err) => warn!("listener accept failed: {:?}", err),
+            Err(err) => warn!("listener accept failed: {err:?}"),
         }
     }
 }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -366,8 +366,7 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({} requested)",
-            num
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
         );
         num = 1;
     }
@@ -582,8 +581,7 @@ pub fn bind_more_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS {
         if num > 1 {
             warn!(
-                "bind_more_with_config() only supports 1 socket on this platform ({} requested)",
-                num
+                "bind_more_with_config() only supports 1 socket on this platform ({num} requested)"
             );
         }
         Ok(vec![socket])

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -366,7 +366,8 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} \
+             requested)"
         );
         num = 1;
     }
@@ -463,7 +464,8 @@ pub fn bind_common_with_config(
 
 #[deprecated(
     since = "2.3.2",
-    note = "Please avoid this function, in favor of sockets::bind_two_in_range_with_offset_and_config"
+    note = "Please avoid this function, in favor of \
+            sockets::bind_two_in_range_with_offset_and_config"
 )]
 #[allow(deprecated)]
 pub fn bind_two_in_range_with_offset(
@@ -483,7 +485,8 @@ pub fn bind_two_in_range_with_offset(
 
 #[deprecated(
     since = "2.3.2",
-    note = "Please avoid this function, in favor of sockets::bind_two_in_range_with_offset_and_config"
+    note = "Please avoid this function, in favor of \
+            sockets::bind_two_in_range_with_offset_and_config"
 )]
 #[allow(deprecated)]
 pub fn bind_two_in_range_with_offset_and_config(

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -34,7 +34,8 @@ pub fn localhost_port_range_for_tests() -> (u16, u16) {
                 let slot: u16 = slot.parse().unwrap();
                 assert!(
                     offset < SLICE_PER_PROCESS,
-                    "Overrunning into the port range of another test! Consider using fewer ports per test."
+                    "Overrunning into the port range of another test! Consider using fewer ports \
+                     per test."
                 );
                 BASE_PORT + slot * SLICE_PER_PROCESS
             }
@@ -217,7 +218,8 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} \
+             requested)"
         );
         num = 1;
     }

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -217,8 +217,7 @@ pub fn multi_bind_in_range_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS && num != 1 {
         // See https://github.com/solana-labs/solana/issues/4607
         warn!(
-            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({} requested)",
-            num
+            "multi_bind_in_range_with_config() only supports 1 socket on this platform ({num} requested)"
         );
         num = 1;
     }
@@ -320,8 +319,7 @@ pub fn bind_more_with_config(
     if !PLATFORM_SUPPORTS_SOCKET_CONFIGS {
         if num > 1 {
             warn!(
-                "bind_more_with_config() only supports 1 socket on this platform ({} requested)",
-                num
+                "bind_more_with_config() only supports 1 socket on this platform ({num} requested)"
             );
         }
         Ok(vec![socket])


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`