### PR TITLE
Remove missing build of programs/bpf_loader/gen-syscall-list/Cargo.toml

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -220,8 +220,6 @@ fi
 
 if [[ -z "$validatorOnly" ]]; then
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion build --manifest-path programs/bpf_loader/gen-syscall-list/Cargo.toml
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   "$cargo" $maybeRustVersion run --bin gen-headers
   mkdir -p "$installDir"/bin/platform-tools-sdk/sbf
   cp -a platform-tools-sdk/sbf/* "$installDir"/bin/platform-tools-sdk/sbf


### PR DESCRIPTION
#### Problem
- The install script doesn't work because `programs/bpf_loader/gen-syscall-list/Cargo.toml` doesn't exist

#### Summary of Changes
-  Remove the build using that manifest path

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
