### PR TITLE
v2.3: [zk-sdk] update pubkey validity proof to reject all zero public keys

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1110,7 +1110,7 @@ pub mod disable_zk_elgamal_proof_program {
 }
 
 pub mod reenable_zk_elgamal_proof_program {
-    solana_pubkey::declare_id!("zkeygbBwEGgThKda6nVFVUjJHSYXbwydbmaPUeNQbmK");
+    solana_pubkey::declare_id!("zkesAyFB19sTkX8i9ReoKaMNDA4YNTPYJpZKPDt7FMW");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/zk-sdk/src/sigma_proofs/errors.rs
+++ b/zk-sdk/src/sigma_proofs/errors.rs
@@ -11,6 +11,8 @@ pub enum SigmaProofVerificationError {
     MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
     Transcript(#[from] TranscriptError),
+    #[error("public key si the identity")]
+    PubkeyIsIdentity,
 }
 
 macro_rules! impl_from_transcript_error {

--- a/zk-sdk/src/sigma_proofs/errors.rs
+++ b/zk-sdk/src/sigma_proofs/errors.rs
@@ -11,7 +11,7 @@ pub enum SigmaProofVerificationError {
     MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
     Transcript(#[from] TranscriptError),
-    #[error("public key si the identity")]
+    #[error("public key is the identity")]
     PubkeyIsIdentity,
 }
 


### PR DESCRIPTION
#### Problem
If the ElGamal public key is an all-zero (the identity) public key, then it is easy to forge a public key validity proof for the public key because the algebraic relation that is checked by the proof verifier becomes trivial.

Technically, this is not a violation of security (the "soundness" of the proof) because everyone knows that the identity public key has the all zero element as the secret key. For example, this property also exists in most ed25519 signature implementations.

However, an all-zero public key should never be used in practice as it does not function properly as an effective public key. It is safer to just reject an identity public key from verification in the first place.

#### Summary of Changes
There is a security advisory on this issue. If the zk proof program was not disabled, then I would just leave the program as is and leave addressing this issue to the application side. But since we do have the program disabled, I thought I would just address it by rejecting all zero public keys.

This PR addresses only the v2.3 branch. For master, we are upgrading to zk-sdk v3.0.0 where this issue is already addressed (https://github.com/solana-program/zk-elgamal-proof/pull/11). Given the timeline for the new set of audits, just backporting to v2.3 seems to be fine and not v2.2.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
