### PR TITLE
Remove sleep and change expectations for test_submit_exceed_max_rate

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -680,14 +680,11 @@ mod test {
             );
         }
 
-        thread::sleep(Duration::from_millis(1500));
-
         agent.flush();
 
-        // We are expecting `max_points_per_sec - 1` data points from `submit()` and two more metric
-        // stats data points.  One from the timeout when all the `submit()`ed values are sent when 1
-        // second is elapsed, and then one more from the explicit `flush()`.
-        assert_eq!(writer.points_written(), max_points_per_sec + 1);
+        // We are expecting `max_points_per_sec - 1` data points from `submit()` and one more metric
+        // stats data points.
+        assert_eq!(writer.points_written(), max_points_per_sec);
     }
 
     #[test]

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -680,7 +680,7 @@ mod test {
             );
         }
 
-        thread::sleep(Duration::from_secs(2));
+        thread::sleep(Duration::from_millis(1500));
 
         agent.flush();
 


### PR DESCRIPTION
#### Problem
CI is failing intermittently during this test since https://github.com/anza-xyz/agave/pull/7196. 
The test is dispatching 120 points, waiting 2 seconds, expecting to see 100 of those points written as it is capped by the max write rate, and then a final point written when the flush is called at the end of the test. 

Before the change the receiver thread woke up whenever new data was received or a timeout occurred at write_frequency/2 (write_frequency is 1s in this test), while now the receiver thread wakes up every 5ms regardless of whether data is present or not. In both cases, whenever the receiver thread wakes up, it checks to see if the duration since the last write time is greater than write_frequency and logs data if it is.

Prior to the change, with the 2 second wait the thread would not log another data point prior to flush. I printed the log times and could see the wakeup prior to the flush occurs at duration since last write: 505.140834ms, meaning it is likely always taking slightly longer than 1s. This leads to two full intervals not fitting into 1s. 

With the change and the 5ms wakeup, the thread does wakeup a second time, leading to an extra metrics write, causing the test to fail

#### Summary of Changes
- Reduced wait between starting metrics gathering and flushing from 2s to 1500ms. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
