### PR TITLE
Refactor - CPI `check_aligned` flag

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -338,7 +338,6 @@ trait SyscallInvokeSigned {
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &InvokeContext,
         check_aligned: bool,
     ) -> Result<Vec<Pubkey>, Error>;
 }
@@ -456,7 +455,6 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &InvokeContext,
         check_aligned: bool,
     ) -> Result<Vec<Pubkey>, Error> {
         let mut signers = Vec::new();
@@ -666,7 +664,6 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &InvokeContext,
         check_aligned: bool,
     ) -> Result<Vec<Pubkey>, Error> {
         if signers_seeds_len > 0 {
@@ -1022,7 +1019,6 @@ fn cpi_common<S: SyscallInvokeSigned>(
         signers_seeds_addr,
         signers_seeds_len,
         memory_mapping,
-        invoke_context,
         check_aligned,
     )?;
     let is_loader_deprecated = *instruction_context
@@ -1441,7 +1437,6 @@ mod tests {
             vm_addr,
             1,
             &memory_mapping,
-            &invoke_context,
             true, // check_aligned
         )
         .unwrap();

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -1080,9 +1080,9 @@ fn cpi_common<S: SyscallInvokeSigned>(
             if translate_account.update_caller_account_region {
                 update_caller_account_region(
                     memory_mapping,
+                    check_aligned,
                     &translate_account.caller_account,
                     &mut callee_account,
-                    is_loader_deprecated,
                 )?;
             }
         }
@@ -1156,11 +1156,12 @@ fn update_callee_account(
 
 fn update_caller_account_region(
     memory_mapping: &mut MemoryMapping,
+    check_aligned: bool,
     caller_account: &CallerAccount,
     callee_account: &mut BorrowedAccount<'_>,
-    is_loader_deprecated: bool,
 ) -> Result<(), Error> {
-    let address_space_reserved_for_account = if is_loader_deprecated {
+    let is_caller_loader_deprecated = !check_aligned;
+    let address_space_reserved_for_account = if is_caller_loader_deprecated {
         caller_account.original_data_len
     } else {
         caller_account


### PR DESCRIPTION
#### Problem

Calling `InvokeContext::get_check_aligned()` hundreds of times per CPI call is kinda expensive because every single one is a `Pubkey` compare. It would be better to only calculate it once and then pass it as a flag. Also, the `is_loader_deprecated` flag is redundant and the two can be merged.

#### Summary of Changes

- Adds a `check_aligned` parameter everywhere in CPI.
- Removes the `invoke_context` parameter where it is unused.
- Replaces the parameter `is_loader_deprecated` with `check_aligned` in `update_caller_account_region()` and `update_callee_account()`.
