### PR TITLE
Feature - Stricter ABI and runtime constraints

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -754,7 +754,7 @@ pub mod apply_cost_tracker_during_replay {
 }
 
 pub mod stricter_abi_and_runtime_constraints {
-    solana_pubkey::declare_id!("1ncomp1ete111111111111111111111111111111111");
+    solana_pubkey::declare_id!("C37iaPi6VE4CZDueU1vL8y6pGp5i8amAbEsF31xzz723");
 }
 
 pub mod add_set_tx_loaded_accounts_data_size_instruction {

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -106,7 +106,8 @@ impl FeatureSet {
                 .is_active(&move_precompile_verification_to_svm::id()),
             remove_accounts_executable_flag_checks: self
                 .is_active(&remove_accounts_executable_flag_checks::id()),
-            bpf_account_data_direct_mapping: self.is_active(&bpf_account_data_direct_mapping::id()),
+            stricter_abi_and_runtime_constraints: self
+                .is_active(&stricter_abi_and_runtime_constraints::id()),
             enable_bpf_loader_set_authority_checked_ix: self
                 .is_active(&enable_bpf_loader_set_authority_checked_ix::id()),
             enable_loader_v4: self.is_active(&enable_loader_v4::id()),
@@ -752,7 +753,7 @@ pub mod apply_cost_tracker_during_replay {
     solana_pubkey::declare_id!("2ry7ygxiYURULZCrypHhveanvP5tzZ4toRwVp89oCNSj");
 }
 
-pub mod bpf_account_data_direct_mapping {
+pub mod stricter_abi_and_runtime_constraints {
     solana_pubkey::declare_id!("1ncomp1ete111111111111111111111111111111111");
 }
 
@@ -1279,7 +1280,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (clean_up_delegation_errors::id(), "Return InsufficientDelegation instead of InsufficientFunds or InsufficientStake where applicable #31206"),
         (vote_state_add_vote_latency::id(), "replace Lockout with LandedVote (including vote latency) in vote state #31264"),
         (checked_arithmetic_in_fee_validation::id(), "checked arithmetic in fee validation #31273"),
-        (bpf_account_data_direct_mapping::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
+        (stricter_abi_and_runtime_constraints::id(), "use memory regions to map account data into the rbpf vm instead of copying the data"),
         (last_restart_slot_sysvar::id(), "enable new sysvar last_restart_slot"),
         (reduce_stake_warmup_cooldown::id(), "reduce stake warmup cooldown from 25% to 9%"),
         (revise_turbine_epoch_stakes::id(), "revise turbine epoch stakes"),

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,6 +536,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         false, // stricter_abi_and_runtime_constraints
+        false, // account_data_direct_mapping
         true,  // for mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -535,7 +535,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        false, // direct_mapping
+        false, // stricter_abi_and_runtime_constraints
         true,  // for mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -202,6 +202,8 @@ pub struct InvokeContext<'a> {
     pub timings: ExecuteDetailsTimings,
     pub syscall_context: Vec<Option<SyscallContext>>,
     traces: Vec<Vec<[u64; 12]>>,
+    /// Stops copying account data if stricter_abi_and_runtime_constraints is enabled
+    pub account_data_direct_mapping: bool,
 }
 
 impl<'a> InvokeContext<'a> {
@@ -226,6 +228,7 @@ impl<'a> InvokeContext<'a> {
             timings: ExecuteDetailsTimings::default(),
             syscall_context: Vec::new(),
             traces: Vec::new(),
+            account_data_direct_mapping: false,
         }
     }
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -51,18 +51,23 @@ struct Serializer {
     vaddr: u64,
     region_start: usize,
     is_loader_v1: bool,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
 }
 
 impl Serializer {
-    fn new(size: usize, start_addr: u64, is_loader_v1: bool, direct_mapping: bool) -> Serializer {
+    fn new(
+        size: usize,
+        start_addr: u64,
+        is_loader_v1: bool,
+        stricter_abi_and_runtime_constraints: bool,
+    ) -> Serializer {
         Serializer {
             buffer: AlignedMemory::with_capacity(size),
             regions: Vec::new(),
             region_start: 0,
             vaddr: start_addr,
             is_loader_v1,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
         }
     }
 
@@ -109,7 +114,7 @@ impl Serializer {
         &mut self,
         account: &mut BorrowedAccount<'_>,
     ) -> Result<u64, InstructionError> {
-        let vm_data_addr = if !self.direct_mapping {
+        let vm_data_addr = if !self.stricter_abi_and_runtime_constraints {
             let vm_data_addr = self.vaddr.saturating_add(self.buffer.len() as u64);
             self.write_all(account.get_data());
             vm_data_addr
@@ -135,7 +140,7 @@ impl Serializer {
         if !self.is_loader_v1 {
             let align_offset =
                 (account.get_data().len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
-            if !self.direct_mapping {
+            if !self.stricter_abi_and_runtime_constraints {
                 self.fill_write(MAX_PERMITTED_DATA_INCREASE + align_offset, 0)
                     .map_err(|_| InstructionError::InvalidArgument)?;
             } else {
@@ -186,7 +191,7 @@ impl Serializer {
 pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -235,7 +240,7 @@ pub fn serialize_parameters(
             accounts,
             instruction_context.get_instruction_data(),
             &program_id,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
             mask_out_rent_epoch_in_vm_serialization,
         )
     } else {
@@ -243,7 +248,7 @@ pub fn serialize_parameters(
             accounts,
             instruction_context.get_instruction_data(),
             &program_id,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
             mask_out_rent_epoch_in_vm_serialization,
         )
     }
@@ -252,7 +257,7 @@ pub fn serialize_parameters(
 pub fn deserialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
@@ -265,7 +270,7 @@ pub fn deserialize_parameters(
         deserialize_parameters_unaligned(
             transaction_context,
             instruction_context,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
             buffer,
             account_lengths,
         )
@@ -273,7 +278,7 @@ pub fn deserialize_parameters(
         deserialize_parameters_aligned(
             transaction_context,
             instruction_context,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
             buffer,
             account_lengths,
         )
@@ -284,7 +289,7 @@ fn serialize_parameters_unaligned(
     accounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -309,7 +314,7 @@ fn serialize_parameters_unaligned(
                 + size_of::<Pubkey>() // owner
                 + size_of::<u8>() // executable
                 + size_of::<u64>(); // rent_epoch
-                if !direct_mapping {
+                if !stricter_abi_and_runtime_constraints {
                     size += account.get_data().len();
                 }
             }
@@ -319,7 +324,12 @@ fn serialize_parameters_unaligned(
          + instruction_data.len() // instruction data
          + size_of::<Pubkey>(); // program id
 
-    let mut s = Serializer::new(size, MM_INPUT_START, true, direct_mapping);
+    let mut s = Serializer::new(
+        size,
+        MM_INPUT_START,
+        true,
+        stricter_abi_and_runtime_constraints,
+    );
 
     let mut accounts_metadata: Vec<SerializedAccountMetadata> = Vec::with_capacity(accounts.len());
     s.write::<u64>((accounts.len() as u64).to_le());
@@ -367,7 +377,7 @@ fn serialize_parameters_unaligned(
 fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -396,7 +406,7 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
             }
             start += size_of::<u64>() // lamports
                 + size_of::<u64>(); // data length
-            if !direct_mapping {
+            if !stricter_abi_and_runtime_constraints {
                 let data = buffer
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?;
@@ -422,7 +432,7 @@ fn serialize_parameters_aligned(
     accounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -450,7 +460,7 @@ fn serialize_parameters_aligned(
                 + size_of::<u64>()  // lamports
                 + size_of::<u64>()  // data len
                 + size_of::<u64>(); // rent epoch
-                if !direct_mapping {
+                if !stricter_abi_and_runtime_constraints {
                     size += data_len
                         + MAX_PERMITTED_DATA_INCREASE
                         + (data_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
@@ -464,7 +474,12 @@ fn serialize_parameters_aligned(
     + instruction_data.len()
     + size_of::<Pubkey>(); // program id;
 
-    let mut s = Serializer::new(size, MM_INPUT_START, false, direct_mapping);
+    let mut s = Serializer::new(
+        size,
+        MM_INPUT_START,
+        false,
+        stricter_abi_and_runtime_constraints,
+    );
 
     // Serialize into the buffer
     s.write::<u64>((accounts.len() as u64).to_le());
@@ -514,7 +529,7 @@ fn serialize_parameters_aligned(
 fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -562,7 +577,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
             {
                 return Err(InstructionError::InvalidRealloc);
             }
-            if !direct_mapping {
+            if !stricter_abi_and_runtime_constraints {
                 let data = buffer
                     .get(start..start + post_len)
                     .ok_or(InstructionError::InvalidArgument)?;
@@ -575,7 +590,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
             } else if borrowed_account.get_data().len() != post_len {
                 borrowed_account.set_data_length(post_len)?;
             }
-            start += if !direct_mapping {
+            start += if !stricter_abi_and_runtime_constraints {
                 let alignment_offset = (pre_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
                 pre_len // data
                     .saturating_add(MAX_PERMITTED_DATA_INCREASE) // realloc padding
@@ -649,7 +664,7 @@ mod tests {
             name: &'static str,
         }
 
-        for direct_mapping in [false] {
+        for stricter_abi_and_runtime_constraints in [false] {
             for TestCase {
                 num_ix_accounts,
                 append_dup_account,
@@ -728,7 +743,7 @@ mod tests {
                 let serialization_result = serialize_parameters(
                     invoke_context.transaction_context,
                     instruction_context,
-                    direct_mapping,
+                    stricter_abi_and_runtime_constraints,
                     true, // mask_out_rent_epoch_in_vm_serialization
                 );
                 assert_eq!(
@@ -744,7 +759,7 @@ mod tests {
                 let mut serialized_regions = concat_regions(&regions);
                 let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                     deserialize(
-                        if !direct_mapping {
+                        if !stricter_abi_and_runtime_constraints {
                             serialized.as_slice_mut()
                         } else {
                             serialized_regions.as_slice_mut()
@@ -777,7 +792,7 @@ mod tests {
 
     #[test]
     fn test_serialize_parameters() {
-        for direct_mapping in [false, true] {
+        for stricter_abi_and_runtime_constraints in [false, true] {
             let program_id = solana_pubkey::new_rand();
             let transaction_accounts = vec![
                 (
@@ -872,18 +887,18 @@ mod tests {
             let (mut serialized, regions, accounts_metadata) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
 
             let mut serialized_regions = concat_regions(&regions);
-            if !direct_mapping {
+            if !stricter_abi_and_runtime_constraints {
                 assert_eq!(serialized.as_slice(), serialized_regions.as_slice());
             }
             let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                 deserialize(
-                    if !direct_mapping {
+                    if !stricter_abi_and_runtime_constraints {
                         serialized.as_slice_mut()
                     } else {
                         serialized_regions.as_slice_mut()
@@ -932,7 +947,7 @@ mod tests {
             deserialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 serialized.as_slice(),
                 &accounts_metadata,
             )
@@ -965,7 +980,7 @@ mod tests {
             let (mut serialized, regions, account_lengths) = serialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -973,7 +988,7 @@ mod tests {
 
             let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                 deserialize_unaligned(
-                    if !direct_mapping {
+                    if !stricter_abi_and_runtime_constraints {
                         serialized.as_slice_mut()
                     } else {
                         serialized_regions.as_slice_mut()
@@ -1004,7 +1019,7 @@ mod tests {
             deserialize_parameters(
                 invoke_context.transaction_context,
                 instruction_context,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 serialized.as_slice(),
                 &account_lengths,
             )

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -724,7 +724,7 @@ mod tests {
             name: &'static str,
         }
 
-        for stricter_abi_and_runtime_constraints in [false] {
+        for stricter_abi_and_runtime_constraints in [false, true] {
             for TestCase {
                 num_ix_accounts,
                 append_dup_account,

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -52,6 +52,7 @@ struct Serializer {
     region_start: usize,
     is_loader_v1: bool,
     stricter_abi_and_runtime_constraints: bool,
+    _account_data_direct_mapping: bool,
 }
 
 impl Serializer {
@@ -60,6 +61,7 @@ impl Serializer {
         start_addr: u64,
         is_loader_v1: bool,
         stricter_abi_and_runtime_constraints: bool,
+        _account_data_direct_mapping: bool,
     ) -> Serializer {
         Serializer {
             buffer: AlignedMemory::with_capacity(size),
@@ -68,6 +70,7 @@ impl Serializer {
             vaddr: start_addr,
             is_loader_v1,
             stricter_abi_and_runtime_constraints,
+            _account_data_direct_mapping,
         }
     }
 
@@ -192,6 +195,7 @@ pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
+    account_data_direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -241,6 +245,7 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
             mask_out_rent_epoch_in_vm_serialization,
         )
     } else {
@@ -249,6 +254,7 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
             mask_out_rent_epoch_in_vm_serialization,
         )
     }
@@ -258,6 +264,7 @@ pub fn deserialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
+    account_data_direct_mapping: bool,
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
@@ -271,6 +278,7 @@ pub fn deserialize_parameters(
             transaction_context,
             instruction_context,
             stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
             buffer,
             account_lengths,
         )
@@ -279,6 +287,7 @@ pub fn deserialize_parameters(
             transaction_context,
             instruction_context,
             stricter_abi_and_runtime_constraints,
+            account_data_direct_mapping,
             buffer,
             account_lengths,
         )
@@ -290,6 +299,7 @@ fn serialize_parameters_unaligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     stricter_abi_and_runtime_constraints: bool,
+    account_data_direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -329,6 +339,7 @@ fn serialize_parameters_unaligned(
         MM_INPUT_START,
         true,
         stricter_abi_and_runtime_constraints,
+        account_data_direct_mapping,
     );
 
     let mut accounts_metadata: Vec<SerializedAccountMetadata> = Vec::with_capacity(accounts.len());
@@ -378,6 +389,7 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
+    _account_data_direct_mapping: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -433,6 +445,7 @@ fn serialize_parameters_aligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     stricter_abi_and_runtime_constraints: bool,
+    account_data_direct_mapping: bool,
     mask_out_rent_epoch_in_vm_serialization: bool,
 ) -> Result<
     (
@@ -479,6 +492,7 @@ fn serialize_parameters_aligned(
         MM_INPUT_START,
         false,
         stricter_abi_and_runtime_constraints,
+        account_data_direct_mapping,
     );
 
     // Serialize into the buffer
@@ -530,6 +544,7 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
+    _account_data_direct_mapping: bool,
     buffer: &[u8],
     account_lengths: I,
 ) -> Result<(), InstructionError> {
@@ -744,7 +759,8 @@ mod tests {
                     invoke_context.transaction_context,
                     instruction_context,
                     stricter_abi_and_runtime_constraints,
-                    true, // mask_out_rent_epoch_in_vm_serialization
+                    false, // account_data_direct_mapping
+                    true,  // mask_out_rent_epoch_in_vm_serialization
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -888,7 +904,8 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 stricter_abi_and_runtime_constraints,
-                true, // mask_out_rent_epoch_in_vm_serialization
+                false, // account_data_direct_mapping
+                true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
 
@@ -948,6 +965,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 stricter_abi_and_runtime_constraints,
+                false, // account_data_direct_mapping
                 serialized.as_slice(),
                 &accounts_metadata,
             )
@@ -981,7 +999,8 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 stricter_abi_and_runtime_constraints,
-                true, // mask_out_rent_epoch_in_vm_serialization
+                false, // account_data_direct_mapping
+                true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
             let mut serialized_regions = concat_regions(&regions);
@@ -1020,6 +1039,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 stricter_abi_and_runtime_constraints,
+                false, // account_data_direct_mapping
                 serialized.as_slice(),
                 &account_lengths,
             )
@@ -1134,6 +1154,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 true,
+                false, // account_data_direct_mapping
                 mask_out_rent_epoch_in_vm_serialization,
             )
             .unwrap();
@@ -1179,6 +1200,7 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 true,
+                false, // account_data_direct_mapping
                 mask_out_rent_epoch_in_vm_serialization,
             )
             .unwrap();
@@ -1426,7 +1448,7 @@ mod tests {
             regions,
             &config,
             SBPFVersion::V3,
-            transaction_context.access_violation_handler(),
+            transaction_context.access_violation_handler(false, false),
         )
         .unwrap();
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -133,7 +133,8 @@ pub fn invoke_builtin_function(
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,
-        false, // stricter_abi_and_runtime_constraints // There is no VM so stricter_abi_and_runtime_constraints can not be implemented here
+        false, // There is no VM so stricter_abi_and_runtime_constraints can not be implemented here
+        false, // There is no VM so account_data_direct_mapping can not be implemented here
         mask_out_rent_epoch_in_vm_serialization,
     )?;
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -133,7 +133,7 @@ pub fn invoke_builtin_function(
     let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
         transaction_context,
         instruction_context,
-        false, // direct_mapping // There is no VM so direct mapping can not be implemented here
+        false, // stricter_abi_and_runtime_constraints // There is no VM so stricter_abi_and_runtime_constraints can not be implemented here
         mask_out_rent_epoch_in_vm_serialization,
     )?;
 

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -123,7 +123,7 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true, // direct_mapping
+                true, // stricter_abi_and_runtime_constraints
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -141,7 +141,7 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false, // direct_mapping
+                false, // stricter_abi_and_runtime_constraints
                 true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -160,7 +160,7 @@ fn bench_serialize_aligned(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true, // direct_mapping
+                true, // stricter_abi_and_runtime_constraints
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -179,7 +179,7 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                false, // direct_mapping
+                false, // stricter_abi_and_runtime_constraints
                 true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -198,7 +198,7 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true, // direct_mapping
+                true, // stricter_abi_and_runtime_constraints
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -217,7 +217,7 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
             let _ = serialize_parameters(
                 &transaction_context,
                 instruction_context,
-                true, // direct_mapping
+                true, // stricter_abi_and_runtime_constraints
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -124,6 +124,7 @@ fn bench_serialize_unaligned(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 true, // stricter_abi_and_runtime_constraints
+                true, // account_data_direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -142,6 +143,7 @@ fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 false, // stricter_abi_and_runtime_constraints
+                false, // account_data_direct_mapping
                 true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -161,6 +163,7 @@ fn bench_serialize_aligned(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 true, // stricter_abi_and_runtime_constraints
+                true, // account_data_direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -180,6 +183,7 @@ fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 false, // stricter_abi_and_runtime_constraints
+                false, // account_data_direct_mapping
                 true,  // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -199,6 +203,7 @@ fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 true, // stricter_abi_and_runtime_constraints
+                true, // account_data_direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();
@@ -218,6 +223,7 @@ fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
                 &transaction_context,
                 instruction_context,
                 true, // stricter_abi_and_runtime_constraints
+                true, // account_data_direct_mapping
                 true, // mask_out_rent_epoch_in_vm_serialization
             )
             .unwrap();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -224,9 +224,9 @@ fn bench_create_vm(bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
-    let direct_mapping = invoke_context
+    let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
-        .bpf_account_data_direct_mapping;
+        .stricter_abi_and_runtime_constraints;
     let raise_cpi_nesting_limit_to_8 = invoke_context
         .get_feature_set()
         .raise_cpi_nesting_limit_to_8;
@@ -249,7 +249,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        direct_mapping,
+        stricter_abi_and_runtime_constraints,
         true, // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
@@ -273,9 +273,9 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     invoke_context.mock_set_remaining(BUDGET);
 
-    let direct_mapping = invoke_context
+    let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
-        .bpf_account_data_direct_mapping;
+        .stricter_abi_and_runtime_constraints;
 
     // Serialize account data
     let (_serialized, regions, account_lengths) = serialize_parameters(
@@ -284,7 +284,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .transaction_context
             .get_current_instruction_context()
             .unwrap(),
-        direct_mapping,
+        stricter_abi_and_runtime_constraints,
         true, // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -250,7 +250,8 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         stricter_abi_and_runtime_constraints,
-        true, // mask_out_rent_epoch_in_vm_serialization
+        false, // account_data_direct_mapping
+        true,  // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 
@@ -285,7 +286,8 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         stricter_abi_and_runtime_constraints,
-        true, // mask_out_rent_epoch_in_vm_serialization
+        false, // account_data_direct_mapping
+        true,  // mask_out_rent_epoch_in_vm_serialization
     )
     .unwrap();
 

--- a/programs/sbf/rust/invoke/src/lib.rs
+++ b/programs/sbf/rust/invoke/src/lib.rs
@@ -877,7 +877,7 @@ fn process_instruction<'a>(
                         // TEST_FORBID_LEN_UPDATE_AFTER_OWNERSHIP_CHANGE_MOVING_DATA_POINTER
                         // is that we don't move the data pointer past the
                         // RcBox. This is needed to avoid the "Invalid account
-                        // info pointer" check when direct mapping is enabled.
+                        // info pointer" check when stricter_abi_and_runtime_constraints is enabled.
                         // This also means we don't need to update the
                         // serialized len like we do in the other test.
                         value: RefCell::new(slice::from_raw_parts_mut(
@@ -1032,7 +1032,7 @@ fn process_instruction<'a>(
             let realloc_program_id = accounts[REALLOC_PROGRAM_INDEX].key;
             let realloc_program_owner = accounts[REALLOC_PROGRAM_INDEX].owner;
             let invoke_program_id = accounts[INVOKE_PROGRAM_INDEX].key;
-            let direct_mapping = instruction_data[1];
+            let stricter_abi_and_runtime_constraints = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             let prev_len = account.data_len();
             let expected = account.data.borrow()[..new_len].to_vec();
@@ -1054,7 +1054,9 @@ fn process_instruction<'a>(
 
             // deserialize_parameters_unaligned predates realloc support, and
             // hardcodes the account data length to the original length.
-            if !bpf_loader_deprecated::check_id(realloc_program_owner) && direct_mapping == 0 {
+            if !bpf_loader_deprecated::check_id(realloc_program_owner)
+                && stricter_abi_and_runtime_constraints == 0
+            {
                 assert_eq!(&*account.data.borrow(), &expected);
                 assert_eq!(
                     unsafe {
@@ -1093,7 +1095,7 @@ fn process_instruction<'a>(
             };
 
             let mut expected = account.data.borrow().to_vec();
-            let direct_mapping = instruction_data[1];
+            let stricter_abi_and_runtime_constraints = instruction_data[1];
             let new_len = usize::from_le_bytes(instruction_data[2..10].try_into().unwrap());
             expected.extend_from_slice(&instruction_data[10..]);
             let mut instruction_data =
@@ -1113,7 +1115,7 @@ fn process_instruction<'a>(
             .unwrap();
 
             assert_eq!(*account.data.borrow(), &prev_data[..new_len]);
-            if direct_mapping == 0 {
+            if stricter_abi_and_runtime_constraints == 0 {
                 assert_eq!(
                     unsafe {
                         slice::from_raw_parts(
@@ -1302,7 +1304,7 @@ fn process_instruction<'a>(
             }
 
             if !invoke_struction.is_empty() {
-                // Invoke another program. With direct mapping, before CPI the callee will update the accounts (incl resizing)
+                // Invoke another program. With stricter_abi_and_runtime_constraints, before CPI the callee will update the accounts (incl resizing)
                 // so the pointer may change.
                 let invoked_program_id = accounts[INVOKED_PROGRAM_INDEX].key;
 

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -2,7 +2,7 @@
 pub struct SVMFeatureSet {
     pub move_precompile_verification_to_svm: bool,
     pub remove_accounts_executable_flag_checks: bool,
-    pub bpf_account_data_direct_mapping: bool,
+    pub stricter_abi_and_runtime_constraints: bool,
     pub enable_bpf_loader_set_authority_checked_ix: bool,
     pub enable_loader_v4: bool,
     pub deplete_cu_meter_on_vm_failure: bool,
@@ -45,7 +45,7 @@ impl SVMFeatureSet {
         Self {
             move_precompile_verification_to_svm: true,
             remove_accounts_executable_flag_checks: true,
-            bpf_account_data_direct_mapping: true,
+            stricter_abi_and_runtime_constraints: true,
             enable_bpf_loader_set_authority_checked_ix: true,
             enable_loader_v4: true,
             deplete_cu_meter_on_vm_failure: true,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -24,7 +24,7 @@ use {
     solana_nonce::{self as nonce, state::DurableNonce},
     solana_program_entrypoint::MAX_PERMITTED_DATA_INCREASE,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-    solana_pubkey::{pubkey, Pubkey},
+    solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader_upgradeable, native_loader},
     solana_signer::Signer,
     solana_svm::{
@@ -296,7 +296,7 @@ impl SvmTestEnvironment<'_> {
 }
 
 // container for a transaction batch and all data needed to run and verify it against svm
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct SvmTestEntry {
     // features are enabled by default; these will be disabled
     pub disabled_features: Vec<Pubkey>,
@@ -494,21 +494,6 @@ impl SvmTestEntry {
         }
 
         feature_set
-    }
-}
-
-// NOTE `1ncomp1ete111111111111111111111111111111111` corresponds to `stricter_abi_and_runtime_constraints::id()`
-// by hardcoding the string, we ensure when the feature is finished, it will automatically be tested
-impl Default for SvmTestEntry {
-    fn default() -> Self {
-        Self {
-            disabled_features: vec![pubkey!("1ncomp1ete111111111111111111111111111111111")],
-            with_loader_v4: false,
-            initial_programs: vec![],
-            initial_accounts: AccountsMap::default(),
-            transaction_batch: vec![],
-            final_accounts: AccountsMap::default(),
-        }
     }
 }
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -497,7 +497,7 @@ impl SvmTestEntry {
     }
 }
 
-// NOTE `1ncomp1ete111111111111111111111111111111111` corresponds to `bpf_account_data_direct_mapping::id()`
+// NOTE `1ncomp1ete111111111111111111111111111111111` corresponds to `stricter_abi_and_runtime_constraints::id()`
 // by hardcoding the string, we ensure when the feature is finished, it will automatically be tested
 impl Default for SvmTestEntry {
     fn default() -> Self {

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -77,7 +77,7 @@ struct CallerAccount<'a> {
     // mapped inside the vm (see serialize_parameters() in
     // BpfExecutor::execute).
     //
-    // This is only set when direct mapping is off (see the relevant comment in
+    // This is only set when stricter_abi_and_runtime_constraints is off (see the relevant comment in
     // CallerAccount::from_account_info).
     serialized_data: &'a mut [u8],
     // Given the corresponding input AccountInfo::data, vm_data_addr points to
@@ -96,11 +96,11 @@ impl<'a> CallerAccount<'a> {
         account_info: &AccountInfo,
         account_metadata: &SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a>, Error> {
-        let direct_mapping = invoke_context
+        let stricter_abi_and_runtime_constraints = invoke_context
             .get_feature_set()
-            .bpf_account_data_direct_mapping;
+            .stricter_abi_and_runtime_constraints;
 
-        if direct_mapping {
+        if stricter_abi_and_runtime_constraints {
             check_account_info_pointer(
                 invoke_context,
                 account_info.key as *const _ as u64,
@@ -124,7 +124,7 @@ impl<'a> CallerAccount<'a> {
                 account_info.lamports.as_ptr() as u64,
                 check_aligned,
             )?;
-            if direct_mapping {
+            if stricter_abi_and_runtime_constraints {
                 if account_info.lamports.as_ptr() as u64 >= ebpf::MM_INPUT_START {
                     return Err(SyscallError::InvalidPointer.into());
                 }
@@ -146,7 +146,9 @@ impl<'a> CallerAccount<'a> {
         )?;
 
         let (serialized_data, vm_data_addr, ref_to_len_in_vm) = {
-            if direct_mapping && account_info.data.as_ptr() as u64 >= ebpf::MM_INPUT_START {
+            if stricter_abi_and_runtime_constraints
+                && account_info.data.as_ptr() as u64 >= ebpf::MM_INPUT_START
+            {
                 return Err(SyscallError::InvalidPointer.into());
             }
 
@@ -156,7 +158,7 @@ impl<'a> CallerAccount<'a> {
                 account_info.data.as_ptr() as *const _ as u64,
                 check_aligned,
             )?;
-            if direct_mapping {
+            if stricter_abi_and_runtime_constraints {
                 check_account_info_pointer(
                     invoke_context,
                     data.as_ptr() as u64,
@@ -174,7 +176,7 @@ impl<'a> CallerAccount<'a> {
 
             let vm_len_addr = (account_info.data.as_ptr() as *const u64 as u64)
                 .saturating_add(size_of::<u64>() as u64);
-            if direct_mapping {
+            if stricter_abi_and_runtime_constraints {
                 // In the same vein as the other check_account_info_pointer() checks, we don't lock
                 // this pointer to a specific address but we don't want it to be inside accounts, or
                 // callees might be able to write to the pointed memory.
@@ -185,8 +187,8 @@ impl<'a> CallerAccount<'a> {
             let ref_to_len_in_vm = translate_type_mut::<u64>(memory_mapping, vm_len_addr, false)?;
             let vm_data_addr = data.as_ptr() as u64;
 
-            let serialized_data = if direct_mapping {
-                // when direct mapping is enabled, the permissions on the
+            let serialized_data = if stricter_abi_and_runtime_constraints {
+                // when stricter_abi_and_runtime_constraints is enabled, the permissions on the
                 // realloc region can change during CPI so we must delay
                 // translating until when we know whether we're going to mutate
                 // the realloc region or not. Consider this case:
@@ -229,11 +231,11 @@ impl<'a> CallerAccount<'a> {
         account_info: &SolAccountInfo,
         account_metadata: &SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a>, Error> {
-        let direct_mapping = invoke_context
+        let stricter_abi_and_runtime_constraints = invoke_context
             .get_feature_set()
-            .bpf_account_data_direct_mapping;
+            .stricter_abi_and_runtime_constraints;
 
-        if direct_mapping {
+        if stricter_abi_and_runtime_constraints {
             check_account_info_pointer(
                 invoke_context,
                 account_info.key_addr,
@@ -278,7 +280,7 @@ impl<'a> CallerAccount<'a> {
                 .unwrap_or(u64::MAX),
         )?;
 
-        let serialized_data = if direct_mapping {
+        let serialized_data = if stricter_abi_and_runtime_constraints {
             // See comment in CallerAccount::from_account_info()
             &mut []
         } else {
@@ -715,14 +717,14 @@ fn translate_account_infos<'a, T, F>(
 where
     F: Fn(&T) -> u64,
 {
-    let direct_mapping = invoke_context
+    let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
-        .bpf_account_data_direct_mapping;
+        .stricter_abi_and_runtime_constraints;
 
     // In the same vein as the other check_account_info_pointer() checks, we don't lock
     // this pointer to a specific address but we don't want it to be inside accounts, or
     // callees might be able to write to the pointed memory.
-    if direct_mapping
+    if stricter_abi_and_runtime_constraints
         && account_infos_addr
             .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
             >= ebpf::MM_INPUT_START
@@ -786,9 +788,9 @@ where
         .unwrap()
         .accounts_metadata;
 
-    let direct_mapping = invoke_context
+    let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
-        .bpf_account_data_direct_mapping;
+        .stricter_abi_and_runtime_constraints;
 
     for (instruction_account_index, instruction_account) in
         next_instruction_accounts.iter().enumerate()
@@ -853,7 +855,7 @@ where
             let update_caller = update_callee_account(
                 &caller_account,
                 callee_account,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 check_aligned,
             )?;
 
@@ -1039,9 +1041,9 @@ fn cpi_common<S: SyscallInvokeSigned>(
     // CPI exit.
     //
     // Synchronize the callee's account changes so the caller can see them.
-    let direct_mapping = invoke_context
+    let stricter_abi_and_runtime_constraints = invoke_context
         .get_feature_set()
-        .bpf_account_data_direct_mapping;
+        .stricter_abi_and_runtime_constraints;
 
     for translate_account in accounts.iter_mut() {
         let mut callee_account = instruction_context.try_borrow_instruction_account(
@@ -1055,12 +1057,12 @@ fn cpi_common<S: SyscallInvokeSigned>(
                 check_aligned,
                 &mut translate_account.caller_account,
                 &mut callee_account,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
             )?;
         }
     }
 
-    if direct_mapping {
+    if stricter_abi_and_runtime_constraints {
         for translate_account in accounts.iter() {
             let mut callee_account = instruction_context.try_borrow_instruction_account(
                 transaction_context,
@@ -1091,11 +1093,11 @@ fn cpi_common<S: SyscallInvokeSigned>(
 // changes.
 //
 // When true is returned, the caller account must be updated after CPI. This
-// is only set for direct mapping when the pointer may have changed.
+// is only set for stricter_abi_and_runtime_constraints when the pointer may have changed.
 fn update_callee_account(
     caller_account: &CallerAccount,
     mut callee_account: BorrowedAccount<'_>,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
     check_aligned: bool,
 ) -> Result<bool, Error> {
     let mut must_update_caller = false;
@@ -1104,7 +1106,7 @@ fn update_callee_account(
         callee_account.set_lamports(*caller_account.lamports)?;
     }
 
-    if direct_mapping {
+    if stricter_abi_and_runtime_constraints {
         let prev_len = callee_account.get_data().len();
         let post_len = *caller_account.ref_to_len_in_vm as usize;
         if prev_len != post_len {
@@ -1183,7 +1185,7 @@ fn update_caller_account_region(
 // This method updates caller_account so the CPI caller can see the callee's
 // changes.
 //
-// Safety: Once `direct_mapping` is enabled all fields of [CallerAccount] used
+// Safety: Once `stricter_abi_and_runtime_constraints` is enabled all fields of [CallerAccount] used
 // in this function should never point inside the address space reserved for
 // accounts (regardless of the current size of an account).
 fn update_caller_account(
@@ -1192,7 +1194,7 @@ fn update_caller_account(
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
     callee_account: &mut BorrowedAccount<'_>,
-    direct_mapping: bool,
+    stricter_abi_and_runtime_constraints: bool,
 ) -> Result<(), Error> {
     *caller_account.lamports = callee_account.get_lamports();
     *caller_account.owner = *callee_account.get_owner();
@@ -1200,15 +1202,18 @@ fn update_caller_account(
     let prev_len = *caller_account.ref_to_len_in_vm as usize;
     let post_len = callee_account.get_data().len();
     let is_caller_loader_deprecated = !check_aligned;
-    let address_space_reserved_for_account = if direct_mapping && is_caller_loader_deprecated {
-        caller_account.original_data_len
-    } else {
-        caller_account
-            .original_data_len
-            .saturating_add(MAX_PERMITTED_DATA_INCREASE)
-    };
+    let address_space_reserved_for_account =
+        if stricter_abi_and_runtime_constraints && is_caller_loader_deprecated {
+            caller_account.original_data_len
+        } else {
+            caller_account
+                .original_data_len
+                .saturating_add(MAX_PERMITTED_DATA_INCREASE)
+        };
 
-    if post_len > address_space_reserved_for_account && (direct_mapping || prev_len != post_len) {
+    if post_len > address_space_reserved_for_account
+        && (stricter_abi_and_runtime_constraints || prev_len != post_len)
+    {
         let max_increase =
             address_space_reserved_for_account.saturating_sub(caller_account.original_data_len);
         ic_msg!(
@@ -1219,9 +1224,9 @@ fn update_caller_account(
     }
 
     if prev_len != post_len {
-        // when direct mapping is enabled we don't cache the serialized data in
+        // when stricter_abi_and_runtime_constraints is enabled we don't cache the serialized data in
         // caller_account.serialized_data. See CallerAccount::from_account_info.
-        if !direct_mapping {
+        if !stricter_abi_and_runtime_constraints {
             // If the account has been shrunk, we're going to zero the unused memory
             // *that was previously used*.
             if post_len < prev_len {
@@ -1253,7 +1258,7 @@ fn update_caller_account(
         *serialized_len_ptr = post_len as u64;
     }
 
-    if !direct_mapping {
+    if !stricter_abi_and_runtime_constraints {
         // Propagate changes in the callee up to the caller.
         let to_slice = &mut caller_account.serialized_data;
         let from_slice = callee_account
@@ -1322,7 +1327,7 @@ mod tests {
                 .map(|a| (a.0, a.1))
                 .collect::<Vec<TransactionAccount>>();
             let mut feature_set = SVMFeatureSet::all_enabled();
-            feature_set.bpf_account_data_direct_mapping = false;
+            feature_set.stricter_abi_and_runtime_constraints = false;
             let feature_set = &feature_set;
             with_mock_invoke_context_with_feature_set!(
                 $invoke_context,
@@ -1480,7 +1485,7 @@ mod tests {
     }
 
     #[test_matrix([false, true])]
-    fn test_update_caller_account_lamports_owner(direct_mapping: bool) {
+    fn test_update_caller_account_lamports_owner(stricter_abi_and_runtime_constraints: bool) {
         let transaction_accounts = transaction_with_one_writable_instruction_account(vec![]);
         let account = transaction_accounts[1].1.clone();
         mock_invoke_context!(
@@ -1521,7 +1526,7 @@ mod tests {
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
-            direct_mapping,
+            stricter_abi_and_runtime_constraints,
         )
         .unwrap();
 
@@ -1650,7 +1655,7 @@ mod tests {
     }
 
     #[test_matrix([false, true])]
-    fn test_update_callee_account_lamports_owner(direct_mapping: bool) {
+    fn test_update_callee_account_lamports_owner(stricter_abi_and_runtime_constraints: bool) {
         let transaction_accounts = transaction_with_one_writable_instruction_account(vec![]);
         let account = transaction_accounts[1].1.clone();
 
@@ -1673,7 +1678,13 @@ mod tests {
         *caller_account.lamports = 42;
         *caller_account.owner = Pubkey::new_unique();
 
-        update_callee_account(&caller_account, callee_account, direct_mapping, true).unwrap();
+        update_callee_account(
+            &caller_account,
+            callee_account,
+            stricter_abi_and_runtime_constraints,
+            true,
+        )
+        .unwrap();
 
         let callee_account = borrow_instruction_account!(invoke_context, 0);
         assert_eq!(callee_account.get_lamports(), 42);
@@ -1681,7 +1692,7 @@ mod tests {
     }
 
     #[test_matrix([false, true])]
-    fn test_update_callee_account_data_writable(direct_mapping: bool) {
+    fn test_update_callee_account_data_writable(stricter_abi_and_runtime_constraints: bool) {
         let transaction_accounts =
             transaction_with_one_writable_instruction_account(b"foobar".to_vec());
         let account = transaction_accounts[1].1.clone();
@@ -1701,7 +1712,7 @@ mod tests {
         let mut caller_account = mock_caller_account.caller_account();
         let callee_account = borrow_instruction_account!(invoke_context, 0);
 
-        // direct mapping does not copy data in update_callee_account()
+        // stricter_abi_and_runtime_constraints does not copy data in update_callee_account()
         caller_account.serialized_data[0] = b'b';
         update_callee_account(&caller_account, callee_account, false, true).unwrap();
         let callee_account = borrow_instruction_account!(invoke_context, 0);
@@ -1712,8 +1723,14 @@ mod tests {
         *caller_account.ref_to_len_in_vm = data.len() as u64;
         caller_account.serialized_data = &mut data;
         assert_eq!(
-            update_callee_account(&caller_account, callee_account, direct_mapping, true).unwrap(),
-            direct_mapping,
+            update_callee_account(
+                &caller_account,
+                callee_account,
+                stricter_abi_and_runtime_constraints,
+                true
+            )
+            .unwrap(),
+            stricter_abi_and_runtime_constraints,
         );
 
         // truncating resize
@@ -1722,8 +1739,14 @@ mod tests {
         caller_account.serialized_data = &mut data;
         let callee_account = borrow_instruction_account!(invoke_context, 0);
         assert_eq!(
-            update_callee_account(&caller_account, callee_account, direct_mapping, true).unwrap(),
-            direct_mapping,
+            update_callee_account(
+                &caller_account,
+                callee_account,
+                stricter_abi_and_runtime_constraints,
+                true
+            )
+            .unwrap(),
+            stricter_abi_and_runtime_constraints,
         );
 
         // close the account
@@ -1733,14 +1756,25 @@ mod tests {
         let mut owner = system_program::id();
         caller_account.owner = &mut owner;
         let callee_account = borrow_instruction_account!(invoke_context, 0);
-        update_callee_account(&caller_account, callee_account, direct_mapping, true).unwrap();
+        update_callee_account(
+            &caller_account,
+            callee_account,
+            stricter_abi_and_runtime_constraints,
+            true,
+        )
+        .unwrap();
         let callee_account = borrow_instruction_account!(invoke_context, 0);
         assert_eq!(callee_account.get_data(), b"");
 
         // growing beyond address_space_reserved_for_account
         *caller_account.ref_to_len_in_vm = (7 + MAX_PERMITTED_DATA_INCREASE) as u64;
-        let result = update_callee_account(&caller_account, callee_account, direct_mapping, true);
-        if direct_mapping {
+        let result = update_callee_account(
+            &caller_account,
+            callee_account,
+            stricter_abi_and_runtime_constraints,
+            true,
+        );
+        if stricter_abi_and_runtime_constraints {
             assert_matches!(
                 result,
                 Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::InvalidRealloc
@@ -1751,7 +1785,7 @@ mod tests {
     }
 
     #[test_matrix([false, true])]
-    fn test_update_callee_account_data_readonly(direct_mapping: bool) {
+    fn test_update_callee_account_data_readonly(stricter_abi_and_runtime_constraints: bool) {
         let transaction_accounts =
             transaction_with_one_readonly_instruction_account(b"foobar".to_vec());
         let account = transaction_accounts[1].1.clone();
@@ -1770,7 +1804,7 @@ mod tests {
         let mut caller_account = mock_caller_account.caller_account();
         let callee_account = borrow_instruction_account!(invoke_context, 0);
 
-        // direct mapping does not copy data in update_callee_account()
+        // stricter_abi_and_runtime_constraints does not copy data in update_callee_account()
         caller_account.serialized_data[0] = b'b';
         assert_matches!(
             update_callee_account(
@@ -1791,7 +1825,7 @@ mod tests {
             update_callee_account(
                 &caller_account,
                 callee_account,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 true,
             ),
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
@@ -1806,7 +1840,7 @@ mod tests {
             update_callee_account(
                 &caller_account,
                 callee_account,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
                 true,
             ),
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
@@ -1882,7 +1916,7 @@ mod tests {
         data: Vec<u8>,
         len: u64,
         regions: Vec<MemoryRegion>,
-        direct_mapping: bool,
+        stricter_abi_and_runtime_constraints: bool,
     }
 
     impl MockCallerAccount {
@@ -1890,12 +1924,12 @@ mod tests {
             lamports: u64,
             owner: Pubkey,
             data: &[u8],
-            direct_mapping: bool,
+            stricter_abi_and_runtime_constraints: bool,
         ) -> MockCallerAccount {
             let vm_addr = MM_INPUT_START;
             let mut region_addr = vm_addr;
             let region_len = mem::size_of::<u64>()
-                + if direct_mapping {
+                + if stricter_abi_and_runtime_constraints {
                     0
                 } else {
                     data.len() + MAX_PERMITTED_DATA_INCREASE
@@ -1903,19 +1937,19 @@ mod tests {
             let mut d = vec![0; region_len];
             let mut regions = vec![];
 
-            // always write the [len] part even when direct mapping
+            // always write the [len] part even when stricter_abi_and_runtime_constraints
             unsafe { ptr::write_unaligned::<u64>(d.as_mut_ptr().cast(), data.len() as u64) };
 
-            // write the account data when not direct mapping
-            if !direct_mapping {
+            // write the account data when not stricter_abi_and_runtime_constraints
+            if !stricter_abi_and_runtime_constraints {
                 d[mem::size_of::<u64>()..][..data.len()].copy_from_slice(data);
             }
 
-            // create a region for [len][data+realloc if !direct_mapping]
+            // create a region for [len][data+realloc if !stricter_abi_and_runtime_constraints]
             regions.push(MemoryRegion::new_writable(&mut d[..region_len], vm_addr));
             region_addr += region_len as u64;
 
-            if direct_mapping {
+            if stricter_abi_and_runtime_constraints {
                 // create a region for the directly mapped data
                 regions.push(MemoryRegion::new_readonly(data, region_addr));
                 region_addr += data.len() as u64;
@@ -1937,7 +1971,7 @@ mod tests {
                 data: d,
                 len: data.len() as u64,
                 regions,
-                direct_mapping,
+                stricter_abi_and_runtime_constraints,
             }
         }
 
@@ -1952,7 +1986,7 @@ mod tests {
         }
 
         fn caller_account(&mut self) -> CallerAccount {
-            let data = if self.direct_mapping {
+            let data = if self.stricter_abi_and_runtime_constraints {
                 &mut []
             } else {
                 &mut self.data[mem::size_of::<u64>()..]

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -345,7 +345,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         sanitize_user_provided_values: true,
         enabled_sbpf_versions: min_sbpf_version..=max_sbpf_version,
         optimize_rodata: false,
-        aligned_memory_mapping: !feature_set.bpf_account_data_direct_mapping,
+        aligned_memory_mapping: !feature_set.stricter_abi_and_runtime_constraints,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
     let mut result = BuiltinProgram::new_loader(config);

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -528,8 +528,8 @@ impl TransactionContext {
     /// Returns a new account data write access handler
     pub fn access_violation_handler(
         &self,
-        _stricter_abi_and_runtime_constraints: bool,
-        _account_data_direct_mapping: bool,
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
     ) -> AccessViolationHandler {
         let accounts = Rc::clone(&self.accounts);
         Box::new(
@@ -599,8 +599,10 @@ impl TransactionContext {
                 }
 
                 // Potentially unshare / make the account shared data unique (CoW logic).
-                region.host_addr = account.data_as_mut_slice().as_mut_ptr() as u64;
-                region.writable = true;
+                if stricter_abi_and_runtime_constraints && account_data_direct_mapping {
+                    region.host_addr = account.data_as_mut_slice().as_mut_ptr() as u64;
+                    region.writable = true;
+                }
             },
         )
     }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -31,7 +31,7 @@ static_assertions::const_assert_eq!(
 #[cfg(not(target_os = "solana"))]
 const MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION: i64 =
     MAX_PERMITTED_DATA_LENGTH as i64 * 2;
-// Note: With direct mapping programs can grow accounts faster than they intend to,
+// Note: With stricter_abi_and_runtime_constraints programs can grow accounts faster than they intend to,
 // because the AccessViolationHandler might grow an account up to
 // MAX_PERMITTED_DATA_LENGTH at once.
 #[cfg(test)]

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -526,7 +526,11 @@ impl TransactionContext {
     }
 
     /// Returns a new account data write access handler
-    pub fn access_violation_handler(&self) -> AccessViolationHandler {
+    pub fn access_violation_handler(
+        &self,
+        _stricter_abi_and_runtime_constraints: bool,
+        _account_data_direct_mapping: bool,
+    ) -> AccessViolationHandler {
         let accounts = Rc::clone(&self.accounts);
         Box::new(
             move |region: &mut MemoryRegion,


### PR DESCRIPTION
#### Problem

It has been tricky to fuzz account data direct mapping because it comes with a lot of observable behavior changes which lead to expected divergence. However, telling expected and unexpected divergence apart has been problematic, especially as some unexpected divergence was declared to be expected by mistake.

#### Summary of Changes

All the observable behavior changes as specified in [SIMD-0219](https://github.com/solana-foundation/solana-improvement-documents/pull/219) are moved into a feature gate called `stricter_abi_and_runtime_constraints`. The serialization vs mapping is toggled by a separate flag called `account_data_direct_mapping`. Meaning there are now three code paths:

- `stricter_abi_and_runtime_constraints` OFF, (`account_data_direct_mapping` is ignored) in which only the old checks apply, account data is de/serialized and compared
- `stricter_abi_and_runtime_constraints` ON, but `account_data_direct_mapping` OFF in which both old and new checks apply, account data is de/serialized
- `stricter_abi_and_runtime_constraints` ON, and `account_data_direct_mapping` ON in which only the new checks apply, account data is mapped

Feature Gate Issue: [#16](https://github.com/anza-xyz/feature-gate-tracker/issues/16)
