### PR TITLE
ledger: Update make_slot_entries() to make merkle shreds only

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -3246,11 +3246,11 @@ pub mod test {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(1, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(3, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(3, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(4, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(4, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert!(!blockstore.is_root(0));
         assert!(!blockstore.is_root(1));
@@ -3282,11 +3282,11 @@ pub mod test {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(1, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(3, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(3, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(4, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(4, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(std::iter::once(&3)).unwrap();
         assert!(!blockstore.is_root(0));
@@ -3310,9 +3310,9 @@ pub mod test {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(1, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(3, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(3, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert!(!blockstore.is_root(0));
         assert!(!blockstore.is_root(1));

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1354,8 +1354,8 @@ mod test {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         // Create some orphan slots
-        let (mut shreds, _) = make_slot_entries(1, 0, 1, /*merkle_variant:*/ true);
-        let (shreds2, _) = make_slot_entries(5, 2, 1, /*merkle_variant:*/ true);
+        let (mut shreds, _) = make_slot_entries(1, 0, 1);
+        let (shreds2, _) = make_slot_entries(5, 2, 1);
         shreds.extend(shreds2);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         let mut repair_weight = RepairWeight::new(0);
@@ -1383,7 +1383,7 @@ mod test {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(2, 0, 1, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(2, 0, 1);
 
         // Write this shred to slot 2, should chain to slot 0, which we haven't received
         // any shreds for
@@ -1491,7 +1491,6 @@ mod test {
             0, // slot
             0, // parent_slot
             num_entries_per_slot as u64,
-            true, // merkle_variant
         );
         let num_shreds_per_slot = shreds.len() as u64;
 
@@ -1585,7 +1584,6 @@ mod test {
                 i, // slot
                 parent,
                 num_entries_per_slot as u64,
-                true, // merkle_variant
             );
 
             blockstore.insert_shreds(shreds, None, false).unwrap();
@@ -1623,7 +1621,6 @@ mod test {
             dead_slot,     // slot
             dead_slot - 1, // parent_slot
             num_entries_per_slot,
-            true, // merkle_variant
         );
         blockstore
             .insert_shreds(shreds[..shreds.len() - 1].to_vec(), None, false)
@@ -1670,12 +1667,7 @@ mod test {
 
         // Insert some shreds to create a SlotMeta,
         let num_entries_per_slot = max_ticks_per_n_shreds(1, None) + 1;
-        let (mut shreds, _) = make_slot_entries(
-            dead_slot,
-            dead_slot - 1,
-            num_entries_per_slot,
-            true, // merkle_variant
-        );
+        let (mut shreds, _) = make_slot_entries(dead_slot, dead_slot - 1, num_entries_per_slot);
         blockstore
             .insert_shreds(shreds[..shreds.len() - 1].to_vec(), None, false)
             .unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4557,7 +4557,6 @@ pub(crate) mod tests {
             NUM_CONSECUTIVE_LEADER_SLOTS, // slot
             1,                            // parent_slot
             8,                            // num_entries
-            true,                         // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert!(bank_forks
@@ -4583,12 +4582,7 @@ pub(crate) mod tests {
 
         // Insert shreds for slot 2 * NUM_CONSECUTIVE_LEADER_SLOTS,
         // chaining to slot 1
-        let (shreds, _) = make_slot_entries(
-            2 * NUM_CONSECUTIVE_LEADER_SLOTS,
-            1,
-            8,
-            true, // merkle_variant
-        );
+        let (shreds, _) = make_slot_entries(2 * NUM_CONSECUTIVE_LEADER_SLOTS, 1, 8);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert!(bank_forks
             .read()
@@ -6472,17 +6466,15 @@ pub(crate) mod tests {
 
         // Simulate repair fixing slot 3 and 5
         let (shreds, _) = make_slot_entries(
-            3,    // slot
-            1,    // parent_slot
-            8,    // num_entries
-            true, // merkle_variant
+            3, // slot
+            1, // parent_slot
+            8, // num_entries
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
         let (shreds, _) = make_slot_entries(
-            5,    // slot
-            3,    // parent_slot
-            8,    // num_entries
-            true, // merkle_variant
+            5, // slot
+            3, // parent_slot
+            8, // num_entries
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -9267,8 +9259,7 @@ pub(crate) mod tests {
         let dummy_slot = working_bank.slot() + 2;
         let initial_slot = working_bank.slot();
         let num_entries = 10;
-        let merkle_variant = true;
-        let (shreds, _) = make_slot_entries(dummy_slot, initial_slot, num_entries, merkle_variant);
+        let (shreds, _) = make_slot_entries(dummy_slot, initial_slot, num_entries);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         // Reset PoH recorder to the completed bank to ensure consistent state

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -120,11 +120,11 @@ mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(0, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(0, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(1, 0, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (shreds, _) = make_slot_entries(2, 1, 42, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(2, 1, 42);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         assert_eq!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5119,9 +5119,9 @@ pub fn make_slot_entries(
     slot: Slot,
     parent_slot: Slot,
     num_entries: u64,
-    merkle_variant: bool,
 ) -> (Vec<Shred>, Vec<Entry>) {
     let entries = create_ticks(num_entries, 1, Hash::new_unique());
+    let merkle_variant = true;
     let shreds = entries_to_test_shreds(&entries, slot, parent_slot, true, 0, merkle_variant);
     (shreds, entries)
 }
@@ -5137,12 +5137,7 @@ pub fn make_many_slot_entries(
     for slot in start_slot..start_slot + num_slots {
         let parent_slot = if slot == 0 { 0 } else { slot - 1 };
 
-        let (slot_shreds, slot_entries) = make_slot_entries(
-            slot,
-            parent_slot,
-            entries_per_slot,
-            true, // merkle_variant
-        );
+        let (slot_shreds, slot_entries) = make_slot_entries(slot, parent_slot, entries_per_slot);
         shreds.extend(slot_shreds);
         entries.extend(slot_entries);
     }
@@ -5268,12 +5263,7 @@ pub fn make_chaining_slot_entries(
             }
         };
 
-        let result = make_slot_entries(
-            *slot,
-            parent_slot,
-            entries_per_slot,
-            true, // merkle_variant
-        );
+        let result = make_slot_entries(*slot, parent_slot, entries_per_slot);
         slots_shreds_and_entries.push(result);
     }
 
@@ -5392,8 +5382,7 @@ pub mod tests {
         let (shreds, _) = make_slot_entries(
             slot,
             parent_slot,
-            100,  // num_entries
-            true, // merkle_variant
+            100, // num_entries
         );
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
@@ -5441,7 +5430,6 @@ pub mod tests {
             0, // slot
             0, // parent_slot
             num_entries,
-            true, // merkle_variant
         );
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -5641,7 +5629,7 @@ pub mod tests {
     #[test]
     fn test_read_shred_bytes() {
         let slot = 0;
-        let (shreds, _) = make_slot_entries(slot, 0, 100, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(slot, 0, 100);
         let num_shreds = shreds.len() as u64;
         let shred_bufs: Vec<_> = shreds.iter().map(Shred::payload).cloned().collect();
 
@@ -5697,7 +5685,7 @@ pub mod tests {
     #[test]
     fn test_shred_cleanup_check() {
         let slot = 1;
-        let (shreds, _) = make_slot_entries(slot, 0, 100, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(slot, 0, 100);
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -5726,7 +5714,6 @@ pub mod tests {
             0, // slot
             0, // parent_slot
             num_entries,
-            true, // merkle_variant
         );
         let num_shreds = shreds.len() as u64;
 
@@ -5774,7 +5761,6 @@ pub mod tests {
             0, // slot
             0, // parent_slot
             num_entries,
-            true, // merkle_variant
         );
         let num_shreds = shreds.len() as u64;
 
@@ -5904,12 +5890,7 @@ pub mod tests {
             let parent_slot = if i == 0 { 0 } else { i - 1 };
             // Write entries
             let num_entries = min_entries * (i + 1);
-            let (shreds, original_entries) = make_slot_entries(
-                slot,
-                parent_slot,
-                num_entries,
-                true, // merkle_variant
-            );
+            let (shreds, original_entries) = make_slot_entries(slot, parent_slot, num_entries);
 
             let num_shreds = shreds.len() as u64;
             assert!(num_shreds > 1);
@@ -6007,7 +5988,6 @@ pub mod tests {
             0, // slot
             0, // parent_slot
             entries_per_slot,
-            true, // merkle_variant
         );
         let shreds_per_slot = shreds.len() as u64;
 
@@ -6042,7 +6022,6 @@ pub mod tests {
                 slot,
                 slot - 1, // parent_slot
                 entries_per_slot,
-                true, // merkle_variant
             );
             let missing_shred = slot_shreds.remove(slot as usize - 1);
             shreds.extend(slot_shreds);
@@ -6087,8 +6066,7 @@ pub mod tests {
         let entries_per_slot = 10;
 
         // Create shreds for slot 0
-        let (mut shreds, _) =
-            make_slot_entries(0, 0, entries_per_slot, /*merkle_variant:*/ true);
+        let (mut shreds, _) = make_slot_entries(0, 0, entries_per_slot);
 
         let shred0 = shreds.remove(0);
         // Insert all but the first shred in the slot, should not be considered complete
@@ -6167,7 +6145,6 @@ pub mod tests {
             disconnected_slot,
             1, // parent_slot
             entries_per_slot,
-            true, // merkle_variant
         );
 
         let mut all_shreds: Vec<_> = vec![shreds0, shreds1, shreds2, shreds3]
@@ -6420,12 +6397,7 @@ pub mod tests {
                 } else {
                     slot.saturating_sub(1)
                 };
-                let (shreds, _) = make_slot_entries(
-                    slot,
-                    parent_slot,
-                    entries_per_slot,
-                    true, // merkle_variant
-                );
+                let (shreds, _) = make_slot_entries(slot, parent_slot, entries_per_slot);
                 shreds.into_iter()
             })
             .collect();
@@ -6712,8 +6684,8 @@ pub mod tests {
 
         // Write some slot that also chains to existing slots and orphan,
         // nothing should change
-        let (shred4, _) = make_slot_entries(4, 0, 1, /*merkle_variant:*/ true);
-        let (shred5, _) = make_slot_entries(5, 1, 1, /*merkle_variant:*/ true);
+        let (shred4, _) = make_slot_entries(4, 0, 1);
+        let (shred5, _) = make_slot_entries(5, 1, 1);
         blockstore.insert_shreds(shred4, None, false).unwrap();
         blockstore.insert_shreds(shred5, None, false).unwrap();
         assert_eq!(
@@ -6744,7 +6716,7 @@ pub mod tests {
         let mut shreds = vec![];
         for slot in 0..num_slots {
             let parent_slot = slot.saturating_sub(1);
-            let (slot_shreds, entry) = make_slot_entries(slot, parent_slot, 1, true);
+            let (slot_shreds, entry) = make_slot_entries(slot, parent_slot, 1);
             shreds.extend(slot_shreds);
             entries.extend(entry);
         }
@@ -7249,7 +7221,7 @@ pub mod tests {
 
     #[test]
     fn test_is_data_shred_present() {
-        let (shreds, _) = make_slot_entries(0, 0, 200, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(0, 0, 200);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let index_cf = &blockstore.index_cf;
@@ -7743,7 +7715,7 @@ pub mod tests {
     #[test]
     fn test_insert_multiple_is_last() {
         solana_logger::setup();
-        let (shreds, _) = make_slot_entries(0, 0, 18, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(0, 0, 18);
         let num_shreds = shreds.len() as u64;
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -7756,7 +7728,7 @@ pub mod tests {
         assert_eq!(slot_meta.last_index, Some(num_shreds - 1));
         assert!(slot_meta.is_full());
 
-        let (shreds, _) = make_slot_entries(0, 0, 600, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(0, 0, 600);
         assert!(shreds.len() > num_shreds as usize);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         let slot_meta = blockstore.meta(0).unwrap().unwrap();
@@ -7946,7 +7918,7 @@ pub mod tests {
     fn test_no_insert_but_modify_slot_meta() {
         // This tests correctness of the SlotMeta in various cases in which a shred
         // that gets filtered out by checks
-        let (shreds0, _) = make_slot_entries(0, 0, 200, /*merkle_variant:*/ true);
+        let (shreds0, _) = make_slot_entries(0, 0, 200);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -7958,8 +7930,8 @@ pub mod tests {
         // Insert a repetitive shred for slot 's', should get ignored, but also
         // insert shreds that chains to 's', should see the update in the SlotMeta
         // for 's'.
-        let (mut shreds2, _) = make_slot_entries(2, 0, 200, /*merkle_variant:*/ true);
-        let (mut shreds3, _) = make_slot_entries(3, 0, 200, /*merkle_variant:*/ true);
+        let (mut shreds2, _) = make_slot_entries(2, 0, 200);
+        let (mut shreds3, _) = make_slot_entries(3, 0, 200);
         shreds2.push(shreds0[1].clone());
         shreds3.insert(0, shreds0[1].clone());
         blockstore.insert_shreds(shreds2, None, false).unwrap();
@@ -7976,7 +7948,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         // Make shred for slot 1
-        let (shreds1, _) = make_slot_entries(1, 0, 1, /*merkle_variant:*/ true);
+        let (shreds1, _) = make_slot_entries(1, 0, 1);
         let max_root = 100;
 
         blockstore.set_roots(std::iter::once(&max_root)).unwrap();
@@ -9302,7 +9274,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let (shreds, _) = make_slot_entries(1, 0, 4, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 4);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         fn make_slot_entries_with_transaction_addresses(addresses: &[Pubkey]) -> Vec<Entry> {
@@ -9989,7 +9961,7 @@ pub mod tests {
         assert_eq!(blockstore.lowest_slot(), 0);
 
         for slot in 0..10 {
-            let (shreds, _) = make_slot_entries(slot, 0, 1, /*merkle_variant:*/ true);
+            let (shreds, _) = make_slot_entries(slot, 0, 1);
             blockstore.insert_shreds(shreds, None, false).unwrap();
         }
         assert_eq!(blockstore.lowest_slot(), 1);
@@ -10005,7 +9977,7 @@ pub mod tests {
         assert_eq!(blockstore.highest_slot().unwrap(), None);
 
         for slot in 0..10 {
-            let (shreds, _) = make_slot_entries(slot, 0, 1, /*merkle_variant:*/ true);
+            let (shreds, _) = make_slot_entries(slot, 0, 1);
             blockstore.insert_shreds(shreds, None, false).unwrap();
             assert_eq!(blockstore.highest_slot().unwrap(), Some(slot));
         }
@@ -10729,8 +10701,7 @@ pub mod tests {
 
         // Create enough entries to ensure there are at least two shreds created
         let num_unique_entries = max_ticks_per_n_shreds(1, None) + 1;
-        let (mut original_shreds, original_entries) =
-            make_slot_entries(0, 0, num_unique_entries, /*merkle_variant:*/ true);
+        let (mut original_shreds, original_entries) = make_slot_entries(0, 0, num_unique_entries);
         let mut duplicate_shreds = original_shreds.clone();
         // Mutate signature so that payloads are not the same as the originals.
         for shred in &mut duplicate_shreds {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1094,9 +1094,9 @@ pub mod tests {
 
         let (shreds, _) = make_many_slot_entries(0, 10, 5);
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        let (slot_11, _) = make_slot_entries(11, 4, 5, true);
+        let (slot_11, _) = make_slot_entries(11, 4, 5);
         blockstore.insert_shreds(slot_11, None, false).unwrap();
-        let (slot_12, _) = make_slot_entries(12, 5, 5, true);
+        let (slot_12, _) = make_slot_entries(12, 5, 5);
         blockstore.insert_shreds(slot_12, None, false).unwrap();
 
         blockstore.purge_slot_cleanup_chaining(5).unwrap();

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -446,7 +446,7 @@ mod tests {
 
         // Write a shred into slot 2 that chains to slot 1,
         // but slot 1 is empty so should not be skipped
-        let (shreds, _) = make_slot_entries(2, 1, 1, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(2, 1, 1);
         blockstore.insert_shreds(shreds, None, false).unwrap();
         assert_eq!(
             cache
@@ -457,7 +457,7 @@ mod tests {
         );
 
         // Write a shred into slot 1
-        let (shreds, _) = make_slot_entries(1, 0, 1, /*merkle_variant:*/ true);
+        let (shreds, _) = make_slot_entries(1, 0, 1);
 
         // Check that slot 1 and 2 are skipped
         blockstore.insert_shreds(shreds, None, false).unwrap();


### PR DESCRIPTION
This PR needs to go in after https://github.com/anza-xyz/agave/pull/6163, as that PR addresses the 3 current instances of `make_slot_entries()` that have `merkle_variant = false`

#### Problem
We'd like to remove legacy shreds from the codebase; see https://github.com/anza-xyz/agave/issues/5982 for more

#### Summary of Changes
Update `make_slot_entries()` to no longer take `merkle_variant` parameter

