### PR TITLE
Repair: remove most calls to new_from_data

### DIFF
--- a/core/src/repair/outstanding_requests.rs
+++ b/core/src/repair/outstanding_requests.rs
@@ -87,7 +87,9 @@ pub(crate) mod tests {
     use {
         super::*,
         crate::repair::serve_repair::ShredRepairType,
-        solana_ledger::shred::{Shred, ShredFlags},
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
         solana_time_utils::timestamp,
     };
 
@@ -109,7 +111,21 @@ pub(crate) mod tests {
         let repair_type = ShredRepairType::Orphan(9);
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
-        let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
+
+        let shredder = Shredder::new(0, 0, 0, 0).unwrap();
+        let keypair = Keypair::new();
+        let reed_solomon_cache = ReedSolomonCache::default();
+        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &keypair,
+            &[],
+            true,
+            Some(Hash::default()),
+            0,
+            0,
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
+        let shred = shreds.pop().unwrap();
 
         let expire_timestamp = outstanding_requests
             .requests
@@ -129,7 +145,20 @@ pub(crate) mod tests {
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
 
-        let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
+        let shredder = Shredder::new(0, 0, 0, 0).unwrap();
+        let keypair = Keypair::new();
+        let reed_solomon_cache = ReedSolomonCache::default();
+        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &keypair,
+            &[],
+            true,
+            Some(Hash::default()),
+            0,
+            0,
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
+        let shred = shreds.pop().unwrap();
         let mut expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)

--- a/core/src/repair/outstanding_requests.rs
+++ b/core/src/repair/outstanding_requests.rs
@@ -111,21 +111,8 @@ pub(crate) mod tests {
         let repair_type = ShredRepairType::Orphan(9);
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
-
-        let shredder = Shredder::new(0, 0, 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
-        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
-            &keypair,
-            &[],
-            true,
-            Some(Hash::default()),
-            0,
-            0,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
-        let shred = shreds.pop().unwrap();
+        let shred = Shredder::single_shred_for_tests(0, &keypair);
 
         let expire_timestamp = outstanding_requests
             .requests
@@ -144,21 +131,8 @@ pub(crate) mod tests {
         let repair_type = ShredRepairType::Orphan(9);
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
-
-        let shredder = Shredder::new(0, 0, 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
-        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
-            &keypair,
-            &[],
-            true,
-            Some(Hash::default()),
-            0,
-            0,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
-        let shred = shreds.pop().unwrap();
+        let shred = Shredder::single_shred_for_tests(0, &keypair);
         let mut expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)

--- a/core/src/repair/outstanding_requests.rs
+++ b/core/src/repair/outstanding_requests.rs
@@ -85,12 +85,8 @@ pub struct RequestStatus<T> {
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        super::*,
-        crate::repair::serve_repair::ShredRepairType,
-        solana_hash::Hash,
-        solana_keypair::Keypair,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
-        solana_time_utils::timestamp,
+        super::*, crate::repair::serve_repair::ShredRepairType, solana_keypair::Keypair,
+        solana_ledger::shred::Shredder, solana_time_utils::timestamp,
     };
 
     #[test]

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -64,20 +64,8 @@ mod test {
     fn run_test_sigverify_shred_cpu_repair(slot: Slot) {
         solana_logger::setup();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
-        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
-            &keypair,
-            &[],
-            true,
-            Some(Hash::default()),
-            0,
-            0,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
-        let shred = shreds.pop().unwrap();
+        let shred = Shredder::single_shred_for_tests(slot, &keypair);
 
         trace!("signature {}", shred.signature());
         let nonce = 9;

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -46,10 +46,9 @@ pub fn repair_response_packet_from_bytes(
 mod test {
     use {
         super::*,
-        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
-            shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+            shred::Shredder,
             sigverify_shreds::{verify_shred_cpu, LruCache},
         },
         solana_packet::PacketFlags,

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -287,24 +287,19 @@ pub mod test {
 
         let completed_shreds: Vec<Shred> = [0, 2, 4, 6]
             .iter()
-            .map(|slot| {
+            .flat_map(|slot| {
                 let shredder = Shredder::new(*slot, slot.saturating_sub(1), 0, 42).unwrap();
-                dbg!(last_shred);
-                let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+                let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
                     &keypair,
                     &[],
                     true,
                     Some(Hash::default()),
-                    0,
-                    0,
+                    last_shred as u32,
+                    last_shred as u32,
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );
-                let shred = shreds.pop().unwrap();
-                assert!(shred.last_in_slot());
-                dbg!(shred.id());
-                assert!(shred.sanitize().is_ok());
-                shred
+                shreds
             })
             .collect();
         blockstore

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -142,9 +142,10 @@ pub mod test {
         super::*,
         crate::repair::repair_service::sleep_shred_deferment_period,
         solana_hash::Hash,
+        solana_keypair::Keypair,
         solana_ledger::{
             get_tmp_ledger_path,
-            shred::{Shred, ShredFlags},
+            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
         solana_runtime::bank_utils,
         trees::tr,
@@ -281,20 +282,27 @@ pub mod test {
         repairs = vec![];
         outstanding_repairs = HashMap::new();
         slot_meta_cache = HashMap::default();
+        let keypair = Keypair::new();
+        let reed_solomon_cache = ReedSolomonCache::default();
+
         let completed_shreds: Vec<Shred> = [0, 2, 4, 6]
             .iter()
             .map(|slot| {
-                let parent_offset = u16::from(*slot != 0);
-                let shred = Shred::new_from_data(
-                    *slot,
-                    last_shred as u32, // index
-                    parent_offset,
-                    &[0u8; 8], // data
-                    ShredFlags::LAST_SHRED_IN_SLOT,
-                    8,                 // reference_tick
-                    0,                 // version
-                    last_shred as u32, // fec_set_index
+                let shredder = Shredder::new(*slot, slot.saturating_sub(1), 0, 42).unwrap();
+                dbg!(last_shred);
+                let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+                    &keypair,
+                    &[],
+                    true,
+                    Some(Hash::default()),
+                    0,
+                    0,
+                    &reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
                 );
+                let shred = shreds.pop().unwrap();
+                assert!(shred.last_in_slot());
+                dbg!(shred.id());
                 assert!(shred.sanitize().is_ok());
                 shred
             })

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1347,8 +1347,7 @@ mod tests {
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path_auto_delete,
             shred::{
-                max_ticks_per_n_shreds, ProcessShredsStats, ReedSolomonCache, Shred, ShredFlags,
-                Shredder,
+                max_ticks_per_n_shreds, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
             },
         },
         solana_perf::packet::{deserialize_from_with_limit, Packet, PacketFlags, PacketRef},
@@ -2277,7 +2276,20 @@ mod tests {
     #[test]
     fn test_verify_shred_response() {
         fn new_test_data_shred(slot: Slot, index: u32) -> Shred {
-            Shred::new_from_data(slot, index, 1, &[], ShredFlags::empty(), 0, 0, 0)
+            let shredder = Shredder::new(slot, slot - 1, 0, 0).unwrap();
+            let keypair = Keypair::new();
+            let reed_solomon_cache = ReedSolomonCache::default();
+            let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+                &keypair,
+                &[],
+                true,
+                Some(Hash::default()),
+                0,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            );
+            shreds.remove(index as usize)
         }
         let repair = ShredRepairType::Orphan(9);
         // Ensure new options are added to this test

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2264,7 +2264,7 @@ mod tests {
     #[test]
     fn test_verify_shred_response() {
         fn new_test_data_shred(slot: Slot, index: u32) -> Shred {
-            let shredder = Shredder::new(slot, slot - 1, 0, 0).unwrap();
+            let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
             let keypair = Keypair::new();
             let reed_solomon_cache = ReedSolomonCache::default();
             let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1370,20 +1370,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_shred_as_ping() {
-        let shredder = Shredder::new(123, 122, 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
-        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
-            &keypair,
-            &[],
-            true,
-            Some(Hash::default()),
-            0,
-            0,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
-        let shred = shreds.pop().unwrap();
+        let shred = Shredder::single_shred_for_tests(123, &keypair);
         let mut pkt = Packet::default();
         shred.copy_to_packet(&mut pkt);
         pkt.meta_mut().size = REPAIR_RESPONSE_SERIALIZED_PING_BYTES;

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -496,6 +496,24 @@ impl Shredder {
             Ok(data)
         }
     }
+    /// Produce a single shred with no payload
+    /// for use in tests and such
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn single_shred_for_tests(slot: Slot, keypair: &Keypair) -> Shred {
+        let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 42).unwrap();
+        let reed_solomon_cache = ReedSolomonCache::default();
+        let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            keypair,
+            &[],
+            true,
+            Some(Hash::default()),
+            0,
+            0,
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
+        shreds.pop().unwrap()
+    }
 }
 
 impl ReedSolomonCache {


### PR DESCRIPTION
#### Problem

-    Repair tests still using legacy shreds
-    Legacy shreds must go  https://github.com/anza-xyz/agave/issues/5982

Summary of Changes

- migrate to merkle shreds

