### PR TITLE
Removes Option wrapper for lt hash param in SnapshotHash::new()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4772,7 +4772,7 @@ impl Bank {
     ///
     /// This fn is used at startup to verify the bank was rebuilt correctly.
     pub fn get_snapshot_hash(&self) -> SnapshotHash {
-        SnapshotHash::new(Some(self.accounts_lt_hash.lock().unwrap().0.checksum()))
+        SnapshotHash::new(self.accounts_lt_hash.lock().unwrap().0.checksum())
     }
 
     pub fn load_account_into_read_cache(&self, key: &Pubkey) {

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -31,14 +31,8 @@ pub struct SnapshotHash(pub Hash);
 impl SnapshotHash {
     /// Make a snapshot hash from accounts hashes
     #[must_use]
-    pub fn new(
-        accounts_lt_hash_checksum: Option<AccountsLtHashChecksum>, // option wrapper will be removed next
-    ) -> Self {
-        let accounts_hash = Hash::new_from_array(
-            accounts_lt_hash_checksum
-                .expect("lattice kind must have lt hash checksum")
-                .0,
-        );
+    pub fn new(accounts_lt_hash_checksum: AccountsLtHashChecksum) -> Self {
+        let accounts_hash = Hash::new_from_array(accounts_lt_hash_checksum.0);
         Self(accounts_hash)
     }
 }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -180,13 +180,13 @@ impl SnapshotPackage {
             snapshot_kind,
             slot: accounts_package.slot,
             block_height: accounts_package.block_height,
-            hash: SnapshotHash::new(Some(
+            hash: SnapshotHash::new(
                 snapshot_info
                     .bank_fields_to_serialize
                     .accounts_lt_hash
                     .0
                     .checksum(),
-            )),
+            ),
             snapshot_storages: accounts_package.snapshot_storages,
             status_cache_slot_deltas: snapshot_info.status_cache_slot_deltas,
             bank_fields_to_serialize: snapshot_info.bank_fields_to_serialize,


### PR DESCRIPTION
#### Problem

`SnasphotHash::new()` takes the lt hash check param wrapped in an `Option`, but this param must always be Some. The Option wrapper should be removed.


#### Summary of Changes

Remove it.