### PR TITLE
Switch Test to use AccountsDB Config For Tests

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -2173,7 +2173,7 @@ mod tests {
         let bank_test_config = BankTestConfig {
             accounts_db_config: AccountsDbConfig {
                 storage_access,
-                ..AccountsDbConfig::default()
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
             },
         };
 


### PR DESCRIPTION
#### Problem
Test is using AccountsDb::Default() instead of ACCOUNTS_DB_CONFIG_FOR_TESTING. This is unneeded and results in slower test times due to using 8192 bins in the accounts index instead of 2 among other potential issues.

#### Summary of Changes
- Change test to use ACCOUNTS_DB_CONFIG_FOR_TESTING


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
