### PR TITLE
initialize cluster slots with the current root bank

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -83,6 +83,11 @@ impl ClusterSlotsService {
         let mut cluster_slots_service_timing = ClusterSlotsServiceTiming::default();
         let mut last_stats = Instant::now();
         let mut epoch_specs = EpochSpecs::from(bank_forks.clone());
+
+        // initialize cluster slots with the current root bank
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        cluster_slots.update(&root_bank, &cluster_info);
+
         while !exit.load(Ordering::Relaxed) {
             let slots = match cluster_slots_update_receiver.recv_timeout(Duration::from_millis(200))
             {


### PR DESCRIPTION
#### Problem
During the first 200ms of starting up cluster slots service, no root epoch is available to determine repair request weighting

```
[2025-08-04T07:55:24.542156419Z ERROR solana_core::cluster_slots_service::cluster_slots] No epoch info for slot 357756098
[2025-08-04T07:55:24.560481761Z ERROR solana_core::cluster_slots_service::cluster_slots] No epoch info for slot 357756137
..
[2025-08-04T07:55:24.642578024Z ERROR solana_core::cluster_slots_service::cluster_slots] No epoch info for slot 357770520
[2025-08-04T07:55:24.655027149Z ERROR solana_core::cluster_slots_service::cluster_slots] No epoch info for slot 357772008
[2025-08-04T07:55:24.690908053Z INFO  solana_core::cluster_slots_service::cluster_slots] Updating epoch_metadata for epoch 828
```

#### Summary of Changes
Initialize the root epoch when starting up the cluster slots service

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
