### PR TITLE
core, repair: migrate tests to non-overlapping ports

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -923,7 +923,7 @@ mod test {
             blockstore::make_many_slot_entries, get_tmp_ledger_path,
             get_tmp_ledger_path_auto_delete, shred::Nonce,
         },
-        solana_net_utils::bind_to_unspecified,
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_perf::packet::Packet,
         solana_runtime::bank_forks::BankForks,
         solana_signer::Signer,
@@ -1357,7 +1357,7 @@ mod test {
     impl ManageAncestorHashesState {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
-            let ancestor_hashes_request_socket = Arc::new(bind_to_unspecified().unwrap());
+            let ancestor_hashes_request_socket = Arc::new(bind_to_localhost_unique().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1357,7 +1357,8 @@ mod test {
     impl ManageAncestorHashesState {
         fn new(bank_forks: Arc<RwLock<BankForks>>) -> Self {
             let ancestor_hashes_request_statuses = Arc::new(DashMap::new());
-            let ancestor_hashes_request_socket = Arc::new(bind_to_localhost_unique().expect("should bind"));
+            let ancestor_hashes_request_socket =
+                Arc::new(bind_to_localhost_unique().expect("should bind"));
             let epoch_schedule = bank_forks
                 .read()
                 .unwrap()

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1277,7 +1277,7 @@ mod test {
         },
         solana_net_utils::{
             bind_to_unspecified,
-            sockets::{bind_to, localhost_port_range_for_tests},
+            sockets::bind_to_localhost_unique,
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -1285,7 +1285,6 @@ mod test {
         solana_time_utils::timestamp,
         std::{
             collections::HashSet,
-            net::{IpAddr, Ipv4Addr},
         },
     };
 
@@ -1302,10 +1301,9 @@ mod test {
         let pubkey = cluster_info.id();
         let slot = 100;
         let shred_index = 50;
-        let port_range = localhost_port_range_for_tests();
-        let reader = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0).expect("should bind");
+        let reader = bind_to_localhost_unique().expect("should bind");
         let address = reader.local_addr().unwrap();
-        let sender = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.1).expect("should bind");
+        let sender = bind_to_localhost_unique().expect("should bind");
         let outstanding_repair_requests = Arc::new(RwLock::new(OutstandingShredRepairs::default()));
 
         // Send a repair request

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1275,10 +1275,7 @@ mod test {
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
-        solana_net_utils::{
-            bind_to_unspecified,
-            sockets::bind_to_localhost_unique,
-        },
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
@@ -1656,7 +1653,7 @@ mod test {
         };
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
-        let receive_socket = &bind_to_unspecified().unwrap();
+        let receive_socket = &bind_to_localhost_unique().expect("should bind - receive socket");
         let duplicate_status = DuplicateSlotRepairStatus {
             correct_ancestor_to_repair: (dead_slot, Hash::default()),
             start_ts: u64::MAX,
@@ -1680,7 +1677,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to_localhost_unique().expect("should bind - repair socket"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1706,7 +1703,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to_localhost_unique().expect("should bind - repair socket"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1725,7 +1722,7 @@ mod test {
             &blockstore,
             &serve_repair,
             &mut RepairStats::default(),
-            &bind_to_unspecified().unwrap(),
+            &bind_to_localhost_unique().expect("should bind - repair socket"),
             &None,
             &RwLock::new(OutstandingRequests::default()),
             &identity_keypair,
@@ -1740,7 +1737,7 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_unspecified().unwrap().local_addr().unwrap(),
+            bind_to_localhost_unique().expect("should bind - dummy socket").local_addr().unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info());
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1280,9 +1280,7 @@ mod test {
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,
         solana_time_utils::timestamp,
-        std::{
-            collections::HashSet,
-        },
+        std::collections::HashSet,
     };
 
     fn new_test_cluster_info() -> ClusterInfo {
@@ -1737,7 +1735,10 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
-            bind_to_localhost_unique().expect("should bind - dummy socket").local_addr().unwrap(),
+            bind_to_localhost_unique()
+                .expect("should bind - dummy socket")
+                .local_addr()
+                .unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info());
         let ledger_path = get_tmp_ledger_path_auto_delete!();


### PR DESCRIPTION
#### Problem

A bunch of tests still relies on either hardcoded ports or bind_to_localhost and bind_to_unspecified. This creates flaky tests in cases where unique port ranges are needed.

This PR is the step in the journey toward resolving the issue.

Related to https://github.com/anza-xyz/agave/pull/7055

#### Summary of Changes
- Fixed [bug](https://github.com/anza-xyz/agave/pull/7104/files#diff-9a18dc1f8c9de64f31e2051673159c8d93878f89646899b02b98804156280256L1308) with inclusive end port in `test_request_repair_for_shred_from_address`
- Migrated instances across core, repair tests that had in place obsolete `bind_to_unspecified`