### PR TITLE
TPU: enable reception on multiple IPs

### DIFF
--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -155,14 +155,8 @@ impl Node {
 
         // multihoming RX for TPU
         tpu_quic.append(
-            &mut Self::bind_to_extra_ip(
-                bind_ip_addr,
-                &bind_ip_addrs,
-                tpu_port_quic,
-                32,
-                socket_config,
-            )
-            .expect("Secondary bind TPU QUIC"),
+            &mut Self::bind_to_extra_ip(&bind_ip_addrs, tpu_port_quic, 32, socket_config)
+                .expect("Secondary bind TPU QUIC"),
         );
 
         let ((tpu_forwards_port, tpu_forwards_socket), (tpu_forwards_quic_port, tpu_forwards_quic)) =
@@ -182,7 +176,6 @@ impl Node {
 
         tpu_forwards_quic.append(
             &mut Self::bind_to_extra_ip(
-                bind_ip_addr,
                 &bind_ip_addrs,
                 tpu_forwards_quic_port,
                 num_quic_endpoints.get(),
@@ -203,7 +196,6 @@ impl Node {
                 .expect("tpu_vote_quic multi_bind");
         tpu_vote_quic.append(
             &mut Self::bind_to_extra_ip(
-                bind_ip_addr,
                 &bind_ip_addrs,
                 tpu_vote_port,
                 num_quic_endpoints.get(),
@@ -338,17 +330,17 @@ impl Node {
 
     /// Binds num sockets to each of the addresses in bind_ip_addrs except primary_ip_addr
     fn bind_to_extra_ip(
-        primary_ip_addr: IpAddr,
         bind_ip_addrs: &BindIpAddrs,
         port: u16,
         num: usize,
         socket_config: SocketConfig,
     ) -> io::Result<Vec<UdpSocket>> {
+        let active_ip_addr = bind_ip_addrs.active();
         let mut sockets = vec![];
         for ip_addr in bind_ip_addrs
             .iter()
             .cloned()
-            .filter(|&ip| ip != primary_ip_addr)
+            .filter(|&ip| ip != active_ip_addr)
         {
             let socket = bind_to_with_config(ip_addr, port, socket_config)?;
             sockets.append(&mut bind_more_with_config(socket, num, socket_config)?);

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -11,8 +11,9 @@ use {
         multihomed_sockets::BindIpAddrs,
         sockets::{
             bind_gossip_port_in_range, bind_in_range_with_config, bind_more_with_config,
-            bind_two_in_range_with_offset_and_config, localhost_port_range_for_tests,
-            multi_bind_in_range_with_config, SocketConfiguration as SocketConfig,
+            bind_to_with_config, bind_two_in_range_with_offset_and_config,
+            localhost_port_range_for_tests, multi_bind_in_range_with_config,
+            SocketConfiguration as SocketConfig,
         },
         PortRange,
     },
@@ -21,7 +22,8 @@ use {
     solana_streamer::quic::DEFAULT_QUIC_ENDPOINTS,
     solana_time_utils::timestamp,
     std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        io,
+        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         num::NonZero,
         sync::Arc,
     },
@@ -136,7 +138,7 @@ impl Node {
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("tvu_quic bind");
 
-        let ((tpu_port, tpu_socket), (_tpu_port_quic, tpu_quic)) =
+        let ((tpu_port, tpu_socket), (tpu_port_quic, tpu_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
@@ -148,10 +150,22 @@ impl Node {
         let tpu_sockets =
             bind_more_with_config(tpu_socket, 32, socket_config).expect("tpu_sockets multi_bind");
 
-        let tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config)
+        let mut tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config)
             .expect("tpu_quic bind");
 
-        let ((tpu_forwards_port, tpu_forwards_socket), (_, tpu_forwards_quic)) =
+        // multihoming RX for TPU
+        tpu_quic.append(
+            &mut Self::bind_to_extra_ip(
+                bind_ip_addr,
+                &bind_ip_addrs,
+                tpu_port_quic,
+                32,
+                socket_config,
+            )
+            .expect("Secondary bind TPU QUIC"),
+        );
+
+        let ((tpu_forwards_port, tpu_forwards_socket), (tpu_forwards_quic_port, tpu_forwards_quic)) =
             bind_two_in_range_with_offset_and_config(
                 bind_ip_addr,
                 port_range,
@@ -162,9 +176,20 @@ impl Node {
             .expect("tpu_forwards primary bind");
         let tpu_forwards_sockets = bind_more_with_config(tpu_forwards_socket, 8, socket_config)
             .expect("tpu_forwards multi_bind");
-        let tpu_forwards_quic =
+        let mut tpu_forwards_quic =
             bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), socket_config)
                 .expect("tpu_forwards_quic multi_bind");
+
+        tpu_forwards_quic.append(
+            &mut Self::bind_to_extra_ip(
+                bind_ip_addr,
+                &bind_ip_addrs,
+                tpu_forwards_quic_port,
+                num_quic_endpoints.get(),
+                socket_config,
+            )
+            .expect("Secondary bind TPU forwards"),
+        );
 
         let (tpu_vote_port, tpu_vote_sockets) =
             multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 1)
@@ -173,9 +198,19 @@ impl Node {
         let (tpu_vote_quic_port, tpu_vote_quic) =
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("tpu_vote_quic");
-        let tpu_vote_quic =
+        let mut tpu_vote_quic =
             bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), socket_config)
                 .expect("tpu_vote_quic multi_bind");
+        tpu_vote_quic.append(
+            &mut Self::bind_to_extra_ip(
+                bind_ip_addr,
+                &bind_ip_addrs,
+                tpu_vote_port,
+                num_quic_endpoints.get(),
+                socket_config,
+            )
+            .expect("Secondary bind TPU vote"),
+        );
 
         let (_, retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
@@ -299,6 +334,26 @@ impl Node {
             sockets,
             bind_ip_addrs,
         }
+    }
+
+    /// Binds num sockets to each of the addresses in bind_ip_addrs except primary_ip_addr
+    fn bind_to_extra_ip(
+        primary_ip_addr: IpAddr,
+        bind_ip_addrs: &BindIpAddrs,
+        port: u16,
+        num: usize,
+        socket_config: SocketConfig,
+    ) -> io::Result<Vec<UdpSocket>> {
+        let mut sockets = vec![];
+        for ip_addr in bind_ip_addrs
+            .iter()
+            .cloned()
+            .filter(|&ip| ip != primary_ip_addr)
+        {
+            let socket = bind_to_with_config(ip_addr, port, socket_config)?;
+            sockets.append(&mut bind_more_with_config(socket, num, socket_config)?);
+        }
+        Ok(sockets)
     }
 }
 


### PR DESCRIPTION
#### Problem

- We would like to be able to receive transactions from multiple bind-ip-addresses

#### Summary of Changes

- Allow TPU server to bind to all supported interfaces, thus enabling it to receive from any of them
- Only enabling this for QUIC as we intend to phase out UDP
