### PR TITLE
svm: use base account size in RollbackAccounts

### DIFF
--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -317,6 +317,7 @@ mod tests {
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::FeePayerOnly {
                 fee_payer: (from_address, from_account_pre.clone()),
+                formalize_loaded_transaction_data_size: false,
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -409,6 +410,7 @@ mod tests {
             rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),
                 fee_payer: (from_address, from_account_pre.clone()),
+                formalize_loaded_transaction_data_size: false,
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -514,6 +516,7 @@ mod tests {
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),
+                formalize_loaded_transaction_data_size: false,
             },
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
@@ -580,6 +583,7 @@ mod tests {
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::FeePayerOnly {
                     fee_payer: (from_address, from_account_pre.clone()),
+                    formalize_loaded_transaction_data_size: false,
                 },
             },
         )))];

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -2833,6 +2833,9 @@ mod tests {
         fee_payer_account.set_lamports(0);
         account_loader.update_accounts_for_failed_tx(&RollbackAccounts::FeePayerOnly {
             fee_payer: (fee_payer, fee_payer_account),
+            formalize_loaded_transaction_data_size: account_loader
+                .feature_set
+                .formalize_loaded_transaction_data_size,
         });
 
         assert_eq!(

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -206,11 +206,12 @@ mod tests {
             fee_payer_address,
             rent_epoch_updated_fee_payer_account,
             fee_payer_rent_epoch,
+            false, // ignored
         );
 
         let expected_fee_payer = (fee_payer_address, fee_payer_account);
         match rollback_accounts {
-            RollbackAccounts::FeePayerOnly { fee_payer } => {
+            RollbackAccounts::FeePayerOnly { fee_payer, .. } => {
                 assert_eq!(expected_fee_payer, fee_payer);
             }
             _ => panic!("Expected FeePayerOnly variant"),
@@ -245,10 +246,12 @@ mod tests {
             nonce_address,
             rent_epoch_updated_fee_payer_account,
             u64::MAX, // ignored
+            false,    // ignored
         );
 
         let expected_rollback_accounts = RollbackAccounts::SameNonceAndFeePayer {
             nonce: (nonce_address, nonce_account),
+            formalize_loaded_transaction_data_size: false,
         };
 
         assert_eq!(expected_rollback_accounts, rollback_accounts);
@@ -285,12 +288,15 @@ mod tests {
             fee_payer_address,
             rent_epoch_updated_fee_payer_account.clone(),
             u64::MAX, // ignored
+            false,    // ignored
         );
 
         let expected_nonce = (nonce_address, nonce_account);
         let expected_fee_payer = (fee_payer_address, fee_payer_account);
         match rollback_accounts {
-            RollbackAccounts::SeparateNonceAndFeePayer { nonce, fee_payer } => {
+            RollbackAccounts::SeparateNonceAndFeePayer {
+                nonce, fee_payer, ..
+            } => {
                 assert_eq!(expected_nonce, nonce);
                 assert_eq!(expected_fee_payer, fee_payer);
             }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -600,6 +600,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             *fee_payer_address,
             loaded_fee_payer.account.clone(),
             fee_payer_loaded_rent_epoch,
+            account_loader
+                .feature_set
+                .formalize_loaded_transaction_data_size,
         );
 
         Ok(ValidatedTransactionDetails {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2125,7 +2125,8 @@ mod tests {
                     None, // nonce
                     *fee_payer_address,
                     post_validation_fee_payer_account.clone(),
-                    fee_payer_rent_epoch
+                    fee_payer_rent_epoch,
+                    formalize_loaded_transaction_data_size,
                 ),
                 compute_budget: compute_budget_and_limits.budget,
                 loaded_accounts_bytes_limit: compute_budget_and_limits
@@ -2202,6 +2203,7 @@ mod tests {
                     *fee_payer_address,
                     post_validation_fee_payer_account.clone(),
                     0, // rent epoch
+                    formalize_loaded_transaction_data_size,
                 ),
                 compute_budget: compute_budget_and_limits.budget,
                 loaded_accounts_bytes_limit: compute_budget_and_limits
@@ -2483,6 +2485,7 @@ mod tests {
                         *fee_payer_address,
                         post_validation_fee_payer_account.clone(),
                         0, // fee_payer_rent_epoch
+                        formalize_loaded_transaction_data_size,
                     ),
                     compute_budget: compute_budget_and_limits.budget,
                     loaded_accounts_bytes_limit: compute_budget_and_limits


### PR DESCRIPTION
#### Problem
simd186 mandates that the loaded account data size includes a `TRANSACTION_ACCOUNT_BASE_SIZE` of 64 bytes. this is correctly used for all transaction data size calculations regardless of the outcome of the transaction. however if the transaction fails loading, rpc and the cost model use a separate function `RollbackAccounts::data_size()` which does not include this

#### Summary of Changes
include the feature gate in `RollbackAccounts` to be able to return the expected size