### PR TITLE
Uses Rust's div_ceil()

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -235,10 +235,9 @@ impl Bank {
             1
         } else {
             const MAX_FACTOR_OF_REWARD_BLOCKS_IN_EPOCH: u64 = 10;
-            let num_chunks = solana_accounts_db::accounts_hash::AccountsHasher::div_ceil(
-                total_stake_accounts,
-                self.partitioned_rewards_stake_account_stores_per_block() as usize,
-            ) as u64;
+            let num_chunks = total_stake_accounts
+                .div_ceil(self.partitioned_rewards_stake_account_stores_per_block() as usize)
+                as u64;
 
             // Limit the reward credit interval to 10% of the total number of slots in a epoch
             num_chunks.clamp(


### PR DESCRIPTION
#### Problem

Partitioned epoch rewards uses the AccountsHasher impl of div_ceil(), which we're trying to remove. Also, div_ceil() is now stable in Rust, so we should use that instead and not reimplement our own.


#### Summary of Changes

Use Rust's div_ceil().