### PR TITLE
validator: Remove use of ValidatorConfig::default()

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -718,6 +718,12 @@ pub fn execute(
             "block_verification_method",
             BlockVerificationMethod
         ),
+        unified_scheduler_handler_threads: value_t!(
+            matches,
+            "unified_scheduler_handler_threads",
+            usize
+        )
+        .ok(),
         block_production_method: value_t_or_exit!(
             matches,
             "block_production_method",
@@ -781,8 +787,6 @@ pub fn execute(
         TransactionStructure
     );
     validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();
-    validator_config.unified_scheduler_handler_threads =
-        value_t!(matches, "unified_scheduler_handler_threads", usize).ok();
 
     let public_rpc_addr = matches
         .value_of("public_rpc_addr")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -729,6 +729,7 @@ pub fn execute(
             "block_production_method",
             BlockProductionMethod
         ),
+        transaction_struct: value_t_or_exit!(matches, "transaction_struct", TransactionStructure),
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
     };
 
@@ -781,12 +782,6 @@ pub fn execute(
         }
         BlockVerificationMethod::UnifiedScheduler => {}
     }
-
-    validator_config.transaction_struct = value_t_or_exit!(
-        matches, // comment to align formatting...
-        "transaction_struct",
-        TransactionStructure
-    );
 
     let public_rpc_addr = matches
         .value_of("public_rpc_addr")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -39,7 +39,7 @@ use {
         },
     },
     solana_gossip::{
-        cluster_info::{BindIpAddrs, Node, NodeConfig},
+        cluster_info::{BindIpAddrs, Node, NodeConfig, DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS},
         contact_info::ContactInfo,
     },
     solana_hash::Hash,
