### PR TITLE
CommitTransactionDetails - include result 

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -20,6 +20,7 @@ use {
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::TransactionProcessingResult,
     },
+    solana_transaction_error::TransactionError,
     std::{num::Saturating, sync::Arc},
 };
 
@@ -29,7 +30,7 @@ pub enum CommitTransactionDetails {
         compute_units: u64,
         loaded_accounts_data_size: u32,
     },
-    NotCommitted,
+    NotCommitted(TransactionError),
 }
 
 #[derive(Clone)]
@@ -86,7 +87,7 @@ impl Committer {
                         .loaded_account_stats
                         .loaded_accounts_data_size,
                 },
-                Err(_) => CommitTransactionDetails::NotCommitted,
+                Err(err) => CommitTransactionDetails::NotCommitted(err.clone()),
             })
             .collect();
 

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -29,6 +29,7 @@ pub enum CommitTransactionDetails {
     Committed {
         compute_units: u64,
         loaded_accounts_data_size: u32,
+        result: Result<(), TransactionError>,
     },
     NotCommitted(TransactionError),
 }
@@ -86,6 +87,7 @@ impl Committer {
                     loaded_accounts_data_size: committed_tx
                         .loaded_account_stats
                         .loaded_accounts_data_size,
+                    result: committed_tx.status.clone(),
                 },
                 Err(err) => CommitTransactionDetails::NotCommitted(err.clone()),
             })

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1156,6 +1156,7 @@ mod tests {
                     CommitTransactionDetails::Committed {
                         compute_units,
                         loaded_accounts_data_size,
+                        result: _,
                     } => (
                         *compute_units,
                         CostModel::calculate_loaded_accounts_data_size_cost(
@@ -1798,6 +1799,7 @@ mod tests {
         let CommitTransactionDetails::Committed {
             compute_units,
             loaded_accounts_data_size,
+            result: _,
         } = consumer_output
             .execute_and_commit_transactions_output
             .commit_transactions_result

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -207,7 +207,7 @@ impl QosService {
                                 ),
                             );
                         }
-                        CommitTransactionDetails::NotCommitted => {
+                        CommitTransactionDetails::NotCommitted(_err) => {
                             cost_tracker.remove(tx_cost);
                         }
                     }
@@ -871,7 +871,9 @@ mod tests {
                 .enumerate()
                 .map(|(n, tx_cost)| {
                     if n % 2 == 0 {
-                        CommitTransactionDetails::NotCommitted
+                        CommitTransactionDetails::NotCommitted(
+                            TransactionError::InsufficientFundsForFee,
+                        )
                     } else {
                         CommitTransactionDetails::Committed {
                             compute_units: tx_cost.as_ref().unwrap().programs_execution_cost()

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -197,6 +197,7 @@ impl QosService {
                         CommitTransactionDetails::Committed {
                             compute_units,
                             loaded_accounts_data_size,
+                            result: _,
                         } => {
                             cost_tracker.update_execution_cost(
                                 tx_cost,
@@ -750,6 +751,7 @@ mod tests {
                         + execute_units_adjustment,
                     loaded_accounts_data_size: loaded_accounts_data_size
                         + loaded_accounts_data_size_adjustment,
+                    result: Ok(()),
                 })
                 .collect();
             let final_txs_cost = total_txs_cost
@@ -880,6 +882,7 @@ mod tests {
                                 + execute_units_adjustment,
                             loaded_accounts_data_size: loaded_accounts_data_size
                                 + loaded_accounts_data_size_adjustment,
+                            result: Ok(()),
                         }
                     }
                 })


### PR DESCRIPTION
#### Problem
- scheduler-bindings project will want to return failure reasons and status to the external process
- for transactions that didn't get committed we do not return the error in `ExecuteAndCommitTransactionsOutput`

#### Summary of Changes
- CommitTransactionDetails:
  - Include the error if not committed
  - Include the result if committed

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
