### PR TITLE
account-decoder: Remove deprecated AccountAdditionalData and AccountAdditionalDataV2

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -73,30 +73,9 @@ pub enum ParsableAccount {
     Vote,
 }
 
-#[deprecated(since = "2.0.0", note = "Use `AccountAdditionalDataV3` instead")]
-#[derive(Clone, Copy, Default)]
-pub struct AccountAdditionalData {
-    pub spl_token_decimals: Option<u8>,
-}
-
-#[deprecated(since = "2.2.0", note = "Use `AccountAdditionalDataV3` instead")]
-#[derive(Clone, Copy, Default)]
-pub struct AccountAdditionalDataV2 {
-    pub spl_token_additional_data: Option<SplTokenAdditionalData>,
-}
-
 #[derive(Clone, Copy, Default)]
 pub struct AccountAdditionalDataV3 {
     pub spl_token_additional_data: Option<SplTokenAdditionalDataV2>,
-}
-
-#[allow(deprecated)]
-impl From<AccountAdditionalDataV2> for AccountAdditionalDataV3 {
-    fn from(v: AccountAdditionalDataV2) -> Self {
-        Self {
-            spl_token_additional_data: v.spl_token_additional_data.map(Into::into),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -138,37 +117,6 @@ impl SplTokenAdditionalDataV2 {
             ..Default::default()
         }
     }
-}
-
-#[deprecated(since = "2.0.0", note = "Use `parse_account_data_v3` instead")]
-#[allow(deprecated)]
-pub fn parse_account_data(
-    pubkey: &Pubkey,
-    program_id: &Pubkey,
-    data: &[u8],
-    additional_data: Option<AccountAdditionalData>,
-) -> Result<ParsedAccount, ParseAccountError> {
-    parse_account_data_v3(
-        pubkey,
-        program_id,
-        data,
-        additional_data.map(|d| AccountAdditionalDataV3 {
-            spl_token_additional_data: d
-                .spl_token_decimals
-                .map(SplTokenAdditionalDataV2::with_decimals),
-        }),
-    )
-}
-
-#[deprecated(since = "2.2.0", note = "Use `parse_account_data_v3` instead")]
-#[allow(deprecated)]
-pub fn parse_account_data_v2(
-    pubkey: &Pubkey,
-    program_id: &Pubkey,
-    data: &[u8],
-    additional_data: Option<AccountAdditionalDataV2>,
-) -> Result<ParsedAccount, ParseAccountError> {
-    parse_account_data_v3(pubkey, program_id, data, additional_data.map(Into::into))
 }
 
 pub fn parse_account_data_v3(

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -1,8 +1,6 @@
 use {
     crate::{
-        parse_account_data::{
-            ParsableAccount, ParseAccountError, SplTokenAdditionalData, SplTokenAdditionalDataV2,
-        },
+        parse_account_data::{ParsableAccount, ParseAccountError, SplTokenAdditionalDataV2},
         parse_token_extension::parse_extension,
     },
     solana_program_option::COption,
@@ -22,25 +20,6 @@ pub use {
     },
     spl_generic_token::{is_known_spl_token_id, spl_token_ids},
 };
-
-#[deprecated(since = "2.0.0", note = "Use `parse_token_v3` instead")]
-#[allow(deprecated)]
-pub fn parse_token(
-    data: &[u8],
-    decimals: Option<u8>,
-) -> Result<TokenAccountType, ParseAccountError> {
-    let additional_data = decimals.map(SplTokenAdditionalData::with_decimals);
-    parse_token_v2(data, additional_data.as_ref())
-}
-
-#[deprecated(since = "2.2.0", note = "Use `parse_token_v3` instead")]
-pub fn parse_token_v2(
-    data: &[u8],
-    additional_data: Option<&SplTokenAdditionalData>,
-) -> Result<TokenAccountType, ParseAccountError> {
-    let additional_data = additional_data.map(|v| (*v).into());
-    parse_token_v3(data, additional_data.as_ref())
-}
 
 pub fn parse_token_v3(
     data: &[u8],
@@ -141,20 +120,6 @@ pub fn convert_account_state(state: AccountState) -> UiAccountState {
         AccountState::Initialized => UiAccountState::Initialized,
         AccountState::Frozen => UiAccountState::Frozen,
     }
-}
-
-#[deprecated(since = "2.0.0", note = "Use `token_amount_to_ui_amount_v3` instead")]
-#[allow(deprecated)]
-pub fn token_amount_to_ui_amount(amount: u64, decimals: u8) -> UiTokenAmount {
-    token_amount_to_ui_amount_v2(amount, &SplTokenAdditionalData::with_decimals(decimals))
-}
-
-#[deprecated(since = "2.2.0", note = "Use `token_amount_to_ui_amount_v3` instead")]
-pub fn token_amount_to_ui_amount_v2(
-    amount: u64,
-    additional_data: &SplTokenAdditionalData,
-) -> UiTokenAmount {
-    token_amount_to_ui_amount_v3(amount, &(*additional_data).into())
 }
 
 pub fn token_amount_to_ui_amount_v3(


### PR DESCRIPTION
#### Problem
AccountAdditionalData and AccountAdditionalDataV2 have been deprecated since 2.0.0.

#### Summary of Changes
Remove the deprecated structs and all the associated code.
