### PR TITLE
SIMD-0286

### DIFF
--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -27,6 +27,7 @@ pub const INSTRUCTION_DATA_BYTES_COST: u64 = 140 /*bytes per us*/ / COMPUTE_UNIT
 /// data size and built-in and SBF instructions.
 pub const MAX_BLOCK_UNITS: u64 = MAX_BLOCK_UNITS_SIMD_0256;
 pub const MAX_BLOCK_UNITS_SIMD_0256: u64 = 60_000_000;
+pub const MAX_BLOCK_UNITS_SIMD_0286: u64 = 100_000_000;
 
 /// Number of compute units that a writable account in a block is allowed. The
 /// limit is to prevent too many transactions write to same account, therefore
@@ -40,3 +41,16 @@ pub const MAX_VOTE_UNITS: u64 = 36_000_000;
 /// The maximum allowed size, in bytes, that accounts data can grow, per block.
 /// This can also be thought of as the maximum size of new allocations per block.
 pub const MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA: u64 = 100_000_000;
+
+/// Return the block limits that will be used upon activation of SIMD-0286.
+/// Returns as
+/// (account_limit, block_limit, vote_limit)
+// ^ Above order is used to be consistent with the order of
+//   `CostTracker::set_limits`.
+pub const fn simd_0286_block_limits() -> (u64, u64, u64) {
+    (
+        MAX_WRITABLE_ACCOUNT_UNITS,
+        MAX_BLOCK_UNITS_SIMD_0286,
+        MAX_VOTE_UNITS,
+    )
+}

--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -43,14 +43,6 @@ pub const MAX_VOTE_UNITS: u64 = 36_000_000;
 pub const MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA: u64 = 100_000_000;
 
 /// Return the block limits that will be used upon activation of SIMD-0286.
