### PR TITLE
refactor: rename cost-units to transaction-cost

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -814,7 +814,7 @@ mod test {
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(1234u64),
-            cost_units: Some(5678),
+            transaction_cost: Some(5678),
         };
 
         let output = {
@@ -894,7 +894,7 @@ Rewards:
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(2345u64),
-            cost_units: Some(5678),
+            transaction_cost: Some(5678),
         };
 
         let output = {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1824,7 +1824,7 @@ mod tests {
                 rewards: Some(vec![]),
                 loaded_addresses: sanitized_tx.get_loaded_addresses(),
                 compute_units_consumed: Some(0),
-                cost_units: Some(tx_cost.sum()),
+                transaction_cost: Some(tx_cost.sum()),
                 ..TransactionStatusMeta::default()
             }
         );

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8082,7 +8082,7 @@ pub mod tests {
                     post_balances.push(i as u64 * 11);
                 }
                 let compute_units_consumed = Some(12345);
-                let cost_units = Some(6789);
+                let transaction_cost = Some(6789);
                 let signature = transaction.signatures[0];
                 let status = TransactionStatusMeta {
                     status: Ok(()),
@@ -8097,7 +8097,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
-                    cost_units,
+                    transaction_cost,
                 }
                 .into();
                 blockstore
@@ -8117,7 +8117,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
-                    cost_units,
+                    transaction_cost,
                 }
                 .into();
                 blockstore
@@ -8137,7 +8137,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
-                    cost_units,
+                    transaction_cost,
                 }
                 .into();
                 blockstore
@@ -8159,7 +8159,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data: Some(TransactionReturnData::default()),
                         compute_units_consumed,
-                        cost_units,
+                        transaction_cost,
                     },
                 }
             })
@@ -8283,9 +8283,9 @@ pub mod tests {
             data: vec![1, 2, 3],
         };
         let compute_units_consumed_1 = Some(3812649u64);
-        let cost_units_1 = Some(1234);
+        let transaction_cost_1 = Some(1234);
         let compute_units_consumed_2 = Some(42u64);
-        let cost_units_2 = Some(5678);
+        let transaction_cost_2 = Some(5678);
 
         // result not found
         assert!(transaction_status_cf
@@ -8309,7 +8309,7 @@ pub mod tests {
             loaded_addresses: test_loaded_addresses.clone(),
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_1,
-            cost_units: cost_units_1,
+            transaction_cost: transaction_cost_1,
         }
         .into();
         assert!(transaction_status_cf
@@ -8330,7 +8330,7 @@ pub mod tests {
             loaded_addresses,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = transaction_status_cf
             .get_protobuf((Signature::default(), 0))
             .unwrap()
@@ -8349,7 +8349,7 @@ pub mod tests {
         assert_eq!(loaded_addresses, test_loaded_addresses);
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_1);
-        assert_eq!(cost_units, cost_units_1);
+        assert_eq!(transaction_cost, transaction_cost_1);
 
         // insert value
         let status = TransactionStatusMeta {
@@ -8365,7 +8365,7 @@ pub mod tests {
             loaded_addresses: test_loaded_addresses.clone(),
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_2,
-            cost_units: cost_units_2,
+            transaction_cost: transaction_cost_2,
         }
         .into();
         assert!(transaction_status_cf
@@ -8386,7 +8386,7 @@ pub mod tests {
             loaded_addresses,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = transaction_status_cf
             .get_protobuf((Signature::from([2u8; 64]), 9))
             .unwrap()
@@ -8407,7 +8407,7 @@ pub mod tests {
         assert_eq!(loaded_addresses, test_loaded_addresses);
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_2);
-        assert_eq!(cost_units, cost_units_2);
+        assert_eq!(transaction_cost, transaction_cost_2);
     }
 
     #[test]
@@ -8504,7 +8504,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
-            cost_units: Some(1234),
+            transaction_cost: Some(1234),
         }
         .into();
 
@@ -8681,7 +8681,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
-            cost_units: Some(1234),
+            transaction_cost: Some(1234),
         }
         .into();
 
@@ -8809,7 +8809,7 @@ pub mod tests {
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
-            cost_units: Some(1234),
+            transaction_cost: Some(1234),
         }
         .into();
 
@@ -8979,7 +8979,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42),
-                    cost_units: Some(1234),
+                    transaction_cost: Some(1234),
                 }
                 .into();
                 blockstore
@@ -9001,7 +9001,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data,
                         compute_units_consumed: Some(42),
-                        cost_units: Some(1234),
+                        transaction_cost: Some(1234),
                     },
                 }
             })
@@ -9103,7 +9103,7 @@ pub mod tests {
                     loaded_addresses: LoadedAddresses::default(),
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42u64),
-                    cost_units: Some(1234),
+                    transaction_cost: Some(1234),
                 }
                 .into();
                 blockstore
@@ -9125,7 +9125,7 @@ pub mod tests {
                         loaded_addresses: LoadedAddresses::default(),
                         return_data,
                         compute_units_consumed: Some(42u64),
-                        cost_units: Some(1234),
+                        transaction_cost: Some(1234),
                     },
                 }
             })
@@ -9802,7 +9802,7 @@ pub mod tests {
                 loaded_addresses: LoadedAddresses::default(),
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: None,
-                cost_units: None,
+                transaction_cost: None,
             }
             .into();
             transaction_status_cf
@@ -10609,7 +10609,7 @@ pub mod tests {
                 data: vec![1, 2, 3],
             }),
             compute_units_consumed: Some(23456),
