### PR TITLE
agave-validator: move socket_addr_space parsing into run command logic

### DIFF
--- a/streamer/src/socket.rs
+++ b/streamer/src/socket.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SocketAddrSpace {
     Unspecified,
     Global,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -28,6 +28,7 @@ use {
         MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_signer::Signer,
+    solana_streamer::socket::SocketAddrSpace,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{collections::HashSet, net::SocketAddr, str::FromStr},
 };
@@ -44,6 +45,7 @@ pub struct RunArgs {
     pub logfile: String,
     pub entrypoints: Vec<SocketAddr>,
     pub known_validators: Option<HashSet<Pubkey>>,
+    pub socket_addr_space: SocketAddrSpace,
     pub rpc_bootstrap_config: RpcBootstrapConfig,
     pub blockstore_options: BlockstoreOptions,
 }
@@ -83,11 +85,14 @@ impl FromClapArgMatches for RunArgs {
             "known validator",
         )?;
 
+        let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
+
         Ok(RunArgs {
             identity_keypair,
             logfile,
             entrypoints,
             known_validators,
+            socket_addr_space,
             rpc_bootstrap_config: RpcBootstrapConfig::from_clap_arg_match(matches)?,
             blockstore_options: BlockstoreOptions::from_clap_arg_match(matches)?,
         })
@@ -1757,6 +1762,7 @@ mod tests {
                 logfile,
                 entrypoints,
                 known_validators,
+                socket_addr_space: SocketAddrSpace::Global,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
                 blockstore_options: BlockstoreOptions::default(),
             }
@@ -1770,6 +1776,7 @@ mod tests {
                 logfile: self.logfile.clone(),
                 entrypoints: self.entrypoints.clone(),
                 known_validators: self.known_validators.clone(),
+                socket_addr_space: self.socket_addr_space.clone(),
                 rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
                 blockstore_options: self.blockstore_options.clone(),
             }
@@ -2146,5 +2153,19 @@ mod tests {
                 expected_args,
             );
         }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_allow_private_addr() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            socket_addr_space: SocketAddrSpace::Unspecified,
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--allow-private-addr"],
+            expected_args,
+        );
     }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1776,7 +1776,7 @@ mod tests {
                 logfile: self.logfile.clone(),
                 entrypoints: self.entrypoints.clone(),
                 known_validators: self.known_validators.clone(),
-                socket_addr_space: self.socket_addr_space.clone(),
+                socket_addr_space: self.socket_addr_space,
                 rpc_bootstrap_config: self.rpc_bootstrap_config.clone(),
                 blockstore_options: self.blockstore_options.clone(),
             }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -64,10 +64,7 @@ use {
     },
     solana_send_transaction_service::send_transaction_service,
     solana_signer::Signer,
-    solana_streamer::{
-        quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
-        socket::SocketAddrSpace,
-    },
+    solana_streamer::quic::{QuicServerParams, DEFAULT_TPU_COALESCE},
     solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_turbine::{
         broadcast_stage::BroadcastStageType,
@@ -98,7 +95,6 @@ const MILLIS_PER_SECOND: u64 = 1000;
 pub fn execute(
     matches: &ArgMatches,
     solana_version: &str,
-    socket_addr_space: SocketAddrSpace,
     ledger_path: &Path,
     operation: Operation,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -296,7 +292,7 @@ pub fn execute(
     };
     let entrypoint_addrs = run_args.entrypoints;
     for addr in &entrypoint_addrs {
-        if !socket_addr_space.check(addr) {
+        if !run_args.socket_addr_space.check(addr) {
             Err(format!("invalid entrypoint address: {addr}"))?;
         }
     }
@@ -1032,7 +1028,7 @@ pub fn execute(
             &start_progress,
             minimal_snapshot_download_speed,
             maximum_snapshot_download_abort,
-            socket_addr_space,
+            run_args.socket_addr_space,
         );
         *start_progress.write().unwrap() = ValidatorStartProgress::Initializing;
     }
@@ -1089,7 +1085,7 @@ pub fn execute(
         should_check_duplicate_instance,
         rpc_to_plugin_manager_receiver,
         start_progress,
-        socket_addr_space,
+        run_args.socket_addr_space,
         ValidatorTpuConfig {
             use_quic: tpu_use_quic,
             vote_use_quic,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,7 +7,6 @@ use {
         commands,
     },
     log::error,
-    solana_streamer::socket::SocketAddrSpace,
     std::{path::PathBuf, process::exit},
 };
 
@@ -22,14 +21,12 @@ pub fn main() {
     let matches = cli_app.get_matches();
     warn_for_deprecated_arguments(&matches);
 
-    let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
     let ledger_path = PathBuf::from(matches.value_of("ledger_path").unwrap());
 
     match matches.subcommand() {
         ("init", _) => commands::run::execute(
             &matches,
             solana_version,
-            socket_addr_space,
             &ledger_path,
             commands::run::execute::Operation::Initialize,
         )
@@ -38,7 +35,6 @@ pub fn main() {
         ("", _) | ("run", _) => commands::run::execute(
             &matches,
             solana_version,
-            socket_addr_space,
             &ledger_path,
             commands::run::execute::Operation::Run,
         )


### PR DESCRIPTION
#### Problem

only run command uses`let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));`, but it’s currently parsed at the top-level function.

#### Summary of Changes

get it join RunArgs struct