### PR TITLE
SchedulingDetails::default min_starting_{buffer|queue}_size: usize::MAX

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -459,7 +459,7 @@ impl Default for SchedulingDetails {
         Self {
             last_report: Instant::now(),
             num_schedule_calls: 0,
-            min_starting_queue_size: 0,
+            min_starting_queue_size: usize::MAX,
             max_starting_queue_size: 0,
             sum_starting_queue_size: 0,
             min_starting_buffer_size: 0,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -462,7 +462,7 @@ impl Default for SchedulingDetails {
             min_starting_queue_size: usize::MAX,
             max_starting_queue_size: 0,
             sum_starting_queue_size: 0,
-            min_starting_buffer_size: 0,
+            min_starting_buffer_size: usize::MAX,
             max_starting_buffer_size: 0,
             sum_starting_buffer_size: 0,
             sum_num_scheduled: 0,


### PR DESCRIPTION
#### Problem
#7163 - metric for minimum queue size is incorrectly reset

#### Summary of Changes
- min_starting_{buffer|queue}_size default to `usize::MAX`
    - updated size gotten for every call to `schedule`
    - metrics only reported if we call `schedule` at least one time 

Fixes #7163 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
