### PR TITLE
Remove `index_in_callee` from `InstructionAccount`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
+ "static_assertions",
  "test-case",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9622,7 +9622,6 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
  "log",
  "percentage",
@@ -9638,6 +9637,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-hash",
  "solana-instruction",
+ "solana-keypair",
  "solana-last-restart-slot",
  "solana-log-collector",
  "solana-measure",
@@ -9648,8 +9648,8 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
+ "solana-signer",
  "solana-slot-hashes",
- "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-transaction",
@@ -9657,10 +9657,10 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-timings",
+ "solana-transaction",
  "solana-transaction-context",
  "solana-type-overrides",
  "test-case",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -408,7 +408,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 pubkey,
                 AccountSharedData::new(0, allocation_size, &Pubkey::new_unique()),
             ));
-            instruction_accounts.push(InstructionAccount::new(0, 0, false, true));
+            instruction_accounts.push(InstructionAccount::new(0, false, true));
             vec![]
         }
         Err(_) => {
@@ -480,7 +480,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                         idx
                     };
                     InstructionAccount::new(
-                        txn_acct_index as IndexOfAccount,
                         txn_acct_index as IndexOfAccount,
                         account_info.is_signer.unwrap_or(false),
                         account_info.is_writable.unwrap_or(false),

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -523,7 +523,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         .transaction_context
         .get_next_instruction_context_mut()
         .unwrap()
-        .configure(
+        .configure_for_tests(
             vec![program_index, program_index.saturating_add(1)],
             instruction_accounts,
             &instruction_data,

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -26,7 +26,6 @@ shuttle-test = ["solana-type-overrides/shuttle-test", "solana-sbpf/shuttle-test"
 [dependencies]
 base64 = { workspace = true }
 bincode = { workspace = true }
-enum-iterator = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
@@ -55,7 +54,6 @@ solana-rent = { workspace = true }
 solana-sbpf = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-stable-layout = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-svm-transaction = { workspace = true }
@@ -65,7 +63,6 @@ solana-sysvar-id = { workspace = true }
 solana-timings = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-type-overrides = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -73,6 +70,9 @@ solana-account-info = { workspace = true }
 solana-instruction = { workspace = true, features = ["bincode"] }
 solana-program-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
+solana-keypair = { workspace = true }
+solana-signer = { workspace = true }
+solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { workspace = true, features = [
     "dev-context-only-utils",
 ] }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -68,9 +68,9 @@ solana-type-overrides = { workspace = true }
 assert_matches = { workspace = true }
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true, features = ["bincode"] }
+solana-keypair = { workspace = true }
 solana-program-runtime = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-keypair = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { workspace = true, features = [

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -32,6 +32,7 @@ use {
     solana_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_transaction_context::{
         IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
+        MAX_ACCOUNTS_PER_TRANSACTION,
     },
     solana_type_overrides::sync::{atomic::Ordering, Arc},
     std::{
@@ -323,7 +324,7 @@ impl<'a> InvokeContext<'a> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
         // This algorithm allocates the array on the stack for speed.
         // On AArch64 in release mode, this function only consumes 640 bytes of stack.
-        let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; 256];
+        let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
         let mut instruction_accounts: Vec<InstructionAccount> =
             Vec::with_capacity(instruction.accounts.len());
 
@@ -477,7 +478,7 @@ impl<'a> InvokeContext<'a> {
         // This algorithm allocates the array on the stack for speed.
         // On AArch64 in release mode, this function only consumes 464 bytes of stack (when it is
         // not inlined).
-        let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; 256];
+        let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
         debug_assert!(instruction.accounts.len() <= u8::MAX as usize);
 
         let mut instruction_accounts: Vec<InstructionAccount> =

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -380,11 +380,14 @@ impl<'a> InvokeContext<'a> {
 
             for current_index in 0..instruction_accounts.len() {
                 let instruction_account = instruction_accounts.get(current_index).unwrap();
+                let index_in_callee = *transaction_callee_map
+                    .get(instruction_account.index_in_transaction as usize)
+                    .unwrap() as usize;
 
-                if current_index != instruction_account.index_in_callee as usize {
+                if current_index != index_in_callee {
                     let (is_signer, is_writable) = {
                         let reference_account = instruction_accounts
-                            .get(instruction_account.index_in_callee as usize)
+                            .get(index_in_callee)
                             .ok_or(InstructionError::NotEnoughAccountKeys)?;
                         (
                             reference_account.is_signer(),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -333,7 +333,7 @@ impl<'a> InvokeContext<'a> {
         // function, we must borrow it again as mutable.
         let program_account_index = {
             let instruction_context = self.transaction_context.get_current_instruction_context()?;
-            debug_assert!(instruction.accounts.len() <= MAX_ACCOUNTS_PER_TRANSACTION);
+            debug_assert!(instruction.accounts.len() <= transaction_callee_map.len());
 
             for account_meta in instruction.accounts.iter() {
                 let index_in_transaction = self
@@ -479,7 +479,7 @@ impl<'a> InvokeContext<'a> {
         // On AArch64 in release mode, this function only consumes 464 bytes of stack (when it is
         // not inlined).
         let mut transaction_callee_map: Vec<u8> = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
-        debug_assert!(instruction.accounts.len() <= MAX_ACCOUNTS_PER_TRANSACTION);
+        debug_assert!(instruction.accounts.len() <= transaction_callee_map.len());
 
         let mut instruction_accounts: Vec<InstructionAccount> =
             Vec::with_capacity(instruction.accounts.len());

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -624,15 +624,8 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index_in_instruction, index_in_transaction)| {
-                let index_in_callee = transaction_indexes
-                    .get(0..index_in_instruction)
-                    .unwrap()
-                    .iter()
-                    .position(|account_index| account_index == index_in_transaction)
-                    .unwrap_or(index_in_instruction);
                 InstructionAccount::new(
                     *index_in_transaction,
-                    index_in_callee as IndexOfAccount,
                     false,
                     is_writable(index_in_instruction),
                 )

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -693,7 +693,7 @@ mod tests {
                 }
 
                 let transaction_accounts_indexes: Vec<IndexOfAccount> =
-                    (1..(num_ix_accounts + 1) as u16).collect();
+                    (0..num_ix_accounts as u16).collect();
                 let mut instruction_accounts =
                     deduplicated_instruction_accounts(&transaction_accounts_indexes, |_| false);
                 if append_dup_account {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -718,7 +718,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure(program_indices, instruction_accounts, &instruction_data);
+                    .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
                 invoke_context.push().unwrap();
                 let instruction_context = invoke_context
                     .transaction_context
@@ -861,7 +861,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure(program_indices, instruction_accounts, &instruction_data);
+                .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1107,7 +1107,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure(program_indices, instruction_accounts, &instruction_data);
+                .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1376,7 +1376,7 @@ mod tests {
         transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure(program_indices, instruction_accounts, &instruction_data);
+            .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
         transaction_context.push().unwrap();
         let instruction_context = transaction_context
             .get_current_instruction_context()

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -107,7 +107,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
     transaction_context
         .get_next_instruction_context_mut()
         .unwrap()
-        .configure(vec![0], instruction_accounts, &instruction_data);
+        .configure_for_tests(vec![0], instruction_accounts, &instruction_data);
     transaction_context.push().unwrap();
     transaction_context
 }

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -5,7 +5,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated},
-    solana_transaction_context::{IndexOfAccount, InstructionAccount, TransactionContext},
+    solana_transaction_context::{InstructionAccount, TransactionContext},
 };
 
 fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionContext {
@@ -89,13 +89,8 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
         .take(num_instruction_accounts)
         .enumerate()
     {
-        let index_in_callee = instruction_accounts
-            .iter()
-            .position(|account| account.index_in_transaction == index_in_transaction)
-            .unwrap_or(instruction_account_index) as IndexOfAccount;
         instruction_accounts.push(InstructionAccount::new(
             index_in_transaction,
-            index_in_callee,
             false,
             instruction_account_index >= 4,
         ));

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7382,7 +7382,6 @@ version = "3.0.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
  "log",
  "percentage",
@@ -7405,7 +7404,6 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
- "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-transaction",
@@ -7415,7 +7413,6 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -71,7 +71,7 @@ macro_rules! with_mock_invoke_context {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure(vec![0, 1], instruction_accounts, &[]);
+            .configure_for_tests(vec![0, 1], instruction_accounts, &[]);
         $invoke_context.push().unwrap();
     };
 }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -61,7 +61,7 @@ macro_rules! with_mock_invoke_context {
                 AccountSharedData::new(2, $account_size, &program_key),
             ),
         ];
-        let instruction_accounts = vec![InstructionAccount::new(2, 0, false, true)];
+        let instruction_accounts = vec![InstructionAccount::new(2, false, true)];
         solana_program_runtime::with_mock_invoke_context!(
             $invoke_context,
             transaction_context,

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -294,8 +294,8 @@ mod test {
                 (system_program::id(), AccountSharedData::default()),
             ];
             let $instruction_accounts = vec![
-                InstructionAccount::new(0, 0, true, true),
-                InstructionAccount::new(1, 1, false, true),
+                InstructionAccount::new(0, true, true),
+                InstructionAccount::new(1, false, true),
             ];
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
         };

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -269,7 +269,7 @@ mod test {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure(vec![2], $instruction_accounts, &[]);
+                .configure_for_tests(vec![2], $instruction_accounts, &[]);
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1167,7 +1167,7 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(
+        instruction_context.configure_for_tests(
             vec![0],
             vec![InstructionAccount::new(1, 0, false, true)],
             &[],
@@ -1316,7 +1316,7 @@ mod tests {
             0,
         );
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(
+        instruction_context.configure_for_tests(
             vec![0],
             vec![InstructionAccount::new(1, 0, false, true)],
             &[],

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1169,7 +1169,7 @@ mod tests {
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
             vec![0],
-            vec![InstructionAccount::new(1, 0, false, true)],
+            vec![InstructionAccount::new(1, false, true)],
             &[],
         );
 
@@ -1318,7 +1318,7 @@ mod tests {
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
             vec![0],
-            vec![InstructionAccount::new(1, 0, false, true)],
+            vec![InstructionAccount::new(1, false, true)],
             &[],
         );
 

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -7182,7 +7182,6 @@ version = "3.0.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
  "log",
  "percentage",
@@ -7205,7 +7204,6 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
- "solana-stable-layout",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-transaction",
@@ -7215,7 +7213,6 @@ dependencies = [
  "solana-timings",
  "solana-transaction-context",
  "solana-type-overrides",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1279,7 +1279,7 @@ mod tests {
                 transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure(vec![], vec![], &[index_in_trace as u8]);
+                    .configure_for_tests(vec![], vec![], &[index_in_trace as u8]);
                 transaction_context.push().unwrap();
             }
         }

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -70,6 +70,7 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
+static_assertions = { workspace = true }
 test-case = { workspace = true }
 
 [lints]

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1309,11 +1309,9 @@ mod tests {
             let instruction_data = $instruction_data;
             let instruction_accounts = $instruction_accounts
                 .iter()
-                .enumerate()
-                .map(|(index_in_callee, index_in_transaction)| {
+                .map(|index_in_transaction| {
                     InstructionAccount::new(
                         *index_in_transaction as IndexOfAccount,
-                        index_in_callee as IndexOfAccount,
                         false,
                         $transaction_accounts[*index_in_transaction as usize].2,
                     )
@@ -1857,8 +1855,8 @@ mod tests {
             .configure_for_tests(
                 vec![0],
                 vec![
-                    InstructionAccount::new(1, 0, false, true),
-                    InstructionAccount::new(1, 0, false, true),
+                    InstructionAccount::new(1, false, true),
+                    InstructionAccount::new(1, false, true),
                 ],
                 &[],
             );

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -15,6 +15,13 @@ use {
 
 const MAX_CPI_INSTRUCTION_DATA_LEN: u64 = 10 * 1024;
 const MAX_CPI_INSTRUCTION_ACCOUNTS: u8 = u8::MAX;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    (MAX_CPI_INSTRUCTION_ACCOUNTS as usize).saturating_add(1),
+    solana_transaction_context::MAX_ACCOUNTS_PER_TRANSACTION,
+);
+
 const MAX_CPI_ACCOUNT_INFOS: usize = 128;
 
 fn check_account_info_pointer(

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -773,9 +773,8 @@ where
     ) -> Result<CallerAccount<'a>, Error>,
 {
     let transaction_context = &invoke_context.transaction_context;
-    let next_instruction_accounts = transaction_context
-        .get_next_instruction_context()?
-        .instruction_accounts();
+    let next_instruction_context = transaction_context.get_next_instruction_context()?;
+    let next_instruction_accounts = next_instruction_context.instruction_accounts();
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let mut accounts = Vec::with_capacity(next_instruction_accounts.len());
 
@@ -793,7 +792,10 @@ where
     for (instruction_account_index, instruction_account) in
         next_instruction_accounts.iter().enumerate()
     {
-        if instruction_account_index as IndexOfAccount != instruction_account.index_in_callee {
+        if next_instruction_context
+            .is_instruction_account_duplicate(instruction_account_index as IndexOfAccount)?
+            .is_some()
+        {
             continue; // Skip duplicate account
         }
 

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1334,7 +1334,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure($program_accounts, instruction_accounts, instruction_data);
+                .configure_for_tests($program_accounts, instruction_accounts, instruction_data);
             $invoke_context.push().unwrap();
         };
     }
@@ -1852,7 +1852,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure(
+            .configure_for_tests(
                 vec![0],
                 vec![
                     InstructionAccount::new(1, 0, false, true),

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2223,7 +2223,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure(vec![0, 1], vec![], &[]);
+                .configure_for_tests(vec![0, 1], vec![], &[]);
             $invoke_context.push().unwrap();
         };
     }
@@ -4456,7 +4456,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure(vec![0], instruction_accounts, &[index_in_trace as u8]);
+                    .configure_for_tests(vec![0], instruction_accounts, &[index_in_trace as u8]);
                 invoke_context.transaction_context.push().unwrap();
             }
         }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4448,7 +4448,6 @@ mod tests {
             {
                 let instruction_accounts = vec![InstructionAccount::new(
                     index_in_trace.saturating_add(1) as IndexOfAccount,
-                    0,
                     false,
                     false,
                 )];

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -69,7 +69,6 @@ pub struct InstructionAccount {
 impl InstructionAccount {
     pub fn new(
         index_in_transaction: IndexOfAccount,
-        _index_in_callee: IndexOfAccount,
         is_signer: bool,
         is_writable: bool,
     ) -> InstructionAccount {


### PR DESCRIPTION
#### Problem

In [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we want `InstructionContext` to have only `index_in_transaction`, `is_signer` and `is_writable`. We must, then, remove `index_in_callee`.

#### Summary of Changes

1. Use the duplication map created in `prepare_next_to_level_instruction`, and in `prepare_next_instruction` for detecting duplicated accounts and retrieving the index_in_instruction from the index_in_transaction.
2. `fn configure` now receives the aforementioned map as an argument, so I crated `fn configure_for_test` to facilitate the usage in tests.
3. Add tests to ensure the functionality is correct.