-/// Returns as
-/// (account_limit, block_limit, vote_limit)
-// ^ Above order is used to be consistent with the order of
-//   `CostTracker::set_limits`.
-pub const fn simd_0286_block_limits() -> (u64, u64, u64) {
-    (
-        MAX_WRITABLE_ACCOUNT_UNITS,
-        MAX_BLOCK_UNITS_SIMD_0286,
-        MAX_VOTE_UNITS,
-    )
+pub const fn simd_0286_block_limits() -> u64 {
+    MAX_BLOCK_UNITS_SIMD_0286
 }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -131,9 +131,19 @@ impl CostTracker {
         self.in_flight_transaction_count = Saturating(0);
     }
 
+    /// Get the overall account limit.
+    pub fn get_account_limit(&self) -> u64 {
+        self.account_cost_limit
+    }
+
     /// Get the overall block limit.
     pub fn get_block_limit(&self) -> u64 {
         self.block_cost_limit
+    }
+
+    /// Get the overall vote limit.
+    pub fn get_vote_limit(&self) -> u64 {
+        self.vote_cost_limit
     }
 
     /// allows to adjust limits initiated during construction

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1111,6 +1111,10 @@ pub mod reenable_zk_elgamal_proof_program {
     solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
 }
 
+pub mod raise_block_limits_to_100m {
+    solana_pubkey::declare_id!("ToBeMade11111111111111111111111111111111111");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1349,6 +1353,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (alpenglow::id(), "Enable Alpenglow"),
         (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
+        (raise_block_limits_to_100m::id(), "SIMD-0286: Raise block limit to 100M"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1112,7 +1112,7 @@ pub mod reenable_zk_elgamal_proof_program {
 }
 
 pub mod raise_block_limits_to_100m {
-    solana_pubkey::declare_id!("ToBeMade11111111111111111111111111111111111");
+    solana_pubkey::declare_id!("P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -94,7 +94,7 @@ use {
     },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_cost_model::cost_tracker::CostTracker,
+    solana_cost_model::{block_cost_limits::simd_0286_block_limits, cost_tracker::CostTracker},
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_gate_interface as feature,
@@ -4044,6 +4044,22 @@ impl Bank {
             debug_do_not_add_builtins,
         );
 
+        // Cost-Tracker is not serialized in snapshot or any configs.
+        // We must apply previously activated features related to limits here
+        // so that the initial bank state is consistent with the feature set.
+        // Cost-tracker limits are propagated through children banks.
+        if self
+            .feature_set
+            .is_active(&feature_set::raise_block_limits_to_100m::id())
+        {
+            let (account_cost_limit, block_cost_limit, vote_cost_limit) = simd_0286_block_limits();
+            self.write_cost_tracker().unwrap().set_limits(
+                account_cost_limit,
+                block_cost_limit,
+                vote_cost_limit,
+            );
+        }
+
         if !debug_do_not_add_builtins {
             for builtin in BUILTINS
                 .iter()
@@ -5319,6 +5335,15 @@ impl Bank {
             self.apply_builtin_program_feature_transitions(
                 allow_new_activations,
                 &new_feature_activations,
+            );
+        }
+
+        if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
+            let (account_cost_limit, block_cost_limit, vote_cost_limit) = simd_0286_block_limits();
+            self.write_cost_tracker().unwrap().set_limits(
+                account_cost_limit,
+                block_cost_limit,
+                vote_cost_limit,
             );
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4052,12 +4052,11 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::raise_block_limits_to_100m::id())
         {
-            let (account_cost_limit, block_cost_limit, vote_cost_limit) = simd_0286_block_limits();
-            self.write_cost_tracker().unwrap().set_limits(
-                account_cost_limit,
-                block_cost_limit,
-                vote_cost_limit,
-            );
+            let block_cost_limit = simd_0286_block_limits();
+            let mut cost_tracker = self.write_cost_tracker().unwrap();
+            let account_cost_limit = cost_tracker.get_account_limit();
+            let vote_cost_limit = cost_tracker.get_vote_limit();
+            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
 
         if !debug_do_not_add_builtins {
@@ -5339,12 +5338,11 @@ impl Bank {
         }
 
         if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
-            let (account_cost_limit, block_cost_limit, vote_cost_limit) = simd_0286_block_limits();
-            self.write_cost_tracker().unwrap().set_limits(
-                account_cost_limit,
-                block_cost_limit,
-                vote_cost_limit,
-            );
+            let block_cost_limit = simd_0286_block_limits();
+            let mut cost_tracker = self.write_cost_tracker().unwrap();
+            let account_cost_limit = cost_tracker.get_account_limit();
+            let vote_cost_limit = cost_tracker.get_vote_limit();
+            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -50,6 +50,7 @@ use {
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_cost_model::block_cost_limits::{MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286},
     solana_cpi::MAX_RETURN_DATA,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_feature_gate_interface::{self as feature, Feature},
@@ -6707,6 +6708,75 @@ fn test_reserved_account_keys() {
         bank.get_reserved_account_keys().len(),
         2,
         "after activating the test feature, bank should have another active reserved key"
+    );
+}
+
+#[test]
+fn test_block_limits() {
+    let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
+    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+
+    // Ensure increased block limits features are inactive.
+    assert!(!bank
+        .feature_set
+        .is_active(&feature_set::raise_block_limits_to_100m::id()));
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    // Activate `raise_block_limits_to_100m` feature
+    bank.store_account(
+        &feature_set::raise_block_limits_to_100m::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    // apply_feature_activations for `FinishInit` will not cause the block limit to be updated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::FinishInit, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    // apply_feature_activations for `NewFromParent` will cause feature to be activated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS_SIMD_0286,
+        "after activating the feature, bank should have new limit"
+    );
+
+    // Make sure the limits propagate to the child-bank.
+    let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS_SIMD_0286,
+        "child bank should have new limit"
+    );
+
+    // Test starting from a genesis config with and without feature account
+    let (mut genesis_config, _keypair) = create_genesis_config(100_000);
+    // Without feature account in genesis, old limits are used.
+    let bank = Bank::new_for_tests(&genesis_config);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    activate_feature(
+        &mut genesis_config,
+        feature_set::raise_block_limits_to_100m::id(),
+    );
+    let bank = Bank::new_for_tests(&genesis_config);
+    assert!(bank
+        .feature_set
+        .is_active(&feature_set::raise_block_limits_to_100m::id()));
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS_SIMD_0286,
+        "bank created from genesis config should have new limit"
     );
 }
 


### PR DESCRIPTION
#### Problem
Add

- https://github.com/anza-xyz/feature-gate-tracker/issues/97
- new block limits

for https://github.com/solana-foundation/solana-improvement-documents/pull/286

New block limit will apply during epoch transition after feature activation and during bank initialization.

#### Summary of Changes

- Add feature for 100M CU limit
- Apply new block limit when feature is activated.
- Add unit test to ensure new block limits get applied.