### PR TITLE
Removes per-account hashes from bank hash details

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -73,9 +73,7 @@ use {
     solana_accounts_db::{
         account_locks::validate_account_locks,
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
-        accounts_db::{
-            AccountStorageEntry, AccountsDb, AccountsDbConfig, DuplicatesLtHash, PubkeyHashAccount,
-        },
+        accounts_db::{AccountStorageEntry, AccountsDb, AccountsDbConfig, DuplicatesLtHash},
         accounts_hash::AccountsLtHash,
         accounts_index::{IndexKey, ScanConfig, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -3704,18 +3702,17 @@ impl Bank {
         }
     }
 
-    /// Returns the accounts, sorted by pubkey, that were part of accounts delta hash calculation
+    /// Returns the accounts, sorted by pubkey, that were part of accounts lt hash calculation
     /// This is used when writing a bank hash details file.
-    pub(crate) fn get_accounts_for_bank_hash_details(&self) -> Vec<PubkeyHashAccount> {
-        let accounts_db = &self.rc.accounts.accounts_db;
-
-        let mut accounts_written_this_slot =
-            accounts_db.get_pubkey_hash_account_for_slot(self.slot());
-
-        // Sort the accounts by pubkey to match the order of the accounts delta hash.
-        // This also makes comparison of files from different nodes deterministic.
-        accounts_written_this_slot.sort_unstable_by_key(|account| account.pubkey);
-        accounts_written_this_slot
+    pub(crate) fn get_accounts_for_bank_hash_details(&self) -> Vec<(Pubkey, AccountSharedData)> {
+        let mut accounts = self
+            .rc
+            .accounts
+            .accounts_db
+            .get_pubkey_account_for_slot(self.slot());
+        // Sort the accounts by pubkey to make diff deterministic.
+        accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        accounts
     }
 
     pub fn cluster_type(&self) -> ClusterType {


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used, and we want to remove all remnants of it. Currently, BankHashDetails uses the merkle-based hash for individual accounts, which is preventing further removal of the merkle-based hash code.


#### Summary of Changes

Remove per-account hashes from BankHashDetails.

The observation is that with the accounts_lt_hash, per-account hashes are *not* needed if the AccountSharedData is present (which it is). We could recalculate the LtHash of each account, but since we're already including the whole AccountSharedData, I don't see what benefit that would have.

> [!IMPORTANT]
> This means comparing the bank hash details files between v3.0-and-newer and v2.3-and-older will be different, as the per-account hashes will be gone. I believe this is OK, as (1) we usually compare bank hash details files between different nodes on the same version, and (2) the AccountSharedData itself is still diff-able.