### PR TITLE
Refactor cluster_info module to reduce complexity of the code and reduce confusion related to blockstore function naming conventions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@ filter = "package(solana-gossip) & test(/^test_star_network_push_ring_200/)"
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external_ip_test_random/)"
+filter = "package(solana-gossip) & test(/^node::tests::new_with_external_ip_test_random/)"
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -13,7 +13,7 @@ use {
         banking_trace::{BankingTracer, Channels, BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT},
         validator::{BlockProductionMethod, TransactionStructure},
     },
-    solana_gossip::cluster_info::{ClusterInfo, Node},
+    solana_gossip::{cluster_info::ClusterInfo, node::Node},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -21,7 +21,7 @@ use {
     solana_core::{banking_stage::BankingStage, banking_trace::BankingTracer},
     solana_entry::entry::{next_hash, Entry},
     solana_genesis_config::GenesisConfig,
-    solana_gossip::cluster_info::{ClusterInfo, Node},
+    solana_gossip::{cluster_info::ClusterInfo, node::Node},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -18,10 +18,7 @@ use {
     log::*,
     solana_clock::{Slot, DEFAULT_MS_PER_SLOT, HOLD_TRANSACTIONS_SLOT_OFFSET},
     solana_genesis_config::GenesisConfig,
-    solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
-        contact_info::ContactInfoQuery,
-    },
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfoQuery, node::Node},
     solana_keypair::Keypair,
     solana_ledger::{
         blockstore::{Blockstore, PurgeType},

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -688,7 +688,7 @@ mod tests {
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
         solana_entry::entry::{self, Entry, EntrySlice},
-        solana_gossip::cluster_info::Node,
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -198,7 +198,7 @@ impl ClusterSlotsService {
 mod test {
     use {
         super::*,
-        solana_gossip::{cluster_info::Node, crds_data::LowestSlot},
+        solana_gossip::{node::Node, crds_data::LowestSlot},
         solana_keypair::Keypair,
         solana_signer::Signer,
         solana_streamer::socket::SocketAddrSpace,

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -914,7 +914,8 @@ mod test {
             vote_simulator::VoteSimulator,
         },
         solana_gossip::{
-            cluster_info::{ClusterInfo, Node},
+            cluster_info::ClusterInfo,
+            node::Node,
             contact_info::{ContactInfo, Protocol},
         },
         solana_hash::Hash,

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1265,7 +1265,7 @@ mod test {
     use {
         super::*,
         crate::repair::quic_endpoint::RemoteRequest,
-        solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
+        solana_gossip::{node::Node, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_ledger::{
             blockstore::{

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4332,7 +4332,7 @@ pub(crate) mod tests {
         solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         solana_entry::entry::{self, Entry},
         solana_genesis_config as genesis_config,
-        solana_gossip::{cluster_info::Node, crds::Cursor},
+        solana_gossip::{crds::Cursor, node::Node},
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
         solana_keypair::Keypair,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -26,8 +26,8 @@ use {
     solana_clock::Slot,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::{
-        cluster_info::ClusterInfo, duplicate_shred_handler::DuplicateShredHandler,
-        duplicate_shred_listener::DuplicateShredListener,
+        duplicate_shred_handler::DuplicateShredHandler,
+        duplicate_shred_listener::DuplicateShredListener, cluster_info::ClusterInfo,
     },
     solana_keypair::Keypair,
     solana_ledger::{
@@ -459,7 +459,7 @@ pub mod tests {
             repair::quic_endpoint::RepairQuicAsyncSenders,
         },
         serial_test::serial,
-        solana_gossip::cluster_info::{ClusterInfo, Node},
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_keypair::Keypair,
         solana_ledger::{
             blockstore::BlockstoreSignals,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -50,12 +50,13 @@ use {
     },
     solana_gossip::{
         cluster_info::{
-            ClusterInfo, Node, DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS,
+            ClusterInfo, DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS,
             DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
         },
         contact_info::ContactInfo,
         crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
         gossip_service::GossipService,
+        node::Node,
     },
     solana_hard_forks::HardForks,
     solana_hash::Hash,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -19,7 +19,7 @@ use {
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
     solana_entry::entry::Entry,
-    solana_gossip::cluster_info::{ClusterInfo, Node},
+    solana_gossip::{cluster_info::ClusterInfo, node::Node},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{

--- a/docs/src/proposals/cluster-test-framework.md
+++ b/docs/src/proposals/cluster-test-framework.md
@@ -86,7 +86,7 @@ pub fn test_large_invalid_gossip_nodes(
     let client = create_client(entry_point_info.client_facing_addr(), VALIDATOR_PORT_RANGE);
     for _ in 0..(num_nodes * 100) {
         client.gossip_push(
-            cluster_info::invalid_contact_info()
+            node::invalid_contact_info()
         );
     }
     sleep(Durration::from_millis(1000));

--- a/gossip/src/duplicate_shred_listener.rs
+++ b/gossip/src/duplicate_shred_listener.rs
@@ -69,7 +69,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            cluster_info::Node, duplicate_shred::tests::new_rand_shred,
+            node::Node, duplicate_shred::tests::new_rand_shred,
             duplicate_shred_listener::DuplicateShredHandlerTrait,
         },
         solana_keypair::Keypair,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        cluster_info::{ClusterInfo, GOSSIP_CHANNEL_CAPACITY},
+        cluster_info::{ClusterInfo, GOSSIP_CHANNEL_CAPACITY, GOSSIP_SLEEP_MILLIS},
         cluster_info_metrics::submit_gossip_stats,
         contact_info::ContactInfo,
         epoch_specs::EpochSpecs,
@@ -344,9 +344,7 @@ fn spy(
         if i % 20 == 0 {
             info!("discovering...\n{}", spy_ref.contact_info_trace());
         }
-        sleep(Duration::from_millis(
-            crate::cluster_info::GOSSIP_SLEEP_MILLIS,
-        ));
+        sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
         i += 1;
     }
     (met_criteria, now.elapsed(), all_peers, tvu_peers)
@@ -390,10 +388,7 @@ pub fn make_gossip_node(
 mod tests {
     use {
         super::*,
-        crate::{
-            cluster_info::{ClusterInfo, Node},
-            contact_info::ContactInfo,
-        },
+        crate::{cluster_info::ClusterInfo, contact_info::ContactInfo, node::Node},
         std::sync::{atomic::AtomicBool, Arc},
     };
 

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -31,6 +31,7 @@ pub mod epoch_slots;
 pub mod epoch_specs;
 pub mod gossip_error;
 pub mod gossip_service;
+pub mod node;
 #[macro_use]
 mod tlv;
 #[macro_use]

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -1,0 +1,389 @@
+use crate::contact_info;
+use crate::contact_info::ContactInfo;
+use solana_net_utils::{
+    find_available_ports_in_range,
+    sockets::{
+        bind_gossip_port_in_range, bind_in_range_with_config, bind_more_with_config,
+        bind_to_with_config, bind_two_in_range_with_offset_and_config,
+        localhost_port_range_for_tests, multi_bind_in_range_with_config,
+        SocketConfiguration as SocketConfig,
+    },
+    PortRange,
+};
+use solana_pubkey::Pubkey;
+use solana_quic_definitions::QUIC_PORT_OFFSET;
+use solana_streamer::{atomic_udp_socket::AtomicUdpSocket, quic::DEFAULT_QUIC_ENDPOINTS};
+use solana_time_utils::timestamp;
+use std::{
+    convert::AsRef,
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
+    num::{NonZero, NonZeroUsize},
+    ops::Deref,
+};
+
+#[derive(Debug)]
+pub struct Sockets {
+    pub gossip: AtomicUdpSocket,
+    pub ip_echo: Option<TcpListener>,
+    pub tvu: Vec<UdpSocket>,
+    pub tvu_quic: UdpSocket,
+    pub tpu: Vec<UdpSocket>,
+    pub tpu_forwards: Vec<UdpSocket>,
+    pub tpu_vote: Vec<UdpSocket>,
+    pub broadcast: Vec<UdpSocket>,
+    // Socket sending out local repair requests,
+    // and receiving repair responses from the cluster.
+    pub repair: UdpSocket,
+    pub repair_quic: UdpSocket,
+    pub retransmit_sockets: Vec<UdpSocket>,
+    // Socket receiving remote repair requests from the cluster,
+    // and sending back repair responses.
+    pub serve_repair: UdpSocket,
+    pub serve_repair_quic: UdpSocket,
+    // Socket sending out local RepairProtocol::AncestorHashes,
+    // and receiving AncestorHashesResponse from the cluster.
+    pub ancestor_hashes_requests: UdpSocket,
+    pub ancestor_hashes_requests_quic: UdpSocket,
+    pub tpu_quic: Vec<UdpSocket>,
+    pub tpu_forwards_quic: Vec<UdpSocket>,
+    pub tpu_vote_quic: Vec<UdpSocket>,
+
+    /// Client-side socket for ForwardingStage vote transactions
+    pub tpu_vote_forwarding_client: UdpSocket,
+    /// Client-side socket for ForwardingStage non-vote transactions
+    pub tpu_transaction_forwarding_client: UdpSocket,
+    /// Connection cache endpoint for QUIC-based Vote
+    pub quic_vote_client: UdpSocket,
+    /// Client-side socket for RPC/SendTransactionService.
+    pub rpc_sts_client: UdpSocket,
+    pub vortexor_receivers: Option<Vec<UdpSocket>>,
+}
+
+pub struct NodeConfig {
+    /// The IP address advertised to the cluster in gossip
+    pub advertised_ip: IpAddr,
+    /// The gossip port advertised to the cluster
+    pub gossip_port: u16,
+    pub port_range: PortRange,
+    /// Multihoming: The IP addresses the node can bind to
+    pub bind_ip_addrs: BindIpAddrs,
+    pub public_tpu_addr: Option<SocketAddr>,
+    pub public_tpu_forwards_addr: Option<SocketAddr>,
+    pub vortexor_receiver_addr: Option<SocketAddr>,
+
+    /// The number of TVU receive sockets to create
+    pub num_tvu_receive_sockets: NonZeroUsize,
+    /// The number of TVU retransmit sockets to create
+    pub num_tvu_retransmit_sockets: NonZeroUsize,
+    /// The number of QUIC tpu endpoints
+    pub num_quic_endpoints: NonZeroUsize,
+}
+
+#[derive(Debug, Clone)]
+pub struct BindIpAddrs {
+    /// The IP addresses this node may bind to
+    /// Index 0 is the primary address
+    /// Index 1+ are secondary addresses
+    addrs: Vec<IpAddr>,
+}
+
+impl BindIpAddrs {
+    pub fn new(addrs: Vec<IpAddr>) -> Result<Self, String> {
+        if addrs.is_empty() {
+            return Err(
+                "BindIpAddrs requires at least one IP address (--bind-address)".to_string(),
+            );
+        }
+        if addrs.len() > 1 {
+            for ip in &addrs {
+                if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+                    return Err(format!(
+                        "Invalid configuration: {ip:?} is not allowed with multiple \
+                         --bind-address values (loopback, unspecified, or multicast)"
+                    ));
+                }
+            }
+        }
+
+        Ok(Self { addrs })
+    }
+
+    #[inline]
+    pub fn primary(&self) -> IpAddr {
+        self.addrs[0]
+    }
+}
+
+// Makes BindIpAddrs behave like &[IpAddr]
+impl Deref for BindIpAddrs {
+    type Target = [IpAddr];
+
+    fn deref(&self) -> &Self::Target {
+        &self.addrs
+    }
+}
+
+// For generic APIs expecting something like AsRef<[IpAddr]>
+impl AsRef<[IpAddr]> for BindIpAddrs {
+    fn as_ref(&self) -> &[IpAddr] {
+        &self.addrs
+    }
+}
+
+#[derive(Debug)]
+pub struct Node {
+    pub info: ContactInfo,
+    pub sockets: Sockets,
+}
+
+impl Node {
+    /// create localhost node for tests
+    pub fn new_localhost() -> Self {
+        let pubkey = solana_pubkey::new_rand();
+        Self::new_localhost_with_pubkey(&pubkey)
+    }
+
+    /// create localhost node for tests with provided pubkey
+    /// unlike the [new_with_external_ip], this will also bind RPC sockets.
+    pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
+        let port_range = localhost_port_range_for_tests();
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let config = NodeConfig {
+            bind_ip_addrs: BindIpAddrs {
+                addrs: vec![bind_ip_addr],
+            },
+            gossip_port: port_range.0,
+            port_range,
+            advertised_ip: bind_ip_addr,
+            public_tpu_addr: None,
+            public_tpu_forwards_addr: None,
+            num_tvu_receive_sockets: NonZero::new(1).unwrap(),
+            num_tvu_retransmit_sockets: NonZero::new(1).unwrap(),
+            num_quic_endpoints: NonZero::new(DEFAULT_QUIC_ENDPOINTS)
+                .expect("Number of QUIC endpoints can not be zero"),
+            vortexor_receiver_addr: None,
+        };
+        let mut node = Self::new_with_external_ip(pubkey, config);
+        let rpc_ports: [u16; 2] = find_available_ports_in_range(bind_ip_addr, port_range).unwrap();
+        let rpc_addr = SocketAddr::new(bind_ip_addr, rpc_ports[0]);
+        let rpc_pubsub_addr = SocketAddr::new(bind_ip_addr, rpc_ports[1]);
+        node.info.set_rpc(rpc_addr).unwrap();
+        node.info.set_rpc_pubsub(rpc_pubsub_addr).unwrap();
+        node
+    }
+
+    #[deprecated(since = "3.0.0", note = "use new_with_external_ip")]
+    pub fn new_single_bind(
+        pubkey: &Pubkey,
+        gossip_addr: &SocketAddr,
+        port_range: PortRange,
+        bind_ip_addr: IpAddr,
+    ) -> Self {
+        let config = NodeConfig {
+            bind_ip_addrs: BindIpAddrs {
+                addrs: vec![bind_ip_addr],
+            },
+            gossip_port: gossip_addr.port(),
+            port_range,
+            advertised_ip: bind_ip_addr,
+            public_tpu_addr: None,
+            public_tpu_forwards_addr: None,
+            num_tvu_receive_sockets: NonZero::new(1).unwrap(),
+            num_tvu_retransmit_sockets: NonZero::new(1).unwrap(),
+            num_quic_endpoints: NonZero::new(DEFAULT_QUIC_ENDPOINTS)
+                .expect("Number of QUIC endpoints can not be zero"),
+            vortexor_receiver_addr: None,
+        };
+        let mut node = Self::new_with_external_ip(pubkey, config);
+        let rpc_ports: [u16; 2] = find_available_ports_in_range(bind_ip_addr, port_range).unwrap();
+        let rpc_addr = SocketAddr::new(bind_ip_addr, rpc_ports[0]);
+        let rpc_pubsub_addr = SocketAddr::new(bind_ip_addr, rpc_ports[1]);
+        node.info.set_rpc(rpc_addr).unwrap();
+        node.info.set_rpc_pubsub(rpc_pubsub_addr).unwrap();
+        node
+    }
+
+    pub fn new_with_external_ip(pubkey: &Pubkey, config: NodeConfig) -> Node {
+        let NodeConfig {
+            advertised_ip,
+            gossip_port,
+            port_range,
+            bind_ip_addrs,
+            public_tpu_addr,
+            public_tpu_forwards_addr,
+            num_tvu_receive_sockets,
+            num_tvu_retransmit_sockets,
+            num_quic_endpoints,
+            vortexor_receiver_addr,
+        } = config;
+        let bind_ip_addr = bind_ip_addrs.primary();
+
+        let gossip_addr = SocketAddr::new(advertised_ip, gossip_port);
+        let (gossip_port, (gossip, ip_echo)) =
+            bind_gossip_port_in_range(&gossip_addr, port_range, bind_ip_addr);
+
+        let socket_config = SocketConfig::default();
+
+        let (tvu_port, tvu_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config,
+            num_tvu_receive_sockets.get(),
+        )
+        .expect("tvu multi_bind");
+        let (tvu_quic_port, tvu_quic) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("tvu_quic bind");
+
+        let ((tpu_port, tpu_socket), (_tpu_port_quic, tpu_quic)) =
+            bind_two_in_range_with_offset_and_config(
+                bind_ip_addr,
+                port_range,
+                QUIC_PORT_OFFSET,
+                socket_config,
+                socket_config,
+            )
+            .expect("tpu_socket primary bind");
+        let tpu_sockets =
+            bind_more_with_config(tpu_socket, 32, socket_config).expect("tpu_sockets multi_bind");
+
+        let tpu_quic = bind_more_with_config(tpu_quic, num_quic_endpoints.get(), socket_config)
+            .expect("tpu_quic bind");
+
+        let ((tpu_forwards_port, tpu_forwards_socket), (_, tpu_forwards_quic)) =
+            bind_two_in_range_with_offset_and_config(
+                bind_ip_addr,
+                port_range,
+                QUIC_PORT_OFFSET,
+                socket_config,
+                socket_config,
+            )
+            .expect("tpu_forwards primary bind");
+        let tpu_forwards_sockets = bind_more_with_config(tpu_forwards_socket, 8, socket_config)
+            .expect("tpu_forwards multi_bind");
+        let tpu_forwards_quic =
+            bind_more_with_config(tpu_forwards_quic, num_quic_endpoints.get(), socket_config)
+                .expect("tpu_forwards_quic multi_bind");
+
+        let (tpu_vote_port, tpu_vote_sockets) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 1)
+                .expect("tpu_vote multi_bind");
+
+        let (tpu_vote_quic_port, tpu_vote_quic) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("tpu_vote_quic");
+        let tpu_vote_quic =
+            bind_more_with_config(tpu_vote_quic, num_quic_endpoints.get(), socket_config)
+                .expect("tpu_vote_quic multi_bind");
+
+        let (_, retransmit_sockets) = multi_bind_in_range_with_config(
+            bind_ip_addr,
+            port_range,
+            socket_config,
+            num_tvu_retransmit_sockets.get(),
+        )
+        .expect("retransmit multi_bind");
+
+        let (_, repair) = bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            .expect("repair bind");
+        let (_, repair_quic) = bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+            .expect("repair_quic bind");
+
+        let (serve_repair_port, serve_repair) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("serve_repair");
+        let (serve_repair_quic_port, serve_repair_quic) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("serve_repair_quic");
+
+        let (_, broadcast) =
+            multi_bind_in_range_with_config(bind_ip_addr, port_range, socket_config, 4)
+                .expect("broadcast multi_bind");
+
+        let (_, ancestor_hashes_requests) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("ancestor_hashes_requests bind");
+        let (_, ancestor_hashes_requests_quic) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
+                .expect("ancestor_hashes_requests QUIC bind should succeed");
+
+        // These are client sockets, so the port is set to be 0 because it must be ephimeral.
+        let tpu_vote_forwarding_client =
+            bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let tpu_transaction_forwarding_client =
+            bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let rpc_sts_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+
+        let mut info = ContactInfo::new(
+            *pubkey,
+            timestamp(), // wallclock
+            0u16,        // shred_version
+        );
+        use contact_info::Protocol::{QUIC, UDP};
+        info.set_gossip((advertised_ip, gossip_port)).unwrap();
+        info.set_tvu(UDP, (advertised_ip, tvu_port)).unwrap();
+        info.set_tvu(QUIC, (advertised_ip, tvu_quic_port)).unwrap();
+        info.set_tpu(public_tpu_addr.unwrap_or_else(|| SocketAddr::new(advertised_ip, tpu_port)))
+            .unwrap();
+        info.set_tpu_forwards(
+            public_tpu_forwards_addr
+                .unwrap_or_else(|| SocketAddr::new(advertised_ip, tpu_forwards_port)),
+        )
+        .unwrap();
+        info.set_tpu_vote(UDP, (advertised_ip, tpu_vote_port))
+            .unwrap();
+        info.set_tpu_vote(QUIC, (advertised_ip, tpu_vote_quic_port))
+            .unwrap();
+        info.set_serve_repair(UDP, (advertised_ip, serve_repair_port))
+            .unwrap();
+        info.set_serve_repair(QUIC, (advertised_ip, serve_repair_quic_port))
+            .unwrap();
+
+        let vortexor_receivers = vortexor_receiver_addr.map(|vortexor_receiver_addr| {
+            multi_bind_in_range_with_config(
+                vortexor_receiver_addr.ip(),
+                (
+                    vortexor_receiver_addr.port(),
+                    vortexor_receiver_addr.port() + 1,
+                ),
+                socket_config,
+                32,
+            )
+            .unwrap_or_else(|_| {
+                panic!("Could not bind to the set vortexor_receiver_addr {vortexor_receiver_addr}")
+            })
+            .1
+        });
+
+        info!("vortexor_receivers is {vortexor_receivers:?}");
+        trace!("new ContactInfo: {info:?}");
+        let sockets = Sockets {
+            gossip: AtomicUdpSocket::new(gossip),
+            tvu: tvu_sockets,
+            tvu_quic,
+            tpu: tpu_sockets,
+            tpu_forwards: tpu_forwards_sockets,
+            tpu_vote: tpu_vote_sockets,
+            broadcast,
+            repair,
+            repair_quic,
+            retransmit_sockets,
+            serve_repair,
+            serve_repair_quic,
+            ip_echo: Some(ip_echo),
+            ancestor_hashes_requests,
+            ancestor_hashes_requests_quic,
+            tpu_quic,
+            tpu_forwards_quic,
+            tpu_vote_quic,
+            tpu_vote_forwarding_client,
+            quic_vote_client,
+            tpu_transaction_forwarding_client,
+            rpc_sts_client,
+            vortexor_receivers,
+        };
+        info!("Bound all network sockets as follows: {:#?}", &sockets);
+        Node { info, sockets }
+    }
+}

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -26,7 +26,7 @@ impl PushActiveSet {
     #[cfg(debug_assertions)]
     const MIN_NUM_BLOOM_ITEMS: usize = 512;
     #[cfg(not(debug_assertions))]
-    const MIN_NUM_BLOOM_ITEMS: usize = crate::cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY;
+    const MIN_NUM_BLOOM_ITEMS: usize = crate::node::CRDS_UNIQUE_PUBKEY_CAPACITY;
 
     pub(crate) fn get_nodes<'a>(
         &'a self,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -5,10 +5,11 @@ extern crate log;
 use {
     rayon::iter::*,
     solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
+        cluster_info::ClusterInfo,
         contact_info::{ContactInfo, Protocol},
         crds::Cursor,
         gossip_service::GossipService,
+        node::Node,
     },
     solana_hash::Hash,
     solana_keypair::Keypair,

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -1,7 +1,7 @@
 use {
     solana_commitment_config::CommitmentConfig,
     solana_core::validator::{Validator, ValidatorConfig},
-    solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
+    solana_gossip::{node::Node, contact_info::ContactInfo},
     solana_keypair::Keypair,
     solana_ledger::shred::Shred,
     solana_pubkey::Pubkey,

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -13,7 +13,7 @@ use {
     solana_entry::entry::{self, Entry, EntrySlice},
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_gossip::{
-        cluster_info::{self, ClusterInfo},
+        cluster_info::{push_messages_to_peer_for_tests, ClusterInfo},
         contact_info::ContactInfo,
         crds::Cursor,
         crds_data::{self, CrdsData},
@@ -665,7 +665,7 @@ pub fn submit_vote_to_cluster_gossip(
         None,
     );
 
-    cluster_info::push_messages_to_peer_for_tests(
+    push_messages_to_peer_for_tests(
         vec![CrdsValue::new(
             CrdsData::Vote(
                 0,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -19,7 +19,7 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_genesis_config::{ClusterType, GenesisConfig},
     solana_gossip::{
-        cluster_info::Node,
+        node::Node,
         contact_info::{ContactInfo, Protocol},
         gossip_service::{discover, discover_validators},
     },

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -25,7 +25,8 @@ use {
         geyser_plugin_manager::GeyserPluginManager, GeyserPluginManagerRequest,
     },
     solana_gossip::{
-        cluster_info::{BindIpAddrs, ClusterInfo, Node, NodeConfig},
+        cluster_info::ClusterInfo,
+        node::{BindIpAddrs, Node, NodeConfig},
         contact_info::Protocol,
     },
     solana_inflation::Inflation,

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -3,7 +3,8 @@ use {
     rand::{thread_rng, Rng},
     solana_entry::entry::Entry,
     solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
+        cluster_info::ClusterInfo,
+        node::Node,
         contact_info::ContactInfo,
     },
     solana_hash::Hash,

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -584,7 +584,7 @@ pub mod test {
         crossbeam_channel::unbounded,
         rand::Rng,
         solana_entry::entry::create_ticks,
-        solana_gossip::cluster_info::{ClusterInfo, Node},
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -497,7 +497,7 @@ mod test {
         rand::Rng,
         solana_entry::entry::create_ticks,
         solana_genesis_config::GenesisConfig,
-        solana_gossip::cluster_info::{ClusterInfo, Node},
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -12,7 +12,7 @@ use {
     rand::Rng,
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
     solana_clock::Slot,
-    solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
+    solana_gossip::{contact_info::Protocol, cluster_info::ClusterInfo},
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
         shred::{self, ShredFlags, ShredId, ShredType},

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -954,7 +954,7 @@ mod tests {
             consensus::tower_storage::NullTowerStorage,
             validator::{Validator, ValidatorConfig, ValidatorTpuConfig},
         },
-        solana_gossip::cluster_info::{ClusterInfo, Node},
+        solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_ledger::{
             create_new_tmp_ledger,
             genesis_utils::{

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -9,7 +9,8 @@ use {
     solana_download_utils::{download_snapshot_archive, DownloadProgressRecord},
     solana_genesis_utils::download_then_check_genesis_hash,
     solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
+        cluster_info::ClusterInfo,
+        node::Node,
         contact_info::{ContactInfo, Protocol},
         crds_data,
         gossip_service::GossipService,

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -4,6 +4,10 @@ use {
     clap::{value_t_or_exit, Arg, ArgMatches},
     solana_accounts_db::{accounts_db, accounts_index},
     solana_clap_utils::{hidden_unless_forced, input_validators::is_within_range},
+    solana_gossip::cluster_info::{
+        DEFAULT_NUM_TVU_RECEIVE_SOCKETS, DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS,
+        MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS,
+    },
     solana_rayon_threadlimit::get_thread_count,
     std::{num::NonZeroUsize, ops::RangeInclusive},
 };
@@ -368,10 +372,10 @@ impl ThreadArg for TvuReceiveThreadsArg {
         "Number of threads (and sockets) to use for receiving shreds on the TVU port";
 
     fn default() -> usize {
-        solana_gossip::cluster_info::DEFAULT_NUM_TVU_RECEIVE_SOCKETS.get()
+        DEFAULT_NUM_TVU_RECEIVE_SOCKETS.get()
     }
     fn min() -> usize {
-        solana_gossip::cluster_info::MINIMUM_NUM_TVU_RECEIVE_SOCKETS.get()
+        1
     }
 }
 
@@ -382,11 +386,11 @@ impl ThreadArg for TvuRetransmitThreadsArg {
     const HELP: &'static str = "Number of threads (and sockets) to use for retransmitting shreds";
 
     fn default() -> usize {
-        solana_gossip::cluster_info::DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS.get()
+        DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS.get()
     }
 
     fn min() -> usize {
-        solana_gossip::cluster_info::MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS.get()
+        MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS.get()
     }
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -40,7 +40,8 @@ use {
         },
     },
     solana_gossip::{
-        cluster_info::{BindIpAddrs, Node, NodeConfig, DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS},
+        cluster_info::DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,
+        node::{BindIpAddrs, Node, NodeConfig},
         contact_info::ContactInfo,
     },
     solana_hash::Hash,


### PR DESCRIPTION

### Summary of Changes

* **New module `gossip/src/node.rs`**

  * Moves `Node`, `NodeConfig`, `BindIpAddrs`, `Sockets`, and related helpers out of `cluster_info.rs`.
  * Exposes the same public API, so no functional change.
* **Mass import rewrite** across \~50 crates/tests to use `solana_gossip::node::{ClusterInfo, Node}` (or `node::…`) instead of `cluster_info::{ClusterInfo, Node}`.
* Re‑exported constants (e.g. `DEFAULT_NUM_TVU_RECEIVE_SOCKETS`) from the new module to preserve public surface.
* **Ledger clean‑up:** split `Blockstore::should_insert_data_shred` into

  * `should_insert_data_shred_pure` (read‑only validation)
  * `should_insert_data_shred` (validation + duplicate‑tracking)
    improving naming clarity (ref issue #5923).
* Minor doc‑comments, dead‑code deletions, and typo fixes.

---

Fixes #5923 and #5824
