### PR TITLE
Removes get_pubkey_hash_for_slot() and get_pubkey_hash_account_for_slot()

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11126,15 +11126,12 @@ fn test_register_hard_fork() {
 #[test]
 fn test_last_restart_slot() {
     fn last_restart_slot_dirty(bank: &Bank) -> bool {
-        let (dirty_accounts, _, _) = bank
+        let dirty_accounts = bank
             .rc
             .accounts
             .accounts_db
-            .get_pubkey_hash_for_slot(bank.slot());
-        let dirty_accounts: HashSet<_> = dirty_accounts
-            .into_iter()
-            .map(|(pubkey, _hash)| pubkey)
-            .collect();
+            .get_pubkeys_for_slot(bank.slot());
+        let dirty_accounts: HashSet<_> = dirty_accounts.into_iter().collect();
         dirty_accounts.contains(&sysvar::last_restart_slot::id())
     }
 


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used, and we want to remove all remnants of it. There are a family of AccountsDb functions that return the modified accounts for a given slot. Some of these functions return a merkle-based account hash. These should now be removed.


#### Summary of Changes

Remove 'em.