### PR TITLE
ledger: Remove deprecated legacy shred functions

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -412,11 +412,6 @@ impl Shred {
     dispatch!(pub fn payload(&self) -> &Payload);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
 
-    #[deprecated(since = "2.3.0")]
-    pub fn set_index(&mut self, _index: u32) {}
-    #[deprecated(since = "2.3.0")]
-    pub fn set_slot(&mut self, _slot: Slot) {}
-
     #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn copy_to_packet(&self, packet: &mut Packet) {
         let payload = self.payload();


### PR DESCRIPTION
#### Problem
These functions were deprecated in https://github.com/anza-xyz/agave/pull/6164

#### Summary of Changes
We have a major (3.0) version bump coming up so rip them out