### PR TITLE
ff cleanup: drop_unchained_merkle_shreds

### DIFF
--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -47,9 +47,7 @@ pub struct ProcessShredsStats {
 pub struct ShredFetchStats {
     pub(super) index_overrun: usize,
     pub shred_count: usize,
-    pub(super) num_shreds_merkle_code: usize,
     pub(super) num_shreds_merkle_code_chained: usize,
-    pub(super) num_shreds_merkle_data: usize,
     pub(super) num_shreds_merkle_data_chained: usize,
     pub ping_count: usize,
     pub ping_err_verify_count: usize,
@@ -165,13 +163,11 @@ impl ShredFetchStats {
             name,
             ("index_overrun", self.index_overrun, i64),
             ("shred_count", self.shred_count, i64),
-            ("num_shreds_merkle_code", self.num_shreds_merkle_code, i64),
             (
                 "num_shreds_merkle_code_chained",
                 self.num_shreds_merkle_code_chained,
                 i64
             ),
-            ("num_shreds_merkle_data", self.num_shreds_merkle_data, i64),
             (
                 "num_shreds_merkle_data_chained",
                 self.num_shreds_merkle_data_chained,


### PR DESCRIPTION
Feature has been activated on all clusters:
```
$ solana -um feature status  ~/features/drop_unchained_merkle_shreds.json
Feature                                      | Status                  | Activation Slot | Description
5KLGJSASDVxKPjLCDWNtnABLpZjsQSrYZ8HKwcEdAMC8 | active since epoch 821  | 354672000       | drops unchained Merkle shreds #2149
```

I kept around the feature set and check functions for future use if we decide to drop un-resigned shreds, or make other shred modifications.

Fixes anza-xyz/feature-gate-tracker#80