### PR TITLE
Add startup_slot to calculate_accounts_lt_hash_at_startup_from_storages

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5695,11 +5695,13 @@ impl AccountsDb {
     /// Intended to be used to verify the accounts lt hash at startup.
     ///
     /// The `duplicates_lt_hash` is the old/duplicate accounts to mix *out* of the storages.
+    /// The 'lt_hash_slot' is the slot for which the lt hash is calculated.
     /// This value comes from index generation.
     pub fn calculate_accounts_lt_hash_at_startup_from_storages(
         &self,
         storages: &[Arc<AccountStorageEntry>],
         duplicates_lt_hash: &DuplicatesLtHash,
+        lt_hash_slot: Slot,
     ) -> AccountsLtHash {
         // Randomized order works well with rayon work splitting, since we only care about
         // uniform distribution of total work size per batch (other ordering strategies might be
@@ -5708,7 +5710,9 @@ impl AccountsDb {
         let mut lt_hash = storages
             .par_iter()
             .fold(LtHash::identity, |mut accum, storage| {
-                let obsolete_accounts = storage.get_obsolete_accounts(None);
+                // Function is calculating the lt_hash for all accounts in the storages as of lt_hash_slot
+                // This means that any accounts marked obsolete at a slot newer than this should be included in the lt_hash
+                let obsolete_accounts = storage.get_obsolete_accounts(Some(lt_hash_slot));
                 storage
                     .accounts
                     .scan_accounts(|offset, account| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4628,13 +4628,11 @@ impl Bank {
             true // initial result is true. We haven't failed yet. If verification fails, we'll panic from bg thread.
         } else {
             let calculated_accounts_lt_hash = if let Some(duplicates_lt_hash) = duplicates_lt_hash {
-
-                accounts_db
-                    .calculate_accounts_lt_hash_at_startup_from_storages(
-                        snapshot_storages.0.as_slice(),
-                        &duplicates_lt_hash,
-                        slot,
-                    )
+                accounts_db.calculate_accounts_lt_hash_at_startup_from_storages(
+                    snapshot_storages.0.as_slice(),
+                    &duplicates_lt_hash,
+                    slot,
+                )
             } else {
                 accounts_db.calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, slot)
             };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4602,6 +4602,7 @@ impl Bank {
                                 accounts_db_.calculate_accounts_lt_hash_at_startup_from_storages(
                                     snapshot_storages.0.as_slice(),
                                     &duplicates_lt_hash.unwrap(),
+                                    slot,
                                 )
                             }));
                         let is_ok =
@@ -4627,10 +4628,13 @@ impl Bank {
             true // initial result is true. We haven't failed yet. If verification fails, we'll panic from bg thread.
         } else {
             let calculated_accounts_lt_hash = if let Some(duplicates_lt_hash) = duplicates_lt_hash {
-                accounts_db.calculate_accounts_lt_hash_at_startup_from_storages(
-                    snapshot_storages.0.as_slice(),
-                    &duplicates_lt_hash,
-                )
+
+                accounts_db
+                    .calculate_accounts_lt_hash_at_startup_from_storages(
+                        snapshot_storages.0.as_slice(),
+                        &duplicates_lt_hash,
+                        slot,
+                    )
             } else {
                 accounts_db.calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors, slot)
             };

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -789,6 +789,7 @@ mod tests {
     fn test_calculate_accounts_lt_hash_at_startup_from_storages(features: Features) {
         let (genesis_config, mint_keypair) = genesis_config_with(features);
         let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let max_slot = 7;
 
         let amount = cmp::max(
             bank.get_minimum_balance_for_rent_exemption(0),
@@ -800,7 +801,7 @@ mod tests {
 
         // create some banks with some modified accounts so that there are stored accounts
         // (note: the number of banks and transfers are arbitrary)
-        for _ in 0..7 {
+        for _ in 0..max_slot {
             let slot = bank.slot() + 1;
             bank =
                 new_bank_from_parent_with_bank_forks(&bank_forks, bank, &Pubkey::default(), slot);
@@ -867,7 +868,11 @@ mod tests {
             .rc
             .accounts
             .accounts_db
-            .calculate_accounts_lt_hash_at_startup_from_storages(&storages, &duplicates_lt_hash);
+            .calculate_accounts_lt_hash_at_startup_from_storages(
+                &storages,
+                &duplicates_lt_hash,
+                max_slot,
+            );
         assert_eq!(
             expected_accounts_lt_hash,
             calculated_accounts_lt_hash_from_storages
@@ -1095,5 +1100,100 @@ mod tests {
         // Wait for the startup verification to complete.  If we don't panic, then we're good!
         roundtrip_bank.wait_for_initial_accounts_hash_verification_completed_for_tests();
         assert_eq!(roundtrip_bank, *bank);
+    }
+
+    // Obsolete accounts add metadata to storage entries that can effect the lt hash calculation
+    // This test ensures that the lt hash is not effected by updates in storages that are not being
+    // considered for the lt hash calculation.
+    #[test]
+    fn test_lt_hash_with_obsolete_accounts() {
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let lt_hash_slot = 0;
+
+        // Create a few accounts
+        let (genesis_config, mint_keypair) =
+            solana_genesis_config::create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let (bank, _forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        bank.transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
+            .unwrap();
+        bank.transfer(2 * LAMPORTS_PER_SOL, &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank.transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
+            .unwrap();
+        bank.fill_bank_with_ticks_for_tests();
+
+        // Force flush the bank to create the account storage entry
+        bank.squash();
+        bank.force_flush_accounts_cache();
+        bank.freeze();
+
+        let (storages, _slots) = bank.rc.accounts.accounts_db.get_storages(RangeFull);
+
+        // Calculate the current lt hash
+        let hash1 = bank
+            .accounts()
+            .accounts_db
+            .calculate_accounts_lt_hash_at_startup_from_storages(
+                storages.as_slice(),
+                &DuplicatesLtHash::default(),
+                lt_hash_slot,
+            );
+
+        // Find the account storage entry for slot 0
+        let target_slot = 0;
+        let account_storage_entry = bank
+            .accounts()
+            .accounts_db
+            .storage
+            .get_slot_storage_entry(target_slot)
+            .unwrap();
+
+        // Find all the accounts in slot 0
+        let accounts = bank
+            .accounts()
+            .accounts_db
+            .get_unique_accounts_from_storage(&account_storage_entry);
+
+        // Find the offset of pubkey `key1` in the accounts db slot0 and save the offset.
+        let offset = accounts
+            .stored_accounts
+            .iter()
+            .find(|account| key1.pubkey() == *account.pubkey())
+            .map(|account| account.index_info.offset())
+            .expect("Pubkey1 is present in Slot0");
+
+        // Mark pubkey1 as obsolete in slot 1
+        // This is a valid scenario that the lt_hash verification could see if slot1 transfers
+        // the balance of pubkey1 to a new pubkey.
+        account_storage_entry.mark_accounts_obsolete(vec![(offset, 0)].into_iter(), 1);
+
+        // Recalculate the hash from storages, calculating the hash as of slot 0 like before
+        let hash = bank
+            .accounts()
+            .accounts_db
+            .calculate_accounts_lt_hash_at_startup_from_storages(
+                storages.as_slice(),
+                &DuplicatesLtHash::default(),
+                lt_hash_slot,
+            );
+
+        // Ensure that the hash is the same as before since the obsolete account updates in slot0
+        // marked at slot1 should be ignored
+        assert_eq!(hash1, hash);
+
+        // Recalculate the hash from storages, but include obsolete account updates marked in slot1
+        let hash2 = bank
+            .accounts()
+            .accounts_db
+            .calculate_accounts_lt_hash_at_startup_from_storages(
+                storages.as_slice(),
+                &DuplicatesLtHash::default(),
+                lt_hash_slot + 1,
+            );
+
+        // The hashes should be different now as pubkey1 account will not be included in the hash
+        assert_ne!(hash2, hash);
     }
 }

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1139,7 +1139,7 @@ mod tests {
         let accounts = bank
             .accounts()
             .accounts_db
-            .get_unique_accounts_from_storage(&account_storage_entry);
+            .get_unique_accounts_from_storage(account_storage_entry);
 
         // Find the offset of pubkey `key1` in the accounts db slot0 and save the offset.
         let offset = accounts

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1167,7 +1167,7 @@ mod tests {
 
         // Ensure that the hash is the same as before since the obsolete account updates in slot0
         // marked at slot1 should be ignored
-        assert_eq!(expected_accounts_lt_hash, calculated_accounts_lt_hash);
+        assert_eq!(calculated_accounts_lt_hash, expected_accounts_lt_hash);
 
         // Recalculate the hash from storages, but include obsolete account updates marked in slot1
         let recalculated_accounts_lt_hash = bank


### PR DESCRIPTION
#### Problem
While startup verification is ongoing, new slots are updating the accounts database and marking accounts in older slots as obsolete. The lattice hash is skipping these slots leading to an invalid hash

#### Summary of Changes
- Pass in the slot that the lattice hash is being calculated at and filter the obsolete accounts based on that information
- Unit test 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
