### PR TITLE
Remove the Default trait impl. for ValidatorConfig

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -299,8 +299,11 @@ pub struct ValidatorConfig {
     pub repair_handler_type: RepairHandlerType,
 }
 
-impl Default for ValidatorConfig {
-    fn default() -> Self {
+impl ValidatorConfig {
+    pub fn default_for_test() -> Self {
+        let max_thread_count =
+            NonZeroUsize::new(num_cpus::get()).expect("thread count is non-zero");
+
         Self {
             halt_at_slot: None,
             expected_genesis_hash: None,
@@ -308,10 +311,10 @@ impl Default for ValidatorConfig {
             expected_shred_version: None,
             voting_disabled: false,
             max_ledger_shreds: None,
-            blockstore_options: BlockstoreOptions::default(),
+            blockstore_options: BlockstoreOptions::default_for_tests(),
             account_paths: Vec::new(),
             account_snapshot_paths: Vec::new(),
-            rpc_config: JsonRpcConfig::default(),
+            rpc_config: JsonRpcConfig::default_for_test(),
             on_start_geyser_plugin_config_files: None,
             geyser_plugin_always_enabled: false,
             rpc_addrs: None,
@@ -350,49 +353,30 @@ impl Default for ValidatorConfig {
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             validator_exit_backpressure: HashMap::default(),
             no_wait_for_vote_to_start_leader: true,
-            accounts_db_config: None,
+            accounts_db_config: Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             wait_to_vote_slot: None,
             runtime_config: RuntimeConfig::default(),
             banking_trace_dir_byte_limit: 0,
             block_verification_method: BlockVerificationMethod::default(),
             block_production_method: BlockProductionMethod::default(),
             transaction_struct: TransactionStructure::default(),
-            enable_block_production_forwarding: false,
+            // enable forwarding by default for tests
+            enable_block_production_forwarding: true,
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             wen_restart_proto_path: None,
             wen_restart_coordinator: None,
             unified_scheduler_handler_threads: None,
             ip_echo_server_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            rayon_global_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            tvu_shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
-            delay_leader_block_for_pending_fork: false,
-            use_tpu_client_next: true,
-            retransmit_xdp: None,
-            repair_handler_type: RepairHandlerType::default(),
-        }
-    }
-}
-
-impl ValidatorConfig {
-    pub fn default_for_test() -> Self {
-        let max_thread_count =
-            NonZeroUsize::new(num_cpus::get()).expect("thread count is non-zero");
-
-        Self {
-            accounts_db_config: Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
-            blockstore_options: BlockstoreOptions::default_for_tests(),
-            rpc_config: JsonRpcConfig::default_for_test(),
-            block_production_method: BlockProductionMethod::default(),
-            enable_block_production_forwarding: true, // enable forwarding by default for tests
             rayon_global_threads: max_thread_count,
             replay_forks_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             replay_transactions_threads: max_thread_count,
             tvu_shred_sigverify_threads: NonZeroUsize::new(get_thread_count())
                 .expect("thread count is non-zero"),
-            ..Self::default()
+            delay_leader_block_for_pending_fork: false,
+            use_tpu_client_next: true,
+            retransmit_xdp: None,
+            repair_handler_type: RepairHandlerType::default(),
         }
     }
 


### PR DESCRIPTION
#### Summary of Changes
Building on top of https://github.com/anza-xyz/agave/pull/7100, this PR removes the `Default` trait implementation from `ValidatorConfig`.

I considered trying to deprecate but I got warnings when trying to add `#[deprecated(...)]` to the default trait implementation. The warnings were in regards to the `deprecated` tag having no effect in how they were being used. Technically speaking, removing this trait is a breaking change but the next release is a major bump so I'm less concerned about this. Curious to hear how others feel though