### PR TITLE
thread-manager: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/thread-manager/src/lib.rs
+++ b/thread-manager/src/lib.rs
@@ -220,7 +220,7 @@ mod tests {
                 .read_to_string(&mut buf)
                 .unwrap();
             let cfg: ThreadManagerConfig = toml::from_str(&buf).unwrap();
-            println!("{:?}", cfg);
+            println!("{cfg:?}");
         }
     }
     // Nobody runs Agave on windows, and on Mac we can not set mask affinity without patching external crate

--- a/thread-manager/src/native_thread_runtime.rs
+++ b/thread-manager/src/native_thread_runtime.rs
@@ -95,7 +95,10 @@ impl<T> JoinHandle<T> {
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {
         if self.std_handle.is_some() {
-            warn!("Attempting to drop a Join Handle of a running thread will leak thread IDs, please join your  threads!");
+            warn!(
+                "Attempting to drop a Join Handle of a running thread will leak thread IDs, \
+                 please join your  threads!"
+            );
             self.join_inner().expect("Child thread panicked");
         }
     }

--- a/thread-manager/src/tokio_runtime.rs
+++ b/thread-manager/src/tokio_runtime.rs
@@ -100,7 +100,7 @@ impl TokioRuntime {
             .event_interval(cfg.event_interval)
             .thread_name_fn(move || {
                 let id = atomic_id.fetch_add(1, Ordering::Relaxed);
-                format!("{}-{}", base_name, id)
+                format!("{base_name}-{id}")
             })
             .on_thread_park({
                 let counters = counters.clone();


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`
