### PR TITLE
Remove duplicate arguments from rpc_bootstrap()

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -559,8 +559,6 @@ pub fn rpc_bootstrap(
     node: &Node,
     identity_keypair: &Arc<Keypair>,
     ledger_path: &Path,
-    full_snapshot_archives_dir: &Path,
-    incremental_snapshot_archives_dir: &Path,
     vote_account: &Pubkey,
     authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     cluster_entrypoints: &[ContactInfo],
@@ -593,6 +591,14 @@ pub fn rpc_bootstrap(
     if bootstrap_config.no_genesis_fetch && bootstrap_config.no_snapshot_fetch {
         return;
     }
+    let full_snapshot_archives_dir = validator_config
+        .snapshot_config
+        .full_snapshot_archives_dir
+        .clone();
+    let incremental_snapshot_archives_dir = validator_config
+        .snapshot_config
+        .incremental_snapshot_archives_dir
+        .clone();
 
     let total_snapshot_download_time = Instant::now();
     let mut get_rpc_nodes_time = Duration::new(0, 0);
@@ -643,8 +649,8 @@ pub fn rpc_bootstrap(
             use_progress_bar,
             &mut gossip,
             &rpc_client,
-            full_snapshot_archives_dir,
-            incremental_snapshot_archives_dir,
+            &full_snapshot_archives_dir,
+            &incremental_snapshot_archives_dir,
             maximum_local_snapshot_age,
             start_progress,
             minimal_snapshot_download_speed,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1134,7 +1134,7 @@ fn download_snapshots(
     }
 
     // Check and see if we've already got the full snapshot; if not, download it
-    if snapshot_utils::get_full_snapshot_archives(&full_snapshot_archives_dir)
+    if snapshot_utils::get_full_snapshot_archives(full_snapshot_archives_dir)
         .into_iter()
         .any(|snapshot_archive| {
             snapshot_archive.slot() == full_snapshot_hash.0

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -368,8 +368,6 @@ pub fn attempt_download_genesis_and_snapshot(
     use_progress_bar: bool,
     gossip: &mut Option<(Arc<ClusterInfo>, Arc<AtomicBool>, GossipService)>,
     rpc_client: &RpcClient,
-    full_snapshot_archives_dir: &Path,
-    incremental_snapshot_archives_dir: &Path,
     maximum_local_snapshot_age: Slot,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
     minimal_snapshot_download_speed: f32,
@@ -402,8 +400,6 @@ pub fn attempt_download_genesis_and_snapshot(
     info!("RPC node root slot: {rpc_client_slot}");
 
     download_snapshots(
-        full_snapshot_archives_dir,
-        incremental_snapshot_archives_dir,
         validator_config,
         bootstrap_config,
         use_progress_bar,
@@ -591,14 +587,6 @@ pub fn rpc_bootstrap(
     if bootstrap_config.no_genesis_fetch && bootstrap_config.no_snapshot_fetch {
         return;
     }
-    let full_snapshot_archives_dir = validator_config
-        .snapshot_config
-        .full_snapshot_archives_dir
-        .clone();
-    let incremental_snapshot_archives_dir = validator_config
-        .snapshot_config
-        .incremental_snapshot_archives_dir
-        .clone();
 
     let total_snapshot_download_time = Instant::now();
     let mut get_rpc_nodes_time = Duration::new(0, 0);
@@ -649,8 +637,6 @@ pub fn rpc_bootstrap(
             use_progress_bar,
             &mut gossip,
             &rpc_client,
-            &full_snapshot_archives_dir,
-            &incremental_snapshot_archives_dir,
             maximum_local_snapshot_age,
             start_progress,
             minimal_snapshot_download_speed,
@@ -1112,8 +1098,6 @@ fn retain_peer_snapshot_hashes_with_highest_incremental_snapshot_slot(
 /// Check to see if we can use our local snapshots, otherwise download newer ones.
 #[allow(clippy::too_many_arguments)]
 fn download_snapshots(
-    full_snapshot_archives_dir: &Path,
-    incremental_snapshot_archives_dir: &Path,
     validator_config: &ValidatorConfig,
     bootstrap_config: &RpcBootstrapConfig,
     use_progress_bar: bool,
@@ -1132,6 +1116,10 @@ fn download_snapshots(
         full: full_snapshot_hash,
         incr: incremental_snapshot_hash,
     } = snapshot_hash.unwrap();
+    let full_snapshot_archives_dir = &validator_config.snapshot_config.full_snapshot_archives_dir;
+    let incremental_snapshot_archives_dir = &validator_config
+        .snapshot_config
+        .incremental_snapshot_archives_dir;
 
     // If the local snapshots are new enough, then use 'em; no need to download new snapshots
     if should_use_local_snapshot(
@@ -1146,7 +1134,7 @@ fn download_snapshots(
     }
 
     // Check and see if we've already got the full snapshot; if not, download it
-    if snapshot_utils::get_full_snapshot_archives(full_snapshot_archives_dir)
+    if snapshot_utils::get_full_snapshot_archives(&full_snapshot_archives_dir)
         .into_iter()
         .any(|snapshot_archive| {
             snapshot_archive.slot() == full_snapshot_hash.0
@@ -1159,8 +1147,6 @@ fn download_snapshots(
         );
     } else {
         download_snapshot(
-            full_snapshot_archives_dir,
-            incremental_snapshot_archives_dir,
             validator_config,
             bootstrap_config,
             use_progress_bar,
@@ -1192,8 +1178,6 @@ fn download_snapshots(
                 );
             } else {
                 download_snapshot(
-                    full_snapshot_archives_dir,
-                    incremental_snapshot_archives_dir,
                     validator_config,
                     bootstrap_config,
                     use_progress_bar,
@@ -1215,8 +1199,6 @@ fn download_snapshots(
 /// Download a snapshot
 #[allow(clippy::too_many_arguments)]
 fn download_snapshot(
-    full_snapshot_archives_dir: &Path,
-    incremental_snapshot_archives_dir: &Path,
     validator_config: &ValidatorConfig,
     bootstrap_config: &RpcBootstrapConfig,
     use_progress_bar: bool,
@@ -1234,6 +1216,10 @@ fn download_snapshot(
     let maximum_incremental_snapshot_archives_to_retain = validator_config
         .snapshot_config
         .maximum_incremental_snapshot_archives_to_retain;
+    let full_snapshot_archives_dir = &validator_config.snapshot_config.full_snapshot_archives_dir;
+    let incremental_snapshot_archives_dir = &validator_config
+        .snapshot_config
+        .incremental_snapshot_archives_dir;
 
     *start_progress.write().unwrap() = ValidatorStartProgress::DownloadingSnapshot {
         slot: desired_snapshot_hash.0,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -921,8 +921,8 @@ pub fn execute(
         full_snapshot_archive_interval,
         incremental_snapshot_archive_interval,
         bank_snapshots_dir,
-        full_snapshot_archives_dir: full_snapshot_archives_dir.clone(),
-        incremental_snapshot_archives_dir: incremental_snapshot_archives_dir.clone(),
+        full_snapshot_archives_dir,
+        incremental_snapshot_archives_dir,
         archive_format,
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
@@ -1204,8 +1204,14 @@ pub fn execute(
     solana_metrics::set_host_id(identity_keypair.pubkey().to_string());
     solana_metrics::set_panic_hook("validator", Some(String::from(solana_version)));
     solana_entry::entry::init_poh();
-    snapshot_utils::remove_tmp_snapshot_archives(&full_snapshot_archives_dir);
-    snapshot_utils::remove_tmp_snapshot_archives(&incremental_snapshot_archives_dir);
+    snapshot_utils::remove_tmp_snapshot_archives(
+        &validator_config.snapshot_config.full_snapshot_archives_dir,
+    );
+    snapshot_utils::remove_tmp_snapshot_archives(
+        &validator_config
+            .snapshot_config
+            .incremental_snapshot_archives_dir,
+    );
 
     let should_check_duplicate_instance = true;
     if !cluster_entrypoints.is_empty() {
@@ -1213,8 +1219,6 @@ pub fn execute(
             &node,
             &identity_keypair,
             &ledger_path,
-            &full_snapshot_archives_dir,
-            &incremental_snapshot_archives_dir,
             &vote_account,
             authorized_voter_keypairs.clone(),
             &cluster_entrypoints,


### PR DESCRIPTION
#### Problem
The snapshot archive paths can be read from the SnapshotConfig contained in the ValidatorConfig that is also passed to the function

#### Summary of Changes
Remove the duplicate args from function