### PR TITLE
View receive_and_buffer - use num_dropped_on_receive_transaction_checks

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -386,7 +386,7 @@ impl TransactionViewReceiveAndBuffer {
 
         let mut num_received = 0usize;
         let mut num_buffered = 0usize;
-        let mut num_dropped_on_status_age_checks = 0usize;
+        let mut num_dropped_on_transaction_checks = 0usize;
         let mut num_dropped_on_capacity = 0usize;
         let mut num_dropped_on_receive = 0usize;
 
@@ -421,7 +421,7 @@ impl TransactionViewReceiveAndBuffer {
                     .zip(transaction_priority_ids.iter())
                 {
                     if result.is_err() {
-                        num_dropped_on_status_age_checks += 1;
+                        num_dropped_on_transaction_checks += 1;
                         container.remove_by_id(priority_id.id);
                         continue;
                     }
@@ -434,7 +434,7 @@ impl TransactionViewReceiveAndBuffer {
                         &mut error_counters,
                     ) {
                         *result = Err(err);
-                        num_dropped_on_status_age_checks += 1;
+                        num_dropped_on_transaction_checks += 1;
                         container.remove_by_id(priority_id.id);
                         continue;
                     }
@@ -504,9 +504,10 @@ impl TransactionViewReceiveAndBuffer {
         count_metrics.update(|count_metrics| {
             count_metrics.num_received += num_received;
             count_metrics.num_buffered += num_buffered;
-            count_metrics.num_dropped_on_age_and_status += num_dropped_on_status_age_checks;
             count_metrics.num_dropped_on_capacity += num_dropped_on_capacity;
             count_metrics.num_dropped_on_receive += num_dropped_on_receive;
+            count_metrics.num_dropped_on_receive_transaction_checks +=
+                num_dropped_on_transaction_checks;
         });
 
         num_received


### PR DESCRIPTION
#### Problem
- Similarly named metrics
- For `view` path, I accumulated transactions dropped into the wrong one:
    - `num_dropped_on_receive_transaction_checks` is dropped due to check_transactions
    - `num_dropped_on_age_and_status` is for txs dropped due to age/status during clean

#### Summary of Changes
- Accumulate into the correct metric

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
