### PR TITLE
Add --quiet flag to cargo build-sbf

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -518,9 +518,9 @@ fn main() {
         .arg(
             Arg::new("quiet")
                 .short('q')
-                .long("quite")
+                .long("quiet")
                 .takes_value(false)
-                .help("Use quiet output"),
+                .help("Do not print cargo log messages"),
         )
         .arg(
             Arg::new("workspace")

--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -42,6 +42,7 @@ pub struct Config<'a> {
     remap_cwd: bool,
     debug: bool,
     verbose: bool,
+    quiet: bool,
     workspace: bool,
     jobs: Option<String>,
     arch: &'a str,
@@ -74,6 +75,7 @@ impl Default for Config<'_> {
             remap_cwd: true,
             debug: false,
             verbose: false,
+            quiet: false,
             workspace: false,
             jobs: None,
             arch: "v0",
@@ -245,6 +247,9 @@ fn invoke_cargo(config: &Config, validated_toolchain_version: String) {
     }
     if config.verbose {
         cargo_build_args.push("--verbose");
+    }
+    if config.quiet {
+        cargo_build_args.push("--quiet");
     }
     if let Some(jobs) = &config.jobs {
         cargo_build_args.push("--jobs");
@@ -511,6 +516,13 @@ fn main() {
                 .help("Use verbose output"),
         )
         .arg(
+            Arg::new("quiet")
+                .short('q')
+                .long("quite")
+                .takes_value(false)
+                .help("Use quiet output"),
+        )
+        .arg(
             Arg::new("workspace")
                 .long("workspace")
                 .takes_value(false)
@@ -613,6 +625,7 @@ fn main() {
         debug: matches.is_present("debug"),
         offline: matches.is_present("offline"),
         verbose: matches.is_present("verbose"),
+        quiet: matches.is_present("quiet"),
         workspace: matches.is_present("workspace"),
         jobs: matches.value_of_t("jobs").ok(),
         arch: matches.value_of("arch").unwrap(),


### PR DESCRIPTION
#### Problem

This PR is for issue #7245 

#### Summary of Changes

I have added `-q` and `--quiet` option for `cargo build-sbf` subcommand. The `--quiet` flag will then be passed to the  cargo build command to suppress output. 

<img width="328" height="79" alt="Screenshot 2025-07-31 at 11 11 20 AM" src="https://github.com/user-attachments/assets/24f647b7-22de-4e45-9dd7-884639d3b3d2" />
