### PR TITLE
Revert - The disabling of `enable_stack_frame_gaps` in `bpf_account_data_direct_mapping`

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -357,7 +357,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
         enable_address_translation: true,
-        enable_stack_frame_gaps: !feature_set.bpf_account_data_direct_mapping,
+        enable_stack_frame_gaps: true,
         instruction_meter_checkpoint_distance: 10000,
         enable_instruction_meter: true,
         enable_instruction_tracing: debugging_features,

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -1348,7 +1348,7 @@ fn process_instruction<'a>(
             let stack = unsafe {
                 slice::from_raw_parts_mut(
                     MM_STACK_START as *mut u8,
-                    MAX_CALL_DEPTH * STACK_FRAME_SIZE,
+                    MAX_CALL_DEPTH * STACK_FRAME_SIZE * 2,
                 )
             };
 
@@ -1361,7 +1361,7 @@ fn process_instruction<'a>(
             // When we don't have dynamic stack frames, the stack grows from lower addresses
             // to higher addresses, so we compare accordingly.
             for i in 10..MAX_CALL_DEPTH {
-                let stack = &mut stack[i * STACK_FRAME_SIZE..][..STACK_FRAME_SIZE];
+                let stack = &mut stack[i * STACK_FRAME_SIZE * 2..][..STACK_FRAME_SIZE];
                 assert!(stack == &ZEROS[..STACK_FRAME_SIZE], "stack not zeroed");
                 stack.fill(42);
             }

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -353,7 +353,7 @@ pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a>> {
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
         enable_address_translation: true,
-        enable_stack_frame_gaps: false,
+        enable_stack_frame_gaps: true,
         instruction_meter_checkpoint_distance: 10000,
         enable_instruction_meter: true,
         enable_instruction_tracing: true,


### PR DESCRIPTION
#### Problem

In the original direct mapping implementation it was necessary to disable stack frame gaps to avoid issues in memory accesses spanning over multiple regions. In the new direct mapping implementation memory accesses are restricted to a single region, thus we can revert this part of the feature gate back to the state it is when the feature is disabled. This way the stack behavior will only change when a program opts into SBPFv1.

#### Summary of Changes

Re-enables `enable_stack_frame_gaps` in the SBPF VM.