### PR TITLE
Removes accounts_hash and incremental_accounts_hash

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1284,32 +1284,10 @@ pub struct IncrementalAccountsHash(pub Hash);
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerdeAccountsHash(pub Hash);
 
-impl From<SerdeAccountsHash> for AccountsHash {
-    fn from(accounts_hash: SerdeAccountsHash) -> Self {
-        Self(accounts_hash.0)
-    }
-}
-impl From<AccountsHash> for SerdeAccountsHash {
-    fn from(accounts_hash: AccountsHash) -> Self {
-        Self(accounts_hash.0)
-    }
-}
-
 /// Snapshot serde-safe incremental accounts hash
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerdeIncrementalAccountsHash(pub Hash);
-
-impl From<SerdeIncrementalAccountsHash> for IncrementalAccountsHash {
-    fn from(incremental_accounts_hash: SerdeIncrementalAccountsHash) -> Self {
-        Self(incremental_accounts_hash.0)
-    }
-}
-impl From<IncrementalAccountsHash> for SerdeIncrementalAccountsHash {
-    fn from(incremental_accounts_hash: IncrementalAccountsHash) -> Self {
-        Self(incremental_accounts_hash.0)
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -46,7 +46,6 @@ use {
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
         rent_collector::RentCollectorWithMetrics,
         runtime_config::RuntimeConfig,
-        serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
         stake_account::StakeAccount,
         stake_weighted_timestamp::{
@@ -77,7 +76,7 @@ use {
         accounts_db::{
             AccountStorageEntry, AccountsDb, AccountsDbConfig, DuplicatesLtHash, PubkeyHashAccount,
         },
-        accounts_hash::{AccountsHash, AccountsLtHash, IncrementalAccountsHash},
+        accounts_hash::AccountsLtHash,
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::{Ancestors, AncestorsForSerialization},
@@ -434,7 +433,6 @@ pub struct BankFieldsToDeserialize {
     pub(crate) versioned_epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
     pub(crate) is_delta: bool,
     pub(crate) accounts_data_len: u64,
-    pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     pub(crate) accounts_lt_hash: AccountsLtHash,
     pub(crate) bank_hash_stats: BankHashStats,
 }
@@ -4757,30 +4755,6 @@ impl Bank {
     /// (cannot be made DCOU due to solana-program-test)
     pub fn set_capitalization_for_tests(&self, capitalization: u64) {
         self.capitalization.store(capitalization, Relaxed);
-    }
-
-    /// Returns the `AccountsHash` that was calculated for this bank's slot
-    ///
-    /// This fn is used when creating a snapshot with ledger-tool, or when
-    /// packaging a snapshot into an archive (used to get the `SnapshotHash`).
-    pub fn get_accounts_hash(&self) -> Option<AccountsHash> {
-        self.rc
-            .accounts
-            .accounts_db
-            .get_accounts_hash(self.slot())
-            .map(|(accounts_hash, _)| accounts_hash)
-    }
-
-    /// Returns the `IncrementalAccountsHash` that was calculated for this bank's slot
-    ///
-    /// This fn is used when creating an incremental snapshot with ledger-tool, or when
-    /// packaging a snapshot into an archive (used to get the `SnapshotHash`).
-    pub fn get_incremental_accounts_hash(&self) -> Option<IncrementalAccountsHash> {
-        self.rc
-            .accounts
-            .accounts_db
-            .get_incremental_accounts_hash(self.slot())
-            .map(|(incremental_accounts_hash, _)| incremental_accounts_hash)
     }
 
     /// Returns the `SnapshotHash` for this bank's slot

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -19,7 +19,7 @@ use {
             AtomicAccountsFileId, DuplicatesLtHash, IndexGenerationInfo,
         },
         accounts_file::{AccountsFile, StorageAccess},
-        accounts_hash::{AccountsHash, AccountsLtHash},
+        accounts_hash::AccountsLtHash,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::AncestorsForSerialization,
         blockhash_queue::BlockhashQueue,
@@ -109,7 +109,7 @@ pub struct BankIncrementalSnapshotPersistence {
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
     obsolete_accounts_delta_hash: [u8; 32],
-    accounts_hash: SerdeAccountsHash,
+    accounts_hash: SerdeAccountsHash, // obsolete
     stats: BankHashStats,
 }
 
@@ -195,7 +195,6 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             inflation: dvb.inflation,
             stakes: dvb.stakes,
             is_delta: dvb.is_delta,
-            incremental_snapshot_persistence: None,
             versioned_epoch_stakes: HashMap::default(), // populated from ExtraFieldsToDeserialize
             accounts_lt_hash: AccountsLtHash(LT_HASH_CANARY), // populated from ExtraFieldsToDeserialize
             bank_hash_stats: BankHashStats::default(),        // populated from AccountsDbFields
@@ -410,7 +409,7 @@ struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     lamports_per_signature: u64,
     #[serde(deserialize_with = "default_on_eof")]
-    incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
+    _incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>, // obsolete
     #[serde(deserialize_with = "default_on_eof")]
     _obsolete_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
@@ -430,7 +429,7 @@ struct ExtraFieldsToDeserialize {
 #[derive(Debug, Serialize)]
 pub struct ExtraFieldsToSerialize<'a> {
     pub lamports_per_signature: u64,
-    pub incremental_snapshot_persistence: Option<&'a BankIncrementalSnapshotPersistence>,
+    pub incremental_snapshot_persistence: Option<&'a BankIncrementalSnapshotPersistence>, // obsolete
     pub obsolete_epoch_accounts_hash: Option<Hash>,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: Option<SerdeAccountsLtHash>,
@@ -463,7 +462,7 @@ where
     // Process extra fields
     let ExtraFieldsToDeserialize {
         lamports_per_signature,
-        incremental_snapshot_persistence,
+        _incremental_snapshot_persistence,
         _obsolete_epoch_accounts_hash,
         versioned_epoch_stakes,
         accounts_lt_hash,
@@ -472,7 +471,6 @@ where
     bank_fields.fee_rate_governor = bank_fields
         .fee_rate_governor
         .clone_with_lamports_per_signature(lamports_per_signature);
-    bank_fields.incremental_snapshot_persistence = incremental_snapshot_persistence;
     bank_fields.versioned_epoch_stakes = versioned_epoch_stakes;
     bank_fields.accounts_lt_hash = accounts_lt_hash
         .expect("snapshot must have accounts_lt_hash")
@@ -633,7 +631,6 @@ pub fn serialize_bank_snapshot_into<W>(
     stream: &mut BufWriter<W>,
     bank_fields: BankFieldsToSerialize,
     bank_hash_stats: BankHashStats,
-    accounts_hash: AccountsHash,
     account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
     extra_fields: ExtraFieldsToSerialize,
     write_version: u64,
@@ -649,7 +646,6 @@ where
         &mut serializer,
         bank_fields,
         bank_hash_stats,
-        accounts_hash,
         account_storage_entries,
         extra_fields,
         write_version,
@@ -661,7 +657,6 @@ pub fn serialize_bank_snapshot_with<S>(
     serializer: S,
     bank_fields: BankFieldsToSerialize,
     bank_hash_stats: BankHashStats,
-    accounts_hash: AccountsHash,
     account_storage_entries: &[Vec<Arc<AccountStorageEntry>>],
     extra_fields: ExtraFieldsToSerialize,
     write_version: u64,
@@ -675,7 +670,6 @@ where
         slot,
         account_storage_entries,
         bank_hash_stats,
-        accounts_hash,
         write_version,
     };
     (serializable_bank, serializable_accounts_db, extra_fields).serialize(serializer)
@@ -697,7 +691,6 @@ impl Serialize for SerializableBankAndStorage<'_> {
         let mut bank_fields = self.bank.get_fields_to_serialize();
         let accounts_db = &self.bank.rc.accounts.accounts_db;
         let bank_hash_stats = self.bank.get_bank_hash_stats();
-        let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         let lamports_per_signature = bank_fields.fee_rate_governor.lamports_per_signature;
         let versioned_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
@@ -708,7 +701,6 @@ impl Serialize for SerializableBankAndStorage<'_> {
                 slot,
                 account_storage_entries: self.snapshot_storages,
                 bank_hash_stats,
-                accounts_hash,
                 write_version,
             },
             ExtraFieldsToSerialize {
@@ -739,7 +731,6 @@ impl Serialize for SerializableBankAndStorageNoExtra<'_> {
         let bank_fields = self.bank.get_fields_to_serialize();
         let accounts_db = &self.bank.rc.accounts.accounts_db;
         let bank_hash_stats = self.bank.get_bank_hash_stats();
-        let accounts_hash = accounts_db.get_accounts_hash(slot).unwrap().0;
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         (
             SerializableVersionedBank::from(bank_fields),
@@ -747,7 +738,6 @@ impl Serialize for SerializableBankAndStorageNoExtra<'_> {
                 slot,
                 account_storage_entries: self.snapshot_storages,
                 bank_hash_stats,
-                accounts_hash,
                 write_version,
             },
         )
@@ -773,7 +763,6 @@ struct SerializableAccountsDb<'a> {
     slot: Slot,
     account_storage_entries: &'a [Vec<Arc<AccountStorageEntry>>],
     bank_hash_stats: BankHashStats,
-    accounts_hash: AccountsHash, // obsolete, will be removed next
     write_version: u64,
 }
 
@@ -796,7 +785,7 @@ impl Serialize for SerializableAccountsDb<'_> {
         }));
         let bank_hash_info = BankHashInfo {
             obsolete_accounts_delta_hash: [0; 32],
-            accounts_hash: self.accounts_hash.into(),
+            accounts_hash: SerdeAccountsHash(Hash::default()), // obsolete, any value works
             stats: self.bank_hash_stats.clone(),
         };
 
@@ -851,13 +840,6 @@ pub(crate) fn reconstruct_bank_from_fields<E>(
 where
     E: SerializableStorage + std::marker::Sync,
 {
-    let capitalizations = (
-        bank_fields.full.capitalization,
-        bank_fields
-            .incremental
-            .as_ref()
-            .map(|bank_fields| bank_fields.capitalization),
-    );
     let mut bank_fields = bank_fields.collapse_into();
     let (accounts_db, reconstructed_accounts_db_info) = reconstruct_accountsdb_from_fields(
         snapshot_accounts_db_fields,
@@ -868,8 +850,6 @@ where
         accounts_db_config,
         accounts_update_notifier,
         exit,
-        capitalizations,
-        bank_fields.incremental_snapshot_persistence.as_ref(),
         true,
     )?;
     bank_fields.bank_hash_stats = reconstructed_accounts_db_info.bank_hash_stats;
@@ -1032,8 +1012,6 @@ fn reconstruct_accountsdb_from_fields<E>(
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-    capitalizations: (u64, Option<u64>),
-    incremental_snapshot_persistence: Option<&BankIncrementalSnapshotPersistence>,
     has_accounts_lt_hash: bool, // always true, will be removed next
 ) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error>
 where
@@ -1045,106 +1023,6 @@ where
         accounts_update_notifier,
         exit,
     );
-
-    // Store the accounts hash & capitalization, from the full snapshot, in the new AccountsDb
-    {
-        let AccountsDbFields(_, _, slot, bank_hash_info, _, _) =
-            &snapshot_accounts_db_fields.full_snapshot_accounts_db_fields;
-
-        if let Some(incremental_snapshot_persistence) = incremental_snapshot_persistence {
-            // If we've booted from local state that was originally intended to be an incremental
-            // snapshot, then we will use the incremental snapshot persistence field to set the
-            // initial accounts hashes in accounts db.
-            let old_accounts_hash = accounts_db.set_accounts_hash_from_snapshot(
-                incremental_snapshot_persistence.full_slot,
-                incremental_snapshot_persistence.full_hash.clone(),
-                incremental_snapshot_persistence.full_capitalization,
-            );
-            assert!(
-                old_accounts_hash.is_none(),
-                "There should not already be an AccountsHash at slot {slot}: {old_accounts_hash:?}",
-            );
-            let old_incremental_accounts_hash = accounts_db
-                .set_incremental_accounts_hash_from_snapshot(
-                    *slot,
-                    incremental_snapshot_persistence.incremental_hash.clone(),
-                    incremental_snapshot_persistence.incremental_capitalization,
-                );
-            assert!(
-                old_incremental_accounts_hash.is_none(),
-                "There should not already be an IncrementalAccountsHash at slot {slot}: {old_incremental_accounts_hash:?}",
-            );
-        } else {
-            // Otherwise, we've booted from a snapshot archive, or from local state that was *not*
-            // intended to be an incremental snapshot.
-            let old_accounts_hash = accounts_db.set_accounts_hash_from_snapshot(
-                *slot,
-                bank_hash_info.accounts_hash.clone(),
-                capitalizations.0,
-            );
-            assert!(
-                old_accounts_hash.is_none(),
-                "There should not already be an AccountsHash at slot {slot}: {old_accounts_hash:?}",
-            );
-        }
-    }
-
-    // Store the accounts hash & capitalization, from the incremental snapshot, in the new AccountsDb
-    {
-        if let Some(AccountsDbFields(_, _, slot, bank_hash_info, _, _)) =
-            snapshot_accounts_db_fields
-                .incremental_snapshot_accounts_db_fields
-                .as_ref()
-        {
-            if let Some(incremental_snapshot_persistence) = incremental_snapshot_persistence {
-                // Use the presence of a BankIncrementalSnapshotPersistence to indicate the
-                // Incremental Accounts Hash feature is enabled, and use its accounts hashes
-                // instead of `BankHashInfo`'s.
-                let AccountsDbFields(_, _, full_slot, full_bank_hash_info, _, _) =
-                    &snapshot_accounts_db_fields.full_snapshot_accounts_db_fields;
-                let full_accounts_hash = &full_bank_hash_info.accounts_hash;
-                assert_eq!(
-                    incremental_snapshot_persistence.full_slot, *full_slot,
-                    "The incremental snapshot's base slot ({}) must match the full snapshot's slot ({full_slot})!",
-                    incremental_snapshot_persistence.full_slot,
-                );
-                assert_eq!(
-                    &incremental_snapshot_persistence.full_hash, full_accounts_hash,
-                    "The incremental snapshot's base accounts hash ({}) must match the full snapshot's accounts hash ({})!",
-                    &incremental_snapshot_persistence.full_hash.0, full_accounts_hash.0,
-                );
-                assert_eq!(
-                    incremental_snapshot_persistence.full_capitalization, capitalizations.0,
-                    "The incremental snapshot's base capitalization ({}) must match the full snapshot's capitalization ({})!",
-                    incremental_snapshot_persistence.full_capitalization, capitalizations.0,
-                );
-                let old_incremental_accounts_hash = accounts_db
-                    .set_incremental_accounts_hash_from_snapshot(
-                        *slot,
-                        incremental_snapshot_persistence.incremental_hash.clone(),
-                        incremental_snapshot_persistence.incremental_capitalization,
-                    );
-                assert!(
-                    old_incremental_accounts_hash.is_none(),
-                    "There should not already be an IncrementalAccountsHash at slot {slot}: {old_incremental_accounts_hash:?}",
-                );
-            } else {
-                // ..and without a BankIncrementalSnapshotPersistence then the Incremental Accounts
-                // Hash feature is disabled; the accounts hash in `BankHashInfo` is valid.
-                let old_accounts_hash = accounts_db.set_accounts_hash_from_snapshot(
-                    *slot,
-                    bank_hash_info.accounts_hash.clone(),
-                    capitalizations
-                        .1
-                        .expect("capitalization from incremental snapshot"),
-                );
-                assert!(
-                    old_accounts_hash.is_none(),
-                    "There should not already be an AccountsHash at slot {slot}: {old_accounts_hash:?}",
-                );
-            };
-        }
-    }
 
     let AccountsDbFields(
         _snapshot_storages,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -22,12 +22,10 @@ mod serde_snapshot_tests {
                 AccountsDb, AtomicAccountsFileId,
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
-            accounts_hash::AccountsHash,
             ancestors::Ancestors,
         },
         solana_clock::Slot,
         solana_epoch_schedule::EpochSchedule,
-        solana_hash::Hash,
         solana_nohash_hasher::BuildNoHashHasher,
         solana_pubkey::Pubkey,
         std::{
@@ -75,8 +73,6 @@ mod serde_snapshot_tests {
             Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
             Arc::default(),
-            (u64::default(), None),
-            None,
             true,
         )
         .map(|(accounts_db, _)| accounts_db)
@@ -103,7 +99,6 @@ mod serde_snapshot_tests {
         W: Write,
     {
         let bank_hash_stats = BankHashStats::default();
-        let accounts_hash = AccountsHash(Hash::default()); // obsolete, any value works
         let write_version = accounts_db.write_version.load(Ordering::Acquire);
         serialize_into(
             stream,
@@ -111,7 +106,6 @@ mod serde_snapshot_tests {
                 slot,
                 account_storage_entries,
                 bank_hash_stats,
-                accounts_hash,
                 write_version,
             },
         )

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,15 +1,14 @@
+#[cfg(feature = "dev-context-only-utils")]
+use solana_hash::Hash;
 use {
     crate::{
         bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         snapshot_hash::SnapshotHash,
     },
     log::*,
-    solana_accounts_db::{
-        accounts::Accounts, accounts_db::AccountStorageEntry, accounts_hash::AccountsHash,
-    },
+    solana_accounts_db::{accounts::Accounts, accounts_db::AccountStorageEntry},
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
-    solana_hash::Hash,
     solana_rent_collector::RentCollector,
     std::{
         sync::{atomic::Ordering, Arc},
@@ -161,7 +160,6 @@ pub struct SnapshotPackage {
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
     pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
-    pub accounts_hash: AccountsHash,
     pub write_version: u64,
 
     /// The instant this snapshot package was sent to the queue.
@@ -193,7 +191,6 @@ impl SnapshotPackage {
             status_cache_slot_deltas: snapshot_info.status_cache_slot_deltas,
             bank_fields_to_serialize: snapshot_info.bank_fields_to_serialize,
             bank_hash_stats: snapshot_info.bank_hash_stats,
-            accounts_hash: AccountsHash(Hash::default()), // obsolete, will be removed next
             write_version: snapshot_info.write_version,
             enqueued: Instant::now(),
         }
@@ -214,7 +211,6 @@ impl SnapshotPackage {
             status_cache_slot_deltas: Vec::default(),
             bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
             bank_hash_stats: BankHashStats::default(),
-            accounts_hash: AccountsHash(Hash::default()),
             write_version: u64::default(),
             enqueued: Instant::now(),
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -25,7 +25,6 @@ use {
         account_storage_reader::AccountStorageReader,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
-        accounts_hash::AccountsHash,
         hardened_unpack::{self, ArchiveChunker, BytesChannelReader, MultiBytes, UnpackError},
         utils::{move_and_async_delete_path, ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR},
     },
@@ -828,7 +827,6 @@ pub fn serialize_and_archive_snapshot_package(
         status_cache_slot_deltas,
         bank_fields_to_serialize,
         bank_hash_stats,
-        accounts_hash,
         write_version,
         enqueued: _,
     } = snapshot_package;
@@ -840,7 +838,6 @@ pub fn serialize_and_archive_snapshot_package(
         status_cache_slot_deltas.as_slice(),
         bank_fields_to_serialize,
         bank_hash_stats,
-        accounts_hash,
         write_version,
         should_flush_and_hard_link_storages,
     )?;
@@ -900,7 +897,6 @@ fn serialize_snapshot(
     slot_deltas: &[BankSlotDelta],
     mut bank_fields: BankFieldsToSerialize,
     bank_hash_stats: BankHashStats,
-    accounts_hash: AccountsHash,
     write_version: u64,
     should_flush_and_hard_link_storages: bool,
 ) -> Result<BankSnapshotInfo> {
@@ -962,7 +958,6 @@ fn serialize_snapshot(
                 stream,
                 bank_fields,
                 bank_hash_stats,
-                accounts_hash,
                 &get_storages_to_serialize(snapshot_storages),
                 extra_fields,
                 write_version,


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used.


#### Summary of Changes

Removes accounts hash and incremental accounts hash.


#### Additional Testing

* [x] ✅ PR can boot from own snapshot archives
* [x] ✅ PR can boot from own fastboot
* [x] ✅ PR can boot from v2.3 snapshot archives
* [x] ✅ PR can boot from v2.3 fastboot
* [x] ✅ v2.3 can boot from PR snapshot archives
* [x] ✅ v2.3 can boot from PR fastboot
* [x] ✅ v2.2 can boot from PR snapshot archives
* [x] ✅ v2.2 can boot from PR fastboot

Notes:
* Using v2.3.5 for v2.3
* Using v2.2.20 for v2.2