### PR TITLE
Removes AccountHash

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4,7 +4,6 @@ use {
     crate::{
         account_info::StoredSize,
         accounts_file::AccountsFileProvider,
-        accounts_hash::AccountHash,
         accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
         ancient_append_vecs,
         append_vec::{
@@ -19,7 +18,6 @@ use {
         accounts_equal, Account, AccountSharedData, InheritableAccountFields, ReadableAccount,
         WritableAccount, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
     },
-    solana_hash::Hash,
     solana_lattice_hash::lt_hash::Checksum as LtHashChecksum,
     solana_pubkey::PUBKEY_BYTES,
     std::{
@@ -1868,14 +1866,12 @@ fn test_stored_readable_account() {
     };
     let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
     let stored_size = 101;
-    let hash = AccountHash(Hash::new_unique());
     let stored_account = StoredAccountMeta {
         meta: &meta,
         account_meta: &account_meta,
         data: &data,
         offset,
         stored_size,
-        hash: &hash,
     };
     assert!(accounts_equal(&account, &stored_account));
 }
@@ -1909,11 +1905,6 @@ fn test_hash_stored_account() {
     const ACCOUNT_DATA_LEN: usize = 3;
     let data: [u8; ACCOUNT_DATA_LEN] = [0x69, 0x6a, 0x6b];
     let offset: usize = 0x6c_6d_6e_6f_70_71_72_73;
-    let hash = AccountHash(Hash::from([
-        0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82,
-        0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91,
-        0x92, 0x93,
-    ]));
 
     let stored_account = StoredAccountMeta {
         meta: &meta,
@@ -1921,7 +1912,6 @@ fn test_hash_stored_account() {
         data: &data,
         offset,
         stored_size: CACHE_VIRTUAL_STORED_SIZE as usize,
-        hash: &hash,
     };
     let account = stored_account.to_account_shared_data();
 

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1,22 +1,4 @@
-use {
-    bytemuck_derive::{Pod, Zeroable},
-    solana_hash::{Hash, HASH_BYTES},
-    solana_lattice_hash::lt_hash::LtHash,
-};
-
-/// Hash of an account
-#[repr(transparent)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Pod, Zeroable)]
-pub struct AccountHash(pub Hash);
-
-// Ensure the newtype wrapper never changes size from the underlying Hash
-// This also ensures there are no padding bytes, which is required to safely implement Pod
-const _: () = assert!(std::mem::size_of::<AccountHash>() == std::mem::size_of::<Hash>());
-
-/// The AccountHash for a zero-lamport account
-pub const ZERO_LAMPORT_ACCOUNT_HASH: AccountHash =
-    AccountHash(Hash::new_from_array([0; HASH_BYTES]));
+use {solana_hash::Hash, solana_lattice_hash::lt_hash::LtHash};
 
 /// Lattice hash of an account
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{accounts_hash::AccountHash, is_zero_lamport::IsZeroLamport},
+    crate::is_zero_lamport::IsZeroLamport,
     solana_account::ReadableAccount,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -59,7 +59,7 @@ impl<'a, T: ReadableAccount> From<Option<&'a T>> for AccountMeta {
 
 /// References to account data stored elsewhere. Getting an `Account` requires cloning
 /// (see `StoredAccountMeta::clone_account()`).
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Debug)]
 pub struct StoredAccountMeta<'append_vec> {
     pub meta: &'append_vec StoredMeta,
     /// account data
@@ -67,16 +67,11 @@ pub struct StoredAccountMeta<'append_vec> {
     pub(crate) data: &'append_vec [u8],
     pub(crate) offset: usize,
     pub(crate) stored_size: usize,
-    pub(crate) hash: &'append_vec AccountHash,
 }
 
 impl<'append_vec> StoredAccountMeta<'append_vec> {
     pub fn pubkey(&self) -> &'append_vec Pubkey {
         &self.meta.pubkey
-    }
-
-    pub fn hash(&self) -> &'append_vec AccountHash {
-        self.hash
     }
 
     pub fn stored_size(&self) -> usize {

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -362,12 +362,10 @@ pub mod tests {
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{get_temp_accounts_paths, AccountStorageEntry},
             accounts_file::AccountsFileProvider,
-            accounts_hash::AccountHash,
             append_vec::{AccountMeta, StoredAccountMeta, StoredMeta},
         },
         rand::Rng,
         solana_account::{accounts_equal, AccountSharedData, WritableAccount},
-        solana_hash::Hash,
         std::sync::Arc,
     };
 
@@ -553,14 +551,12 @@ pub mod tests {
         let data = Vec::default();
         let offset = 99 * std::mem::size_of::<u64>(); // offset needs to be 8 byte aligned
         let stored_size = 101;
-        let hash = AccountHash(Hash::new_unique());
         let stored_account = StoredAccountMeta {
             meta: &meta,
             account_meta: &account_meta,
             data: &data,
             offset,
             stored_size,
-            hash: &hash,
         };
 
         let account_from_storage = AccountFromStorage::new(&stored_account);
@@ -587,7 +583,6 @@ pub mod tests {
                 for starting_slot in 0..max_slots {
                     let db = AccountsDb::new_single_for_tests();
                     let data = Vec::default();
-                    let hash = AccountHash(Hash::new_unique());
                     let mut raw = Vec::new();
                     let mut raw2 = Vec::new();
                     let mut raw4 = Vec::new();
@@ -628,7 +623,6 @@ pub mod tests {
                             data: &data,
                             offset,
                             stored_size,
-                            hash: &hash,
                         });
                         raw4.push((raw.0, raw.1.clone()));
                     }
@@ -724,9 +718,6 @@ pub mod tests {
     fn test_storable_accounts_by_slot() {
         for entries in 0..6 {
             let data = Vec::default();
-            let hashes = (0..entries)
-                .map(|_| AccountHash(Hash::new_unique()))
-                .collect::<Vec<_>>();
             let mut raw = Vec::new();
             let mut raw2 = Vec::new();
             for entry in 0..entries {
@@ -764,7 +755,6 @@ pub mod tests {
                     data: &data,
                     offset,
                     stored_size,
-                    hash: &hashes[entry as usize],
                 });
             }
 
@@ -866,7 +856,6 @@ pub mod tests {
             data: &[],
             offset: 0,
             stored_size: 0,
-            hash: &AccountHash(Hash::new_unique()),
         });
 
         let mut slot_accounts = Vec::new();


### PR DESCRIPTION
#### Problem

The `AccountHash` type is now obsolete with the removal of the merkle-based accounts hashing. Yet it is still used in places within the code. These can be removed.


#### Summary of Changes

Remove AccountHash.

Since we still have to write the bytes of the hash into the AppendVec file format, we can't removing them there. So create a new type, `ObsoleteAccountHash`, for this purpose. Otherwise, remove AccountHash everywhere else.