### PR TITLE
SPL: Use ATA interface crate instead of program crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11246,7 +11246,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-version",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-token",
  "tempfile",
  "thiserror 2.0.12",
@@ -11499,7 +11499,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-vote-interface",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
  "spl-token-2022",
@@ -12086,27 +12086,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "7.0.0"
+name = "spl-associated-token-account-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+checksum = "5e6bbe0794e532ac08428d3abf5bf8ae75bd81dfddd785c388e326c00c92c6f5"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token",
- "spl-token-2022",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
-dependencies = [
  "solana-instruction",
  "solana-pubkey",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,7 +564,7 @@ solana-zk-keygen = { path = "zk-keygen", version = "=3.0.0" }
 solana-zk-sdk = "3.0.0"
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=3.0.0" }
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.0.0" }
-spl-associated-token-account = "7.0.0"
+spl-associated-token-account-interface = "1.0.0"
 spl-generic-token = "1.0.1"
 spl-instruction-padding = "0.3.0"
 spl-memo = "6.0.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9581,7 +9581,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-vote-interface",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
  "spl-token-2022",
@@ -10012,27 +10012,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "7.0.0"
+name = "spl-associated-token-account-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+checksum = "5e6bbe0794e532ac08428d3abf5bf8ae75bd81dfddd785c388e326c00c92c6f5"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token",
- "spl-token-2022",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
-dependencies = [
  "solana-instruction",
  "solana-pubkey",
 ]

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8271,7 +8271,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-error",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-token",
  "termcolor",
 ]
@@ -8668,7 +8668,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-vote-interface",
- "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
  "spl-token-2022",
@@ -9096,27 +9096,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "7.0.0"
+name = "spl-associated-token-account-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+checksum = "5e6bbe0794e532ac08428d3abf5bf8ae75bd81dfddd785c388e326c00c92c6f5"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token",
- "spl-token-2022",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
-dependencies = [
  "solana-instruction",
  "solana-pubkey",
 ]

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -68,7 +68,7 @@ solana-transaction-error = "2.2.1"
 solana-transaction-status = { path = "../../transaction-status" }
 solana-validator-exit = "2.2.1"
 solana-version = { path = "../../version" }
-spl-associated-token-account = "7.0.0"
+spl-associated-token-account-interface = "1.0.0"
 spl-token = "8.0.0"
 spl-token-2022 = "8.0.0"
 termcolor = "1.4.1"

--- a/svm/examples/paytube/Cargo.toml
+++ b/svm/examples/paytube/Cargo.toml
@@ -37,7 +37,7 @@ solana-system-interface = { workspace = true }
 solana-system-program = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
 solana-transaction-error = { workspace = true }
-spl-associated-token-account = { workspace = true }
+spl-associated-token-account-interface = { workspace = true }
 spl-token = { workspace = true }
 termcolor = { workspace = true }
 

--- a/svm/examples/paytube/src/settler.rs
+++ b/svm/examples/paytube/src/settler.rs
@@ -24,7 +24,7 @@ use {
     },
     solana_system_interface::instruction as system_instruction,
     solana_transaction::Transaction as SolanaTransaction,
-    spl_associated_token_account::get_associated_token_address,
+    spl_associated_token_account_interface::address::get_associated_token_address,
     std::collections::HashMap,
 };
 

--- a/svm/examples/paytube/src/transaction.rs
+++ b/svm/examples/paytube/src/transaction.rs
@@ -14,7 +14,7 @@ use {
         sanitized::SanitizedTransaction as SolanaSanitizedTransaction,
         Transaction as SolanaTransaction,
     },
-    spl_associated_token_account::get_associated_token_address,
+    spl_associated_token_account_interface::address::get_associated_token_address,
     std::collections::HashSet,
 };
 

