### PR TITLE
Removes calculate_accounts_delta_hash()

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -11,10 +11,7 @@ use {
     solana_accounts_db::{
         account_info::{AccountInfo, StorageLocation},
         accounts::{AccountAddressFilter, Accounts},
-        accounts_db::{
-            test_utils::create_test_accounts, AccountFromStorage, AccountsDb,
-            ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
-        },
+        accounts_db::{AccountFromStorage, AccountsDb, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS},
         accounts_index::ScanConfig,
         ancestors::Ancestors,
     },
@@ -40,19 +37,6 @@ fn new_accounts_db(account_paths: Vec<PathBuf>) -> AccountsDb {
         None,
         Arc::default(),
     )
-}
-
-#[bench]
-fn bench_accounts_delta_hash(bencher: &mut Bencher) {
-    solana_logger::setup();
-    let accounts_db = new_accounts_db(vec![PathBuf::from("accounts_delta_hash")]);
-    let accounts = Accounts::new(Arc::new(accounts_db));
-    let mut pubkeys: Vec<Pubkey> = vec![];
-    create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
-    accounts.accounts_db.add_root_and_flush_write_cache(0);
-    bencher.iter(|| {
-        accounts.accounts_db.calculate_accounts_delta_hash(0);
-    });
 }
 
 #[bench]

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -703,7 +703,7 @@ impl Serialize for SerializableBankAndStorage<'_> {
         let mut bank_fields = self.bank.get_fields_to_serialize();
         let accounts_db = &self.bank.rc.accounts.accounts_db;
         let bank_hash_stats = self.bank.get_bank_hash_stats();
-        let accounts_delta_hash = accounts_db.get_accounts_delta_hash(slot).unwrap();
+        let accounts_delta_hash = AccountsDeltaHash(Hash::default()); // obsolete, any value works
         let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         let lamports_per_signature = bank_fields.fee_rate_governor.lamports_per_signature;
@@ -747,7 +747,7 @@ impl Serialize for SerializableBankAndStorageNoExtra<'_> {
         let bank_fields = self.bank.get_fields_to_serialize();
         let accounts_db = &self.bank.rc.accounts.accounts_db;
         let bank_hash_stats = self.bank.get_bank_hash_stats();
-        let accounts_delta_hash = accounts_db.get_accounts_delta_hash(slot).unwrap();
+        let accounts_delta_hash = AccountsDeltaHash(Hash::default()); // obsolete, any value works
         let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         (

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -557,7 +557,6 @@ mod tests {
                     minimized_account_set.insert(*pubkey);
                 }
             }
-            accounts.calculate_accounts_delta_hash(current_slot);
             accounts.add_root_and_flush_write_cache(current_slot);
         }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -67,7 +67,7 @@ impl AccountsPackage {
         let snapshot_info = {
             let accounts_db = &bank.rc.accounts.accounts_db;
             let write_version = accounts_db.write_version.load(Ordering::Acquire);
-            let accounts_delta_hash = AccountsDeltaHash(Hash::default());
+            let accounts_delta_hash = AccountsDeltaHash(Hash::default()); // obsolete, any value works
             let bank_hash_stats = bank.get_bank_hash_stats();
             let bank_fields_to_serialize = bank.get_fields_to_serialize();
             SupplementalSnapshotInfo {


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

This PR removes `calculate_accounts_delta_hash()`.