### PR TITLE
fix: missing `Ok` wrap in error handling of `process_faucet_request`

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -432,7 +432,7 @@ async fn process(
                         }
                         Err(e) => {
                             info!("Error in request: {}", e);
-                            ERROR_RESPONSE.to_vec()
+                            Ok(ERROR_RESPONSE.to_vec())
                         }
                     }
                 }


### PR DESCRIPTION
#### Problem

improper error handling in `process_faucet_request` - a response was returned without wrapping it in `Ok`, which could cause issues in result propagation.

#### Summary of Changes

wrapped the response in `Ok` to ensure correct result handling and align with expected function signature.
