### PR TITLE
gossip: refactor cluster_info / move sockets to separate module / extract tpu #5824

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2365,48 +2365,6 @@ impl ClusterInfo {
     }
 }
 
-#[derive(Debug)]
-pub struct Sockets {
-    pub gossip: Arc<[UdpSocket]>,
-    pub ip_echo: Option<TcpListener>,
-    pub tvu: Vec<UdpSocket>,
-    pub tvu_quic: UdpSocket,
-    pub tpu: Vec<UdpSocket>,
-    pub tpu_forwards: Vec<UdpSocket>,
-    pub tpu_vote: Vec<UdpSocket>,
-    pub broadcast: Vec<UdpSocket>,
-    // Socket sending out local repair requests,
-    // and receiving repair responses from the cluster.
-    pub repair: UdpSocket,
-    pub repair_quic: UdpSocket,
-    pub retransmit_sockets: Vec<UdpSocket>,
-    // Socket receiving remote repair requests from the cluster,
-    // and sending back repair responses.
-    pub serve_repair: UdpSocket,
-    pub serve_repair_quic: UdpSocket,
-    // Socket sending out local RepairProtocol::AncestorHashes,
-    // and receiving AncestorHashesResponse from the cluster.
-    pub ancestor_hashes_requests: UdpSocket,
-    pub ancestor_hashes_requests_quic: UdpSocket,
-    pub tpu_quic: Vec<UdpSocket>,
-    pub tpu_forwards_quic: Vec<UdpSocket>,
-    pub tpu_vote_quic: Vec<UdpSocket>,
-
-    /// Client-side socket for ForwardingStage vote transactions
-    pub tpu_vote_forwarding_client: UdpSocket,
-    /// Client-side socket for ForwardingStage non-vote transactions
-    pub tpu_transaction_forwarding_clients: Box<[UdpSocket]>,
-    /// Socket for alpenglow consensus logic
-    pub alpenglow: Option<UdpSocket>,
-    /// Connection cache endpoint for QUIC-based Vote
-    pub quic_vote_client: UdpSocket,
-    /// Connection cache endpoint for QUIC-based Alpenglow messages
-    pub quic_alpenglow_client: UdpSocket,
-    /// Client-side socket for RPC/SendTransactionService.
-    pub rpc_sts_client: UdpSocket,
-    pub vortexor_receivers: Option<Vec<UdpSocket>>,
-}
-
 pub struct NodeConfig {
     /// The IP address advertised to the cluster in gossip
     pub advertised_ip: IpAddr,
@@ -2872,7 +2830,7 @@ mod tests {
         }
         check_sockets(&node.sockets.gossip, ip, range);
         check_sockets(&node.sockets.tvu, ip, range);
-        check_sockets(&node.sockets.tpu, ip, range);
+        check_sockets(&node.sockets.tpu.transactions, ip, range);
     }
 
     #[test]

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -48,6 +48,7 @@ mod protocol;
 mod push_active_set;
 mod received_cache;
 pub mod restart_crds_values;
+pub mod sockets;
 pub mod weighted_shuffle;
 
 #[macro_use]

