### PR TITLE
rpc: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/client/src/transaction_executor.rs
+++ b/client/src/transaction_executor.rs
@@ -76,7 +76,7 @@ impl TransactionExecutor {
                     return Some((sig, timestamp(), id));
                 }
                 Err(e) => {
-                    info!("error: {:#?}", e);
+                    info!("error: {e:#?}");
                 }
             }
             None
@@ -136,7 +136,7 @@ impl TransactionExecutor {
                             let mut retain = true;
                             let sent_ts = sigs_w[i].1;
                             if let Some(e) = &statuses[j] {
-                                debug!("error: {:?}", e);
+                                debug!("error: {e:?}");
                                 if e.status.is_ok() {
                                     success += 1;
                                 } else {
@@ -169,8 +169,7 @@ impl TransactionExecutor {
                         );
                         if last_log.elapsed().as_millis() > 5000 {
                             info!(
-                                "success: {} error: {} timed_out: {}",
-                                success, error_count, timed_out,
+                                "success: {success} error: {error_count} timed_out: {timed_out}",
                             );
                             last_log = Instant::now();
                         }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -238,7 +238,8 @@ impl GeyserPluginManager {
             return Err(jsonrpc_core::Error {
                 code: ErrorCode::InvalidRequest,
                 message: format!(
-                    "There already exists a plugin named {} loaded, while reloading {name}. Did not load requested plugin",
+                    "There already exists a plugin named {} loaded, while reloading {name}. Did \
+                     not load requested plugin",
                     new_plugin.name()
                 ),
                 data: None,
@@ -357,7 +358,8 @@ pub(crate) fn load_plugin_from_config(
         Ok(file) => file,
         Err(err) => {
             return Err(GeyserPluginManagerError::CannotOpenConfigFile(format!(
-                "Failed to open the plugin config file {geyser_plugin_config_file:?}, error: {err:?}"
+                "Failed to open the plugin config file {geyser_plugin_config_file:?}, error: \
+                 {err:?}"
             )));
         }
     };
@@ -373,7 +375,8 @@ pub(crate) fn load_plugin_from_config(
         Ok(value) => value,
         Err(err) => {
             return Err(GeyserPluginManagerError::InvalidConfigFileFormat(format!(
-                "The config file {geyser_plugin_config_file:?} is not in a valid Json5 format, error: {err:?}"
+                "The config file {geyser_plugin_config_file:?} is not in a valid Json5 format, \
+                 error: {err:?}"
             )));
         }
     };

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -79,8 +79,7 @@ impl GeyserPluginService {
         )>,
     ) -> Result<Self, GeyserPluginServiceError> {
         info!(
-            "Starting GeyserPluginService from config files: {:?}",
-            geyser_plugin_config_files
+            "Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}"
         );
         let mut plugin_manager = GeyserPluginManager::new();
 

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -78,9 +78,7 @@ impl GeyserPluginService {
             Arc<AtomicBool>,
         )>,
     ) -> Result<Self, GeyserPluginServiceError> {
-        info!(
-            "Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}"
-        );
+        info!("Starting GeyserPluginService from config files: {geyser_plugin_config_files:?}");
         let mut plugin_manager = GeyserPluginManager::new();
 
         for geyser_plugin_config_file in geyser_plugin_config_files {

--- a/pubsub-client/src/nonblocking/pubsub_client.rs
+++ b/pubsub-client/src/nonblocking/pubsub_client.rs
@@ -627,7 +627,7 @@ impl PubsubClient {
                                 }
                             }
                         } else {
-                            error!("Unknown request id: {}", id);
+                            error!("Unknown request id: {id}");
                             break;
                         }
                         continue;

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -324,7 +324,8 @@ fn connect_with_retry(
 
                 connection_retries -= 1;
                 debug!(
-                    "Too many requests: server responded with {response:?}, {connection_retries} retries left, pausing for {duration:?}"
+                    "Too many requests: server responded with {response:?}, {connection_retries} \
+                     retries left, pausing for {duration:?}"
                 );
 
                 sleep(duration);

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -324,8 +324,7 @@ fn connect_with_retry(
 
                 connection_retries -= 1;
                 debug!(
-                    "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
-                    response, connection_retries, duration
+                    "Too many requests: server responded with {response:?}, {connection_retries} retries left, pausing for {duration:?}"
                 );
 
                 sleep(duration);
@@ -785,7 +784,7 @@ impl PubsubClient {
         let handler = move |message| match sender.send(message) {
             Ok(_) => (),
             Err(err) => {
-                info!("receive error: {:?}", err);
+                info!("receive error: {err:?}");
             }
         };
         Self::cleanup_with_handler(exit, socket, handler);
@@ -810,7 +809,7 @@ impl PubsubClient {
                     // Nothing useful, means we received a ping message
                 }
                 Err(err) => {
-                    info!("receive error: {:?}", err);
+                    info!("receive error: {err:?}");
                     break;
                 }
             }

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -174,8 +174,7 @@ impl RpcSender for HttpSender {
 
                     too_many_requests_retries -= 1;
                     debug!(
-                                "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
-                                response, too_many_requests_retries, duration
+                                "Too many requests: server responded with {response:?}, {too_many_requests_retries} retries left, pausing for {duration:?}"
                             );
 
                     sleep(duration).await;
@@ -194,7 +193,7 @@ impl RpcSender for HttpSender {
                                         match serde_json::from_value::<RpcSimulateTransactionResult>(json["error"]["data"].clone()) {
                                             Ok(data) => RpcResponseErrorData::SendTransactionPreflightFailure(data),
                                             Err(err) => {
-                                                debug!("Failed to deserialize RpcSimulateTransactionResult: {:?}", err);
+                                                debug!("Failed to deserialize RpcSimulateTransactionResult: {err:?}");
                                                 RpcResponseErrorData::Empty
                                             }
                                         }

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -174,8 +174,9 @@ impl RpcSender for HttpSender {
 
                     too_many_requests_retries -= 1;
                     debug!(
-                                "Too many requests: server responded with {response:?}, {too_many_requests_retries} retries left, pausing for {duration:?}"
-                            );
+                        "Too many requests: server responded with {response:?}, \
+                         {too_many_requests_retries} retries left, pausing for {duration:?}"
+                    );
 
                     sleep(duration).await;
                     stats_updater.add_rate_limited_time(duration);

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -719,9 +719,8 @@ impl RpcClient {
         }
 
         Err(RpcError::ForUser(
-            "unable to confirm transaction. \
-             This can happen in situations such as transaction expiration \
-             and insufficient fee-payer funds"
+            "unable to confirm transaction. This can happen in situations such as transaction \
+             expiration and insufficient fee-payer funds"
                 .to_string(),
         )
         .into())
@@ -1204,9 +1203,8 @@ impl RpcClient {
             }
         } else {
             return Err(RpcError::ForUser(
-                "unable to confirm transaction. \
-                                      This can happen in situations such as transaction expiration \
-                                      and insufficient fee-payer funds"
+                "unable to confirm transaction. This can happen in situations such as transaction \
+                 expiration and insufficient fee-payer funds"
                     .to_string(),
             )
             .into());
@@ -1237,11 +1235,12 @@ impl RpcClient {
                 .await
                 .unwrap_or(confirmations);
             if now.elapsed().as_secs() >= MAX_HASH_AGE_IN_SECONDS as u64 {
-                return Err(
-                    RpcError::ForUser("transaction not finalized. \
-                                      This can happen when a transaction lands in an abandoned fork. \
-                                      Please retry.".to_string()).into(),
-                );
+                return Err(RpcError::ForUser(
+                    "transaction not finalized. This can happen when a transaction lands in an \
+                     abandoned fork. Please retry."
+                        .to_string(),
+                )
+                .into());
             }
         }
     }
@@ -3890,9 +3889,7 @@ impl RpcClient {
 
         let minimum_balance: u64 = serde_json::from_value(minimum_balance_json)
             .map_err(|err| ClientError::new_with_request(err.into(), request))?;
-        trace!(
-            "Response minimum balance {data_len:?} {minimum_balance:?}"
-        );
+        trace!("Response minimum balance {data_len:?} {minimum_balance:?}");
         Ok(minimum_balance)
     }
 
@@ -4447,8 +4444,7 @@ impl RpcClient {
         })
         .map_err(|_| {
             RpcError::ForUser(
-                "airdrop request failed. \
-                    This can happen when the rate limit is reached."
+                "airdrop request failed. This can happen when the rate limit is reached."
                     .to_string(),
             )
             .into()

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -989,7 +989,7 @@ impl RpcClient {
                     data,
                 }) = err.kind()
                 {
-                    debug!("{} {}", code, message);
+                    debug!("{code} {message}");
                     if let RpcResponseErrorData::SendTransactionPreflightFailure(
                         RpcSimulateTransactionResult {
                             logs: Some(logs), ..
@@ -2316,8 +2316,7 @@ impl RpcClient {
             }
 
             info!(
-                "Waiting for stake to drop below {} current: {:.1}",
-                max_stake_percent, current_percent
+                "Waiting for stake to drop below {max_stake_percent} current: {current_percent:.1}"
             );
             sleep(Duration::from_secs(5)).await;
         }
@@ -2945,7 +2944,7 @@ impl RpcClient {
                 }
                 let result = serde_json::from_value(result_json)
                     .map_err(|err| ClientError::new_with_request(err.into(), request))?;
-                trace!("Response block timestamp {:?} {:?}", slot, result);
+                trace!("Response block timestamp {slot:?} {result:?}");
                 Ok(result)
             })
             .map_err(|err| err.into_with_request(request))?
@@ -3604,7 +3603,7 @@ impl RpcClient {
                     context,
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                trace!("Response account {pubkey:?} {rpc_account:?}");
                 let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
 
                 Ok(Response {
@@ -3892,9 +3891,7 @@ impl RpcClient {
         let minimum_balance: u64 = serde_json::from_value(minimum_balance_json)
             .map_err(|err| ClientError::new_with_request(err.into(), request))?;
         trace!(
-            "Response minimum balance {:?} {:?}",
-            data_len,
-            minimum_balance
+            "Response minimum balance {data_len:?} {minimum_balance:?}"
         );
         Ok(minimum_balance)
     }
@@ -4227,7 +4224,7 @@ impl RpcClient {
                     context,
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
-                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                trace!("Response account {pubkey:?} {rpc_account:?}");
                 let response = {
                     if let Some(rpc_account) = rpc_account {
                         if let UiAccountData::Json(account_data) = rpc_account.data {
@@ -4514,10 +4511,7 @@ impl RpcClient {
                 return balance_result;
             }
             trace!(
-                "wait_for_balance_with_commitment [{}] {:?} {:?}",
-                run,
-                balance_result,
-                expected_balance
+                "wait_for_balance_with_commitment [{run}] {balance_result:?} {expected_balance:?}"
             );
             if let (Some(expected_balance), Ok(balance_result)) = (expected_balance, balance_result)
             {
@@ -4591,7 +4585,7 @@ impl RpcClient {
                     }
                 }
                 Err(err) => {
-                    debug!("check_confirmations request failed: {:?}", err);
+                    debug!("check_confirmations request failed: {err:?}");
                 }
             };
             if now.elapsed().as_secs() > 20 {
@@ -4707,7 +4701,7 @@ impl RpcClient {
                     return Ok(new_blockhash);
                 }
             }
-            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+            debug!("Got same blockhash ({blockhash:?}), will retry...");
 
             // Retry ~twice during a slot
             sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2)).await;

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -83,7 +83,7 @@ fn test_rpc_send_tx() {
         .parse()
         .unwrap();
 
-    info!("blockhash: {:?}", blockhash);
+    info!("blockhash: {blockhash:?}");
     let tx = system_transaction::transfer(
         &alice,
         &bob_pubkey,
@@ -442,7 +442,7 @@ fn test_rpc_subscriptions() {
         sleep(Duration::from_millis(100));
     }
     if mint_balance != expected_mint_balance {
-        error!("mint-check timeout. mint_balance {:?}", mint_balance);
+        error!("mint-check timeout. mint_balance {mint_balance:?}");
     }
 
     // Wait for all signature subscriptions

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -165,9 +165,7 @@ impl OptimisticallyConfirmedBankTracker {
                 match sender.send(notification.clone()) {
                     Ok(_) => {}
                     Err(err) => {
-                        info!(
-                            "Failed to send notification {notification:?}, error: {err:?}"
-                        );
+                        info!("Failed to send notification {notification:?}, error: {err:?}");
                     }
                 }
             }
@@ -249,9 +247,7 @@ impl OptimisticallyConfirmedBankTracker {
             let root = roots[i];
             if root > *newest_root_slot {
                 let parent = roots[i - 1];
-                debug!(
-                    "Doing SlotNotification::Root for root {root}, parent: {parent}"
-                );
+                debug!("Doing SlotNotification::Root for root {root}, parent: {parent}");
                 Self::notify_slot_status(
                     slot_notification_subscribers,
                     SlotNotification::Root((root, parent)),
@@ -342,7 +338,8 @@ impl OptimisticallyConfirmedBankTracker {
 
                 if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
                     debug!(
-                        "Calling notify_gossip_subscribers to send deferred notification {frozen_slot:?}"
+                        "Calling notify_gossip_subscribers to send deferred notification \
+                         {frozen_slot:?}"
                     );
 
                     Self::notify_or_defer_confirmed_banks(

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -166,8 +166,7 @@ impl OptimisticallyConfirmedBankTracker {
                     Ok(_) => {}
                     Err(err) => {
                         info!(
-                            "Failed to send notification {:?}, error: {:?}",
-                            notification, err
+                            "Failed to send notification {notification:?}, error: {err:?}"
                         );
                     }
                 }
@@ -251,8 +250,7 @@ impl OptimisticallyConfirmedBankTracker {
             if root > *newest_root_slot {
                 let parent = roots[i - 1];
                 debug!(
-                    "Doing SlotNotification::Root for root {}, parent: {}",
-                    root, parent
+                    "Doing SlotNotification::Root for root {root}, parent: {parent}"
                 );
                 Self::notify_slot_status(
                     slot_notification_subscribers,
@@ -276,7 +274,7 @@ impl OptimisticallyConfirmedBankTracker {
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
         prioritization_fee_cache: &PrioritizationFeeCache,
     ) {
-        debug!("received bank notification: {:?}", notification);
+        debug!("received bank notification: {notification:?}");
         match notification {
             BankNotification::OptimisticallyConfirmed(slot) => {
                 let bank = bank_forks.read().unwrap().get(slot);
@@ -344,8 +342,7 @@ impl OptimisticallyConfirmedBankTracker {
 
                 if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
                     debug!(
-                        "Calling notify_gossip_subscribers to send deferred notification {:?}",
-                        frozen_slot
+                        "Calling notify_gossip_subscribers to send deferred notification {frozen_slot:?}"
                     );
 
                     Self::notify_or_defer_confirmed_banks(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2538,7 +2538,10 @@ fn encode_account<T: ReadableAccount>(
             .unwrap_or(account.data().len())
             > MAX_BASE58_BYTES
     {
-        let message = format!("Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please use Base64 encoding.");
+        let message = format!(
+            "Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please \
+             use Base64 encoding."
+        );
         Err(error::Error {
             code: error::ErrorCode::InvalidRequest,
             message,
@@ -3006,9 +3009,7 @@ pub mod rpc_bank {
             data_len: usize,
             commitment: Option<CommitmentConfig>,
         ) -> Result<u64> {
-            debug!(
-                "get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}"
-            );
+            debug!("get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}");
             if data_len as u64 > solana_system_interface::MAX_PERMITTED_DATA_LENGTH {
                 return Err(Error::invalid_request());
             }
@@ -3049,9 +3050,7 @@ pub mod rpc_bank {
             start_slot: Slot,
             limit: u64,
         ) -> Result<Vec<String>> {
-            debug!(
-                "get_slot_leaders rpc request received (start: {start_slot} limit: {limit})"
-            );
+            debug!("get_slot_leaders rpc request received (start: {start_slot} limit: {limit})");
 
             let limit = limit as usize;
             if limit > MAX_GET_SLOT_LEADERS {
@@ -3271,9 +3270,7 @@ pub mod rpc_accounts {
             pubkey_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
-            debug!(
-                "get_token_account_balance rpc request received: {pubkey_str:?}"
-            );
+            debug!("get_token_account_balance rpc request received: {pubkey_str:?}");
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_token_account_balance(&pubkey, commitment)
         }
@@ -3363,9 +3360,7 @@ pub mod rpc_accounts_scan {
             program_id_str: String,
             config: Option<RpcProgramAccountsConfig>,
         ) -> BoxFuture<Result<OptionalContext<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_program_accounts rpc request received: {program_id_str:?}"
-            );
+            debug!("get_program_accounts rpc request received: {program_id_str:?}");
             async move {
                 let program_id = verify_pubkey(&program_id_str)?;
                 let (config, filters, with_context, sort_results) = if let Some(config) = config {
@@ -3409,9 +3404,7 @@ pub mod rpc_accounts_scan {
             mint_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcTokenAccountBalance>>>> {
-            debug!(
-                "get_token_largest_accounts rpc request received: {mint_str:?}"
-            );
+            debug!("get_token_largest_accounts rpc request received: {mint_str:?}");
             async move {
                 let mint = verify_pubkey(&mint_str)?;
                 meta.get_token_largest_accounts(mint, commitment).await
@@ -3426,9 +3419,7 @@ pub mod rpc_accounts_scan {
             token_account_filter: RpcTokenAccountsFilter,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_token_accounts_by_owner rpc request received: {owner_str:?}"
-            );
+            debug!("get_token_accounts_by_owner rpc request received: {owner_str:?}");
             async move {
                 let owner = verify_pubkey(&owner_str)?;
                 let token_account_filter = verify_token_account_filter(token_account_filter)?;
@@ -3445,9 +3436,7 @@ pub mod rpc_accounts_scan {
             token_account_filter: RpcTokenAccountsFilter,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
-            debug!(
-                "get_token_accounts_by_delegate rpc request received: {delegate_str:?}"
-            );
+            debug!("get_token_accounts_by_delegate rpc request received: {delegate_str:?}");
             async move {
                 let delegate = verify_pubkey(&delegate_str)?;
                 let token_account_filter = verify_token_account_filter(token_account_filter)?;
@@ -4100,9 +4089,7 @@ pub mod rpc_full {
         ) -> BoxFuture<Result<Vec<Slot>>> {
             let (end_slot, maybe_config) =
                 wrapper.map(|wrapper| wrapper.unzip()).unwrap_or_default();
-            debug!(
-                "get_blocks rpc request received: {start_slot}-{end_slot:?}"
-            );
+            debug!("get_blocks rpc request received: {start_slot}-{end_slot:?}");
             Box::pin(async move {
                 meta.get_blocks(start_slot, end_slot, config.or(maybe_config))
                     .await
@@ -4116,9 +4103,7 @@ pub mod rpc_full {
             limit: usize,
             config: Option<RpcContextConfig>,
         ) -> BoxFuture<Result<Vec<Slot>>> {
-            debug!(
-                "get_blocks_with_limit rpc request received: {start_slot}-{limit}",
-            );
+            debug!("get_blocks_with_limit rpc request received: {start_slot}-{limit}",);
             Box::pin(async move { meta.get_blocks_with_limit(start_slot, limit, config).await })
         }
 
@@ -4637,7 +4622,8 @@ pub mod tests {
             if let Some(account) = bank.get_account(key) {
                 assert!(
                     *account.owner() != bpf_loader_upgradeable::id(),
-                    "LoaderV3 is not supported; to add it, parse the program account and add its programdata size.",
+                    "LoaderV3 is not supported; to add it, parse the program account and add its \
+                     programdata size.",
                 );
                 loaded_accounts_data_size +=
                     (account.data().len() + TRANSACTION_ACCOUNT_BASE_SIZE) as u32;
@@ -7221,9 +7207,9 @@ pub mod tests {
         let expected = (
             JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
             String::from(
-                "Transaction version (0) is not supported by the requesting client. \
-                Please try the request again with the following configuration parameter: \
-                \"maxSupportedTransactionVersion\": 0",
+                "Transaction version (0) is not supported by the requesting client. Please try \
+                 the request again with the following configuration parameter: \
+                 \"maxSupportedTransactionVersion\": 0",
             ),
         );
         assert_eq!(response, expected);
@@ -7250,7 +7236,8 @@ pub mod tests {
         {
             assert_eq!(
                 version, None,
-                "requests which don't set max_supported_transaction_version shouldn't receive a version"
+                "requests which don't set max_supported_transaction_version shouldn't receive a \
+                 version"
             );
             if let EncodedTransaction::Json(transaction) = transaction {
                 if transaction.signatures[0] == confirmed_block_signatures[0].to_string() {
@@ -7294,7 +7281,8 @@ pub mod tests {
         {
             assert_eq!(
                 version, None,
-                "requests which don't set max_supported_transaction_version shouldn't receive a version"
+                "requests which don't set max_supported_transaction_version shouldn't receive a \
+                 version"
             );
             if let EncodedTransaction::LegacyBinary(transaction) = transaction {
                 let decoded_transaction: Transaction =
@@ -8924,9 +8912,10 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base58 encoded solana_transaction::Transaction too large: {tx58_len} bytes (max: encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
-            )
-        ));
+                "base58 encoded solana_transaction::Transaction too large: {tx58_len} bytes (max: \
+                 encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
+            ))
+        );
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
         let tx64_len = tx64.len();
@@ -8934,9 +8923,10 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
-            )
-        ));
+                "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
+                 encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
+            ))
+        );
 
         let too_big = PACKET_DATA_SIZE + 1;
         let tx_ser = vec![0x00u8; too_big];
@@ -8945,7 +8935,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_transaction::Transaction too large: {too_big} bytes (max: {PACKET_DATA_SIZE} bytes)"
+                "decoded solana_transaction::Transaction too large: {too_big} bytes (max: \
+                 {PACKET_DATA_SIZE} bytes)"
             ))
         );
 
@@ -8954,7 +8945,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_transaction::Transaction too large: {too_big} bytes (max: {PACKET_DATA_SIZE} bytes)"
+                "decoded solana_transaction::Transaction too large: {too_big} bytes (max: \
+                 {PACKET_DATA_SIZE} bytes)"
             ))
         );
 
@@ -8964,8 +8956,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64.clone(), TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(
-                "failed to deserialize solana_transaction::Transaction: invalid value: \
-                continue signal on byte-three, expected a terminal signal on or before byte-three"
+                "failed to deserialize solana_transaction::Transaction: invalid value: continue \
+                 signal on byte-three, expected a terminal signal on or before byte-three"
                     .to_string()
             )
         );
@@ -8982,8 +8974,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58.clone(), TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(
-                "failed to deserialize solana_transaction::Transaction: invalid value: \
-                continue signal on byte-three, expected a terminal signal on or before byte-three"
+                "failed to deserialize solana_transaction::Transaction: invalid value: continue \
+                 signal on byte-three, expected a terminal signal on or before byte-three"
                     .to_string()
             )
         );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -344,7 +344,7 @@ impl JsonRpcRequestProcessor {
 
     #[allow(deprecated)]
     fn bank(&self, commitment: Option<CommitmentConfig>) -> Arc<Bank> {
-        debug!("RPC commitment_config: {:?}", commitment);
+        debug!("RPC commitment_config: {commitment:?}");
 
         let commitment = commitment.unwrap_or_default();
         if commitment.is_confirmed() {
@@ -366,10 +366,10 @@ impl JsonRpcRequestProcessor {
 
         match commitment.commitment {
             CommitmentLevel::Processed => {
-                debug!("RPC using the heaviest slot: {:?}", slot);
+                debug!("RPC using the heaviest slot: {slot:?}");
             }
             CommitmentLevel::Finalized => {
-                debug!("RPC using block: {:?}", slot);
+                debug!("RPC using block: {slot:?}");
             }
             CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
         };
@@ -1016,7 +1016,7 @@ impl JsonRpcRequestProcessor {
                 None => Err(Error::invalid_request()),
             },
             Err(err) => {
-                warn!("slot_meta_iterator failed: {:?}", err);
+                warn!("slot_meta_iterator failed: {err:?}");
                 Err(Error::invalid_request())
             }
         }
@@ -1897,7 +1897,7 @@ impl JsonRpcRequestProcessor {
                             bigtable_before = None;
                         }
                         Err(err) => {
-                            warn!("Failed to query Bigtable: {:?}", err);
+                            warn!("Failed to query Bigtable: {err:?}");
                             return Err(RpcCustomError::LongTermStorageUnreachable.into());
                         }
                         Ok(_) => {}
@@ -1929,7 +1929,7 @@ impl JsonRpcRequestProcessor {
                     }
                     Err(StorageError::SignatureNotFound) => {}
                     Err(err) => {
-                        warn!("Failed to query Bigtable: {:?}", err);
+                        warn!("Failed to query Bigtable: {err:?}");
                         return Err(RpcCustomError::LongTermStorageUnreachable.into());
                     }
                 }
@@ -2591,8 +2591,7 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
     {
         if let Some(incorrect_owner_len) = incorrect_owner_len {
             info!(
-                "Incorrect num bytes ({:?}) provided for spl_token_owner_filter",
-                incorrect_owner_len
+                "Incorrect num bytes ({incorrect_owner_len:?}) provided for spl_token_owner_filter"
             );
         }
         owner_key
@@ -2642,8 +2641,7 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
     {
         if let Some(incorrect_mint_len) = incorrect_mint_len {
             info!(
-                "Incorrect num bytes ({:?}) provided for spl_token_mint_filter",
-                incorrect_mint_len
+                "Incorrect num bytes ({incorrect_mint_len:?}) provided for spl_token_mint_filter"
             );
         }
         mint
@@ -2703,7 +2701,7 @@ fn _send_transaction(
     );
     meta.transaction_sender
         .send(transaction_info)
-        .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {}", err));
+        .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {err}"));
 
     Ok(signature.to_string())
 }
@@ -2792,7 +2790,7 @@ pub mod rpc_minimal {
             pubkey_str: String,
             config: Option<RpcContextConfig>,
         ) -> Result<RpcResponse<u64>> {
-            debug!("get_balance rpc request received: {:?}", pubkey_str);
+            debug!("get_balance rpc request received: {pubkey_str:?}");
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_balance(&pubkey, config.unwrap_or_default())
         }
@@ -2927,7 +2925,7 @@ pub mod rpc_minimal {
             let slot = slot.unwrap_or_else(|| bank.slot());
             let epoch = bank.epoch_schedule().get_epoch(slot);
 
-            debug!("get_leader_schedule rpc request received: {:?}", slot);
+            debug!("get_leader_schedule rpc request received: {slot:?}");
 
             Ok(meta
                 .leader_schedule_cache
@@ -3009,8 +3007,7 @@ pub mod rpc_bank {
             commitment: Option<CommitmentConfig>,
         ) -> Result<u64> {
             debug!(
-                "get_minimum_balance_for_rent_exemption rpc request received: {:?}",
-                data_len
+                "get_minimum_balance_for_rent_exemption rpc request received: {data_len:?}"
             );
             if data_len as u64 > solana_system_interface::MAX_PERMITTED_DATA_LENGTH {
                 return Err(Error::invalid_request());
@@ -3053,8 +3050,7 @@ pub mod rpc_bank {
             limit: u64,
         ) -> Result<Vec<String>> {
             debug!(
-                "get_slot_leaders rpc request received (start: {} limit: {})",
-                start_slot, limit
+                "get_slot_leaders rpc request received (start: {start_slot} limit: {limit})"
             );
 
             let limit = limit as usize;
@@ -3223,7 +3219,7 @@ pub mod rpc_accounts {
             pubkey_str: String,
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Option<UiAccount>>>> {
-            debug!("get_account_info rpc request received: {:?}", pubkey_str);
+            debug!("get_account_info rpc request received: {pubkey_str:?}");
             async move {
                 let pubkey = verify_pubkey(&pubkey_str)?;
                 meta.get_account_info(pubkey, config).await
@@ -3276,8 +3272,7 @@ pub mod rpc_accounts {
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
             debug!(
-                "get_token_account_balance rpc request received: {:?}",
-                pubkey_str
+                "get_token_account_balance rpc request received: {pubkey_str:?}"
             );
             let pubkey = verify_pubkey(&pubkey_str)?;
             meta.get_token_account_balance(&pubkey, commitment)
@@ -3289,7 +3284,7 @@ pub mod rpc_accounts {
             mint_str: String,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<UiTokenAmount>> {
-            debug!("get_token_supply rpc request received: {:?}", mint_str);
+            debug!("get_token_supply rpc request received: {mint_str:?}");
             let mint = verify_pubkey(&mint_str)?;
             meta.get_token_supply(&mint, commitment)
         }
@@ -3369,8 +3364,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcProgramAccountsConfig>,
         ) -> BoxFuture<Result<OptionalContext<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_program_accounts rpc request received: {:?}",
-                program_id_str
+                "get_program_accounts rpc request received: {program_id_str:?}"
             );
             async move {
                 let program_id = verify_pubkey(&program_id_str)?;
@@ -3416,8 +3410,7 @@ pub mod rpc_accounts_scan {
             commitment: Option<CommitmentConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcTokenAccountBalance>>>> {
             debug!(
-                "get_token_largest_accounts rpc request received: {:?}",
-                mint_str
+                "get_token_largest_accounts rpc request received: {mint_str:?}"
             );
             async move {
                 let mint = verify_pubkey(&mint_str)?;
@@ -3434,8 +3427,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_token_accounts_by_owner rpc request received: {:?}",
-                owner_str
+                "get_token_accounts_by_owner rpc request received: {owner_str:?}"
             );
             async move {
                 let owner = verify_pubkey(&owner_str)?;
@@ -3454,8 +3446,7 @@ pub mod rpc_accounts_scan {
             config: Option<RpcAccountInfoConfig>,
         ) -> BoxFuture<Result<RpcResponse<Vec<RpcKeyedAccount>>>> {
             debug!(
-                "get_token_accounts_by_delegate rpc request received: {:?}",
-                delegate_str
+                "get_token_accounts_by_delegate rpc request received: {delegate_str:?}"
             );
             async move {
                 let delegate = verify_pubkey(&delegate_str)?;
@@ -3653,7 +3644,7 @@ pub mod rpc_full {
                 .blockstore
                 .get_recent_perf_samples(limit)
                 .map_err(|err| {
-                    warn!("get_recent_performance_samples failed: {:?}", err);
+                    warn!("get_recent_performance_samples failed: {err:?}");
                     Error::invalid_request()
                 })?
                 .into_iter()
@@ -3794,13 +3785,13 @@ pub mod rpc_full {
             let transaction =
                 request_airdrop_transaction(&faucet_addr, &pubkey, lamports, blockhash).map_err(
                     |err| {
-                        info!("request_airdrop_transaction failed: {:?}", err);
+                        info!("request_airdrop_transaction failed: {err:?}");
                         Error::internal_error()
                     },
                 )?;
 
             let wire_transaction = serialize(&transaction).map_err(|err| {
-                info!("request_airdrop: serialize error: {:?}", err);
+                info!("request_airdrop: serialize error: {err:?}");
                 Error::internal_error()
             })?;
 
@@ -4096,7 +4087,7 @@ pub mod rpc_full {
             slot: Slot,
             config: Option<RpcEncodingConfigWrapper<RpcBlockConfig>>,
         ) -> BoxFuture<Result<Option<UiConfirmedBlock>>> {
-            debug!("get_block rpc request received: {:?}", slot);
+            debug!("get_block rpc request received: {slot:?}");
             Box::pin(async move { meta.get_block(slot, config).await })
         }
 
@@ -4110,8 +4101,7 @@ pub mod rpc_full {
             let (end_slot, maybe_config) =
                 wrapper.map(|wrapper| wrapper.unzip()).unwrap_or_default();
             debug!(
-                "get_blocks rpc request received: {}-{:?}",
-                start_slot, end_slot
+                "get_blocks rpc request received: {start_slot}-{end_slot:?}"
             );
             Box::pin(async move {
                 meta.get_blocks(start_slot, end_slot, config.or(maybe_config))
@@ -4127,8 +4117,7 @@ pub mod rpc_full {
             config: Option<RpcContextConfig>,
         ) -> BoxFuture<Result<Vec<Slot>>> {
             debug!(
-                "get_blocks_with_limit rpc request received: {}-{}",
-                start_slot, limit,
+                "get_blocks_with_limit rpc request received: {start_slot}-{limit}",
             );
             Box::pin(async move { meta.get_blocks_with_limit(start_slot, limit, config).await })
         }
@@ -4147,7 +4136,7 @@ pub mod rpc_full {
             signature_str: String,
             config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
         ) -> BoxFuture<Result<Option<EncodedConfirmedTransactionWithStatusMeta>>> {
-            debug!("get_transaction rpc request received: {:?}", signature_str);
+            debug!("get_transaction rpc request received: {signature_str:?}");
             let signature = verify_signature(&signature_str);
             if let Err(err) = signature {
                 return Box::pin(future::err(err));
@@ -6467,11 +6456,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({
@@ -6511,11 +6499,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "innerInstructions": false, "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({
@@ -6555,11 +6542,10 @@ pub mod tests {
                  "id":1,
                  "method":"simulateTransaction",
                  "params":[
-                   "{}",
+                   "{tx_serialized_encoded}",
                    {{ "innerInstructions": true, "encoding": "base64" }}
                  ]
             }}"#,
-            tx_serialized_encoded,
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = json!({

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -104,9 +104,9 @@ impl RpcHealth {
             let num_slots = cluster_latest_optimistically_confirmed_slot
                 .saturating_sub(my_latest_optimistically_confirmed_slot);
             warn!(
-                "health check: behind by {num_slots} \
-                slots: me={my_latest_optimistically_confirmed_slot}, \
-                latest cluster={cluster_latest_optimistically_confirmed_slot}",
+                "health check: behind by {num_slots} slots: \
+                 me={my_latest_optimistically_confirmed_slot}, latest \
+                 cluster={cluster_latest_optimistically_confirmed_slot}",
             );
             RpcHealthStatus::Behind { num_slots }
         }

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -87,7 +87,7 @@ impl PubSubService {
         pubsub_addr: SocketAddr,
     ) -> (Trigger, Self) {
         let subscription_control = subscriptions.control().clone();
-        info!("rpc_pubsub bound to {:?}", pubsub_addr);
+        info!("rpc_pubsub bound to {pubsub_addr:?}");
 
         let (trigger, tripwire) = Tripwire::new();
         let thread_hdl = Builder::new()
@@ -454,7 +454,7 @@ async fn listen(
         select! {
             result = listener.accept() => match result {
                 Ok((socket, addr)) => {
-                    debug!("new client ({:?})", addr);
+                    debug!("new client ({addr:?})");
                     let subscription_control = subscription_control.clone();
                     let config = config.clone();
                     let tripwire = tripwire.clone();
@@ -464,13 +464,13 @@ async fn listen(
                             socket, subscription_control, config, tripwire
                         );
                         match handle.await {
-                            Ok(()) => debug!("connection closed ({:?})", addr),
-                            Err(err) => warn!("connection handler error ({:?}): {}", addr, err),
+                            Ok(()) => debug!("connection closed ({addr:?})"),
+                            Err(err) => warn!("connection handler error ({addr:?}): {err}"),
                         }
                         drop(counter_token); // Force moving token into the task.
                     });
                 }
-                Err(e) => error!("couldn't accept connection: {:?}", e),
+                Err(e) => error!("couldn't accept connection: {e:?}"),
             },
             _ = &mut tripwire => return Ok(()),
         }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -272,7 +272,7 @@ impl RpcRequestMiddleware {
             .map(|m| m.len())
             .unwrap_or(0)
             .to_string();
-        info!("get {} -> {:?} ({} bytes)", path, filename, file_length);
+        info!("get {path} -> {filename:?} ({file_length} bytes)");
 
         if cfg!(not(test)) {
             assert!(
@@ -335,7 +335,7 @@ impl RpcRequestMiddleware {
             RpcHealthStatus::Behind { .. } => "behind",
             RpcHealthStatus::Unknown => "unknown",
         };
-        info!("health check: {}", response);
+        info!("health check: {response}");
         response
     }
 }
@@ -716,8 +716,8 @@ impl JsonRpcService {
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         runtime: Arc<TokioRuntime>,
     ) -> Result<Self, String> {
-        info!("rpc bound to {:?}", rpc_addr);
-        info!("rpc configuration: {:?}", config);
+        info!("rpc bound to {rpc_addr:?}");
+        info!("rpc configuration: {config:?}");
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let health = Arc::new(RpcHealth::new(
@@ -778,7 +778,7 @@ impl JsonRpcService {
                         )
                     })
                     .unwrap_or_else(|err| {
-                        error!("Failed to initialize BigTable ledger storage: {:?}", err);
+                        error!("Failed to initialize BigTable ledger storage: {err:?}");
                         (None, None)
                     })
             } else {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -867,9 +867,8 @@ impl JsonRpcService {
 
                 if let Err(e) = server {
                     warn!(
-                        "JSON RPC service unavailable error: {:?}. \nAlso, check that port {} is \
+                        "JSON RPC service unavailable error: {e:?}. Also, check that port {} is \
                          not already in use by another application",
-                        e,
                         rpc_addr.port()
                     );
                     close_handle_sender.send(Err(e.to_string())).unwrap();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -867,8 +867,8 @@ impl JsonRpcService {
 
                 if let Err(e) = server {
                     warn!(
-                        "JSON RPC service unavailable error: {:?}. \n\
-                           Also, check that port {} is not already in use by another application",
+                        "JSON RPC service unavailable error: {:?}. \nAlso, check that port {} is \
+                         not already in use by another application",
                         e,
                         rpc_addr.port()
                     );

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -525,7 +525,7 @@ pub struct RpcSubscriptions {
 impl Drop for RpcSubscriptions {
     fn drop(&mut self) {
         self.shutdown().unwrap_or_else(|err| {
-            warn!("RPC Notification - shutdown error: {:?}", err);
+            warn!("RPC Notification - shutdown error: {err:?}");
         });
     }
 }
@@ -748,8 +748,7 @@ impl RpcSubscriptions {
                 Ok(()) => (),
                 Err(SendError(notification)) => {
                     warn!(
-                        "Dropped RPC Notification - receiver disconnected : {:?}",
-                        notification
+                        "Dropped RPC Notification - receiver disconnected : {notification:?}"
                     );
                 }
             }
@@ -797,7 +796,7 @@ impl RpcSubscriptions {
                                 .node_progress_watchers()
                                 .get(&SubscriptionParams::Slot)
                             {
-                                debug!("slot notify: {:?}", slot_info);
+                                debug!("slot notify: {slot_info:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-slot", 1);
                                 notifier.notify(slot_info, sub, false);
                             }
@@ -826,7 +825,7 @@ impl RpcSubscriptions {
                                     timestamp: vote_info.timestamp(),
                                     signature: signature.to_string(),
                                 };
-                                debug!("vote notify: {:?}", vote_info);
+                                debug!("vote notify: {vote_info:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-vote", 1);
                                 notifier.notify(&rpc_vote, sub, false);
                             }
@@ -836,7 +835,7 @@ impl RpcSubscriptions {
                                 .node_progress_watchers()
                                 .get(&SubscriptionParams::Root)
                             {
-                                debug!("root notify: {:?}", root);
+                                debug!("root notify: {root:?}");
                                 inc_new_counter_info!("rpc-subscription-notify-root", 1);
                                 notifier.notify(root, sub, false);
                             }
@@ -1015,7 +1014,7 @@ impl RpcSubscriptions {
                                 let block_update_result = blockstore
                                     .get_complete_block(s, false)
                                     .map_err(|e| {
-                                        error!("get_complete_block error: {}", e);
+                                        error!("get_complete_block error: {e}");
                                         RpcBlockUpdateError::BlockStoreError
                                     })
                                     .and_then(|block| filter_block_result_txs(block, s, params));

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -747,9 +747,7 @@ impl RpcSubscriptions {
             match notification_sender.send(notification_entry.into()) {
                 Ok(()) => (),
                 Err(SendError(notification)) => {
-                    warn!(
-                        "Dropped RPC Notification - receiver disconnected : {notification:?}"
-                    );
+                    warn!("Dropped RPC Notification - receiver disconnected : {notification:?}");
                 }
             }
         }
@@ -1131,7 +1129,8 @@ impl RpcSubscriptions {
         let total_ms = total_time.as_ms();
         if total_notified > 0 || total_ms > 10 {
             debug!(
-                "notified({}): accounts: {} / {} logs: {} / {} programs: {} / {} signatures: {} / {}",
+                "notified({}): accounts: {} / {} logs: {} / {} programs: {} / {} signatures: {} / \
+                 {}",
                 source,
                 num_accounts_found.load(Ordering::Relaxed),
                 num_accounts_notified.load(Ordering::Relaxed),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -396,7 +396,7 @@ impl SendTransactionService {
                 )
                 .is_some()
             {
-                info!("Transaction is rooted: {}", signature);
+                info!("Transaction is rooted: {signature}");
                 result.rooted += 1;
                 stats.rooted_transactions.fetch_add(1, Ordering::Relaxed);
                 return false;
@@ -416,14 +416,14 @@ impl SendTransactionService {
                 let verify_nonce_account =
                     nonce_account::verify_nonce_account(&nonce_account, &durable_nonce);
                 if verify_nonce_account.is_none() && signature_status.is_none() && expired {
-                    info!("Dropping expired durable-nonce transaction: {}", signature);
+                    info!("Dropping expired durable-nonce transaction: {signature}");
                     result.expired += 1;
                     stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
                     return false;
                 }
             }
             if transaction_info.last_valid_block_height < root_bank.block_height() {
-                info!("Dropping expired transaction: {}", signature);
+                info!("Dropping expired transaction: {signature}");
                 result.expired += 1;
                 stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
                 return false;
@@ -434,7 +434,7 @@ impl SendTransactionService {
 
             if let Some(max_retries) = max_retries {
                 if transaction_info.retries >= max_retries {
-                    info!("Dropping transaction due to max retries: {}", signature);
+                    info!("Dropping transaction due to max retries: {signature}");
                     result.max_retries_elapsed += 1;
                     stats
                         .transactions_exceeding_max_retries
@@ -456,7 +456,7 @@ impl SendTransactionService {
                             // Transaction sent before is unknown to the working bank, it might have been
                             // dropped or landed in another fork. Re-send it.
 
-                            info!("Retrying transaction: {}", signature);
+                            info!("Retrying transaction: {signature}");
                             result.retried += 1;
                             transaction_info.retries += 1;
                         }
@@ -483,7 +483,7 @@ impl SendTransactionService {
                 }
                 Some((_slot, status)) => {
                     if !status {
-                        info!("Dropping failed transaction: {}", signature);
+                        info!("Dropping failed transaction: {signature}");
                         result.failed += 1;
                         stats.failed_transactions.fetch_add(1, Ordering::Relaxed);
                         false

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -89,10 +89,7 @@ impl ClientOptimizer {
                 let times = self.times.read().unwrap();
                 let (min_time, min_index) = min_index(&times);
                 trace!(
-                    "done experimenting min: {} time: {} times: {:?}",
-                    min_index,
-                    min_time,
-                    times
+                    "done experimenting min: {min_index} time: {min_time} times: {times:?}"
                 );
 
                 // Only 1 thread should grab the num_clients-1 index, so this should be ok.

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -88,9 +88,7 @@ impl ClientOptimizer {
             if index == (self.num_clients - 1) || time_ms == u64::MAX {
                 let times = self.times.read().unwrap();
                 let (min_time, min_index) = min_index(&times);
-                trace!(
-                    "done experimenting min: {min_index} time: {min_time} times: {times:?}"
-                );
+                trace!("done experimenting min: {min_index} time: {min_time} times: {times:?}");
 
                 // Only 1 thread should grab the num_clients-1 index, so this should be ok.
                 self.cur_index.store(min_index, Ordering::Relaxed);

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -187,7 +187,7 @@ impl WorkersCache {
         }
 
         let current_worker = workers.get(peer).expect(
-            "Failed to fetch worker for peer {peer}.\nPeer existence must be checked before this \
+            "Failed to fetch worker for peer {peer}. Peer existence must be checked before this \
              call using `contains` method.",
         );
         let send_res = current_worker.try_send_transactions(txs_batch);
@@ -228,7 +228,7 @@ impl WorkersCache {
 
         let body = async move {
             let current_worker = workers.get(peer).expect(
-                "Failed to fetch worker for peer {peer}.\nPeer existence must be checked before \
+                "Failed to fetch worker for peer {peer}. Peer existence must be checked before \
                  this call using `contains` method.",
             );
             let send_res = current_worker.send_transactions(txs_batch).await;

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -280,7 +280,7 @@ impl WorkersCache {
         }
         while let Some(res) = tasks.join_next().await {
             if let Err(err) = res {
-                debug!("A shutdown task failed: {}", err);
+                debug!("A shutdown task failed: {err}");
             }
         }
     }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -187,8 +187,8 @@ impl WorkersCache {
         }
 
         let current_worker = workers.get(peer).expect(
-            "Failed to fetch worker for peer {peer}.\n\
-             Peer existence must be checked before this call using `contains` method.",
+            "Failed to fetch worker for peer {peer}.\nPeer existence must be checked before this \
+             call using `contains` method.",
         );
         let send_res = current_worker.try_send_transactions(txs_batch);
 
@@ -214,7 +214,8 @@ impl WorkersCache {
     /// is removed from the cache.
     #[allow(
         dead_code,
-        reason = "This method will be used in the upcoming changes to implement optional backpressure on the sender."
+        reason = "This method will be used in the upcoming changes to implement optional \
+                  backpressure on the sender."
     )]
     pub async fn send_transactions_to_address(
         &mut self,
@@ -227,8 +228,8 @@ impl WorkersCache {
 
         let body = async move {
             let current_worker = workers.get(peer).expect(
-                "Failed to fetch worker for peer {peer}.\n\
-                 Peer existence must be checked before this call using `contains` method.",
+                "Failed to fetch worker for peer {peer}.\nPeer existence must be checked before \
+                 this call using `contains` method.",
             );
             let send_res = current_worker.send_transactions(txs_batch).await;
             if let Err(WorkersCacheError::ReceiverDropped) = send_res {

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -222,7 +222,8 @@ async fn test_basic_transactions_sending() {
             let elapsed = now.elapsed();
             assert!(
                 elapsed < TEST_MAX_TIME,
-                "Failed to send {expected_num_txs} transaction in {elapsed:?}.  Only sent {actual_num_packets}",
+                "Failed to send {expected_num_txs} transaction in {elapsed:?}.  Only sent \
+                 {actual_num_packets}",
             );
         }
 
@@ -311,8 +312,8 @@ async fn test_connection_denied_until_allowed() {
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
     assert!(
         actual_num_packets < expected_num_txs,
-        "Expected to receive {expected_num_txs} packets in {TEST_MAX_TIME:?}\n\
-         Got packets: {actual_num_packets}"
+        "Expected to receive {expected_num_txs} packets in {TEST_MAX_TIME:?}\nGot packets: \
+         {actual_num_packets}"
     );
 
     // Wait for the exchange to finish.
@@ -638,9 +639,9 @@ async fn test_rate_limiting_establish_connection() {
         count_received_packets_for(receiver, tx_size, Duration::from_secs(70)).await;
     assert!(
         actual_num_packets > 0,
-        "As we wait longer than 1 minute, at least one transaction should be delivered.  \
-         After 1 minute the server is expected to accept our connection.\n\
-         Actual packets delivered: {actual_num_packets}"
+        "As we wait longer than 1 minute, at least one transaction should be delivered.  After 1 \
+         minute the server is expected to accept our connection.\nActual packets delivered: \
+         {actual_num_packets}"
     );
 
     // Stop the sender.
@@ -652,15 +653,13 @@ async fn test_rate_limiting_establish_connection() {
     assert!(
         stats.connection_error_timed_out > 0,
         "As the quinn timeout is below 1 minute, a few connections will fail to connect during \
-         the 1 minute delay.\n\
-         Actual connection_error_timed_out: {}",
+         the 1 minute delay.\nActual connection_error_timed_out: {}",
         stats.connection_error_timed_out
     );
     assert!(
         stats.successfully_sent > 0,
         "As we run the test for longer than 1 minute, we expect a connection to be established, \
-         and a number of transactions to be delivered.\n\
-         Actual successfully_sent: {}",
+         and a number of transactions to be delivered.\nActual successfully_sent: {}",
         stats.successfully_sent
     );
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -222,10 +222,7 @@ async fn test_basic_transactions_sending() {
             let elapsed = now.elapsed();
             assert!(
                 elapsed < TEST_MAX_TIME,
-                "Failed to send {} transaction in {:?}.  Only sent {}",
-                expected_num_txs,
-                elapsed,
-                actual_num_packets,
+                "Failed to send {expected_num_txs} transaction in {elapsed:?}.  Only sent {actual_num_packets}",
             );
         }
 

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -222,7 +222,7 @@ async fn test_basic_transactions_sending() {
             let elapsed = now.elapsed();
             assert!(
                 elapsed < TEST_MAX_TIME,
-                "Failed to send {expected_num_txs} transaction in {elapsed:?}.  Only sent \
+                "Failed to send {expected_num_txs} transaction in {elapsed:?}. Only sent \
                  {actual_num_packets}",
             );
         }
@@ -312,7 +312,7 @@ async fn test_connection_denied_until_allowed() {
     let actual_num_packets = count_received_packets_for(receiver, tx_size, TEST_MAX_TIME).await;
     assert!(
         actual_num_packets < expected_num_txs,
-        "Expected to receive {expected_num_txs} packets in {TEST_MAX_TIME:?}\nGot packets: \
+        "Expected to receive {expected_num_txs} packets in {TEST_MAX_TIME:?} Got packets: \
          {actual_num_packets}"
     );
 
@@ -639,8 +639,8 @@ async fn test_rate_limiting_establish_connection() {
         count_received_packets_for(receiver, tx_size, Duration::from_secs(70)).await;
     assert!(
         actual_num_packets > 0,
-        "As we wait longer than 1 minute, at least one transaction should be delivered.  After 1 \
-         minute the server is expected to accept our connection.\nActual packets delivered: \
+        "As we wait longer than 1 minute, at least one transaction should be delivered. After 1 \
+         minute the server is expected to accept our connection. Actual packets delivered: \
          {actual_num_packets}"
     );
 
@@ -653,7 +653,7 @@ async fn test_rate_limiting_establish_connection() {
     assert!(
         stats.connection_error_timed_out > 0,
         "As the quinn timeout is below 1 minute, a few connections will fail to connect during \
-         the 1 minute delay.\nActual connection_error_timed_out: {}",
+         the 1 minute delay. Actual connection_error_timed_out: {}",
         stats.connection_error_timed_out
     );
     assert!(

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -247,7 +247,8 @@ impl LeaderTpuCache {
                 }
                 Err(err) => {
                     warn!(
-                        "Failed to fetch slot leaders (current estimated slot: {estimated_current_slot}): {err}"
+                        "Failed to fetch slot leaders (current estimated slot: \
+                         {estimated_current_slot}): {err}"
                     );
                     has_error = true;
                 }
@@ -777,7 +778,8 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed to get slot leaders connecting to: {websocket_url}, timeout: {tpu_leader_service_creation_timeout:?}. Invalid slot range"
+                "Failed to get slot leaders connecting to: {websocket_url}, timeout: \
+                 {tpu_leader_service_creation_timeout:?}. Invalid slot range"
             ))
         })??;
 
@@ -798,7 +800,8 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed find any cluster node info for upcoming leaders, timeout: {tpu_leader_service_creation_timeout:?}."
+                "Failed find any cluster node info for upcoming leaders, timeout: \
+                 {tpu_leader_service_creation_timeout:?}."
             ))
         })??;
         let leader_tpu_cache = Arc::new(RwLock::new(LeaderTpuCache::new(

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -162,7 +162,7 @@ impl LeaderTpuCache {
                     leader_sockets.push(*tpu_socket);
                 } else {
                     // The leader is probably delinquent
-                    trace!("TPU not available for leader {}", leader);
+                    trace!("TPU not available for leader {leader}");
                 }
             } else {
                 // Overran the local leader schedule cache
@@ -227,7 +227,7 @@ impl LeaderTpuCache {
                     cluster_refreshed = true;
                 }
                 Err(err) => {
-                    warn!("Failed to fetch cluster tpu sockets: {}", err);
+                    warn!("Failed to fetch cluster tpu sockets: {err}");
                     has_error = true;
                 }
             }
@@ -247,8 +247,7 @@ impl LeaderTpuCache {
                 }
                 Err(err) => {
                     warn!(
-                        "Failed to fetch slot leaders (current estimated slot: {}): {}",
-                        estimated_current_slot, err
+                        "Failed to fetch slot leaders (current estimated slot: {estimated_current_slot}): {err}"
                     );
                     has_error = true;
                 }
@@ -778,8 +777,7 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed to get slot leaders connecting to: {}, timeout: {:?}. Invalid slot range",
-                websocket_url, tpu_leader_service_creation_timeout
+                "Failed to get slot leaders connecting to: {websocket_url}, timeout: {tpu_leader_service_creation_timeout:?}. Invalid slot range"
             ))
         })??;
 
@@ -800,8 +798,7 @@ impl LeaderTpuService {
         .await
         .map_err(|_| {
             TpuSenderError::Custom(format!(
-                "Failed find any cluster node info for upcoming leaders, timeout: {:?}.",
-                tpu_leader_service_creation_timeout
+                "Failed find any cluster node info for upcoming leaders, timeout: {tpu_leader_service_creation_timeout:?}."
             ))
         })??;
         let leader_tpu_cache = Arc::new(RwLock::new(LeaderTpuCache::new(

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -861,21 +861,51 @@ mod test {
             assert_eq!(reserialized_value, expected_json_output_value);
         }
 
-        let json_input = "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,\
-                          2,3],\"postBalances\":[4,5,6]}";
-        let expected_json_output =
-            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
-             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
-             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}";
+        #[rustfmt::skip]
+        let json_input = "{\
+            \"err\":null,\
+            \"status\":{\"Ok\":null},\
+            \"fee\":1234,\
+            \"preBalances\":[1,2,3],\
+            \"postBalances\":[4,5,6]\
+        }";
+        #[rustfmt::skip]
+        let expected_json_output = "{\
+            \"err\":null,\
+            \"status\":{\"Ok\":null},\
+            \"fee\":1234,\
+            \"preBalances\":[1,2,3],\
+            \"postBalances\":[4,5,6],\
+            \"innerInstructions\":null,\
+            \"logMessages\":null,\
+            \"preTokenBalances\":null,\
+            \"postTokenBalances\":null,\
+            \"rewards\":null\
+        }";
         test_serde::<UiTransactionStatusMeta>(json_input, expected_json_output);
 
-        let json_input = "{\"accountIndex\":5,\"mint\":\"\
-                          DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"uiTokenAmount\": {
-                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
-        let expected_json_output = "{\"accountIndex\":5,\"mint\":\"\
-                                    DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"\
-                                    uiTokenAmount\": {
-                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
+        #[rustfmt::skip]
+        let json_input = "{\
+            \"accountIndex\":5,\
+            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
+            \"uiTokenAmount\": {
+                \"amount\": \"1\",\
+                \"decimals\": 0,\
+                \"uiAmount\": 1.0,\
+                \"uiAmountString\": \"1\"\
+            }\
+        }";
+        #[rustfmt::skip]
+        let expected_json_output = "{\
+            \"accountIndex\":5,\
+            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
+            \"uiTokenAmount\": {
+                \"amount\": \"1\",\
+                \"decimals\": 0,\
+                \"uiAmount\": 1.0,\
+                \"uiAmountString\": \"1\"\
+            }\
+        }";
         test_serde::<UiTransactionTokenBalance>(json_input, expected_json_output);
     }
 

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -861,47 +861,21 @@ mod test {
             assert_eq!(reserialized_value, expected_json_output_value);
         }
 
-        let json_input = "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6]\
-        }";
-        let expected_json_output = "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null\
-        }";
+        let json_input = "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,\
+                          2,3],\"postBalances\":[4,5,6]}";
+        let expected_json_output =
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}";
         test_serde::<UiTransactionStatusMeta>(json_input, expected_json_output);
 
-        let json_input = "{\
-            \"accountIndex\":5,\
-            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
-            \"uiTokenAmount\": {
-                \"amount\": \"1\",\
-                \"decimals\": 0,\
-                \"uiAmount\": 1.0,\
-                \"uiAmountString\": \"1\"\
-            }\
-        }";
-        let expected_json_output = "{\
-            \"accountIndex\":5,\
-            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
-            \"uiTokenAmount\": {
-                \"amount\": \"1\",\
-                \"decimals\": 0,\
-                \"uiAmount\": 1.0,\
-                \"uiAmountString\": \"1\"\
-            }\
-        }";
+        let json_input = "{\"accountIndex\":5,\"mint\":\"\
+                          DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"uiTokenAmount\": {
+                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
+        let expected_json_output = "{\"accountIndex\":5,\"mint\":\"\
+                                    DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"\
+                                    uiTokenAmount\": {
+                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
         test_serde::<UiTransactionTokenBalance>(json_input, expected_json_output);
     }
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -903,11 +903,24 @@ mod test {
             compute_units_consumed: None,
             cost_units: None,
         };
+        #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
-             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
-             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null,\"\
-             loadedAddresses\":{\"readonly\": [],\"writable\": []}}",
+            "{\
+             \"err\":null,\
+             \"status\":{\"Ok\":null},\
+             \"fee\":1234,\
+             \"preBalances\":[1,2,3],\
+             \"postBalances\":[4,5,6],\
+             \"innerInstructions\":null,\
+             \"logMessages\":null,\
+             \"preTokenBalances\":null,\
+             \"postTokenBalances\":null,\
+             \"rewards\":null,\
+             \"loadedAddresses\":{\
+                 \"readonly\": [],\
+                 \"writable\": []\
+             }\
+             }",
         )
         .unwrap();
         let ui_meta_from: UiTransactionStatusMeta = meta.clone().into();
@@ -916,10 +929,20 @@ mod test {
             expected_json_output_value
         );
 
+        #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
-             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
-             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}",
+            "{\
+             \"err\":null,\
+             \"status\":{\"Ok\":null},\
+             \"fee\":1234,\
+             \"preBalances\":[1,2,3],\
+             \"postBalances\":[4,5,6],\
+             \"innerInstructions\":null,\
+             \"logMessages\":null,\
+             \"preTokenBalances\":null,\
+             \"postTokenBalances\":null,\
+             \"rewards\":null\
+             }",
         )
         .unwrap();
         let ui_meta_parse_with_rewards = parse_ui_transaction_status_meta(meta.clone(), &[], true);

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -904,22 +904,10 @@ mod test {
             cost_units: None,
         };
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null,\
-            \"loadedAddresses\":{\
-                \"readonly\": [],\
-                \"writable\": []\
-            }\
-        }",
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null,\"\
+             loadedAddresses\":{\"readonly\": [],\"writable\": []}}",
         )
         .unwrap();
         let ui_meta_from: UiTransactionStatusMeta = meta.clone().into();
@@ -929,18 +917,9 @@ mod test {
         );
 
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null\
-        }",
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}",
         )
         .unwrap();
         let ui_meta_parse_with_rewards = parse_ui_transaction_status_meta(meta.clone(), &[], true);


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`