### PR TITLE
Removes has_accounts_lt_hash param from reconstruct_accounts_db_from_fields()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6766,7 +6766,7 @@ impl AccountsDb {
         &self,
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
-        should_calculate_duplicates_lt_hash: bool,
+        should_calculate_duplicates_lt_hash: bool, // always true, will be removed next
     ) -> IndexGenerationInfo {
         let mut total_time = Measure::start("generate_index");
         let mut slots = self.storage.all_slots();

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -850,7 +850,6 @@ where
         accounts_db_config,
         accounts_update_notifier,
         exit,
-        true,
     )?;
     bank_fields.bank_hash_stats = reconstructed_accounts_db_info.bank_hash_stats;
 
@@ -1012,7 +1011,6 @@ fn reconstruct_accountsdb_from_fields<E>(
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-    has_accounts_lt_hash: bool, // always true, will be removed next
 ) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -1081,11 +1079,7 @@ where
     let IndexGenerationInfo {
         accounts_data_len,
         duplicates_lt_hash,
-    } = accounts_db.generate_index(
-        limit_load_slot_count_from_snapshot,
-        verify_index,
-        has_accounts_lt_hash,
-    );
+    } = accounts_db.generate_index(limit_load_slot_count_from_snapshot, verify_index, true);
     info!("Building accounts index... Done in {:?}", start.elapsed());
 
     handle.join().unwrap();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -73,7 +73,6 @@ mod serde_snapshot_tests {
             Some(solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
             Arc::default(),
-            true,
         )
         .map(|(accounts_db, _)| accounts_db)
     }


### PR DESCRIPTION
#### Problem

The `has_accounts_lt_hash` param on `reconstruct_accountsdb_from_fields()` is always true, so the param should be removed.


#### Summary of Changes

Remove it.