### PR TITLE
cli: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -6,7 +6,8 @@ use {
 pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
     name: "compute_unit_price",
     long: "--with-compute-unit-price",
-    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute \
+           unit.",
 };
 
 pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {

--- a/clap-utils/src/fee_payer.rs
+++ b/clap-utils/src/fee_payer.rs
@@ -6,9 +6,9 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \
-           or the pubkey of an offline signer, provided an appropriate --signer argument \
-           is also passed. Defaults to the client keypair.",
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword or the \
+           pubkey of an offline signer, provided an appropriate --signer argument is also passed. \
+           Defaults to the client keypair.",
 };
 
 pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/clap-utils/src/fee_payer.rs
+++ b/clap-utils/src/fee_payer.rs
@@ -6,8 +6,8 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \n\
-           or the pubkey of an offline signer, provided an appropriate --signer argument \n\
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \
+           or the pubkey of an offline signer, provided an appropriate --signer argument \
            is also passed. Defaults to the client keypair.",
 };
 

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -198,7 +198,7 @@ pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {
             let lamports = if lamports.is_empty() {
                 0
             } else {
-                format!("{:0<9}", lamports)[..9].parse().ok()?
+                format!("{lamports:0<9}")[..9].parse().ok()?
             };
             Some(
                 LAMPORTS_PER_SOL

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -176,7 +176,8 @@ impl DefaultSigner {
                 })
                 .map_err(|_| {
                     std::io::Error::other(format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new one",
+                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
+                         one",
                         self.path
                     ))
                 })?;
@@ -773,7 +774,8 @@ pub fn signer_from_path_with_config(
         }
         SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::other(format!(
-                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a keypair file: {e}"
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
             ))
             .into()),
             Ok(file) => Ok(Box::new(file)),
@@ -807,9 +809,9 @@ pub fn signer_from_path_with_config(
             } else if config.allow_null_signer || matches.is_present(SIGN_ONLY_ARG.name) {
                 Ok(Box::new(NullSigner::new(&pubkey)))
             } else {
-                Err(std::io::Error::other(
-                    format!("missing signature for supplied pubkey: {pubkey}"),
-                )
+                Err(std::io::Error::other(format!(
+                    "missing signature for supplied pubkey: {pubkey}"
+                ))
                 .into())
             }
         }
@@ -893,8 +895,8 @@ pub fn resolve_signer_from_path(
         }
         SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::other(format!(
-                "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
             ))
             .into()),
             Ok(_) => Ok(Some(path.to_string())),
@@ -933,7 +935,8 @@ pub const ASK_KEYWORD: &str = "ASK";
 pub const SKIP_SEED_PHRASE_VALIDATION_ARG: ArgConstant<'static> = ArgConstant {
     long: "skip-seed-phrase-validation",
     name: "skip_seed_phrase_validation",
-    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 official English word list",
+    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 \
+           official English word list",
 };
 
 /// Prompts user for a passphrase and then asks for confirmirmation to check for mistakes
@@ -1012,8 +1015,8 @@ pub fn keypair_from_path(
         }
         SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::other(format!(
-                "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
             ))
             .into()),
             Ok(file) => Ok(file),
@@ -1043,7 +1046,8 @@ pub fn keypair_from_seed_phrase(
     let seed_phrase = prompt_password(format!("[{keypair_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
-        "[{keypair_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
+        "[{keypair_name}] If this seed phrase has an associated passphrase, enter it now. \
+         Otherwise, press ENTER to continue: ",
     );
 
     let keypair = if skip_validation {

--- a/clap-v3-utils/src/compute_budget.rs
+++ b/clap-v3-utils/src/compute_budget.rs
@@ -6,7 +6,8 @@ use {
 pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
     name: "compute_unit_price",
     long: "--with-compute-unit-price",
-    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute \
+           unit.",
 };
 
 pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {

--- a/clap-v3-utils/src/fee_payer.rs
+++ b/clap-v3-utils/src/fee_payer.rs
@@ -6,9 +6,9 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \
-           or the pubkey of an offline signer, provided an appropriate --signer argument \
-           is also passed. Defaults to the client keypair.",
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword or the \
+           pubkey of an offline signer, provided an appropriate --signer argument is also passed. \
+           Defaults to the client keypair.",
 };
 
 #[allow(deprecated)]

--- a/clap-v3-utils/src/fee_payer.rs
+++ b/clap-v3-utils/src/fee_payer.rs
@@ -6,8 +6,8 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \n\
-           or the pubkey of an offline signer, provided an appropriate --signer argument \n\
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \
+           or the pubkey of an offline signer, provided an appropriate --signer argument \
            is also passed. Defaults to the client keypair.",
 };
 

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -18,7 +18,8 @@ use {
 pub mod signer;
 #[deprecated(
     since = "1.17.0",
-    note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly instead"
+    note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly \
+            instead"
 )]
 #[allow(deprecated)]
 pub use signer::{

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -98,7 +98,9 @@ where
 // Return an error if a keypair file cannot be parsed
 #[deprecated(
     since = "1.18.0",
-    note = "please use `SignerSourceParserBuilder::default().allow_file_path().allow_prompt().allow_legacy().build()` instead"
+    note = "please use \
+            `SignerSourceParserBuilder::default().allow_file_path().allow_prompt().allow_legacy().\
+            build()` instead"
 )]
 pub fn is_keypair_or_ask_keyword<T>(string: T) -> Result<(), String>
 where
@@ -115,7 +117,8 @@ where
 // Return an error if a `SignerSourceKind::Prompt` cannot be parsed
 #[deprecated(
     since = "1.18.0",
-    note = "please use `SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build()` instead"
+    note = "please use \
+            `SignerSourceParserBuilder::default().allow_prompt().allow_legacy().build()` instead"
 )]
 pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
@@ -135,7 +138,9 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 #[deprecated(
     since = "1.18.0",
