### PR TITLE
fix: correct broken CONTRIBUTING.md link in KaTeX README

### DIFF
--- a/docs/static/katex/README.md
+++ b/docs/static/katex/README.md
@@ -84,7 +84,7 @@ Learn more about using KaTeX [on the website](https://katex.org)!
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
- Changed relative path from CONTRIBUTING.md to ../../../CONTRIBUTING.md
Now the link is correct