@@ -656,6 +656,7 @@ pub fn execute(
         run_verification: !matches.is_present("skip_startup_ledger_verification"),
         debug_keys,
         contact_debug_interval,
+        contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
         send_transaction_service_config: send_transaction_service::Config {
             retry_rate_ms: rpc_send_retry_rate_ms,
             leader_forward_count,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -30,6 +30,7 @@ use {
     solana_core::{
         banking_trace::DISABLED_BAKING_TRACE_DIR,
         consensus::tower_storage,
+        repair::repair_handler::RepairHandlerType,
         snapshot_packager_service::SnapshotPackagerService,
         system_monitor_service::SystemMonitorService,
         validator::{
@@ -652,6 +653,7 @@ pub fn execute(
         known_validators: run_args.known_validators,
         repair_validators,
         repair_whitelist,
+        repair_handler_type: RepairHandlerType::default(),
         gossip_validators,
         max_ledger_shreds,
         blockstore_options: run_args.blockstore_options,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -68,7 +68,10 @@ use {
         socket::SocketAddrSpace,
     },
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
-    solana_turbine::xdp::{set_cpu_affinity, XdpConfig},
+    solana_turbine::{
+        broadcast_stage::BroadcastStageType,
+        xdp::{set_cpu_affinity, XdpConfig},
+    },
     std::{
         collections::HashSet,
         fs::{self, File},
@@ -714,6 +717,7 @@ pub fn execute(
         wen_restart_proto_path: value_t!(matches, "wen_restart", PathBuf).ok(),
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         retransmit_xdp,
+        broadcast_stage_type: BroadcastStageType::Standard,
         use_tpu_client_next: !matches.is_present("use_connection_cache"),
         block_verification_method: value_t_or_exit!(
             matches,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -729,6 +729,7 @@ pub fn execute(
             "block_production_method",
             BlockProductionMethod
         ),
+        enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
     };
 
     let reserved = validator_config
@@ -786,7 +787,6 @@ pub fn execute(
         "transaction_struct",
         TransactionStructure
     );
-    validator_config.enable_block_production_forwarding = staked_nodes_overrides_path.is_some();
 
     let public_rpc_addr = matches
         .value_of("public_rpc_addr")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -660,6 +660,7 @@ pub fn execute(
         run_verification: !matches.is_present("skip_startup_ledger_verification"),
         debug_keys,
         warp_slot: None,
+        generator_config: None,
         contact_debug_interval,
         contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
         send_transaction_service_config: send_transaction_service::Config {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -702,6 +702,7 @@ pub fn execute(
         snapshot_config,
         tpu_coalesce,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
+        wait_to_vote_slot: None,
         runtime_config: RuntimeConfig {
             log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
             ..RuntimeConfig::default()

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -659,6 +659,7 @@ pub fn execute(
         blockstore_options: run_args.blockstore_options,
         run_verification: !matches.is_present("skip_startup_ledger_verification"),
         debug_keys,
+        warp_slot: None,
         contact_debug_interval,
         contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
         send_transaction_service_config: send_transaction_service::Config {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -713,7 +713,6 @@ pub fn execute(
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         retransmit_xdp,
         use_tpu_client_next: !matches.is_present("use_connection_cache"),
-        ..ValidatorConfig::default()
     };
 
     let reserved = validator_config

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -713,6 +713,11 @@ pub fn execute(
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         retransmit_xdp,
         use_tpu_client_next: !matches.is_present("use_connection_cache"),
+        block_verification_method: value_t_or_exit!(
+            matches,
+            "block_verification_method",
+            BlockVerificationMethod
+        ),
     };
 
     let reserved = validator_config
@@ -752,11 +757,7 @@ pub fn execute(
         value_t_or_exit!(matches, "maximum_snapshot_download_abort", u64);
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, matches);
-    validator_config.block_verification_method = value_t_or_exit!(
-        matches,
-        "block_verification_method",
-        BlockVerificationMethod
-    );
+
     match validator_config.block_verification_method {
         BlockVerificationMethod::BlockstoreProcessor => {
             warn!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -716,6 +716,7 @@ pub fn execute(
             .is_present("delay_leader_block_for_pending_fork"),
         wen_restart_proto_path: value_t!(matches, "wen_restart", PathBuf).ok(),
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
+        turbine_disabled: Arc::<AtomicBool>::default(),
         retransmit_xdp,
         broadcast_stage_type: BroadcastStageType::Standard,
         use_tpu_client_next: !matches.is_present("use_connection_cache"),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -746,6 +746,7 @@ pub fn execute(
         ),
         transaction_struct: value_t_or_exit!(matches, "transaction_struct", TransactionStructure),
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
+        banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         validator_exit_backpressure: [(
             SnapshotPackagerService::NAME.to_string(),
@@ -789,8 +790,6 @@ pub fn execute(
         value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
     let maximum_snapshot_download_abort =
         value_t_or_exit!(matches, "maximum_snapshot_download_abort", u64);
-
-    configure_banking_trace_dir_byte_limit(&mut validator_config, matches);
 
     match validator_config.block_verification_method {
         BlockVerificationMethod::BlockstoreProcessor => {
@@ -1179,11 +1178,8 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
     None
 }
 
-fn configure_banking_trace_dir_byte_limit(
-    validator_config: &mut ValidatorConfig,
-    matches: &ArgMatches,
-) {
-    validator_config.banking_trace_dir_byte_limit = if matches.is_present("disable_banking_trace") {
+fn parse_banking_trace_dir_byte_limit(matches: &ArgMatches) -> u64 {
+    if matches.is_present("disable_banking_trace") {
         // disable with an explicit flag; This effectively becomes `opt-out` by resetting to
         // DISABLED_BAKING_TRACE_DIR, while allowing us to specify a default sensible limit in clap
         // configuration for cli help.
@@ -1192,7 +1188,7 @@ fn configure_banking_trace_dir_byte_limit(
         // a default value in clap configuration (BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT) or
         // explicit user-supplied override value
         value_t_or_exit!(matches, "banking_trace_dir_byte_limit", u64)
-    };
+    }
 }
 
 fn new_snapshot_config(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -574,6 +574,7 @@ pub fn execute(
         expected_genesis_hash: matches
             .value_of("expected_genesis_hash")
             .map(|s| Hash::from_str(s).unwrap()),
+        fixed_leader_schedule: None,
         expected_bank_hash: matches
             .value_of("expected_bank_hash")
             .map(|s| Hash::from_str(s).unwrap()),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -718,6 +718,11 @@ pub fn execute(
             "block_verification_method",
             BlockVerificationMethod
         ),
+        block_production_method: value_t_or_exit!(
+            matches,
+            "block_production_method",
+            BlockProductionMethod
+        ),
     };
 
     let reserved = validator_config
@@ -769,11 +774,7 @@ pub fn execute(
         }
         BlockVerificationMethod::UnifiedScheduler => {}
     }
-    validator_config.block_production_method = value_t_or_exit!(
-        matches, // comment to align formatting...
-        "block_production_method",
-        BlockProductionMethod
-    );
+
     validator_config.transaction_struct = value_t_or_exit!(
         matches, // comment to align formatting...
         "transaction_struct",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -17,6 +17,7 @@ use {
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
             AccountsIndexConfig, IndexLimitMb, ScanFilter,
         },
+        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         utils::{
             create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
             create_and_canonicalize_directory,
@@ -566,6 +567,7 @@ pub fn execute(
         require_tower: matches.is_present("require_tower"),
         tower_storage,
         halt_at_slot: value_t!(matches, "dev_halt_at_slot", Slot).ok(),
+        max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         expected_genesis_hash: matches
             .value_of("expected_genesis_hash")
             .map(|s| Hash::from_str(s).unwrap()),


### PR DESCRIPTION
#### Problem
The `ValidatorConfig` offers the `Default` trait implementation. While the trait is "convenient", using it in production is a potential footgun and we should specify all fields.

#### Summary of Changes
Remove the `..ValidatorConfig::default()` that is currently run when the validator is started.

Note that the instance I just removed was the only instance - I will be deprecating/removing the trait implementation in a subsequent PR (https://github.com/anza-xyz/agave/pull/7101)