### PR TITLE
agave-validator: move tests

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2147,24 +2147,4 @@ mod tests {
             );
         }
     }
-
-    #[test]
-    fn verify_args_struct_by_command_run_with_incremental_snapshot_fetch() {
-        // long arg
-        {
-            let default_run_args = RunArgs::default();
-            let expected_args = RunArgs {
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    incremental_snapshot_fetch: false,
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec!["--no-incremental-snapshots"],
-                expected_args,
-            );
-        }
-    }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2125,59 +2125,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_only_known_rpc() {
-        // long arg
-        {
-            let default_run_args = RunArgs::default();
-            let known_validators_pubkey = Pubkey::new_unique();
-            let known_validators = Some(HashSet::from([known_validators_pubkey]));
-            let expected_args = RunArgs {
-                known_validators,
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    only_known_rpc: true,
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec![
-                    // --known-validator is required
-                    "--known-validator",
-                    &known_validators_pubkey.to_string(),
-                    "--only-known-rpc",
-                ],
-                expected_args,
-            );
-        }
-
-        // alias
-        {
-            let default_run_args = RunArgs::default();
-            let known_validators_pubkey = Pubkey::new_unique();
-            let known_validators = Some(HashSet::from([known_validators_pubkey]));
-            let expected_args = RunArgs {
-                known_validators,
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    only_known_rpc: true,
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec![
-                    // --known-validator is required
-                    "--known-validator",
-                    &known_validators_pubkey.to_string(),
-                    "--no-untrusted-rpc",
-                ],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
     fn verify_args_struct_by_command_run_with_max_genesis_archive_unpacked_size() {
         // long arg
         {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1916,26 +1916,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_no_genesis_fetch() {
-        // long arg
-        {
-            let default_run_args = RunArgs::default();
-            let expected_args = RunArgs {
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    no_genesis_fetch: true,
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args.clone(),
-                vec!["--no-genesis-fetch"],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
     fn verify_args_struct_by_command_run_with_no_snapshot_fetch() {
         // long arg
         {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -2005,36 +2005,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_check_vote_account() {
-        // long arg
-        {
-            let default_run_args = RunArgs::default();
-            let expected_args = RunArgs {
-                entrypoints: vec![SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    8000,
-                )],
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    check_vote_account: Some("https://api.mainnet-beta.solana.com".to_string()),
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args,
-                vec![
-                    // entrypoint is required for check-vote-account
-                    "--entrypoint",
-                    "127.0.0.1:8000",
-                    "--check-vote-account",
-                    "https://api.mainnet-beta.solana.com",
-                ],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
     fn verify_args_struct_by_command_run_with_known_validators() {
         // long arg + single known validator
         {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1916,26 +1916,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_args_struct_by_command_run_with_no_snapshot_fetch() {
-        // long arg
-        {
-            let default_run_args = RunArgs::default();
-            let expected_args = RunArgs {
-                rpc_bootstrap_config: RpcBootstrapConfig {
-                    no_snapshot_fetch: true,
-                    ..RpcBootstrapConfig::default()
-                },
-                ..default_run_args.clone()
-            };
-            verify_args_struct_by_command_run_with_identity_setup(
-                default_run_args.clone(),
-                vec!["--no-snapshot-fetch"],
-                expected_args,
-            );
-        }
-    }
-
-    #[test]
     fn verify_args_struct_by_command_run_with_entrypoints() {
         // short arg + single entrypoint
         {

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -80,4 +80,24 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_snapshot_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    no_snapshot_fetch: true,
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args.clone(),
+                vec!["--no-snapshot-fetch"],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -59,7 +59,11 @@ mod tests {
         crate::commands::run::args::{
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
-        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+        solana_pubkey::Pubkey,
+        std::{
+            collections::HashSet,
+            net::{IpAddr, Ipv4Addr, SocketAddr},
+        },
     };
 
     #[test]
@@ -126,6 +130,59 @@ mod tests {
                     "127.0.0.1:8000",
                     "--check-vote-account",
                     "https://api.mainnet-beta.solana.com",
+                ],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_only_known_rpc() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    only_known_rpc: true,
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // --known-validator is required
+                    "--known-validator",
+                    &known_validators_pubkey.to_string(),
+                    "--only-known-rpc",
+                ],
+                expected_args,
+            );
+        }
+
+        // alias
+        {
+            let default_run_args = RunArgs::default();
+            let known_validators_pubkey = Pubkey::new_unique();
+            let known_validators = Some(HashSet::from([known_validators_pubkey]));
+            let expected_args = RunArgs {
+                known_validators,
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    only_known_rpc: true,
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // --known-validator is require
+                    "--known-validator",
+                    &known_validators_pubkey.to_string(),
+                    "--no-untrusted-rpc",
                 ],
                 expected_args,
             );

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -125,7 +125,7 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec![
-                    // entrypoint is required for check-vote-account
+                    // required by --check-vote-account
                     "--entrypoint",
                     "127.0.0.1:8000",
                     "--check-vote-account",
@@ -154,7 +154,7 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec![
-                    // --known-validator is required
+                    // required by --only-known-rpc
                     "--known-validator",
                     &known_validators_pubkey.to_string(),
                     "--only-known-rpc",
@@ -179,7 +179,7 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args,
                 vec![
-                    // --known-validator is require
+                    // required by --no-untrusted-rpc
                     "--known-validator",
                     &known_validators_pubkey.to_string(),
                     "--no-untrusted-rpc",

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -59,6 +59,7 @@ mod tests {
         crate::commands::run::args::{
             tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
         },
+        std::net::{IpAddr, Ipv4Addr, SocketAddr},
     };
 
     #[test]
@@ -96,6 +97,36 @@ mod tests {
             verify_args_struct_by_command_run_with_identity_setup(
                 default_run_args.clone(),
                 vec!["--no-snapshot-fetch"],
+                expected_args,
+            );
+        }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_check_vote_account() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                entrypoints: vec![SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    8000,
+                )],
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    check_vote_account: Some("https://api.mainnet-beta.solana.com".to_string()),
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec![
+                    // entrypoint is required for check-vote-account
+                    "--entrypoint",
+                    "127.0.0.1:8000",
+                    "--check-vote-account",
+                    "https://api.mainnet-beta.solana.com",
+                ],
                 expected_args,
             );
         }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -188,4 +188,24 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_incremental_snapshot_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    incremental_snapshot_fetch: false,
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args,
+                vec!["--no-incremental-snapshots"],
+                expected_args,
+            );
+        }
+    }
 }

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -51,3 +51,33 @@ impl FromClapArgMatches for RpcBootstrapConfig {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::commands::run::args::{
+            tests::verify_args_struct_by_command_run_with_identity_setup, RunArgs,
+        },
+    };
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_genesis_fetch() {
+        // long arg
+        {
+            let default_run_args = RunArgs::default();
+            let expected_args = RunArgs {
+                rpc_bootstrap_config: RpcBootstrapConfig {
+                    no_genesis_fetch: true,
+                    ..RpcBootstrapConfig::default()
+                },
+                ..default_run_args.clone()
+            };
+            verify_args_struct_by_command_run_with_identity_setup(
+                default_run_args.clone(),
+                vec!["--no-genesis-fetch"],
+                expected_args,
+            );
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

some tests are currently written in args.rs, but they can be moved to the corresponding modules for better organization


#### Summary of Changes

move them