### PR TITLE
Sort files added to snapshot tar archive to balance their sizes for streamlined unpacking 

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1222,7 +1222,7 @@ fn select_from_range_with_start_end_rates(
     start_rate: usize,
     end_rate: usize,
 ) -> usize {
-    let range_len = range.end - range.start;
+    let range_len = range.len();
     let cycle = start_rate + end_rate;
     let cycle_index = nth % cycle;
     let cycle_num = nth.checked_div(cycle).expect("rates sum must be positive");

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1120,16 +1120,15 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            let mut mul = 399991;
-            if mul >= snapshot_storages.len() {
-                info!("los snapshot count {}", snapshot_storages.len());
-                mul = 3;
-                if mul >= snapshot_storages.len() {
-                    mul = 1;
-                }
-            }
-            for i in 0..snapshot_storages.len() {
-                let storage = &snapshot_storages[(i * mul + 24534) % snapshot_storages.len()];
+            let mut sorted_storage_indices = (0..snapshot_storages.len()).collect::<Vec<_>>();
+            sorted_storage_indices.sort_by_key(|&i| snapshot_storages[i].accounts.len());
+            for i in 0..sorted_storage_indices.len() {
+                let index = sorted_storage_indices[if i % 2 == 0 {
+                    i / 2
+                } else {
+                    sorted_storage_indices.len() - i / 2 - 1
+                }];
+                let storage = &snapshot_storages[index];
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1120,9 +1120,16 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            assert!(399991 < snapshot_storages.len());
+            let mut mul = 399991;
+            if mul >= snapshot_storages.len() {
+                info!("los snapshot count {}", snapshot_storages.len());
+                mul = 3;
+                if mul >= snapshot_storages.len() {
+                    mul = 1;
+                }
+            }
             for i in 0..snapshot_storages.len() {
-                let storage = &snapshot_storages[(i * 399991 + 24534) % snapshot_storages.len()];
+                let storage = &snapshot_storages[(i * mul + 24534) % snapshot_storages.len()];
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1123,9 +1123,10 @@ fn archive_snapshot(
             let mut sorted_storage_indices = (0..snapshot_storages.len()).collect::<Vec<_>>();
             sorted_storage_indices.sort_by_key(|&i| snapshot_storages[i].accounts.len());
             for i in 0..sorted_storage_indices.len() {
-                // Balance large and small files with bias towards small (1 large + 2 small), such
-                // that during unpacking large writes and mixed with file metadata operations.
-                let index = get_from_start_or_end_index_by_ratio(&sorted_storage_indices, i, 3);
+                // Balance large and small files with bias towards small (1 large + 4 small), such
+                // that during unpacking large writes and mixed with file metadata operations
+                // and towards the end of archive (sizes equalize) writes are >256KiB / file.
+                let index = get_from_start_or_end_index_by_ratio(&sorted_storage_indices, i, 5);
                 let storage = &snapshot_storages[index];
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1120,7 +1120,9 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            for storage in snapshot_storages {
+            assert!(399991 < snapshot_storages.len());
+            for i in 0..snapshot_storages.len() {
+                let storage = &snapshot_storages[(i * 399991 + 24534) % snapshot_storages.len()];
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1210,15 +1210,15 @@ fn archive_snapshot(
 
 /// Get the `nth` element (0-based) from `values` selected from start or end with `ratio`.
 ///
-/// 1:ratio elements are selected from the start and the rest from the end.
+/// 1:ratio elements are selected from the end and the rest from the start.
 /// This function calculates permutation of `values` balancing extreme elements.
 fn get_from_start_or_end_index_by_ratio(values: &[usize], nth: usize, ratio: usize) -> usize {
     let nth_div = nth / ratio;
     let nth_rem = nth % ratio;
     let value_index = if nth_rem == 0 {
-        nth_div
+        values.len() - 1 - nth_div
     } else {
-        values.len() - (nth_div * (ratio - 1) + nth_rem)
+        nth_div * (ratio - 1) + nth_rem - 1
     };
     values[value_index]
 }
@@ -3689,17 +3689,17 @@ mod tests {
         let shuffled: Vec<_> = (0..values.len())
             .map(|i| get_from_start_or_end_index_by_ratio(&values, i, 3))
             .collect();
-        assert_eq!(shuffled, vec![1, 10, 9, 2, 8, 7, 3, 6, 5, 4]);
+        assert_eq!(shuffled, vec![10, 1, 2, 9, 3, 4, 8, 5, 6, 7]);
 
         let shuffled: Vec<_> = (0..values.len())
             .map(|i| get_from_start_or_end_index_by_ratio(&values, i, 2))
             .collect();
-        assert_eq!(shuffled, vec![1, 10, 2, 9, 3, 8, 4, 7, 5, 6]);
+        assert_eq!(shuffled, vec![10, 1, 9, 2, 8, 3, 7, 4, 6, 5]);
 
         let values = [1, 2, 3, 4, 5, 6, 7, 8, 9];
         let shuffled: Vec<_> = (0..values.len())
             .map(|i| get_from_start_or_end_index_by_ratio(&values, i, 3))
             .collect();
-        assert_eq!(shuffled, vec![1, 9, 8, 2, 7, 6, 3, 5, 4]);
+        assert_eq!(shuffled, vec![9, 1, 2, 8, 3, 4, 7, 5, 6]);
     }
 }


### PR DESCRIPTION
#### Problem
Currently snapshot tar archive is created from account storages in slot order. In practice this creates spikes in resource usage (write bandwidth vs file metadata operations) during unpacking the data on disk, since there are large chunks of large files vs small files that are stored at consecutive positions in the archive.

Since there is no unpacking order requirement (except for version and snapshot files, which are always added to the archive first) when reading the archive and creating files, we can achieve an easy improvement by better balanced order.

#### Summary of Changes
* sort accounts storages by size before putting them into the archive
* use interleaved pattern of large file and (a few) small files
* the current ratio is 1 large file per 4 small files, since large files are significantly larger than small ones and there is much less of them - this ratio is based on experimental test (ratio biased less than 1-4 to small files has a tail where file open ops dominate unpacking), but can be arrived to checking histogram of accounts file sizes, e.g. 80% of file len currently is ~415KiB, so each file open will be accompanied with large write that saturates write bandwidth

Performance profile analysis shows that decompression thread is saturating CPU better across the whole unpacking process (without dips in cpu usage and spending lots of time on syscall to wait for free buffers).

##### Performance metrics
unpacking snapshot created with master
```
solana_accounts_db::io_uring::file_creator] files creation stats - large buf headroom: 116980, 
   no buf count: 18058, avg pending writes at no buf: 129187894
solana_runtime::snapshot_utils] snapshot untar took 96.2s
```

unpacking snapshot created with this PR
```
solana_accounts_db::io_uring::file_creator] files creation stats - large buf headroom: 162609, 
   no buf count: 11485, avg pending writes at no buf: 59077814
solana_runtime::snapshot_utils] snapshot untar took 94.9s
```
Stats when producing data and adding files to create:
* wall time slightly better (it's noisy, typical gain seems to be in order of 0.5-1s)
* we more often hit plenty of free buffers (large buf headroom -> increase by 50%)
* we are less likely to run out of free buffers (no buf count -> decrease 39%)
* the last stat (pending writes at no buf) is worse in a way, but since we hit no buf condition less likely, I think it's biased

