### PR TITLE
docs: fix a broken link

### DIFF
--- a/docs/src/cli/examples/test-validator.md
+++ b/docs/src/cli/examples/test-validator.md
@@ -13,7 +13,7 @@ starts a full-featured, single-node cluster on the developer's workstation.
 
 - No RPC rate-limits
 - No airdrop limits
-- Direct [on-chain program](https://solana.com/uk/docs/core/programs) deployment
+- Direct [on-chain program](https://solana.com/docs/core/programs) deployment
   (`--bpf-program ...`)
 - Clone accounts from a public cluster, including programs (`--clone ...`)
 - Load accounts from files

--- a/docs/src/cli/examples/test-validator.md
+++ b/docs/src/cli/examples/test-validator.md
@@ -13,7 +13,7 @@ starts a full-featured, single-node cluster on the developer's workstation.
 
 - No RPC rate-limits
 - No airdrop limits
-- Direct [on-chain program](https://solana.com/docs/core/programs) deployment
+- Direct [on-chain program](https://solana.com/docs/programs/rust) deployment
   (`--bpf-program ...`)
 - Clone accounts from a public cluster, including programs (`--clone ...`)
 - Load accounts from files

--- a/docs/src/cli/examples/test-validator.md
+++ b/docs/src/cli/examples/test-validator.md
@@ -13,7 +13,7 @@ starts a full-featured, single-node cluster on the developer's workstation.
 
 - No RPC rate-limits
 - No airdrop limits
-- Direct [on-chain program](https://solana.com/docs/programs) deployment
+- Direct [on-chain program](https://solana.com/uk/docs/core/programs) deployment
   (`--bpf-program ...`)
 - Clone accounts from a public cluster, including programs (`--clone ...`)
 - Load accounts from files


### PR DESCRIPTION
Fixed a broken link to https://solana.com/docs/programs
Replaced link with the correct one: https://solana.com/docs/programs/rust