### PR TITLE
QUIC: generate unique server_name for client connections

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -27,7 +27,8 @@ use {
     solana_rpc_client_api::client_error::ErrorKind as ClientErrorKind,
     solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
     solana_tls_utils::{
-        new_dummy_x509_certificate, tls_client_config_builder, QuicClientCertificate,
+        new_dummy_x509_certificate, socket_addr_to_quic_server_name, tls_client_config_builder,
+        QuicClientCertificate,
     },
     solana_transaction_error::TransportResult,
     std::{
@@ -154,8 +155,8 @@ impl QuicNewConnection {
     ) -> Result<Self, QuicError> {
         let mut make_connection_measure = Measure::start("make_connection_measure");
         let endpoint = endpoint.get_endpoint().await;
-
-        let connecting = endpoint.connect(addr, "connect")?;
+        let server_name = socket_addr_to_quic_server_name(addr);
+        let connecting = endpoint.connect(addr, &server_name)?;
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
         if let Ok(connecting_result) = timeout(QUIC_CONNECTION_HANDSHAKE_TIMEOUT, connecting).await
         {
@@ -190,7 +191,8 @@ impl QuicNewConnection {
         addr: SocketAddr,
         stats: &ClientStats,
     ) -> Result<Arc<Connection>, QuicError> {
-        let connecting = self.endpoint.connect(addr, "connect")?;
+        let server_name = socket_addr_to_quic_server_name(addr);
+        let connecting = self.endpoint.connect(addr, &server_name)?;
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
         let connection = match connecting.into_0rtt() {
             Ok((connection, zero_rtt)) => {

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -12,6 +12,7 @@ use {
     solana_clock::{DEFAULT_MS_PER_SLOT, MAX_PROCESSING_AGE, NUM_CONSECUTIVE_LEADER_SLOTS},
     solana_measure::measure::Measure,
     solana_time_utils::timestamp,
+    solana_tls_utils::socket_addr_to_quic_server_name,
     std::{
         net::SocketAddr,
         sync::{atomic::Ordering, Arc},
@@ -209,7 +210,8 @@ impl ConnectionWorker {
     /// If an error occurs, the state may transition to `Retry` or `Closing`,
     /// depending on the nature of the error.
     async fn create_connection(&mut self, retries_attempt: usize) {
-        let connecting = self.endpoint.connect(self.peer, "connect");
+        let server_name = socket_addr_to_quic_server_name(self.peer);
+        let connecting = self.endpoint.connect(self.peer, &server_name);
         match connecting {
             Ok(connecting) => {
                 let mut measure_connection = Measure::start("establish connection");

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -17,7 +17,8 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::BankForks,
     solana_tls_utils::{
-        new_dummy_x509_certificate, tls_client_config_builder, tls_server_config_builder,
+        new_dummy_x509_certificate, socket_addr_to_quic_server_name, tls_client_config_builder,
+        tls_server_config_builder,
     },
     std::{
         cmp::Reverse,
@@ -44,7 +45,6 @@ const CLIENT_CHANNEL_BUFFER: usize = 1 << 14;
 const ROUTER_CHANNEL_BUFFER: usize = 64;
 const CONNECTION_CACHE_CAPACITY: usize = 3072;
 const ALPN_TURBINE_PROTOCOL_ID: &[u8] = b"solana-turbine";
-const CONNECT_SERVER_NAME: &str = "solana-turbine";
 
 // Transport config.
 const DATAGRAM_RECEIVE_BUFFER_SIZE: usize = 256 * 1024 * 1024;
@@ -504,9 +504,8 @@ async fn make_connection(
     cache: Arc<Mutex<HashMap<Pubkey, Connection>>>,
     stats: Arc<TurbineQuicStats>,
 ) -> Result<(), Error> {
-    let connection = endpoint
-        .connect(remote_address, CONNECT_SERVER_NAME)?
-        .await?;
+    let server_name = socket_addr_to_quic_server_name(remote_address);
+    let connection = endpoint.connect(remote_address, &server_name)?.await?;
     handle_connection(
         endpoint,
         connection.remote_address(),


### PR DESCRIPTION
#### Problem

- QUIC clients reuse the same server_name for all connections which can cause QUIC tokens to be mixed up, as they are stored in a big hashmap deep inside Quinn, keyed by server_name
- This prevents features like address validation and 0RTT from working correctly

#### Summary of Changes

- Generate server_name based on the SocketAddr of the peer we are connecting to, thus ensuring it is appropriate for the server.


Fixes https://github.com/anza-xyz/agave/issues/7197