### PR TITLE
BlockProductionManager

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -457,7 +457,7 @@ fn main() {
     let banking_stage = BankingStage::new_num_threads(
         block_production_method,
         transaction_struct,
-        &poh_recorder,
+        poh_recorder.clone(),
         transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -238,7 +238,7 @@ fn bench_banking(
     let _banking_stage = BankingStage::new(
         block_production_method,
         transaction_struct,
-        &poh_recorder,
+        poh_recorder,
         transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,

--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        block_production_manager::BlockProductionManager,
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
     },
@@ -11,7 +12,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         net::UdpSocket,
-        sync::{Arc, RwLock},
+        sync::{Arc, Mutex, RwLock},
     },
 };
 
@@ -80,4 +81,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub outstanding_repair_requests: Arc<RwLock<OutstandingRequests<ShredRepairType>>>,
     pub cluster_slots: Arc<ClusterSlots>,
     pub gossip_socket: Option<AtomicUdpSocket>,
+    pub block_production_manager: Option<Arc<Mutex<BlockProductionManager>>>,
 }

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -826,7 +826,7 @@ impl BankingSimulator {
         let banking_stage = BankingStage::new_num_threads(
             block_production_method.clone(),
             transaction_struct.clone(),
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -437,7 +437,7 @@ impl BankingStage {
             vote_storage,
         ));
 
-        Self::spawn_scheduler_and_workers_with_structure(
+        Self::spawn_scheduler_and_workers_with_transaction_structure(
             Arc::new(AtomicBool::new(false)),
             &mut bank_thread_hdls,
             block_production_method,
@@ -455,7 +455,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn spawn_scheduler_and_workers_with_structure(
+    pub(crate) fn spawn_scheduler_and_workers_with_transaction_structure(
         exit_signal: Arc<AtomicBool>,
         bank_thread_hdls: &mut Vec<JoinHandle<()>>,
         block_production_method: BlockProductionMethod,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -455,7 +455,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn spawn_scheduler_and_workers_with_structure(
+    pub(crate) fn spawn_scheduler_and_workers_with_structure(
         bank_thread_hdls: &mut Vec<JoinHandle<()>>,
         block_production_method: BlockProductionMethod,
         transaction_struct: TransactionStructure,
@@ -608,7 +608,7 @@ impl BankingStage {
         }
     }
 
-    fn spawn_vote_worker(
+    pub(crate) fn spawn_vote_worker(
         tpu_receiver: BankingPacketReceiver,
         gossip_receiver: BankingPacketReceiver,
         decision_maker: DecisionMaker,

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -31,7 +31,10 @@ use {
     solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::TransactionError,
     std::{
-        sync::{atomic::Ordering, Arc, RwLock},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
         time::Instant,
     },
 };
@@ -46,6 +49,7 @@ mod transaction {
 pub const UNPROCESSED_BUFFER_STEP_SIZE: usize = 16;
 
 pub struct VoteWorker {
+    exit_signal: Arc<AtomicBool>,
     decision_maker: DecisionMaker,
     tpu_receiver: PacketReceiver,
     gossip_receiver: PacketReceiver,
@@ -56,6 +60,7 @@ pub struct VoteWorker {
 
 impl VoteWorker {
     pub fn new(
+        exit_signal: Arc<AtomicBool>,
         decision_maker: DecisionMaker,
         tpu_receiver: PacketReceiver,
         gossip_receiver: PacketReceiver,
@@ -64,6 +69,7 @@ impl VoteWorker {
         consumer: Consumer,
     ) -> Self {
         Self {
+            exit_signal,
             decision_maker,
             tpu_receiver,
             gossip_receiver,
@@ -79,7 +85,7 @@ impl VoteWorker {
 
         let mut last_metrics_update = Instant::now();
 
-        loop {
+        while !self.exit_signal.load(Ordering::Relaxed) {
             if !self.storage.is_empty()
                 || last_metrics_update.elapsed() >= SLOT_BOUNDARY_CHECK_PERIOD
             {

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -46,7 +46,7 @@ impl BlockProductionManager {
         let vote_shutdown_signal = Arc::new(AtomicBool::new(false));
         let non_vote_shutdown_signal = Arc::new(AtomicBool::new(false));
 
-        let vote_thread_handle = Self::spawn_vote_thread(&context);
+        let vote_thread_handle = Self::spawn_vote_thread(vote_shutdown_signal.clone(), &context);
 
         Self {
             vote_shutdown_signal,
@@ -114,8 +114,12 @@ impl BlockProductionManager {
         Ok(())
     }
 
-    fn spawn_vote_thread(context: &BlockProductionContext) -> JoinHandle<()> {
+    fn spawn_vote_thread(
+        vote_shutdown_signal: Arc<AtomicBool>,
+        context: &BlockProductionContext,
+    ) -> JoinHandle<()> {
         BankingStage::spawn_vote_worker(
+            vote_shutdown_signal.clone(),
             context.tpu_vote_receiver.clone(),
             context.gossip_vote_receiver.clone(),
             DecisionMaker::new(context.poh_recorder.clone()),

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -66,9 +66,14 @@ impl BlockProductionManager {
         transaction_structure: TransactionStructure,
     ) -> thread::Result<()> {
         if !self.non_vote_thread_handles.is_empty() {
+            info!("shutting down non-vote block-production threads");
             self.shutdown_non_vote_threads()?;
         }
 
+        info!(
+            "spawning non-vote block-production threads with method: {}, transaction structure: {}",
+            block_production_method, transaction_structure
+        );
         self.non_vote_shutdown_signal
             .store(false, Ordering::Relaxed);
         BankingStage::spawn_scheduler_and_workers_with_structure(

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -79,7 +79,7 @@ impl BlockProductionManager {
         );
         self.non_vote_shutdown_signal
             .store(false, Ordering::Relaxed);
-        BankingStage::spawn_scheduler_and_workers_with_structure(
+        BankingStage::spawn_scheduler_and_workers_with_transaction_structure(
             self.non_vote_shutdown_signal.clone(),
             &mut self.non_vote_thread_handles,
             block_production_method,

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -1,0 +1,120 @@
+use {
+    crate::{
+        banking_stage::{
+            committer::Committer, decision_maker::DecisionMaker, vote_storage::VoteStorage,
+            BankingStage,
+        },
+        validator::{BlockProductionMethod, TransactionStructure},
+    },
+    agave_banking_stage_ingress_types::BankingPacketReceiver,
+    solana_ledger::blockstore_processor::TransactionStatusSender,
+    solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
+    solana_runtime::{
+        bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache,
+        vote_sender_types::ReplayVoteSender,
+    },
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        thread::{self, JoinHandle},
+    },
+};
+
+/// Handle to manage block production.
+pub struct BlockProductionManager {
+    /// Signal to shutdown vote thread.
+    vote_shutdown_signal: Arc<AtomicBool>,
+    /// Vote thread handle.
+    vote_thread_handle: JoinHandle<()>,
+
+    /// Signal to shutdown non-vote thread(s).
+    non_vote_shutdown_signal: Arc<AtomicBool>,
+    /// Non-vote thread handle(s).
+    non_vote_thread_handles: Vec<JoinHandle<()>>,
+
+    context: BlockProductionContext,
+}
+
+impl BlockProductionManager {
+    pub fn with_context(context: BlockProductionContext) -> Self {
+        let vote_shutdown_signal = Arc::new(AtomicBool::new(false));
+        let non_vote_shutdown_signal = Arc::new(AtomicBool::new(false));
+
+        let vote_thread_handle = Self::spawn_vote_thread(&context);
+
+        Self {
+            vote_shutdown_signal,
+            vote_thread_handle,
+            non_vote_shutdown_signal,
+            non_vote_thread_handles: vec![],
+            context,
+        }
+    }
+
+    /// Perform final shutdown.
+    pub fn shutdown(mut self) -> thread::Result<()> {
+        self.shutdown_non_vote_threads()?;
+
+        // Signal and wait for vote thread shutdown.
+        {
+            self.vote_shutdown_signal.store(true, Ordering::Relaxed);
+            self.vote_thread_handle.join()?;
+        }
+
+        Ok(())
+    }
+
+    /// Shtudown and wait for non-vote threads.
+    pub fn shutdown_non_vote_threads(&mut self) -> thread::Result<()> {
+        self.non_vote_shutdown_signal.store(true, Ordering::Relaxed);
+        for handle in self.non_vote_thread_handles.drain(..) {
+            handle.join()?;
+        }
+
+        Ok(())
+    }
+
+    fn spawn_vote_thread(context: &BlockProductionContext) -> JoinHandle<()> {
+        BankingStage::spawn_vote_worker(
+            context.tpu_vote_receiver.clone(),
+            context.gossip_vote_receiver.clone(),
+            DecisionMaker::new(context.poh_recorder.clone()),
+            context.bank_forks.clone(),
+            Committer::new(
+                context.transaction_status_sender.clone(),
+                context.replay_vote_sender.clone(),
+                context.prioritization_fee_cache.clone(),
+            ),
+            context.transaction_recorder.clone(),
+            context.log_messages_bytes_limit,
+            VoteStorage::new(context.bank_forks.read().unwrap().working_bank().as_ref()),
+        )
+    }
+
+    fn spawn_non_vote_threads(
+        &mut self,
+        block_production_method: BlockProductionMethod,
+        transaction_structure: TransactionStructure,
+    ) {
+        BankingStage::spawn_scheduler_and_workers_with(
+            block_production_method,
+            transaction_structure,
+        )
+    }
+}
+
+/// Context for creating block-production threads.
+pub struct BlockProductionContext {
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+    transaction_recorder: TransactionRecorder,
+    non_vote_receiver: BankingPacketReceiver,
+    tpu_vote_receiver: BankingPacketReceiver,
+    gossip_vote_receiver: BankingPacketReceiver,
+    transaction_status_sender: Option<TransactionStatusSender>,
+    replay_vote_sender: ReplayVoteSender,
+    log_messages_bytes_limit: Option<usize>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+}

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -71,6 +71,7 @@ impl BlockProductionManager {
         self.non_vote_shutdown_signal
             .store(false, Ordering::Relaxed);
         BankingStage::spawn_scheduler_and_workers_with_structure(
+            self.non_vote_shutdown_signal.clone(),
             &mut self.non_vote_thread_handles,
             block_production_method,
             transaction_structure,

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -63,7 +63,6 @@ impl BlockProductionManager {
         transaction_structure: TransactionStructure,
     ) -> thread::Result<()> {
         if !self.non_vote_thread_handles.is_empty() {
-            info!("shutting down non-vote block-production threads");
             self.shutdown_non_vote_threads()?;
         }
 
@@ -100,17 +99,20 @@ impl BlockProductionManager {
 
         // Signal and wait for vote thread shutdown.
         {
+            info!("shutting down vote block-production thread");
             self.vote_shutdown_signal.store(true, Ordering::Relaxed);
             if let Some(hdl) = self.vote_thread_handle.take() {
                 hdl.join()?;
             }
         }
+        info!("block-production threads shutdown complete");
 
         Ok(())
     }
 
     /// Shtudown and wait for non-vote threads.
     fn shutdown_non_vote_threads(&mut self) -> thread::Result<()> {
+        info!("shutting down non-vote block-production threads");
         self.non_vote_shutdown_signal.store(true, Ordering::Relaxed);
         for handle in self.non_vote_thread_handles.drain(..) {
             handle.join()?;

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -139,14 +139,14 @@ impl BlockProductionManager {
 
 /// Context for creating block-production threads.
 pub struct BlockProductionContext {
-    poh_recorder: Arc<RwLock<PohRecorder>>,
-    transaction_recorder: TransactionRecorder,
-    non_vote_receiver: BankingPacketReceiver,
-    tpu_vote_receiver: BankingPacketReceiver,
-    gossip_vote_receiver: BankingPacketReceiver,
-    transaction_status_sender: Option<TransactionStatusSender>,
-    replay_vote_sender: ReplayVoteSender,
-    log_messages_bytes_limit: Option<usize>,
-    bank_forks: Arc<RwLock<BankForks>>,
-    prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    pub poh_recorder: Arc<RwLock<PohRecorder>>,
+    pub transaction_recorder: TransactionRecorder,
+    pub non_vote_receiver: BankingPacketReceiver,
+    pub tpu_vote_receiver: BankingPacketReceiver,
+    pub gossip_vote_receiver: BankingPacketReceiver,
+    pub transaction_status_sender: Option<TransactionStatusSender>,
+    pub replay_vote_sender: ReplayVoteSender,
+    pub log_messages_bytes_limit: Option<usize>,
+    pub bank_forks: Arc<RwLock<BankForks>>,
+    pub prioritization_fee_cache: Arc<PrioritizationFeeCache>,
 }

--- a/core/src/block_production_manager.rs
+++ b/core/src/block_production_manager.rs
@@ -1,9 +1,6 @@
 use {
     crate::{
-        banking_stage::{
-            committer::Committer, decision_maker::DecisionMaker, vote_storage::VoteStorage,
-            BankingStage,
-        },
+        banking_stage::{committer::Committer, vote_storage::VoteStorage, BankingStage},
         validator::{BlockProductionMethod, TransactionStructure},
     },
     agave_banking_stage_ingress_types::BankingPacketReceiver,
@@ -81,13 +78,12 @@ impl BlockProductionManager {
             &mut self.non_vote_thread_handles,
             block_production_method,
             transaction_structure,
-            DecisionMaker::new(self.context.poh_recorder.clone()),
+            self.context.poh_recorder.clone(),
             Committer::new(
                 self.context.transaction_status_sender.clone(),
                 self.context.replay_vote_sender.clone(),
                 self.context.prioritization_fee_cache.clone(),
             ),
-            &self.context.poh_recorder,
             self.context.transaction_recorder.clone(),
             self.context.non_vote_receiver.clone(),
             BankingStage::num_threads(),
@@ -131,7 +127,7 @@ impl BlockProductionManager {
             vote_shutdown_signal.clone(),
             context.tpu_vote_receiver.clone(),
             context.gossip_vote_receiver.clone(),
-            DecisionMaker::new(context.poh_recorder.clone()),
+            context.poh_recorder.clone(),
             context.bank_forks.clone(),
             Committer::new(
                 context.transaction_status_sender.clone(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod admin_rpc_post_init;
 pub mod banking_simulation;
 pub mod banking_stage;
 pub mod banking_trace;
+pub mod block_production_manager;
 pub mod cluster_info_vote_listener;
 pub mod cluster_slots_service;
 pub mod commitment_service;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -426,9 +426,6 @@ impl Tpu {
             self.tpu_forwards_quic_t.map_or(Ok(()), |t| t.join()),
             self.tpu_vote_quic_t.join(),
         ];
-        // drop early to remove internal arc references, which other stages depend on
-        // being dropped for shutdown.
-        drop(self.block_production_manager);
         let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -409,6 +409,10 @@ impl Tpu {
         }
     }
 
+    pub fn block_production_manager(&self) -> Arc<Mutex<BlockProductionManager>> {
+        self.block_production_manager.clone()
+    }
+
     pub fn join(self) -> thread::Result<()> {
         let results = vec![
             self.fetch_stage.join(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -426,6 +426,9 @@ impl Tpu {
             self.tpu_forwards_quic_t.map_or(Ok(()), |t| t.join()),
             self.tpu_vote_quic_t.join(),
         ];
+        // drop early to remove internal arc references, which other stages depend on
+        // being dropped for shutdown.
+        drop(self.block_production_manager);
         let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -181,7 +181,17 @@ impl BlockVerificationMethod {
 }
 
 #[derive(
-    Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display, Serialize, Deserialize,
+    Clone,
+    Debug,
+    EnumString,
+    EnumVariantNames,
+    Default,
+    IntoStaticStr,
+    Display,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
 )]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
@@ -202,7 +212,17 @@ impl BlockProductionMethod {
 }
 
 #[derive(
-    Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display, Serialize, Deserialize,
+    Clone,
+    Debug,
+    EnumString,
+    EnumVariantNames,
+    Default,
+    IntoStaticStr,
+    Display,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
 )]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -180,8 +180,11 @@ impl BlockVerificationMethod {
     }
 }
 
-#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[derive(
+    Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum BlockProductionMethod {
     CentralScheduler,
     #[default]
@@ -198,8 +201,11 @@ impl BlockProductionMethod {
     }
 }
 
-#[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
+#[derive(
+    Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum TransactionStructure {
     Sdk,
     #[default]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1663,6 +1663,7 @@ impl Validator {
             outstanding_repair_requests,
             cluster_slots,
             gossip_socket: Some(node.sockets.gossip.clone()),
+            block_production_manager: Some(tpu.block_production_manager()),
         });
 
         Ok(Self {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1038,6 +1038,7 @@ mod tests {
                         solana_core::cluster_slots_service::cluster_slots::ClusterSlots::default(),
                     ),
                     gossip_socket: None,
+                    block_production_manager: None,
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -74,7 +74,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(commands::set_log_filter::command())
         .subcommand(commands::staked_nodes_overrides::command())
         .subcommand(commands::wait_for_restart_window::command())
-        .subcommand(commands::set_public_address::command());
+        .subcommand(commands::set_public_address::command())
+        .subcommand(commands::manage_block_production::command());
 
     commands::run::add_args(app, default_args)
         .args(&thread_args(&default_args.thread_args))

--- a/validator/src/commands/manage_block_production/mod.rs
+++ b/validator/src/commands/manage_block_production/mod.rs
@@ -1,0 +1,114 @@
+use {
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{value_t, App, Arg, ArgMatches, SubCommand},
+    solana_core::validator::{BlockProductionMethod, TransactionStructure},
+    std::path::Path,
+};
+
+const COMMAND: &str = "manage-block-production";
+
+#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Default))]
+pub struct ManageBlockProductionArgs {
+    pub block_production_method: BlockProductionMethod,
+    pub transaction_structure: TransactionStructure,
+}
+
+impl FromClapArgMatches for ManageBlockProductionArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(ManageBlockProductionArgs {
+            block_production_method: value_t!(
+                matches,
+                "block_production_method",
+                BlockProductionMethod
+            )
+            .unwrap_or_default(),
+            transaction_structure: value_t!(matches, "transaction_struct", TransactionStructure)
+                .unwrap_or_default(),
+        })
+    }
+}
+
+pub fn command<'a>() -> App<'a, 'a> {
+    SubCommand::with_name(COMMAND)
+        .about("Manage block production")
+        .arg(
+            Arg::with_name("block_production_method")
+                .long("block-production-method")
+                .value_name("METHOD")
+                .takes_value(true)
+                .possible_values(BlockProductionMethod::cli_names())
+                .default_value(BlockProductionMethod::default().into())
+                .help(BlockProductionMethod::cli_message()),
+        )
+        .arg(
+            Arg::with_name("transaction_struct")
+                .long("transaction-structure")
+                .value_name("STRUCT")
+                .takes_value(true)
+                .possible_values(TransactionStructure::cli_names())
+                .default_value(TransactionStructure::default().into())
+                .help(TransactionStructure::cli_message()),
+        )
+}
+
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
+    let manage_block_production_args = ManageBlockProductionArgs::from_clap_arg_match(matches)?;
+
+    println!(
+        "Respawning block-production threads with method: {}, transaction structure: {}",
+        manage_block_production_args.block_production_method,
+        manage_block_production_args.transaction_structure
+    );
+    let admin_client = admin_rpc_service::connect(ledger_path);
+    admin_rpc_service::runtime().block_on(async move {
+        admin_client
+            .await?
+            .manage_block_production(
+                manage_block_production_args.block_production_method,
+                manage_block_production_args.transaction_structure,
+            )
+            .await
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_args_struct_by_command_manage_block_production_default() {
+        let app = command();
+        let matches = app.get_matches_from(vec![COMMAND]);
+        let args = ManageBlockProductionArgs::from_clap_arg_match(&matches).unwrap();
+
+        assert_eq!(args, ManageBlockProductionArgs::default());
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_manage_block_production_with_args() {
+        let app = command();
+        let matches = app.get_matches_from(vec![
+            COMMAND,
+            "--block-production-method",
+            "central-scheduler",
+            "--transaction-structure",
+            "sdk",
+        ]);
+        println!("{:?}", matches);
+        let args = ManageBlockProductionArgs::from_clap_arg_match(&matches).unwrap();
+
+        assert_eq!(
+            args,
+            ManageBlockProductionArgs {
+                block_production_method: BlockProductionMethod::CentralScheduler,
+                transaction_structure: TransactionStructure::Sdk,
+            }
+        );
+    }
+}

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod authorized_voter;
 pub mod contact_info;
 pub mod exit;
+pub mod manage_block_production;
 pub mod monitor;
 pub mod plugin;
 pub mod repair_shred_from_peer;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -74,6 +74,9 @@ pub fn main() {
         ("set-public-address", Some(subcommand_matches)) => {
             commands::set_public_address::execute(subcommand_matches, &ledger_path)
         }
+        ("manage-block-production", Some(subcommand_matches)) => {
+            commands::manage_block_production::execute(subcommand_matches, &ledger_path)
+        }
         _ => unreachable!(),
     }
     .unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem
- For scheduler-bindings project we want to control block-production at runtime:
    - Need to be able to swap over to an external packing process
    - Need to be able to fallback to internal pack/schedule
- We currently have no way of managing various block-production settings at runtime 

#### Summary of Changes
- Introduce `BlockProductionManager`
    - Manages all threads related to block-production/banking-stage
    - Vote thread is spawned once at the start of the process, and only exited at shutdown
    - Non-vote threads are spawned on request, only after setting exit signal and waiting for shutdown of previously spawned non-vote threads.
        - Allows for new options on `BlockProductionMethod` and `TransactionStructure`
- Replace `BankingStage` in `Tpu` with `Arc<Mutex<BlockProductionManager>>`
    - Arc is held in 2 places: by `Tpu` and by adminrpc (post-init)
- Add admin-rpc functionality for `manage-block-production` to enable changing of settings at runtime
    - the same framework will be used to switch between interal agave pack/scheduling and an external pack process in future PRs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
