### PR TITLE
Shuffle order of scanning account storages in calculate_accounts_lt_hash_at_startup

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -339,7 +339,7 @@ impl<'a> AccountStoragesOrderer<'a> {
         }
     }
 
-    pub fn iter(&'a self) -> impl Iterator<Item = &'a AccountStorageEntry> + 'a {
+    pub fn iter(&'a self) -> impl ExactSizeIterator<Item = &'a AccountStorageEntry> + 'a {
         self.indices.iter().map(|i| self.storages[*i].as_ref())
     }
 

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -298,12 +298,21 @@ impl Default for AccountStorageStatus {
     }
 }
 
-pub struct AccountStoragesOrderBalancer<'a> {
+/// Wrapper over slice of `Arc<AccountStorageEntry>` that provides an ordered access to storages.
+///
+/// A few strategies are available for ordering storages:
+/// - `with_small_to_large_ratio`: interleaving small and large storage written bytes
+/// - `with_random_order`: orders storages randomly
+pub struct AccountStoragesOrderer<'a> {
     storages: &'a [Arc<AccountStorageEntry>],
     indices: Vec<usize>,
 }
 
-impl<'a> AccountStoragesOrderBalancer<'a> {
+impl<'a> AccountStoragesOrderer<'a> {
+    /// Create balaning orderer that interleaves storages with small and large written bytes.
+    ///
+    /// Storages are returned in cycles based on `small_to_large_ratio` - `ratio.0` small storages
+    /// preceding `ratio.1` large storages.
     pub fn with_small_to_large_ratio(
         storages: &'a [Arc<AccountStorageEntry>],
         small_to_large_ratio: (usize, usize),
@@ -321,7 +330,8 @@ impl<'a> AccountStoragesOrderBalancer<'a> {
         Self { storages, indices }
     }
 
-    pub fn randomized(storages: &'a [Arc<AccountStorageEntry>]) -> Self {
+    /// Create randomizing orderer.
+    pub fn with_random_order(storages: &'a [Arc<AccountStorageEntry>]) -> Self {
         let mut indices: Vec<usize> = (0..storages.len()).collect();
         indices.shuffle(&mut rand::thread_rng());
         Self { storages, indices }

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -3,7 +3,7 @@
 use {
     crate::accounts_db::{AccountStorageEntry, AccountsFileId},
     dashmap::DashMap,
-    rayon::iter::{IntoParallelIterator, ParallelIterator},
+    rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator},
     solana_clock::Slot,
     solana_nohash_hasher::{BuildNoHashHasher, IntMap},
     std::{
@@ -321,7 +321,9 @@ impl<'a> AccountStoragesOrderBalancer<'a> {
         (0..self.indices.len()).map(move |i| self.nth_storage(i))
     }
 
-    pub fn into_par_iter(self) -> impl ParallelIterator<Item = &'a AccountStorageEntry> + 'a {
+    pub fn into_par_iter(
+        self,
+    ) -> impl IndexedParallelIterator<Item = &'a AccountStorageEntry> + 'a {
         (0..self.indices.len())
             .into_par_iter()
             .map(move |i| self.nth_storage(i))
@@ -329,7 +331,7 @@ impl<'a> AccountStoragesOrderBalancer<'a> {
 
     fn nth_storage(&self, nth: usize) -> &'a AccountStorageEntry {
         let range_index = select_from_range_with_start_end_rates(
-            0..self.storages.len(),
+            0..self.indices.len(),
             nth,
             self.small_to_large_ratio.clone(),
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5715,11 +5715,10 @@ impl AccountsDb {
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
     ) -> AccountsLtHash {
-        let storages = AccountStoragesOrderBalancer::new(storages, (7, 1));
+        let storages = AccountStoragesOrderBalancer::new(storages, (4, 1));
         let mut lt_hash = storages
             .into_par_iter()
-            .with_min_len(16)
-            .with_max_len(64)
+            .by_uniform_blocks(100)
             .fold(LtHash::identity, |mut accum, storage| {
                 let obsolete_accounts = storage.get_obsolete_accounts(None);
                 storage

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5719,7 +5719,7 @@ impl AccountsDb {
         // useful for optimizing disk read sizes and buffers usage in a single IO queue).
         let storages = AccountStoragesOrderer::with_random_order(storages);
         let mut lt_hash = storages
-            .into_par_iter()
+            .par_iter()
             .fold(LtHash::identity, |mut accum, storage| {
                 let obsolete_accounts = storage.get_obsolete_accounts(None);
                 storage

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -22,6 +22,7 @@ mod geyser_plugin_utils;
 pub mod stats;
 pub mod tests;
 
+use crate::account_storage::AccountStoragesReshuffler;
 #[cfg(test)]
 use crate::append_vec::StoredAccountMeta;
 #[cfg(feature = "dev-context-only-utils")]
@@ -5714,8 +5715,9 @@ impl AccountsDb {
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
     ) -> AccountsLtHash {
+        let storages = AccountStoragesReshuffler::new(storages).into_par_balanced();
         let mut lt_hash = storages
-            .par_iter()
+            //            .par_iter()
             .fold(LtHash::identity, |mut accum, storage| {
                 let obsolete_accounts = storage.get_obsolete_accounts(None);
                 storage

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -22,7 +22,7 @@ mod geyser_plugin_utils;
 pub mod stats;
 pub mod tests;
 
-use crate::account_storage::AccountStoragesReshuffler;
+use crate::account_storage::AccountStoragesOrderBalancer;
 #[cfg(test)]
 use crate::append_vec::StoredAccountMeta;
 #[cfg(feature = "dev-context-only-utils")]
@@ -5715,9 +5715,9 @@ impl AccountsDb {
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
     ) -> AccountsLtHash {
-        let storages = AccountStoragesReshuffler::new(storages).into_par_balanced();
+        let storages = AccountStoragesOrderBalancer::new(storages, (1, 1));
         let mut lt_hash = storages
-            //            .par_iter()
+            .into_par_iter()
             .fold(LtHash::identity, |mut accum, storage| {
                 let obsolete_accounts = storage.get_obsolete_accounts(None);
                 storage

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5715,9 +5715,11 @@ impl AccountsDb {
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
     ) -> AccountsLtHash {
-        let storages = AccountStoragesOrderBalancer::new(storages, (1, 1));
+        let storages = AccountStoragesOrderBalancer::new(storages, (7, 1));
         let mut lt_hash = storages
             .into_par_iter()
+            .with_min_len(16)
+            .with_max_len(64)
             .fold(LtHash::identity, |mut accum, storage| {
                 let obsolete_accounts = storage.get_obsolete_accounts(None);
                 storage

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -21,7 +21,7 @@ use {
     log::*,
     regex::Regex,
     solana_accounts_db::{
-        account_storage::{AccountStorageMap, AccountStoragesOrderBalancer},
+        account_storage::{AccountStorageMap, AccountStoragesOrderer},
         account_storage_reader::AccountStorageReader,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
@@ -1125,7 +1125,7 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            let storages_orderer = AccountStoragesOrderBalancer::with_small_to_large_ratio(
+            let storages_orderer = AccountStoragesOrderer::with_small_to_large_ratio(
                 snapshot_storages,
                 INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -21,7 +21,7 @@ use {
     log::*,
     regex::Regex,
     solana_accounts_db::{
-        account_storage::AccountStorageMap,
+        account_storage::{AccountStorageMap, AccountStoragesOrderBalancer},
         account_storage_reader::AccountStorageReader,
         accounts_db::{AccountStorageEntry, AtomicAccountsFileId},
         accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
@@ -38,7 +38,7 @@ use {
         io::{self, BufRead, BufReader, BufWriter, Error as IoError, Read, Seek, Write},
         mem,
         num::{NonZeroU64, NonZeroUsize},
-        ops::{Range, RangeInclusive},
+        ops::RangeInclusive,
         path::{Path, PathBuf},
         process::ExitStatus,
         str::FromStr,
@@ -87,7 +87,7 @@ pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-sna
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
-const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
+const INTERLEAVED_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
 
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
 pub enum SnapshotVersion {
@@ -1125,15 +1125,11 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            let mut sorted_storage_indices = (0..snapshot_storages.len()).collect::<Vec<_>>();
-            sorted_storage_indices.sort_by_key(|&i| snapshot_storages[i].accounts.len());
-            for i in 0..sorted_storage_indices.len() {
-                let index = select_from_range_with_start_end_rates(
-                    0..sorted_storage_indices.len(),
-                    i,
-                    INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
-                );
-                let storage = &snapshot_storages[sorted_storage_indices[index]];
+            let storages_orderer = AccountStoragesOrderBalancer::new(
+                snapshot_storages,
+                INTERLEAVED_SMALL_TO_LARGE_RATIO,
+            );
+            for storage in storages_orderer.into_iter() {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 
@@ -1213,31 +1209,6 @@ fn archive_snapshot(
         hash: snapshot_hash,
         archive_format,
     })
-}
-
-/// Select the `nth` (`0 <= nth < range.len()`) value from a `range`, choosing values alternately
-/// from its start or end according to a `start_rate : end_rate` ratio.
-///
-/// For every `start_rate` values selected from the start, `end_rate` values are selected from the end.
-/// The resulting sequence alternates in a balanced and interleaved fashion between the range's start and end.
-/// ```
-fn select_from_range_with_start_end_rates(
-    range: Range<usize>,
-    nth: usize,
-    (start_rate, end_rate): (usize, usize),
-) -> usize {
-    let range_len = range.len();
-    let cycle = start_rate + end_rate;
-    let cycle_index = nth % cycle;
-    let cycle_num = nth.checked_div(cycle).expect("rates sum must be positive");
-
-    let index = if cycle_index < start_rate {
-        cycle_num * start_rate + cycle_index
-    } else {
-        let end_index = cycle_num * end_rate + cycle_index - start_rate;
-        range_len - end_index - 1
-    };
-    range.start + index
 }
 
 /// Get the bank snapshots in a directory
@@ -3698,33 +3669,5 @@ mod tests {
                 .to_string()
                 .starts_with("invalid full snapshot slot file size"));
         }
-    }
-
-    #[test]
-    fn test_select_from_start_or_end_index_by_ratio() {
-        let interleaved: Vec<_> = (0..10)
-            .map(|i| select_from_range_with_start_end_rates(1..11, i, (2, 1)))
-            .collect();
-        assert_eq!(interleaved, vec![1, 2, 10, 3, 4, 9, 5, 6, 8, 7]);
-
-        let interleaved: Vec<_> = (0..10)
-            .map(|i| select_from_range_with_start_end_rates(1..11, i, (1, 1)))
-            .collect();
-        assert_eq!(interleaved, vec![1, 10, 2, 9, 3, 8, 4, 7, 5, 6]);
-
-        let interleaved: Vec<_> = (0..9)
-            .map(|i| select_from_range_with_start_end_rates(1..10, i, (2, 1)))
-            .collect();
-        assert_eq!(interleaved, vec![1, 2, 9, 3, 4, 8, 5, 6, 7]);
-
-        let interleaved: Vec<_> = (0..9)
-            .map(|i| select_from_range_with_start_end_rates(1..10, i, (1, 2)))
-            .collect();
-        assert_eq!(interleaved, vec![1, 9, 8, 2, 7, 6, 3, 5, 4]);
-
-        let interleaved: Vec<_> = (0..13)
-            .map(|i| select_from_range_with_start_end_rates(1..14, i, (2, 3)))
-            .collect();
-        assert_eq!(interleaved, vec![1, 2, 13, 12, 11, 3, 4, 10, 9, 8, 5, 6, 7]);
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1129,7 +1129,7 @@ fn archive_snapshot(
                 snapshot_storages,
                 INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );
-            for storage in storages_orderer.into_iter() {
+            for storage in storages_orderer.iter() {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -87,7 +87,7 @@ pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-sna
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
-const INTERLEAVED_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
+const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
 
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
 pub enum SnapshotVersion {
@@ -1127,7 +1127,7 @@ fn archive_snapshot(
 
             let storages_orderer = AccountStoragesOrderBalancer::new(
                 snapshot_storages,
-                INTERLEAVED_SMALL_TO_LARGE_RATIO,
+                INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );
             for storage in storages_orderer.into_iter() {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1125,7 +1125,7 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            let storages_orderer = AccountStoragesOrderBalancer::new(
+            let storages_orderer = AccountStoragesOrderBalancer::with_small_to_large_ratio(
                 snapshot_storages,
                 INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1125,11 +1125,6 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
-            // Balance large and small files with bias towards small (4 small + 1 large), such
-            // that during unpacking large writes are mixed with file metadata operations
-            // and towards the end of archive (sizes equalize) writes are >256KiB / file.
-            const FILE_BALANCING_RATES: (usize, usize) = (4, 1); // (small_files_per_cycle, large_files_per_cycle)
-
             let mut sorted_storage_indices = (0..snapshot_storages.len()).collect::<Vec<_>>();
             sorted_storage_indices.sort_by_key(|&i| snapshot_storages[i].accounts.len());
             for i in 0..sorted_storage_indices.len() {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1125,6 +1125,11 @@ fn archive_snapshot(
                 .append_dir_all(SNAPSHOTS_DIR, &staging_snapshots_dir)
                 .map_err(E::ArchiveSnapshotsDir)?;
 
+            // Balance large and small files with bias towards small (4 small + 1 large), such
+            // that during unpacking large writes are mixed with file metadata operations
+            // and towards the end of archive (sizes equalize) writes are >256KiB / file.
+            const FILE_BALANCING_RATES: (usize, usize) = (4, 1); // (small_files_per_cycle, large_files_per_cycle)
+
             let mut sorted_storage_indices = (0..snapshot_storages.len()).collect::<Vec<_>>();
             sorted_storage_indices.sort_by_key(|&i| snapshot_storages[i].accounts.len());
             for i in 0..sorted_storage_indices.len() {


### PR DESCRIPTION
#### Problem
We scan storages using rayon work splitting heuristic that treats each collection element as relatively similar in cost / processing time. However account storages have vastly differing sizes and their default order actually has clusters of large vs small storages.
This causes work to be split into a unit batch that apparently has mostly large storages and may run for >100s longer than other theads that sit idle without being able to pick more work.

#### Summary of Changes
* refactor code used to order storages for placement in snapshot archive to `account_storage.rs` module as more generic `AccountStoragesOrderer` util wrapper
* add an additional strategy for simple randomized order of storages (doesn't require magic numbers and works well when we only need uniform total size per batch of items) 
* use randomized order in calculate_accounts_lt_hash_at_startup

At current snapshot (slot 356410350) unpacking and verification:
```
startup_verify_accounts total_us=117597515i verify_accounts_lt_hash_us=117597513i
```
vs baseline (master for the same data):
```
startup_verify_accounts total_us=372777563i verify_accounts_lt_hash_us=372777560i
```