### PR TITLE
xdp: fix draining at exit when zerocopy is enabled

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -77,6 +77,7 @@ pub fn tx_loop<T: AsRef<[u8]>>(
     };
 
     let umem = socket.umem();
+    let umem_tx_capacity = umem.available();
     let Tx {
         // this is where we'll queue frames
         ring,
@@ -271,11 +272,11 @@ pub fn tx_loop<T: AsRef<[u8]>>(
     assert_eq!(batched_packets, 0);
 
     // drain the ring
-    while umem.available() < umem.capacity() || ring.available() < ring.capacity() {
+    while umem.available() < umem_tx_capacity || ring.available() < ring.capacity() {
         log::debug!(
             "draining xdp ring umem {}/{} ring {}/{}",
             umem.available(),
-            umem.capacity(),
+            umem_tx_capacity,
             ring.available(),
             ring.capacity()
         );


### PR DESCRIPTION
Starting from 219f805fcb4e46dd97d1fa3d8d75147c188ed57a we always add some umem frames to the fill ring to avoid driver bugs. Since we don't actually use the RX path, those frames are never filled and returned to the umem, therefore shouldn't wait for them when we drain on exit.