### PR TITLE
xdp: tx_loop: allow overriding MACs and IP

### DIFF
--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -187,11 +187,14 @@ impl XdpRetransmitter {
                     .name(format!("solRetransmIO{i:02}"))
                     .spawn(move || {
                         tx_loop(
+                            cpu_id,
                             &dev,
-                            src_port,
                             QueueId(i as u64),
                             config.zero_copy,
-                            cpu_id,
+                            None,
+                            None,
+                            src_port,
+                            None,
                             receiver,
                             drop_sender,
                         )

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        netlink::MacAddress,
         route::Router,
         umem::{Frame, FrameOffset},
     },
@@ -69,7 +70,7 @@ impl NetworkDevice {
         self.if_index
     }
 
-    pub fn mac_addr(&self) -> Result<[u8; 6], io::Error> {
+    pub fn mac_addr(&self) -> Result<MacAddress, io::Error> {
         let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
         if fd < 0 {
             return Err(io::Error::last_os_error());
@@ -94,11 +95,13 @@ impl NetworkDevice {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(unsafe {
-            slice::from_raw_parts(req.ifr_ifru.ifru_hwaddr.sa_data.as_ptr() as *const u8, 6)
-        }
-        .try_into()
-        .unwrap())
+        Ok(MacAddress(
+            unsafe {
+                slice::from_raw_parts(req.ifr_ifru.ifru_hwaddr.sa_data.as_ptr() as *const u8, 6)
+            }
+            .try_into()
+            .unwrap(),
+        ))
     }
 
     pub fn ipv4_addr(&self) -> Result<Ipv4Addr, io::Error> {

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -20,18 +20,22 @@ use {
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     libc::{sysconf, _SC_PAGESIZE},
     std::{
-        net::{IpAddr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         thread,
         time::Duration,
     },
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
+    cpu_id: usize,
     dev: &NetworkDevice,
-    src_port: u16,
     queue_id: QueueId,
     zero_copy: bool,
-    cpu_id: usize,
+    src_mac: Option<MacAddress>,
+    src_ip: Option<Ipv4Addr>,
+    src_port: u16,
+    dest_mac: Option<MacAddress>,
     receiver: Receiver<(A, T)>,
     drop_sender: Sender<(A, T)>,
 ) {
@@ -43,8 +47,16 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
     // each queue is bound to its own CPU core
     set_cpu_affinity([cpu_id]).unwrap();
 
-    let src_mac = dev.mac_addr().unwrap();
-    let src_ip = dev.ipv4_addr().unwrap();
+    let src_mac = src_mac.unwrap_or_else(|| {
+        // if no source MAC is provided, use the device's MAC address
+        dev.mac_addr()
+            .expect("no src_mac provided, device must have a MAC address")
+    });
+    let src_ip = src_ip.unwrap_or_else(|| {
+        // if no source IP is provided, use the device's IPv4 address
+        dev.ipv4_addr()
+            .expect("no src_ip provided, device must have an IPv4 address")
+    });
 
     // some drivers require frame_size=page_size
     let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
@@ -209,19 +221,38 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
                     panic!("IPv6 not supported");
                 };
 
-                let next_hop = router.route(addr.ip()).unwrap();
-                // sanity check that the address is routable through our NIC
-                if next_hop.if_index != dev.if_index() {
-                    log::warn!(
-                        "turbine peer {} must be routed through if_index: {} our if_index: {}",
-                        addr,
-                        next_hop.if_index,
-                        dev.if_index()
-                    );
-                    batched_packets -= 1;
-                    umem.release(frame.offset());
-                    continue;
-                }
+                let dest_mac = if let Some(mac) = dest_mac {
+                    mac
+                } else {
+                    let next_hop = router.route(addr.ip()).unwrap();
+
+                    let mut skip = false;
+
+                    // sanity check that the address is routable through our NIC
+                    if next_hop.if_index != dev.if_index() {
+                        log::warn!(
+                            "dropping packet: turbine peer {addr} must be routed through if_index: {} our if_index: {}",
+                            next_hop.if_index,
+                            dev.if_index()
+                        );
+                        skip = true;
+                    }
+
+                    // we need the MAC address to send the packet
+                    if next_hop.mac_addr.is_none() {
+                        log::warn!("dropping packet: turbine peer {addr} must be routed through {} which has no known MAC address", next_hop.ip_addr);
+                        skip = true;
+                    };
+
+                    if skip {
+                        batched_packets -= 1;
+                        umem.release(frame.offset());
+                        continue;
+                    }
+
+                    next_hop.mac_addr.unwrap()
+                };
+
                 const PACKET_HEADER_SIZE: usize =
                     ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
                 let len = payload.as_ref().len();
@@ -231,12 +262,7 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
                 // write the payload first as it's needed for checksum calculation (if enabled)
                 packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload.as_ref());
 
-                write_eth_header(
-                    packet,
-                    &src_mac,
-                    // the unwrap case is for loopback interfaces which don't have a mac address
-                    &next_hop.mac_addr.unwrap_or(MacAddress([0u8; 6])).0,
-                );
+                write_eth_header(packet, &src_mac.0, &dest_mac.0);
 
                 write_ip_header(
                     &mut packet[ETH_HEADER_SIZE..],


### PR DESCRIPTION
This is useful for sending via bonded NICs, skipping the bond device and targeting the slaved NICs directly so they can be used in zero copy mode.

Slaved NICs don't have an IP assigned to them, so the source IP can't be discovered but must be passed explicitly (eg the bond IP).

Overriding MACs can be useful while testing to ensure frames don't leave the switch/metro.