### PR TITLE
Move TotalAccountsStats from runtime to ledger-tool

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -26,7 +26,7 @@ use {
     },
     solana_native_token::lamports_to_sol,
     solana_pubkey::Pubkey,
-    solana_runtime::bank::{Bank, TotalAccountsStats},
+    solana_runtime::bank::Bank,
     solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::{
         BlockEncodingOptions, ConfirmedBlock, Encodable, EncodedConfirmedBlock,
@@ -816,6 +816,33 @@ impl AccountsOutputStreamer {
                 println!("\n{:#?}", self.total_accounts_stats.borrow());
                 Ok(())
             }
+        }
+    }
+}
+
+/// Struct to collect stats when scanning all accounts for AccountsOutputStreamer
+#[derive(Debug, Default, Copy, Clone, Serialize)]
+pub struct TotalAccountsStats {
+    /// Total number of accounts
+    pub num_accounts: usize,
+    /// Total data size of all accounts
+    pub data_len: usize,
+
+    /// Total number of executable accounts
+    pub num_executable_accounts: usize,
+    /// Total data size of executable accounts
+    pub executable_data_len: usize,
+}
+
+impl TotalAccountsStats {
+    pub fn accumulate_account(&mut self, account: &AccountSharedData) {
+        let data_len = account.data().len();
+        self.num_accounts += 1;
+        self.data_len += data_len;
+
+        if account.executable() {
+            self.num_executable_accounts += 1;
+            self.executable_data_len += data_len;
         }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5952,33 +5952,6 @@ enum ApplyFeatureActivationsCaller {
     WarpFromParent,
 }
 
-/// Struct to collect stats when scanning all accounts in `get_total_accounts_stats()`
-#[derive(Debug, Default, Copy, Clone, Serialize)]
-pub struct TotalAccountsStats {
-    /// Total number of accounts
-    pub num_accounts: usize,
-    /// Total data size of all accounts
-    pub data_len: usize,
-
-    /// Total number of executable accounts
-    pub num_executable_accounts: usize,
-    /// Total data size of executable accounts
-    pub executable_data_len: usize,
-}
-
-impl TotalAccountsStats {
-    pub fn accumulate_account(&mut self, account: &AccountSharedData) {
-        let data_len = account.data().len();
-        self.num_accounts += 1;
-        self.data_len += data_len;
-
-        if account.executable() {
-            self.num_executable_accounts += 1;
-            self.executable_data_len += data_len;
-        }
-    }
-}
-
 impl Drop for Bank {
     fn drop(&mut self) {
         if let Some(drop_callback) = self.drop_callback.read().unwrap().0.as_ref() {


### PR DESCRIPTION
#### Problem

After recent rent cleanup, `TotalAccountsStats` is no longer used by runtime. The only usage for it is in ledger-tool. We should move it out of solana-runtime.


#### Summary of Changes

Move TotalAccountsStats to ledger-tool, which is where it is used. runtime doesn't need to know this type.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
