### PR TITLE
Removes AccountHash from bench_hash_account()

### DIFF
--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -38,9 +38,6 @@ fn bench_hash_account(c: &mut Criterion) {
         let num_bytes = META_SIZE.checked_add(data_size).unwrap();
         group.throughput(Throughput::Bytes(num_bytes as u64));
         let account = AccountSharedData::new(lamports, data_size, &owner);
-        group.bench_function(BenchmarkId::new("blake3", data_size), |b| {
-            b.iter(|| AccountsDb::hash_account(&account, &address));
-        });
         group.bench_function(BenchmarkId::new("lattice", data_size), |b| {
             b.iter(|| AccountsDb::lt_hash_account(&account, &address));
         });


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing is no longer used, and we want to remove all remnants of it.

The obsolete AccountHash hash calculation is benchmarked in `bench_hash_account()`. It can be removed.


#### Summary of Changes

Remove it.