### PR TITLE
AccountsDb::load_account_with takes bool instead of fn

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4408,16 +4408,13 @@ impl AccountsDb {
 
     /// Load account with `pubkey` and maybe put into read cache.
     ///
-    /// If the account is not already cached, invoke `should_put_in_read_cache_fn`.
-    /// The caller can inspect the account and indicate if it should be put into the read cache or not.
-    ///
     /// Return the account and the slot when the account was last stored.
     /// Return None for ZeroLamport accounts.
     pub fn load_account_with(
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
-        should_put_in_read_cache_fn: impl Fn(&AccountSharedData) -> bool,
+        should_put_in_read_cache: bool,
     ) -> Option<(AccountSharedData, Slot)> {
         let (slot, storage_location, _maybe_account_accessor) =
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, None, false)?;
@@ -4451,7 +4448,7 @@ impl AccountsDb {
             return None;
         }
 
-        if !in_write_cache && should_put_in_read_cache_fn(&account) {
+        if !in_write_cache && should_put_in_read_cache {
             /*
             We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
             safe/reflect 'A''s latest state on this fork.

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3171,34 +3171,34 @@ fn test_load_with_read_only_accounts_cache() {
 
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, |_| false)
+        .load_account_with(&Ancestors::default(), &account_key, false)
         .unwrap();
     assert_eq!(account.lamports(), 1);
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     assert_eq!(slot, 1);
 
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, |_| true)
+        .load_account_with(&Ancestors::default(), &account_key, true)
         .unwrap();
     assert_eq!(account.lamports(), 1);
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     assert_eq!(slot, 1);
 
     db.store_for_tests((2, &[(&account_key, &zero_lamport_account)][..]));
-    let account = db.load_account_with(&Ancestors::default(), &account_key, |_| false);
+    let account = db.load_account_with(&Ancestors::default(), &account_key, false);
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
 
     db.read_only_accounts_cache.reset_for_tests();
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
-    let account = db.load_account_with(&Ancestors::default(), &account_key, |_| true);
+    let account = db.load_account_with(&Ancestors::default(), &account_key, true);
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
     db.store_for_tests((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, |_| false)
+        .load_account_with(&Ancestors::default(), &account_key, false)
         .unwrap();
     assert_eq!(account.lamports(), 2);
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
@@ -3207,7 +3207,7 @@ fn test_load_with_read_only_accounts_cache() {
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
     db.store_for_tests((2, &[(&account_key, &slot2_account)][..]));
     let (account, slot) = db
-        .load_account_with(&Ancestors::default(), &account_key, |_| true)
+        .load_account_with(&Ancestors::default(), &account_key, true)
         .unwrap();
     assert_eq!(account.lamports(), 2);
     // The account shouldn't be added to read_only_cache because it is in write_cache.

--- a/core/src/mock_alpenglow_consensus.rs
+++ b/core/src/mock_alpenglow_consensus.rs
@@ -737,7 +737,7 @@ fn get_test_config_from_account<T: DeserializeOwned>(bank: &Bank) -> Option<T> {
     let data = bank
         .accounts()
         .accounts_db
-        .load_account_with(&bank.ancestors, &control_pubkey::ID, |_| true)?
+        .load_account_with(&bank.ancestors, &control_pubkey::ID, true)?
         .0;
     data.deserialize_data().ok()
 }

--- a/gossip/src/stake_weighting_config.rs
+++ b/gossip/src/stake_weighting_config.rs
@@ -73,7 +73,7 @@ pub(crate) fn get_gossip_config_from_account(bank: &Bank) -> Option<WeightingCon
         .load_account_with(
             &bank.ancestors,
             &weighting_config_control_pubkey::id(),
-            |_| true,
+            true,
         )?
         .0;
     bincode::deserialize::<WeightingConfig>(data.data()).ok()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4203,19 +4203,20 @@ impl Bank {
         &self,
         pubkey: &Pubkey,
     ) -> Option<AccountSharedData> {
-        self.load_account_with(pubkey, |_| false)
+        self.load_account_with(pubkey, false)
             .map(|(acc, _slot)| acc)
     }
 
     fn load_account_with(
         &self,
         pubkey: &Pubkey,
-        callback: impl for<'local> Fn(&'local AccountSharedData) -> bool,
+        should_put_in_read_cache: bool,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.rc
-            .accounts
-            .accounts_db
-            .load_account_with(&self.ancestors, pubkey, callback)
+        self.rc.accounts.accounts_db.load_account_with(
+            &self.ancestors,
+            pubkey,
+            should_put_in_read_cache,
+        )
     }
 
     // Hi! leaky abstraction here....


### PR DESCRIPTION
#### Problem
- `should_put_in_read_cache_fn` is never a function
    - it is also ALWAYS false outside of our tests, so it's possible we remove the parameter entirely, and just adjust our tests appropriately

#### Summary of Changes
- `should_put_in_read_cache_fn` -> `should_put_in_read_cache` as simple boolean