### PR TITLE
Reject scheduled work from previous slots

### DIFF
--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -225,6 +225,7 @@ fn timing_scheduler<T: ReceiveAndBuffer, S: Scheduler<T::Transaction>>(
                             black_box(&mut container),
                             bench_env.filter_1,
                             bench_env.filter_2,
+                            1, // dummy slot
                         )
                         .unwrap();
                 }

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -894,6 +894,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
+            slot: 0,
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -943,6 +944,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
+            slot: bank.slot(),
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -995,6 +997,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid,
                 ids: vec![id1, id2],
                 transactions: txs,
@@ -1065,6 +1068,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid1,
                 ids: vec![id1],
                 transactions: txs1,
@@ -1074,6 +1078,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid2,
                 ids: vec![id2],
                 transactions: txs2,
@@ -1187,6 +1192,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: TransactionBatchId::new(1),
                 ids: vec![0, 1, 2, 3, 4, 5],
                 transactions: txs,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -37,6 +37,7 @@ impl MaxAge {
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork<Tx> {
+    pub slot: Slot,
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,
     pub transactions: Vec<Tx>,

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -5,6 +5,7 @@ use {
         scheduler_common::SchedulingCommon, scheduler_error::SchedulerError,
         transaction_state::TransactionState, transaction_state_container::StateContainer,
     },
+    solana_clock::Slot,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::num::Saturating,
 };
@@ -19,6 +20,7 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         container: &mut S,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
+        slot: Slot,
     ) -> Result<SchedulingSummary, SchedulerError>;
 
     /// Receive completed batches of transactions without blocking.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -150,7 +150,8 @@ where
                             MAX_PROCESSING_AGE,
                         )
                     },
-                    |_| PreLockFilterAction::AttemptToSchedule // no pre-lock filter for now
+                    |_| PreLockFilterAction::AttemptToSchedule, // no pre-lock filter for now
+                    bank_start.working_bank.slot(),
                 )?);
 
                 self.count_metrics.update(|count_metrics| {
@@ -532,6 +533,7 @@ mod tests {
         finished_consume_work_sender
             .send(FinishedConsumeWork {
                 work: ConsumeWork {
+                    slot: 0,
                     batch_id: TransactionBatchId::new(0),
                     ids: vec![],
                     transactions: vec![],


### PR DESCRIPTION
#### Problem
- Our queues to workers carry-over work between slots
- This is not desirable since it may lead to us packing low-value txs at the beginning of our next slot

#### Summary of Changes
- Reject work from previous slots in workers, send back as retryable

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
