### PR TITLE
Replace get_total_accounts_stats with calculate_accounts_data_size

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5505,7 +5505,7 @@ impl Bank {
         }
     }
 
-    /// Get all the accounts for this bank and calculate stats
+    /// Get all the accounts for this bank and calculate total data_len
     pub fn get_total_accounts_data_len(&self) -> ScanResult<u64> {
         let accounts = self.get_all_accounts(false)?;
         let mut data_len = 0_u64;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5505,7 +5505,14 @@ impl Bank {
         }
     }
 
-    /// Get all the accounts for this bank and calculate total data_len
+    /// Calculates the accounts data size of all accounts
+    ///
+    /// Panics if total overflows a u64.
+    ///
+    /// Note, this may be *very* expensive, as *all* accounts are collected
+    /// into a Vec before summming each account's data size.
+    ///
+    /// Only intended to be called by tests or when the number of accounts is small.
     pub fn get_total_accounts_data_len(&self) -> ScanResult<u64> {
         let accounts = self.get_all_accounts(false)?;
         let mut data_len = 0_u64;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10345,8 +10345,8 @@ fn test_accounts_data_size_and_resize_transactions() {
 fn test_accounts_data_size_with_default_bank() {
     let bank = Bank::default_for_tests();
     assert_eq!(
-        bank.load_accounts_data_size() as usize,
-        bank.get_total_accounts_stats().unwrap().data_len
+        bank.load_accounts_data_size(),
+        bank.get_total_accounts_data_len().unwrap()
     );
 }
 
@@ -10366,8 +10366,8 @@ fn test_accounts_data_size_from_genesis() {
 
     let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     assert_eq!(
-        bank.load_accounts_data_size() as usize,
-        bank.get_total_accounts_stats().unwrap().data_len
+        bank.load_accounts_data_size(),
+        bank.get_total_accounts_data_len().unwrap()
     );
 
     // Create accounts over a number of banks and ensure the accounts data size remains correct
@@ -10394,8 +10394,8 @@ fn test_accounts_data_size_from_genesis() {
         bank.fill_bank_with_ticks_for_tests();
 
         assert_eq!(
-            bank.load_accounts_data_size() as usize,
-            bank.get_total_accounts_stats().unwrap().data_len,
+            bank.load_accounts_data_size(),
+            bank.get_total_accounts_data_len().unwrap(),
         );
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10346,7 +10346,7 @@ fn test_accounts_data_size_with_default_bank() {
     let bank = Bank::default_for_tests();
     assert_eq!(
         bank.load_accounts_data_size(),
-        bank.get_total_accounts_data_len().unwrap()
+        bank.calculate_accounts_data_size().unwrap()
     );
 }
 
@@ -10367,7 +10367,7 @@ fn test_accounts_data_size_from_genesis() {
     let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     assert_eq!(
         bank.load_accounts_data_size(),
-        bank.get_total_accounts_data_len().unwrap()
+        bank.calculate_accounts_data_size().unwrap()
     );
 
     // Create accounts over a number of banks and ensure the accounts data size remains correct
@@ -10395,7 +10395,7 @@ fn test_accounts_data_size_from_genesis() {
 
         assert_eq!(
             bank.load_accounts_data_size(),
-            bank.get_total_accounts_data_len().unwrap(),
+            bank.calculate_accounts_data_size().unwrap(),
         );
     }
 }


### PR DESCRIPTION
#### Problem

After recent rent cleanup, TotalAccountStat with rent info is no longer *fully*
used in validator code. The only usage is to get account data size when starting
from genesis and tests. 

split from #7109


#### Summary of Changes

Replace get_total_accounts_stats with calculate_accounts_data_size to only calculate and return the total accounts data size, removing unnecessary stat calculations.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
