### PR TITLE
Move fee-payer check to SigVerify

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -156,7 +156,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     trace!("start");
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(verified_s, None);
+    let verifier = TransactionSigVerifier::new(verified_s, None, None);
     let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerBench", "bench");
 
     bencher.iter(move || {
@@ -230,7 +230,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32) {
     let (batches0, num_valid_packets) = prepare_batches(discard_factor);
     let (verified_s, _verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(verified_s, None);
+    let verifier = TransactionSigVerifier::new(verified_s, None, None);
 
     let mut c = 0;
     let mut total_shrink_time = 0;

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -230,7 +230,7 @@ fn prepare_batches(discard_factor: i32) -> (Vec<PacketBatch>, usize) {
 fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32) {
     let (batches0, num_valid_packets) = prepare_batches(discard_factor);
     let (verified_s, _verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(verified_s, None, None);
+    let mut verifier = TransactionSigVerifier::new(verified_s, None, None);
 
     let mut c = 0;
     let mut total_shrink_time = 0;

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -22,7 +22,7 @@ use {
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::{
-        account_loader::validate_fee_payer,
+        account_loader::validate_fee_payer_with_error_counters,
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_result::TransactionProcessingResultExtensions,
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
@@ -462,7 +462,7 @@ impl Consumer {
             .load_with_fixed_root(&bank.ancestors, fee_payer)
             .ok_or(TransactionError::AccountNotFound)?;
 
-        validate_fee_payer(
+        validate_fee_payer_with_error_counters(
             fee_payer,
             &mut fee_payer_account,
             0,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -283,6 +283,7 @@ impl ClusterInfoVoteListener {
             &mut packet_batches,
             /*reject_non_vote=*/ false,
             votes.len(),
+            |_| true,
         );
         let root_bank = root_bank_cache.root_bank();
         let epoch_schedule = root_bank.epoch_schedule();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -87,7 +87,7 @@ impl SigVerifier for TransactionSigVerifier {
     }
 
     fn verify_batches(
-        &self,
+        &mut self,
         mut batches: Vec<PacketBatch>,
         valid_packets: usize,
     ) -> Vec<PacketBatch> {

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -80,6 +80,7 @@ impl SigVerifier for TransactionSigVerifier {
             &self.recycler_out,
             self.reject_non_vote,
             valid_packets,
+            |_| true,
         );
         batches
     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -502,7 +502,7 @@ mod tests {
         trace!("start");
         let (packet_s, packet_r) = unbounded();
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
-        let verifier = TransactionSigVerifier::new(verified_s, None);
+        let verifier = TransactionSigVerifier::new(verified_s, None, None);
         let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerTest", "test");
 
         let now = Instant::now();

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -56,7 +56,11 @@ pub struct SigVerifyStage {
 
 pub trait SigVerifier {
     type SendType: std::fmt::Debug;
-    fn verify_batches(&self, batches: Vec<PacketBatch>, valid_packets: usize) -> Vec<PacketBatch>;
+    fn verify_batches(
+        &mut self,
+        batches: Vec<PacketBatch>,
+        valid_packets: usize,
+    ) -> Vec<PacketBatch>;
     fn send_packets(&mut self, packet_batches: Vec<PacketBatch>) -> Result<(), Self::SendType>;
 }
 
@@ -217,7 +221,7 @@ impl SigVerifierStats {
 impl SigVerifier for DisabledSigVerifier {
     type SendType = ();
     fn verify_batches(
-        &self,
+        &mut self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
     ) -> Vec<PacketBatch> {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -287,6 +287,7 @@ impl Tpu {
             let verifier = TransactionSigVerifier::new(
                 non_vote_sender,
                 enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
+                Some(bank_forks.clone()),
             );
             SigVerifier::Local(SigVerifyStage::new(
                 packet_receiver,
@@ -300,6 +301,7 @@ impl Tpu {
             let verifier = TransactionSigVerifier::new_reject_non_vote(
                 tpu_vote_sender,
                 Some(forward_stage_sender),
+                Some(bank_forks.clone()),
             );
             SigVerifyStage::new(
                 vote_packet_receiver,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -565,6 +565,7 @@ fn start_verify_transactions_gpu<Tx: TransactionWithMeta + Send + Sync + 'static
                 &out_recycler,
                 false,
                 num_packets,
+                |_| true,
             );
             let verified = packet_batches
                 .iter()

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -63,7 +63,7 @@ pub fn calculate_fee_details(
 }
 
 /// Calculate fees from signatures.
-fn calculate_signature_fee(
+pub fn calculate_signature_fee(
     SignatureCounts {
         num_transaction_signatures,
         num_ed25519_signatures,
@@ -82,7 +82,7 @@ fn calculate_signature_fee(
     signature_count.saturating_mul(lamports_per_signature)
 }
 
-struct SignatureCounts {
+pub struct SignatureCounts {
     pub num_transaction_signatures: u64,
     pub num_ed25519_signatures: u64,
     pub num_secp256k1_signatures: u64,

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -33,7 +33,14 @@ fn bench_sigverify_simple(b: &mut Bencher) {
     let recycler_out = Recycler::default();
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -59,7 +66,14 @@ fn bench_sigverify_low_packets_small_batch(b: &mut Bencher) {
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -69,7 +83,14 @@ fn bench_sigverify_low_packets_large_batch(b: &mut Bencher) {
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -79,7 +100,14 @@ fn bench_sigverify_medium_packets_small_batch(b: &mut Bencher) {
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -89,7 +117,14 @@ fn bench_sigverify_medium_packets_large_batch(b: &mut Bencher) {
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -99,7 +134,14 @@ fn bench_sigverify_high_packets_small_batch(b: &mut Bencher) {
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -110,7 +152,14 @@ fn bench_sigverify_high_packets_large_batch(b: &mut Bencher) {
     let recycler_out = Recycler::default();
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 
@@ -155,7 +204,14 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
     let recycler_out = Recycler::default();
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(
+            &mut batches,
+            &recycler,
+            &recycler_out,
+            false,
+            num_packets,
+            |_| true,
+        );
     })
 }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -3,9 +3,10 @@ use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_loader::{
-            load_transaction, update_rent_exempt_status_for_account, validate_fee_payer,
-            AccountLoader, CheckedTransactionDetails, LoadedTransaction, TransactionCheckResult,
-            TransactionLoadResult, ValidatedTransactionDetails,
+            load_transaction, update_rent_exempt_status_for_account,
+            validate_fee_payer_with_error_counters, AccountLoader, CheckedTransactionDetails,
+            LoadedTransaction, TransactionCheckResult, TransactionLoadResult,
+            ValidatedTransactionDetails,
         },
         account_overrides::AccountOverrides,
         message_processor::process_message,
@@ -584,7 +585,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         update_rent_exempt_status_for_account(rent_collector, &mut loaded_fee_payer.account);
 
         let fee_payer_index = 0;
-        validate_fee_payer(
+        validate_fee_payer_with_error_counters(
             fee_payer_address,
             &mut loaded_fee_payer.account,
             fee_payer_index,

--- a/vortexor/src/vortexor.rs
+++ b/vortexor/src/vortexor.rs
@@ -91,7 +91,7 @@ impl Vortexor {
         tpu_receiver: Receiver<PacketBatch>,
         non_vote_sender: TracedSender,
     ) -> SigVerifyStage {
-        let verifier = TransactionSigVerifier::new(non_vote_sender, None);
+        let verifier = TransactionSigVerifier::new(non_vote_sender, None, None);
         SigVerifyStage::new(
             tpu_receiver,
             verifier,


### PR DESCRIPTION
#### Problem
- fee-payer check on ingestion is relatively well parallelized, yet we do it in serial in the scheduler

#### Summary of Changes
- move initial fee-payer check from scheduler (receive_and_buffer) to sigverify

This is the final PR in a chain:
- #7232

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
