### PR TITLE
Optimize VoteRewardsAccounts

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -24,7 +24,7 @@ use {
         iter::{IntoParallelRefIterator, ParallelIterator},
         ThreadPool,
     },
-    solana_account::ReadableAccount,
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},
     solana_measure::measure_us,
     solana_pubkey::Pubkey,
@@ -147,7 +147,7 @@ impl Bank {
         self.store_vote_accounts_partitioned(vote_account_rewards, metrics);
 
         // update reward history of JUST vote_rewards, stake_rewards is vec![] here
-        self.update_reward_history(vec![], &vote_account_rewards.rewards[..]);
+        self.update_reward_history(vec![], vote_account_rewards);
 
         let StakeRewardCalculation {
             stake_rewards,
@@ -210,7 +210,12 @@ impl Bank {
         metrics: &RewardsMetrics,
     ) {
         let (_, measure_us) = measure_us!({
-            self.store_accounts((self.slot(), &vote_account_rewards.accounts_to_store[..]));
+            let accounts_to_store: Vec<(Pubkey, AccountSharedData)> = vote_account_rewards
+                .accounts_with_rewards
+                .iter()
+                .map(|(pubkey, _, account)| (*pubkey, account.clone()))
+                .collect();
+            self.store_accounts((self.slot(), &accounts_to_store[..]));
         });
 
         metrics
@@ -606,10 +611,11 @@ mod tests {
                     post_balance: vote_reward_info.vote_rewards,
                     commission: Some(vote_reward_info.commission),
                 };
-                vote_rewards_account.rewards.push((*vote_key, info));
-                vote_rewards_account
-                    .accounts_to_store
-                    .push((*vote_key, vote_reward_info.vote_account.clone()));
+                vote_rewards_account.accounts_with_rewards.push((
+                    *vote_key,
+                    info,
+                    vote_reward_info.vote_account.clone(),
+                ));
                 vote_rewards_account.total_vote_rewards_lamports += vote_reward_info.vote_rewards;
             });
 
@@ -619,7 +625,7 @@ mod tests {
         bank.store_vote_accounts_partitioned(&vote_rewards_account, &metrics);
         assert_eq!(
             expected_vote_rewards_num,
-            vote_rewards_account.accounts_to_store.len()
+            vote_rewards_account.accounts_with_rewards.len()
         );
         assert_eq!(
             vote_rewards
@@ -654,7 +660,7 @@ mod tests {
         let total_vote_rewards = vote_rewards.total_vote_rewards_lamports;
 
         bank.store_vote_accounts_partitioned(&vote_rewards, &metrics);
-        assert_eq!(expected, vote_rewards.accounts_to_store.len());
+        assert_eq!(expected, vote_rewards.accounts_with_rewards.len());
         assert_eq!(0, total_vote_rewards);
     }
 
@@ -688,9 +694,9 @@ mod tests {
             .stake_reward_calculation;
 
         let total_vote_rewards: u64 = vote_rewards
-            .rewards
+            .accounts_with_rewards
             .iter()
-            .map(|reward| reward.1.lamports)
+            .map(|(_, reward_info, _)| reward_info.lamports)
             .sum::<i64>() as u64;
 
         // assert that total rewards matches the sum of vote rewards and stake rewards
@@ -800,18 +806,17 @@ mod tests {
         let vote_state = VoteState::deserialize(vote_account.data()).unwrap();
 
         assert_eq!(
-            vote_rewards_accounts.rewards.len(),
-            vote_rewards_accounts.accounts_to_store.len()
+            vote_rewards_accounts.accounts_with_rewards.len(),
+            vote_rewards_accounts.accounts_with_rewards.len()
         );
-        assert_eq!(vote_rewards_accounts.rewards.len(), 1);
-        let rewards = &vote_rewards_accounts.rewards[0];
-        let account = &vote_rewards_accounts.accounts_to_store[0].1;
+        assert_eq!(vote_rewards_accounts.accounts_with_rewards.len(), 1);
+        let (vote_pubkey_from_result, rewards, account) = &vote_rewards_accounts.accounts_with_rewards[0];
         let vote_rewards = 0;
         let commission = vote_state.commission;
         assert_eq!(account.lamports(), vote_account.lamports());
         assert!(accounts_equal(account, &vote_account));
         assert_eq!(
-            rewards.1,
+            *rewards,
             RewardInfo {
                 reward_type: RewardType::Voting,
                 lamports: vote_rewards as i64,
@@ -819,7 +824,7 @@ mod tests {
                 commission: Some(commission),
             }
         );
-        assert_eq!(&rewards.0, vote_pubkey);
+        assert_eq!(vote_pubkey_from_result, vote_pubkey);
 
         assert_eq!(stake_reward_calculation.stake_rewards.len(), 1);
         let expected_reward = {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -81,11 +81,8 @@ pub(crate) enum EpochRewardPhase {
 
 #[derive(Debug, Default)]
 pub(super) struct VoteRewardsAccounts {
-    /// reward info for each vote account pubkey.
-    /// This type is used by `update_reward_history()`
-    pub(super) rewards: Vec<(Pubkey, RewardInfo)>,
-    /// account to be stored, corresponds to pubkey in `rewards`
-    pub(super) accounts_to_store: Vec<(Pubkey, AccountSharedData)>,
+    /// accounts with rewards to be stored
+    pub(super) accounts_with_rewards: Vec<(Pubkey, RewardInfo, AccountSharedData)>,
     /// total lamports across all `vote_rewards`
     pub(super) total_vote_rewards_lamports: u64,
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -9,10 +9,13 @@ use {
         inflation_rewards::points::PointValue, stake_account::StakeAccount,
         stake_history::StakeHistory,
     },
-    solana_account::AccountSharedData,
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
-        partitioned_rewards::PartitionedEpochRewardsConfig, stake_rewards::StakeReward,
+        partitioned_rewards::PartitionedEpochRewardsConfig,
+        stake_rewards::StakeReward,
+        storable_accounts::{AccountForStorage, StorableAccounts},
     },
+    solana_clock::Slot,
     solana_pubkey::Pubkey,
     solana_reward_info::RewardInfo,
     solana_stake_interface::state::{Delegation, Stake},
@@ -85,6 +88,53 @@ pub(super) struct VoteRewardsAccounts {
     pub(super) accounts_with_rewards: Vec<(Pubkey, RewardInfo, AccountSharedData)>,
     /// total lamports across all `vote_rewards`
     pub(super) total_vote_rewards_lamports: u64,
+}
+
+/// Wrapper struct to implement StorableAccounts for VoteRewardsAccounts
+pub(super) struct VoteRewardsAccountsStorable<'a> {
+    pub slot: Slot,
+    pub vote_rewards_accounts: &'a VoteRewardsAccounts,
+}
+
+impl<'a> StorableAccounts<'a> for VoteRewardsAccountsStorable<'a> {
+    fn account<Ret>(
+        &self,
+        index: usize,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+    ) -> Ret {
+        let (pubkey, _, account) = &self.vote_rewards_accounts.accounts_with_rewards[index];
+        callback((pubkey, account).into())
+    }
+
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.vote_rewards_accounts.accounts_with_rewards[index]
+            .2
+            .lamports()
+            == 0
+    }
+
+    fn data_len(&self, index: usize) -> usize {
+        self.vote_rewards_accounts.accounts_with_rewards[index]
+            .2
+            .data()
+            .len()
+    }
+
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        &self.vote_rewards_accounts.accounts_with_rewards[index].0
+    }
+
+    fn slot(&self, _index: usize) -> Slot {
+        self.target_slot()
+    }
+
+    fn target_slot(&self) -> Slot {
+        self.slot
+    }
+
+    fn len(&self) -> usize {
+        self.vote_rewards_accounts.accounts_with_rewards.len()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11091,7 +11091,10 @@ fn test_system_instruction_unsigned_transaction() {
 fn test_calc_vote_accounts_to_store_empty() {
     let vote_account_rewards = DashMap::default();
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-    assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+    assert_eq!(
+        result.accounts_with_rewards.len(),
+        result.accounts_with_rewards.len()
+    );
     assert!(result.accounts_with_rewards.is_empty());
 }
 
@@ -11110,7 +11113,10 @@ fn test_calc_vote_accounts_to_store_overflow() {
         },
     );
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-    assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+    assert_eq!(
+        result.accounts_with_rewards.len(),
+        result.accounts_with_rewards.len()
+    );
     assert!(result.accounts_with_rewards.is_empty());
 }
 
@@ -11131,7 +11137,10 @@ fn test_calc_vote_accounts_to_store_normal() {
                 },
             );
             let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-            assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+            assert_eq!(
+                result.accounts_with_rewards.len(),
+                result.accounts_with_rewards.len()
+            );
             assert_eq!(result.accounts_with_rewards.len(), 1);
             let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
             _ = vote_account.checked_add_lamports(vote_rewards);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11091,8 +11091,8 @@ fn test_system_instruction_unsigned_transaction() {
 fn test_calc_vote_accounts_to_store_empty() {
     let vote_account_rewards = DashMap::default();
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-    assert_eq!(result.rewards.len(), result.accounts_to_store.len());
-    assert!(result.rewards.is_empty());
+    assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+    assert!(result.accounts_with_rewards.is_empty());
 }
 
 #[test]
@@ -11110,8 +11110,8 @@ fn test_calc_vote_accounts_to_store_overflow() {
         },
     );
     let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-    assert_eq!(result.rewards.len(), result.accounts_to_store.len());
-    assert!(result.rewards.is_empty());
+    assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+    assert!(result.accounts_with_rewards.is_empty());
 }
 
 #[test]
@@ -11131,14 +11131,13 @@ fn test_calc_vote_accounts_to_store_normal() {
                 },
             );
             let result = Bank::calc_vote_accounts_to_store(vote_account_rewards);
-            assert_eq!(result.rewards.len(), result.accounts_to_store.len());
-            assert_eq!(result.rewards.len(), 1);
-            let rewards = &result.rewards[0];
-            let account = &result.accounts_to_store[0].1;
+            assert_eq!(result.accounts_with_rewards.len(), result.accounts_with_rewards.len());
+            assert_eq!(result.accounts_with_rewards.len(), 1);
+            let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
             _ = vote_account.checked_add_lamports(vote_rewards);
             assert!(accounts_equal(account, &vote_account));
             assert_eq!(
-                rewards.1,
+                *rewards,
                 RewardInfo {
                     reward_type: RewardType::Voting,
                     lamports: vote_rewards as i64,
@@ -11146,7 +11145,7 @@ fn test_calc_vote_accounts_to_store_normal() {
                     commission: Some(commission),
                 }
             );
-            assert_eq!(rewards.0, pubkey);
+            assert_eq!(*pubkey_result, pubkey);
         }
     }
 }


### PR DESCRIPTION
#### Problem

VoteRewardsAccounts is inefficient. 

```
pub struct VoteRewardsAccounts {
    pub rewards: Vec<(Pubkey, RewardInfo)>,
    pub accounts_to_store: Vec<(Pubkey, AccountSharedData)>,
    pub total_vote_rewards_lamports: u64,
}
```

It can be optimized.

```
pub struct VoteRewardsAccounts {
    pub accounts_with_rewards: Vec<(Pubkey, RewardInfo, AccountSharedData)>,
    pub total_vote_rewards_lamports: u64,
}
```

The new structure provides better memory efficiency by:
  - Reducing memory allocations (one vector instead of two)
  - Improving cache locality (related data stored together)
  - Eliminating the need to store pubkeys twice and keep Pubkeys in sync between separate vectors


#### Summary of Changes

Optimize VoteRewardsAccount data structure.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