--- a/gossip/src/sockets.rs
+++ b/gossip/src/sockets.rs
@@ -1,0 +1,66 @@
+//! This module defines structures [`Sockets`] and [`TpuSockets`] used by a
+//! validator to communicate with the cluster over different protocols.
+
+use std::{
+    io::Result,
+    net::{TcpListener, UdpSocket},
+    sync::Arc,
+};
+
+pub trait TryClone: Sized {
+    fn try_clone(&self) -> Result<Self>;
+}
+
+impl TryClone for Box<[UdpSocket]> {
+    fn try_clone(&self) -> Result<Self> {
+        self.iter()
+            .map(|s| s.try_clone())
+            .collect::<Result<Vec<_>>>()
+            .map(|v| v.into_boxed_slice())
+    }
+}
+
+/// [`Sockets`] structure groups together all node-level sockets.
+#[derive(Debug)]
+pub struct Sockets {
+    pub gossip: Arc<[UdpSocket]>,
+    pub ip_echo: Option<TcpListener>,
+    pub tvu: Vec<UdpSocket>,
+    pub tvu_quic: UdpSocket,
+    pub tpu: TpuSockets,
+    // Socket sending out local repair requests and receiving repair responses from the cluster.
+    pub repair: UdpSocket,
+    pub repair_quic: UdpSocket,
+    pub retransmit_sockets: Vec<UdpSocket>,
+    // Socket receiving remote repair requests from the cluster and sending back repair responses.
+    pub serve_repair: UdpSocket,
+    pub serve_repair_quic: UdpSocket,
+    // Socket sending out local RepairProtocol::AncestorHashes and receiving AncestorHashesResponse from the cluster.
+    pub ancestor_hashes_requests: UdpSocket,
+    pub ancestor_hashes_requests_quic: UdpSocket,
+    // Socket for alpenglow consensus logic
+    pub alpenglow: Option<UdpSocket>,
+    // Connection cache endpoint for QUIC-based Alpenglow messages.
+    pub alpenglow_client_quic: UdpSocket,
+    // Client-side socket for RPC/SendTransactionService.
+    pub rpc_sts_client: UdpSocket,
+}
+
+/// [`TpuSockets`] structure groups together all tpu related sockets.
+#[derive(Debug)]
+pub struct TpuSockets {
+    pub transactions: Vec<UdpSocket>,
+    pub transaction_forwards: Vec<UdpSocket>,
+    pub vote: Vec<UdpSocket>,
+    pub broadcast: Vec<UdpSocket>,
+    pub transactions_quic: Vec<UdpSocket>,
+    pub transactions_forwards_quic: Vec<UdpSocket>,
+    pub vote_quic: Vec<UdpSocket>,
+    // Client-side socket for the forwarding votes.
+    pub vote_forwarding_client: UdpSocket,
+    pub vortexor_receivers: Option<Vec<UdpSocket>>,
+    // Connection cache endpoint for QUIC-based Vote.
+    pub vote_client_quic: UdpSocket,
+    // Client-side socket for ForwardingStage non-vote transactions.
+    pub transaction_forwarding_clients: Box<[UdpSocket]>,
+}

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -760,7 +760,7 @@ pub mod test {
 
         // Start up the broadcast stage
         let broadcast_service = BroadcastStage::new(
-            leader_info.sockets.broadcast,
+            leader_info.sockets.tpu.broadcast,
             cluster_info,
             entry_receiver,
             retransmit_slots_receiver,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -88,19 +88,19 @@ fn verify_reachable_ports(
         udp_sockets.push(&node.sockets.serve_repair);
     }
     if verify_address(&node.info.tpu(Protocol::UDP)) {
-        udp_sockets.extend(node.sockets.tpu.iter());
-        udp_sockets.extend(&node.sockets.tpu_quic);
+        udp_sockets.extend(node.sockets.tpu.transactions.iter());
+        udp_sockets.extend(&node.sockets.tpu.transactions_quic);
     }
     if verify_address(&node.info.tpu_forwards(Protocol::UDP)) {
-        udp_sockets.extend(node.sockets.tpu_forwards.iter());
-        udp_sockets.extend(&node.sockets.tpu_forwards_quic);
+        udp_sockets.extend(node.sockets.tpu.transaction_forwards.iter());
+        udp_sockets.extend(&node.sockets.tpu.transactions_forwards_quic);
     }
     if verify_address(&node.info.tpu_vote(Protocol::UDP)) {
-        udp_sockets.extend(node.sockets.tpu_vote.iter());
+        udp_sockets.extend(node.sockets.tpu.vote.iter());
     }
     if verify_address(&node.info.tvu(Protocol::UDP)) {
         udp_sockets.extend(node.sockets.tvu.iter());
-        udp_sockets.extend(node.sockets.broadcast.iter());
+        udp_sockets.extend(node.sockets.tpu.broadcast.iter());
         udp_sockets.extend(node.sockets.retransmit_sockets.iter());
     }
     if !solana_net_utils::verify_all_reachable_udp(


### PR DESCRIPTION
#### Problem
This is second PR of the https://github.com/anza-xyz/agave/issues/5824

#### Summary of Changes
- The `cluster_info::Sockets` has been moved to separate module
- Tpu related sockets been moved to separate structure `TpuSockets`
