### PR TITLE
SPL: Use spl-instruction-padding-interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7155,7 +7155,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-status",
  "solana-version",
- "spl-instruction-padding",
+ "spl-instruction-padding-interface",
  "tempfile",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -12166,16 +12166,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-instruction-padding"
-version = "0.3.0"
+name = "spl-instruction-padding-interface"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352d4c4a6d455fc96320342aeab9f522f057e2666ebe40b2e079d054339ab8f"
+checksum = "0f738b75144edbb32c01de832632eecad71113b62a48ef8e55e60c5a692bae4e"
 dependencies = [
  "num_enum",
- "solana-account-info",
- "solana-cpi",
  "solana-instruction",
- "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -566,7 +566,6 @@ solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.0.0" }
 spl-associated-token-account-interface = "1.0.0"
 spl-generic-token = "1.0.1"
-spl-instruction-padding = "0.3.0"
 spl-memo = "6.0.0"
 spl-pod = "0.5.1"
 spl-token = "8.0.0"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -67,7 +67,7 @@ solana-tpu-client = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
-spl-instruction-padding = { version = "=0.3.0", features = ["no-entrypoint"] }
+spl-instruction-padding-interface = { version = "=0.1.0" }
 thiserror = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -28,7 +28,7 @@ use {
     solana_time_utils::timestamp,
     solana_tps_client::*,
     solana_transaction::Transaction,
-    spl_instruction_padding::instruction::wrap_instruction,
+    spl_instruction_padding_interface::instruction::wrap_instruction,
     std::{
         collections::{HashSet, VecDeque},
         process::exit,

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -599,7 +599,7 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
         let program_id = matches
             .value_of("instruction_padding_program_id")
             .map(|target_str| target_str.parse().unwrap())
-            .unwrap_or_else(|| spl_instruction_padding::ID);
+            .unwrap_or_else(|| spl_instruction_padding_interface::ID);
         let data_size = data_size
             .parse()
             .map_err(|_| "Can't parse padded instruction data size")?;

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -43,7 +43,7 @@ fn program_account(program_data: &[u8]) -> AccountSharedData {
 fn test_bench_tps_local_cluster(config: Config) {
     let native_instruction_processors = vec![];
     let additional_accounts = vec![(
-        spl_instruction_padding::ID,
+        spl_instruction_padding_interface::ID,
         program_account(include_bytes!("fixtures/spl_instruction_padding.so")),
     )];
 
@@ -120,7 +120,10 @@ fn test_bench_tps_test_validator(config: Config) {
             ..Rent::default()
         })
         .faucet_addr(Some(faucet_addr))
-        .add_program("spl_instruction_padding", spl_instruction_padding::ID)
+        .add_program(
+            "spl_instruction_padding",
+            spl_instruction_padding_interface::ID,
+        )
         .start_with_mint_address(mint_pubkey, SocketAddrSpace::Unspecified)
         .expect("validator start failed");
 
@@ -203,7 +206,7 @@ fn test_bench_tps_local_cluster_with_padding() {
         tx_count: 100,
         duration: Duration::from_secs(10),
         instruction_padding_config: Some(InstructionPaddingConfig {
-            program_id: spl_instruction_padding::ID,
+            program_id: spl_instruction_padding_interface::ID,
             data_size: 0,
         }),
         ..Config::default()
@@ -217,7 +220,7 @@ fn test_bench_tps_tpu_client_with_padding() {
         tx_count: 100,
         duration: Duration::from_secs(10),
         instruction_padding_config: Some(InstructionPaddingConfig {
-            program_id: spl_instruction_padding::ID,
+            program_id: spl_instruction_padding_interface::ID,
             data_size: 0,
         }),
         ..Config::default()


### PR DESCRIPTION
#### Problem

As outlined in #7256, we need to get Agave off of crates that depend back on Agave.

spl-instruction-padding is one of those crates

#### Summary of changes

Use spl-instruction-padding-interface instead. Everything else is exactly the same.