### PR TITLE
Change bool addref return value from update_slot_list to a ref_change i64

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -16,6 +16,7 @@ use {
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     std::{
+        cmp,
         collections::{hash_map::Entry, HashMap, HashSet},
         fmt::Debug,
         sync::{
@@ -654,17 +655,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         );
 
         match ref_count_change.cmp(&0) {
-            std::cmp::Ordering::Equal => {
+            cmp::Ordering::Equal => {
                 // Do nothing
             }
-            std::cmp::Ordering::Greater => {
-                assert_eq!(
-                    ref_count_change, 1,
-                    "Unexpected ref_count_change value: {ref_count_change}"
-                );
+            cmp::Ordering::Greater => {
+                // If the ref count change is positive, it must be 1 as only one entry is being added
+                assert_eq!(ref_count_change, 1);
                 current.addref();
             }
-            std::cmp::Ordering::Less => {
+            cmp::Ordering::Less => {
                 current.unref_by_count(ref_count_change.unsigned_abs());
             }
         }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -687,6 +687,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> i64 {
         let mut ref_change = 1;
 
+        // Cached accounts are not supported by this function, use cache_entry_at_slot instead
         assert!(!account_info.is_cached());
 
         let old_slot = other_slot.unwrap_or(slot);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1903,20 +1903,14 @@ mod tests {
 
                     // calculate expected reclaims
                     let mut expected_reclaims = Vec::default();
-                    expected
-                        .iter()
-                        .any(|(slot, _info)| slot == &new_slot || Some(*slot) == other_slot);
-                    {
-                        // this is the logical equivalent of 'InMemAccountsIndex::update_slot_list', but slower (and ignoring addref)
-                        expected.retain(|(slot, info)| {
-                            let retain = slot != &new_slot && Some(*slot) != other_slot;
-                            if !retain {
-                                expected_reclaims.push((*slot, *info));
-                            }
-                            retain
-                        });
-                        expected.push((new_slot, info));
-                    }
+                    expected.retain(|(slot, info)| {
+                        let retain = slot != &new_slot && Some(*slot) != other_slot;
+                        if !retain {
+                            expected_reclaims.push((*slot, *info));
+                        }
+                        retain
+                    });
+                    expected.push((new_slot, info));
 
                     // Calculate the expected ref count change. It is expected to be 1 - the number of reclaims
                     let expected_result = 1 - expected_reclaims.len() as i64;


### PR DESCRIPTION
This is Pull Request 2 in a series to add support to upsert for obsolete accounts.
#### Problem
Currently lock_and_update_slot_list only supports adding a ref or not. With obsolete accounts, this will need to support decrementing a ref as well.

#### Summary of Changes
- Change update_slot_list to return ref_change rather than add_ref or not
- Modify lock_and_update_slot_list to support all possible return conditions from lock_and_update_slot_list

Note: This does not change any current functionality

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
