### PR TITLE
Abstract `InstructionAccount` inside `InstructionContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9609,6 +9609,7 @@ dependencies = [
  "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
+ "solana-svm-transaction",
  "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -523,7 +523,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     invoke_context
         .transaction_context
-        .get_next_instruction_context()
+        .get_next_instruction_context_mut()
         .unwrap()
         .configure(
             vec![program_index, program_index.saturating_add(1)],

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -58,6 +58,7 @@ solana-slot-hashes = { workspace = true }
 solana-stable-layout = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-sysvar-id = { workspace = true }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -28,6 +28,7 @@ use {
     },
     solana_svm_callback::InvokeContextCallback,
     solana_svm_feature_set::SVMFeatureSet,
+    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
     solana_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_transaction_context::{
         IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
@@ -306,32 +307,23 @@ impl<'a> InvokeContext<'a> {
         instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
-        let (instruction_accounts, program_indices) =
-            self.prepare_instruction(&instruction, signers)?;
+        self.prepare_next_instruction(&instruction, signers)?;
         let mut compute_units_consumed = 0;
-        self.process_instruction(
-            &instruction.data,
-            &instruction_accounts,
-            &program_indices,
-            &mut compute_units_consumed,
-            &mut ExecuteTimings::default(),
-        )?;
+        self.process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default())?;
         Ok(())
     }
 
-    /// Helper to prepare for process_instruction()
-    #[allow(clippy::type_complexity)]
-    pub fn prepare_instruction(
+    fn prepare_next_instruction_inner(
         &mut self,
         instruction: &Instruction,
         signers: &[Pubkey],
-    ) -> Result<(Vec<InstructionAccount>, Vec<IndexOfAccount>), InstructionError> {
+        instruction_accounts: &mut Vec<InstructionAccount>,
+    ) -> Result<IndexOfAccount, InstructionError> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
         // This algorithm allocates the array on the stack for speed.
         // On AArch64 in release mode, this function only consumes 640 bytes of stack.
         let mut transaction_callee_map: [u8; 256] = [u8::MAX; 256];
-        let mut instruction_accounts: Vec<InstructionAccount> =
-            Vec::with_capacity(instruction.accounts.len());
+
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
         debug_assert!(instruction.accounts.len() <= u8::MAX as usize);
 
@@ -460,28 +452,88 @@ impl<'a> InvokeContext<'a> {
             ic_msg!(self, "Account {} is not executable", callee_program_id);
             return Err(InstructionError::AccountNotExecutable);
         }
-        let program_account_index = borrowed_program_account.get_index_in_transaction();
 
-        Ok((instruction_accounts, vec![program_account_index]))
+        Ok(borrowed_program_account.get_index_in_transaction())
+    }
+
+    /// Helper to prepare for process_instruction() when the instruction is not a top level one,
+    /// and depends on `AccountMeta`s
+    pub fn prepare_next_instruction(
+        &mut self,
+        instruction: &Instruction,
+        signers: &[Pubkey],
+    ) -> Result<(), InstructionError> {
+        let mut instruction_accounts: Vec<InstructionAccount> =
+            Vec::with_capacity(instruction.accounts.len());
+
+        // The point of creating an inner function for the logic is to appease the borrow checker,
+        // since we cannot borrow the current instruction context as immutable and borrow the next
+        // instruction context as mutable. An alternative would be to place everything inside a
+        // block, but I think that would hinder readability.
+        let program_account_index =
+            self.prepare_next_instruction_inner(instruction, signers, &mut instruction_accounts)?;
+
+        self.transaction_context
+            .get_next_instruction_context_mut()?
+            .configure(
+                vec![program_account_index],
+                instruction_accounts,
+                &instruction.data,
+            );
+        Ok(())
+    }
+
+    /// Helper to prepare for process_instruction()/process_precompile() when the instruction is
+    /// a top level one
+    pub fn prepare_next_top_level_instruction(
+        &mut self,
+        message: &impl SVMMessage,
+        instruction: &SVMInstruction,
+        program_indices: Vec<IndexOfAccount>,
+    ) -> Result<(), InstructionError> {
+        // We reference accounts by an u8 index, so we have a total of 256 accounts.
+        // This algorithm allocates the array on the stack for speed.
+        // On AArch64 in release mode, this function only consumes 464 bytes of stack (when it is
+        // not inlined).
+        let mut transaction_callee_map: [u8; 256] = [u8::MAX; 256];
+        debug_assert!(instruction.accounts.len() <= u8::MAX as usize);
+
+        let mut instruction_accounts: Vec<InstructionAccount> =
+            Vec::with_capacity(instruction.accounts.len());
+        for index_in_transaction in instruction.accounts.iter() {
+            debug_assert!((*index_in_transaction as usize) < transaction_callee_map.len());
+
+            let index_in_callee = transaction_callee_map
+                .get_mut(*index_in_transaction as usize)
+                .unwrap();
+
+            if (*index_in_callee as usize) > instruction_accounts.len() {
+                *index_in_callee = instruction_accounts.len() as u8;
+            }
+
+            let index_in_transaction = *index_in_transaction as usize;
+            instruction_accounts.push(InstructionAccount::new(
+                index_in_transaction as IndexOfAccount,
+                index_in_transaction as IndexOfAccount,
+                *index_in_callee as IndexOfAccount,
+                message.is_signer(index_in_transaction),
+                message.is_writable(index_in_transaction),
+            ));
+        }
+
+        self.transaction_context
+            .get_next_instruction_context_mut()?
+            .configure(program_indices, instruction_accounts, instruction.data);
+        Ok(())
     }
 
     /// Processes an instruction and returns how many compute units were used
     pub fn process_instruction(
         &mut self,
-        instruction_data: &[u8],
-        instruction_accounts: &[InstructionAccount],
-        program_indices: &[IndexOfAccount],
         compute_units_consumed: &mut u64,
         timings: &mut ExecuteTimings,
     ) -> Result<(), InstructionError> {
         *compute_units_consumed = 0;
-        self.transaction_context
-            .get_next_instruction_context()?
-            .configure(
-                program_indices.to_vec(),
-                instruction_accounts.to_vec(),
-                instruction_data,
-            );
         self.push()?;
         self.process_executable_chain(compute_units_consumed, timings)
             // MUST pop if and only if `push` succeeded, independent of `result`.
@@ -494,19 +546,9 @@ impl<'a> InvokeContext<'a> {
         &mut self,
         program_id: &Pubkey,
         instruction_data: &[u8],
-        instruction_accounts: &[InstructionAccount],
-        program_indices: &[IndexOfAccount],
         message_instruction_datas_iter: impl Iterator<Item = &'ix_data [u8]>,
     ) -> Result<(), InstructionError> {
-        self.transaction_context
-            .get_next_instruction_context()?
-            .configure(
-                program_indices.to_vec(),
-                instruction_accounts.to_vec(),
-                instruction_data,
-            );
         self.push()?;
-
         let instruction_datas: Vec<_> = message_instruction_datas_iter.collect();
         self.environment_config
             .epoch_stake_callback
@@ -903,13 +945,12 @@ pub fn mock_process_instruction_with_feature_set<
     );
     invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
     pre_adjustments(&mut invoke_context);
-    let result = invoke_context.process_instruction(
-        instruction_data,
-        &instruction_accounts,
-        &program_indices,
-        &mut 0,
-        &mut ExecuteTimings::default(),
-    );
+    invoke_context
+        .transaction_context
+        .get_next_instruction_context_mut()
+        .unwrap()
+        .configure(program_indices, instruction_accounts, instruction_data);
+    let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
     assert_eq!(result, expected_result);
     post_adjustments(&mut invoke_context);
     let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();
@@ -1046,7 +1087,7 @@ mod tests {
                         );
                         invoke_context
                             .transaction_context
-                            .get_next_instruction_context()
+                            .get_next_instruction_context_mut()
                             .unwrap()
                             .configure(vec![3], instruction_accounts, &[]);
                         let result = invoke_context.push();
@@ -1121,7 +1162,7 @@ mod tests {
         for _ in 0..invoke_stack.len() {
             invoke_context
                 .transaction_context
-                .get_next_instruction_context()
+                .get_next_instruction_context_mut()
                 .unwrap()
                 .configure(
                     vec![one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount],
@@ -1204,7 +1245,7 @@ mod tests {
         // Account modification tests
         invoke_context
             .transaction_context
-            .get_next_instruction_context()
+            .get_next_instruction_context_mut()
             .unwrap()
             .configure(vec![4], instruction_accounts, &[]);
         invoke_context.push().unwrap();
@@ -1263,7 +1304,7 @@ mod tests {
         let compute_units_to_consume = 10;
         invoke_context
             .transaction_context
-            .get_next_instruction_context()
+            .get_next_instruction_context_mut()
             .unwrap()
             .configure(vec![4], instruction_accounts, &[]);
         invoke_context.push().unwrap();
@@ -1275,18 +1316,13 @@ mod tests {
             },
             metas.clone(),
         );
-        let (inner_instruction_accounts, program_indices) = invoke_context
-            .prepare_instruction(&inner_instruction, &[])
+        invoke_context
+            .prepare_next_instruction(&inner_instruction, &[])
             .unwrap();
 
         let mut compute_units_consumed = 0;
-        let result = invoke_context.process_instruction(
-            &inner_instruction.data,
-            &inner_instruction_accounts,
-            &program_indices,
-            &mut compute_units_consumed,
-            &mut ExecuteTimings::default(),
-        );
+        let result = invoke_context
+            .process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default());
 
         // Because the instruction had compute cost > 0, then regardless of the execution result,
         // the number of compute units consumed should be a non-default which is something greater
@@ -1314,7 +1350,7 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .get_next_instruction_context()
+            .get_next_instruction_context_mut()
             .unwrap()
             .configure(vec![0], vec![], &[]);
         invoke_context.push().unwrap();
@@ -1338,7 +1374,7 @@ mod tests {
             (Pubkey::new_unique(), dummy_account),
             (program_key, program_account),
         ];
-        let instruction_accounts = [
+        let instruction_accounts = vec![
             InstructionAccount::new(0, 0, 0, false, true),
             InstructionAccount::new(1, 1, 1, false, false),
         ];
@@ -1353,13 +1389,12 @@ mod tests {
         let new_len = (user_account_data_len as i64).saturating_add(resize_delta) as u64;
         let instruction_data = bincode::serialize(&MockInstruction::Resize { new_len }).unwrap();
 
-        let result = invoke_context.process_instruction(
-            &instruction_data,
-            &instruction_accounts,
-            &[2],
-            &mut 0,
-            &mut ExecuteTimings::default(),
-        );
+        invoke_context
+            .transaction_context
+            .get_next_instruction_context_mut()
+            .unwrap()
+            .configure(vec![2], instruction_accounts, &instruction_data);
+        let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
 
         assert!(result.is_ok());
         assert_eq!(

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -717,7 +717,7 @@ mod tests {
                 );
                 invoke_context
                     .transaction_context
-                    .get_next_instruction_context()
+                    .get_next_instruction_context_mut()
                     .unwrap()
                     .configure(program_indices, instruction_accounts, &instruction_data);
                 invoke_context.push().unwrap();
@@ -860,7 +860,7 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .get_next_instruction_context()
+                .get_next_instruction_context_mut()
                 .unwrap()
                 .configure(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
@@ -1106,7 +1106,7 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .get_next_instruction_context()
+                .get_next_instruction_context_mut()
                 .unwrap()
                 .configure(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
@@ -1375,7 +1375,7 @@ mod tests {
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
         let instruction_data = [];
         transaction_context
-            .get_next_instruction_context()
+            .get_next_instruction_context_mut()
             .unwrap()
             .configure(program_indices, instruction_accounts, &instruction_data);
         transaction_context.push().unwrap();

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -106,7 +106,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
         TransactionContext::new(transaction_accounts, Rent::default(), 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .get_next_instruction_context()
+        .get_next_instruction_context_mut()
         .unwrap()
         .configure(vec![0], instruction_accounts, &instruction_data);
     transaction_context.push().unwrap();

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -50,7 +50,7 @@ use {
     solana_sysvar::Sysvar,
     solana_sysvar_id::SysvarId,
     solana_timings::ExecuteTimings,
-    solana_transaction_context::{IndexOfAccount, InstructionAccount},
+    solana_transaction_context::IndexOfAccount,
     solana_type_overrides::sync::Arc,
     std::{
         alloc::Layout,
@@ -2201,6 +2201,7 @@ mod tests {
         solana_slot_hashes::{self as slot_hashes, SlotHashes},
         solana_stable_layout::stable_instruction::StableInstruction,
         solana_sysvar::stake_history::{self, StakeHistory, StakeHistoryEntry},
+        solana_transaction_context::InstructionAccount,
         std::{
             hash::{DefaultHasher, Hash, Hasher},
             mem,
@@ -2234,7 +2235,7 @@ mod tests {
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
             $invoke_context
                 .transaction_context
-                .get_next_instruction_context()
+                .get_next_instruction_context_mut()
                 .unwrap()
                 .configure(vec![0, 1], vec![], &[]);
             $invoke_context.push().unwrap();
@@ -4450,7 +4451,7 @@ mod tests {
                 )];
                 invoke_context
                     .transaction_context
-                    .get_next_instruction_context()
+                    .get_next_instruction_context_mut()
                     .unwrap()
                     .configure(vec![0], instruction_accounts, &[index_in_trace as u8]);
                 invoke_context.transaction_context.push().unwrap();

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7375,6 +7375,7 @@ dependencies = [
  "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
+ "solana-svm-transaction",
  "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -68,7 +68,7 @@ macro_rules! with_mock_invoke_context {
         );
         $invoke_context
             .transaction_context
-            .get_next_instruction_context()
+            .get_next_instruction_context_mut()
             .unwrap()
             .configure(vec![0, 1], instruction_accounts, &[]);
         $invoke_context.push().unwrap();

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -267,7 +267,7 @@ mod test {
         ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
                 .transaction_context
-                .get_next_instruction_context()
+                .get_next_instruction_context_mut()
                 .unwrap()
                 .configure(vec![2], $instruction_accounts, &[]);
             $invoke_context.push().unwrap();

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7173,6 +7173,7 @@ dependencies = [
  "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
+ "solana-svm-transaction",
  "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1288,7 +1288,7 @@ mod tests {
             }
             if stack_height > transaction_context.get_instruction_context_stack_height() {
                 transaction_context
-                    .get_next_instruction_context()
+                    .get_next_instruction_context_mut()
                     .unwrap()
                     .configure(vec![], vec![], &[index_in_trace as u8]);
                 transaction_context.push().unwrap();


### PR DESCRIPTION
#### Problem

After preparing the instruction to be executed, we still have vectors of instruction accounts managed in many places. These vectors should be only managed by the corresponding instruction context to avoid confusion and misusage. Likewise, concentrating their management in one site facilitates maintenance.

#### Summary of Changes

1. Rename `prepare_instruction` to `prepare_next_instruction`
3. Create `prepare_top_level_instruction` to deduplicate accounts with the new algorithm. It works similarly to `prepare_next_instruction`.
4. Both the aforementioned functions now configure the next instruction to be executed, so that we don't have `InstructionAccount`s floating around unlinked to any instruction.
5. Refactor `prepare_next_instruction` to appease the borrow checker.
6. Rename `get_next_instruction_context ` to `get_next_instruction_context_mut`, since it returns a mutable reference.
7. Create a new `get_next_instruction_context` to return an immutable reference and appease the borrow checker.
8. `fn configure` receives `Vec<InstructionAccount>` and `program_indices` by value to make it clear that slices of them do not optimize anything, since we convert everything to a vector afterwards. We were passing slices and then calling `to_vec`, which entails a copy. Moving the vector (possible in all usages) avoids that.

#### Not for this PR

It would nice for the InstructionContext to instead hold a reference to the instruction data instead of cloning it, but that requires too many changes for this PR.