--- a/svm/examples/paytube/tests/spl_tokens.rs
+++ b/svm/examples/paytube/tests/spl_tokens.rs
@@ -9,7 +9,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_svm_example_paytube::{transaction::PayTubeTransaction, PayTubeChannel},
-    spl_associated_token_account::get_associated_token_address,
+    spl_associated_token_account_interface::address::get_associated_token_address,
 };
 
 #[test]

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -41,7 +41,7 @@ solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
-spl-associated-token-account = { version = "=7.0.0", features = ["no-entrypoint"] }
+spl-associated-token-account-interface = { version = "=1.0.0" }
 spl-token = { version = "=8.0.0", features = ["no-entrypoint"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -36,7 +36,7 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_transaction::Transaction,
     solana_transaction_status::TransactionStatus,
-    spl_associated_token_account::get_associated_token_address,
+    spl_associated_token_account_interface::address::get_associated_token_address,
     spl_token::solana_program::program_error::ProgramError,
     std::{
         cmp::{self},

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -9,8 +9,8 @@ use {
     solana_message::Message,
     solana_native_token::lamports_to_sol,
     solana_rpc_client::rpc_client::RpcClient,
-    spl_associated_token_account::{
-        get_associated_token_address, instruction::create_associated_token_account,
+    spl_associated_token_account_interface::{
+        address::get_associated_token_address, instruction::create_associated_token_account,
     },
     spl_token::{
         solana_program::program_pack::Pack,

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -42,7 +42,7 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-vote-interface = { workspace = true }
-spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
+spl-associated-token-account-interface = { workspace = true, features = ["borsh"] }
 spl-memo = { workspace = true, features = ["no-entrypoint"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -86,6 +86,7 @@ fn check_num_associated_token_accounts(
 mod test {
     use {
         super::*,
+        solana_instruction::AccountMeta,
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_sdk_ids::sysvar,
@@ -105,9 +106,13 @@ mod test {
         let mint = Pubkey::new_unique();
         let associated_account_address = get_associated_token_address(&wallet_address, &mint);
         let token_program_id = spl_token::id();
+        // mimic the deprecated instruction
         let mut create_ix =
             create_associated_token_account(&funder, &wallet_address, &mint, &token_program_id);
         create_ix.data = vec![];
+        create_ix
+            .accounts
+            .push(AccountMeta::new_readonly(sysvar::rent::id(), false));
         let mut message = Message::new(&[create_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         let expected_parsed_ix = ParsedInstructionEnum {

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -5,7 +5,7 @@ use {
     borsh::BorshDeserialize,
     serde_json::json,
     solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
-    spl_associated_token_account::instruction::AssociatedTokenAccountInstruction,
+    spl_associated_token_account_interface::instruction::AssociatedTokenAccountInstruction,
 };
 
 pub fn parse_associated_token(
@@ -84,15 +84,13 @@ fn check_num_associated_token_accounts(
 
 #[cfg(test)]
 mod test {
-    #[allow(deprecated)]
-    use spl_associated_token_account::create_associated_token_account as create_associated_token_account_deprecated;
     use {
         super::*,
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_sdk_ids::sysvar,
-        spl_associated_token_account::{
-            get_associated_token_address, get_associated_token_address_with_program_id,
+        spl_associated_token_account_interface::{
+            address::{get_associated_token_address, get_associated_token_address_with_program_id},
             instruction::{
                 create_associated_token_account, create_associated_token_account_idempotent,
                 recover_nested,
@@ -106,8 +104,10 @@ mod test {
         let wallet_address = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let associated_account_address = get_associated_token_address(&wallet_address, &mint);
-        #[allow(deprecated)]
-        let create_ix = create_associated_token_account_deprecated(&funder, &wallet_address, &mint);
+        let token_program_id = spl_token::id();
+        let mut create_ix =
+            create_associated_token_account(&funder, &wallet_address, &mint, &token_program_id);
+        create_ix.data = vec![];
         let mut message = Message::new(&[create_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         let expected_parsed_ix = ParsedInstructionEnum {
@@ -118,7 +118,7 @@ mod test {
                 "wallet": wallet_address.to_string(),
                 "mint": mint.to_string(),
                 "systemProgram": solana_sdk_ids::system_program::id().to_string(),
-                "tokenProgram": spl_token::id().to_string(),
+                "tokenProgram": token_program_id.to_string(),
             }),
         };
         assert_eq!(

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -30,7 +30,7 @@ static PARSABLE_PROGRAM_IDS: std::sync::LazyLock<HashMap<Pubkey, ParsableProgram
                 ParsableProgram::AddressLookupTable,
             ),
             (
-                spl_associated_token_account::id(),
+                spl_associated_token_account_interface::program::id(),
                 ParsableProgram::SplAssociatedTokenAccount,
             ),
             (spl_memo::v1::id(), ParsableProgram::SplMemo),


### PR DESCRIPTION
#### Problem

In order to publish the v3 SDK crates and have them usable in Agave, we also need to have SPL crates using the v3 SDK crates. However, we have a circular dependency between Agave and SPL which currently makes this impossible.

The overall plan is to have Agave only use "interface" crates from SPL, which have no dependencies on Agave crates.

You can see more info about the project at https://github.com/orgs/anza-xyz/projects/27

ATA is already in a good position since it has a small "interface"-style crate which Agave is partly using. Agave still needs the program crate to deserialize instructions.

#### Summary of changes

Use the interface crate everywhere.

The only substantive change is in the instruction parsing test. The interface crate does not have the deprecated instruction creator, so we mimic it inline instead.

The best part: the ata program crate is completely gone from lockfiles!