### PR TITLE
Fix release build compilation error

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -99,6 +99,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
             });
         }
 
+        #[cfg(debug_assertions)]
         debug_assert!(
             self.common.batches.is_empty(),
             "batches must start empty for scheduling"

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -196,6 +196,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         // Check transactions against filter, remove from container if it fails.
         chunked_pops(container, &mut self.prio_graph, &mut window_budget);
 
+        #[cfg(debug_assertions)]
         debug_assert!(
             self.common.batches.is_empty(),
             "batches must start empty for scheduling"


### PR DESCRIPTION
#### Problem
"./cargo build --release" fails with compilation error over a cfg guard added in this [PR](https://github.com/anza-xyz/agave/pull/7193).
> [error[E0599]:] no method named `is_empty` found for struct `Batches` in the current scope
   --> core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs:200:33
    |
200 |             self.common.batches.is_empty(),
    |                                 ^^^^^^^^ method not found in `Batches<Tx>`
    |
   ::: core/src/banking_stage/transaction_scheduler/scheduler_common.rs:21:1
    |
21  | pub struct Batches<Tx> {
    | ---------------------- method `is_empty` not found for this struct

#### Summary of Changes
Add cfg guard to the method invokations because the compiler doesn't ignore/skip checks inside debug_assert!() on release build. Alternatively, I can remove the cfg guard on the method definition.
