### PR TITLE
Removes AccountsDb::verify_accounts_hash_and_lamports()

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -13,15 +13,13 @@ use {
         accounts::{AccountAddressFilter, Accounts},
         accounts_db::{
             test_utils::create_test_accounts, AccountFromStorage, AccountsDb,
-            VerifyAccountsHashAndLamportsConfig, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
+            ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
         },
         accounts_index::ScanConfig,
         ancestors::Ancestors,
     },
-    solana_clock::Epoch,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_sysvar::epoch_schedule::EpochSchedule,
     std::{
         collections::{HashMap, HashSet},
         path::PathBuf,
@@ -42,39 +40,6 @@ fn new_accounts_db(account_paths: Vec<PathBuf>) -> AccountsDb {
         None,
         Arc::default(),
     )
-}
-
-#[bench]
-fn bench_accounts_hash_bank_hash(bencher: &mut Bencher) {
-    let accounts_db = new_accounts_db(vec![PathBuf::from("bench_accounts_hash_internal")]);
-    let accounts = Accounts::new(Arc::new(accounts_db));
-    let mut pubkeys: Vec<Pubkey> = vec![];
-    let num_accounts = 60_000;
-    let slot = 0;
-    create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
-    let ancestors = Ancestors::from(vec![0]);
-    let (_, total_lamports) = accounts
-        .accounts_db
-        .update_accounts_hash_for_tests(0, &ancestors, false, false);
-    accounts.add_root(slot);
-    accounts.accounts_db.flush_accounts_cache(true, Some(slot));
-    bencher.iter(|| {
-        assert!(accounts
-            .accounts_db
-            .verify_accounts_hash_and_lamports_for_tests(
-                0,
-                total_lamports,
-                VerifyAccountsHashAndLamportsConfig {
-                    ancestors: &ancestors,
-                    epoch_schedule: &EpochSchedule::default(),
-                    epoch: Epoch::default(),
-                    ignore_mismatch: false,
-                    store_detailed_debug_info: false,
-                    use_bg_thread_pool: false,
-                }
-            )
-            .is_ok())
-    });
 }
 
 #[bench]

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -3,8 +3,8 @@ use {
         account_locks::{validate_account_locks, AccountLocks},
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{
-            AccountStorageEntry, AccountsAddRootTiming, AccountsDb, LoadHint, LoadedAccount,
-            ScanAccountStorageData, ScanStorageResult, VerifyAccountsHashAndLamportsConfig,
+            AccountsAddRootTiming, AccountsDb, LoadHint, LoadedAccount, ScanAccountStorageData,
+            ScanStorageResult,
         },
         accounts_index::{IndexKey, ScanConfig, ScanError, ScanOrder, ScanResult},
         ancestors::Ancestors,
@@ -304,30 +304,6 @@ impl Accounts {
             .into_iter()
             .map(|Reverse((balance, pubkey))| (pubkey, balance))
             .collect())
-    }
-
-    /// Only called from startup or test code.
-    #[must_use]
-    pub fn verify_accounts_hash_and_lamports(
-        &self,
-        snapshot_storages_and_slots: (&[Arc<AccountStorageEntry>], &[Slot]),
-        slot: Slot,
-        total_lamports: u64,
-        base: Option<(Slot, /*capitalization*/ u64)>,
-        config: VerifyAccountsHashAndLamportsConfig,
-    ) -> bool {
-        if let Err(err) = self.accounts_db.verify_accounts_hash_and_lamports(
-            snapshot_storages_and_slots,
-            slot,
-            total_lamports,
-            base,
-            config,
-        ) {
-            warn!("verify_accounts_hash failed: {err:?}, slot: {slot}");
-            false
-        } else {
-            true
-        }
     }
 
     fn load_while_filtering<F: Fn(&AccountSharedData) -> bool>(


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

This PR removes the merkle-based `AccountsDb::verify_accounts_hash_and_lamports()`.