### PR TITLE
Creating dedicated path for update index cached

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1458,8 +1458,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             })
             .for_each(f);
     }
-    /// Caches the given pubkey at the given slot with the new account information.
-    pub fn cache(&self, new_slot: Slot, pubkey: &Pubkey, account_info: T) {
+    /// Updates the account index when an account for pubkey to tracck an entry added to the write cache
+    pub fn index_cached_pubkey(
+        &self,
+        new_slot: Slot,
+        pubkey: &Pubkey,
+        account: &impl ReadableAccount,
+        account_indexes: &AccountSecondaryIndexes,
+        account_info: T,
+    ) {
         // We don't atomically update both primary index and secondary index together.
         // This certainly creates a small time window with inconsistent state across the two indexes.
         // However, this is acceptable because:
@@ -1474,7 +1481,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let map = self.get_bin(pubkey);
 
         map.cache(pubkey, new_slot, account_info);
-        //self.update_secondary_indexes(pubkey, account, account_indexes);
+        self.update_secondary_indexes(pubkey, account, account_indexes);
     }
 
     /// Updates the given pubkey at the given slot with the new account information.

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -531,7 +531,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         self.set_age_to_future(entry, true);
     }
 
-    /// Finds or creates an entry in the accounts index for pubkey and  
+    /// Finds or creates an entry in the accounts index for pubkey and
     /// adds a cached entry at slot to the slot_list if not present
     pub fn cache(&self, pubkey: &Pubkey, slot: Slot, account_info: T) {
         self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -519,7 +519,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
     /// Insert a cached entry into the accounts index
     /// If the entry is already present, just mark dirty and set the age to the future
-    /// Code is required just for test for now, but will be used in future PRs so not putting in the test area
     fn cache_entry_at_slot(&self, entry: &AccountMapEntry<T>, slot: Slot, account_info: T) {
         let mut slot_list = entry.slot_list.write().unwrap();
         if !slot_list
@@ -532,6 +531,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         self.set_age_to_future(entry, true);
     }
 
+    /// Finds or creates an entry in the accounts index for pubkey and  
+    /// adds a cached entry at slot to the slot_list if not present
     pub fn cache(&self, pubkey: &Pubkey, slot: Slot, account_info: T) {
         self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {
             self.cache_entry_at_slot(entry, slot, account_info)


### PR DESCRIPTION
#### Problem
Add items to the account index targeting the write cache never reclaims older items. Splitting this out from the other update_index path allows both paths to be more efficient.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
