### PR TITLE
Verifies snapshot's SlotHistory's number of entries

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -449,8 +449,18 @@ pub enum VerifySlotDeltasError {
     #[error("slot {0} was in history but missing from slot deltas")]
     SlotNotFoundInDeltas(Slot),
 
-    #[error("slot history is bad and cannot be used to verify slot deltas")]
-    BadSlotHistory,
+    #[error("snapshot slot history is invalid: {0}")]
+    VerifySlotHistory(#[from] VerifySlotHistoryError),
+}
+
+/// Errors that can happen in `verify_slot_history()`
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum VerifySlotHistoryError {
+    #[error("newest slot does not match snapshot")]
+    InvalidNewestSlot,
+
+    #[error("invalid number of entries")]
+    InvalidNumEntries,
 }
 
 /// Errors that can happen in `verify_epoch_stakes()`


### PR DESCRIPTION
#### Problem

Copied from https://github.com/anza-xyz/agave/pull/7074:

> Fixes an issue where Agave blindly uses a SlotHistory sysvar of zero or oversize length (but consensus hardcodes the length of this sysvar).


#### Summary of Changes

Verify the snapshot's SlotHistory's number of entries.