### PR TITLE
move const MAX_CODE_SHREDS_PER_SLOT to shred

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -104,12 +104,6 @@ pub use {
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 
-// An upper bound on maximum number of data shreds we can handle in a slot
-// 32K shreds would allow ~320K peak TPS
-// (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
-pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
-pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
-
 pub type CompletedSlotsSender = Sender<Vec<Slot>>;
 pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;
 
@@ -5316,7 +5310,7 @@ pub mod tests {
         crate::{
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             leader_schedule::{FixedSchedule, IdentityKeyedLeaderSchedule},
-            shred::max_ticks_per_n_shreds,
+            shred::{max_ticks_per_n_shreds, MAX_DATA_SHREDS_PER_SLOT},
         },
         assert_matches::assert_matches,
         bincode::{serialize, Options},

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -108,6 +108,7 @@ pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 // 32K shreds would allow ~320K peak TPS
 // (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
 pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
+pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
 
 pub type CompletedSlotsSender = Sender<Vec<Slot>>;
 pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
         bit_vec::BitVec,
-        blockstore::MAX_DATA_SHREDS_PER_SLOT,
-        shred::{self, Shred, ShredType},
+        shred::{self, Shred, ShredType, MAX_DATA_SHREDS_PER_SLOT},
     },
     bitflags::bitflags,
     serde::{Deserialize, Deserializer, Serialize, Serializer},

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -63,7 +63,7 @@ pub use {
 };
 use {
     self::{shred_code::ShredCode, traits::Shred as _},
-    crate::blockstore::{self, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT},
+    crate::blockstore::{self},
     assert_matches::debug_assert_matches,
     bitflags::bitflags,
     num_enum::{IntoPrimitive, TryFromPrimitive},
@@ -117,6 +117,12 @@ const SIZE_OF_SIGNATURE: usize = SIGNATURE_BYTES;
 pub const DATA_SHREDS_PER_FEC_BLOCK: usize = 32;
 pub const CODING_SHREDS_PER_FEC_BLOCK: usize = 32;
 pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHREDS_PER_FEC_BLOCK;
+
+/// An upper bound on maximum number of data shreds we can handle in a slot
+/// 32K shreds would allow ~320K peak TPS
+/// (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
+pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
+pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
 
 // Statically compute the typical data batch size assuming:
 // 1. 32:32 erasure coding batch

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -133,6 +133,10 @@ pub const fn get_data_shred_bytes_per_batch_typical() -> u64 {
     (DATA_SHREDS_PER_FEC_BLOCK * capacity) as u64
 }
 
+// For legacy tests and benchmarks.
+const_assert_eq!(LEGACY_SHRED_DATA_CAPACITY, 1051);
+pub const LEGACY_SHRED_DATA_CAPACITY: usize = legacy::ShredData::CAPACITY;
+
 // LAST_SHRED_IN_SLOT also implies DATA_COMPLETE_SHRED.
 // So it cannot be LAST_SHRED_IN_SLOT if not also DATA_COMPLETE_SHRED.
 bitflags! {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -63,7 +63,7 @@ pub use {
 };
 use {
     self::{shred_code::ShredCode, traits::Shred as _},
-    crate::blockstore::{self, MAX_DATA_SHREDS_PER_SLOT},
+    crate::blockstore::{self, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT},
     assert_matches::debug_assert_matches,
     bitflags::bitflags,
     num_enum::{IntoPrimitive, TryFromPrimitive},
@@ -132,10 +132,6 @@ pub const fn get_data_shred_bytes_per_batch_typical() -> u64 {
         };
     (DATA_SHREDS_PER_FEC_BLOCK * capacity) as u64
 }
-
-// For legacy tests and benchmarks.
-const_assert_eq!(LEGACY_SHRED_DATA_CAPACITY, 1051);
-pub const LEGACY_SHRED_DATA_CAPACITY: usize = legacy::ShredData::CAPACITY;
 
 // LAST_SHRED_IN_SLOT also implies DATA_COMPLETE_SHRED.
 // So it cannot be LAST_SHRED_IN_SLOT if not also DATA_COMPLETE_SHRED.
@@ -815,7 +811,7 @@ where
     };
     match ShredType::from(shred_variant) {
         ShredType::Code => {
-            if index >= MAX_DATA_SHREDS_PER_SLOT as u32 {
+            if index >= MAX_CODE_SHREDS_PER_SLOT as u32 {
                 stats.index_out_of_bounds += 1;
                 return true;
             }
@@ -1294,7 +1290,7 @@ mod tests {
             assert_eq!(stats.slot_out_of_range, 1);
         }
         {
-            let index = u32::try_from(MAX_DATA_SHREDS_PER_SLOT).unwrap();
+            let index = u32::try_from(MAX_CODE_SHREDS_PER_SLOT).unwrap();
             {
                 let mut cursor = Cursor::new(packet.buffer_mut());
                 cursor

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -49,8 +49,6 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
-#[cfg(test)]
-pub(crate) use self::shred_code::MAX_CODE_SHREDS_PER_SLOT;
 pub(crate) use self::{
     merkle_tree::{PROOF_ENTRIES_FOR_32_32_BATCH, SIZE_OF_MERKLE_ROOT},
     payload::serde_bytes_payload,
@@ -89,7 +87,7 @@ mod legacy;
 pub(crate) mod merkle;
 mod merkle_tree;
 mod payload;
-pub mod shred_code;
+mod shred_code;
 mod shred_data;
 mod stats;
 mod traits;
@@ -813,7 +811,7 @@ where
     };
     match ShredType::from(shred_variant) {
         ShredType::Code => {
-            if index >= shred_code::MAX_CODE_SHREDS_PER_SLOT as u32 {
+            if index >= MAX_DATA_SHREDS_PER_SLOT as u32 {
                 stats.index_out_of_bounds += 1;
                 return true;
             }
@@ -1292,7 +1290,7 @@ mod tests {
             assert_eq!(stats.slot_out_of_range, 1);
         }
         {
-            let index = u32::try_from(MAX_CODE_SHREDS_PER_SLOT).unwrap();
+            let index = u32::try_from(MAX_DATA_SHREDS_PER_SLOT).unwrap();
             {
                 let mut cursor = Cursor::new(packet.buffer_mut());
                 cursor

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -13,9 +13,6 @@ use {
     static_assertions::const_assert_eq,
 };
 
-const_assert_eq!(MAX_CODE_SHREDS_PER_SLOT, 32_768);
-pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
-
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -118,7 +115,7 @@ pub(super) fn erasure_shard_index<T: ShredCodeTrait>(shred: &T) -> Option<usize>
     if shred
         .first_coding_index()?
         .checked_add(u32::from(coding_header.num_coding_shreds.checked_sub(1)?))? as usize
-        >= MAX_CODE_SHREDS_PER_SLOT
+        >= MAX_DATA_SHREDS_PER_SLOT
     {
         return None;
     }
@@ -136,7 +133,7 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
     }
     let common_header = shred.common_header();
     let coding_header = shred.coding_header();
-    if common_header.index as usize >= MAX_CODE_SHREDS_PER_SLOT {
+    if common_header.index as usize >= MAX_DATA_SHREDS_PER_SLOT {
         return Err(Error::InvalidShredIndex(
             ShredType::Code,
             common_header.index,

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -1,11 +1,14 @@
 use {
-    crate::shred::{
-        common::dispatch,
-        legacy, merkle,
-        payload::Payload,
-        traits::{Shred, ShredCode as ShredCodeTrait},
-        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
-        DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+    crate::{
+        blockstore::MAX_CODE_SHREDS_PER_SLOT,
+        shred::{
+            common::dispatch,
+            legacy, merkle,
+            payload::Payload,
+            traits::{Shred, ShredCode as ShredCodeTrait},
+            CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
+            DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
+        },
     },
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,
@@ -115,7 +118,7 @@ pub(super) fn erasure_shard_index<T: ShredCodeTrait>(shred: &T) -> Option<usize>
     if shred
         .first_coding_index()?
         .checked_add(u32::from(coding_header.num_coding_shreds.checked_sub(1)?))? as usize
-        >= MAX_DATA_SHREDS_PER_SLOT
+        >= MAX_CODE_SHREDS_PER_SLOT
     {
         return None;
     }
@@ -133,7 +136,7 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
     }
     let common_header = shred.common_header();
     let coding_header = shred.coding_header();
-    if common_header.index as usize >= MAX_DATA_SHREDS_PER_SLOT {
+    if common_header.index as usize >= MAX_DATA_SHREDS_PER_SLOT.max(MAX_CODE_SHREDS_PER_SLOT) {
         return Err(Error::InvalidShredIndex(
             ShredType::Code,
             common_header.index,

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -134,7 +134,7 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
     }
     let common_header = shred.common_header();
     let coding_header = shred.coding_header();
-    if common_header.index as usize >= MAX_DATA_SHREDS_PER_SLOT.max(MAX_CODE_SHREDS_PER_SLOT) {
+    if common_header.index as usize >= MAX_CODE_SHREDS_PER_SLOT {
         return Err(Error::InvalidShredIndex(
             ShredType::Code,
             common_header.index,

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -1,14 +1,12 @@
 use {
-    crate::{
-        blockstore::MAX_CODE_SHREDS_PER_SLOT,
-        shred::{
-            common::dispatch,
-            legacy, merkle,
-            payload::Payload,
-            traits::{Shred, ShredCode as ShredCodeTrait},
-            CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
-            DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
-        },
+    crate::shred::{
+        common::dispatch,
+        legacy, merkle,
+        payload::Payload,
+        traits::{Shred, ShredCode as ShredCodeTrait},
+        CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
+        DATA_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
+        SIZE_OF_NONCE,
     },
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,

--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -4,7 +4,7 @@ use {
     solana_clock::Slot,
     solana_ledger::{
         blockstore::MAX_DATA_SHREDS_PER_SLOT,
-        shred::{shred_code::MAX_CODE_SHREDS_PER_SLOT, ShredId, ShredType},
+        shred::{ShredId, ShredType},
     },
     std::{
         cmp::Reverse,
@@ -323,7 +323,7 @@ impl CacheEntry {
         let code = {
             // There at least as many coding shreds as data shreds.
             let max_index = self.max_index_code.max(self.max_index_data) as usize + extend_buffer;
-            self.index_code..max_index.min(MAX_CODE_SHREDS_PER_SLOT)
+            self.index_code..max_index.min(MAX_DATA_SHREDS_PER_SLOT)
         }
         .filter(|&k| matches!(self.code.get(k), None | Some(None)))
         .map(|k| (ShredType::Code, k));

--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -2,9 +2,8 @@ use {
     crate::retransmit_stage::RetransmitSlotStats,
     itertools::Itertools,
     solana_clock::Slot,
-    solana_ledger::{
-        blockstore::{MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT},
-        shred::{ShredId, ShredType},
+    solana_ledger::shred::{
+        ShredId, ShredType, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
     },
     std::{
         cmp::Reverse,

--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -3,7 +3,7 @@ use {
     itertools::Itertools,
     solana_clock::Slot,
     solana_ledger::{
-        blockstore::MAX_DATA_SHREDS_PER_SLOT,
+        blockstore::{MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT},
         shred::{ShredId, ShredType},
     },
     std::{
@@ -323,7 +323,7 @@ impl CacheEntry {
         let code = {
             // There at least as many coding shreds as data shreds.
             let max_index = self.max_index_code.max(self.max_index_data) as usize + extend_buffer;
-            self.index_code..max_index.min(MAX_DATA_SHREDS_PER_SLOT)
+            self.index_code..max_index.min(MAX_CODE_SHREDS_PER_SLOT)
         }
         .filter(|&k| matches!(self.code.get(k), None | Some(None)))
         .map(|k| (ShredType::Code, k));

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -11,7 +11,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         blockstore,
-        shred::{shred_code, ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
+        shred::{ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
     },
     solana_time_utils::AtomicInterval,
     std::{borrow::Cow, sync::RwLock},
@@ -275,7 +275,7 @@ impl StandardBroadcastRun {
                 is_last_in_slot,
                 process_stats,
                 blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
-                shred_code::MAX_CODE_SHREDS_PER_SLOT as u32,
+                blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
         // Insert the first data shred synchronously so that blockstore stores

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -9,9 +9,9 @@ use {
     solana_entry::entry::Entry,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::{
-        blockstore,
-        shred::{ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder},
+    solana_ledger::shred::{
+        ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder, MAX_CODE_SHREDS_PER_SLOT,
+        MAX_DATA_SHREDS_PER_SLOT,
     },
     solana_time_utils::AtomicInterval,
     std::{borrow::Cow, sync::RwLock},
@@ -274,8 +274,8 @@ impl StandardBroadcastRun {
                 reference_tick as u8,
                 is_last_in_slot,
                 process_stats,
-                blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
-                blockstore::MAX_CODE_SHREDS_PER_SLOT as u32,
+                MAX_DATA_SHREDS_PER_SLOT as u32,
+                MAX_CODE_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
         // Insert the first data shred synchronously so that blockstore stores

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -275,7 +275,7 @@ impl StandardBroadcastRun {
                 is_last_in_slot,
                 process_stats,
                 blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
-                blockstore::MAX_DATA_SHREDS_PER_SLOT as u32,
+                blockstore::MAX_CODE_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
         // Insert the first data shred synchronously so that blockstore stores


### PR DESCRIPTION
#### Problem

- MAX_CODE_SHREDS_PER_SLOT and MAX_DATA_SHREDS_PER_SLOT are defined in different places
- once https://github.com/solana-foundation/solana-improvement-documents/pull/317 is merged and now they are 100% linked.
- The way it was implemented exposed the entire shred_code module for no reason

#### Summary of Changes

- mv MAX_CODE_SHREDS_PER_SLOT and MAX_DATA_SHREDS_PER_SLOT
- make shred_code module private