### PR TITLE
deps: Cleanup lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12131,20 +12131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
 name = "spl-memo-interface"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10046,20 +10046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
 name = "spl-memo-interface"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -9131,20 +9131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
 name = "spl-memo-interface"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
#### Problem

After #7291 landed, #7298 didn't mention any conflicts. However, since the first one migrated away from spl-memo, and so did #7298, there was an entry not cleaned up between the two PRs.

#### Summary of changes

Remove the unneeded entry for spl-memo in all lockfiles.