### PR TITLE
Fixed minor spelling errors in code comments and documentation across multiple files.

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -767,13 +767,13 @@ mod tests {
             })
             .collect();
         shreds.shuffle(rng);
-        // Assert that all shreds verfiy and sanitize.
+        // Assert that all shreds verify and sanitize.
         for shred in &shreds {
             let pubkey = keypairs[&shred.slot()].pubkey();
             assert!(shred.verify(&pubkey));
             assert_matches!(shred.sanitize(), Ok(()));
         }
-        // Verfiy using layout api.
+        // Verify using layout api.
         for shred in &shreds {
             let shred = shred.payload();
             let slot = shred::layout::get_slot(shred).unwrap();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -613,7 +613,7 @@ enum IndexImplementation {
 /// - is validator global and fork graph aware, so it can optimize the commonalities across banks.
 /// - handles the visibility rules of un/re/deployments.
 /// - stores the usage statistics and verification status of each program.
-/// - is elastic and uses a probabilistic eviction stragety based on the usage statistics.
+/// - is elastic and uses a probabilistic eviction strategy based on the usage statistics.
 /// - also keeps the compiled executables around, but only for the most used programs.
 /// - supports various kinds of tombstones to avoid loading programs which can not be loaded.
 /// - cleans up entries on orphan branches when the block store is rerooted.

--- a/svm/examples/json-rpc/README.md
+++ b/svm/examples/json-rpc/README.md
@@ -28,4 +28,4 @@ cargo run --manifest-path json-rpc-client/Cargo.toml -- -C config.yml -k json-rp
 ```
 
 The client will communicate with the server and print the responses it
-recieves from the server.
+receives from the server.


### PR DESCRIPTION


### Code Comments
- **`ledger/src/sigverify_shreds.rs`**: Fixed "verfiy" → "verify" in test comments
- **`program-runtime/src/loaded_programs.rs`**: Fixed "stragety" → "strategy" in enum documentation

### Documentation
- **`svm/examples/json-rpc/README.md`**: Fixed "recieves" → "receives" in client description

