### PR TITLE
Removes AccountsPackageKind

### DIFF
--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -16,14 +16,6 @@ use {
 mod compare;
 pub use compare::*;
 
-/// Accounts packages are sent to the Accounts Hash Verifier for processing.  There are multiple
-/// types of accounts packages, which are specified as variants in this enum.  All accounts
-/// packages do share some processing: such as calculating the accounts hash.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AccountsPackageKind {
-    Snapshot(SnapshotKind),
-}
-
 /// This struct packages up fields to send to SnapshotPackagerService
 pub struct SnapshotPackage {
     pub snapshot_kind: SnapshotKind,

--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -1,5 +1,5 @@
 use {
-    super::{AccountsPackageKind, SnapshotKind, SnapshotPackage},
+    super::{SnapshotKind, SnapshotPackage},
     std::cmp::Ordering::{self, Equal, Greater, Less},
 };
 
@@ -7,26 +7,6 @@ use {
 #[must_use]
 pub fn cmp_snapshot_packages_by_priority(a: &SnapshotPackage, b: &SnapshotPackage) -> Ordering {
     cmp_snapshot_kinds_by_priority(&a.snapshot_kind, &b.snapshot_kind).then(a.slot.cmp(&b.slot))
-}
-
-/// Compare accounts package kinds by priority
-///
-/// Priority, from highest to lowest:
-/// - Full Snapshot
-/// - Incremental Snapshot
-///
-/// If two `Snapshot`s are compared, their snapshot kinds are the tiebreaker.
-#[must_use]
-pub fn cmp_accounts_package_kinds_by_priority(
-    a: &AccountsPackageKind,
-    b: &AccountsPackageKind,
-) -> Ordering {
-    use AccountsPackageKind as Kind;
-    match (a, b) {
-        (Kind::Snapshot(snapshot_kind_a), Kind::Snapshot(snapshot_kind_b)) => {
-            cmp_snapshot_kinds_by_priority(snapshot_kind_a, snapshot_kind_b)
-        }
-    }
 }
 
 /// Compare snapshot kinds by priority
@@ -115,48 +95,6 @@ mod tests {
         ] {
             let actual_result =
                 cmp_snapshot_packages_by_priority(&snapshot_package_a, &snapshot_package_b);
-            assert_eq!(expected_result, actual_result);
-        }
-    }
-
-    #[test]
-    fn test_cmp_accounts_package_kinds_by_priority() {
-        for (accounts_package_kind_a, accounts_package_kind_b, expected_result) in [
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                Equal,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                Greater,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::Snapshot(SnapshotKind::FullSnapshot),
-                Less,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(6)),
-                Less,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                Equal,
-            ),
-            (
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(5)),
-                AccountsPackageKind::Snapshot(SnapshotKind::IncrementalSnapshot(4)),
-                Greater,
-            ),
-        ] {
-            let actual_result = cmp_accounts_package_kinds_by_priority(
-                &accounts_package_kind_a,
-                &accounts_package_kind_b,
-            );
             assert_eq!(expected_result, actual_result);
         }
     }


### PR DESCRIPTION
#### Problem

Now that AccountsPackage was removed in #7299, AccountsPackageKind is redundant.


#### Summary of Changes

Remove it.