### PR TITLE
Use vector instead of slice in `InstructionContext::configure`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -526,8 +526,8 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         .get_next_instruction_context()
         .unwrap()
         .configure(
-            &[program_index, program_index.saturating_add(1)],
-            &instruction_accounts,
+            vec![program_index, program_index.saturating_add(1)],
+            instruction_accounts,
             &instruction_data,
         );
     invoke_context.push().unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -477,7 +477,11 @@ impl<'a> InvokeContext<'a> {
         *compute_units_consumed = 0;
         self.transaction_context
             .get_next_instruction_context()?
-            .configure(program_indices, instruction_accounts, instruction_data);
+            .configure(
+                program_indices.to_vec(),
+                instruction_accounts.to_vec(),
+                instruction_data,
+            );
         self.push()?;
         self.process_executable_chain(compute_units_consumed, timings)
             // MUST pop if and only if `push` succeeded, independent of `result`.
@@ -496,7 +500,11 @@ impl<'a> InvokeContext<'a> {
     ) -> Result<(), InstructionError> {
         self.transaction_context
             .get_next_instruction_context()?
-            .configure(program_indices, instruction_accounts, instruction_data);
+            .configure(
+                program_indices.to_vec(),
+                instruction_accounts.to_vec(),
+                instruction_data,
+            );
         self.push()?;
 
         let instruction_datas: Vec<_> = message_instruction_datas_iter.collect();
@@ -1040,7 +1048,7 @@ mod tests {
                             .transaction_context
                             .get_next_instruction_context()
                             .unwrap()
-                            .configure(&[3], &instruction_accounts, &[]);
+                            .configure(vec![3], instruction_accounts, &[]);
                         let result = invoke_context.push();
                         assert_eq!(result, Err(InstructionError::UnbalancedInstruction));
                         result?;
@@ -1116,8 +1124,8 @@ mod tests {
                 .get_next_instruction_context()
                 .unwrap()
                 .configure(
-                    &[one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount],
-                    &instruction_accounts,
+                    vec![one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount],
+                    instruction_accounts.clone(),
                     &[],
                 );
             if Err(InstructionError::CallDepth) == invoke_context.push() {
@@ -1198,7 +1206,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&[4], &instruction_accounts, &[]);
+            .configure(vec![4], instruction_accounts, &[]);
         invoke_context.push().unwrap();
         let inner_instruction =
             Instruction::new_with_bincode(callee_program_id, &instruction, metas.clone());
@@ -1257,7 +1265,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&[4], &instruction_accounts, &[]);
+            .configure(vec![4], instruction_accounts, &[]);
         invoke_context.push().unwrap();
         let inner_instruction = Instruction::new_with_bincode(
             callee_program_id,
@@ -1308,7 +1316,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&[0], &[], &[]);
+            .configure(vec![0], vec![], &[]);
         invoke_context.push().unwrap();
         assert_eq!(*invoke_context.get_compute_budget(), execution_budget);
         invoke_context.pop().unwrap();

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -707,7 +707,7 @@ mod tests {
                 if append_dup_account {
                     instruction_accounts.push(instruction_accounts.last().cloned().unwrap());
                 }
-                let program_indices = [0];
+                let program_indices = vec![0];
                 let instruction_data = vec![];
 
                 with_mock_invoke_context!(
@@ -719,7 +719,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context()
                     .unwrap()
-                    .configure(&program_indices, &instruction_accounts, &instruction_data);
+                    .configure(program_indices, instruction_accounts, &instruction_data);
                 invoke_context.push().unwrap();
                 let instruction_context = invoke_context
                     .transaction_context
@@ -855,14 +855,14 @@ mod tests {
             let instruction_accounts =
                 deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
             let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            let program_indices = [0];
+            let program_indices = vec![0];
             let mut original_accounts = transaction_accounts.clone();
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(&program_indices, &instruction_accounts, &instruction_data);
+                .configure(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1101,14 +1101,14 @@ mod tests {
             let instruction_accounts =
                 deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
             let instruction_data = vec![];
-            let program_indices = [0];
+            let program_indices = vec![0];
             let mut original_accounts = transaction_accounts.clone();
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(&program_indices, &instruction_accounts, &instruction_data);
+                .configure(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1369,7 +1369,7 @@ mod tests {
             /* max_instruction_stack_depth */ 1,
             /* max_instruction_trace_length */ 1,
         );
-        let program_indices = [6];
+        let program_indices = vec![6];
         let transaction_accounts_indexes = [0, 1, 2, 3, 4, 5];
         let instruction_accounts =
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
@@ -1377,7 +1377,7 @@ mod tests {
         transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&program_indices, &instruction_accounts, &instruction_data);
+            .configure(program_indices, instruction_accounts, &instruction_data);
         transaction_context.push().unwrap();
         let instruction_context = transaction_context
             .get_current_instruction_context()

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -108,7 +108,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
     transaction_context
         .get_next_instruction_context()
         .unwrap()
-        .configure(&[0], &instruction_accounts, &instruction_data);
+        .configure(vec![0], instruction_accounts, &instruction_data);
     transaction_context.push().unwrap();
     transaction_context
 }

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1320,7 +1320,6 @@ mod tests {
          $transaction_accounts:expr,
          $program_accounts:expr,
          $instruction_accounts:expr) => {
-            let program_accounts = $program_accounts;
             let instruction_data = $instruction_data;
             let instruction_accounts = $instruction_accounts
                 .iter()
@@ -1352,7 +1351,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(program_accounts, &instruction_accounts, instruction_data);
+                .configure($program_accounts, instruction_accounts, instruction_data);
             $invoke_context.push().unwrap();
         };
     }
@@ -1378,7 +1377,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1423,7 +1422,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1460,7 +1459,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1504,7 +1503,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1556,7 +1555,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1670,7 +1669,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1702,7 +1701,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1772,7 +1771,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1]
         );
 
@@ -1847,7 +1846,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            &[0],
+            vec![0],
             &[1, 1]
         );
 

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -2236,7 +2236,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(&[0, 1], &[], &[]);
+                .configure(vec![0, 1], vec![], &[]);
             $invoke_context.push().unwrap();
         };
     }
@@ -4441,7 +4441,7 @@ mod tests {
                     .transaction_context
                     .get_instruction_context_stack_height()
             {
-                let instruction_accounts = [InstructionAccount::new(
+                let instruction_accounts = vec![InstructionAccount::new(
                     index_in_trace.saturating_add(1) as IndexOfAccount,
                     0, // This is incorrect / inconsistent but not required
                     0,
@@ -4452,7 +4452,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context()
                     .unwrap()
-                    .configure(&[0], &instruction_accounts, &[index_in_trace as u8]);
+                    .configure(vec![0], instruction_accounts, &[index_in_trace as u8]);
                 invoke_context.transaction_context.push().unwrap();
             }
         }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -70,7 +70,7 @@ macro_rules! with_mock_invoke_context {
             .transaction_context
             .get_next_instruction_context()
             .unwrap()
-            .configure(&[0, 1], &instruction_accounts, &[]);
+            .configure(vec![0, 1], instruction_accounts, &[]);
         $invoke_context.push().unwrap();
     };
 }

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -269,7 +269,7 @@ mod test {
                 .transaction_context
                 .get_next_instruction_context()
                 .unwrap()
-                .configure(&[2], &$instruction_accounts, &[]);
+                .configure(vec![2], $instruction_accounts, &[]);
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1167,7 +1167,11 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
+        instruction_context.configure(
+            vec![0],
+            vec![InstructionAccount::new(1, 1, 0, false, true)],
+            &[],
+        );
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state
@@ -1312,7 +1316,11 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(&[0], &[InstructionAccount::new(1, 1, 0, false, true)], &[]);
+        instruction_context.configure(
+            vec![0],
+            vec![InstructionAccount::new(1, 1, 0, false, true)],
+            &[],
+        );
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1290,7 +1290,7 @@ mod tests {
                 transaction_context
                     .get_next_instruction_context()
                     .unwrap()
-                    .configure(&[], &[], &[index_in_trace as u8]);
+                    .configure(vec![], vec![], &[index_in_trace as u8]);
                 transaction_context.push().unwrap();
             }
         }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -627,8 +627,8 @@ impl InstructionContext {
     #[cfg(not(target_os = "solana"))]
     pub fn configure(
         &mut self,
-        program_accounts: &[IndexOfAccount],
-        instruction_accounts: &[InstructionAccount],
+        program_accounts: Vec<IndexOfAccount>,
+        instruction_accounts: Vec<InstructionAccount>,
         instruction_data: &[u8],
     ) {
         self.program_accounts = program_accounts.to_vec();


### PR DESCRIPTION
#### Problem

The main reason for this PR is to de-clutter #7120. See https://github.com/anza-xyz/agave/pull/7120#discussion_r2226965714.

The function receives slices to be clone right afterwards. We never use the arguments again in the call sites, so they can be moved.

#### Summary of Changes

Change instruction accounts and program indices from slice to vectors.
