### PR TITLE
Removes SerdeAccountsHash and SerdeIncrementalAccountsHash

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1,4 +1,4 @@
-use {solana_hash::Hash, solana_lattice_hash::lt_hash::LtHash};
+use solana_lattice_hash::lt_hash::LtHash;
 
 /// Lattice hash of an account
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -10,13 +10,3 @@ pub const ZERO_LAMPORT_ACCOUNT_LT_HASH: AccountLtHash = AccountLtHash(LtHash::id
 /// Lattice hash of all accounts
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AccountsLtHash(pub LtHash);
-
-/// Snapshot serde-safe accounts hash
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SerdeAccountsHash(pub Hash);
-
-/// Snapshot serde-safe incremental accounts hash
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SerdeIncrementalAccountsHash(pub Hash);

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -324,9 +324,7 @@ mod tests {
         use {
             super::*,
             crate::{bank::BankHashStats, serde_snapshot::BankIncrementalSnapshotPersistence},
-            solana_accounts_db::accounts_hash::{
-                AccountsLtHash, SerdeAccountsHash, SerdeIncrementalAccountsHash,
-            },
+            solana_accounts_db::accounts_hash::AccountsLtHash,
             solana_clock::Slot,
             solana_frozen_abi::abi_example::AbiExample,
             solana_hash::Hash,
@@ -355,7 +353,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "RHixw67oBUdJQn9TLES55Nb4Sr1wuAfo7NTJH56oRxb")
+            frozen_abi(digest = "BTGQGexXMBBxcAByvhs2vaT2Wkaz1ki5sFFnhjdzDhAX")
         )]
         #[derive(Serialize)]
         pub struct BankAbiTestWrapper {
@@ -374,9 +372,9 @@ mod tests {
 
             let incremental_snapshot_persistence = BankIncrementalSnapshotPersistence {
                 full_slot: Slot::default(),
-                full_hash: SerdeAccountsHash(Hash::new_unique()),
+                full_hash: [1; 32],
                 full_capitalization: u64::default(),
-                incremental_hash: SerdeIncrementalAccountsHash(Hash::new_unique()),
+                incremental_hash: [2; 32],
                 incremental_capitalization: u64::default(),
             };
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -60,10 +60,7 @@ mod tests;
 mod types;
 mod utils;
 
-pub(crate) use {
-    solana_accounts_db::accounts_hash::{SerdeAccountsHash, SerdeIncrementalAccountsHash},
-    storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
-};
+pub(crate) use storage::{SerializableAccountStorageEntry, SerializedAccountsFileId};
 
 const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
 
@@ -96,11 +93,11 @@ pub struct BankIncrementalSnapshotPersistence {
     /// slot of full snapshot
     pub full_slot: Slot,
     /// accounts hash from the full snapshot
-    pub full_hash: SerdeAccountsHash,
+    pub full_hash: [u8; 32],
     /// capitalization from the full snapshot
     pub full_capitalization: u64,
     /// hash of the accounts in the incremental snapshot slot range, including zero-lamport accounts
-    pub incremental_hash: SerdeIncrementalAccountsHash,
+    pub incremental_hash: [u8; 32],
     /// capitalization of the accounts in the incremental snapshot slot range
     pub incremental_capitalization: u64,
 }
@@ -109,7 +106,7 @@ pub struct BankIncrementalSnapshotPersistence {
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
     obsolete_accounts_delta_hash: [u8; 32],
-    accounts_hash: SerdeAccountsHash, // obsolete
+    obsolete_accounts_hash: [u8; 32],
     stats: BankHashStats,
 }
 
@@ -785,7 +782,7 @@ impl Serialize for SerializableAccountsDb<'_> {
         }));
         let bank_hash_info = BankHashInfo {
             obsolete_accounts_delta_hash: [0; 32],
-            accounts_hash: SerdeAccountsHash(Hash::default()), // obsolete, any value works
+            obsolete_accounts_hash: [0; 32],
             stats: self.bank_hash_stats.clone(),
         };
 


### PR DESCRIPTION
#### Problem

AccountsHash has been removed. We can do the same for SerdeAccountsHash (and SerdeIncrementalAccountsHash).


#### Summary of Changes

Removes SerdeAccountsHash and SerdeIncrementalAccountsHash.

Note, we cannot remove these fields from the snapshot, but we can (1) replace the types, and (2) mark (i.e. rename) the fields as obsolete.