### PR TITLE
shredder: allow creating shreds with raw bytes

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -70,7 +70,7 @@ pub struct ShredCode {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) enum Shred {
+pub(crate) enum Shred {
     ShredCode(ShredCode),
     ShredData(ShredData),
 }
@@ -1019,7 +1019,7 @@ fn make_shreds_code_header_only(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn make_shreds_from_data(
+pub(crate) fn make_shreds_from_data(
     thread_pool: &ThreadPool,
     keypair: &Keypair,
     // The Merkle root of the previous erasure batch if chained.


### PR DESCRIPTION
#### Problem

- Legacy shreds must go #5982 
- API of merkle shreds did not allow to create shreds with invalid payloads


#### Summary of Changes

- remove legacy shreds
- decouple serialization from shred-making into separate functions