### PR TITLE
CommitTransactionDetails add fee_payer_post_balance

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -29,6 +29,7 @@ pub enum CommitTransactionDetails {
     Committed {
         compute_units: u64,
         loaded_accounts_data_size: u32,
+        fee_payer_post_balance: u64,
         result: Result<(), TransactionError>,
     },
     NotCommitted(TransactionError),
@@ -88,6 +89,7 @@ impl Committer {
                         .loaded_account_stats
                         .loaded_accounts_data_size,
                     result: committed_tx.status.clone(),
+                    fee_payer_post_balance: committed_tx.fee_payer_post_balance,
                 },
                 Err(err) => CommitTransactionDetails::NotCommitted(err.clone()),
             })

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1157,6 +1157,7 @@ mod tests {
                         compute_units,
                         loaded_accounts_data_size,
                         result: _,
+                        fee_payer_post_balance: _,
                     } => (
                         *compute_units,
                         CostModel::calculate_loaded_accounts_data_size_cost(
@@ -1804,6 +1805,7 @@ mod tests {
             compute_units,
             loaded_accounts_data_size,
             result: _,
+            fee_payer_post_balance: _,
         } = consumer_output
             .execute_and_commit_transactions_output
             .commit_transactions_result

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -198,6 +198,7 @@ impl QosService {
                             compute_units,
                             loaded_accounts_data_size,
                             result: _,
+                            fee_payer_post_balance: _,
                         } => {
                             cost_tracker.update_execution_cost(
                                 tx_cost,
@@ -752,6 +753,7 @@ mod tests {
                     loaded_accounts_data_size: loaded_accounts_data_size
                         + loaded_accounts_data_size_adjustment,
                     result: Ok(()),
+                    fee_payer_post_balance: 0,
                 })
                 .collect();
             let final_txs_cost = total_txs_cost
@@ -883,6 +885,7 @@ mod tests {
                             loaded_accounts_data_size: loaded_accounts_data_size
                                 + loaded_accounts_data_size_adjustment,
                             result: Ok(()),
+                            fee_payer_post_balance: 1,
                         }
                     }
                 })

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -463,6 +463,7 @@ pub(crate) mod tests {
             executed_units: 0,
             fee_details: FeeDetails::default(),
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            fee_payer_post_balance: 0,
         });
 
         let balances = TransactionBalancesSet {
@@ -593,6 +594,7 @@ pub(crate) mod tests {
             executed_units: 0,
             fee_details: FeeDetails::default(),
             loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            fee_payer_post_balance: 0,
         });
 
         let balances = TransactionBalancesSet {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3719,6 +3719,7 @@ impl Bank {
                                 loaded_accounts_count: loaded_accounts.len(),
                                 loaded_accounts_data_size,
                             },
+                            fee_payer_post_balance: loaded_accounts[0].1.lamports(),
                         })
                     }
                     ProcessedTransaction::FeesOnly(fees_only_tx) => Ok(CommittedTransaction {
@@ -3732,6 +3733,11 @@ impl Bank {
                             loaded_accounts_count: fees_only_tx.rollback_accounts.count(),
                             loaded_accounts_data_size,
                         },
+                        fee_payer_post_balance: fees_only_tx
+                            .rollback_accounts
+                            .fee_payer()
+                            .1
+                            .lamports(),
                     }),
                 }
             })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3701,12 +3701,21 @@ impl Bank {
 
                 match processing_result {
                     ProcessedTransaction::Executed(executed_tx) => {
+                        let successful = executed_tx.was_successful();
                         let execution_details = executed_tx.execution_details;
                         let LoadedTransaction {
                             accounts: loaded_accounts,
                             fee_details,
+                            rollback_accounts,
                             ..
                         } = executed_tx.loaded_transaction;
+
+                        // Rollback value is used for failure.
+                        let fee_payer_post_balance = if successful {
+                            loaded_accounts[0].1.lamports()
+                        } else {
+                            rollback_accounts.fee_payer().1.lamports()
+                        };
 
                         Ok(CommittedTransaction {
                             status: execution_details.status,
@@ -3719,7 +3728,7 @@ impl Bank {
                                 loaded_accounts_count: loaded_accounts.len(),
                                 loaded_accounts_data_size,
                             },
-                            fee_payer_post_balance: loaded_accounts[0].1.lamports(),
+                            fee_payer_post_balance,
                         })
                     }
                     ProcessedTransaction::FeesOnly(fees_only_tx) => Ok(CommittedTransaction {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1952,7 +1952,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 loaded_accounts_count: 2,
                 loaded_accounts_data_size: nonce_size as u32,
             },
-            fee_payer_post_balance: genesis_config.rent.minimum_balance(0) - 1,
+            fee_payer_post_balance: genesis_config.rent.minimum_balance(0) - 1 - 5000,
         })]
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1952,6 +1952,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
                 loaded_accounts_count: 2,
                 loaded_accounts_data_size: nonce_size as u32,
             },
+            fee_payer_post_balance: genesis_config.rent.minimum_balance(0) - 1,
         })]
     );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1958,6 +1958,149 @@ fn test_load_and_execute_commit_transactions_fees_only() {
 }
 
 #[test]
