### PR TITLE
Removes AccountsPackage

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -24,7 +24,7 @@ use {
         },
         snapshot_config::SnapshotConfig,
         snapshot_hash::SnapshotHash,
-        snapshot_package::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
+        snapshot_package::{SnapshotKind, SnapshotPackage},
         snapshot_utils::{
             self, deserialize_snapshot_data_file, get_highest_bank_snapshot_post,
             get_highest_full_snapshot_archive_info, get_highest_incremental_snapshot_archive_info,
@@ -788,15 +788,12 @@ fn bank_to_full_snapshot_archive_with(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
-    let snapshot_storages = bank.get_snapshot_storages(None);
-    let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
+    let snapshot_package = SnapshotPackage::new(
+        SnapshotKind::FullSnapshot,
         bank,
-        snapshot_storages,
-        status_cache_slot_deltas,
+        bank.get_snapshot_storages(None),
+        bank.status_cache.read().unwrap().root_slot_deltas(),
     );
-    let snapshot_package = SnapshotPackage::new(accounts_package);
 
     let snapshot_config = SnapshotConfig {
         full_snapshot_archives_dir: full_snapshot_archives_dir.as_ref().to_path_buf(),
@@ -846,15 +843,12 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.force_flush_accounts_cache();
     bank.clean_accounts();
 
-    let snapshot_storages = bank.get_snapshot_storages(Some(full_snapshot_slot));
-    let status_cache_slot_deltas = bank.status_cache.read().unwrap().root_slot_deltas();
-    let accounts_package = AccountsPackage::new_for_snapshot(
-        AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(full_snapshot_slot)),
+    let snapshot_package = SnapshotPackage::new(
+        SnapshotKind::IncrementalSnapshot(full_snapshot_slot),
         bank,
-        snapshot_storages,
-        status_cache_slot_deltas,
+        bank.get_snapshot_storages(Some(full_snapshot_slot)),
+        bank.status_cache.read().unwrap().root_slot_deltas(),
     );
-    let snapshot_package = SnapshotPackage::new(accounts_package);
 
     // Note: Since the snapshot_storages above are *only* the incremental storages,
     // this bank snapshot *cannot* be used by fastboot.

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -5,11 +5,8 @@ use {
         bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
         snapshot_hash::SnapshotHash,
     },
-    log::*,
-    solana_accounts_db::{accounts::Accounts, accounts_db::AccountStorageEntry},
+    solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
-    solana_epoch_schedule::EpochSchedule,
-    solana_rent_collector::RentCollector,
     std::{
         sync::{atomic::Ordering, Arc},
         time::Instant,
@@ -19,129 +16,6 @@ use {
 mod compare;
 pub use compare::*;
 
-/// This struct packages up fields to send from AccountsBackgroundService to AccountsHashVerifier
-pub struct AccountsPackage {
-    pub package_kind: AccountsPackageKind,
-    pub slot: Slot,
-    pub block_height: Slot,
-    pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-    pub expected_capitalization: u64,
-    pub accounts: Arc<Accounts>,
-    pub epoch_schedule: EpochSchedule,
-    pub rent_collector: RentCollector,
-
-    /// Supplemental information needed for snapshots
-    pub snapshot_info: Option<SupplementalSnapshotInfo>,
-
-    /// The instant this accounts package was send to the queue.
-    /// Used to track how long accounts packages wait before processing.
-    pub enqueued: Instant,
-}
-
-impl AccountsPackage {
-    /// Package up bank files, storages, and slot deltas for a snapshot
-    pub fn new_for_snapshot(
-        package_kind: AccountsPackageKind,
-        bank: &Bank,
-        snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-        status_cache_slot_deltas: Vec<BankSlotDelta>,
-    ) -> Self {
-        let slot = bank.slot();
-        let AccountsPackageKind::Snapshot(snapshot_kind) = package_kind;
-        info!(
-            "Package snapshot for bank {} has {} account storage entries (snapshot kind: {:?})",
-            slot,
-            snapshot_storages.len(),
-            snapshot_kind,
-        );
-        if let SnapshotKind::IncrementalSnapshot(incremental_snapshot_base_slot) = snapshot_kind {
-            assert!(
-                slot > incremental_snapshot_base_slot,
-                "Incremental snapshot base slot must be less than the bank being snapshotted!"
-            );
-        }
-
-        let snapshot_info = {
-            let accounts_db = &bank.rc.accounts.accounts_db;
-            let write_version = accounts_db.write_version.load(Ordering::Acquire);
-            let bank_hash_stats = bank.get_bank_hash_stats();
-            let bank_fields_to_serialize = bank.get_fields_to_serialize();
-            SupplementalSnapshotInfo {
-                status_cache_slot_deltas,
-                bank_fields_to_serialize,
-                bank_hash_stats,
-                write_version,
-            }
-        };
-
-        Self::_new(package_kind, bank, snapshot_storages, Some(snapshot_info))
-    }
-
-    fn _new(
-        package_kind: AccountsPackageKind,
-        bank: &Bank,
-        snapshot_storages: Vec<Arc<AccountStorageEntry>>,
-        snapshot_info: Option<SupplementalSnapshotInfo>,
-    ) -> Self {
-        Self {
-            package_kind,
-            slot: bank.slot(),
-            block_height: bank.block_height(),
-            snapshot_storages,
-            expected_capitalization: bank.capitalization(),
-            accounts: bank.accounts(),
-            epoch_schedule: bank.epoch_schedule().clone(),
-            rent_collector: bank.rent_collector().clone(),
-            snapshot_info,
-            enqueued: Instant::now(),
-        }
-    }
-
-    /// Create a new Accounts Package where basically every field is defaulted.
-    /// Only use for tests; many of the fields are invalid!
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn default_for_tests() -> Self {
-        use solana_accounts_db::accounts_db::AccountsDb;
-        let accounts_db = AccountsDb::default_for_tests();
-        let accounts = Accounts::new(Arc::new(accounts_db));
-        Self {
-            package_kind: AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-            slot: Slot::default(),
-            block_height: Slot::default(),
-            snapshot_storages: Vec::default(),
-            expected_capitalization: u64::default(),
-            accounts: Arc::new(accounts),
-            epoch_schedule: EpochSchedule::default(),
-            rent_collector: RentCollector::default(),
-            snapshot_info: Some(SupplementalSnapshotInfo {
-                status_cache_slot_deltas: Vec::default(),
-                bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
-                bank_hash_stats: BankHashStats::default(),
-                write_version: u64::default(),
-            }),
-            enqueued: Instant::now(),
-        }
-    }
-}
-
-impl std::fmt::Debug for AccountsPackage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AccountsPackage")
-            .field("kind", &self.package_kind)
-            .field("slot", &self.slot)
-            .field("block_height", &self.block_height)
-            .finish_non_exhaustive()
-    }
-}
-
-/// Supplemental information needed for snapshots
-pub struct SupplementalSnapshotInfo {
-    pub status_cache_slot_deltas: Vec<BankSlotDelta>,
-    pub bank_fields_to_serialize: BankFieldsToSerialize,
-    pub bank_hash_stats: BankHashStats,
-    pub write_version: u64,
-}
-
 /// Accounts packages are sent to the Accounts Hash Verifier for processing.  There are multiple
 /// types of accounts packages, which are specified as variants in this enum.  All accounts
 /// packages do share some processing: such as calculating the accounts hash.
@@ -150,7 +24,7 @@ pub enum AccountsPackageKind {
     Snapshot(SnapshotKind),
 }
 
-/// This struct packages up fields to send from AccountsHashVerifier to SnapshotPackagerService
+/// This struct packages up fields to send to SnapshotPackagerService
 pub struct SnapshotPackage {
     pub snapshot_kind: SnapshotKind,
     pub slot: Slot,
@@ -168,30 +42,36 @@ pub struct SnapshotPackage {
 }
 
 impl SnapshotPackage {
-    pub fn new(accounts_package: AccountsPackage) -> Self {
-        let AccountsPackageKind::Snapshot(snapshot_kind) = accounts_package.package_kind;
-        let Some(snapshot_info) = accounts_package.snapshot_info else {
-            panic!(
-                "The AccountsPackage must have snapshot info in order to make a SnapshotPackage!"
+    pub fn new(
+        snapshot_kind: SnapshotKind,
+        bank: &Bank,
+        snapshot_storages: Vec<Arc<AccountStorageEntry>>,
+        status_cache_slot_deltas: Vec<BankSlotDelta>,
+    ) -> Self {
+        let slot = bank.slot();
+        if let SnapshotKind::IncrementalSnapshot(incremental_snapshot_base_slot) = snapshot_kind {
+            assert!(
+                slot > incremental_snapshot_base_slot,
+                "Incremental snapshot base slot must be less than the bank being snapshotted!"
             );
-        };
+        }
 
+        let bank_fields_to_serialize = bank.get_fields_to_serialize();
         Self {
             snapshot_kind,
-            slot: accounts_package.slot,
-            block_height: accounts_package.block_height,
-            hash: SnapshotHash::new(
-                snapshot_info
-                    .bank_fields_to_serialize
-                    .accounts_lt_hash
-                    .0
-                    .checksum(),
-            ),
-            snapshot_storages: accounts_package.snapshot_storages,
-            status_cache_slot_deltas: snapshot_info.status_cache_slot_deltas,
-            bank_fields_to_serialize: snapshot_info.bank_fields_to_serialize,
-            bank_hash_stats: snapshot_info.bank_hash_stats,
-            write_version: snapshot_info.write_version,
+            slot,
+            block_height: bank.block_height(),
+            hash: SnapshotHash::new(bank_fields_to_serialize.accounts_lt_hash.0.checksum()),
+            snapshot_storages,
+            status_cache_slot_deltas,
+            bank_fields_to_serialize,
+            bank_hash_stats: bank.get_bank_hash_stats(),
+            write_version: bank
+                .rc
+                .accounts
+                .accounts_db
+                .write_version
+                .load(Ordering::Acquire),
             enqueued: Instant::now(),
         }
     }

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -1,5 +1,5 @@
 use {
-    super::{AccountsPackage, AccountsPackageKind, SnapshotKind, SnapshotPackage},
+    super::{AccountsPackageKind, SnapshotKind, SnapshotPackage},
     std::cmp::Ordering::{self, Equal, Greater, Less},
 };
 
@@ -7,13 +7,6 @@ use {
 #[must_use]
 pub fn cmp_snapshot_packages_by_priority(a: &SnapshotPackage, b: &SnapshotPackage) -> Ordering {
     cmp_snapshot_kinds_by_priority(&a.snapshot_kind, &b.snapshot_kind).then(a.slot.cmp(&b.slot))
-}
-
-/// Compare accounts packages by priority; first by type, then by slot
-#[must_use]
-pub fn cmp_accounts_packages_by_priority(a: &AccountsPackage, b: &AccountsPackage) -> Ordering {
-    cmp_accounts_package_kinds_by_priority(&a.package_kind, &b.package_kind)
-        .then(a.slot.cmp(&b.slot))
 }
 
 /// Compare accounts package kinds by priority
@@ -122,135 +115,6 @@ mod tests {
         ] {
             let actual_result =
                 cmp_snapshot_packages_by_priority(&snapshot_package_a, &snapshot_package_b);
-            assert_eq!(expected_result, actual_result);
-        }
-    }
-
-    #[test]
-    fn test_cmp_accounts_packages_by_priority() {
-        fn new(package_kind: AccountsPackageKind, slot: Slot) -> AccountsPackage {
-            AccountsPackage {
-                package_kind,
-                slot,
-                block_height: slot,
-                ..AccountsPackage::default_for_tests()
-            }
-        }
-
-        for (accounts_package_a, accounts_package_b, expected_result) in [
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    11,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    22,
-                ),
-                Less,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    22,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    22,
-                ),
-                Equal,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    33,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    22,
-                ),
-                Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                    123,
-                ),
-                Less,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
-                    123,
-                ),
-                Less,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    11,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    22,
-                ),
-                Less,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    22,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    22,
-                ),
-                Equal,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    33,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    22,
-                ),
-                Greater,
-            ),
-            (
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                    123,
-                ),
-                new(
-                    AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
-                    123,
-                ),
-                Greater,
-            ),
-        ] {
-            let actual_result =
-                cmp_accounts_packages_by_priority(&accounts_package_a, &accounts_package_b);
             assert_eq!(expected_result, actual_result);
         }
     }


### PR DESCRIPTION
#### Problem

When handling a snapshot request, we create an AccountsPackage and then immediately convert it to a SnapshotPackage. We don't use the AccountsPackage at all, now that AccountsHashVerifier has been removed.


#### Summary of Changes

Removes AccountsPackage.