### PR TITLE
Removes log_accounts param from AccountsDb::purge_slots_from_cache_and_store()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4828,19 +4828,10 @@ impl AccountsDb {
         &self,
         removed_slots: impl Iterator<Item = &'a Slot> + Clone,
         purge_stats: &PurgeStats,
-        log_accounts: bool,
     ) {
         let mut remove_cache_elapsed_across_slots = 0;
         let mut num_cached_slots_removed = 0;
         let mut total_removed_cached_bytes = 0;
-        if log_accounts {
-            if let Some(min) = removed_slots.clone().min() {
-                info!(
-                    "purge_slots_from_cache_and_store: {:?}",
-                    self.get_pubkey_hash_for_slot(*min).0
-                );
-            }
-        }
         for remove_slot in removed_slots {
             // This function is only currently safe with respect to `flush_slot_cache()` because
             // both functions run serially in AccountsBackgroundService.
@@ -5045,7 +5036,7 @@ impl AccountsDb {
         self.external_purge_slots_stats
             .safety_checks_elapsed
             .fetch_add(safety_checks_elapsed.as_us(), Ordering::Relaxed);
-        self.purge_slots_from_cache_and_store(non_roots, &self.external_purge_slots_stats, false);
+        self.purge_slots_from_cache_and_store(non_roots, &self.external_purge_slots_stats);
         self.external_purge_slots_stats
             .report("external_purge_slots_stats", Some(1000));
     }
@@ -5127,7 +5118,6 @@ impl AccountsDb {
         self.purge_slots_from_cache_and_store(
             remove_slots.iter().map(|(slot, _)| slot),
             &remove_unrooted_purge_stats,
-            true,
         );
         remove_unrooted_purge_stats.report("remove_unrooted_slots_purge_slots_stats", None);
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -353,7 +353,7 @@ impl<'a> SnapshotMinimizer<'a> {
     fn purge_dead_slots(&self, dead_slots: Vec<Slot>) {
         let stats = PurgeStats::default();
         self.accounts_db()
-            .purge_slots_from_cache_and_store(dead_slots.iter(), &stats, false);
+            .purge_slots_from_cache_and_store(dead_slots.iter(), &stats);
     }
 
     /// Convenience function for getting accounts_db


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used, and we want to remove all remnants of it. There are a family of AccountsDb functions that return the modified accounts for a given slot. Some of these functions return a merkle-based account hash. These should now be removed.


#### Summary of Changes

For this PR, AccountsDb::purge_slots_from_cache_and_store() takes a parameter, `log_accounts`, that conditionally logs out all the accounts from the oldest removed slot. We don't need to log these accounts anymore[^1], so we can not call AccountsDb::get_pubkey_hash_for_slot() (which will allow us to remove get_pubkey_hash_for_slot() next).

[^1]: The logging of the accounts was added in https://github.com/solana-labs/solana/pull/24948 to help identify the underlying issue reported in https://github.com/solana-labs/solana/issues/24710. That issue was marked fixed/resolved/closed, so logging accounts is no longer necessary. We could always re-add later, if needed. We also have the BankHashDetails file now, which I believe contains all this information (and more).