### PR TITLE
v2.3: [zk-sdk] Hash `c_max_proof` in the percentage with cap sigma proof transcript

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1110,7 +1110,7 @@ pub mod disable_zk_elgamal_proof_program {
 }
 
 pub mod reenable_zk_elgamal_proof_program {
-    solana_pubkey::declare_id!("zkemPXcuM3G4wpMDZ36Cpw34EjUpvm1nuioiSGbGZPR");
+    solana_pubkey::declare_id!("zkeygbBwEGgThKda6nVFVUjJHSYXbwydbmaPUeNQbmK");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -389,6 +389,7 @@ impl PercentageWithCapProof {
         let c_equality = c - c_max_proof;
 
         transcript.append_scalar(b"z_max", &z_max);
+        transcript.append_scalar(b"c_max_proof", &c_max_proof);
         transcript.append_scalar(b"z_x", &z_x);
         transcript.append_scalar(b"z_delta_real", &z_delta_real);
         transcript.append_scalar(b"z_claimed", &z_claimed);


### PR DESCRIPTION
#### Problem
The `c_max_proof` was not added to the transcript of the percentage with cap sigma proof. This was fixed in https://github.com/anza-xyz/agave/pull/6523, but it was reverted in https://github.com/anza-xyz/agave/pull/6544.

#### Summary of Changes
I added the one line to hash `c_max_proof` to the transcript. The zk program that this affects is disabled, so it should be safe to add this change. This PR addresses only the v2.3 branch. For master, we are upgrading to zk-sdk v3.0.0 where this issue is already addressed (https://github.com/solana-program/zk-elgamal-proof/pull/11). Given the timeline for the new set of audits, just backporting to v2.3 seems to be fine and not v2.2. 