### PR TITLE
Use a single index for the program account in `InstructionContext`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -523,7 +523,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         .get_next_instruction_context_mut()
         .unwrap()
         .configure_for_tests(
-            vec![program_index, program_index.saturating_add(1)],
+            program_index.saturating_add(1),
             instruction_accounts,
             &instruction_data,
         );

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1173,7 +1173,7 @@ mod tests {
             transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure(0, vec![InstructionAccount::new(0, 0, false, false)], &[]);
+                .configure_for_tests(0, vec![InstructionAccount::new(0, false, false)], &[]);
             transaction_context.pop().unwrap();
         }
         assert_eq!(
@@ -1476,7 +1476,7 @@ mod tests {
         let svm_instruction =
             SVMInstruction::from(sanitized.message().instructions().first().unwrap());
         invoke_context
-            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, vec![90])
+            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, 90)
             .unwrap();
 
         test_case_1(&invoke_context);
@@ -1485,7 +1485,7 @@ mod tests {
         let svm_instruction =
             SVMInstruction::from(sanitized.message().instructions().get(1).unwrap());
         invoke_context
-            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, vec![90])
+            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, 90)
             .unwrap();
 
         test_case_2(&invoke_context);
@@ -1548,7 +1548,7 @@ mod tests {
             SVMInstruction::from(sanitized.message().instructions().first().unwrap());
 
         invoke_context
-            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, vec![90])
+            .prepare_next_top_level_instruction(&sanitized, &svm_instruction, 90)
             .unwrap();
 
         {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -475,7 +475,7 @@ impl<'a> InvokeContext<'a> {
         &mut self,
         message: &impl SVMMessage,
         instruction: &SVMInstruction,
-        program_indices: Vec<IndexOfAccount>,
+        program_account_index: IndexOfAccount,
     ) -> Result<(), InstructionError> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
         // This algorithm allocates the array on the stack for speed.
@@ -508,7 +508,7 @@ impl<'a> InvokeContext<'a> {
         self.transaction_context
             .get_next_instruction_context_mut()?
             .configure(
-                program_indices,
+vec![program_account_index],
                 instruction_accounts,
                 transaction_callee_map,
                 instruction.data,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -460,7 +460,7 @@ impl<'a> InvokeContext<'a> {
         self.transaction_context
             .get_next_instruction_context_mut()?
             .configure(
-                vec![program_account_index],
+                program_account_index,
                 instruction_accounts,
                 transaction_callee_map,
                 &instruction.data,
@@ -507,7 +507,7 @@ impl<'a> InvokeContext<'a> {
         self.transaction_context
             .get_next_instruction_context_mut()?
             .configure(
-vec![program_account_index],
+                program_account_index,
                 instruction_accounts,
                 transaction_callee_map,
                 instruction.data,
@@ -931,7 +931,7 @@ pub fn mock_process_instruction_with_feature_set<
         .transaction_context
         .get_next_instruction_context_mut()
         .unwrap()
-        .configure_for_tests(vec![program_index], instruction_accounts, instruction_data);
+        .configure_for_tests(program_index, instruction_accounts, instruction_data);
     let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
     assert_eq!(result, expected_result);
     post_adjustments(&mut invoke_context);
@@ -1069,7 +1069,7 @@ mod tests {
                             .transaction_context
                             .get_next_instruction_context_mut()
                             .unwrap()
-                            .configure_for_tests(vec![3], instruction_accounts, &[]);
+                            .configure_for_tests(3, instruction_accounts, &[]);
                         let result = invoke_context.push();
                         assert_eq!(result, Err(InstructionError::UnbalancedInstruction));
                         result?;
@@ -1143,7 +1143,7 @@ mod tests {
                 .get_next_instruction_context_mut()
                 .unwrap()
                 .configure_for_tests(
-                    vec![one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount],
+                    one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount,
                     instruction_accounts.clone(),
                     &[],
                 );
@@ -1223,7 +1223,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(vec![4], instruction_accounts, &[]);
+            .configure_for_tests(4, instruction_accounts, &[]);
         invoke_context.push().unwrap();
         let inner_instruction =
             Instruction::new_with_bincode(callee_program_id, &instruction, metas.clone());
@@ -1280,7 +1280,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(vec![4], instruction_accounts, &[]);
+            .configure_for_tests(4, instruction_accounts, &[]);
         invoke_context.push().unwrap();
         let inner_instruction = Instruction::new_with_bincode(
             callee_program_id,
@@ -1326,7 +1326,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(vec![0], vec![], &[]);
+            .configure_for_tests(0, vec![], &[]);
         invoke_context.push().unwrap();
         assert_eq!(*invoke_context.get_compute_budget(), execution_budget);
         invoke_context.pop().unwrap();
@@ -1367,7 +1367,7 @@ mod tests {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(vec![2], instruction_accounts, &instruction_data);
+            .configure_for_tests(2, instruction_accounts, &instruction_data);
         let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
 
         assert!(result.is_ok());

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1159,10 +1159,21 @@ mod tests {
     #[test]
     fn test_max_instruction_trace_length() {
         const MAX_INSTRUCTIONS: usize = 8;
-        let mut transaction_context =
-            TransactionContext::new(Vec::new(), Rent::default(), 1, MAX_INSTRUCTIONS);
+        let mut transaction_context = TransactionContext::new(
+            vec![(
+                Pubkey::new_unique(),
+                AccountSharedData::new(1, 1, &Pubkey::new_unique()),
+            )],
+            Rent::default(),
+            1,
+            MAX_INSTRUCTIONS,
+        );
         for _ in 0..MAX_INSTRUCTIONS {
             transaction_context.push().unwrap();
+            transaction_context
+                .get_next_instruction_context_mut()
+                .unwrap()
+                .configure(0, vec![InstructionAccount::new(0, 0, false, false)], &[]);
             transaction_context.pop().unwrap();
         }
         assert_eq!(

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -942,7 +942,7 @@ pub fn mock_process_instruction_with_feature_set<
 
 pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut InvokeContext)>(
     loader_id: &Pubkey,
-    program_indices: Vec<IndexOfAccount>,
+    program_index: Option<IndexOfAccount>,
     instruction_data: &[u8],
     transaction_accounts: Vec<TransactionAccount>,
     instruction_account_metas: Vec<AccountMeta>,
@@ -951,6 +951,12 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
     pre_adjustments: F,
     post_adjustments: G,
 ) -> Vec<AccountSharedData> {
+    let program_indices = if let Some(index) = program_index {
+        vec![index]
+    } else {
+        vec![]
+    };
+
     mock_process_instruction_with_feature_set(
         loader_id,
         program_indices,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -558,7 +558,7 @@ vec![program_account_index],
         let builtin_id = {
             debug_assert!(instruction_context.get_number_of_program_accounts() <= 1);
             let borrowed_root_account = instruction_context
-                .try_borrow_program_account(self.transaction_context, 0)
+                .try_borrow_last_program_account(self.transaction_context)
                 .map_err(|_| InstructionError::UnsupportedProgramId)?;
             let owner_id = borrowed_root_account.get_owner();
             if native_loader::check_id(owner_id) {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -243,7 +243,7 @@ pub fn serialize_parameters(
 
     let (program_id, is_loader_deprecated) = {
         let program_account =
-            instruction_context.try_borrow_last_program_account(transaction_context)?;
+            instruction_context.try_borrow_program_account(transaction_context)?;
         (
             *program_account.get_key(),
             *program_account.get_owner() == bpf_loader_deprecated::id(),
@@ -300,7 +300,7 @@ pub fn deserialize_parameters(
     accounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
     let is_loader_deprecated = *instruction_context
-        .try_borrow_last_program_account(transaction_context)?
+        .try_borrow_program_account(transaction_context)?
         .get_owner()
         == bpf_loader_deprecated::id();
     let account_lengths = accounts_metadata.iter().map(|a| a.original_data_len);

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -774,7 +774,6 @@ mod tests {
                 if append_dup_account {
                     instruction_accounts.push(instruction_accounts.last().cloned().unwrap());
                 }
-                let program_indices = vec![0];
                 let instruction_data = vec![];
 
                 with_mock_invoke_context!(
@@ -786,7 +785,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
+                    .configure_for_tests(0, instruction_accounts, &instruction_data);
                 invoke_context.push().unwrap();
                 let instruction_context = invoke_context
                     .transaction_context
@@ -923,14 +922,13 @@ mod tests {
             let instruction_accounts =
                 deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
             let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-            let program_indices = vec![0];
             let mut original_accounts = transaction_accounts.clone();
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
+                .configure_for_tests(0, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1173,14 +1171,13 @@ mod tests {
             let instruction_accounts =
                 deduplicated_instruction_accounts(&[1, 1, 2, 3, 4, 4, 5, 6], |index| index >= 4);
             let instruction_data = vec![];
-            let program_indices = vec![0];
             let mut original_accounts = transaction_accounts.clone();
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
+                .configure_for_tests(0, instruction_accounts, &instruction_data);
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1443,7 +1440,6 @@ mod tests {
             /* max_instruction_stack_depth */ 1,
             /* max_instruction_trace_length */ 1,
         );
-        let program_indices = vec![6];
         let transaction_accounts_indexes = [0, 1, 2, 3, 4, 5];
         let instruction_accounts =
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
@@ -1451,7 +1447,7 @@ mod tests {
         transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(program_indices, instruction_accounts, &instruction_data);
+            .configure_for_tests(6, instruction_accounts, &instruction_data);
         transaction_context.push().unwrap();
         let instruction_context = transaction_context
             .get_current_instruction_context()

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -116,7 +116,7 @@ pub fn invoke_builtin_function(
     invoke_context.consume_checked(1)?;
 
     let log_collector = invoke_context.get_log_collector();
-    let program_id = instruction_context.get_last_program_key(transaction_context)?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     stable_log::program_invoke(
         &log_collector,
         program_id,
@@ -257,7 +257,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .get_current_instruction_context()
             .unwrap();
         let caller = instruction_context
-            .get_last_program_key(transaction_context)
+            .get_program_key(transaction_context)
             .unwrap();
 
         stable_log::program_invoke(
@@ -426,7 +426,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .get_current_instruction_context()
             .unwrap();
         let caller = *instruction_context
-            .get_last_program_key(transaction_context)
+            .get_program_key(transaction_context)
             .unwrap();
         transaction_context
             .set_return_data(caller, data.to_vec())

--- a/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
+++ b/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
@@ -143,7 +143,7 @@ impl TestSetup {
     fn run(&self) {
         mock_process_instruction(
             &self.loader_address,
-            Vec::new(),
+            None,
             &self.instruction_data,
             self.transaction_accounts.clone(),
             self.instruction_accounts.clone(),

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -102,7 +102,7 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
     transaction_context
         .get_next_instruction_context_mut()
         .unwrap()
-        .configure_for_tests(vec![0], instruction_accounts, &instruction_data);
+        .configure_for_tests(0, instruction_accounts, &instruction_data);
     transaction_context.push().unwrap();
     transaction_context
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1904,14 +1904,9 @@ mod tests {
         instruction_accounts: Vec<AccountMeta>,
         expected_result: Result<(), InstructionError>,
     ) -> Vec<AccountSharedData> {
-        let program_indices = if let Some(index) = program_index {
-            vec![index]
-        } else {
-            vec![]
-        };
         mock_process_instruction(
             loader_id,
-            program_indices,
+            program_index,
             instruction_data,
             transaction_accounts,
             instruction_accounts,
@@ -1999,7 +1994,7 @@ mod tests {
         // Case: limited budget
         mock_process_instruction(
             &loader_id,
-            vec![0],
+            Some(0),
             &[],
             vec![(program_id, program_account)],
             Vec::new(),
@@ -2561,7 +2556,7 @@ mod tests {
                 bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
             mock_process_instruction(
                 &bpf_loader_upgradeable::id(),
-                Vec::new(),
+                None,
                 &instruction_data,
                 transaction_accounts,
                 instruction_accounts,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -2013,7 +2013,7 @@ mod tests {
         // Case: Account not a program
         mock_process_instruction_with_feature_set(
             &loader_id,
-            vec![0],
+            Some(0),
             &[],
             vec![(program_id, parameter_account.clone())],
             Vec::new(),
@@ -2709,7 +2709,7 @@ mod tests {
 
         mock_process_instruction_with_feature_set(
             &bpf_loader_upgradeable::id(),
-            Vec::new(),
+            None,
             &instruction_data,
             transaction_accounts.clone(),
             instruction_accounts.clone(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1898,15 +1898,20 @@ mod tests {
 
     fn process_instruction(
         loader_id: &Pubkey,
-        program_indices: &[IndexOfAccount],
+        program_index: Option<IndexOfAccount>,
         instruction_data: &[u8],
         transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
         instruction_accounts: Vec<AccountMeta>,
         expected_result: Result<(), InstructionError>,
     ) -> Vec<AccountSharedData> {
+        let program_indices = if let Some(index) = program_index {
+            vec![index]
+        } else {
+            vec![]
+        };
         mock_process_instruction(
             loader_id,
-            program_indices.to_vec(),
+            program_indices,
             instruction_data,
             transaction_accounts,
             instruction_accounts,
@@ -1948,7 +1953,7 @@ mod tests {
         // Case: No program account
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &[],
             Vec::new(),
             Vec::new(),
@@ -1958,7 +1963,7 @@ mod tests {
         // Case: Only a program account
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![(program_id, program_account.clone())],
             Vec::new(),
@@ -1968,7 +1973,7 @@ mod tests {
         // Case: With program and parameter account
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account.clone()),
@@ -1981,7 +1986,7 @@ mod tests {
         // Case: With duplicate accounts
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account.clone()),
@@ -2027,7 +2032,7 @@ mod tests {
         );
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![(program_id, parameter_account)],
             Vec::new(),
@@ -2052,7 +2057,7 @@ mod tests {
         // Case: With program and parameter account
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account.clone()),
@@ -2065,7 +2070,7 @@ mod tests {
         // Case: With duplicate accounts
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account),
@@ -2093,7 +2098,7 @@ mod tests {
         // Case: With program and parameter account
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account.clone()),
@@ -2106,7 +2111,7 @@ mod tests {
         // Case: With duplicate accounts
         process_instruction(
             &loader_id,
-            &[0],
+            Some(0),
             &[],
             vec![
                 (program_id, program_account),
@@ -2144,7 +2149,7 @@ mod tests {
         // Case: Success
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction_data,
             vec![
                 (buffer_address, buffer_account),
@@ -2164,7 +2169,7 @@ mod tests {
         // Case: Already initialized
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction_data,
             vec![
                 (buffer_address, accounts.first().unwrap().clone()),
@@ -2209,7 +2214,7 @@ mod tests {
         .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts.clone(),
@@ -2229,7 +2234,7 @@ mod tests {
             .unwrap();
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts.clone(),
@@ -2267,7 +2272,7 @@ mod tests {
             .unwrap();
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts.clone(),
@@ -2303,7 +2308,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts.clone(),
@@ -2323,7 +2328,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts.clone(),
@@ -2343,7 +2348,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             vec![
@@ -2375,7 +2380,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (buffer_address, buffer_account.clone()),
@@ -2409,7 +2414,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![(buffer_address, buffer_account.clone())],
             instruction_accounts,
@@ -2982,7 +2987,7 @@ mod tests {
         // Case: Set to new authority
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3011,7 +3016,7 @@ mod tests {
         // Case: Not upgradeable
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3032,7 +3037,7 @@ mod tests {
         // Case: Authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3053,7 +3058,7 @@ mod tests {
         let invalid_upgrade_authority_address = Pubkey::new_unique();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3084,7 +3089,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3102,7 +3107,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3158,7 +3163,7 @@ mod tests {
         // Case: Set to new authority
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3188,7 +3193,7 @@ mod tests {
         // Case: set to same authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3205,7 +3210,7 @@ mod tests {
         // Case: present authority not in instruction
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3222,7 +3227,7 @@ mod tests {
         // Case: new authority not in instruction
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3239,7 +3244,7 @@ mod tests {
         // Case: present authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3264,7 +3269,7 @@ mod tests {
         // Case: New authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3290,7 +3295,7 @@ mod tests {
         let invalid_upgrade_authority_address = Pubkey::new_unique();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3321,7 +3326,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3343,7 +3348,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3399,7 +3404,7 @@ mod tests {
         // Case: New authority required
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), authority_meta.clone()],
@@ -3421,7 +3426,7 @@ mod tests {
             .unwrap();
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3442,7 +3447,7 @@ mod tests {
         // Case: Authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3460,7 +3465,7 @@ mod tests {
         // Case: wrong authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (buffer_address, buffer_account.clone()),
@@ -3482,7 +3487,7 @@ mod tests {
         // Case: No authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), authority_meta.clone()],
@@ -3500,7 +3505,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3522,7 +3527,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta, authority_meta, new_authority_meta],
@@ -3577,7 +3582,7 @@ mod tests {
             .unwrap();
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3598,7 +3603,7 @@ mod tests {
         // Case: set to same authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3612,7 +3617,7 @@ mod tests {
         // Case: Missing current authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), new_authority_meta.clone()],
@@ -3622,7 +3627,7 @@ mod tests {
         // Case: Missing new authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta.clone(), authority_meta.clone()],
@@ -3632,7 +3637,7 @@ mod tests {
         // Case: wrong present authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (buffer_address, buffer_account.clone()),
@@ -3654,7 +3659,7 @@ mod tests {
         // Case: present authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3672,7 +3677,7 @@ mod tests {
         // Case: new authority did not sign
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3698,7 +3703,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![
@@ -3720,7 +3725,7 @@ mod tests {
             .unwrap();
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts.clone(),
             vec![buffer_meta, authority_meta, new_authority_meta],
@@ -3803,7 +3808,7 @@ mod tests {
         // Case: close a buffer account
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             transaction_accounts,
             vec![
@@ -3825,7 +3830,7 @@ mod tests {
         // Case: close with wrong authority
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (buffer_address, buffer_account.clone()),
@@ -3847,7 +3852,7 @@ mod tests {
         // Case: close an uninitialized account
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (uninitialized_address, uninitialized_account.clone()),
@@ -3877,7 +3882,7 @@ mod tests {
         // Case: close a program account
         let accounts = process_instruction(
             &loader_id,
-            &[],
+            None,
             &instruction,
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3916,7 +3921,7 @@ mod tests {
         program_account = accounts.get(3).unwrap().clone();
         process_instruction(
             &loader_id,
-            &[1],
+            Some(1),
             &[],
             vec![
                 (programdata_address, programdata_account.clone()),
@@ -3929,7 +3934,7 @@ mod tests {
         // Case: Reopen should fail
         process_instruction(
             &loader_id,
-            &[],
+            None,
             &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                 max_data_len: 0,
             })
@@ -4043,7 +4048,7 @@ mod tests {
                 program_account.set_executable(true);
                 process_instruction(
                     &loader_id,
-                    &[],
+                    None,
                     &[],
                     vec![(program_id, program_account)],
                     Vec::new(),

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -461,7 +461,7 @@ fn process_instruction_inner(
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
-    let program_id = instruction_context.get_last_program_key(transaction_context)?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     if loader_v4::check_id(program_id) {
         invoke_context.consume_checked(DEFAULT_COMPUTE_UNITS)?;
         match limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)? {
@@ -487,7 +487,7 @@ fn process_instruction_inner(
         }
         .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     } else {
-        let program = instruction_context.try_borrow_last_program_account(transaction_context)?;
+        let program = instruction_context.try_borrow_program_account(transaction_context)?;
         let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
         let loaded_program = invoke_context
             .program_cache_for_tx_batch

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -536,7 +536,7 @@ mod tests {
     };
 
     fn process_instruction(
-        program_indices: Vec<IndexOfAccount>,
+        program_index: Option<IndexOfAccount>,
         instruction_data: &[u8],
         transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
         instruction_accounts: &[(IndexOfAccount, bool, bool)],
@@ -552,6 +552,12 @@ mod tests {
                 },
             )
             .collect::<Vec<_>>();
+        let program_indices = if let Some(index) = program_index {
+            vec![index]
+        } else {
+            vec![]
+        };
+
         mock_process_instruction(
             &loader_v4::id(),
             program_indices,
@@ -638,7 +644,7 @@ mod tests {
 
         // Error: Missing program account
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[],
@@ -647,7 +653,7 @@ mod tests {
 
         // Error: Missing authority account
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[(0, false, true)],
@@ -656,7 +662,7 @@ mod tests {
 
         // Error: Program not owned by loader
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[(1, false, true), (1, true, false), (2, true, true)],
@@ -665,7 +671,7 @@ mod tests {
 
         // Error: Program is not writeable
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[(0, false, false), (1, true, false), (2, true, true)],
@@ -674,7 +680,7 @@ mod tests {
 
         // Error: Authority did not sign
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[(0, false, true), (1, false, false), (2, true, true)],
@@ -683,7 +689,7 @@ mod tests {
 
         // Error: Program is finalized
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts.clone(),
             &[(2, false, true), (1, true, false), (0, true, true)],
@@ -692,7 +698,7 @@ mod tests {
 
         // Error: Incorrect authority provided
         process_instruction(
-            vec![],
+            None,
             &instruction,
             transaction_accounts,
             &[(0, false, true), (2, true, false), (2, true, true)],
@@ -736,7 +742,7 @@ mod tests {
 
         // Overwrite existing data
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Write {
                 offset: 2,
                 bytes: vec![8, 8, 8, 8],
@@ -749,7 +755,7 @@ mod tests {
 
         // Empty write
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Write {
                 offset: 2,
                 bytes: Vec::new(),
@@ -762,7 +768,7 @@ mod tests {
 
         // Error: Program is not retracted
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Write {
                 offset: 8,
                 bytes: vec![8, 8, 8, 8],
@@ -775,7 +781,7 @@ mod tests {
 
         // Error: Write out of bounds
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Write {
                 offset: transaction_accounts[0]
                     .1
@@ -833,7 +839,7 @@ mod tests {
 
         // Overwrite existing data
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: 1,
                 source_offset: 2,
@@ -847,7 +853,7 @@ mod tests {
 
         // Empty copy
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: 1,
                 source_offset: 2,
@@ -861,7 +867,7 @@ mod tests {
 
         // Error: Program is not retracted
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: 1,
                 source_offset: 2,
@@ -875,7 +881,7 @@ mod tests {
 
         // Error: Destination and source collide
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: 1,
                 source_offset: 2,
@@ -889,7 +895,7 @@ mod tests {
 
         // Error: Read out of bounds
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: 1,
                 source_offset: transaction_accounts[2]
@@ -908,7 +914,7 @@ mod tests {
 
         // Error: Write out of bounds
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Copy {
                 destination_offset: transaction_accounts[0]
                     .1
@@ -987,7 +993,7 @@ mod tests {
 
         // No change
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[0]
                     .1
@@ -1012,7 +1018,7 @@ mod tests {
             .1
             .set_lamports(smaller_program_lamports);
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[0]
                     .1
@@ -1036,7 +1042,7 @@ mod tests {
             .1
             .set_lamports(larger_program_lamports);
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[4]
                     .1
@@ -1057,7 +1063,7 @@ mod tests {
 
         // Decrease program account size, with a recipient
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[0]
                     .1
@@ -1087,7 +1093,7 @@ mod tests {
 
         // Decrease program account size, without a recipient
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[0]
                     .1
@@ -1109,7 +1115,7 @@ mod tests {
 
         // Close program account
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false), (2, false, true)],
@@ -1128,7 +1134,7 @@ mod tests {
 
         // Close uninitialized program account
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
             transaction_accounts.clone(),
             &[(3, false, true), (1, true, false), (2, true, true)],
@@ -1137,7 +1143,7 @@ mod tests {
 
         // Error: Program not owned by loader
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
             transaction_accounts.clone(),
             &[(1, false, true), (1, true, false), (2, true, true)],
@@ -1146,7 +1152,7 @@ mod tests {
 
         // Error: Program is not writeable
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
             transaction_accounts.clone(),
             &[(3, false, false), (1, true, false), (2, true, true)],
@@ -1155,7 +1161,7 @@ mod tests {
 
         // Error: Close program account without a recipient
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1164,7 +1170,7 @@ mod tests {
 
         // Error: Authority did not sign
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
             transaction_accounts.clone(),
             &[(3, true, true), (1, false, false), (2, true, true)],
@@ -1173,7 +1179,7 @@ mod tests {
 
         // Error: Program is not retracted
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 8 }).unwrap(),
             transaction_accounts.clone(),
             &[(5, false, true), (1, true, false), (2, false, true)],
@@ -1182,7 +1188,7 @@ mod tests {
 
         // Error: Recipient is not writeable
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength { new_size: 0 }).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false), (2, false, false)],
@@ -1191,7 +1197,7 @@ mod tests {
 
         // Error: Insufficient funds
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::SetProgramLength {
                 new_size: transaction_accounts[4]
                     .1
@@ -1256,7 +1262,7 @@ mod tests {
 
         // Deploy from its own data
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1272,7 +1278,7 @@ mod tests {
 
         // Error: Program was deployed recently, cooldown still in effect
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1282,7 +1288,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
             transaction_accounts.clone(),
             &[(3, false, true), (1, true, false)],
@@ -1291,7 +1297,7 @@ mod tests {
 
         // Error: Program fails verification
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
             transaction_accounts.clone(),
             &[(4, false, true), (1, true, false)],
@@ -1300,7 +1306,7 @@ mod tests {
 
         // Error: Program is deployed already
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Deploy).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1347,7 +1353,7 @@ mod tests {
 
         // Retract program
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1361,7 +1367,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
             transaction_accounts.clone(),
             &[(2, false, true), (1, true, false)],
@@ -1370,7 +1376,7 @@ mod tests {
 
         // Error: Program is not deployed
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
             transaction_accounts.clone(),
             &[(3, false, true), (1, true, false)],
@@ -1380,7 +1386,7 @@ mod tests {
         // Error: Program was deployed recently, cooldown still in effect
         transaction_accounts[4].1 = clock(0);
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Retract).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (1, true, false)],
@@ -1434,7 +1440,7 @@ mod tests {
 
         // Transfer authority
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (3, true, false), (4, true, false)],
@@ -1448,7 +1454,7 @@ mod tests {
 
         // Error: No new authority provided
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (3, true, false)],
@@ -1457,7 +1463,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts.clone(),
             &[(2, false, true), (3, true, false), (4, true, false)],
@@ -1466,7 +1472,7 @@ mod tests {
 
         // Error: New authority did not sign
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (3, true, false), (4, false, false)],
@@ -1475,7 +1481,7 @@ mod tests {
 
         // Error: Authority did not change
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::TransferAuthority).unwrap(),
             transaction_accounts,
             &[(0, false, true), (3, true, false), (3, true, false)],
@@ -1541,7 +1547,7 @@ mod tests {
 
         // Finalize program with a next version
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (1, false, false)],
@@ -1555,7 +1561,7 @@ mod tests {
 
         // Finalize program with itself as next version
         let accounts = process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (0, false, false)],
@@ -1569,7 +1575,7 @@ mod tests {
 
         // Error: Program must be deployed to be finalized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(1, false, true), (5, true, false)],
@@ -1578,7 +1584,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(4, false, true), (5, true, false)],
@@ -1587,7 +1593,7 @@ mod tests {
 
         // Error: Next version not owned by loader
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (5, false, false)],
@@ -1596,7 +1602,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (4, false, false)],
@@ -1605,7 +1611,7 @@ mod tests {
 
         // Error: Next version is finalized
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (2, false, false)],
@@ -1614,7 +1620,7 @@ mod tests {
 
         // Error: Incorrect authority of next version
         process_instruction(
-            vec![],
+            None,
             &bincode::serialize(&LoaderV4Instruction::Finalize).unwrap(),
             transaction_accounts.clone(),
             &[(0, false, true), (5, true, false), (3, false, false)],
@@ -1665,7 +1671,7 @@ mod tests {
 
         // Execute program
         process_instruction(
-            vec![0],
+            Some(0),
             &[0, 1, 2, 3],
             transaction_accounts.clone(),
             &[(1, false, true)],
@@ -1674,7 +1680,7 @@ mod tests {
 
         // Error: Program not owned by loader
         process_instruction(
-            vec![1],
+            Some(1),
             &[0, 1, 2, 3],
             transaction_accounts.clone(),
             &[(1, false, true)],
@@ -1683,7 +1689,7 @@ mod tests {
 
         // Error: Program is uninitialized
         process_instruction(
-            vec![2],
+            Some(2),
             &[0, 1, 2, 3],
             transaction_accounts.clone(),
             &[(1, false, true)],
@@ -1693,7 +1699,7 @@ mod tests {
         // Error: Program is not deployed
         // This is only checked in integration with load_program_accounts() in the SVM
         process_instruction(
-            vec![3],
+            Some(3),
             &[0, 1, 2, 3],
             transaction_accounts.clone(),
             &[(1, false, true)],
@@ -1702,7 +1708,7 @@ mod tests {
 
         // Error: Program fails verification
         process_instruction(
-            vec![4],
+            Some(4),
             &[0, 1, 2, 3],
             transaction_accounts,
             &[(1, false, true)],

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -552,15 +552,10 @@ mod tests {
                 },
             )
             .collect::<Vec<_>>();
-        let program_indices = if let Some(index) = program_index {
-            vec![index]
-        } else {
-            vec![]
-        };
 
         mock_process_instruction(
             &loader_v4::id(),
-            program_indices,
+            program_index,
             instruction_data,
             transaction_accounts,
             instruction_accounts,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -71,7 +71,7 @@ macro_rules! with_mock_invoke_context {
             .transaction_context
             .get_next_instruction_context_mut()
             .unwrap()
-            .configure_for_tests(vec![0, 1], instruction_accounts, &[]);
+            .configure_for_tests(1, instruction_accounts, &[]);
         $invoke_context.push().unwrap();
     };
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1485,7 +1485,7 @@ fn assert_instruction_count() {
         print!("  {:36} {:8}", program_name, *expected_consumption);
         mock_process_instruction(
             &loader_id,
-            vec![0],
+            Some(0),
             &[],
             transaction_accounts,
             instruction_accounts,

--- a/programs/stake/benches/stake.rs
+++ b/programs/stake/benches/stake.rs
@@ -126,7 +126,7 @@ impl TestSetup {
 
         let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
-            Vec::new(),
+            None,
             &instruction.data,
             transaction_accounts,
             instruction.accounts.clone(),
@@ -166,7 +166,7 @@ impl TestSetup {
 
         let accounts = mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
-            Vec::new(),
+            None,
             &instruction.data,
             transaction_accounts,
             instruction.accounts.clone(),
@@ -184,7 +184,7 @@ impl TestSetup {
     fn run(&self, instruction_data: &[u8]) {
         mock_process_instruction_with_feature_set(
             &solana_stake_program::id(),
-            Vec::new(),
+            None,
             instruction_data,
             self.transaction_accounts.clone(),
             self.instruction_accounts.clone(),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -460,7 +460,7 @@ mod tests {
     ) -> Vec<AccountSharedData> {
         mock_process_instruction_with_feature_set(
             &id(),
-            Vec::new(),
+            None,
             instruction_data,
             transaction_accounts,
             instruction_accounts,
@@ -6977,7 +6977,7 @@ mod tests {
 
         mock_process_instruction_with_feature_set(
             &id(),
-            Vec::new(),
+            None,
             &instruction_data,
             transaction_accounts,
             instruction_accounts,

--- a/programs/system/benches/system.rs
+++ b/programs/system/benches/system.rs
@@ -460,7 +460,7 @@ impl TestSetup {
     fn run(&self) {
         mock_process_instruction(
             &solana_system_program::id(),
-            Vec::new(),
+            None,
             &self.instruction_data,
             self.transaction_accounts.clone(),
             self.instruction_accounts.clone(),

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -269,7 +269,7 @@ mod test {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests(vec![2], $instruction_accounts, &[]);
+                .configure_for_tests(2, $instruction_accounts, &[]);
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -592,7 +592,7 @@ mod tests {
     ) -> Vec<AccountSharedData> {
         mock_process_instruction(
             &system_program::id(),
-            Vec::new(),
+            None,
             instruction_data,
             transaction_accounts,
             instruction_accounts,
@@ -1589,7 +1589,7 @@ mod tests {
             ]);
         mock_process_instruction(
             &system_program::id(),
-            Vec::new(),
+            None,
             &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
             vec![
                 (nonce_address, accounts[0].clone()),
@@ -1885,7 +1885,7 @@ mod tests {
         let new_recent_blockhashes_account = create_recent_blockhashes_account_for_test(vec![]);
         mock_process_instruction(
             &system_program::id(),
-            Vec::new(),
+            None,
             &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
             vec![
                 (nonce_address, accounts[0].clone()),

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -129,7 +129,7 @@ fn bench_process_vote_instruction(
     bencher.iter(|| {
         mock_process_instruction(
             &solana_vote_program::id(),
-            Vec::new(),
+            None,
             &instruction_data,
             transaction_accounts.clone(),
             instruction_account_metas.clone(),

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -107,7 +107,7 @@ fn bench_process_deprecated_vote_instruction(
     bencher.iter(|| {
         mock_process_instruction_with_feature_set(
             &solana_vote_program::id(),
-            Vec::new(),
+            None,
             &instruction_data,
             transaction_accounts.clone(),
             instruction_account_metas.clone(),

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -180,7 +180,7 @@ fn process_deprecated_instruction(
     deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
     mock_process_instruction_with_feature_set(
         &id(),
-        Vec::new(),
+        None,
         instruction_data,
         transaction_accounts,
         instruction_accounts,

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -159,7 +159,7 @@ fn process_instruction(
 ) -> Vec<AccountSharedData> {
     mock_process_instruction(
         &id(),
-        Vec::new(),
+        None,
         instruction_data,
         transaction_accounts,
         instruction_accounts,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -272,7 +272,7 @@ mod tests {
     ) -> Vec<AccountSharedData> {
         mock_process_instruction(
             &id(),
-            Vec::new(),
+            None,
             instruction_data,
             transaction_accounts,
             instruction_accounts,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1169,7 +1169,7 @@ mod tests {
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
             0,
-            vec![InstructionAccount::new(1, 0, false, true)],
+            vec![InstructionAccount::new(1, false, true)],
             &[],
         );
 
@@ -1318,7 +1318,7 @@ mod tests {
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
             0,
-            vec![InstructionAccount::new(1, 0, false, true)],
+            vec![InstructionAccount::new(1, false, true)],
             &[],
         );
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1168,8 +1168,8 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
-            vec![0],
-            vec![InstructionAccount::new(1, false, true)],
+            0,
+            vec![InstructionAccount::new(1, 0, false, true)],
             &[],
         );
 
@@ -1317,8 +1317,8 @@ mod tests {
         );
         let mut instruction_context = InstructionContext::default();
         instruction_context.configure_for_tests(
-            vec![0],
-            vec![InstructionAccount::new(1, false, true)],
+            0,
+            vec![InstructionAccount::new(1, 0, false, true)],
             &[],
         );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5203,7 +5203,7 @@ fn test_same_program_id_uses_unique_executable_accounts() {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         instruction_context
-            .try_borrow_program_account(transaction_context, 0)?
+            .try_borrow_last_program_account(transaction_context)?
             .set_data_length(2)
     });
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3409,7 +3409,7 @@ fn test_add_builtin() {
     declare_process_instruction!(MockBuiltin, 1, |invoke_context| {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        let program_id = instruction_context.get_last_program_key(transaction_context)?;
+        let program_id = instruction_context.get_program_key(transaction_context)?;
         if mock_vote_program_id() != *program_id {
             return Err(InstructionError::IncorrectProgramId);
         }
@@ -5203,7 +5203,7 @@ fn test_same_program_id_uses_unique_executable_accounts() {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         instruction_context
-            .try_borrow_last_program_account(transaction_context)?
+            .try_borrow_program_account(transaction_context)?
             .set_data_length(2)
     });
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -48,7 +48,6 @@ pub(crate) const TRANSACTION_ACCOUNT_BASE_SIZE: usize = 64;
 const ADDRESS_LOOKUP_TABLE_BASE_SIZE: usize = 8248;
 
 // for the load instructions
-pub(crate) type TransactionProgramIndices = Vec<Vec<IndexOfAccount>>;
 pub type TransactionCheckResult = Result<CheckedTransactionDetails>;
 type TransactionValidationResult = Result<ValidatedTransactionDetails>;
 
@@ -137,7 +136,7 @@ pub(crate) struct LoadedTransactionAccount {
 )]
 pub struct LoadedTransaction {
     pub accounts: Vec<TransactionAccount>,
-    pub(crate) program_indices: TransactionProgramIndices,
+    pub(crate) program_indices: Vec<IndexOfAccount>,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
@@ -449,7 +448,7 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
 #[derive(PartialEq, Eq, Debug, Clone)]
 struct LoadedTransactionAccounts {
     pub(crate) accounts: Vec<TransactionAccount>,
-    pub(crate) program_indices: TransactionProgramIndices,
+    pub(crate) program_indices: Vec<IndexOfAccount>,
     pub(crate) loaded_accounts_data_size: u32,
 }
 
@@ -629,7 +628,7 @@ fn load_transaction_accounts_simd186<CB: TransactionProcessingCallback>(
 
         loaded_transaction_accounts
             .program_indices
-            .push(vec![instruction.program_id_index as IndexOfAccount]);
+            .push(instruction.program_id_index as IndexOfAccount);
     }
 
     Ok(loaded_transaction_accounts)
@@ -679,9 +678,10 @@ fn load_transaction_accounts_old<CB: TransactionProcessingCallback>(
     let program_indices = message
         .program_instructions_iter()
         .map(|(program_id, instruction)| {
-            let mut account_indices = Vec::with_capacity(2);
             if native_loader::check_id(program_id) {
-                return Ok(account_indices);
+                // Just as with an empty vector, trying to borrow the program account will fail
+                // with a u16::MAX
+                return Ok(u16::MAX as IndexOfAccount);
             }
 
             let program_index = instruction.program_id_index as usize;
@@ -699,11 +699,10 @@ fn load_transaction_accounts_old<CB: TransactionProcessingCallback>(
                 error_metrics.invalid_program_for_execution += 1;
                 return Err(TransactionError::InvalidProgramForExecution);
             }
-            account_indices.insert(0, program_index as IndexOfAccount);
 
             let owner_id = program_account.owner();
             if native_loader::check_id(owner_id) {
-                return Ok(account_indices);
+                return Ok(program_index as IndexOfAccount);
             }
 
             if !validated_loaders.contains(owner_id) {
@@ -729,9 +728,9 @@ fn load_transaction_accounts_old<CB: TransactionProcessingCallback>(
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
             }
-            Ok(account_indices)
+            Ok(program_index as IndexOfAccount)
         })
-        .collect::<Result<Vec<Vec<IndexOfAccount>>>>()?;
+        .collect::<Result<Vec<IndexOfAccount>>>()?;
 
     Ok(LoadedTransactionAccounts {
         accounts,
@@ -1059,7 +1058,7 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts.len(), 3);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.program_indices.len(), 1);
-                assert_eq!(loaded_transaction.program_indices[0].len(), 0);
+                assert_eq!(loaded_transaction.program_indices[0], u16::MAX);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx)
                 if formalize_loaded_transaction_data_size =>
@@ -1235,8 +1234,8 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts.len(), 3);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.program_indices.len(), 2);
-                assert_eq!(loaded_transaction.program_indices[0], &[1]);
-                assert_eq!(loaded_transaction.program_indices[1], &[2]);
+                assert_eq!(loaded_transaction.program_indices[0], 1);
+                assert_eq!(loaded_transaction.program_indices[1], 2);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
             TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
@@ -1641,7 +1640,7 @@ mod tests {
                             mock_bank.accounts_map[&native_loader::id()].clone()
                         )
                     ],
-                    program_indices: vec![vec![]],
+                    program_indices: vec![u16::MAX],
                     loaded_accounts_data_size,
                 }
             );
@@ -1809,7 +1808,7 @@ mod tests {
                         mock_bank.accounts_map[&key1.pubkey()].clone()
                     ),
                 ],
-                program_indices: vec![vec![1]],
+                program_indices: vec![1],
                 loaded_accounts_data_size,
             }
         );
@@ -1998,7 +1997,7 @@ mod tests {
                         mock_bank.accounts_map[&key1.pubkey()].clone()
                     ),
                 ],
-                program_indices: vec![vec![1]],
+                program_indices: vec![1],
                 loaded_accounts_data_size,
             }
         );
@@ -2097,7 +2096,7 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
-                program_indices: vec![vec![1], vec![1]],
+                program_indices: vec![1, 1],
                 loaded_accounts_data_size,
             }
         );
@@ -2266,7 +2265,7 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
-                program_indices: vec![vec![1], vec![1]],
+                program_indices: vec![1, 1],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget: SVMTransactionExecutionBudget::default(),

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -14,19 +14,19 @@ use {
 /// The accounts are committed back to the bank only if every instruction succeeds.
 pub(crate) fn process_message(
     message: &impl SVMMessage,
-    program_indices: &[Vec<IndexOfAccount>],
+    program_indices: &[IndexOfAccount],
     invoke_context: &mut InvokeContext,
     execute_timings: &mut ExecuteTimings,
     accumulated_consumed_units: &mut u64,
 ) -> Result<(), TransactionError> {
     debug_assert_eq!(program_indices.len(), message.num_instructions());
-    for (top_level_instruction_index, ((program_id, instruction), program_indices)) in message
+    for (top_level_instruction_index, ((program_id, instruction), program_account_index)) in message
         .program_instructions_iter()
         .zip(program_indices.iter())
         .enumerate()
     {
         invoke_context
-            .prepare_next_top_level_instruction(message, &instruction, program_indices.clone())
+            .prepare_next_top_level_instruction(message, &instruction, *program_account_index)
             .map_err(|err| {
                 TransactionError::InstructionError(top_level_instruction_index as u8, err)
             })?;
@@ -187,7 +187,7 @@ mod tests {
             ),
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
-        let program_indices = vec![vec![2]];
+        let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_system_program_id,
@@ -423,7 +423,7 @@ mod tests {
             ),
         ];
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3);
-        let program_indices = vec![vec![2]];
+        let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
@@ -695,7 +695,7 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &[vec![1], vec![2], vec![3], vec![4]],
+            &[1, 2, 3, 4],
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -990,11 +990,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     let stack_height = u8::try_from(stack_height).unwrap_or(u8::MAX);
                     let instruction = CompiledInstruction::new_from_raw_parts(
                         instruction_context
-                            .get_index_of_program_account_in_transaction(
-                                instruction_context
-                                    .get_number_of_program_accounts()
-                                    .saturating_sub(1),
-                            )
+                            .get_index_of_program_account_in_transaction()
                             .unwrap_or_default() as u8,
                         instruction_context.get_instruction_data().to_vec(),
                         (0..instruction_context.get_number_of_instruction_accounts())

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1265,8 +1265,15 @@ mod tests {
     #[test]
     fn test_inner_instructions_list_from_instruction_trace() {
         let instruction_trace = [1, 2, 1, 1, 2, 3, 2];
-        let mut transaction_context =
-            TransactionContext::new(vec![], Rent::default(), 3, instruction_trace.len());
+        let mut transaction_context = TransactionContext::new(
+            vec![(
+                Pubkey::new_unique(),
+                AccountSharedData::new(1, 1, &bpf_loader::ID),
+            )],
+            Rent::default(),
+            3,
+            instruction_trace.len(),
+        );
         for (index_in_trace, stack_height) in instruction_trace.into_iter().enumerate() {
             while stack_height <= transaction_context.get_instruction_context_stack_height() {
                 transaction_context.pop().unwrap();
@@ -1275,7 +1282,7 @@ mod tests {
                 transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure_for_tests(vec![], vec![], &[index_in_trace as u8]);
+                    .configure_for_tests(0, vec![], &[index_in_trace as u8]);
                 transaction_context.push().unwrap();
             }
         }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1342,7 +1342,7 @@ mod tests {
 
         let loaded_transaction = LoadedTransaction {
             accounts: vec![(Pubkey::new_unique(), AccountSharedData::default())],
-            program_indices: vec![vec![0]],
+            program_indices: vec![0],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -1437,7 +1437,7 @@ mod tests {
                 (key1, AccountSharedData::default()),
                 (key2, AccountSharedData::default()),
             ],
-            program_indices: vec![vec![0]],
+            program_indices: vec![0],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1035,7 +1035,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
     )?;
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
-    let caller_program_id = instruction_context.get_last_program_key(transaction_context)?;
+    let caller_program_id = instruction_context.get_program_key(transaction_context)?;
     let signers = S::translate_signers(
         caller_program_id,
         signers_seeds_addr,

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1345,7 +1345,7 @@ mod tests {
          $transaction_context:ident,
          $instruction_data:expr,
          $transaction_accounts:expr,
-         $program_accounts:expr,
+         $program_account:expr,
          $instruction_accounts:expr) => {
             let instruction_data = $instruction_data;
             let instruction_accounts = $instruction_accounts
@@ -1375,7 +1375,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests($program_accounts, instruction_accounts, instruction_data);
+                .configure_for_tests($program_account, instruction_accounts, instruction_data);
             $invoke_context.push().unwrap();
         };
     }
@@ -1401,7 +1401,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1447,7 +1447,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1484,7 +1484,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1529,7 +1529,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1582,7 +1582,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1700,7 +1700,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1739,7 +1739,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1843,7 +1843,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1]
         );
 
@@ -1921,7 +1921,7 @@ mod tests {
             transaction_context,
             b"instruction data",
             transaction_accounts,
-            vec![0],
+            0,
             &[1, 1]
         );
 
@@ -1938,7 +1938,7 @@ mod tests {
             .get_next_instruction_context_mut()
             .unwrap()
             .configure_for_tests(
-                vec![0],
+                0,
                 vec![
                     InstructionAccount::new(1, false, true),
                     InstructionAccount::new(1, false, true),

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2223,7 +2223,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests(vec![1], vec![], &[]);
+                .configure_for_tests(1, vec![], &[]);
             $invoke_context.push().unwrap();
         };
     }
@@ -4455,7 +4455,7 @@ mod tests {
                     .transaction_context
                     .get_next_instruction_context_mut()
                     .unwrap()
-                    .configure_for_tests(vec![0], instruction_accounts, &[index_in_trace as u8]);
+                    .configure_for_tests(0, instruction_accounts, &[index_in_trace as u8]);
                 invoke_context.transaction_context.push().unwrap();
             }
         }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1462,7 +1462,7 @@ declare_builtin_function!(
         let program_id = *transaction_context
             .get_current_instruction_context()
             .and_then(|instruction_context| {
-                instruction_context.get_last_program_key(transaction_context)
+                instruction_context.get_program_key(transaction_context)
             })?;
 
         transaction_context.set_return_data(program_id, return_data)?;
@@ -1582,7 +1582,7 @@ declare_builtin_function!(
                 let _ = result_header;
 
                 *program_id = *instruction_context
-                    .get_last_program_key(invoke_context.transaction_context)?;
+                    .get_program_key(invoke_context.transaction_context)?;
                 data.clone_from_slice(instruction_context.get_instruction_data());
                 let account_metas = (0..instruction_context.get_number_of_instruction_accounts())
                     .map(|instruction_account_index| {
@@ -2223,7 +2223,7 @@ mod tests {
                 .transaction_context
                 .get_next_instruction_context_mut()
                 .unwrap()
-                .configure_for_tests(vec![0, 1], vec![], &[]);
+                .configure_for_tests(vec![1], vec![], &[]);
             $invoke_context.push().unwrap();
         };
     }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -294,14 +294,6 @@ impl TransactionContext {
             .map(|index| index as IndexOfAccount)
     }
 
-    /// Searches for a program account by its key
-    pub fn find_index_of_program_account(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
-        self.account_keys
-            .iter()
-            .rposition(|key| key == pubkey)
-            .map(|index| index as IndexOfAccount)
-    }
-
     /// Gets the max length of the InstructionContext trace
     pub fn get_instruction_trace_capacity(&self) -> usize {
         self.instruction_trace_capacity

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -845,23 +845,12 @@ impl InstructionContext {
         &'a self,
         transaction_context: &'b TransactionContext,
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
-        let result = self.try_borrow_program_account(
-            transaction_context,
+        let index_in_transaction = self.get_index_of_program_account_in_transaction(
             self.get_number_of_program_accounts().saturating_sub(1),
-        );
+        )?;
+        let result = self.try_borrow_account(transaction_context, index_in_transaction, None);
         debug_assert!(result.is_ok());
         result
-    }
-
-    /// Tries to borrow a program account from this Instruction
-    pub fn try_borrow_program_account<'a, 'b: 'a>(
-        &'a self,
-        transaction_context: &'b TransactionContext,
-        program_account_index: IndexOfAccount,
-    ) -> Result<BorrowedAccount<'a>, InstructionError> {
-        let index_in_transaction =
-            self.get_index_of_program_account_in_transaction(program_account_index)?;
-        self.try_borrow_account(transaction_context, index_in_transaction, None)
     }
 
     /// Gets an instruction account of this Instruction

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -719,7 +719,7 @@ impl InstructionContext {
         &self,
     ) -> Result<IndexOfAccount, InstructionError> {
         if self.program_account_index_in_tx == u16::MAX {
-            Err(InstructionError::MissingAccount)
+            Err(InstructionError::NotEnoughAccountKeys)
         } else {
             Ok(self.program_account_index_in_tx)
         }
@@ -1378,7 +1378,7 @@ mod tests {
         );
 
         let result = instruction_context.get_index_of_program_account_in_transaction();
-        assert_eq!(result, Err(InstructionError::MissingAccount));
+        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
 
         let transaction_context = TransactionContext::new(
             vec![(
@@ -1391,9 +1391,9 @@ mod tests {
         );
         let result = instruction_context.get_program_key(&transaction_context);
 
-        assert_eq!(result, Err(InstructionError::MissingAccount));
+        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
 
         let result = instruction_context.try_borrow_program_account(&transaction_context);
-        assert_eq!(result.err(), Some(InstructionError::MissingAccount));
+        assert_eq!(result.err(), Some(InstructionError::NotEnoughAccountKeys));
     }
 }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -637,13 +637,13 @@ impl InstructionContext {
     #[cfg(not(target_os = "solana"))]
     pub fn configure(
         &mut self,
-        program_accounts: Vec<IndexOfAccount>,
+        program_index: IndexOfAccount,
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u8>,
         instruction_data: &[u8],
     ) {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
-        self.program_account_index_in_tx = *program_accounts.first().unwrap();
+        self.program_account_index_in_tx = program_index;
         self.instruction_accounts = instruction_accounts;
         self.instruction_data = instruction_data.to_vec();
         self.dedup_map = deduplication_map;
@@ -653,7 +653,7 @@ impl InstructionContext {
     #[cfg(not(target_os = "solana"))]
     pub fn configure_for_tests(
         &mut self,
-        program_accounts: Vec<IndexOfAccount>,
+        program_index: IndexOfAccount,
         instruction_accounts: Vec<InstructionAccount>,
         instruction_data: &[u8],
     ) {
@@ -669,7 +669,7 @@ impl InstructionContext {
         }
 
         self.configure(
-            program_accounts,
+            program_index,
             instruction_accounts,
             dedup_map,
             instruction_data,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -1367,4 +1367,33 @@ mod tests {
         );
         assert_eq!(build_transaction_context(account).push(), Ok(()),);
     }
+
+    #[test]
+    fn test_invalid_native_loader_index() {
+        let mut instruction_context = InstructionContext::default();
+        instruction_context.configure(
+            u16::MAX,
+            vec![InstructionAccount::new(0, 0, false, false)],
+            &[],
+        );
+
+        let result = instruction_context.get_index_of_program_account_in_transaction();
+        assert_eq!(result, Err(InstructionError::MissingAccount));
+
+        let transaction_context = TransactionContext::new(
+            vec![(
+                Pubkey::new_unique(),
+                AccountSharedData::new(1, 1, &Pubkey::new_unique()),
+            )],
+            Rent::default(),
+            20,
+            20,
+        );
+        let result = instruction_context.get_program_key(&transaction_context);
+
+        assert_eq!(result, Err(InstructionError::MissingAccount));
+
+        let result = instruction_context.try_borrow_program_account(&transaction_context);
+        assert_eq!(result.err(), Some(InstructionError::MissingAccount));
+    }
 }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -1371,9 +1371,9 @@ mod tests {
     #[test]
     fn test_invalid_native_loader_index() {
         let mut instruction_context = InstructionContext::default();
-        instruction_context.configure(
+        instruction_context.configure_for_tests(
             u16::MAX,
-            vec![InstructionAccount::new(0, 0, false, false)],
+            vec![InstructionAccount::new(0, false, false)],
             &[],
         );
 


### PR DESCRIPTION
#### Problem

Event though the `InstructionContext` supports a vector of multiple indexes for program accounts in an instruction, the program runtime never accesses any element from that vector except the last one.

Also, in [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we want to share the `InstructionContext` struct with only a single index in transaction for the program id being executed.

#### Summary of Changes

1. Modify the account loading functions to return a `u16::MAX` when we invoke the native loader.
2. Remove unnecessary functions.
3. Remove the vector from `InstructionContext` and use a single `IndexOfAccount` instead.
4. Adapt the correlated functions in `InstructionContext`.
5. Change the argument types of many function used in tests (one per commit).
6. Change the parameter type in `fn configure`.