-    note = "please use `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` instead"
+    note = "please use \
+            `SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build()` \
+            instead"
 )]
 #[allow(deprecated)]
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>

--- a/clap-v3-utils/src/keygen/derivation_path.rs
+++ b/clap-v3-utils/src/keygen/derivation_path.rs
@@ -13,9 +13,10 @@ pub fn derivation_path_arg<'a>() -> Arg<'a> {
         .takes_value(true)
         .min_values(0)
         .max_values(1)
-        .help("Derivation path. All indexes will be promoted to hardened. \
-            If arg is not presented then derivation path will not be used. \
-            If arg is presented with empty DERIVATION_PATH value then m/44'/501'/0'/0' will be used."
+        .help(
+            "Derivation path. All indexes will be promoted to hardened. If arg is not presented \
+             then derivation path will not be used. If arg is presented with empty \
+             DERIVATION_PATH value then m/44'/501'/0'/0' will be used.",
         )
 }
 

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -121,15 +121,17 @@ pub fn no_passphrase_and_message() -> (String, String) {
 pub fn acquire_passphrase_and_message(
     matches: &ArgMatches,
 ) -> Result<(String, String), Box<dyn error::Error>> {
+    #[rustfmt::skip]
+    const PROMPT: &str =
+        "\nFor added security, enter a BIP39 passphrase\n\
+         \nNOTE! This passphrase improves security of the recovery seed phrase NOT the\n\
+         keypair file itself, which is stored as insecure plain text\n\
+         \nBIP39 Passphrase (empty for none): ";
+
     if matches.try_contains_id(NO_PASSPHRASE_ARG.name)? {
         Ok(no_passphrase_and_message())
     } else {
-        match prompt_passphrase(
-            "\nFor added security, enter a BIP39 passphrase\n\
-             \nNOTE! This passphrase improves security of the recovery seed phrase NOT the\n\
-             keypair file itself, which is stored as insecure plain text\n\
-             \nBIP39 Passphrase (empty for none): ",
-        ) {
+        match prompt_passphrase(PROMPT) {
             Ok(passphrase) => {
                 println!();
                 Ok((passphrase, " and your BIP39 passphrase".to_string()))

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -1349,7 +1349,7 @@ mod tests {
             legacy: false,
         };
 
-        let signer_arg = format!("{}={}", pubkey, signature);
+        let signer_arg = format!("{pubkey}={signature}");
 
         let clap_app = Command::new("test").arg(
             Arg::new(SIGNER_ARG.name)
@@ -1390,7 +1390,7 @@ mod tests {
             legacy: false,
         };
 
-        let signer_arg = format!("{}={}", pubkey, signature);
+        let signer_arg = format!("{pubkey}={signature}");
 
         let clap_app = Command::new("test").arg(
             Arg::new(SIGNER_ARG.name)

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -171,12 +171,11 @@ impl DefaultSigner {
                     }
                 })
                 .map_err(|_| {
-                    std::io::Error::other(
-                        format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new one",
+                    std::io::Error::other(format!(
+                        "No default signer found, run \"solana-keygen new -o {}\" to create a new \
+                         one",
                         self.path
-                    ),
-                    )
+                    ))
                 })?;
             *self.is_path_checked.borrow_mut() = true;
         }
@@ -652,9 +651,10 @@ pub fn signer_from_source_with_config(
             )?))
         }
         SignerSourceKind::Filepath(path) => match read_keypair_file(path) {
-            Err(e) => Err(std::io::Error::other(
-                format!("could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a keypair file: {e}"),
-            )
+            Err(e) => Err(std::io::Error::other(format!(
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
+            ))
             .into()),
             Ok(file) => Ok(Box::new(file)),
         },
@@ -680,17 +680,21 @@ pub fn signer_from_source_with_config(
             }
         }
         SignerSourceKind::Pubkey(pubkey) => {
-            let presigner = try_pubkeys_sigs_of(matches, SIGNER_ARG.name).ok().flatten()
+            let presigner = try_pubkeys_sigs_of(matches, SIGNER_ARG.name)
+                .ok()
+                .flatten()
                 .as_ref()
                 .and_then(|presigners| presigner_from_pubkey_sigs(pubkey, presigners));
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
-            } else if config.allow_null_signer || matches.try_contains_id(SIGN_ONLY_ARG.name).unwrap_or(false) {
+            } else if config.allow_null_signer
+                || matches.try_contains_id(SIGN_ONLY_ARG.name).unwrap_or(false)
+            {
                 Ok(Box::new(NullSigner::new(pubkey)))
             } else {
-                Err(std::io::Error::other(
-                    format!("missing signature for supplied pubkey: {pubkey}"),
-                )
+                Err(std::io::Error::other(format!(
+                    "missing signature for supplied pubkey: {pubkey}"
+                ))
                 .into())
             }
         }
@@ -793,8 +797,8 @@ pub fn resolve_signer_from_source(
         }
         SignerSourceKind::Filepath(path) => match read_keypair_file(path) {
             Err(e) => Err(std::io::Error::other(format!(
-                "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
             ))
             .into()),
             Ok(_) => Ok(Some(path.to_string())),
@@ -834,7 +838,8 @@ pub const ASK_KEYWORD: &str = "ASK";
 pub const SKIP_SEED_PHRASE_VALIDATION_ARG: ArgConstant<'static> = ArgConstant {
     long: "skip-seed-phrase-validation",
     name: "skip_seed_phrase_validation",
-    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 official English word list",
+    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 \
+           official English word list",
 };
 
 /// Prompts user for a passphrase and then asks for confirmirmation to check for mistakes
@@ -1071,8 +1076,8 @@ fn encodable_key_from_source<K: EncodableKey + SeedDerivable>(
         )?),
         SignerSourceKind::Filepath(path) => match K::read_from_file(path) {
             Err(e) => Err(std::io::Error::other(format!(
-                "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a \
+                 keypair file: {e}"
             ))
             .into()),
             Ok(file) => Ok(file),
@@ -1152,7 +1157,8 @@ fn encodable_key_from_seed_phrase<K: EncodableKey + SeedDerivable>(
     let seed_phrase = prompt_password(format!("[{key_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
-        "[{key_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
+        "[{key_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, \
+         press ENTER to continue: ",
     );
 
     let key = if skip_validation {

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3547,7 +3547,16 @@ mod tests {
 
         c.use_csv = true;
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
+        assert_eq!(
+            s,
+            "Account Balance: 0.00001 SOL\nValidator Identity: \
+             11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \
+             \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z \
+             from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent \
+             Change,APR,Commission\n1,100,1970-01-01 00:00:00 \
+             UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 \
+             UTC,0.000000012,0.0000001,11%,13.00%,1%\n"
+        );
         println!("{s}");
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3541,9 +3541,8 @@ mod tests {
             recent_timestamp: BlockTimestamp::default(),
             ..CliVoteAccount::default()
         };
-        let s = format!("{c}");
         #[rustfmt::skip]
-        let expected_output =
+        let expected_output_common =
             "Account Balance: 0.00001 SOL\n\
              Validator Identity: 11111111111111111111111111111111\n\
              Vote Authority: None\n\
@@ -3551,32 +3550,33 @@ mod tests {
              Credits: 0\n\
              Commission: 0%\n\
              Root Slot: ~\n\
-             Recent Timestamp: 1970-01-01T00:00:00Z from slot 0\n\
-             Epoch Rewards:\n  \
+             Recent Timestamp: 1970-01-01T00:00:00Z from slot 0\n";
+
+        let s = format!("{c}");
+        #[rustfmt::skip]
+        let expected_epoch_rewards_output =
+            "Epoch Rewards:\n  \
              Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  \
              1       100          1970-01-01 00:00:00 UTC  ◎0.00000001         ◎0.0000001                 11.000%          10.00%          1%\n  \
              2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.0000001                 11.000%          13.00%          1%\n";
-        assert_eq!(s, expected_output);
+        assert_eq!(
+            s,
+            format!("{expected_output_common}{expected_epoch_rewards_output}")
+        );
         println!("{s}");
 
         c.use_csv = true;
         let s = format!("{c}");
         #[rustfmt::skip]
-        let expected_output =
-            "Account Balance: 0.00001 SOL\n\
-             Validator Identity: \
-             11111111111111111111111111111111\n\
-             Vote Authority: None\n\
-             Withdraw Authority: \n\
-             Credits: 0\n\
-             Commission: 0%\n\
-             Root Slot: ~\n\
-             Recent Timestamp: 1970-01-01T00:00:00Z from slot 0\n\
-             Epoch Rewards:\n\
+        let expected_epoch_rewards_output =
+            "Epoch Rewards:\n\
              Epoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n\
              1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n\
              2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n";
-        assert_eq!(s, expected_output);
+        assert_eq!(
+            s,
+            format!("{expected_output_common}{expected_epoch_rewards_output}")
+        );
         println!("{s}");
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3547,16 +3547,22 @@ mod tests {
 
         c.use_csv = true;
         let s = format!("{c}");
-        assert_eq!(
-            s,
-            "Account Balance: 0.00001 SOL\nValidator Identity: \
-             11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \
-             \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z \
-             from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent \
-             Change,APR,Commission\n1,100,1970-01-01 00:00:00 \
-             UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 \
-             UTC,0.000000012,0.0000001,11%,13.00%,1%\n"
-        );
+        #[rustfmt::skip]
+        let expected_output =
+            "Account Balance: 0.00001 SOL\n\
+             Validator Identity: \
+             11111111111111111111111111111111\n\
+             Vote Authority: None\n\
+             Withdraw Authority: \n\
+             Credits: 0\n\
+             Commission: 0%\n\
+             Root Slot: ~\n\
+             Recent Timestamp: 1970-01-01T00:00:00Z from slot 0\n\
+             Epoch Rewards:\n\
+             Epoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n\
+             1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n\
+             2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n";
+        assert_eq!(s, expected_output);
         println!("{s}");
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -118,9 +118,9 @@ impl VerboseDisplay for CliPrioritizationFeeStats {
     fn write_str(&self, f: &mut dyn std::fmt::Write) -> fmt::Result {
         writeln!(f, "{:<11} prioritization_fee", "slot")?;
         for fee in &self.fees {
-            write!(f, "{}", fee)?;
+            write!(f, "{fee}")?;
         }
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3542,7 +3542,21 @@ mod tests {
             ..CliVoteAccount::default()
         };
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: None\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\n  Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  1       100          1970-01-01 00:00:00 UTC  ◎0.00000001         ◎0.0000001                 11.000%          10.00%          1%\n  2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.0000001                 11.000%          13.00%          1%\n");
+        #[rustfmt::skip]
+        let expected_output =
+            "Account Balance: 0.00001 SOL\n\
+             Validator Identity: 11111111111111111111111111111111\n\
+             Vote Authority: None\n\
+             Withdraw Authority: \n\
+             Credits: 0\n\
+             Commission: 0%\n\
+             Root Slot: ~\n\
+             Recent Timestamp: 1970-01-01T00:00:00Z from slot 0\n\
+             Epoch Rewards:\n  \
+             Epoch   Reward Slot  Time                        Amount              New Balance         Percent Change             APR  Commission\n  \
+             1       100          1970-01-01 00:00:00 UTC  ◎0.00000001         ◎0.0000001                 11.000%          10.00%          1%\n  \
+             2       200          1970-01-12 13:46:40 UTC  ◎0.000000012        ◎0.0000001                 11.000%          13.00%          1%\n";
+        assert_eq!(s, expected_output);
         println!("{s}");
 
         c.use_csv = true;

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -78,8 +78,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_pubkey_or_keypair)
                                 .help(
-                                    "Lookup table authority address \
-                                    [default: the default configured keypair].",
+                                    "Lookup table authority address [default: the default \
+                                     configured keypair].",
                                 ),
                         )
                         .arg(
@@ -113,8 +113,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority \
-                                    [default: the default configured keypair]",
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
                                 ),
                         )
                         .arg(
@@ -143,8 +143,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority \
-                                    [default: the default configured keypair]",
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
                                 ),
                         )
                         .arg(
@@ -187,8 +187,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority \
-                                    [default: the default configured keypair]",
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
                                 ),
                         )
                         .arg(
@@ -227,8 +227,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority \
-                                    [default: the default configured keypair]",
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
                                 ),
                         ),
                 )

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -44,8 +44,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                    [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -84,8 +84,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .hide_possible_values(true)
                 .global(true)
                 .help(
-                    "Return information at the selected commitment level \
-                    [possible values: processed, confirmed, finalized]",
+                    "Return information at the selected commitment level [possible values: \
+                     processed, confirmed, finalized]",
                 ),
         )
         .arg(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -718,11 +718,11 @@ pub fn parse_command(
         ("delegate-stake", Some(matches)) => {
             parse_stake_delegate_stake(matches, default_signer, wallet_manager)
         }
-        ("redelegate-stake", _) => {
-            Err(CliError::CommandNotRecognized(
-                "`redelegate-stake` no longer exists and will be completely removed in a future release".to_string(),
-            ))
-        }
+        ("redelegate-stake", _) => Err(CliError::CommandNotRecognized(
+            "`redelegate-stake` no longer exists and will be completely removed in a future \
+             release"
+                .to_string(),
+        )),
         ("withdraw-stake", Some(matches)) => {
             parse_stake_withdraw_stake(matches, default_signer, wallet_manager)
         }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -105,8 +105,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .multiple(true)
                         .index(1)
                         .help(
-                            "A list of accounts which if provided the fee response will represent\
-                            the fee to land a transaction with those accounts as writable",
+                            "A list of accounts which if provided the fee response will \
+                             representthe fee to land a transaction with those accounts as \
+                             writable",
                         ),
                 )
                 .arg(
@@ -301,8 +302,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 .about("Stream transaction logs")
                 .arg(pubkey!(
                     Arg::with_name("address").index(1).value_name("ADDRESS"),
-                    "Account to monitor \
-                    [default: monitor all transactions except for votes]."
+                    "Account to monitor [default: monitor all transactions except for votes]."
                 ))
                 .arg(
                     Arg::with_name("include_votes")
@@ -327,8 +327,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("slot-limit")
                         .takes_value(true)
                         .help(
-                            "Limit results to this many slots from the end of the epoch \
-                            [default: full epoch]",
+                            "Limit results to this many slots from the end of the epoch [default: \
+                             full epoch]",
                         ),
                 ),
         )
@@ -351,8 +351,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VALIDATOR_ACCOUNT_PUBKEYS")
                         .multiple(true),
-                    "Only show stake accounts delegated to the provided pubkeys. \
-                    Accepts both vote and identity pubkeys."
+                    "Only show stake accounts delegated to the provided pubkeys. Accepts both \
+                     vote and identity pubkeys."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("withdraw_authority")
@@ -2296,7 +2296,10 @@ pub fn process_calculate_rent(
     use_lamports_unit: bool,
 ) -> ProcessResult {
     if data_length > MAX_PERMITTED_DATA_LENGTH.try_into().unwrap() {
-        eprintln!("Warning: Maximum account size is {MAX_PERMITTED_DATA_LENGTH} bytes, {data_length} provided");
+        eprintln!(
+            "Warning: Maximum account size is {MAX_PERMITTED_DATA_LENGTH} bytes, {data_length} \
+             provided"
+        );
     }
     let rent_account = rpc_client.get_account(&sysvar::rent::id())?;
     let rent: Rent = rent_account.deserialize_data()?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -106,7 +106,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .help(
                             "A list of accounts which if provided the fee response will \
-                             representthe fee to land a transaction with those accounts as \
+                             represent the fee to land a transaction with those accounts as \
                              writable",
                         ),
                 )

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1840,8 +1840,7 @@ pub fn process_show_stakes(
 
             if !pubkeys.is_empty() {
                 return Err(CliError::RpcRequestError(format!(
-                    "Failed to retrieve matching vote account for {:?}.",
-                    pubkeys
+                    "Failed to retrieve matching vote account for {pubkeys:?}."
                 ))
                 .into());
             }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -234,9 +234,10 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("program_id")
                                 .long("program-id")
                                 .value_name("PROGRAM_ID"),
-                            "Executable program; must be a signer for initial deploys, \
-                             can be an address for upgrades [default: address of keypair at \
-                             /path/to/program-keypair.json if present, otherwise a random address]."
+                            "Executable program; must be a signer for initial deploys, can be an \
+                             address for upgrades [default: address of keypair at \
+                             /path/to/program-keypair.json if present, otherwise a random \
+                             address]."
                         ))
                         .arg(
                             Arg::with_name("final")
@@ -250,8 +251,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(false)
                                 .help(
-                                    "Maximum length of the upgradeable program \
-                                    [default: the length of the original deployed program]",
+                                    "Maximum length of the upgradeable program [default: the \
+                                     length of the original deployed program]",
                                 ),
                         )
                         .arg(
@@ -272,20 +273,20 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .default_value("5")
                                 .help(
                                     "Maximum number of attempts to sign or resign transactions \
-                                    after blockhash expiration. \
-                                    If any transactions sent during the program deploy are still \
-                                    unconfirmed after the initially chosen recent blockhash \
-                                    expires, those transactions will be resigned with a new \
-                                    recent blockhash and resent. Use this setting to adjust \
-                                    the maximum number of transaction signing iterations. Each \
-                                    blockhash is valid for about 60 seconds, which means using \
-                                    the default value of 5 will lead to sending transactions \
-                                    for at least 5 minutes or until all transactions are confirmed,\
-                                    whichever comes first.",
+                                     after blockhash expiration. If any transactions sent during \
+                                     the program deploy are still unconfirmed after the initially \
+                                     chosen recent blockhash expires, those transactions will be \
+                                     resigned with a new recent blockhash and resent. Use this \
+                                     setting to adjust the maximum number of transaction signing \
+                                     iterations. Each blockhash is valid for about 60 seconds, \
+                                     which means using the default value of 5 will lead to \
+                                     sending transactions for at least 5 minutes or until all \
+                                     transactions are confirmed,whichever comes first.",
                                 ),
                         )
                         .arg(Arg::with_name("use_rpc").long("use-rpc").help(
-                            "Send write transactions to the configured RPC instead of validator TPUs",
+                            "Send write transactions to the configured RPC instead of validator \
+                             TPUs",
                         ))
                         .arg(compute_unit_price_arg())
                         .arg(
@@ -298,9 +299,12 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("skip_feature_verify")
                                 .long("skip-feature-verify")
                                 .takes_value(false)
-                                .help("Don't verify program against the activated feature set. \
-                                This setting means a program containing a syscall not yet active on \
-                                mainnet will succeed local verification, but fail during the last step of deployment.")
+                                .help(
+                                    "Don't verify program against the activated feature set. This \
+                                     setting means a program containing a syscall not yet active \
+                                     on mainnet will succeed local verification, but fail during \
+                                     the last step of deployment.",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -335,9 +339,12 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("skip_feature_verify")
                                 .long("skip-feature-verify")
                                 .takes_value(false)
-                                .help("Don't verify program against the activated feature set. \
-                                This setting means a program containing a syscall not yet active on \
-                                mainnet will succeed local verification, but fail during the last step of deployment.")
+                                .help(
+                                    "Don't verify program against the activated feature set. This \
+                                     setting means a program containing a syscall not yet active \
+                                     on mainnet will succeed local verification, but fail during \
+                                     the last step of deployment.",
+                                ),
                         )
                         .offline_args(),
                 )
@@ -378,8 +385,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(false)
                                 .help(
-                                    "Maximum length of the upgradeable program \
-                                    [default: the length of the original deployed program]",
+                                    "Maximum length of the upgradeable program [default: the \
+                                     length of the original deployed program]",
                                 ),
                         )
                         .arg(
@@ -390,16 +397,15 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .default_value("5")
                                 .help(
                                     "Maximum number of attempts to sign or resign transactions \
-                                    after blockhash expiration. \
-                                    If any transactions sent during the program deploy are still \
-                                    unconfirmed after the initially chosen recent blockhash \
-                                    expires, those transactions will be resigned with a new \
-                                    recent blockhash and resent. Use this setting to adjust \
-                                    the maximum number of transaction signing iterations. Each \
-                                    blockhash is valid for about 60 seconds, which means using \
-                                    the default value of 5 will lead to sending transactions \
-                                    for at least 5 minutes or until all transactions are confirmed,\
-                                    whichever comes first.",
+                                     after blockhash expiration. If any transactions sent during \
+                                     the program deploy are still unconfirmed after the initially \
+                                     chosen recent blockhash expires, those transactions will be \
+                                     resigned with a new recent blockhash and resent. Use this \
+                                     setting to adjust the maximum number of transaction signing \
+                                     iterations. Each blockhash is valid for about 60 seconds, \
+                                     which means using the default value of 5 will lead to \
+                                     sending transactions for at least 5 minutes or until all \
+                                     transactions are confirmed,whichever comes first.",
                                 ),
                         )
                         .arg(Arg::with_name("use_rpc").long("use-rpc").help(
@@ -410,9 +416,12 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("skip_feature_verify")
                                 .long("skip-feature-verify")
                                 .takes_value(false)
-                                .help("Don't verify program against the activated feature set. \
-                                This setting means a program containing a syscall not yet active on \
-                                mainnet will succeed local verification, but fail during the last step of deployment.")
+                                .help(
+                                    "Don't verify program against the activated feature set. This \
+                                     setting means a program containing a syscall not yet active \
+                                     on mainnet will succeed local verification, but fail during \
+                                     the last step of deployment.",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -598,8 +607,8 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("recipient_account")
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
-                            "Recipient of closed account's lamports \
-                             [default: the default configured keypair]."
+                            "Recipient of closed account's lamports [default: the default \
+                             configured keypair]."
                         ))
                         .arg(
                             Arg::with_name("lamports")
@@ -643,9 +652,7 @@ impl ProgramSubCommands for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("migrate")
-                        .about(
-                            "Migrates an upgradeable program to loader-v4",
-                        )
+                        .about("Migrates an upgradeable program to loader-v4")
                         .arg(
                             Arg::with_name("program_id")
                                 .index(1)
@@ -662,8 +669,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Upgrade authority [default: the default configured \
-                                     keypair]",
+                                    "Upgrade authority [default: the default configured keypair]",
                                 ),
                         )
                         .arg(compute_unit_price_arg()),
@@ -1533,9 +1539,7 @@ fn fetch_verified_buffer_program_data(
     };
 
     verify_elf(&buffer_program_data, feature_set).map_err(|err| {
-        format!(
-            "Buffer account {buffer_pubkey} has invalid program data: {err:?}"
-        )
+        format!("Buffer account {buffer_pubkey} has invalid program data: {err:?}")
     })?;
 
     Ok(buffer_program_data)
@@ -1568,7 +1572,8 @@ fn fetch_buffer_program_data(
         }
         if authority_address != Some(buffer_authority) {
             return Err(format!(
-                "Buffer's authority {authority_address:?} does not match authority provided {buffer_authority}"
+                "Buffer's authority {authority_address:?} does not match authority provided \
+                 {buffer_authority}"
             )
             .into());
         }
@@ -3018,8 +3023,8 @@ fn extend_program_data_if_needed(
         let max_program_len = max_permitted_data_length
             .saturating_sub(UpgradeableLoaderState::size_of_programdata(0));
         return Err(format!(
-            "New program ({program_id}) data account is too big: {required_len}.\n\
-             Maximum program size: {max_program_len}.",
+            "New program ({program_id}) data account is too big: {required_len}.\nMaximum program \
+             size: {max_program_len}.",
         )
         .into());
     }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1534,8 +1534,7 @@ fn fetch_verified_buffer_program_data(
 
     verify_elf(&buffer_program_data, feature_set).map_err(|err| {
         format!(
-            "Buffer account {buffer_pubkey} has invalid program data: {:?}",
-            err
+            "Buffer account {buffer_pubkey} has invalid program data: {err:?}"
         )
     })?;
 
@@ -1569,8 +1568,7 @@ fn fetch_buffer_program_data(
         }
         if authority_address != Some(buffer_authority) {
             return Err(format!(
-                "Buffer's authority {:?} does not match authority provided {}",
-                authority_address, buffer_authority
+                "Buffer's authority {authority_address:?} does not match authority provided {buffer_authority}"
             )
             .into());
         }
@@ -3250,7 +3248,7 @@ fn send_deploy_messages(
 
             if !transaction_errors.is_empty() {
                 for transaction_error in &transaction_errors {
-                    error!("{:?}", transaction_error);
+                    error!("{transaction_error:?}");
                 }
                 return Err(
                     format!("{} write transactions failed", transaction_errors.len()).into(),
@@ -3717,8 +3715,8 @@ mod tests {
             "test",
             "program",
             "upgrade",
-            format!("{}", buffer_key).as_str(),
-            format!("{}", program_key).as_str(),
+            format!("{buffer_key}").as_str(),
+            format!("{program_key}").as_str(),
             "--skip-feature-verify",
         ]);
         assert_eq!(

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -169,9 +169,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help(
-                                    "Program account signer for deploying a new program",
-                                ),
+                                .help("Program account signer for deploying a new program"),
                         )
                         .arg(
                             Arg::with_name("program-id")
@@ -186,9 +184,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help(
-                                    "Optional intermediate buffer account to write data to",
-                                ),
+                                .help("Optional intermediate buffer account to write data to"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -253,7 +249,8 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Current program authority [default: the default configured keypair]",
+                                    "Current program authority [default: the default configured \
+                                     keypair]",
                                 ),
                         )
                         .arg(
@@ -263,9 +260,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_valid_signer)
-                                .help(
-                                    "New program authority",
-                                ),
+                                .help("New program authority"),
                         )
                         .offline_args()
                         .arg(compute_unit_price_arg()),
@@ -298,7 +293,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Reserves the address and links it as the programs next-version, which is a hint that frontends can show to users",
+                                    "Reserves the address and links it as the programs \
+                                     next-version, which is a hint that frontends can show to \
+                                     users",
                                 ),
                         )
                         .offline_args()
@@ -672,12 +669,20 @@ pub fn process_deploy_program(
     {
         // Deploy new program
         if program_account_exists {
-            return Err("Program account does exist already. Did you perhaps intent to redeploy an existing program instead? Then use --program-id instead of --program-keypair.".into());
+            return Err(
+                "Program account does exist already. Did you perhaps intent to redeploy an \
+                 existing program instead? Then use --program-id instead of --program-keypair."
+                    .into(),
+            );
         }
     } else {
         // Redeploy an existing program
         if !program_account_exists {
-            return Err("Program account does not exist. Did you perhaps intent to deploy a new program instead? Then use --program-keypair instead of --program-id.".into());
+            return Err(
+                "Program account does not exist. Did you perhaps intent to deploy a new program \
+                 instead? Then use --program-keypair instead of --program-id."
+                    .into(),
+            );
         }
     }
     if let Some(program_account) = program_account.as_ref() {

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -815,14 +815,13 @@ pub fn process_deploy_program(
     if upload_signer_index.is_none() {
         if upload_account.is_none() {
             return Err(format!(
-                "No ELF was provided or uploaded to the account {:?}",
-                upload_address,
+                "No ELF was provided or uploaded to the account {upload_address:?}",
             )
             .into());
         }
     } else {
         if upload_range.is_empty() {
-            return Err(format!("Attempting to upload empty range {:?}", upload_range).into());
+            return Err(format!("Attempting to upload empty range {upload_range:?}").into());
         }
         let first_write_message = Message::new(
             &[instruction::write(
@@ -1258,7 +1257,7 @@ fn send_messages(
 
         if !transaction_errors.is_empty() {
             for transaction_error in &transaction_errors {
-                error!("{:?}", transaction_error);
+                error!("{transaction_error:?}");
             }
             return Err(format!("{} write transactions failed", transaction_errors.len()).into());
         }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -515,8 +515,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .help(
-                            "The rent-exempt amount to move into the new \
-                             stake account, in SOL. Required for offline signing.",
+                            "The rent-exempt amount to move into the new stake account, in SOL. \
+                             Required for offline signing.",
                         ),
                 ),
         )
@@ -755,8 +755,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help(
-                            "Display rewards for NUM recent epochs, max 10 \
-                            [default: latest epoch only]",
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
                         ),
                 ),
         )
@@ -2009,8 +2009,8 @@ pub fn process_split_stake(
             let lamports = Sol(lamports);
             let stake_minimum_delegation = Sol(stake_minimum_delegation);
             return Err(CliError::BadParameter(format!(
-                "need at least {stake_minimum_delegation} for minimum stake delegation, \
-                 provided: {lamports}"
+                "need at least {stake_minimum_delegation} for minimum stake delegation, provided: \
+                 {lamports}"
             ))
             .into());
         }
@@ -2023,7 +2023,8 @@ pub fn process_split_stake(
                 owner if owner == system_program::id() => {
                     if !account.data.is_empty() {
                         Err(CliError::BadParameter(format!(
-                            "Account {split_stake_account_address} has data and cannot be used to split stake"
+                            "Account {split_stake_account_address} has data and cannot be used to \
+                             split stake"
                         )))
                     } else {
                         // if `stake_account`'s owner is the system_program and its data is
@@ -2032,8 +2033,9 @@ pub fn process_split_stake(
                     }
                 }
                 _ => Err(CliError::BadParameter(format!(
-                    "Account {split_stake_account_address} already exists and cannot be used to split stake"
-                )))
+                    "Account {split_stake_account_address} already exists and cannot be used to \
+                     split stake"
+                ))),
             }
         };
         let current_balance =

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -370,8 +370,8 @@ impl VoteSubCommands for App<'_, '_> {
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help(
-                            "Display rewards for NUM recent epochs, max 10 \
-                            [default: latest epoch only]",
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
                         ),
                 ),
         )

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -47,6 +47,19 @@ use {
     std::{fmt::Write as FmtWrite, fs::File, io::Write, rc::Rc, str::FromStr},
 };
 
+// Formatted specifically for the manually-indented heredoc string
+#[rustfmt::skip]
+const CONFIRM_AFTER_HELP_MESSAGE: &str =
+    "Note: This will show more detailed information for finalized \
+     transactions with verbose mode (-v/--verbose).\
+     \n\
+     \nAccount modes:\
+     \n  |srwx|\
+     \n    s: signed\
+     \n    r: readable (always true)\
+     \n    w: writable\
+     \n    x: program account (inner instructions excluded)";
+
 pub trait WalletSubCommands {
     fn wallet_subcommands(self) -> Self;
 }
@@ -135,19 +148,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The transaction signature to confirm"),
                 )
-                .after_help(
-                    // Formatted specifically for the manually-indented heredoc string
-                    "Note: This will show more detailed information for finalized \
-                    transactions with verbose mode (-v/--verbose).\
-                    \n\
-                    \nAccount modes:\
-                    \n  |srwx|\
-                    \n    s: signed\
-                    \n    r: readable (always true)\
-                    \n    w: writable\
-                    \n    x: program account (inner instructions excluded)\
-                    ",
-                ),
+                .after_help(CONFIRM_AFTER_HELP_MESSAGE),
         )
         .subcommand(
             SubCommand::with_name("create-address-with-seed")

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -183,8 +183,8 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \
-                             or one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, or one \
+                             of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
                 .arg(pubkey!(
@@ -205,8 +205,8 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \
-                             or one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, or one \
+                             of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
                 .arg(

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -183,7 +183,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \n\
+                            "The program_id that the address will ultimately be used for, \
                              or one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
@@ -205,7 +205,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \n\
+                            "The program_id that the address will ultimately be used for, \
                              or one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -60,6 +60,17 @@ const CONFIRM_AFTER_HELP_MESSAGE: &str =
      \n    w: writable\
      \n    x: program account (inner instructions excluded)";
 
+#[rustfmt::skip]
+const SEEDS_ARG_HELP_MESSAGE: &str =
+    "The seeds. \n\
+     Each one must match the pattern PREFIX:VALUE. \n\
+     PREFIX can be one of [string, pubkey, hex, u8] \n\
+     or matches the pattern [u,i][16,32,64,128][le,be] \
+     (for example u64le) for number values \n\
+     [u,i] - represents whether the number is unsigned or signed, \n\
+     [16,32,64,128] - represents the bit length, and \n\
+     [le,be] - represents the byte order - little endian or big endian";
+
 pub trait WalletSubCommands {
     fn wallet_subcommands(self) -> Self;
 }
@@ -204,16 +215,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("SEED")
                         .takes_value(true)
                         .validator(is_structured_seed)
-                        .help(
-                            "The seeds. \n\
-                            Each one must match the pattern PREFIX:VALUE. \n\
-                            PREFIX can be one of [string, pubkey, hex, u8] \n\
-                            or matches the pattern [u,i][16,32,64,128][le,be] \
-                            (for example u64le) for number values \n\
-                            [u,i] - represents whether the number is unsigned or signed, \n\
-                            [16,32,64,128] - represents the bit length, and \n\
-                            [le,be] - represents the byte order - little endian or big endian",
-                        ),
+                        .help(SEEDS_ARG_HELP_MESSAGE),
                 ),
         )
         .subcommand(

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1179,17 +1179,20 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
             "Deploying program failed: Error processing Instruction 0: account data too small for instruction",
         );
     } else {
+        #[rustfmt::skip]
+        let expected_error =
+            "Deploying program failed: \
+             RPC response error -32002: \
+             Transaction simulation failed: \
+             Error processing Instruction 0: \
+             account data too small for instruction; 3 log messages:\n  \
+             Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
+             ProgramData account not large enough\n  \
+             Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n";
         expect_command_failure(
             &config,
             "Can not upgrade a program when ELF does not fit into the allocated data account",
-            "Deploying program failed: \
-            RPC response error -32002: \
-            Transaction simulation failed: \
-            Error processing Instruction 0: \
-            account data too small for instruction; 3 log messages:\n  \
-            Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
-            ProgramData account not large enough\n  \
-            Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
+            expected_error
         );
     }
 

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1482,9 +1482,8 @@ fn test_cli_program_extend_program() {
         skip_feature_verification: true,
     });
 
