### PR TITLE
SIMD-0306

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1115,6 +1115,10 @@ pub mod raise_block_limits_to_100m {
     solana_pubkey::declare_id!("P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz");
 }
 
+pub mod raise_account_cu_limit {
+    solana_pubkey::declare_id!("ToBeMade21111111111111111111111111111111111");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -1354,6 +1358,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (disable_zk_elgamal_proof_program::id(), "Disables zk-elgamal-proof program"),
         (reenable_zk_elgamal_proof_program::id(), "Re-enables zk-elgamal-proof program"),
         (raise_block_limits_to_100m::id(), "SIMD-0286: Raise block limit to 100M"),
+        (raise_account_cu_limit::id(), "SIMD-0306: Raise account CU limit to 40% max"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1116,7 +1116,7 @@ pub mod raise_block_limits_to_100m {
 }
 
 pub mod raise_account_cu_limit {
-    solana_pubkey::declare_id!("ToBeMade21111111111111111111111111111111111");
+    solana_pubkey::declare_id!("htsptAwi2yRoZH83SKaUXykeZGtZHgxkS2QwW1pssR8");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4048,7 +4048,14 @@ impl Bank {
         {
             let block_cost_limit = simd_0286_block_limits();
             let mut cost_tracker = self.write_cost_tracker().unwrap();
-            let account_cost_limit = cost_tracker.get_account_limit();
+            let account_cost_limit = if self
+                .feature_set
+                .is_active(&feature_set::raise_account_cu_limit::id())
+            {
+                (block_cost_limit as f64 * 0.4) as u64
+            } else {
+                cost_tracker.get_account_limit()
+            };
             let vote_cost_limit = cost_tracker.get_vote_limit();
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
@@ -5321,7 +5328,14 @@ impl Bank {
         if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
             let block_cost_limit = simd_0286_block_limits();
             let mut cost_tracker = self.write_cost_tracker().unwrap();
-            let account_cost_limit = cost_tracker.get_account_limit();
+            let account_cost_limit = if self
+                .feature_set
+                .is_active(&feature_set::raise_account_cu_limit::id())
+            {
+                (block_cost_limit as f64 * 0.4) as u64
+            } else {
+                cost_tracker.get_account_limit()
+            };
             let vote_cost_limit = cost_tracker.get_vote_limit();
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4053,6 +4053,17 @@ impl Bank {
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
 
+        if self
+            .feature_set
+            .is_active(&feature_set::raise_account_cu_limit::id())
+        {
+            let mut cost_tracker = self.write_cost_tracker().unwrap();
+            let block_cost_limit = cost_tracker.get_block_limit();
+            let vote_cost_limit = cost_tracker.get_vote_limit();
+            let account_cost_limit = (block_cost_limit as f64 * 0.4) as u64;
+            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
+        }
+
         if !debug_do_not_add_builtins {
             for builtin in BUILTINS
                 .iter()
@@ -5312,6 +5323,14 @@ impl Bank {
             let mut cost_tracker = self.write_cost_tracker().unwrap();
             let account_cost_limit = cost_tracker.get_account_limit();
             let vote_cost_limit = cost_tracker.get_vote_limit();
+            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
+        }
+
+        if new_feature_activations.contains(&feature_set::raise_account_cu_limit::id()) {
+            let mut cost_tracker = self.write_cost_tracker().unwrap();
+            let block_cost_limit = cost_tracker.get_block_limit();
+            let vote_cost_limit = cost_tracker.get_vote_limit();
+            let account_cost_limit = (block_cost_limit as f64 * 0.4) as u64;
             cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4024,7 +4024,7 @@ impl Bank {
         let block_cost_limit = cost_tracker.get_block_limit();
         let vote_cost_limit = cost_tracker.get_vote_limit();
         // SIMD-0306 makes account cost limit 40% of the block cost limit.
-        let account_cost_limit = block_cost_limit * 40 / 100;
+        let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
         cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -50,7 +50,7 @@ use {
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
-    solana_cost_model::block_cost_limits::{MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286},
+    solana_cost_model::block_cost_limits::{MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS},
     solana_cpi::MAX_RETURN_DATA,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_feature_gate_interface::{self as feature, Feature},
@@ -6713,6 +6713,8 @@ fn test_reserved_account_keys() {
 
 #[test]
 fn test_block_limits() {
+    const MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST: u64 = 24_000_000;
+    const MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND: u64 = 40_000_000;
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
     let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
 
@@ -6723,6 +6725,14 @@ fn test_block_limits() {
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+    assert!(!bank
+        .feature_set
+        .is_active(&feature_set::raise_account_cu_limit::id()));
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS,
         "before activating the feature, bank should have old/default limit"
     );
 
@@ -6746,13 +6756,96 @@ fn test_block_limits() {
         MAX_BLOCK_UNITS_SIMD_0286,
         "after activating the feature, bank should have new limit"
     );
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS,
+        "after activating the feature, bank should have new limit"
+    );
 
     // Make sure the limits propagate to the child-bank.
-    let bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
+    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), 2);
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS_SIMD_0286,
         "child bank should have new limit"
+    );
+
+    // Activate `raise_account_cu_limit` feature
+    bank.store_account(
+        &feature_set::raise_account_cu_limit::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+
+    // apply_feature_activations for `FinishInit` will not cause the block limit to be updated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::FinishInit, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    // apply_feature_activations for `NewFromParent` will cause feature to be activated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND,
+        "after activating the feature, bank should have new limit"
+    );
+
+    // Test SIMD-0306 getting activated first
+    let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
+    let mut bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+
+    // Activate `raise_account_cu_limit` feature
+    bank.store_account(
+        &feature_set::raise_account_cu_limit::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    // apply_feature_activations for `FinishInit` will not cause the block limit to be updated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::FinishInit, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    // apply_feature_activations for `NewFromParent` will cause feature to be activated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS,
+        "after activating the feature, bank should have new limit"
+    );
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_FIRST,
+        "after activating the feature, bank should have new limit"
+    );
+
+    // Activate `raise_block_limits_to_100m` feature
+    bank.store_account(
+        &feature_set::raise_block_limits_to_100m::id(),
+        &feature::create_account(&Feature::default(), 42),
+    );
+    // apply_feature_activations for `FinishInit` will not cause the block limit to be updated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::FinishInit, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+
+    // apply_feature_activations for `NewFromParent` will cause feature to be activated
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_block_limit(),
+        MAX_BLOCK_UNITS_SIMD_0286,
+        "after activating the feature, bank should have new limit"
+    );
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND,
+        "after activating the feature, bank should have new limit"
     );
 
     // Test starting from a genesis config with and without feature account
@@ -6762,6 +6855,11 @@ fn test_block_limits() {
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS,
+        "before activating the feature, bank should have old/default limit"
+    );
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS,
         "before activating the feature, bank should have old/default limit"
     );
 
@@ -6776,6 +6874,20 @@ fn test_block_limits() {
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS_SIMD_0286,
+        "bank created from genesis config should have new limit"
+    );
+
+    activate_feature(
+        &mut genesis_config,
+        feature_set::raise_account_cu_limit::id(),
+    );
+    let bank = Bank::new_for_tests(&genesis_config);
+    assert!(bank
+        .feature_set
+        .is_active(&feature_set::raise_account_cu_limit::id()));
+    assert_eq!(
+        bank.read_cost_tracker().unwrap().get_account_limit(),
+        MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_SECOND,
         "bank created from genesis config should have new limit"
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -50,7 +50,9 @@ use {
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
-    solana_cost_model::block_cost_limits::{MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS},
+    solana_cost_model::block_cost_limits::{
+        MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS,
+    },
     solana_cpi::MAX_RETURN_DATA,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_feature_gate_interface::{self as feature, Feature},


### PR DESCRIPTION
Builds on #7124 
#### Problem
Add

- https://github.com/anza-xyz/feature-gate-tracker/issues/98
- new account CU limit

for https://github.com/solana-foundation/solana-improvement-documents/pull/306

New account CU limit will apply during epoch transition after feature activation and during bank initialization.

#### Summary of Changes

- Add feature for increased account limit up to 40% of global limit
- Apply new limit when feature is activated.
- Add unit test to ensure new block limits get applied.
- Ensure any order works for this feature and `raise_block_limits_to_100m`