### PR TITLE
accounts-db: Use `PubkeyHasher` in `SlotCache`

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -25,7 +25,6 @@ dev-context-only-utils = [
     "dep:solana-stake-program",
     "dep:solana-vote-program",
     "solana-account/dev-context-only-utils",
-    "solana-pubkey/rand",
     "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [
@@ -85,7 +84,7 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-nohash-hasher = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rayon-threadlimit = { workspace = true }
 solana-rent = { workspace = true, optional = true }
 solana-rent-collector = { workspace = true }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -1,10 +1,9 @@
 use {
-    ahash::RandomState as AHashRandomState,
     dashmap::DashMap,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
     solana_nohash_hasher::BuildNoHashHasher,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     std::{
         collections::BTreeSet,
         ops::Deref,
@@ -17,7 +16,7 @@ use {
 
 #[derive(Debug)]
 pub struct SlotCache {
-    cache: DashMap<Pubkey, Arc<CachedAccount>, AHashRandomState>,
+    cache: DashMap<Pubkey, Arc<CachedAccount>, PubkeyHasherBuilder>,
     same_account_writes: AtomicU64,
     same_account_writes_size: AtomicU64,
     unique_account_writes_size: AtomicU64,
@@ -128,7 +127,7 @@ impl SlotCache {
 }
 
 impl Deref for SlotCache {
-    type Target = DashMap<Pubkey, Arc<CachedAccount>, AHashRandomState>;
+    type Target = DashMap<Pubkey, Arc<CachedAccount>, PubkeyHasherBuilder>;
     fn deref(&self) -> &Self::Target {
         &self.cache
     }


### PR DESCRIPTION
#### Problem

`SlotCache` used pubkeys as keys, yet it used the AHash hasher. 

#### Summary of Changes

To imporove performance of lookups, use `PubkeyHasher`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
