### PR TITLE
Move txn logging to accounts

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -85,7 +85,7 @@ where
     )
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
-    accounts.store_accounts_par((slot, storable_accounts.as_slice()), None);
+    accounts.store_accounts_par((slot, storable_accounts.as_slice()));
     accounts.accounts_db.add_root_and_flush_write_cache(slot);
 
     let pubkeys = Arc::new(pubkeys);
@@ -109,7 +109,7 @@ where
         // Write to a different slot than the one being read from. Because
         // there's a new account pubkey being written to every time, will
         // compete for the accounts index lock on every store
-        accounts.store_accounts_par((slot + 1, new_storable_accounts.as_slice()), None);
+        accounts.store_accounts_par((slot + 1, new_storable_accounts.as_slice()));
     });
 }
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -565,7 +565,7 @@ impl Accounts {
             accounts.account_default_if_zero_lamport(index, |account| {
                 let txn = transactions
                     .map(|txs| *txs.get(index).expect("txs must be present if provided"));
-                let account_shared_data = account.to_account_shared_data();
+                let account_shared_data = account.take_account();
                 let pubkey = account.pubkey();
 
                 self.accounts_db.notify_account_at_accounts_update(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -75,7 +75,6 @@ use {
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
     solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
-    solana_transaction::sanitized::SanitizedTransaction,
     std::{
         borrow::Cow,
         boxed::Box,
@@ -941,7 +940,7 @@ pub struct AccountsDb {
     zero_lamport_accounts_to_purge_after_full_snapshot: DashSet<(Slot, Pubkey)>,
 
     /// GeyserPlugin accounts update notifier
-    accounts_update_notifier: Option<AccountsUpdateNotifier>,
+    pub(crate) accounts_update_notifier: Option<AccountsUpdateNotifier>,
 
     pub(crate) active_stats: ActiveStats,
 
@@ -5616,7 +5615,6 @@ impl AccountsDb {
     pub(crate) fn store_accounts_unfrozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        transactions: Option<&'a [&'a SanitizedTransaction]>,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         // If all transactions in a batch are errored,
@@ -5636,7 +5634,7 @@ impl AccountsDb {
 
         // Store the accounts in the write cache
         let mut store_accounts_time = Measure::start("store_accounts");
-        let infos = self.write_accounts_to_cache(accounts.target_slot(), &accounts, transactions);
+        let infos = self.write_accounts_to_cache(accounts.target_slot(), &accounts);
         store_accounts_time.stop();
         self.stats
             .store_accounts_to_cache_us
@@ -5779,43 +5777,16 @@ impl AccountsDb {
         &self,
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
-        txs: Option<&[&SanitizedTransaction]>,
     ) -> Vec<AccountInfo> {
-        let mut current_write_version = if self.accounts_update_notifier.is_some() {
-            self.write_version
-                .fetch_add(accounts_and_meta_to_store.len() as u64, Ordering::AcqRel)
-        } else {
-            0
-        };
-
         (0..accounts_and_meta_to_store.len())
             .map(|index| {
-                let txn = txs.map(|txs| *txs.get(index).expect("txs must be present if provided"));
                 accounts_and_meta_to_store.account(index, |account| {
                     let account_shared_data = account.take_account();
                     let pubkey = account.pubkey();
                     let account_info =
                         AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
 
-                    // if geyser is enabled, send the account update notification
-                    // with the original version of the account
-                    self.notify_account_at_accounts_update(
-                        slot,
-                        &account_shared_data,
-                        &txn,
-                        pubkey,
-                        current_write_version,
-                    );
-                    current_write_version = current_write_version.saturating_add(1);
-
-                    // ...but when actually storing the account, if its balance is zero,
-                    // use the default, which zeroes out all the account fields
-                    let account_to_store = if account.is_zero_lamport() {
-                        AccountSharedData::default()
-                    } else {
-                        account_shared_data
-                    };
-                    self.accounts_cache.store(slot, pubkey, account_to_store);
+                    self.accounts_cache.store(slot, pubkey, account_shared_data);
                     account_info
                 })
             })
@@ -7160,16 +7131,11 @@ impl AccountsDb {
         // Pre-populate new zero-lamport accounts with single-lamport placeholders.
         self.store_accounts_unfrozen(
             (slot, pre_populate_zero_lamport.as_slice()),
-            None,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
 
         // Then store the actual accounts provided by the caller.
-        self.store_accounts_unfrozen(
-            accounts,
-            None,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        );
+        self.store_accounts_unfrozen(accounts, UpdateIndexThreadSelection::PoolWithThreshold);
     }
 
     #[allow(clippy::needless_range_loop)]

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -29,10 +29,11 @@ mod tests {
     use {
         super::*,
         crate::{
+            accounts_db::{AccountsDbConfig, MarkObsoleteAccounts, ACCOUNTS_DB_CONFIG_FOR_TESTING},
             accounts::Accounts,
             accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier, AccountsUpdateNotifierInterface},
             utils::create_account_shared_data,
-        }
+        },
         dashmap::DashMap,
         solana_account::ReadableAccount as _,
         std::sync::{

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4111,7 +4111,7 @@ impl Bank {
             })
         });
         self.update_bank_hash_stats(&accounts);
-        self.rc.accounts.store_accounts_par(accounts, None);
+        self.rc.accounts.store_accounts_par(accounts);
         m.stop();
         self.rc
             .accounts


### PR DESCRIPTION
#### Problem
Accounts_db should not be aware of txn data, but it is required to inform geyser.


#### Summary of Changes
- Move TXN data logging up to the accounts layer. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
