### PR TITLE
test-validator: add --max-genesis-archive-size flag

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -399,7 +399,8 @@ fn main() {
 
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
-    genesis.max_genesis_archive_unpacked_size = Some(u64::MAX);
+    genesis.max_genesis_archive_unpacked_size =
+        value_t!(matches, "max_genesis_archive_size", u64).ok();
     genesis.log_messages_bytes_limit = value_t!(matches, "log_messages_bytes_limit", usize).ok();
     genesis.transaction_account_lock_limit =
         value_t!(matches, "transaction_account_lock_limit", usize).ok();

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -874,6 +874,19 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                      already exists then this parameter is silently ignored",
                 ),
         )
+        .arg(
+            Arg::with_name("max_genesis_archive_size")
+                .long("max-genesis-archive-size")
+                .value_name("BYTES")
+                .validator(is_parsable::<u64>)
+                .takes_value(true)
+                .help(
+                    "Set the maximum allowed size of an unpacked genesis archive \
+                     to enable --clone of a large number of accounts. For values \
+                     exceeding the production default of 10MiB, it may be necessary \
+                     to set a higher OS-level memory lock limit.",
+                ),
+        )
 }
 
 pub struct DefaultTestArgs {


### PR DESCRIPTION
#### Problem
solana-test-validator is broken in 3.0, at least on typical consumer machines. normal validators have a maximum archive size of 10Mib (`MAX_GENESIS_ARCHIVE_UNPACKED_SIZE`) but test validators allow it to be `u64::MAX`. there were some recent changes to how accounts-db memory allocation works where it appears to require that the maximum value be allocated up front. it attempts to adjust the maximum memory locks that can be taken based on this value. this means running the test validator does this:

```
cargo run --bin solana-test-validator -- -r
   Compiling agave-validator v3.0.0 (/home/hana/work/solana/agave/validator)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.26s
     Running `target/debug/solana-test-validator -r`
Ledger location: test-ledger
Log: test-ledger/validator.log
Error: failed to start validator: Failed to create ledger at test-ledger: io error: Error checking to unpack genesis archive: IO error: unable to set memory lock limit
```

#### Summary of Changes
use the default value that real validators use, and add a new flag to increase the value if desired. this seems philosophically more correct to me than setting a higher value, because we woudl like the test validator to behave in-line with real validators when practical