### PR TITLE
Reports total transaction fee collected in frozen bank to cost_tracker

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -53,10 +53,10 @@ impl CostUpdateService {
                     is_leader_block,
                 } => {
                     let (total_transaction_fee, total_priority_fee) = {
-                        let read_collector_fee_details = bank.read_collector_fee_details().unwrap();
+                        let collector_fee_details = bank.get_collector_fee_details();
                         (
-                            read_collector_fee_details.total_transaction_fee(),
-                            read_collector_fee_details.total_priority_fee(),
+                            collector_fee_details.total_transaction_fee(),
+                            collector_fee_details.total_priority_fee(),
                         )
                     };
                     for loop_count in 1..=MAX_LOOP_COUNT {

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -14,6 +14,7 @@ pub enum CostUpdate {
     FrozenBank {
         bank: Arc<Bank>,
         is_leader_block: bool,
+        total_transaction_fee: u64,
     },
 }
 
@@ -51,6 +52,7 @@ impl CostUpdateService {
                 CostUpdate::FrozenBank {
                     bank,
                     is_leader_block,
+                    total_transaction_fee,
                 } => {
                     for loop_count in 1..=MAX_LOOP_COUNT {
                         {
@@ -68,7 +70,11 @@ impl CostUpdateService {
                                     "inflight transaction count is {in_flight_transaction_count} \
                                      for slot {slot} after {loop_count} iteration(s)"
                                 );
-                                cost_tracker.report_stats(slot, is_leader_block);
+                                cost_tracker.report_stats(
+                                    slot,
+                                    is_leader_block,
+                                    total_transaction_fee,
+                                );
                                 break;
                             }
                         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3221,7 +3221,6 @@ impl ReplayStage {
                     .send(CostUpdate::FrozenBank {
                         bank: bank.clone_without_scheduler(),
                         is_leader_block,
-                        total_transaction_fee: bank.get_collected_transaction_fee(),
                     })
                     .unwrap_or_else(|err| {
                         warn!("cost_update_sender failed sending bank stats: {err:?}")

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3221,6 +3221,7 @@ impl ReplayStage {
                     .send(CostUpdate::FrozenBank {
                         bank: bank.clone_without_scheduler(),
                         is_leader_block,
+                        total_transaction_fee: bank.get_collected_transaction_fee(),
                     })
                     .unwrap_or_else(|err| {
                         warn!("cost_update_sender failed sending bank stats: {err:?}")

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -216,7 +216,12 @@ impl CostTracker {
         self.transaction_count.0
     }
 
-    pub fn report_stats(&self, bank_slot: solana_clock::Slot, is_leader: bool) {
+    pub fn report_stats(
+        &self,
+        bank_slot: solana_clock::Slot,
+        is_leader: bool,
+        total_transaction_fee: u64,
+    ) {
         // skip reporting if block is empty
         if self.transaction_count.0 == 0 {
             return;
@@ -263,7 +268,8 @@ impl CostTracker {
                 "secp256r1_instruction_signature_count",
                 self.secp256r1_instruction_signature_count.0,
                 i64
-            )
+            ),
+            ("total_transaction_fee", total_transaction_fee as i64, i64),
         );
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -221,6 +221,7 @@ impl CostTracker {
         bank_slot: solana_clock::Slot,
         is_leader: bool,
         total_transaction_fee: u64,
+        total_priority_fee: u64,
     ) {
         // skip reporting if block is empty
         if self.transaction_count.0 == 0 {
@@ -270,6 +271,7 @@ impl CostTracker {
                 i64
             ),
             ("total_transaction_fee", total_transaction_fee as i64, i64),
+            ("total_priority_fee", total_priority_fee as i64, i64),
         );
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -233,13 +233,13 @@ impl CostTracker {
         datapoint_info!(
             "cost_tracker_stats",
             "is_leader" => is_leader.to_string(),
-            ("bank_slot", bank_slot as i64, i64),
-            ("block_cost", self.block_cost as i64, i64),
-            ("vote_cost", self.vote_cost as i64, i64),
-            ("transaction_count", self.transaction_count.0 as i64, i64),
-            ("number_of_accounts", self.number_of_accounts() as i64, i64),
+            ("bank_slot", bank_slot, i64),
+            ("block_cost", self.block_cost, i64),
+            ("vote_cost", self.vote_cost, i64),
+            ("transaction_count", self.transaction_count.0, i64),
+            ("number_of_accounts", self.number_of_accounts(), i64),
             ("costliest_account", costliest_account.to_string(), String),
-            ("costliest_account_cost", costliest_account_cost as i64, i64),
+            ("costliest_account_cost", costliest_account_cost, i64),
             (
                 "allocated_accounts_data_size",
                 self.allocated_accounts_data_size.0,
@@ -270,8 +270,8 @@ impl CostTracker {
                 self.secp256r1_instruction_signature_count.0,
                 i64
             ),
-            ("total_transaction_fee", total_transaction_fee as i64, i64),
-            ("total_priority_fee", total_priority_fee as i64, i64),
+            ("total_transaction_fee", total_transaction_fee, i64),
+            ("total_priority_fee", total_priority_fee, i64),
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -247,7 +247,7 @@ impl AddAssign for SquashTiming {
     }
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct CollectorFeeDetails {
     transaction_fee: u64,
     priority_fee: u64,
@@ -5695,8 +5695,8 @@ impl Bank {
     }
 
     /// Return total transaction fee collected
-    pub fn read_collector_fee_details(&self) -> LockResult<RwLockReadGuard<CollectorFeeDetails>> {
-        self.collector_fee_details.read()
+    pub fn get_collector_fee_details(&self) -> CollectorFeeDetails {
+        self.collector_fee_details.read().unwrap().clone()
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5689,6 +5689,11 @@ impl Bank {
     pub fn set_accounts_lt_hash_for_snapshot_minimizer(&self, accounts_lt_hash: AccountsLtHash) {
         *self.accounts_lt_hash.lock().unwrap() = accounts_lt_hash;
     }
+
+    /// Return total transaction fee collected
+    pub fn get_collected_transaction_fee(&self) -> u64 {
+        self.collector_fee_details.read().unwrap().total()
+    }
 }
 
 impl InvokeContextCallback for Bank {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -263,8 +263,12 @@ impl CollectorFeeDetails {
             .saturating_add(fee_details.prioritization_fee());
     }
 
-    pub(crate) fn total(&self) -> u64 {
+    pub fn total_transaction_fee(&self) -> u64 {
         self.transaction_fee.saturating_add(self.priority_fee)
+    }
+
+    pub fn total_priority_fee(&self) -> u64 {
+        self.priority_fee
     }
 }
 
@@ -5691,8 +5695,8 @@ impl Bank {
     }
 
     /// Return total transaction fee collected
-    pub fn get_collected_transaction_fee(&self) -> u64 {
-        self.collector_fee_details.read().unwrap().total()
+    pub fn read_collector_fee_details(&self) -> LockResult<RwLockReadGuard<CollectorFeeDetails>> {
+        self.collector_fee_details.read()
     }
 }
 

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -49,7 +49,7 @@ impl Bank {
     // form of transaction fees as well.
     pub(super) fn distribute_transaction_fee_details(&self) {
         let fee_details = self.collector_fee_details.read().unwrap();
-        if fee_details.total() == 0 {
+        if fee_details.total_transaction_fee() == 0 {
             // nothing to distribute, exit early
             return;
         }


### PR DESCRIPTION
#### Problem

Would be nice to have total_transaction_fee collected in metrcs

#### Summary of Changes
- when bank is frozen, report total fee collected to cost_tracker_stats 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
