### PR TITLE
fix(docs): correct broken link in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -152,4 +152,4 @@ appearing.  To check for progress:
 If this happens and the error is non-fatal, click "Retry" on the "publish crate" job
 
 ### Update software on testnet.solana.com
-See the documentation at https://github.com/solana-labs/cluster-ops/. devnet.solana.com and mainnet-beta.solana.com run stable releases that have been tested on testnet. Do not update devnet or mainnet-beta with a beta release.
+See the documentation at https://github.com/solana-labs/cluster. devnet.solana.com and mainnet-beta.solana.com run stable releases that have been tested on testnet. Do not update devnet or mainnet-beta with a beta release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -152,4 +152,4 @@ appearing.  To check for progress:
 If this happens and the error is non-fatal, click "Retry" on the "publish crate" job
 
 ### Update software on testnet.solana.com
-See the documentation at https://github.com/solana-labs/cluster. devnet.solana.com and mainnet-beta.solana.com run stable releases that have been tested on testnet. Do not update devnet or mainnet-beta with a beta release.
+See the documentation at https://docs.anza.xyz/clusters/. devnet.solana.com and mainnet-beta.solana.com run stable releases that have been tested on testnet. Do not update devnet or mainnet-beta with a beta release.


### PR DESCRIPTION
Fixed broken URL in RELEASE.md from https://github.com/solana-labs/cluster-ops/ to https://github.com/solana-labs/cluster