### PR TITLE
rpc-client: Remove deprecated set_node_version

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -601,11 +601,6 @@ impl RpcClient {
         self.sender.url()
     }
 
-    #[deprecated(since = "2.0.2", note = "RpcClient::node_version is no longer used")]
-    pub async fn set_node_version(&self, _version: semver::Version) -> Result<(), ()> {
-        Ok(())
-    }
-
     /// Get the configured default [commitment level][cl].
     ///
     /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment


### PR DESCRIPTION
#### Problem
set_node_version() has been deprecated since 2.0.2

#### Summary of Changes
Remove deprecated function
