### PR TITLE
bench-streamer: move to non-overlapping ports

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -3,9 +3,8 @@
 use {
     clap::{crate_description, crate_name, value_t_or_exit, Arg, Command},
     crossbeam_channel::unbounded,
-    solana_net_utils::{
-        bind_to_unspecified,
-        sockets::{multi_bind_in_range_with_config, SocketConfiguration},
+    solana_net_utils::sockets::{
+        bind_to_localhost_unique, multi_bind_in_range_with_config, SocketConfiguration,
     },
     solana_streamer::{
         packet::{Packet, PacketBatchRecycler, PinnedPacketBatch, PACKET_DATA_SIZE},
@@ -28,7 +27,7 @@ use {
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn producer(dest_addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<usize> {
-    let send = bind_to_unspecified().unwrap();
+    let send = bind_to_localhost_unique().expect("should bind");
 
     let batch_size = 1024;
     let payload = [0u8; PACKET_DATA_SIZE];


### PR DESCRIPTION
#### Problem
A bunch of code still relies on either hardcoded ports or bind_to_localhost and bind_to_unspecified. This creates flaky tests in cases where unique port ranges are needed.

This PR is the step in the journey toward resolving the issue.

Related to https://github.com/anza-xyz/agave/pull/7055

#### Summary of Changes
Function producer has been moved from `bind_to_unspecified` to the new `bind_to_localhost_unique`.
