### PR TITLE
Removes hash_calculation_pubkey_bins

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -107,10 +107,6 @@ const UNREF_ACCOUNTS_BATCH_SIZE: usize = 10_000;
 const DEFAULT_FILE_SIZE: u64 = 4 * 1024 * 1024;
 const DEFAULT_NUM_DIRS: u32 = 4;
 
-// When calculating hashes, it is helpful to break the pubkeys found into bins based on the pubkey value.
-// More bins means smaller vectors to sort, copy, etc.
-pub const DEFAULT_HASH_CALCULATION_PUBKEY_BINS: usize = 65536;
-
 // When getting accounts for shrinking from the index, this is the # of accounts to lookup per thread.
 // This allows us to split up accounts index accesses across multiple threads.
 const SHRINK_COLLECT_CHUNK_SIZE: usize = 50;
@@ -307,7 +303,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    hash_calculation_pubkey_bins: Some(4),
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -330,7 +325,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_clean_threads: None,
     num_foreground_threads: None,
     num_hash_threads: None,
-    hash_calculation_pubkey_bins: None,
 };
 
 struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
@@ -445,7 +439,6 @@ pub struct AccountsDbConfig {
     pub ancient_append_vec_offset: Option<i64>,
     pub ancient_storage_ideal_size: Option<u64>,
     pub max_ancient_storages: Option<usize>,
-    pub hash_calculation_pubkey_bins: Option<usize>,
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
@@ -1278,9 +1271,6 @@ pub struct AccountsDb {
     /// true iff we want to skip the initial hash calculation on startup
     pub skip_initial_hash_calc: bool,
 
-    /// The number of pubkey bins used for accounts hash calculation
-    pub hash_calculation_pubkey_bins: usize,
-
     pub storage: AccountStorage,
 
     pub accounts_cache: AccountsCache,
@@ -1584,9 +1574,6 @@ impl AccountsDb {
             max_ancient_storages: accounts_db_config
                 .max_ancient_storages
                 .unwrap_or(DEFAULT_MAX_ANCIENT_STORAGES),
-            hash_calculation_pubkey_bins: accounts_db_config
-                .hash_calculation_pubkey_bins
-                .unwrap_or(DEFAULT_HASH_CALCULATION_PUBKEY_BINS),
             account_indexes: accounts_db_config.account_indexes.unwrap_or_default(),
             shrink_ratio: accounts_db_config.shrink_ratio,
             accounts_update_notifier,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -128,13 +128,6 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .takes_value(true)
             .help("The number of ancient storages the ancient slot combining should converge to.")
             .hidden(hidden_unless_forced()),
-        Arg::with_name("accounts_db_hash_calculation_pubkey_bins")
-            .long("accounts-db-hash-calculation-pubkey-bins")
-            .value_name("USIZE")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .help("The number of pubkey bins used for accounts hash calculation.")
-            .hidden(hidden_unless_forced()),
     ]
     .into_boxed_slice()
 }
@@ -308,12 +301,6 @@ pub fn get_accounts_db_config(
         )
         .ok(),
         max_ancient_storages: value_t!(arg_matches, "accounts_db_max_ancient_storages", usize).ok(),
-        hash_calculation_pubkey_bins: value_t!(
-            arg_matches,
-            "accounts_db_hash_calculation_pubkey_bins",
-            usize
-        )
-        .ok(),
         exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         storage_access,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1434,15 +1434,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
-        Arg::with_name("accounts_db_hash_calculation_pubkey_bins")
-            .long("accounts-db-hash-calculation-pubkey-bins")
-            .value_name("USIZE")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .help("The number of pubkey bins used for accounts hash calculation.")
-            .hidden(hidden_unless_forced()),
-    )
-    .arg(
         Arg::with_name("accounts_db_cache_limit_mb")
             .long("accounts-db-cache-limit-mb")
             .value_name("MEGABYTES")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -411,12 +411,6 @@ pub fn execute(
         )
         .ok(),
         max_ancient_storages: value_t!(matches, "accounts_db_max_ancient_storages", usize).ok(),
-        hash_calculation_pubkey_bins: value_t!(
-            matches,
-            "accounts_db_hash_calculation_pubkey_bins",
-            usize
-        )
-        .ok(),
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         storage_access,
         scan_filter_for_shrinking,


### PR DESCRIPTION
#### Problem

The merkle-based accounts hashing has been removed, which means all config parameters can also be removed.


#### Summary of Changes

 For this PR, we can remove `hash_calculation_pubkey_bins` from AccountsDb. (And thus also AccountsDbConfig and the cli.)