### PR TITLE
ledger: Update entries_to_test_shreds() to make merkle shreds only

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1612,7 +1612,6 @@ mod tests {
             0,    // parent_slot
             true, // is_full_slot
             0,    // version
-            true, // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
@@ -1757,7 +1756,6 @@ mod tests {
             0,    // parent_slot
             true, // is_full_slot
             0,    // version
-            true, // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();

--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -367,7 +367,6 @@ pub mod test {
                     parent.unwrap_or(slot),
                     is_slot_complete,
                     0,
-                    true, // merkle_variant
                 );
 
                 // remove next to last shred

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4803,7 +4803,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1), // parent_slot
                 false,                  // is_full_slot
                 0,                      // version
-                true,                   // merkle_variant
             )
         });
 
@@ -4840,7 +4839,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1), // parent_slot
                 false,                  // is_full_slot
                 0,                      // version
-                true,                   // merkle_variant
             )
         });
 
@@ -4866,7 +4864,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1),
                 false,
                 0,
-                true, // merkle_variant
             )
         });
 
@@ -4891,7 +4888,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1),
                 false,
                 0,
-                true, // merkle_variant
             )
         });
 
@@ -4912,7 +4908,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1),
                 true,
                 0,
-                true, // merkle_variant
             )
         });
 
@@ -4935,7 +4930,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1),
                 false,
                 0,
-                true, // merkle_variant
             )
         });
 
@@ -4965,7 +4959,6 @@ pub(crate) mod tests {
                 slot.saturating_sub(1), // parent_slot
                 true,                   // is_full_slot
                 0,                      // version
-                true,                   // merkle_variant
             )
         });
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2917,7 +2917,6 @@ mod tests {
                 i - 1, // parent_slot
                 true,  // is_full_slot
                 1,     // version
-                true,  // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, true).unwrap();
         }
@@ -3007,7 +3006,6 @@ mod tests {
                 i - 1, // parent_slot
                 true,  // is_full_slot
                 1,     // version
-                true,  // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, true).unwrap();
         }

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -24,7 +24,7 @@ fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Pa
     let blockstore =
         Blockstore::open(ledger_path).expect("Expected to be able to open database ledger");
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
 }
@@ -50,7 +50,6 @@ fn setup_read_bench(
         slot.saturating_sub(1), // parent_slot
         true,                   // is_full_slot
         0,                      // version
-        true,                   // merkle_variant
     );
     blockstore
         .insert_shreds(shreds, None, false)
@@ -140,7 +139,7 @@ fn bench_insert_data_shred_small(bench: &mut Bencher) {
     let num_entries = 32 * 1024;
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
 }
