### PR TITLE
SPL: Use spl-memo-interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7570,7 +7570,7 @@ dependencies = [
  "solana-udp-client",
  "solana-version",
  "solana-vote-program",
- "spl-memo",
+ "spl-memo-interface",
  "tempfile",
  "test-case",
  "thiserror 2.0.12",
@@ -7634,7 +7634,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-transaction-status-client-types",
  "solana-vote-program",
- "spl-memo",
+ "spl-memo-interface",
 ]
 
 [[package]]
@@ -8040,7 +8040,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "solana-wen-restart",
- "spl-memo",
+ "spl-memo-interface",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -8383,7 +8383,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
- "spl-memo",
+ "spl-memo-interface",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -11483,7 +11483,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-vote-interface",
  "spl-associated-token-account-interface",
- "spl-memo",
+ "spl-memo-interface",
  "spl-token",
  "spl-token-2022",
  "spl-token-confidential-transfer-proof-extraction",
@@ -12171,6 +12171,16 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "spl-memo-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24af0730130fea732616be9425fe8eb77782e2aab2f0e76837b6a66aaba96c6b"
+dependencies = [
+ "solana-instruction",
  "solana-pubkey",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,7 +564,7 @@ solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=
 solana-zk-token-sdk = { path = "zk-token-sdk", version = "=3.0.0" }
 spl-associated-token-account-interface = "1.0.0"
 spl-generic-token = "1.0.1"
-spl-memo = "6.0.0"
+spl-memo-interface = "1.0.0"
 spl-pod = "0.5.1"
 spl-token = "8.0.0"
 spl-token-2022 = "8.0.1"
@@ -643,9 +643,9 @@ crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d
 
 # We include the following crates as our dependencies above from crates.io:
 #
-#  * spl-associated-token-account
+#  * spl-associated-token-account-interface
 #  * spl-instruction-padding
-#  * spl-memo
+#  * spl-memo-interface
 #  * spl-pod
 #  * spl-token
 #  * spl-token-2022

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -48,7 +48,7 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-vote-program = { workspace = true }
-spl-memo = { workspace = true, features = ["no-entrypoint"] }
+spl-memo-interface = { workspace = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -19,7 +19,7 @@ use {
         Rewards, UiReturnDataEncoding, UiTransactionReturnData, UiTransactionStatusMeta,
     },
     solana_transaction_status_client_types::UiTransactionError,
-    spl_memo::{id as spl_memo_id, v1::id as spl_memo_v1_id},
+    spl_memo_interface::{v1::id as spl_memo_v1_id, v3::id as spl_memo_v3_id},
     std::{collections::HashMap, fmt, io, time::Duration},
 };
 
@@ -42,7 +42,7 @@ impl Default for BuildBalanceMessageConfig {
 
 fn is_memo_program(k: &Pubkey) -> bool {
     let k_str = k.to_string();
-    (k_str == spl_memo_v1_id().to_string()) || (k_str == spl_memo_id().to_string())
+    (k_str == spl_memo_v1_id().to_string()) || (k_str == spl_memo_v3_id().to_string())
 }
 
 pub fn build_balance_message_with_config(

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -96,7 +96,7 @@ solana-transaction-status-client-types = { workspace = true }
 solana-udp-client = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
-spl-memo = { version = "=6.0.0", features = ["no-entrypoint"] }
+spl-memo-interface = { version = "=1.0.0" }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 

--- a/cli/src/memo.rs
+++ b/cli/src/memo.rs
@@ -1,4 +1,4 @@
-use {solana_instruction::Instruction, solana_pubkey::Pubkey, spl_memo::id};
+use {solana_instruction::Instruction, solana_pubkey::Pubkey, spl_memo_interface::v3::id};
 
 pub trait WithMemo {
     fn with_memo<T: AsRef<str>>(self, memo: Option<T>) -> Self;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -207,7 +207,7 @@ solana-unified-scheduler-pool = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
 solana-vote = { workspace = true, features = ["dev-context-only-utils"] }
-spl-memo = { workspace = true, features = ["no-entrypoint"] }
+spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -68,7 +68,7 @@ impl TestSetup {
 
     fn install_memo_program_account(&mut self) {
         self.genesis_config.accounts.insert(
-            spl_memo::id(),
+            spl_memo_interface::v3::id(),
             Account {
                 lamports: u64::MAX,
                 // borrows memo elf for executing memo ix in order to set up test condition
@@ -150,7 +150,11 @@ impl TestSetup {
     fn memo_ix(&self) -> (Instruction, u32) {
         // construct a memo instruction that would consume more CU than DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
         let memo = "The quick brown fox jumped over the lazy dog. ".repeat(22) + "!";
-        let memo_ix = spl_memo::build_memo(memo.as_bytes(), &[]);
+        let memo_ix = spl_memo_interface::instruction::build_memo(
+            &spl_memo_interface::v3::id(),
+            memo.as_bytes(),
+            &[],
+        );
         let memo_ix_cost = 356_963;
 
         (memo_ix, memo_ix_cost)

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -43,6 +43,6 @@ solana-system-interface = "=1.0"
 solana-system-transaction = "=2.2.1"
 solana-transaction = "=2.2.3"
 solana-version = { workspace = true }
-spl-memo = { version = "=6.0.0", features = ["no-entrypoint"] }
+spl-memo-interface = { version = "=1.0.0" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -200,7 +200,7 @@ impl Faucet {
                             )
                         );
                         let memo_instruction = Instruction {
-                            program_id: Pubkey::from(spl_memo::id().to_bytes()),
+                            program_id: spl_memo_interface::v3::id(),
                             accounts: vec![],
                             data: memo.as_bytes().to_vec(),
                         };
@@ -630,7 +630,7 @@ mod tests {
             assert_eq!(tx.signatures.len(), 1);
             assert_eq!(
                 message.account_keys,
-                vec![mint_pubkey, Pubkey::from(spl_memo::id().to_bytes())]
+                vec![mint_pubkey, spl_memo_interface::v3::id()]
             );
             assert_eq!(message.recent_blockhash, blockhash);
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5892,7 +5892,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-transaction-status-client-types",
  "solana-vote-program",
- "spl-memo",
+ "spl-memo-interface",
 ]
 
 [[package]]
@@ -6463,7 +6463,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
- "spl-memo",
+ "spl-memo-interface",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -9566,7 +9566,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-vote-interface",
  "spl-associated-token-account-interface",
- "spl-memo",
+ "spl-memo-interface",
  "spl-token",
  "spl-token-2022",
  "spl-token-group-interface",
@@ -10086,6 +10086,16 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "spl-memo-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24af0730130fea732616be9425fe8eb77782e2aab2f0e76837b6a66aaba96c6b"
+dependencies = [
+ "solana-instruction",
  "solana-pubkey",
 ]
 

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -261,9 +261,9 @@ name = "bpf_loader"
 [patch.crates-io]
 # We include the following crates as our dependencies from crates.io:
 #
-#  * spl-associated-token-account
+#  * spl-associated-token-account-interface
 #  * spl-instruction-padding
-#  * spl-memo
+#  * spl-memo-interface
 #  * spl-pod
 #  * spl-token
 #  * spl-token-2022

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -5727,7 +5727,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-transaction-status-client-types",
  "solana-vote-program",
- "spl-memo",
+ "spl-memo-interface",
 ]
 
 [[package]]
@@ -6287,7 +6287,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-version",
- "spl-memo",
+ "spl-memo-interface",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -8654,7 +8654,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-vote-interface",
  "spl-associated-token-account-interface",
- "spl-memo",
+ "spl-memo-interface",
  "spl-token",
  "spl-token-2022",
  "spl-token-group-interface",
@@ -9171,6 +9171,16 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "spl-memo-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24af0730130fea732616be9425fe8eb77782e2aab2f0e76837b6a66aaba96c6b"
+dependencies = [
+ "solana-instruction",
  "solana-pubkey",
 ]
 

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -43,7 +43,7 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-vote-interface = { workspace = true }
 spl-associated-token-account-interface = { workspace = true, features = ["borsh"] }
-spl-memo = { workspace = true, features = ["no-entrypoint"] }
+spl-memo-interface = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 spl-token-group-interface = { workspace = true }

--- a/transaction-status/benches/extract_memos.rs
+++ b/transaction-status/benches/extract_memos.rs
@@ -8,8 +8,8 @@ use {
 #[allow(clippy::arithmetic_side_effects)]
 fn bench_extract_memos(b: &mut Bencher) {
     let mut account_keys: Vec<Pubkey> = (0..64).map(|_| Pubkey::new_unique()).collect();
-    account_keys[62] = spl_memo::v1::id();
-    account_keys[63] = spl_memo::id();
+    account_keys[62] = spl_memo_interface::v1::id();
+    account_keys[63] = spl_memo_interface::v3::id();
     let memo = "Test memo";
 
     let instructions: Vec<_> = (0..20)

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -69,7 +69,9 @@ fn extract_memos_inner(
                 KeyType::MemoProgram => Some(&ix.data),
                 KeyType::OtherProgram => None,
                 KeyType::Unknown(program_id) => {
-                    if **program_id == spl_memo::v1::id() || **program_id == spl_memo::id() {
+                    if **program_id == spl_memo_interface::v1::id()
+                        || **program_id == spl_memo_interface::v3::id()
+                    {
                         account_keys[index] = KeyType::MemoProgram;
                         Some(&ix.data)
                     } else {
@@ -116,9 +118,9 @@ mod test {
         ];
         let static_keys = vec![
             fee_payer,
-            spl_memo::v1::id(),
+            spl_memo_interface::v1::id(),
             another_program_id,
-            spl_memo::id(),
+            spl_memo_interface::v3::id(),
         ];
         let account_keys = AccountKeys::new(&static_keys, None);
 

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -33,8 +33,8 @@ static PARSABLE_PROGRAM_IDS: std::sync::LazyLock<HashMap<Pubkey, ParsableProgram
                 spl_associated_token_account_interface::program::id(),
                 ParsableProgram::SplAssociatedTokenAccount,
             ),
-            (spl_memo::v1::id(), ParsableProgram::SplMemo),
-            (spl_memo::id(), ParsableProgram::SplMemo),
+            (spl_memo_interface::v1::id(), ParsableProgram::SplMemo),
+            (spl_memo_interface::v3::id(), ParsableProgram::SplMemo),
             (solana_sdk_ids::bpf_loader::id(), ParsableProgram::BpfLoader),
             (
                 solana_sdk_ids::bpf_loader_upgradeable::id(),
@@ -164,19 +164,31 @@ mod test {
             data: vec![240, 159, 166, 150],
         };
         assert_eq!(
-            parse(&spl_memo::v1::id(), &memo_instruction, &no_keys, None).unwrap(),
+            parse(
+                &spl_memo_interface::v1::id(),
+                &memo_instruction,
+                &no_keys,
+                None
+            )
+            .unwrap(),
             ParsedInstruction {
                 program: "spl-memo".to_string(),
-                program_id: spl_memo::v1::id().to_string(),
+                program_id: spl_memo_interface::v1::id().to_string(),
                 parsed: json!("🦖"),
                 stack_height: None,
             }
         );
         assert_eq!(
-            parse(&spl_memo::id(), &memo_instruction, &no_keys, Some(1)).unwrap(),
+            parse(
+                &spl_memo_interface::v3::id(),
+                &memo_instruction,
+                &no_keys,
+                Some(1)
+            )
+            .unwrap(),
             ParsedInstruction {
                 program: "spl-memo".to_string(),
-                program_id: spl_memo::id().to_string(),
+                program_id: spl_memo_interface::v3::id().to_string(),
                 parsed: json!("🦖"),
                 stack_height: Some(1),
             }


### PR DESCRIPTION
#### Problem

As outlined in #7256, we need to get Agave off of crates that depend back on Agave.

spl-memo is one of those crates

#### Summary of changes

Use spl-memo-interface instead. The only difference is that `build_memo` takes in a program id, which is used in one test.