### PR TITLE
gossip, benches: reduce number of values in bench_crds_shards_find

### DIFF
--- a/gossip/benches/crds_shards.rs
+++ b/gossip/benches/crds_shards.rs
@@ -37,31 +37,31 @@ fn bench_crds_shards_find(b: &mut Bencher, num_values: usize, mask_bits: u32) {
 }
 
 fn bench_crds_shards_find_0(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 0);
+    bench_crds_shards_find(bencher, 20_000, 0);
 }
 
 fn bench_crds_shards_find_1(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 1);
+    bench_crds_shards_find(bencher, 20_000, 1);
 }
 
 fn bench_crds_shards_find_3(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 3);
+    bench_crds_shards_find(bencher, 20_000, 3);
 }
 
 fn bench_crds_shards_find_5(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 5);
+    bench_crds_shards_find(bencher, 20_000, 5);
 }
 
 fn bench_crds_shards_find_7(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 7);
+    bench_crds_shards_find(bencher, 20_000, 7);
 }
 
 fn bench_crds_shards_find_8(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 8);
+    bench_crds_shards_find(bencher, 20_000, 8);
 }
 
 fn bench_crds_shards_find_9(bencher: &mut Bencher) {
-    bench_crds_shards_find(bencher, 100_000, 9);
+    bench_crds_shards_find(bencher, 20_000, 9);
 }
 
 benchmark_group!(


### PR DESCRIPTION
#### Problem
Benchmark run-time increased significantly after migrating to new bencher in #6996

Issue reported [here](https://discord.com/channels/428295358100013066/560503042458517505/1397586427440795729)
First proposed solution [here](https://discord.com/channels/428295358100013066/439194979856809985/1397777999679586394) 
Second proposed solution [here](https://github.com/anza-xyz/agave/pull/7138#issuecomment-3113517614)

This is alternate PR  #7138 and https://github.com/anza-xyz/agave/pull/7165
Flamegraphs https://github.com/anza-xyz/agave/pull/7138#issuecomment-3113461727

#### Summary of Changes
The number of values in `bench_crds_shards_find` has been reduced from 100_000 to 20_000 making benchmarks passing in reasonable time of ~17min on my box.