### PR TITLE
zk-token-sdk: Remove deprecated split_u64

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -34,21 +34,6 @@ pub enum Role {
 }
 
 /// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:
-///  - the `bit_length` low bits of `amount` interpreted as u64
-///  - the (64 - `bit_length`) high bits of `amount` interpreted as u64
-#[deprecated(since = "1.18.0", note = "please use `try_split_u64` instead")]
-#[cfg(not(target_os = "solana"))]
-pub fn split_u64(amount: u64, bit_length: usize) -> (u64, u64) {
-    if bit_length == 64 {
-        (amount, 0)
-    } else {
-        let lo = amount << (64 - bit_length) >> (64 - bit_length);
-        let hi = amount >> bit_length;
-        (lo, hi)
-    }
-}
-
-/// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:
 /// - the `bit_length` low bits of `amount` interpreted as u64
 /// - the `(64 - bit_length)` high bits of `amount` interpretted as u64
 #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Problem
split_u64() has been deprecated since 1.18.0

#### Summary of Changes
Remove deprecated function
