### PR TITLE
Removes should_calculate_duplicates_lt_hash param from generate_index()

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -174,7 +174,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     append_vec.accounts.write_accounts(&storable_accounts, 0);
 
     assert!(!db.accounts_index.contains(&pubkey));
-    db.generate_index(None, false, false);
+    db.generate_index(None, false);
 }
 
 define_accounts_db_test!(
@@ -205,7 +205,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     let storable_accounts = (slot0, &data[..]);
     append_vec.accounts.write_accounts(&storable_accounts, 0);
     assert!(!db.accounts_index.contains(&pubkey));
-    let result = db.generate_index(None, false, false);
+    let result = db.generate_index(None, false);
     let entry = db.accounts_index.get_cloned(&pubkey).unwrap();
     assert_eq!(entry.slot_list.read().unwrap().len(), 1);
     assert_eq!(append_vec.alive_bytes(), aligned_stored_size(0));
@@ -6680,7 +6680,7 @@ fn test_obsolete_accounts_empty_default_duplicate_hash(mark_obsolete_accounts: b
         .write_accounts(&(slot1, &[(&pubkey, &account1)][..]), 0);
 
     assert!(!db.accounts_index.contains(&pubkey));
-    let result = db.generate_index(None, false, true);
+    let result = db.generate_index(None, false);
     if mark_obsolete_accounts {
         // If obsolete accounts are marked, the duplicates lt hash should be the default value
         // This is because all duplicates are marked as obsolete and skipped during lt hash calculation.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1079,7 +1079,7 @@ where
     let IndexGenerationInfo {
         accounts_data_len,
         duplicates_lt_hash,
-    } = accounts_db.generate_index(limit_load_slot_count_from_snapshot, verify_index, true);
+    } = accounts_db.generate_index(limit_load_slot_count_from_snapshot, verify_index);
     info!("Building accounts index... Done in {:?}", start.elapsed());
 
     handle.join().unwrap();


### PR DESCRIPTION
#### Problem

The `should_calculate_duplicates_lt_hash` param on `generate_index()` is always true, so the param should be removed.


#### Summary of Changes

Remove it.