### PR TITLE
greedy_scheduler: cache Batches

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -134,9 +134,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                 .check_locks(transaction_state.transaction())
             {
                 self.working_account_set.clear();
-                num_sent += self
-                    .common
-                    .send_batches(self.config.target_transactions_per_batch)?;
+                num_sent += self.common.send_batches()?;
             }
 
             // Now check if the transaction can actually be scheduled.
@@ -187,9 +185,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                         >= self.config.target_transactions_per_batch
                     {
                         self.working_account_set.clear();
-                        num_sent += self
-                            .common
-                            .send_batches(self.config.target_transactions_per_batch)?;
+                        num_sent += self.common.send_batches()?;
                     }
 
                     // if the thread is at target_cu_per_thread, remove it from the schedulable threads
@@ -208,9 +204,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         }
 
         self.working_account_set.clear();
-        num_sent += self
-            .common
-            .send_batches(self.config.target_transactions_per_batch)?;
+        num_sent += self.common.send_batches()?;
         let Saturating(num_scheduled) = num_scheduled;
         assert_eq!(
             num_scheduled, num_sent,

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -269,9 +269,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                         if self.common.batches.transactions()[thread_id].len()
                             >= self.config.target_transactions_per_batch
                         {
-                            num_sent += self
-                                .common
-                                .send_batch(thread_id, self.config.target_transactions_per_batch)?;
+                            num_sent += self.common.send_batch(thread_id)?;
                         }
 
                         // if the thread is at max_cu_per_thread, remove it from the schedulable threads
@@ -294,9 +292,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             }
 
             // Send all non-empty batches
-            num_sent += self
-                .common
-                .send_batches(self.config.target_transactions_per_batch)?;
+            num_sent += self.common.send_batches()?;
 
             // Refresh window budget and do chunked pops
             window_budget += unblock_this_batch.len();
@@ -309,9 +305,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         }
 
         // Send batches for any remaining transactions
-        num_sent += self
-            .common
-            .send_batches(self.config.target_transactions_per_batch)?;
+        num_sent += self.common.send_batches()?;
 
         // Push unschedulable ids back into the container
         container.push_ids_into_queue(unschedulable_ids.into_iter());

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -14,10 +14,8 @@ use {
         read_write_account_set::ReadWriteAccountSet,
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
         transaction_scheduler::{
-            scheduler_common::{select_thread, Batches},
-            transaction_priority_id::TransactionPriorityId,
-            transaction_state::TransactionState,
-            transaction_state_container::StateContainer,
+            scheduler_common::select_thread, transaction_priority_id::TransactionPriorityId,
+            transaction_state::TransactionState, transaction_state_container::StateContainer,
         },
     },
     crossbeam_channel::{Receiver, Sender},
@@ -79,7 +77,11 @@ impl<Tx: TransactionWithMeta> PrioGraphScheduler<Tx> {
         config: PrioGraphSchedulerConfig,
     ) -> Self {
         Self {
-            common: SchedulingCommon::new(consume_work_senders, finished_consume_work_receiver),
+            common: SchedulingCommon::new(
+                consume_work_senders,
+                finished_consume_work_receiver,
+                config.target_transactions_per_batch,
+            ),
             prio_graph: PrioGraph::new(passthrough_priority),
             config,
         }
@@ -131,7 +133,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             });
         }
 
-        let mut batches = Batches::new(num_threads, self.config.target_transactions_per_batch);
         // Some transactions may be unschedulable due to multi-thread conflicts.
         // These transactions cannot be scheduled until some conflicting work is completed.
         // However, the scheduler should not allow other transactions that conflict with
@@ -195,6 +196,10 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         // Check transactions against filter, remove from container if it fails.
         chunked_pops(container, &mut self.prio_graph, &mut window_budget);
 
+        debug_assert!(
+            self.common.batches.is_empty(),
+            "batches must start empty for scheduling"
+        );
         let mut unblock_this_batch = Vec::with_capacity(
             self.common.consume_work_senders.len() * self.config.target_transactions_per_batch,
         );
