### PR TITLE
BankFieldsToDeserialize must have AccountsLtHash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -403,7 +403,7 @@ impl TransactionLogCollector {
 /// Since it is difficult to insert fields to serialize/deserialize against existing code already deployed,
 /// new fields can be optionally serialized and optionally deserialized. At some point, the serialization and
 /// deserialization will use a new mechanism or otherwise be in sync more clearly.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BankFieldsToDeserialize {
     pub(crate) blockhash_queue: BlockhashQueue,
@@ -436,8 +436,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
     pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
-    // When removing the accounts lt hash featurization code, also remove this Option wrapper
-    pub(crate) accounts_lt_hash: Option<AccountsLtHash>,
+    pub(crate) accounts_lt_hash: AccountsLtHash,
     pub(crate) bank_hash_stats: BankHashStats,
 }
 
@@ -1804,11 +1803,7 @@ impl Bank {
             fee_structure: FeeStructure::default(),
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
-            accounts_lt_hash: Mutex::new(
-                fields
-                    .accounts_lt_hash
-                    .expect("accounts_lt_hash must exist in snapshot"),
-            ),
+            accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
             cache_for_accounts_lt_hash: DashMap::default(),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
             block_id: RwLock::new(None),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -165,6 +165,9 @@ struct DeserializableVersionedBank {
 
 impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
     fn from(dvb: DeserializableVersionedBank) -> Self {
+        // This serves as a canary for the LtHash.
+        // If it is not replaced during deserialization, it indicates a bug.
+        const LT_HASH_CANARY: LtHash = LtHash([0xCAFE; LtHash::NUM_ELEMENTS]);
         BankFieldsToDeserialize {
             blockhash_queue: dvb.blockhash_queue,
             ancestors: dvb.ancestors,
@@ -196,8 +199,8 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             is_delta: dvb.is_delta,
             incremental_snapshot_persistence: None,
             versioned_epoch_stakes: HashMap::default(), // populated from ExtraFieldsToDeserialize
-            accounts_lt_hash: AccountsLtHash(LtHash([0xCAFE; LtHash::NUM_ELEMENTS])), // populated from ExtraFieldsToDeserialize
-            bank_hash_stats: BankHashStats::default(), // populated from AccountsDbFields
+            accounts_lt_hash: AccountsLtHash(LT_HASH_CANARY), // populated from ExtraFieldsToDeserialize
+            bank_hash_stats: BankHashStats::default(),        // populated from AccountsDbFields
         }
     }
 }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -19,7 +19,7 @@ use {
             AtomicAccountsFileId, DuplicatesLtHash, IndexGenerationInfo,
         },
         accounts_file::{AccountsFile, StorageAccess},
-        accounts_hash::{AccountsDeltaHash, AccountsHash},
+        accounts_hash::{AccountsDeltaHash, AccountsHash, AccountsLtHash},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::AncestorsForSerialization,
         blockhash_queue::BlockhashQueue,
@@ -32,6 +32,7 @@ use {
     solana_hard_forks::HardForks,
     solana_hash::Hash,
     solana_inflation::Inflation,
+    solana_lattice_hash::lt_hash::LtHash,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     solana_rent_collector::RentCollector,
@@ -195,8 +196,8 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             is_delta: dvb.is_delta,
             incremental_snapshot_persistence: None,
             versioned_epoch_stakes: HashMap::default(), // populated from ExtraFieldsToDeserialize
-            accounts_lt_hash: None,                     // populated from ExtraFieldsToDeserialize
-            bank_hash_stats: BankHashStats::default(),  // populated from AccountsDbFields
+            accounts_lt_hash: AccountsLtHash(LtHash([0xCAFE; LtHash::NUM_ELEMENTS])), // populated from ExtraFieldsToDeserialize
+            bank_hash_stats: BankHashStats::default(), // populated from AccountsDbFields
         }
     }
 }
@@ -472,7 +473,9 @@ where
         .clone_with_lamports_per_signature(lamports_per_signature);
     bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
     bank_fields.versioned_epoch_stakes = versioned_epoch_stakes;
-    bank_fields.accounts_lt_hash = accounts_lt_hash.map(Into::into);
+    bank_fields.accounts_lt_hash = accounts_lt_hash
+        .expect("snapshot must have accounts_lt_hash")
+        .into();
 
     Ok((bank_fields, accounts_db_fields))
 }
@@ -875,7 +878,7 @@ where
         exit,
         capitalizations,
         bank_fields.incremental_snapshot_persistence.as_ref(),
-        bank_fields.accounts_lt_hash.is_some(),
+        true,
     )?;
     bank_fields.bank_hash_stats = reconstructed_accounts_db_info.bank_hash_stats;
 
@@ -1039,7 +1042,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     exit: Arc<AtomicBool>,
     capitalizations: (u64, Option<u64>),
     incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
-    has_accounts_lt_hash: bool,
+    has_accounts_lt_hash: bool, // always true, will be removed next
 ) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error>
 where
     E: SerializableStorage + std::marker::Sync,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -77,7 +77,7 @@ mod serde_snapshot_tests {
             Arc::default(),
             (u64::default(), None),
             None,
-            false,
+            true,
         )
         .map(|(accounts_db, _)| accounts_db)
     }


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

For this PR, BankFieldsToDeserialize must have AccountsLtHash.