@@ -154,7 +153,7 @@ fn bench_insert_data_shred_big(bench: &mut Bencher) {
     let num_entries = 32 * 1024;
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5095,7 +5095,7 @@ pub fn entries_to_test_shreds(
     is_full_slot: bool,
     version: u16,
 ) -> Vec<Shred> {
-    let (data_shreds, _coding_shreds) = Shredder::new(slot, parent_slot, 0, version)
+    Shredder::new(slot, parent_slot, 0, version)
         .unwrap()
         .make_merkle_shreds_from_entries(
             &Keypair::new(),
@@ -5108,8 +5108,8 @@ pub fn entries_to_test_shreds(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .partition(Shred::is_data);
-    data_shreds
+        .filter(Shred::is_data)
+        .collect()
 }
 
 // used for tests only

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -522,7 +522,6 @@ impl Blockstore {
                     parent.unwrap_or(slot),
                     is_slot_complete,
                     0,
-                    true, // merkle_variant
                 );
                 self.insert_shreds(shreds, None, false).unwrap();
             }
@@ -5095,11 +5094,10 @@ pub fn entries_to_test_shreds(
     parent_slot: Slot,
     is_full_slot: bool,
     version: u16,
-    merkle_variant: bool,
 ) -> Vec<Shred> {
-    Shredder::new(slot, parent_slot, 0, version)
+    let (data_shreds, _coding_shreds) = Shredder::new(slot, parent_slot, 0, version)
         .unwrap()
-        .entries_to_shreds(
+        .make_merkle_shreds_from_entries(
             &Keypair::new(),
             entries,
             is_full_slot,
@@ -5107,11 +5105,11 @@ pub fn entries_to_test_shreds(
             Some(Hash::new_from_array(rand::thread_rng().gen())),
             0, // next_shred_index,
             0, // next_code_index
-            merkle_variant,
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .0
+        .partition(Shred::is_data);
+    data_shreds
 }
 
 // used for tests only
@@ -5121,8 +5119,7 @@ pub fn make_slot_entries(
     num_entries: u64,
 ) -> (Vec<Shred>, Vec<Entry>) {
     let entries = create_ticks(num_entries, 1, Hash::new_unique());
-    let merkle_variant = true;
-    let shreds = entries_to_test_shreds(&entries, slot, parent_slot, true, 0, merkle_variant);
+    let shreds = entries_to_test_shreds(&entries, slot, parent_slot, true, 0);
     (shreds, entries)
 }
 
@@ -5830,14 +5827,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let entries = create_ticks(8, 0, Hash::default());
-        let shreds = entries_to_test_shreds(
-            &entries[0..4],
-            1,
-            0,
-            false,
-            0,
-            true, // merkle_variant
-        );
+        let shreds = entries_to_test_shreds(&entries[0..4], 1, 0, false, 0);
         blockstore
             .insert_shreds(shreds, None, false)
             .expect("Expected successful write of shreds");
@@ -5863,14 +5853,7 @@ pub mod tests {
         // Write entries
         for slot in 0..num_slots {
             let entries = create_ticks(entries_per_slot, 0, Hash::default());
-            let shreds = entries_to_test_shreds(
-                &entries,
-                slot,
-                slot.saturating_sub(1),
-                false,
-                0,
-                true, // merkle_variant
-            );
+            let shreds = entries_to_test_shreds(&entries, slot, slot.saturating_sub(1), false, 0);
             assert!(shreds.len() as u64 >= shreds_per_slot);
             blockstore
                 .insert_shreds(shreds, None, false)
@@ -5948,8 +5931,7 @@ pub mod tests {
         let slot = 0;
         let num_entries = max_ticks_per_n_shreds(1, None) + 1;
         let entries = create_ticks(num_entries, slot, Hash::default());
-        let shreds =
-            entries_to_test_shreds(&entries, slot, 0, true, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
         let num_shreds = shreds.len();
         assert!(num_shreds > 1);
         assert!(blockstore
@@ -6757,8 +6739,7 @@ pub mod tests {
         assert!(gap > 3);
         // Create enough entries to ensure there are at least two shreds created
         let entries = create_ticks(1, 0, Hash::default());
-        let mut shreds =
-            entries_to_test_shreds(&entries, slot, 0, true, 0, /*merkle_variant:*/ true);
+        let mut shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
         shreds.retain(|s| (s.index() % gap as u32) == 0);
         let num_shreds = 2;
         shreds.truncate(num_shreds);
@@ -6999,8 +6980,7 @@ pub mod tests {
         );
 
         let entries = create_ticks(100, 0, Hash::default());
-        let mut shreds =
-            entries_to_test_shreds(&entries, slot, 0, true, 0, /*merkle_variant:*/ true);
+        let mut shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
 
         const ONE: u64 = 1;
         const OTHER: u64 = 4;
@@ -7040,8 +7020,7 @@ pub mod tests {
         // Write entries
         let num_entries = 10;
         let entries = create_ticks(num_entries, 0, Hash::default());
-        let shreds =
-            entries_to_test_shreds(&entries, slot, 0, true, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
         let num_shreds = shreds.len();
 
         blockstore.insert_shreds(shreds, None, false).unwrap();
@@ -7883,8 +7862,7 @@ pub mod tests {
         let num_ticks = 8;
         let entries = create_ticks(num_ticks, 0, Hash::default());
         let slot = 1;
-        let shreds =
-            entries_to_test_shreds(&entries, slot, 0, false, 0, /*merkle_variant:*/ true);
+        let shreds = entries_to_test_shreds(&entries, slot, 0, false, 0);
         let next_shred_index = shreds.len();
         blockstore
             .insert_shreds(shreds, None, false)
@@ -7983,7 +7961,6 @@ pub mod tests {
                 slot - 1, // parent_slot
                 true,     // is_full_slot
                 0,        // version
-                true,     // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
             blockstore.set_roots([slot].iter()).unwrap();
@@ -8009,7 +7986,6 @@ pub mod tests {
             slot - 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         let more_shreds = entries_to_test_shreds(
             &entries,
@@ -8017,7 +7993,6 @@ pub mod tests {
             slot, // parent_slot
             true, // is_full_slot
             0,    // version
-            true, // merkle_variant
         );
         let unrooted_shreds = entries_to_test_shreds(
             &entries,
@@ -8025,7 +8000,6 @@ pub mod tests {
             slot + 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -8903,7 +8877,6 @@ pub mod tests {
             slot - 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -9030,7 +9003,6 @@ pub mod tests {
             slot - 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -9307,7 +9279,6 @@ pub mod tests {
                 slot - 1, // parent_slot
                 true,     // is_full_slot
                 0,        // version
-                true,     // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -9338,8 +9309,7 @@ pub mod tests {
             let entries = make_slot_entries_with_transaction_addresses(&[
                 address0, address1, address0, address1,
             ]);
-            let shreds =
-                entries_to_test_shreds(&entries, slot, 8, true, 0, /*merkle_variant:*/ true);
+            let shreds = entries_to_test_shreds(&entries, slot, 8, true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
             let mut counter = 0;

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -608,7 +608,6 @@ pub mod tests {
                 x.saturating_sub(1), // parent_slot
                 true,                // is_full_slot
                 0,                   // version
-                true,                // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature = entries
@@ -649,7 +648,6 @@ pub mod tests {
                 x.saturating_sub(1), // parent_slot
                 true,                // is_full_slot
                 0,                   // version
-                true,                // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature = entries
@@ -691,7 +689,6 @@ pub mod tests {
                 slot.saturating_sub(1),
                 true, // is_full_slot
                 0,    // version
-                true, // merkle_variant
             );
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
@@ -941,7 +938,6 @@ pub mod tests {
             slot - 1, // parent_slot
             true,     // is_full_slot
             0,        // version
-            true,     // merkle_variant
         );
         blockstore.insert_shreds(shreds, None, false).unwrap();
 

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -21,14 +21,7 @@ fn test_multiple_threads_insert_shred() {
         let threads: Vec<_> = (0..num_threads)
             .map(|i| {
                 let entries = entry::create_ticks(1, 0, Hash::default());
-                let shreds = blockstore::entries_to_test_shreds(
-                    &entries,
-                    i + 1,
-                    0,
-                    false,
-                    0,
-                    true, // merkle_variant
-                );
+                let shreds = blockstore::entries_to_test_shreds(&entries, i + 1, 0, false, 0);
                 let blockstore_ = blockstore.clone();
                 Builder::new()
                     .name("blockstore-writer".to_string())

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4930,14 +4930,8 @@ fn test_duplicate_with_pruned_ancestor() {
             0,
             Hash::default(),
         );
-        let shreds = entries_to_test_shreds(
-            &entries,
-            last_majority_vote,
-            last_minority_vote,
-            true,
-            0,
-            true, // merkle_variant
-        );
+        let shreds =
+            entries_to_test_shreds(&entries, last_majority_vote, last_minority_vote, true, 0);
         our_blockstore.insert_shreds(shreds, None, false).unwrap();
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4427,14 +4427,8 @@ pub fn populate_blockstore_for_tests(
 ) {
     let slot = bank.slot();
     let parent_slot = bank.parent_slot();
-    let shreds = solana_ledger::blockstore::entries_to_test_shreds(
-        &entries,
-        slot,
-        parent_slot,
-        true,
-        0,
-        true, // merkle_variant
-    );
+    let shreds =
+        solana_ledger::blockstore::entries_to_test_shreds(&entries, slot, parent_slot, true, 0);
     blockstore.insert_shreds(shreds, None, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();
 

--- a/wen-restart/src/wen_restart.rs
+++ b/wen-restart/src/wen_restart.rs
@@ -3016,14 +3016,7 @@ mod tests {
         let mut entries = create_ticks(num_slots * TICKS_PER_SLOT, 0, test_state.last_blockhash);
         assert!(entries.len() > 1);
         entries.pop();
-        let shreds = entries_to_test_shreds(
-            &entries,
-            not_full_slot,
-            parent_slot,
-            false,
-            0,
-            true, // merkle_variant
-        );
+        let shreds = entries_to_test_shreds(&entries, not_full_slot, parent_slot, false, 0);
         test_state
             .blockstore
             .insert_shreds(shreds, None, false)


### PR DESCRIPTION
This PR needs to go in after https://github.com/anza-xyz/agave/pull/7097

#### Problem
We'd like to remove legacy shreds from the codebase; see https://github.com/anza-xyz/agave/issues/5982 for more details and associated PR's.

#### Summary of Changes
Update `entries_to_test_shreds()` to no longer take `merkle_variant` parameter

