### PR TITLE
ci: ensure bootstrap node is ready before starting other nodes

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -156,19 +156,7 @@ startNodes() {
   initCompleteFiles=()
   maybeExpectedGenesisHash=
   for i in $(seq 0 $((${#nodes[@]} - 1))); do
-    declare cmd=${nodes[$i]}
-
-    declare initCompleteFile="init-complete-node$i.log"
-    rm -f "$initCompleteFile"
-    initCompleteFiles+=("$initCompleteFile")
-
-    startNode "$i" "$cmd $maybeExpectedGenesisHash"
-    if $addLogs; then
-      logs+=("$(getNodeLogFile "$i" "$cmd")")
-    fi
-
-    # 1 == bootstrap validator, wait until it boots before starting
-    # other validators
+    # wait for bootstrap validator to boot before starting other validators
     if [[ "$i" -eq 1 ]]; then
       SECONDS=
       waitForNodeToInit "$initCompleteFile"
@@ -179,6 +167,17 @@ startNodes() {
           --url http://127.0.0.1:8899 genesis-hash
       ) | tee genesis-hash.log
       maybeExpectedGenesisHash="--expected-genesis-hash $(tail -n1 genesis-hash.log)"
+    fi
+
+    declare cmd=${nodes[$i]}
+
+    declare initCompleteFile="init-complete-node$i.log"
+    rm -f "$initCompleteFile"
+    initCompleteFiles+=("$initCompleteFile")
+
+    startNode "$i" "$cmd $maybeExpectedGenesisHash"
+    if $addLogs; then
+      logs+=("$(getNodeLogFile "$i" "$cmd")")
     fi
   done
 


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1402093272872128613

localnet test is flaky

#### Summary of Changes

in the `startNodes` function, we have a comment that makes sense, but the actual logic doesn’t quite align with it.

let’s say we have three nodes: the bootstrap node, node 1, and node 2. the current logic starts the nodes in order: first the bootstrap node (index 0), then node 1 (index 1), and so on. however, when starting node 1, the code waits for its own init-complete file instead of checking if the bootstrap node (node 0) is ready. I’ve moved the init-complete check to the top of the loop. this way, when we start node 1, we’ll correctly wait for node 0’s init-complete log (the bootstrap node) before proceeding