### PR TITLE
transaction-view: limit the number of packets buffered in one go

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -297,6 +297,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
 
         // Receive packet batches.
         const TIMEOUT: Duration = Duration::from_millis(10);
+        const PACKET_BURST_LIMIT: usize = 1000;
         let start = Instant::now();
         let mut num_received = 0;
         let mut received_message = false;
@@ -336,7 +337,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             }
         }
 
-        while start.elapsed() < TIMEOUT {
+        while start.elapsed() < TIMEOUT && num_received < PACKET_BURST_LIMIT {
             match self.receiver.try_recv() {
                 Ok(packet_batch_message) => {
                     received_message = true;


### PR DESCRIPTION
receive_and_buffer_packets => handle_packet_batch is slooow since it checks fee payers (loads accounts), and checks tx statuses (status cache). Limit the number of txs it operates on in one go so that it "yields" to other parts of the scheduler more often.