### PR TITLE
Add SIGTERM handler to agave-validator

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -36,6 +36,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+signal-hook = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1126,14 +1126,17 @@ pub fn execute(
     {
         let mut signals = Signals::new([SIGTERM])?;
 
-        std::thread::spawn(move || {
+        std::thread::Builder::new()
+            .name("solSigTerm".into())
+            .spawn(move || {
             for signal in signals.forever() {
                 if signal == SIGTERM {
-                    warn!("Validator received SIGTERM. Initiating graceful exit.");
+                    info!("Validator received SIGTERM. Initiating graceful exit.");
                     validator_config.validator_exit.write().unwrap().exit();
                 }
             }
-        });
+        })
+        .unwrap();
     }
 
     info!("Validator initialized");

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_os = "windows"))]
+use signal_hook::{consts::SIGTERM, iterator::Signals};
 use {
     crate::{
         admin_rpc_service::{self, load_staked_nodes_overrides, StakedNodesOverrides},
@@ -1119,6 +1121,21 @@ pub fn execute(
     if let Some(filename) = init_complete_file {
         File::create(filename).map_err(|err| format!("unable to create {filename}: {err}"))?;
     }
+
+    #[cfg(not(windows))]
+    {
+        let mut signals = Signals::new([SIGTERM])?;
+
+        std::thread::spawn(move || {
+            for signal in signals.forever() {
+                if signal == SIGTERM {
+                    warn!("Validator received SIGTERM. Initiating graceful exit.");
+                    validator_config.validator_exit.write().unwrap().exit();
+                }
+            }
+        });
+    }
+
     info!("Validator initialized");
     validator.join();
     info!("Validator exiting..");


### PR DESCRIPTION
#### Problem
Many operators use systemd to run Agave. A very common restart sequence is:
`agave-validator exit && systemctl restart`

The `exit` command here returns after sending an exit request to the validator, but it doesn't wait for the validator to finish exiting†. Thus `systemctl restart` runs before the validator has shutdown. `systemctl restart` sends `SIGTERM` immediately. If the process is still running after `TimeoutStopSec` seconds it sends `SIGKILL`.

the `SIGTERM` often leads to ungraceful exits. This is suboptimal, but has recently become particularly problematic in the specific case of downgrading from v2.3 to v2.2 (see discussions in Discord [#validator-support](https://discord.com/channels/428295358100013066/560174212967432193/1397600439356362794) and [#releng](https://discord.com/channels/428295358100013066/910937142182682656/1397661826656895016)).

† a `--wait-for-exit` flag has been added in PR #6780 but that change is not in v2.2.

#### Summary of Changes
Add a `SIGTERM` handler that initiates a graceful shutdown.


#### Testing
on `shared-dev8` I tested downgrading this PR branch to v2.2.20:
* Get `agave-validator` running against testnet from `fa6b70d6`
* `agave-install init v2.2.20` to switch my local pathed version to v2.2.20
* `agave-validator exit && ./restart`
Here are some select lines from `~/logs/agave-validator.log`. Note that `SIGTERM` is received 4.6s before the validator ultimately exits gracefully
```
[2025-07-25T16:17:59.873354435Z INFO  agave_validator::commands::run::execute] agave-validator 3.0.0 (src:fa6b70d6; feat:1632274241, client:Agave)
[2025-07-25T16:29:37.064021310Z INFO  agave_validator::admin_rpc_service] validator exit requested
[2025-07-25T16:29:37.139315658Z INFO  solana_core::snapshot_packager_service] Received exit request, tearing down...
[2025-07-25T16:29:37.177872175Z WARN  agave_validator::commands::run::execute] Validator received SIGTERM. Initiating graceful exit.
[2025-07-25T16:29:41.798534760Z INFO  agave_validator::commands::run::execute] Validator exiting..
[2025-07-25T16:29:42.449708304Z INFO  agave_validator] agave-validator 2.2.20 (src:dabc99a5; feat:3073396398, client:Agave)
```


(And the full exit log output)
```
[2025-07-25T16:17:59.873354435Z INFO  agave_validator::commands::run::execute] agave-validator 3.0.0 (src:fa6b70d6; feat:1632274241, client:Agave)
[2025-07-25T16:17:59.873681628Z INFO  agave_validator::commands::run::execute] Starting validator with: ArgsOs {
<snip>
[2025-07-25T16:29:36.697817829Z INFO  solana_core::replay_stage] new root 347538076
[2025-07-25T16:29:36.697827918Z INFO  solana_core::replay_stage] vote bank: Some((347538107, SameFork)) reset bank: 347538107
[2025-07-25T16:29:36.697866402Z INFO  solana_poh::poh_recorder] reset poh from: Euc1E5Gnw2qzLqDGW6jUvPTfS63MvMudmUzeXDsJszx6,22242438922,347538106 to: Euc1E5Gnw2qzLqDGW6jUvPTfS63MvMudmUzeXDsJszx6,347538107
[2025-07-25T16:29:36.697871000Z INFO  solana_core::replay_stage] HdACVc2PNdfL6bCEg11kAjDNVAVogomvcKSXJwQAFZDD reset PoH to tick 22242438912 (within slot 347538107). I am not in the leader schedule yet
[2025-07-25T16:29:37.064021310Z INFO  agave_validator::admin_rpc_service] validator exit requested
[2025-07-25T16:29:37.064103697Z INFO  agave_validator::admin_rpc_service] Wait for these services to complete: ["SnapshotPackagerService"]
[2025-07-25T16:29:37.064137431Z INFO  solana_rpc::rpc_pubsub_service] PubSubService has stopped
[2025-07-25T16:29:37.109635689Z INFO  solana_runtime::accounts_background_service] AccountsBackgroundService has stopped
[2025-07-25T16:29:37.139123522Z INFO  solana_core::completed_data_sets_service] CompletedDataSetsService has stopped
[2025-07-25T16:29:37.139315658Z INFO  solana_core::snapshot_packager_service] Received exit request, tearing down...
[2025-07-25T16:29:37.139332590Z INFO  solana_core::snapshot_packager_service] Flushing account storages...
[2025-07-25T16:29:37.147205997Z INFO  solana_core::snapshot_packager_service] Flushing account storages... Done in 7.867606ms
[2025-07-25T16:29:37.147222147Z INFO  solana_core::snapshot_packager_service] Hard linking account storages...
[2025-07-25T16:29:37.177872175Z WARN  agave_validator::commands::run::execute] Validator received SIGTERM. Initiating graceful exit.
[2025-07-25T16:29:37.405433519Z INFO  solana_rpc::rpc_subscriptions] RPC Notification thread - shutting down
[2025-07-25T16:29:37.405751295Z INFO  solana_rpc::rpc_subscriptions] RPC Notification thread - shut down.
[2025-07-25T16:29:37.423506165Z INFO  solana_ledger::blockstore_cleanup_service] BlockstoreCleanupService has stopped
[2025-07-25T16:29:37.980010792Z INFO  solana_ledger::blockstore_metric_report_service] BlockstoreMetricReportService has stopped
[2025-07-25T16:29:38.064175698Z INFO  agave_validator::admin_rpc_service] SnapshotPackagerService's exit backpressure flag is raised
[2025-07-25T16:29:38.152112863Z INFO  solana_core::snapshot_packager_service] Hard linking account storages... Done in 1.004886117s
[2025-07-25T16:29:38.152173749Z INFO  solana_core::snapshot_packager_service] Teardown completed in 1.012843012s.
[2025-07-25T16:29:38.152188016Z INFO  solana_core::snapshot_packager_service] SnapshotPackagerService has stopped
[2025-07-25T16:29:38.492104103Z INFO  solana_unified_scheduler_pool] Scheduler pool cleaner: dropped 0 idle inners, 0 trashed inners, triggered 23 timeout listeners
[2025-07-25T16:29:39.064243139Z INFO  agave_validator::admin_rpc_service] All services have completed
[2025-07-25T16:29:39.353489061Z INFO  solana_runtime::bank_forks] BankForks::drop(): started...
[2025-07-25T16:29:39.353583371Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.355417236Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.359830828Z INFO  solana_unified_scheduler_pool] SchedulerPool::uninstalled_from_bank_forks(): started...
[2025-07-25T16:29:39.359914608Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364548621Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364578497Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364583828Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364588607Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364600249Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364604407Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364608194Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364612061Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364616269Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364622652Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364629394Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364633011Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364636548Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364640736Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364644483Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364648280Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364651687Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364656817Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364660484Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364679580Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364685852Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364693016Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364698136Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364707273Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364710669Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364718234Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364725548Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364731509Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364735717Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364741769Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364748542Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:39.364752840Z INFO  solana_runtime::accounts_background_service] bank DropCallback signal queue disconnected.
[2025-07-25T16:29:40.263075500Z INFO  solana_accounts_db::read_only_accounts_cache] AccountsReadCacheEvictor has stopped
[2025-07-25T16:29:41.526560948Z INFO  solana_unified_scheduler_pool] cleaner_main_loop: ...finished
[2025-07-25T16:29:41.526675336Z INFO  solana_unified_scheduler_pool] SchedulerPool::uninstalled_from_bank_forks(): ...finished
[2025-07-25T16:29:41.527937211Z INFO  solana_runtime::bank_forks] BankForks::drop(): ...finished
[2025-07-25T16:29:41.798534760Z INFO  agave_validator::commands::run::execute] Validator exiting..
[2025-07-25T16:29:42.449708304Z INFO  agave_validator] agave-validator 2.2.20 (src:dabc99a5; feat:3073396398, client:Agave)
[2025-07-25T16:29:42.449774199Z INFO  agave_validator] Starting validator with: ArgsOs {
```