-            cost_units: Some(5678),
+            transaction_cost: Some(5678),
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -246,7 +246,7 @@ impl RpcSender for MockSender {
                             loaded_addresses: OptionSerializer::Skip,
                             return_data: OptionSerializer::Skip,
                             compute_units_consumed: OptionSerializer::Skip,
-                            cost_units: OptionSerializer::Skip,
+                            transaction_cost: OptionSerializer::Skip,
                         }),
                 },
                 block_time: Some(1628633791),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -189,7 +189,7 @@ impl TransactionStatusService {
                         loaded_addresses,
                         return_data,
                         compute_units_consumed: Some(executed_units),
-                        cost_units: cost,
+                        transaction_cost: cost,
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1025,7 +1025,7 @@ mod tests {
                 loaded_addresses: LoadedAddresses::default(),
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: Some(1234),
-                cost_units: Some(5678),
+                transaction_cost: Some(5678),
             },
         });
         let expected_block = ConfirmedBlock {
@@ -1086,7 +1086,7 @@ mod tests {
                 meta.rewards = None; // Legacy bincode implementation does not support rewards
                 meta.return_data = None; // Legacy bincode implementation does not support return data
                 meta.compute_units_consumed = None; // Legacy bincode implementation does not support CU consumed
-                meta.cost_units = None; // Legacy bincode implementation does not support CU
+                meta.transaction_cost = None; // Legacy bincode implementation does not support CU
             }
             assert_eq!(block, bincode_block.into());
         } else {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -257,7 +257,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data: None,
             compute_units_consumed: None,
-            cost_units: None,
+            transaction_cost: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -66,7 +66,7 @@ message TransactionStatusMeta {
     // Set to `None` for txs executed on earlier versions.
     optional uint64 compute_units_consumed = 16;
     // Total transaction cost
-    optional uint64 cost_units = 17;
+    optional uint64 transaction_cost = 17;
 }
 
 message TransactionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -421,7 +421,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = value;
         let err = match status {
             Ok(()) => None,
@@ -482,7 +482,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data,
             return_data_none,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         }
     }
 }
@@ -515,7 +515,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             return_data_none,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -585,7 +585,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         })
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -195,7 +195,7 @@ pub struct StoredTransactionStatusMeta {
     #[serde(deserialize_with = "default_on_eof")]
     pub compute_units_consumed: Option<u64>,
     #[serde(deserialize_with = "default_on_eof")]
-    pub cost_units: Option<u64>,
+    pub transaction_cost: Option<u64>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -212,7 +212,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             rewards,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = value;
         Self {
             status,
@@ -230,7 +230,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         }
     }
 }
@@ -251,7 +251,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             loaded_addresses,
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -277,7 +277,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
                 .map(|rewards| rewards.into_iter().map(|reward| reward.into()).collect()),
             return_data,
             compute_units_consumed,
-            cost_units,
+            transaction_cost,
         })
     }
 }

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -367,7 +367,7 @@ pub struct UiTransactionStatusMeta {
         default = "OptionSerializer::skip",
         skip_serializing_if = "OptionSerializer::should_skip"
     )]
-    pub cost_units: OptionSerializer<u64>,
+    pub transaction_cost: OptionSerializer<u64>,
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
@@ -397,7 +397,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
                 meta.return_data.map(|return_data| return_data.into()),
             ),
             compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
-            cost_units: OptionSerializer::or_skip(meta.cost_units),
+            transaction_cost: OptionSerializer::or_skip(meta.transaction_cost),
         }
     }
 }
@@ -641,7 +641,7 @@ pub struct TransactionStatusMeta {
     pub loaded_addresses: LoadedAddresses,
     pub return_data: Option<TransactionReturnData>,
     pub compute_units_consumed: Option<u64>,
-    pub cost_units: Option<u64>,
+    pub transaction_cost: Option<u64>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -659,7 +659,7 @@ impl Default for TransactionStatusMeta {
             loaded_addresses: LoadedAddresses::default(),
             return_data: None,
             compute_units_consumed: None,
-            cost_units: None,
+            transaction_cost: None,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -186,7 +186,7 @@ fn build_simple_ui_transaction_status_meta(
         loaded_addresses: OptionSerializer::Skip,
         return_data: OptionSerializer::Skip,
         compute_units_consumed: OptionSerializer::Skip,
-        cost_units: OptionSerializer::Skip,
+        transaction_cost: OptionSerializer::Skip,
     }
 }
 
@@ -225,7 +225,7 @@ fn parse_ui_transaction_status_meta(
             meta.return_data.map(|return_data| return_data.into()),
         ),
         compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
-        cost_units: OptionSerializer::or_skip(meta.cost_units),
+        transaction_cost: OptionSerializer::or_skip(meta.transaction_cost),
     }
 }
 
@@ -901,7 +901,7 @@ mod test {
             },
             return_data: None,
             compute_units_consumed: None,
-            cost_units: None,
+            transaction_cost: None,
         };
         #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/5245 introduced `cost_units` to rpc response for total `transaction_cost`. Context [here](https://anza-xyz.slack.com/archives/C02380KC571/p1752769169225069).

If change is accepted, would like to have it backported to v2.3 before it hits mainnet-beta on July 28 (based on [release schedule](https://github.com/anza-xyz/agave/wiki/v2.3-Release-Schedule) ).

#### Summary of Changes
- rename it to `tranasction_cost` for consistency 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
