### PR TITLE
pub calculate_signature_fee

### DIFF
--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -63,7 +63,7 @@ pub fn calculate_fee_details(
 }
 
 /// Calculate fees from signatures.
-fn calculate_signature_fee(
+pub fn calculate_signature_fee(
     SignatureCounts {
         num_transaction_signatures,
         num_ed25519_signatures,
@@ -82,7 +82,7 @@ fn calculate_signature_fee(
     signature_count.saturating_mul(lamports_per_signature)
 }
 
-struct SignatureCounts {
+pub struct SignatureCounts {
     pub num_transaction_signatures: u64,
     pub num_ed25519_signatures: u64,
     pub num_secp256k1_signatures: u64,


### PR DESCRIPTION
#### Problem
- We want to calculate fee and check fee-payer in parallel before scheduler
- Cannot do that currently in an easy way since `fee` crate requires a `SVMMessage`
  - we will not resolve ALTs in sigverify at this time, so cannot get a true `SVMMessage`

#### Summary of Changes
- Publicly expose signature fee calculation and SignatureCounts

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
