### PR TITLE
pubsub-client: Remove deprecated set_node_version

### DIFF
--- a/pubsub-client/src/nonblocking/pubsub_client.rs
+++ b/pubsub-client/src/nonblocking/pubsub_client.rs
@@ -302,11 +302,6 @@ impl PubsubClient {
         self.ws.await.unwrap() // WS future should not be cancelled or panicked
     }
 
-    #[deprecated(since = "2.0.2", note = "PubsubClient::node_version is no longer used")]
-    pub async fn set_node_version(&self, _version: semver::Version) -> Result<(), ()> {
-        Ok(())
-    }
-
     async fn subscribe<'a, T>(&self, operation: &str, params: Value) -> SubscribeResult<'a, T>
     where
         T: DeserializeOwned + Send + 'a,


### PR DESCRIPTION
#### Problem
set_node_version() has been deprecated since 2.0.2

#### Summary of Changes
Remove deprecated function
