### PR TITLE
Ledger: remove ways to construct legacy CodingShred and set last_in_slot

### DIFF
--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -7,7 +7,6 @@ use {
         CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
         DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
-    solana_clock::Slot,
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,
     solana_signature::Signature,
@@ -35,6 +34,7 @@ impl ShredCode {
     dispatch!(pub(super) fn into_payload(self) -> Payload);
     dispatch!(pub(super) fn payload(&self) -> &Payload);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
     pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
@@ -56,28 +56,6 @@ impl ShredCode {
             Self::Legacy(_) => Err(Error::InvalidShredType),
             Self::Merkle(shred) => shred.merkle_root(),
         }
-    }
-
-    pub(super) fn new_from_parity_shard(
-        slot: Slot,
-        index: u32,
-        parity_shard: &[u8],
-        fec_set_index: u32,
-        num_data_shreds: u16,
-        num_coding_shreds: u16,
-        position: u16,
-        version: u16,
-    ) -> Self {
-        Self::from(legacy::ShredCode::new_from_parity_shard(
-            slot,
-            index,
-            parity_shard,
-            fec_set_index,
-            num_data_shreds,
-            num_coding_shreds,
-            position,
-            version,
-        ))
     }
 
     pub(super) fn num_data_shreds(&self) -> u16 {

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -27,6 +27,7 @@ impl ShredData {
     dispatch!(pub(super) fn parent(&self) -> Result<Slot, Error>);
     dispatch!(pub(super) fn payload(&self) -> &Payload);
     dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
 
     pub(super) fn signed_data(&self) -> Result<SignedData, Error> {
@@ -128,14 +129,6 @@ impl ShredData {
                 debug_assert!(chained || !resigned);
                 merkle::ShredData::capacity(proof_size, chained, resigned)
             }
-        }
-    }
-
-    // Only for tests.
-    pub(super) fn set_last_in_slot(&mut self) {
-        match self {
-            Self::Legacy(shred) => shred.set_last_in_slot(),
-            Self::Merkle(_) => panic!("Not Implemented!"),
         }
     }
 


### PR DESCRIPTION
#### Problem

- Legacy shreds must go  https://github.com/anza-xyz/agave/issues/5982

#### Summary of Changes

- Remove relevant constructors (new_from_parity_shard) from ledger
- Remove associated legacy-specific tests