### PR TITLE
Add local-cluster and dependents to dcou tainted list

### DIFF
--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 clap = { workspace = true }
 log = { workspace = true }
@@ -51,7 +54,7 @@ jemallocator = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-faucet = { workspace = true }
-solana-local-cluster = { workspace = true }
+solana-local-cluster = { workspace = true, features = ["dev-context-only-utils"] }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-core/dev-context-only-utils"]
 
 [dependencies]
 crossbeam-channel = { workspace = true }

--- a/scripts/dcou-tainted-packages.sh
+++ b/scripts/dcou-tainted-packages.sh
@@ -5,7 +5,11 @@ declare dcou_tainted_packages=(
   agave-ledger-tool
   agave-store-histogram
   agave-store-tool
+  solana-accounts-cluster-bench
   solana-banking-bench
   solana-bench-tps
   solana-dos
+  solana-local-cluster
+  solana-transaction-dos
+  solana-vortexor
 )

--- a/scripts/dcou-tainted-packages.sh
+++ b/scripts/dcou-tainted-packages.sh
@@ -2,10 +2,10 @@
 
 # shellcheck disable=SC2034 # This file is intended to be `source`d
 declare dcou_tainted_packages=(
-  solana-banking-bench
   agave-ledger-tool
-  solana-bench-tps
-  agave-store-tool
   agave-store-histogram
+  agave-store-tool
+  solana-banking-bench
+  solana-bench-tps
   solana-dos
 )

--- a/transaction-dos/Cargo.toml
+++ b/transaction-dos/Cargo.toml
@@ -11,6 +11,9 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 bincode = { workspace = true }
 clap = { workspace = true }
@@ -43,6 +46,6 @@ solana-version = { workspace = true }
 [dev-dependencies]
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-hash = { workspace = true }
-solana-local-cluster = { workspace = true }
+solana-local-cluster = { workspace = true, features = ["dev-context-only-utils"] }
 solana-poh-config = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/vortexor/Cargo.toml
+++ b/vortexor/Cargo.toml
@@ -18,6 +18,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 crate-type = ["lib"]
 name = "solana_vortexor"
 
+[features]
+dev-context-only-utils = []
+
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 async-channel = { workspace = true }
@@ -67,6 +70,6 @@ x509-parser = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-local-cluster = { workspace = true }
+solana-local-cluster = { workspace = true, features = ["dev-context-only-utils"] }
 solana-native-token = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }


### PR DESCRIPTION
#### Problem
solana-local-cluster essentially provides a testing framework, and makes
use of may *_for_tests() functions. Many of these function should be
DCOU, but local-cluster not being on the exclusion means we cannot make
all of those test functions DCOU

#### Summary of changes
Sort the tainted packages list cuz it bugged me lol, and then add `solana-local-cluster` to the list.
