### PR TITLE
Update solana-gossip spy to support multiple entrypoints

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1362,14 +1362,14 @@ fn main() {
         let rpc_addr = if !skip_gossip {
             info!("Finding cluster entry: {entrypoint_addr:?}");
             let (gossip_nodes, _validators) = discover_peers(
-                None, // keypair
+                None,
                 &vec![entrypoint_addr],
-                None,                    // num_nodes
-                Duration::from_secs(60), // timeout
-                None,                    // find_nodes_by_pubkey
-                &[entrypoint_addr],      // find_node_by_gossip_addr
-                None,                    // my_gossip_addr
-                shred_version.unwrap(),  // my_shred_version
+                None,
+                Duration::from_secs(60),
+                None,
+                &[entrypoint_addr],
+                None,
+                shred_version.unwrap(),
                 SocketAddrSpace::Unspecified,
             )
             .unwrap_or_else(|err| {

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_clock::Slot,
     solana_commitment_config::CommitmentConfig,
-    solana_gossip::gossip_service::discover,
+    solana_gossip::gossip_service::discover_peers,
     solana_hash::Hash,
     solana_instruction::{AccountMeta, Instruction},
     solana_keypair::{read_keypair_file, Keypair},
@@ -1361,13 +1361,13 @@ fn main() {
 
         let rpc_addr = if !skip_gossip {
             info!("Finding cluster entry: {entrypoint_addr:?}");
-            let (gossip_nodes, _validators) = discover(
+            let (gossip_nodes, _validators) = discover_peers(
                 None, // keypair
-                Some(&entrypoint_addr),
+                &vec![entrypoint_addr],
                 None,                    // num_nodes
                 Duration::from_secs(60), // timeout
                 None,                    // find_nodes_by_pubkey
-                Some(&entrypoint_addr),  // find_node_by_gossip_addr
+                &[entrypoint_addr],      // find_node_by_gossip_addr
                 None,                    // my_gossip_addr
                 shred_version.unwrap(),  // my_shred_version
                 SocketAddrSpace::Unspecified,

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -777,14 +777,14 @@ fn main() {
         info!("Finding cluster entry: {:?}", cmd_params.entrypoint_addr);
         let socket_addr_space = SocketAddrSpace::new(cmd_params.allow_private_addr);
         let (gossip_nodes, validators) = discover_peers(
-            None, // keypair
+            None,
             &vec![cmd_params.entrypoint_addr],
-            None,                              // num_nodes
-            Duration::from_secs(60),           // timeout
-            None,                              // find_nodes_by_pubkey
-            &[cmd_params.entrypoint_addr],     // find_node_by_gossip_addr
-            None,                              // my_gossip_addr
-            cmd_params.shred_version.unwrap(), // my_shred_version
+            None,
+            Duration::from_secs(60),
+            None,
+            &[cmd_params.entrypoint_addr],
+            None,
+            cmd_params.shred_version.unwrap(),
             socket_addr_space,
         )
         .unwrap_or_else(|err| {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -53,7 +53,7 @@ use {
     solana_dos::cli::*,
     solana_gossip::{
         contact_info::{ContactInfo, Protocol},
-        gossip_service::{discover, get_client},
+        gossip_service::{discover_peers, get_client},
     },
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -776,13 +776,13 @@ fn main() {
     let (nodes, client) = if !cmd_params.skip_gossip {
         info!("Finding cluster entry: {:?}", cmd_params.entrypoint_addr);
         let socket_addr_space = SocketAddrSpace::new(cmd_params.allow_private_addr);
-        let (gossip_nodes, validators) = discover(
+        let (gossip_nodes, validators) = discover_peers(
             None, // keypair
-            Some(&cmd_params.entrypoint_addr),
+            &vec![cmd_params.entrypoint_addr],
             None,                              // num_nodes
             Duration::from_secs(60),           // timeout
             None,                              // find_nodes_by_pubkey
-            Some(&cmd_params.entrypoint_addr), // find_node_by_gossip_addr
+            &[cmd_params.entrypoint_addr],     // find_node_by_gossip_addr
             None,                              // my_gossip_addr
             cmd_params.shred_version.unwrap(), // my_shred_version
             socket_addr_space,

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -301,9 +301,9 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
         &entrypoint_addrs,
         num_nodes,
         discover_timeout,
-        pubkeys.as_deref(), // find_nodes_by_pubkey
-        &[],                // find_node_by_gossip_addr
-        Some(&gossip_addr), // my_gossip_addr
+        pubkeys.as_deref(),
+        &[],
+        Some(&gossip_addr),
         shred_version,
         socket_addr_space,
     )?;
@@ -348,13 +348,13 @@ fn process_rpc_url(
 
     #[allow(deprecated)]
     let (_all_peers, validators) = discover_peers(
-        None, // keypair
+        None,
         &entrypoint_addrs,
-        Some(1), // num_nodes
+        Some(1),
         Duration::from_secs(timeout),
-        None,               // find_nodes_by_pubkey
-        &entrypoint_addrs,  // find_node_by_gossip_addr
-        Some(&gossip_addr), // my_gossip_addr
+        None,
+        &entrypoint_addrs,
+        Some(&gossip_addr),
         shred_version,
         socket_addr_space,
     )?;

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -170,10 +170,10 @@ fn parse_matches() -> ArgMatches<'static> {
 
 /// Determine bind address by checking these sources in order:
 /// 1. cli args:
-///     1. bind-address
-///     1. gossip-host
-/// 1. connect to entrypoints to determine my public IP address
-/// 1. default to localhost
+///     a. bind-address
+///     b. gossip-host
+/// 2. connect to entrypoints to determine my public IP address
+/// 3. default to localhost
 fn parse_bind_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> IpAddr {
     if let Some(bind_address) = matches.value_of("bind_address") {
         solana_net_utils::parse_host(bind_address).unwrap_or_else(|e| {

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -15,7 +15,6 @@ use {
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     std::{
-        collections::HashSet,
         error,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         process::exit,
@@ -325,8 +324,6 @@ fn parse_entrypoints(matches: &ArgMatches) -> Vec<SocketAddr> {
         .into_iter()
         .map(|entrypoint| solana_net_utils::parse_host_port(&entrypoint))
         .filter_map(Result::ok)
-        .collect::<HashSet<_>>()
-        .into_iter()
         .collect::<Vec<_>>()
 }
 

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -172,7 +172,6 @@ fn parse_matches() -> ArgMatches<'static> {
 ///     a. bind-address
 ///     b. gossip-host
 /// 2. connect to entrypoints to determine my public IP address
-/// 3. default to localhost
 fn parse_bind_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> IpAddr {
     if let Some(bind_address) = matches.value_of("bind_address") {
         solana_net_utils::parse_host(bind_address).unwrap_or_else(|e| {

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -167,9 +167,7 @@ fn parse_matches() -> ArgMatches<'static> {
 }
 
 /// Determine bind address by checking these sources in order:
-/// 1. cli args:
-///    a. bind-address
-///    b. gossip-host
+/// 1. --bind-address cli arg
 /// 2. connect to entrypoints to determine my public IP address
 fn parse_bind_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> IpAddr {
     if let Some(bind_address) = matches.value_of("bind_address") {

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -65,7 +65,6 @@ fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'
                         .value_name("HOST:PORT")
                         .takes_value(true)
                         .required(true)
-                        .multiple(true)
                         .validator(solana_net_utils::is_host_port)
                         .help("Rendezvous with the cluster at this entry point"),
                 )

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -1,12 +1,12 @@
 //! A command-line executable for monitoring a cluster's gossip plane.
 #[allow(deprecated)]
-use solana_gossip::{contact_info::ContactInfo, gossip_service::discover};
+use solana_gossip::{contact_info::ContactInfo, gossip_service::discover_peers};
 use {
     clap::{
-        crate_description, crate_name, value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches,
-        SubCommand,
+        crate_description, crate_name, value_t, value_t_or_exit, values_t, App, AppSettings, Arg,
+        ArgMatches, SubCommand,
     },
-    log::{error, info},
+    log::{info, warn},
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::{keypair_of, pubkeys_of},
@@ -15,6 +15,7 @@ use {
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     std::{
+        collections::HashSet,
         error,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         process::exit,
@@ -22,7 +23,7 @@ use {
     },
 };
 
-fn parse_matches() -> ArgMatches<'static> {
+fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, 'v> {
     let shred_version_arg = Arg::with_name("shred_version")
         .long("shred-version")
         .value_name("VERSION")
@@ -44,9 +45,9 @@ fn parse_matches() -> ArgMatches<'static> {
         .validator(solana_net_utils::is_host)
         .help("IP address to bind the node to for gossip");
 
-    App::new(crate_name!())
-        .about(crate_description!())
-        .version(solana_version::version!())
+    App::new(name)
+        .about(about)
+        .version(version)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             Arg::with_name("allow_private_addr")
@@ -65,6 +66,7 @@ fn parse_matches() -> ArgMatches<'static> {
                         .value_name("HOST:PORT")
                         .takes_value(true)
                         .required(true)
+                        .multiple(true)
                         .validator(solana_net_utils::is_host_port)
                         .help("Rendezvous with the cluster at this entry point"),
                 )
@@ -104,6 +106,7 @@ fn parse_matches() -> ArgMatches<'static> {
                         .long("entrypoint")
                         .value_name("HOST:PORT")
                         .takes_value(true)
+                        .multiple(true)
                         .validator(solana_net_utils::is_host_port)
                         .help("Rendezvous with the cluster at this entrypoint"),
                 )
@@ -154,27 +157,49 @@ fn parse_matches() -> ArgMatches<'static> {
                         .help("Maximum time to wait in seconds [default: wait forever]"),
                 ),
         )
-        .get_matches()
 }
 
-fn parse_bind_address(matches: &ArgMatches, entrypoint_addr: Option<SocketAddr>) -> IpAddr {
+fn parse_matches() -> ArgMatches<'static> {
+    get_clap_app(
+        crate_name!(),
+        crate_description!(),
+        solana_version::version!(),
+    )
+    .get_matches()
+}
+
+/// Determine bind address by checking these sources in order:
+/// 1. cli args:
+///     1. bind-address
+///     1. gossip-host
+/// 1. connect to entrypoints to determine my public IP address
+/// 1. default to localhost
+fn parse_bind_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> IpAddr {
     if let Some(bind_address) = matches.value_of("bind_address") {
         solana_net_utils::parse_host(bind_address).unwrap_or_else(|e| {
             eprintln!("failed to parse bind-address: {e}");
             exit(1);
         })
-    } else if let Some(entrypoint_addr) = entrypoint_addr {
+    } else if let Some(bind_addr) = get_bind_address_from_entrypoints(entrypoint_addrs) {
+        bind_addr
+    } else {
+        eprintln!(
+            "Failed to find a valid bind address. Bind address can be provided directly with \
+             --bind-address or by the entrypoint functioning as an ip echo server."
+        );
+        exit(1);
+    }
+}
+
+/// Find my public IP address by attempting connections to entrypoints until one succeeds.
+fn get_bind_address_from_entrypoints(entrypoint_addrs: &[SocketAddr]) -> Option<IpAddr> {
+    entrypoint_addrs.iter().find_map(|entrypoint_addr| {
         solana_net_utils::get_public_ip_addr_with_binding(
-            &entrypoint_addr,
+            entrypoint_addr,
             IpAddr::V4(Ipv4Addr::UNSPECIFIED),
         )
-        .unwrap_or_else(|err| {
-            eprintln!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
-            exit(1);
-        })
-    } else {
-        IpAddr::V4(Ipv4Addr::LOCALHOST)
-    }
+        .ok()
+    })
 }
 
 // allow deprecations here to workaround limitations with dependency specification in
@@ -227,25 +252,24 @@ fn process_spy_results(
     }
 }
 
-fn get_entrypoint_shred_version(entrypoint: &Option<SocketAddr>) -> Option<u16> {
-    let Some(entrypoint) = entrypoint else {
-        error!("cannot obtain shred-version without an entrypoint");
-        return None;
-    };
-    match solana_net_utils::get_cluster_shred_version(entrypoint) {
-        Err(err) => {
-            error!("get_cluster_shred_version failed: {entrypoint}, {err}");
-            None
+/// Check entrypoints until one returns a valid non-zero shred version
+fn get_entrypoint_shred_version(entrypoint_addrs: &[SocketAddr]) -> Option<u16> {
+    entrypoint_addrs.iter().find_map(|entrypoint_addr| {
+        match solana_net_utils::get_cluster_shred_version(entrypoint_addr) {
+            Err(err) => {
+                warn!("get_cluster_shred_version failed: {entrypoint_addr}, {err}");
+                None
+            }
+            Ok(0) => {
+                warn!("entrypoint {entrypoint_addr} returned shred-version zero");
+                None
+            }
+            Ok(shred_version) => {
+                info!("obtained shred-version {shred_version} from entrypoint: {entrypoint_addr}");
+                Some(shred_version)
+            }
         }
-        Ok(0) => {
-            error!("entrypoint {entrypoint} returned shred-version zero");
-            None
-        }
-        Ok(shred_version) => {
-            info!("obtained shred-version {shred_version} from entrypoint: {entrypoint}");
-            Some(shred_version)
-        }
-    }
+    })
 }
 
 fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std::io::Result<()> {
@@ -261,24 +285,24 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
         .map(|secs| secs.to_string().parse().unwrap());
     let pubkeys = pubkeys_of(matches, "node_pubkey");
     let identity_keypair = keypair_of(matches, "identity");
-    let entrypoint_addr = parse_entrypoint(matches);
-    let gossip_addr = get_gossip_address(matches, entrypoint_addr);
+    let entrypoint_addrs = parse_entrypoints(matches);
+    let gossip_addr = get_gossip_address(matches, &entrypoint_addrs);
 
     let mut shred_version = value_t_or_exit!(matches, "shred_version", u16);
     if shred_version == 0 {
-        shred_version = get_entrypoint_shred_version(&entrypoint_addr)
+        shred_version = get_entrypoint_shred_version(&entrypoint_addrs)
             .expect("need non-zero shred-version to join the cluster");
     }
 
     let discover_timeout = Duration::from_secs(timeout.unwrap_or(u64::MAX));
     #[allow(deprecated)]
-    let (_all_peers, validators) = discover(
+    let (_all_peers, validators) = discover_peers(
         identity_keypair,
-        entrypoint_addr.as_ref(),
+        &entrypoint_addrs,
         num_nodes,
         discover_timeout,
         pubkeys.as_deref(), // find_nodes_by_pubkey
-        None,               // find_node_by_gossip_addr
+        &[],                // find_node_by_gossip_addr
         Some(&gossip_addr), // my_gossip_addr
         shred_version,
         socket_addr_space,
@@ -295,13 +319,15 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
     Ok(())
 }
 
-fn parse_entrypoint(matches: &ArgMatches) -> Option<SocketAddr> {
-    matches.value_of("entrypoint").map(|entrypoint| {
-        solana_net_utils::parse_host_port(entrypoint).unwrap_or_else(|e| {
-            eprintln!("failed to parse entrypoint address: {e}");
-            exit(1);
-        })
-    })
+fn parse_entrypoints(matches: &ArgMatches) -> Vec<SocketAddr> {
+    values_t!(matches, "entrypoint", String)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|entrypoint| solana_net_utils::parse_host_port(&entrypoint))
+        .filter_map(Result::ok)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
 }
 
 fn process_rpc_url(
@@ -311,24 +337,24 @@ fn process_rpc_url(
     let any = matches.is_present("any");
     let all = matches.is_present("all");
     let timeout = value_t_or_exit!(matches, "timeout", u64);
-    let entrypoint_addr = parse_entrypoint(matches);
-    let gossip_addr = get_gossip_address(matches, entrypoint_addr);
+    let entrypoint_addrs = parse_entrypoints(matches);
+    let gossip_addr = get_gossip_address(matches, &entrypoint_addrs);
 
     let mut shred_version = value_t_or_exit!(matches, "shred_version", u16);
     if shred_version == 0 {
-        shred_version = get_entrypoint_shred_version(&entrypoint_addr)
+        shred_version = get_entrypoint_shred_version(&entrypoint_addrs)
             .expect("need non-zero shred-version to join the cluster");
     }
 
     #[allow(deprecated)]
-    let (_all_peers, validators) = discover(
+    let (_all_peers, validators) = discover_peers(
         None, // keypair
-        entrypoint_addr.as_ref(),
+        &entrypoint_addrs,
         Some(1), // num_nodes
         Duration::from_secs(timeout),
-        None,                     // find_nodes_by_pubkey
-        entrypoint_addr.as_ref(), // find_node_by_gossip_addr
-        Some(&gossip_addr),       // my_gossip_addr
+        None,               // find_nodes_by_pubkey
+        &entrypoint_addrs,  // find_node_by_gossip_addr
+        Some(&gossip_addr), // my_gossip_addr
         shred_version,
         socket_addr_space,
     )?;
@@ -340,7 +366,7 @@ fn process_rpc_url(
                 #[allow(deprecated)]
                 let addrs = node.gossip();
                 addrs
-                    .map(|addr| Some(addr) == entrypoint_addr)
+                    .map(|addr| entrypoint_addrs.contains(&addr))
                     .unwrap_or_default()
             }
         })
@@ -366,8 +392,8 @@ fn process_rpc_url(
     Ok(())
 }
 
-fn get_gossip_address(matches: &ArgMatches, entrypoint_addr: Option<SocketAddr>) -> SocketAddr {
-    let bind_address = parse_bind_address(matches, entrypoint_addr);
+fn get_gossip_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> SocketAddr {
+    let bind_address = parse_bind_address(matches, entrypoint_addrs);
     SocketAddr::new(
         bind_address,
         value_t!(matches, "gossip_port", u16).unwrap_or_else(|_| {

--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -168,8 +168,8 @@ fn parse_matches() -> ArgMatches<'static> {
 
 /// Determine bind address by checking these sources in order:
 /// 1. cli args:
-///     a. bind-address
-///     b. gossip-host
+///    a. bind-address
+///    b. gossip-host
 /// 2. connect to entrypoints to determine my public IP address
 fn parse_bind_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> IpAddr {
     if let Some(bind_address) = matches.value_of("bind_address") {

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -151,20 +151,21 @@ pub fn discover_validators(
     socket_addr_space: SocketAddrSpace,
 ) -> std::io::Result<Vec<ContactInfo>> {
     const DISCOVER_CLUSTER_TIMEOUT: Duration = Duration::from_secs(120);
-    let (_all_peers, validators) = discover(
-        None, // keypair
-        Some(entrypoint),
+    let (_all_peers, validators) = discover_peers(
+        None,
+        &vec![*entrypoint],
         Some(num_nodes),
         DISCOVER_CLUSTER_TIMEOUT,
-        None,             // find_nodes_by_pubkey
-        None,             // find_node_by_gossip_addr
-        None,             // my_gossip_addr
-        my_shred_version, // my_shred_version
+        None,
+        &[],
+        None,
+        my_shred_version,
         socket_addr_space,
     )?;
     Ok(validators)
 }
 
+#[deprecated(since = "3.0.0", note = "use `discover_peers` instead")]
 pub fn discover(
     keypair: Option<Keypair>,
     entrypoint: Option<&SocketAddr>,
@@ -179,11 +180,45 @@ pub fn discover(
     Vec<ContactInfo>, // all gossip peers
     Vec<ContactInfo>, // tvu peers (validators)
 )> {
+    let entrypoints = &entrypoint.into_iter().copied().collect::<Vec<SocketAddr>>();
+
+    let find_nodes_by_gossip_addr = &find_node_by_gossip_addr
+        .into_iter()
+        .copied()
+        .collect::<Vec<SocketAddr>>();
+
+    discover_peers(
+        keypair,
+        entrypoints,
+        num_nodes,
+        timeout,
+        find_nodes_by_pubkey,
+        find_nodes_by_gossip_addr,
+        my_gossip_addr,
+        my_shred_version,
+        socket_addr_space,
+    )
+}
+
+pub fn discover_peers(
+    keypair: Option<Keypair>,
+    entrypoints: &Vec<SocketAddr>,
+    num_nodes: Option<usize>, // num_nodes only counts validators, excludes spy nodes
+    timeout: Duration,
+    find_nodes_by_pubkey: Option<&[Pubkey]>,
+    find_nodes_by_gossip_addr: &[SocketAddr],
+    my_gossip_addr: Option<&SocketAddr>,
+    my_shred_version: u16,
+    socket_addr_space: SocketAddrSpace,
+) -> std::io::Result<(
+    Vec<ContactInfo>, // all gossip peers
+    Vec<ContactInfo>, // tvu peers (validators)
+)> {
     let keypair = keypair.unwrap_or_else(Keypair::new);
     let exit = Arc::new(AtomicBool::new(false));
-    let (gossip_service, ip_echo, spy_ref) = make_gossip_node(
+    let (gossip_service, ip_echo, spy_ref) = make_node(
         keypair,
-        entrypoint,
+        entrypoints,
         exit.clone(),
         my_gossip_addr,
         my_shred_version,
@@ -192,7 +227,7 @@ pub fn discover(
     );
 
     let id = spy_ref.id();
-    info!("Entrypoint: {entrypoint:?}");
+    info!("Entrypoints: {entrypoints:?}");
     info!("Node Id: {id:?}");
     if let Some(my_gossip_addr) = my_gossip_addr {
         info!("Gossip Address: {my_gossip_addr:?}");
@@ -210,7 +245,7 @@ pub fn discover(
         num_nodes,
         timeout,
         find_nodes_by_pubkey,
-        find_node_by_gossip_addr,
+        find_nodes_by_gossip_addr,
     );
 
     exit.store(true, Ordering::Relaxed);
@@ -278,7 +313,7 @@ fn spy(
     num_nodes: Option<usize>,
     timeout: Duration,
     find_nodes_by_pubkey: Option<&[Pubkey]>,
-    find_node_by_gossip_addr: Option<&SocketAddr>,
+    find_nodes_by_gossip_addr: &[SocketAddr],
 ) -> (
     bool,             // if found the specified nodes
     Duration,         // elapsed time until found the nodes or timed-out
@@ -306,13 +341,14 @@ fn spy(
             false
         };
 
-        let found_node_by_gossip_addr = if let Some(gossip_addr) = find_node_by_gossip_addr {
-            all_peers
-                .iter()
-                .any(|node| node.gossip() == Some(*gossip_addr))
-        } else {
-            false
-        };
+        // if find_nodes_by_gossip_addr is not empty and all_peers contains
+        // all the nodes from find_nodes_by_gossip_addr
+        let found_node_by_gossip_addr = !find_nodes_by_gossip_addr.is_empty()
+            && find_nodes_by_gossip_addr.iter().all(|node_addr| {
+                all_peers
+                    .iter()
+                    .any(|peer| (*peer).gossip() == Some(*node_addr))
+            });
 
         if let Some(num) = num_nodes {
             // Only consider validators and archives for `num_nodes`
@@ -325,7 +361,7 @@ fn spy(
                     met_criteria = true;
                 }
 
-                if find_nodes_by_pubkey.is_none() && find_node_by_gossip_addr.is_none() {
+                if find_nodes_by_pubkey.is_none() && find_nodes_by_gossip_addr.is_empty() {
                     met_criteria = true;
                 }
             }
@@ -345,9 +381,34 @@ fn spy(
 
 /// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
 /// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
+#[deprecated(since = "3.0.0", note = "use `make_node` instead")]
 pub fn make_gossip_node(
     keypair: Keypair,
     entrypoint: Option<&SocketAddr>,
+    exit: Arc<AtomicBool>,
+    gossip_addr: Option<&SocketAddr>,
+    shred_version: u16,
+    should_check_duplicate_instance: bool,
+    socket_addr_space: SocketAddrSpace,
+) -> (GossipService, Option<TcpListener>, Arc<ClusterInfo>) {
+    let entrypoints = &entrypoint.into_iter().copied().collect::<Vec<SocketAddr>>();
+
+    make_node(
+        keypair,
+        entrypoints,
+        exit,
+        gossip_addr,
+        shred_version,
+        should_check_duplicate_instance,
+        socket_addr_space,
+    )
+}
+
+/// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
+/// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
+pub fn make_node(
+    keypair: Keypair,
+    entrypoints: &[SocketAddr],
     exit: Arc<AtomicBool>,
     gossip_addr: Option<&SocketAddr>,
     shred_version: u16,
@@ -360,9 +421,13 @@ pub fn make_gossip_node(
         ClusterInfo::spy_node(keypair.pubkey(), shred_version)
     };
     let cluster_info = ClusterInfo::new(node, Arc::new(keypair), socket_addr_space);
-    if let Some(entrypoint) = entrypoint {
-        cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(entrypoint));
-    }
+
+    cluster_info.set_entrypoints(
+        entrypoints
+            .iter()
+            .map(ContactInfo::new_gossip_entry_point)
+            .collect::<Vec<_>>(),
+    );
     let gossip_sockets = Arc::new([gossip_socket]);
     let cluster_info = Arc::new(cluster_info);
     let gossip_service = GossipService::new(
@@ -426,40 +491,40 @@ mod tests {
 
         let spy_ref = Arc::new(cluster_info);
 
-        let (met_criteria, elapsed, _, tvu_peers) = spy(spy_ref.clone(), None, TIMEOUT, None, None);
+        let (met_criteria, elapsed, _, tvu_peers) = spy(spy_ref.clone(), None, TIMEOUT, None, &[]);
         assert!(!met_criteria);
         assert!((TIMEOUT..TIMEOUT + Duration::from_secs(1)).contains(&elapsed));
         assert_eq!(tvu_peers, spy_ref.tvu_peers(ContactInfo::clone));
 
         // Find num_nodes
-        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(1), TIMEOUT, None, None);
+        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(1), TIMEOUT, None, &[]);
         assert!(met_criteria);
-        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(2), TIMEOUT, None, None);
+        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(2), TIMEOUT, None, &[]);
         assert!(met_criteria);
 
         // Find specific node by pubkey
-        let (met_criteria, _, _, _) = spy(spy_ref.clone(), None, TIMEOUT, Some(&[peer0]), None);
+        let (met_criteria, _, _, _) = spy(spy_ref.clone(), None, TIMEOUT, Some(&[peer0]), &[]);
         assert!(met_criteria);
         let (met_criteria, _, _, _) = spy(
             spy_ref.clone(),
             None,
             TIMEOUT,
             Some(&[solana_pubkey::new_rand()]),
-            None,
+            &[],
         );
         assert!(!met_criteria);
 
         // Find num_nodes *and* specific node by pubkey
-        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(1), TIMEOUT, Some(&[peer0]), None);
+        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(1), TIMEOUT, Some(&[peer0]), &[]);
         assert!(met_criteria);
-        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(3), TIMEOUT, Some(&[peer0]), None);
+        let (met_criteria, _, _, _) = spy(spy_ref.clone(), Some(3), TIMEOUT, Some(&[peer0]), &[]);
         assert!(!met_criteria);
         let (met_criteria, _, _, _) = spy(
             spy_ref.clone(),
             Some(1),
             TIMEOUT,
             Some(&[solana_pubkey::new_rand()]),
-            None,
+            &[],
         );
         assert!(!met_criteria);
 
@@ -469,7 +534,7 @@ mod tests {
             None,
             TIMEOUT,
             None,
-            Some(&peer0_info.gossip().unwrap()),
+            &[peer0_info.gossip().unwrap()],
         );
         assert!(met_criteria);
 
@@ -478,7 +543,7 @@ mod tests {
             None,
             TIMEOUT,
             None,
-            Some(&"1.1.1.1:1234".parse().unwrap()),
+            &["1.1.1.1:1234".parse().unwrap()],
         );
         assert!(!met_criteria);
     }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -341,9 +341,9 @@ fn spy(
             false
         };
 
-        // if find_nodes_by_gossip_addr is not empty and all_peers contains
+        // if find_nodes_by_gossip_addr is not empty and all_peers contain
         // all the nodes from find_nodes_by_gossip_addr
-        let found_node_by_gossip_addr = !find_nodes_by_gossip_addr.is_empty()
+        let found_nodes_by_gossip_addr = !find_nodes_by_gossip_addr.is_empty()
             && find_nodes_by_gossip_addr.iter().all(|node_addr| {
                 all_peers
                     .iter()
@@ -357,7 +357,7 @@ fn spy(
             nodes.dedup();
 
             if nodes.len() >= num {
-                if found_nodes_by_pubkey || found_node_by_gossip_addr {
+                if found_nodes_by_pubkey || found_nodes_by_gossip_addr {
                     met_criteria = true;
                 }
 
@@ -365,7 +365,7 @@ fn spy(
                     met_criteria = true;
                 }
             }
-        } else if found_nodes_by_pubkey || found_node_by_gossip_addr {
+        } else if found_nodes_by_pubkey || found_nodes_by_gossip_addr {
             met_criteria = true;
         }
         if i % 20 == 0 {

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -165,7 +165,7 @@ pub fn discover_validators(
     Ok(validators)
 }
 
-#[deprecated(since = "3.0.0", note = "use `discover_peers` instead")]
+#[deprecated(since = "3.1.0", note = "use `discover_peers` instead")]
 pub fn discover(
     keypair: Option<Keypair>,
     entrypoint: Option<&SocketAddr>,
@@ -381,7 +381,7 @@ fn spy(
 
 /// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
 /// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
-#[deprecated(since = "3.0.0", note = "use `make_node` instead")]
+#[deprecated(since = "3.1.0", note = "use `make_node` instead")]
 pub fn make_gossip_node(
     keypair: Keypair,
     entrypoint: Option<&SocketAddr>,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -165,41 +165,6 @@ pub fn discover_validators(
     Ok(validators)
 }
 
-#[deprecated(since = "3.1.0", note = "use `discover_peers` instead")]
-pub fn discover(
-    keypair: Option<Keypair>,
-    entrypoint: Option<&SocketAddr>,
-    num_nodes: Option<usize>, // num_nodes only counts validators, excludes spy nodes
-    timeout: Duration,
-    find_nodes_by_pubkey: Option<&[Pubkey]>,
-    find_node_by_gossip_addr: Option<&SocketAddr>,
-    my_gossip_addr: Option<&SocketAddr>,
-    my_shred_version: u16,
-    socket_addr_space: SocketAddrSpace,
-) -> std::io::Result<(
-    Vec<ContactInfo>, // all gossip peers
-    Vec<ContactInfo>, // tvu peers (validators)
-)> {
-    let entrypoints = &entrypoint.into_iter().copied().collect::<Vec<SocketAddr>>();
-
-    let find_nodes_by_gossip_addr = &find_node_by_gossip_addr
-        .into_iter()
-        .copied()
-        .collect::<Vec<SocketAddr>>();
-
-    discover_peers(
-        keypair,
-        entrypoints,
-        num_nodes,
-        timeout,
-        find_nodes_by_pubkey,
-        find_nodes_by_gossip_addr,
-        my_gossip_addr,
-        my_shred_version,
-        socket_addr_space,
-    )
-}
-
 pub fn discover_peers(
     keypair: Option<Keypair>,
     entrypoints: &Vec<SocketAddr>,
@@ -377,29 +342,6 @@ fn spy(
         i += 1;
     }
     (met_criteria, now.elapsed(), all_peers, tvu_peers)
-}
-
-#[deprecated(since = "3.1.0", note = "use `make_node` instead")]
-pub fn make_gossip_node(
-    keypair: Keypair,
-    entrypoint: Option<&SocketAddr>,
-    exit: Arc<AtomicBool>,
-    gossip_addr: Option<&SocketAddr>,
-    shred_version: u16,
-    should_check_duplicate_instance: bool,
-    socket_addr_space: SocketAddrSpace,
-) -> (GossipService, Option<TcpListener>, Arc<ClusterInfo>) {
-    let entrypoints = &entrypoint.into_iter().copied().collect::<Vec<SocketAddr>>();
-
-    make_node(
-        keypair,
-        entrypoints,
-        exit,
-        gossip_addr,
-        shred_version,
-        should_check_duplicate_instance,
-        socket_addr_space,
-    )
 }
 
 pub fn make_node(

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -379,8 +379,6 @@ fn spy(
     (met_criteria, now.elapsed(), all_peers, tvu_peers)
 }
 
-/// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
-/// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
 #[deprecated(since = "3.1.0", note = "use `make_node` instead")]
 pub fn make_gossip_node(
     keypair: Keypair,
@@ -404,8 +402,6 @@ pub fn make_gossip_node(
     )
 }
 
-/// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
-/// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
 pub fn make_node(
     keypair: Keypair,
     entrypoints: &[SocketAddr],

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -536,11 +536,11 @@ pub fn start_gossip_voter(
     shred_version: u16,
 ) -> GossipVoter {
     let exit = Arc::new(AtomicBool::new(false));
-    let (gossip_service, tcp_listener, cluster_info) = gossip_service::make_gossip_node(
+    let (gossip_service, tcp_listener, cluster_info) = gossip_service::make_node(
         // Need to use our validator's keypair to gossip EpochSlots and votes for our
         // node later.
         node_keypair.insecure_clone(),
-        Some(gossip_addr),
+        &[*gossip_addr],
         exit.clone(),
         None,
         shred_version,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -22,7 +22,7 @@ use {
     solana_genesis_config::GenesisConfig,
     solana_gossip::{
         contact_info::{ContactInfo, Protocol},
-        gossip_service::{discover, discover_validators},
+        gossip_service::{discover_peers, discover_validators},
         node::Node,
     },
     solana_keypair::Keypair,
@@ -484,13 +484,13 @@ impl LocalCluster {
             );
         });
 
-        discover(
+        discover_peers(
             None,
-            Some(&cluster.entry_point_info.gossip().unwrap()),
+            &vec![cluster.entry_point_info.gossip().unwrap()],
             Some(config.node_stakes.len() + config.num_listeners as usize),
             Duration::from_secs(120),
             None,
-            None,
+            &[],
             None,
             leader_contact_info.shred_version(),
             socket_addr_space,

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -622,14 +622,14 @@ fn main() {
     let rpc_addr = if !skip_gossip {
         info!("Finding cluster entry: {entrypoint_addr:?}");
         let (gossip_nodes, _validators) = discover_peers(
-            None, // keypair
+            None,
             &vec![entrypoint_addr],
-            None,                    // num_nodes
-            Duration::from_secs(60), // timeout
-            None,                    // find_node_by_pubkey
-            &[entrypoint_addr],      // find_node_by_gossip_addr
-            None,                    // my_gossip_addr
-            shred_version.unwrap(),  // my_shred_version
+            None,
+            Duration::from_secs(60),
+            None,
+            &[entrypoint_addr],
+            None,
+            shred_version.unwrap(),
             SocketAddrSpace::Unspecified,
         )
         .unwrap_or_else(|err| {

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -13,7 +13,7 @@ use {
     solana_client::transaction_executor::TransactionExecutor,
     solana_commitment_config::CommitmentConfig,
     solana_faucet::faucet::{request_airdrop_transaction, FAUCET_PORT},
-    solana_gossip::gossip_service::discover,
+    solana_gossip::gossip_service::discover_peers,
     solana_instruction::{AccountMeta, Instruction},
     solana_keypair::{read_keypair_file, Keypair},
     solana_message::Message,
@@ -621,13 +621,13 @@ fn main() {
 
     let rpc_addr = if !skip_gossip {
         info!("Finding cluster entry: {entrypoint_addr:?}");
-        let (gossip_nodes, _validators) = discover(
+        let (gossip_nodes, _validators) = discover_peers(
             None, // keypair
-            Some(&entrypoint_addr),
+            &vec![entrypoint_addr],
             None,                    // num_nodes
             Duration::from_secs(60), // timeout
             None,                    // find_node_by_pubkey
-            Some(&entrypoint_addr),  // find_node_by_gossip_addr
+            &[entrypoint_addr],      // find_node_by_gossip_addr
             None,                    // my_gossip_addr
             shred_version.unwrap(),  // my_shred_version
             SocketAddrSpace::Unspecified,


### PR DESCRIPTION
#### Problem
`solana-gossip spy` only accepts one `--entrypoint` arg. Devops would like to run multiple entrypoints and multiple known validators for each cluster and have them all reference each other for improved redundancy

#### Summary of Changes
* Update `solana-gossip spy` and `solana-gossip rpc-url` to accept multiple `--entrypoint` args.
* Deprecate `GossipService::discover` and `GossipService::make_gossip_node` in order to change the interface to accept `&Vec<SocketAddr>` instead of `Option<&SocketAddr>`
    * `discover` is deprecated and replaced with `discover_peers`
    * `make_gossip_node` is deprecated and replaced with `make_node`
*  Update other crates that use the deprecated functions

#### Testing
* Pass multiple entrypoints
    * `solana-gossip spy -n entrypoint.mainnet-beta.anza.xyz:8001 -n entrypoint1.mainnet-beta.anza.xyz:8001    -n entrypoint2.mainnet-beta.anza.xyz:8001    -n entrypoint3.mainnet-beta.anza.xyz:8001    -n entrypoint4.mainnet-beta.anza.xyz:8001`
        * successfully joined cluster
* Pass multiple entrypoints for different clusters
    * Provide no shred version: `solana-gossip spy -n entrypoint1.mainnet-beta.anza.xyz:8001 -n entrypoint1.devnet.anza.xyz:8001`
        * this got the mainnet-beta shred version (50093) and succesfully joined mb
    * Provide mb shred version: `solana-gossip spy -n entrypoint1.mainnet-beta.anza.xyz:8001 -n entrypoint1.devnet.anza.xyz:8001 --shred-version 50093`
        * successfully joined mb
    * Provide devnet shred version: `solana-gossip spy -n entrypoint1.mainnet-beta.anza.xyz:8001 -n entrypoint1.devnet.anza.xyz:8001 --shred-version 29062`
        * successfully joined devnet
    * Provide invalid shred version: `solana-gossip spy -n entrypoint1.mainnet-beta.anza.xyz:8001 -n entrypoint1.devnet.anza.xyz:8001 --shred-version 12345`
        * As expected this never finds any nodes with this shred version
* Pass duplicate entrypoints
    * `solana-gossip spy -n entrypoint1.devnet.anza.xyz:8001 -n entrypoint1.devnet.anza.xyz:8001`
        * successfully joined cluster
* Error conditions:
    * Exit if no bind address found
        * Attempt connecting to a node that isn't listening: `solana-gossip spy -n 147.28.198.65:8001`
            Exits with: `Failed to find a valid bind address. Bind address can be provided directly with --bind-address or by the entrypoint functioning as an ip echo server.`
    * Exit if no shred version found
         * `solana-gossip spy -n 147.28.198.65:8001 --gossip-host 0.0.0.0`
            * Panics with `need non-zero shred-version to join the cluster`. This behaivor is unchanged by this PR.
