### PR TITLE
Remove rent fields

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -867,13 +867,11 @@ impl AccountsScanner {
         S: SerializeSeq,
     {
         let mut total_accounts_stats = self.total_accounts_stats.borrow_mut();
-        let rent_collector = self.bank.rent_collector();
-
         let scan_func = |account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
             if let Some((pubkey, account, _slot)) =
                 account_tuple.filter(|(_, account, _)| self.should_process_account(account))
             {
-                total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
+                total_accounts_stats.accumulate_account(&account);
                 self.maybe_output_account(seq_serializer, pubkey, &account);
             }
         };
@@ -888,7 +886,7 @@ impl AccountsScanner {
                     .get_account_modified_slot_with_fixed_root(pubkey)
                     .filter(|(account, _)| self.should_process_account(account))
                 {
-                    total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
+                    total_accounts_stats.accumulate_account(&account);
                     self.maybe_output_account(seq_serializer, pubkey, &account);
                 }
             }),
@@ -899,7 +897,7 @@ impl AccountsScanner {
                 .iter()
                 .filter(|(_, account)| self.should_process_account(account))
                 .for_each(|(pubkey, account)| {
-                    total_accounts_stats.accumulate_account(pubkey, account, rent_collector);
+                    total_accounts_stats.accumulate_account(account);
                     self.maybe_output_account(seq_serializer, pubkey, account);
                 }),
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5964,24 +5964,10 @@ pub struct TotalAccountsStats {
     pub num_executable_accounts: usize,
     /// Total data size of executable accounts
     pub executable_data_len: usize,
-
-    /// Total number of rent exempt accounts
-    pub num_rent_exempt_accounts: usize,
-    /// Total number of rent paying accounts
-    pub num_rent_paying_accounts: usize,
-    /// Total number of rent paying accounts without data
-    pub num_rent_paying_accounts_without_data: usize,
-    /// Total amount of lamports in rent paying accounts
-    pub lamports_in_rent_paying_accounts: u64,
 }
 
 impl TotalAccountsStats {
-    pub fn accumulate_account(
-        &mut self,
-        address: &Pubkey,
-        account: &AccountSharedData,
-        rent_collector: &RentCollector,
-    ) {
+    pub fn accumulate_account(&mut self, account: &AccountSharedData) {
         let data_len = account.data().len();
         self.num_accounts += 1;
         self.data_len += data_len;
@@ -5989,24 +5975,6 @@ impl TotalAccountsStats {
         if account.executable() {
             self.num_executable_accounts += 1;
             self.executable_data_len += data_len;
-        }
-
-        if !rent_collector.should_collect_rent(address, account.executable())
-            || rent_collector
-                .get_rent_due(
-                    account.lamports(),
-                    account.data().len(),
-                    account.rent_epoch(),
-                )
-                .is_exempt()
-        {
-            self.num_rent_exempt_accounts += 1;
-        } else {
-            self.num_rent_paying_accounts += 1;
-            self.lamports_in_rent_paying_accounts += account.lamports();
-            if data_len == 0 {
-                self.num_rent_paying_accounts_without_data += 1;
-            }
         }
     }
 }


### PR DESCRIPTION
#### Problem

Rent is disabled. All rent related fields can be removed from TotalAccountsStat.


#### Summary of Changes

Remove rent fields from TotalAccountsStat.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