+fn test_load_and_execute_commit_transactions_failure() {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
+    genesis_config.rent = Rent::default();
+    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let bank = Bank::new_from_parent(
+        bank,
+        &Pubkey::new_unique(),
+        genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
+    );
+
+    let fee_payer = Pubkey::new_unique();
+    let starting_balance = 2 * genesis_config.rent.minimum_balance(0) + 10_000;
+    bank.store_account(
+        &fee_payer,
+        &AccountSharedData::new(starting_balance, 0, &system_program::id()),
+    );
+
+    let recipient = Pubkey::new_unique();
+    let transfer_amount = genesis_config.rent.minimum_balance(0);
+
+    // Invoke transaction with valid system-program instruction followed by a
+    // failing instruction to trigger a failed execution.
+    // The system transfer is used to modify the loaded account state to verify the
+    // fee payer post balance is correct.
+    let transaction = Transaction::new_unsigned(Message::new_with_blockhash(
+        &[
+            system_instruction::transfer(&fee_payer, &recipient, transfer_amount),
+            Instruction::new_with_bincode(system_program::id(), &(), vec![]),
+        ],
+        Some(&fee_payer),
+        &bank.last_blockhash(),
+    ));
+
+    let batch = bank.prepare_batch_for_tests(vec![transaction]);
+    let commit_results = bank
+        .load_execute_and_commit_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            ExecutionRecordingConfig::new_single_setting(true),
+            &mut ExecuteTimings::default(),
+            None,
+        )
+        .0;
+
+    assert_eq!(
+        commit_results,
+        vec![Ok(CommittedTransaction {
+            status: Err(TransactionError::InstructionError(
+                1,
+                InstructionError::InvalidInstructionData
+            )),
+            log_messages: Some(vec![
+                "Program 11111111111111111111111111111111 invoke [1]".to_string(),
+                "Program 11111111111111111111111111111111 success".to_string(),
+                "Program 11111111111111111111111111111111 invoke [1]".to_string(),
+                "Program 11111111111111111111111111111111 failed: invalid instruction data"
+                    .to_string()
+            ]),
+            inner_instructions: Some(vec![vec![], vec![]]),
+            return_data: None,
+            executed_units: 300,
+            fee_details: FeeDetails::new(5000, 0),
+            loaded_account_stats: TransactionLoadedAccountsStats {
+                loaded_accounts_count: 3,
+                loaded_accounts_data_size: 142, // size of system account (initially recipient does not exist)
+            },
+            fee_payer_post_balance: starting_balance - 5000,
+        })]
+    );
+}
+
+#[test]
+fn test_load_and_execute_commit_transactions_success() {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
+    genesis_config.rent = Rent::default();
+    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let bank = Bank::new_from_parent(
+        bank,
+        &Pubkey::new_unique(),
+        genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
+    );
+
+    let fee_payer = Pubkey::new_unique();
+    let starting_balance = 2 * genesis_config.rent.minimum_balance(0) + 10_000;
+    bank.store_account(
+        &fee_payer,
+        &AccountSharedData::new(starting_balance, 0, &system_program::id()),
+    );
+
+    let recipient = Pubkey::new_unique();
+    let transfer_amount = genesis_config.rent.minimum_balance(0);
+
+    // Invoke transaction with valid system-program instruction to trigger
+    // a successful execution
+    let transaction = Transaction::new_unsigned(Message::new_with_blockhash(
+        &[system_instruction::transfer(
+            &fee_payer,
+            &recipient,
+            transfer_amount,
+        )],
+        Some(&fee_payer),
+        &bank.last_blockhash(),
+    ));
+
+    let batch = bank.prepare_batch_for_tests(vec![transaction]);
+    let commit_results = bank
+        .load_execute_and_commit_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            ExecutionRecordingConfig::new_single_setting(true),
+            &mut ExecuteTimings::default(),
+            None,
+        )
+        .0;
+
+    assert_eq!(
+        commit_results,
+        vec![Ok(CommittedTransaction {
+            status: Ok(()),
+            log_messages: Some(vec![
+                "Program 11111111111111111111111111111111 invoke [1]".to_string(),
+                "Program 11111111111111111111111111111111 success".to_string(),
+            ]),
+            inner_instructions: Some(vec![vec![]]),
+            return_data: None,
+            executed_units: 150,
+            fee_details: FeeDetails::new(5000, 0),
+            loaded_account_stats: TransactionLoadedAccountsStats {
+                loaded_accounts_count: 3,
+                loaded_accounts_data_size: 142, // size of system account (initially recipient does not exist)
+            },
+            fee_payer_post_balance: starting_balance - 5000 - transfer_amount,
+        })]
+    );
+}
+
+#[test]
 fn test_readonly_relaxed_locks() {
     let (genesis_config, _) = create_genesis_config(3);
     let bank = Bank::new_for_tests(&genesis_config);

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -99,6 +99,15 @@ impl RollbackAccounts {
         }
     }
 
+    /// Return a reference to the fee payer account.
+    pub fn fee_payer(&self) -> &TransactionAccount {
+        match self {
+            Self::FeePayerOnly { fee_payer } => fee_payer,
+            Self::SameNonceAndFeePayer { nonce } => nonce,
+            Self::SeparateNonceAndFeePayer { fee_payer, .. } => fee_payer,
+        }
+    }
+
     /// Number of accounts tracked for rollback
     pub fn count(&self) -> usize {
         match self {

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -16,6 +16,7 @@ pub struct CommittedTransaction {
     pub executed_units: u64,
     pub fee_details: FeeDetails,
     pub loaded_account_stats: TransactionLoadedAccountsStats,
+    pub fee_payer_post_balance: u64,
 }
 
 pub trait TransactionCommitResultExtensions {


### PR DESCRIPTION
#### Problem
- for scheduling it's useful to return fee-payer balance after transaction execution
- we want to return this data in scheduler-bindings

#### Summary of Changes
- Return fee payer balance, post execution, in commit details

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
