### PR TITLE
runtime: defend against malicious SlotHistory

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2174,7 +2174,14 @@ impl Bank {
     }
 
     pub fn get_slot_history(&self) -> SlotHistory {
-        from_account(&self.get_account(&sysvar::slot_history::id()).unwrap()).unwrap()
+        let history: SlotHistory =
+            from_account(&self.get_account(&sysvar::slot_history::id()).unwrap()).unwrap();
+        assert_eq!(
+            history.bits.len(),
+            solana_slot_history::MAX_ENTRIES,
+            "malformed slot history sysvar"
+        );
+        history
     }
 
     fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {


### PR DESCRIPTION

#### Problem

Fixes an issue where Agave blindly uses a SlotHistory sysvar of zero or oversize length (but consensus hardcodes the length of this sysvar).


#### Summary of Changes

Crash fast if a snapshot is loaded with a SlotHistory sysvar that has an odd length.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
