### PR TITLE
update shred format tests to use merkle shreds

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1099,7 +1099,7 @@ mod tests {
         assert_matches!(shred.parent(), Ok(9));
         let mut packet = Packet::default();
         shred.copy_to_packet(&mut packet);
-        wire::corrupt_and_set_parent_offset(&mut packet.buffer_mut(), 1000);
+        wire::corrupt_and_set_parent_offset(packet.buffer_mut(), 1000);
         let shred_res = Shred::new_from_serialized_shred(packet.data(..).unwrap().to_vec());
         assert_matches!(
             shred_res,

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -116,8 +116,8 @@ pub(super) fn get_parent_offset(shred: &[u8]) -> Option<u16> {
 
 #[cfg(test)]
 /// this will corrupt the shred by setting parent offset bytes
-pub(crate) fn corrupt_and_set_parent_offset(shred: &mut [u8], offset: u16) {
-    let bytes = offset.to_le_bytes();
+pub(crate) fn corrupt_and_set_parent_offset(shred: &mut [u8], parent_offset: u16) {
+    let bytes = parent_offset.to_le_bytes();
     assert_eq!(get_shred_type(shred).unwrap(), ShredType::Data);
     shred.get_mut(83..83 + 2).unwrap().copy_from_slice(&bytes);
 }

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -114,6 +114,14 @@ pub(super) fn get_parent_offset(shred: &[u8]) -> Option<u16> {
     Some(u16::from_le_bytes(bytes))
 }
 
+#[cfg(test)]
+/// this will corrupt the shred by setting parent offset bytes
+pub(crate) fn corrupt_and_set_parent_offset(shred: &mut [u8], offset: u16) {
+    let bytes = offset.to_le_bytes();
+    assert_eq!(get_shred_type(shred).unwrap(), ShredType::Data);
+    shred.get_mut(83..83 + 2).unwrap().copy_from_slice(&bytes);
+}
+
 // Returns DataShredHeader.flags if the shred is data.
 // Returns Error::InvalidShredType for coding shreds.
 #[inline]


### PR DESCRIPTION
#### Problem
Legacy shreds need to go https://github.com/anza-xyz/agave/issues/5982

#### Summary of Changes

- Update the serialization format tests in shred.rs to use merkle shreds