### PR TITLE
Limit snapshot unpacking buffers by archive input size

### DIFF
--- a/accounts-db/src/buffered_reader.rs
+++ b/accounts-db/src/buffered_reader.rs
@@ -373,8 +373,9 @@ pub fn large_file_buf_reader(
 ) -> io::Result<Box<dyn BufRead>> {
     #[cfg(target_os = "linux")]
     if agave_io_uring::io_uring_supported() {
-        use crate::io_uring::sequential_file_reader::SequentialFileReader;
+        use crate::io_uring::sequential_file_reader::{SequentialFileReader, DEFAULT_READ_SIZE};
 
+        let buf_size = buf_size.max(DEFAULT_READ_SIZE);
         return Ok(Box::new(SequentialFileReader::with_capacity(
             buf_size, path,
         )?));

--- a/accounts-db/src/file_io.rs
+++ b/accounts-db/src/file_io.rs
@@ -116,8 +116,9 @@ pub fn file_creator<'a>(
 ) -> io::Result<Box<dyn FileCreator + 'a>> {
     #[cfg(target_os = "linux")]
     if agave_io_uring::io_uring_supported() {
-        use crate::io_uring::file_creator::IoUringFileCreator;
+        use crate::io_uring::file_creator::{IoUringFileCreator, DEFAULT_WRITE_SIZE};
 
+        let buf_size = buf_size.max(DEFAULT_WRITE_SIZE);
         let io_uring_creator = IoUringFileCreator::with_buffer_capacity(buf_size, file_complete)?;
         return Ok(Box::new(io_uring_creator));
     }

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -95,6 +95,7 @@ pub enum UnpackPath<'a> {
 
 fn unpack_archive<'a, A, C, D>(
     mut archive: Archive<A>,
+    input_archive_size: u64,
     apparent_limit_size: u64,
     actual_limit_size: u64,
     limit_count: u64,
@@ -113,10 +114,9 @@ where
     let mut total_entries = 0;
     let mut open_dirs = Vec::new();
 
-    // Bound the buffer based on provided limit of unpacked data (buffering a fraction,
-    // e.g. 25%, of absolute maximum won't be necessary) - this works well for genesis,
-    // while normal case hit the UNPACK_WRITE_BUF_SIZE tuned for it prod snapshot archive.
-    let buf_size = (apparent_limit_size.div_ceil(4) as usize)
+    // Bound the buffer based on provided limit of unpacked data and input archive size
+    // (decompression multiplies content size, but buffering more than origin isn't necessary).
+    let buf_size = (input_archive_size.min(actual_limit_size) as usize)
         .clamp(MIN_UNPACK_WRITE_BUF_SIZE, MAX_UNPACK_WRITE_BUF_SIZE);
     let mut files_creator = file_creator(buf_size, file_path_processor)?;
 
@@ -344,12 +344,14 @@ pub type UnpackedAppendVecMap = HashMap<String, PathBuf>;
 /// Unpacks snapshot and collects AppendVec file names & paths
 pub fn unpack_snapshot<A: Read>(
     archive: Archive<A>,
+    input_archive_size: u64,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
 ) -> Result<UnpackedAppendVecMap> {
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
     unpack_snapshot_with_processors(
         archive,
+        input_archive_size,
         ledger_dir,
         account_paths,
         |file, path| {
@@ -364,12 +366,14 @@ pub fn unpack_snapshot<A: Read>(
 /// sends entry file paths through the `sender` channel
 pub fn streaming_unpack_snapshot<A: Read>(
     archive: Archive<A>,
+    input_archive_size: u64,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
     sender: &Sender<PathBuf>,
 ) -> Result<()> {
     unpack_snapshot_with_processors(
         archive,
+        input_archive_size,
         ledger_dir,
         account_paths,
         |_, _| {},
@@ -387,6 +391,7 @@ pub fn streaming_unpack_snapshot<A: Read>(
 
 fn unpack_snapshot_with_processors<A, F, G>(
     archive: Archive<A>,
+    input_archive_size: u64,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
     mut accounts_path_processor: F,
@@ -401,6 +406,7 @@ where
 
     unpack_archive(
         archive,
+        input_archive_size,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_APPARENT_SIZE,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_ACTUAL_SIZE,
         MAX_SNAPSHOT_ARCHIVE_UNPACKED_COUNT,
@@ -520,9 +526,15 @@ pub fn unpack_genesis_archive(
 
     fs::create_dir_all(destination_dir)?;
     let tar_bz2 = File::open(archive_filename)?;
+    let archive_size = tar_bz2.metadata()?.len();
     let tar = BzDecoder::new(BufReader::new(tar_bz2));
     let archive = Archive::new(tar);
-    unpack_genesis(archive, destination_dir, max_genesis_archive_unpacked_size)?;
+    unpack_genesis(
+        archive,
+        archive_size,
+        destination_dir,
+        max_genesis_archive_unpacked_size,
+    )?;
     info!(
         "Extracted {:?} in {:?}",
         archive_filename,
@@ -533,11 +545,13 @@ pub fn unpack_genesis_archive(
 
 fn unpack_genesis<A: Read>(
     archive: Archive<A>,
+    input_archive_size: u64,
     unpack_dir: &Path,
     max_genesis_archive_unpacked_size: u64,
 ) -> Result<()> {
     unpack_archive(
         archive,
+        input_archive_size,
         max_genesis_archive_unpacked_size,
         max_genesis_archive_unpacked_size,
         MAX_GENESIS_ARCHIVE_UNPACKED_COUNT,
@@ -816,13 +830,14 @@ mod tests {
 
     fn finalize_and_unpack_snapshot(archive: tar::Builder<Vec<u8>>) -> Result<()> {
         with_finalize_and_unpack(archive, |a, b| {
-            unpack_snapshot_with_processors(a, b, &[PathBuf::new()], |_, _| {}, |_| {}).map(|_| ())
+            unpack_snapshot_with_processors(a, 256, b, &[PathBuf::new()], |_, _| {}, |_| {})
+                .map(|_| ())
         })
     }
 
     fn finalize_and_unpack_genesis(archive: tar::Builder<Vec<u8>>) -> Result<()> {
         with_finalize_and_unpack(archive, |a, b| {
-            unpack_genesis(a, b, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
+            unpack_genesis(a, 256, b, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE)
         })
     }
 
@@ -1072,6 +1087,7 @@ mod tests {
         let result = with_finalize_and_unpack(archive, |ar, tmp| {
             unpack_snapshot_with_processors(
                 ar,
+                256,
                 tmp,
                 &[tmp.join("accounts_dest")],
                 |_, _| {},

--- a/accounts-db/src/hardened_unpack.rs
+++ b/accounts-db/src/hardened_unpack.rs
@@ -53,8 +53,6 @@ const MAX_GENESIS_ARCHIVE_UNPACKED_COUNT: u64 = 100;
 // - Large files: their data may accumulate in backlog buffers while waiting for file open
 //   operations to complete.
 const MAX_UNPACK_WRITE_BUF_SIZE: usize = 512 * 1024 * 1024;
-// Minimum for unpacking small archives - allows ~2-4 write-capacity-sized operations concurrently.
-const MIN_UNPACK_WRITE_BUF_SIZE: usize = 2 * 1024 * 1024;
 
 fn checked_total_size_sum(total_size: u64, entry_size: u64, limit_size: u64) -> Result<u64> {
     trace!("checked_total_size_sum: {total_size} + {entry_size} < {limit_size}");
@@ -116,8 +114,8 @@ where
 
     // Bound the buffer based on provided limit of unpacked data and input archive size
     // (decompression multiplies content size, but buffering more than origin isn't necessary).
-    let buf_size = (input_archive_size.min(actual_limit_size) as usize)
-        .clamp(MIN_UNPACK_WRITE_BUF_SIZE, MAX_UNPACK_WRITE_BUF_SIZE);
+    let buf_size =
+        (input_archive_size.min(actual_limit_size) as usize).min(MAX_UNPACK_WRITE_BUF_SIZE);
     let mut files_creator = file_creator(buf_size, file_path_processor)?;
 
     for entry in archive.entries()? {

--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -28,7 +28,7 @@ use {
 // Based on transfers seen with `dd bs=SIZE` for NVME drives: values >=64KiB are fine,
 // but usually peak around 256KiB-1MiB. Also compare with particular NVME parameters, e.g.
 // 32 pages (Maximum Data Transfer Size) * page size (MPSMIN = Memory Page Size) = 128KiB.
-const DEFAULT_WRITE_SIZE: usize = 512 * 1024;
+pub const DEFAULT_WRITE_SIZE: usize = 512 * 1024;
 
 // 99.9% of accounts storage files are < 8MiB
 type BacklogVec = SmallVec<[PendingWrite; 8 * 1024 * 1024 / DEFAULT_WRITE_SIZE]>;

--- a/accounts-db/src/io_uring/sequential_file_reader.rs
+++ b/accounts-db/src/io_uring/sequential_file_reader.rs
@@ -20,7 +20,7 @@ use {
 // Based on transfers seen with `dd bs=SIZE` for NVME drives: values >=64KiB are fine,
 // but peak at 1MiB. Also compare with particular NVME parameters, e.g.
 // 32 pages (Maximum Data Transfer Size) * page size (MPSMIN = Memory Page Size) = 128KiB.
-const DEFAULT_READ_SIZE: usize = 1024 * 1024;
+pub const DEFAULT_READ_SIZE: usize = 1024 * 1024;
 const SQPOLL_IDLE_TIMEOUT: u32 = 50;
 // For large file we don't really use workers as few regularly submitted requests get handled
 // within sqpoll thread. Allow some workers just in case, but limit them.
@@ -88,10 +88,8 @@ impl<B: AsMut<[u8]>> SequentialFileReader<B> {
     ) -> io::Result<Self> {
         let buffer = backing_buffer.as_mut();
         assert!(buffer.len() >= read_capacity, "buffer too small");
-        assert!(
-            buffer.len() % read_capacity == 0,
-            "buffer size must be a multiple of read_capacity"
-        );
+        let read_aligned_buf_len = buffer.len() / read_capacity * read_capacity;
+        let buffer = &mut buffer[..read_aligned_buf_len];
 
         let file = OpenOptions::new()
             .read(true)

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -84,6 +84,9 @@ pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str =
     r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar\.zst|tar\.lz4)$";
 
+// Allows scheduling a large number of reads such that temporary disk access delays
+// shouldn't block decompression (unless read bandwidth is saturated).
+const MAX_SNAPSHOT_READER_BUF_SIZE: u64 = 128 * 1024 * 1024;
 // Balance large and small files order in snapshot tar with bias towards small (4 small + 1 large),
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
@@ -1677,8 +1680,8 @@ fn streaming_unarchive_snapshot(
     Builder::new()
         .name("solTarUnpack".to_string())
         .spawn(move || {
-            let archive_size = std::fs::metadata(&snapshot_archive_path)?.len();
-            let buf_size = archive_size.min(MAX_SNAPSHOT_DATA_FILE_SIZE);
+            let archive_size = fs::metadata(&snapshot_archive_path)?.len();
+            let buf_size = archive_size.min(MAX_SNAPSHOT_READER_BUF_SIZE);
             let decompressor =
                 decompressed_tar_reader(archive_format, snapshot_archive_path, buf_size)?;
             hardened_unpack::streaming_unpack_snapshot(
@@ -2416,7 +2419,7 @@ fn unpack_snapshot_local(
     num_threads: usize,
 ) -> Result<UnpackedAppendVecMap> {
     assert!(num_threads > 0);
-    let archive_size = std::fs::metadata(snapshot_path.as_ref())?.len();
+    let archive_size = fs::metadata(&snapshot_path)?.len();
     let archive = Archive::new(decompressed_tar_reader(
         archive_format,
         snapshot_path,


### PR DESCRIPTION
#### Problem
Currently buffer sizes for reading snapshot and unpacking it are picked for performance on prod-sized data. However tests and solana-test-validator operate on snapshots with much smaller sizes, so using large buffers is undesirable:
* large memory pressure on test workers
* exceeding vanilla memlock limits on user machine or some github CI workers

Another observation is that buffering more than input file size isn't really helpful, similarly buffer size for unpacking files doesn't really need to be larger than original compressed archive size.

#### Summary of Changes
* check file size when preparing to unpack snapshot
* use archive size as desired buffer size for reading snapshot file
* use archive size as desired buffer size for creating unpacked files
* above buf sizes are subject to clamping by prod-tuned min (read/write size) and max (buf sizes providing saturation of disk bandwidth)
