### PR TITLE
Removes BankIncrementalSnapshotPersistence from SnapshotPackage

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -6,7 +6,6 @@ use {
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_measure::measure_us,
     solana_runtime::{
-        serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_config::SnapshotConfig,
         snapshot_controller::SnapshotController,
         snapshot_package::{
@@ -177,7 +176,7 @@ impl AccountsHashVerifier {
     ) -> io::Result<()> {
         Self::purge_old_accounts_hashes(&accounts_package, snapshot_config);
 
-        Self::submit_for_packaging(accounts_package, pending_snapshot_packages, None);
+        Self::submit_for_packaging(accounts_package, pending_snapshot_packages);
 
         Ok(())
     }
@@ -216,7 +215,6 @@ impl AccountsHashVerifier {
     fn submit_for_packaging(
         accounts_package: AccountsPackage,
         pending_snapshot_packages: &Mutex<PendingSnapshotPackages>,
-        bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     ) {
         if !matches!(
             accounts_package.package_kind,
@@ -225,8 +223,7 @@ impl AccountsHashVerifier {
             return;
         }
 
-        let snapshot_package =
-            SnapshotPackage::new(accounts_package, bank_incremental_snapshot_persistence);
+        let snapshot_package = SnapshotPackage::new(accounts_package);
         pending_snapshot_packages
             .lock()
             .unwrap()

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -796,7 +796,7 @@ fn bank_to_full_snapshot_archive_with(
         snapshot_storages,
         status_cache_slot_deltas,
     );
-    let snapshot_package = SnapshotPackage::new(accounts_package, None);
+    let snapshot_package = SnapshotPackage::new(accounts_package);
 
     let snapshot_config = SnapshotConfig {
         full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
@@ -854,7 +854,7 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_storages,
         status_cache_slot_deltas,
     );
-    let snapshot_package = SnapshotPackage::new(accounts_package, None);
+    let snapshot_package = SnapshotPackage::new(accounts_package);
 
     // Note: Since the snapshot_storages above are *only* the incremental storages,
     // this bank snapshot *cannot* be used by fastboot.

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
         bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
-        serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
     },
     log::*,
@@ -171,7 +170,6 @@ pub struct SnapshotPackage {
     pub accounts_delta_hash: AccountsDeltaHash, // obsolete, will be removed next
     pub accounts_hash: AccountsHash,
     pub write_version: u64,
-    pub bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>, // obsolete, will be removed next
 
     /// The instant this snapshot package was sent to the queue.
     /// Used to track how long snapshot packages wait before handling.
@@ -179,10 +177,7 @@ pub struct SnapshotPackage {
 }
 
 impl SnapshotPackage {
-    pub fn new(
-        accounts_package: AccountsPackage,
-        bank_incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
-    ) -> Self {
+    pub fn new(accounts_package: AccountsPackage) -> Self {
         let AccountsPackageKind::Snapshot(snapshot_kind) = accounts_package.package_kind;
         let Some(snapshot_info) = accounts_package.snapshot_info else {
             panic!(
@@ -207,7 +202,6 @@ impl SnapshotPackage {
             accounts_delta_hash: snapshot_info.accounts_delta_hash,
             bank_hash_stats: snapshot_info.bank_hash_stats,
             accounts_hash: AccountsHash(Hash::default()), // obsolete, will be removed next
-            bank_incremental_snapshot_persistence,
             write_version: snapshot_info.write_version,
             enqueued: Instant::now(),
         }
@@ -230,7 +224,6 @@ impl SnapshotPackage {
             accounts_delta_hash: AccountsDeltaHash(Hash::default()),
             bank_hash_stats: BankHashStats::default(),
             accounts_hash: AccountsHash(Hash::default()),
-            bank_incremental_snapshot_persistence: None,
             write_version: u64::default(),
             enqueued: Instant::now(),
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2,9 +2,8 @@ use {
     crate::{
         bank::{BankFieldsToDeserialize, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         serde_snapshot::{
-            self, AccountsDbFields, BankIncrementalSnapshotPersistence, ExtraFieldsToSerialize,
-            SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
-            SnapshotStreams,
+            self, AccountsDbFields, ExtraFieldsToSerialize, SerializableAccountStorageEntry,
+            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams,
         },
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,
@@ -831,7 +830,6 @@ pub fn serialize_and_archive_snapshot_package(
         bank_hash_stats,
         accounts_delta_hash,
         accounts_hash,
-        bank_incremental_snapshot_persistence,
         write_version,
         enqueued: _,
     } = snapshot_package;
@@ -845,7 +843,6 @@ pub fn serialize_and_archive_snapshot_package(
         bank_hash_stats,
         accounts_delta_hash,
         accounts_hash,
-        bank_incremental_snapshot_persistence.as_ref(),
         write_version,
         should_flush_and_hard_link_storages,
     )?;
@@ -907,7 +904,6 @@ fn serialize_snapshot(
     bank_hash_stats: BankHashStats,
     accounts_delta_hash: AccountsDeltaHash,
     accounts_hash: AccountsHash,
-    bank_incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     write_version: u64,
     should_flush_and_hard_link_storages: bool,
 ) -> Result<BankSnapshotInfo> {
@@ -960,7 +956,7 @@ fn serialize_snapshot(
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let extra_fields = ExtraFieldsToSerialize {
                 lamports_per_signature: bank_fields.fee_rate_governor.lamports_per_signature,
-                incremental_snapshot_persistence: bank_incremental_snapshot_persistence,
+                incremental_snapshot_persistence: None,
                 obsolete_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

For this PR, remove BankIncrementalSnapshotPersistence from SnapshotPackage

Note the BankIncrementalSnapshotPersistence is also used when restoring from a snapshot. This PR purposely does not touch that code.