### PR TITLE
Upgrade solana quic definitions to 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9805,9 +9805,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606feac5110eb5d8afaa43ccaeea3ec49ccec36773387930b5ba545e745aea2"
+checksum = "7011ee2af2baad991762b6d63ea94b08d06f7928effb76ce273b232c9902c205"
 dependencies = [
  "solana-keypair",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,7 +486,7 @@ solana-program-test = { path = "program-test", version = "=3.0.0" }
 solana-pubkey = { version = "2.4.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=3.0.0" }
 solana-quic-client = { path = "quic-client", version = "=3.0.0" }
-solana-quic-definitions = "2.2.1"
+solana-quic-definitions = "2.3.0"
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=3.0.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=3.0.0", default-features = false }
 solana-rent = "2.2.1"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -76,7 +76,7 @@ solana-net-utils = { workspace = true }
 solana-packet = "=2.2.1"
 solana-perf = { workspace = true }
 solana-pubkey = { version = "=2.4.0", features = ["rand"] }
-solana-quic-definitions = "=2.2.1"
+solana-quic-definitions = "=2.3.0"
 solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-runtime = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7527,9 +7527,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606feac5110eb5d8afaa43ccaeea3ec49ccec36773387930b5ba545e745aea2"
+checksum = "7011ee2af2baad991762b6d63ea94b08d06f7928effb76ce273b232c9902c205"
 dependencies = [
  "solana-keypair",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7325,9 +7325,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606feac5110eb5d8afaa43ccaeea3ec49ccec36773387930b5ba545e745aea2"
+checksum = "7011ee2af2baad991762b6d63ea94b08d06f7928effb76ce273b232c9902c205"
 dependencies = [
  "solana-keypair",
 ]


### PR DESCRIPTION
Problem

The solana-quic-definitions 2.3.0 has the updated value of

pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);

which is changed from shorter 2 seconds.

The short idle timeout forces the clients to send frequent keep alive messages and as result increase the total network overhead in maintaining the connections.

Summary of Changes

Updated solana-quic-definitions to 2.3.0 from 2.2.1

Fixes #