-    expect_command_failure(
-        &config,
-        "Program upgrade must fail, as the buffer is 1 byte too short",
+    #[rustfmt::skip]
+    let expected_error =
         "Deploying program failed: \
          RPC response error -32002: \
          Transaction simulation failed: \
@@ -1492,7 +1491,11 @@ fn test_cli_program_extend_program() {
          account data too small for instruction; 3 log messages:\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
          ProgramData account not large enough\n  \
-         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n",
+         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n";
+    expect_command_failure(
+        &config,
+        "Program upgrade must fail, as the buffer is 1 byte too short",
+        expected_error
     );
 
     // Wait one slot to avoid "Program was deployed in this block already" error

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1995,8 +1995,7 @@ fn test_cli_program_write_buffer() {
         &config,
         "It should not be possible to deploy a program into an account that is too small",
         &format!(
-            "Buffer account data size ({}) is smaller than the minimum size ({})",
-            buffer_account_len, min_buffer_account_len
+            "Buffer account data size ({buffer_account_len}) is smaller than the minimum size ({min_buffer_account_len})"
         ),
     );
 }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1193,7 +1193,8 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
              account data too small for instruction; 3 log messages:\n  \
              Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
              ProgramData account not large enough\n  \
-             Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n";
+             Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small \
+             for instruction\n";
         expect_command_failure(
             &config,
             "Can not upgrade a program when ELF does not fit into the allocated data account",
@@ -1496,7 +1497,8 @@ fn test_cli_program_extend_program() {
          account data too small for instruction; 3 log messages:\n  \
          Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [1]\n  \
          ProgramData account not large enough\n  \
-         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for instruction\n";
+         Program BPFLoaderUpgradeab1e11111111111111111111111 failed: account data too small for \
+         instruction\n";
     expect_command_failure(
         &config,
         "Program upgrade must fail, as the buffer is 1 byte too short",

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -77,8 +77,7 @@ fn expect_command_failure(config: &CliConfig, should_fail_because: &str, error_e
     let error_actual = error_actual.to_string();
     assert!(
         error_expected == error_actual,
-        "Command failed as expected, but with an unexpected error. \
-         Expected: {error_expected}, \
+        "Command failed as expected, but with an unexpected error. Expected: {error_expected}, \
          Actual:   {error_actual}",
     );
 }
@@ -89,9 +88,8 @@ fn expect_account_absent(rpc_client: &RpcClient, pubkey: Pubkey, absent_because:
     let error_actual = error_actual.to_string();
     assert!(
         format!("AccountNotFound: pubkey={pubkey}") == error_actual,
-        "Failed to retrieve an account details. \
-         Expected account to be absent, but got a different error: \
-         {error_actual}",
+        "Failed to retrieve an account details. Expected account to be absent, but got a \
+         different error: {error_actual}",
     );
 }
 
@@ -476,10 +474,11 @@ fn test_cli_program_deploy_feature(enable_feature: bool, skip_preflight: bool) {
         assert!(res.is_ok());
     } else {
         expect_command_failure(
-                &config,
-                "Program contains a syscall from a deactivated feature",
-                "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)"
-            );
+            &config,
+            "Program contains a syscall from a deactivated feature",
+            "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 \
+             (ELF file offset 0x188)",
+        );
 
         // If we bypass the verification, there should be no error
         config.command = CliCommand::Program(ProgramCliCommand::Deploy {
@@ -654,7 +653,12 @@ fn test_cli_program_upgrade_with_feature(enable_feature: bool) {
         expect_command_failure(
             &config,
             "Program contains a syscall to a disabled feature",
-            format!("Buffer account {} has invalid program data: \"ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)\"", buffer_signer.pubkey()).as_str(),
+            format!(
+                "Buffer account {} has invalid program data: \"ELF error: ELF error: Unresolved \
+                 symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)\"",
+                buffer_signer.pubkey()
+            )
+            .as_str(),
         );
 
         // If we skip verification, the failure should be at a later stage
@@ -1176,7 +1180,8 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
         expect_command_failure(
             &config,
             "Cannot upgrade a program when ELF does not fit into the allocated data account",
-            "Deploying program failed: Error processing Instruction 0: account data too small for instruction",
+            "Deploying program failed: Error processing Instruction 0: account data too small for \
+             instruction",
         );
     } else {
         #[rustfmt::skip]
@@ -1192,7 +1197,7 @@ fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
         expect_command_failure(
             &config,
             "Can not upgrade a program when ELF does not fit into the allocated data account",
-            expected_error
+            expected_error,
         );
     }
 
@@ -1495,7 +1500,7 @@ fn test_cli_program_extend_program() {
     expect_command_failure(
         &config,
         "Program upgrade must fail, as the buffer is 1 byte too short",
-        expected_error
+        expected_error,
     );
 
     // Wait one slot to avoid "Program was deployed in this block already" error
@@ -1995,7 +2000,8 @@ fn test_cli_program_write_buffer() {
         &config,
         "It should not be possible to deploy a program into an account that is too small",
         &format!(
-            "Buffer account data size ({buffer_account_len}) is smaller than the minimum size ({min_buffer_account_len})"
+            "Buffer account data size ({buffer_account_len}) is smaller than the minimum size \
+             ({min_buffer_account_len})"
         ),
     );
 }
@@ -2070,7 +2076,8 @@ fn test_cli_program_write_buffer_feature(enable_feature: bool) {
         expect_command_failure(
             &config,
             "Program contains a syscall from a deactivated feature",
-            "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 (ELF file offset 0x188)"
+            "ELF error: ELF error: Unresolved symbol (sol_alt_bn128_group_op) at instruction #49 \
+             (ELF file offset 0x188)",
         );
 
         // If we bypass the verification, there should be no error

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -77,8 +77,8 @@ fn expect_command_failure(config: &CliConfig, should_fail_because: &str, error_e
     let error_actual = error_actual.to_string();
     assert!(
         error_expected == error_actual,
-        "Command failed as expected, but with an unexpected error.\n\
-         Expected: {error_expected}\n\
+        "Command failed as expected, but with an unexpected error. \
+         Expected: {error_expected}, \
          Actual:   {error_actual}",
     );
 }
@@ -89,8 +89,8 @@ fn expect_account_absent(rpc_client: &RpcClient, pubkey: Pubkey, absent_because:
     let error_actual = error_actual.to_string();
     assert!(
         format!("AccountNotFound: pubkey={pubkey}") == error_actual,
-        "Failed to retrieve an account details.\n\
-         Expected account to be absent, but got a different error:\n\
+        "Failed to retrieve an account details. \
+         Expected account to be absent, but got a different error: \
          {error_actual}",
     );
 }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Shift some specially crafted strings out + apply `rustfmt::skip` attribute
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`