### PR TITLE
ci: increase timeout for solana-cargo-build-sbf tests

### DIFF
--- a/.buildkite/scripts/build-stable.sh
+++ b/.buildkite/scripts/build-stable.sh
@@ -16,7 +16,7 @@ for i in $(seq 1 $parallelism); do
 {
   "name": "partition-$i",
   "command": "ci/docker-run-default-image.sh ci/stable/run-partition.sh $i $parallelism",
-  "timeout_in_minutes": 25,
+  "timeout_in_minutes": 40,
   "agent": "$agent",
   "retry": 3
 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -79,7 +79,7 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
 filter = 'package(solana-cargo-build-sbf)'
-slow-timeout = { period = "60s", terminate-after = 5 }
+slow-timeout = { period = "60s", terminate-after = 8 }
 
 [[profile.ci.overrides]]
 filter = 'package(solana-ledger) & test(/^test_purge_huge$/)'


### PR DESCRIPTION
#### Problem

the solana-cargo-build-sbf tests run slower on some CI servers.

#### Summary of Changes

I haven’t looked into it deeply yet. just increasing the timeout for now to unblock others and avoid frustration