### PR TITLE
report cost-tracker-stats during ledger-tool replay

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -610,7 +610,31 @@ fn setup_slot_recording(
     let record_slots = arg_matches.occurrences_of("record_slots") > 0;
     let verify_slots = arg_matches.occurrences_of("verify_slots") > 0;
     match (record_slots, verify_slots) {
-        (false, false) => (None, None),
+        (false, false) => {
+            // for regualr replay ledger, report cost-tracker-stats after each
+            // slot is confirmed.
+            let slot_callback = Arc::new(move |bank: &Bank| {
+                let (total_transaction_fee, total_priority_fee) = {
+                    let collector_fee_details = bank.get_collector_fee_details();
+                    (
+                        collector_fee_details.total_transaction_fee(),
+                        collector_fee_details.total_priority_fee(),
+                    )
+                };
+
+                let cost_tracker = bank.read_cost_tracker().unwrap();
+                let slot = bank.slot();
+                let is_leader_block = false;
+                cost_tracker.report_stats(
+                    slot,
+                    is_leader_block,
+                    total_transaction_fee,
+                    total_priority_fee,
+                );
+            });
+
+            (Some(slot_callback as ProcessSlotCallback), None)
+        }
         (true, true) => {
             // .default_value() does not work with .conflicts_with() in clap 2.33
             // .conflicts_with("verify_slots")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -614,6 +614,9 @@ fn setup_slot_recording(
             // for regualr replay ledger, report cost-tracker-stats after each
             // slot is confirmed.
             let slot_callback = Arc::new(move |bank: &Bank| {
+                // Block must be frozen by this point
+                assert!(bank.is_frozen());
+
                 let (total_transaction_fee, total_priority_fee) = {
                     let collector_fee_details = bank.get_collector_fee_details();
                     (


### PR DESCRIPTION
#### Problem

- Metrics `cost_tracker_stats` can be helpful in analyzing block composition and fee collection;
- It is reported by `replay_stage` of live validator;
- Would be nice if `ledger-tool` can also report same stats for replayed slots

#### Summary of Changes
- add `slot_callback` to report `cost_tracker_stats` for confirmed slots, when ledger-tool is not used to record or verify slots file.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
