### PR TITLE
Disable QUIC client token store

### DIFF
--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -6,7 +6,7 @@ use {
     quinn::{
         crypto::rustls::{QuicClientConfig, QuicServerConfig},
         ClientConfig, ConnectError, Connecting, Connection, ConnectionError, Endpoint,
-        EndpointConfig, IdleTimeout, SendDatagramError, ServerConfig, TokioRuntime,
+        EndpointConfig, IdleTimeout, NoneTokenStore, SendDatagramError, ServerConfig, TokioRuntime,
         TransportConfig, VarInt,
     },
     rustls::{
@@ -325,6 +325,11 @@ fn new_client_config(
     config.alpn_protocols = vec![ALPN_REPAIR_PROTOCOL_ID.to_vec()];
     let mut config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(config).unwrap()));
     config.transport_config(Arc::new(new_transport_config()));
+    // The quinn TokenStore allows for TLS session resumption by caching
+    // key material. This store is keyed by the server hostname.
+    // However, all peers use the fake hostname "connect", which breaks
+    // that feature. Therefore, the TokenStore is disabled.
+    config.token_store(Arc::new(NoneTokenStore));
     Ok(config)
 }
 


### PR DESCRIPTION
#### Problem

The quinn "TokenStore" is a default-enabled quinn feature that caches tokens received by servers in QUIC "NEW_TOKEN" frames.  The cache key is the server's hostname, which is unfortunately the same string for all nodes in the cluster:

  "connect"

Agave clients have therefore been sending out arbitrary tokens they've received in one server's NEW_TOKEN frame in a connection attempt to another server.  That server would then immediately discard that connection attempt per RFC 9000.

This patch fixes that behavior.

#### Summary of Changes


Disables the QUIC fast session resumption feature by using a "NoneTokenStore".


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
