### PR TITLE
Configure more SVM conformace tests

### DIFF
--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -112,9 +112,30 @@ fn execute_fixtures() {
     run_from_folder(&base_dir);
     base_dir.pop();
 
+    // bpf-loader-v2 tests
+    base_dir.push("bpf-loader-v2");
+    run_from_folder(&base_dir);
+    base_dir.pop();
+
+    // bpf-loader-v3 tests
+    base_dir.push("bpf-loader-v3");
+    run_from_folder(&base_dir);
+    base_dir.pop();
+
+    // bpf-loader-v3 tests
+    base_dir.push("bpf-loader-v3-programs");
+    run_from_folder(&base_dir);
+    base_dir.pop();
+
     // System program tests
     base_dir.push("system");
     run_from_folder(&base_dir);
+    base_dir.pop();
+
+    // non-builtin-programs tests
+    base_dir.push("unknown");
+    run_from_folder(&base_dir);
+    base_dir.pop();
 
     cleanup();
 }


### PR DESCRIPTION
#### Problem

The test-vectors repository from firedancer allows us to test more vector for conformance. They were not yet in CI.

#### Summary of Changes

Add more test fixtures that did not require any change in the test setting.
