### PR TITLE
Removes AccountsDb::accounts_delta_hash

### DIFF
--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -234,10 +234,6 @@ mod tests {
         let mut bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank.freeze();
         add_root_and_flush_write_cache(&bank0);
-        bank.rc
-            .accounts
-            .accounts_db
-            .set_accounts_delta_hash(bank.slot(), AccountsDeltaHash(Hash::new_unique()));
         bank.rc.accounts.accounts_db.set_accounts_hash(
             bank.slot(),
             (AccountsHash(Hash::new_unique()), u64::default()),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1160,7 +1160,7 @@ where
     let AccountsDbFields(
         _snapshot_storages,
         snapshot_version,
-        snapshot_slot,
+        _snapshot_slot,
         snapshot_bank_hash_info,
         _snapshot_historical_roots,
         _snapshot_historical_roots_with_hash,
@@ -1190,14 +1190,6 @@ where
     );
 
     // Process deserialized data, set necessary fields in self
-    let old_accounts_delta_hash = accounts_db.set_accounts_delta_hash_from_snapshot(
-        snapshot_slot,
-        snapshot_bank_hash_info.accounts_delta_hash,
-    );
-    assert!(
-        old_accounts_delta_hash.is_none(),
-        "There should not already be an AccountsDeltaHash at slot {snapshot_slot}: {old_accounts_delta_hash:?}",
-        );
     accounts_db.storage.initialize(storage);
     accounts_db
         .next_id


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

This PR removes the `AccountsDb::accounts_delta_hash` field.