@@ -228,9 +233,9 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                     |thread_set| {
                         select_thread(
                             thread_set,
-                            batches.total_cus(),
+                            self.common.batches.total_cus(),
                             self.common.in_flight_tracker.cus_in_flight_per_thread(),
-                            batches.transactions(),
+                            self.common.batches.transactions(),
                             self.common.in_flight_tracker.num_in_flight_per_thread(),
                         )
                     },
@@ -252,7 +257,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                         cost,
                     }) => {
                         num_scheduled += 1;
-                        batches.add_transaction_to_batch(
+                        self.common.batches.add_transaction_to_batch(
                             thread_id,
                             id.id,
                             transaction,
@@ -261,20 +266,18 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
                         );
 
                         // If target batch size is reached, send only this batch.
-                        if batches.transactions()[thread_id].len()
+                        if self.common.batches.transactions()[thread_id].len()
                             >= self.config.target_transactions_per_batch
                         {
-                            num_sent += self.common.send_batch(
-                                &mut batches,
-                                thread_id,
-                                self.config.target_transactions_per_batch,
-                            )?;
+                            num_sent += self
+                                .common
+                                .send_batch(thread_id, self.config.target_transactions_per_batch)?;
                         }
 
                         // if the thread is at max_cu_per_thread, remove it from the schedulable threads
                         // if there are no more schedulable threads, stop scheduling.
                         if self.common.in_flight_tracker.cus_in_flight_per_thread()[thread_id]
-                            + batches.total_cus()[thread_id]
+                            + self.common.batches.total_cus()[thread_id]
                             >= max_cu_per_thread
                         {
                             schedulable_threads.remove(thread_id);
@@ -293,7 +296,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             // Send all non-empty batches
             num_sent += self
                 .common
-                .send_batches(&mut batches, self.config.target_transactions_per_batch)?;
+                .send_batches(self.config.target_transactions_per_batch)?;
 
             // Refresh window budget and do chunked pops
             window_budget += unblock_this_batch.len();
@@ -308,7 +311,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         // Send batches for any remaining transactions
         num_sent += self
             .common
-            .send_batches(&mut batches, self.config.target_transactions_per_batch)?;
+            .send_batches(self.config.target_transactions_per_batch)?;
 
         // Push unschedulable ids back into the container
         container.push_ids_into_queue(unschedulable_ids.into_iter());

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -27,14 +27,35 @@ pub struct Batches<Tx> {
 
 impl<Tx> Batches<Tx> {
     pub fn new(num_threads: usize, target_num_transactions_per_batch: usize) -> Self {
-        Self {
-            ids: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
-
-            transactions: (0..num_threads)
+        fn make_vecs<T>(
+            num_threads: usize,
+            target_num_transactions_per_batch: usize,
+        ) -> Vec<Vec<T>> {
+            (0..num_threads)
                 .map(|_| Vec::with_capacity(target_num_transactions_per_batch))
-                .collect(),
-            max_ages: vec![Vec::with_capacity(target_num_transactions_per_batch); num_threads],
+                .collect()
+        }
+
+        Self {
+            ids: make_vecs(num_threads, target_num_transactions_per_batch),
+            transactions: make_vecs(num_threads, target_num_transactions_per_batch),
+            max_ages: make_vecs(num_threads, target_num_transactions_per_batch),
             total_cus: vec![0; num_threads],
+        }
+    }
+
+    pub fn clear(&mut self) {
+        for ids in &mut self.ids {
+            ids.clear();
+        }
+        for transactions in &mut self.transactions {
+            transactions.clear();
+        }
+        for max_ages in &mut self.max_ages {
+            max_ages.clear();
+        }
+        for total_cus in &mut self.total_cus {
+            *total_cus = 0;
         }
     }
 


### PR DESCRIPTION
This avoids a bunch of allocations/deallocations in the hot path.

This must be the 4th time I do this change. Finally committing and PRing so I don't have to do it again next month. 