### PR TITLE
Add new UpsertReclaim enum ReclaimOldSlots

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -122,6 +122,9 @@ pub enum UpsertReclaim {
     PopulateReclaims,
     /// overwrite existing data in the same slot and do not return in 'reclaims'
     IgnoreReclaims,
+    // Reclaim all older versions of the account from the index and return
+    // in the 'reclaims'
+    ReclaimOldSlots,
 }
 
 #[derive(Debug)]
@@ -3172,6 +3175,182 @@ pub mod tests {
         let _ = index.handle_dead_keys(&[&account_key], secondary_indexes);
         assert!(secondary_index.index.is_empty());
         assert!(secondary_index.reverse_index.is_empty());
+    }
+
+    #[test]
+    fn test_reclaim_older_items_in_slot_list() {
+        solana_logger::setup();
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<u64, u64>::default_for_tests();
+        let mut gc = Vec::new();
+        let reclaim_slot = 5;
+        let account_value = 50;
+
+        // Insert multiple older items into the slot list
+        for slot in 0..reclaim_slot {
+            index.upsert(
+                slot,
+                slot,
+                &key,
+                &AccountSharedData::default(),
+                &AccountSecondaryIndexes::default(),
+                slot,
+                &mut gc,
+                UpsertReclaim::IgnoreReclaims,
+            );
+        }
+        let entry = index.get_cloned(&key).unwrap();
+        assert_eq!(entry.slot_list.read().unwrap().len(), reclaim_slot as usize);
+
+        // Insert an item newer than the one that we will reclaim old slots on
+        index.upsert(
+            reclaim_slot + 1,
+            reclaim_slot + 1,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            account_value + 1,
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+        let entry = index.get_cloned(&key).unwrap();
+        assert_eq!(
+            entry.slot_list.read().unwrap().len(),
+            (reclaim_slot + 1) as usize
+        );
+
+        // Reclaim all older slots
+        index.upsert(
+            reclaim_slot,
+            reclaim_slot,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            account_value,
+            &mut gc,
+            UpsertReclaim::ReclaimOldSlots,
+        );
+
+        // Verify that older items are reclaimed
+        assert_eq!(gc.len(), reclaim_slot as usize);
+        for (slot, value) in gc.iter() {
+            assert!(*slot < reclaim_slot);
+            assert_eq!(*value, *slot);
+        }
+
+        // Verify that the item added is in in the slot list
+        let ancestors = vec![(reclaim_slot, 0)].into_iter().collect();
+        index
+            .get_with_and_then(
+                &key,
+                Some(&ancestors),
+                None,
+                false,
+                |(slot, account_info)| {
+                    assert_eq!(slot, reclaim_slot);
+                    assert_eq!(account_info, account_value);
+                },
+            )
+            .unwrap();
+
+        // Verify that the newer item remains in the slot list
+        let ancestors = vec![((reclaim_slot + 1), 0)].into_iter().collect();
+        index
+            .get_with_and_then(
+                &key,
+                Some(&ancestors),
+                None,
+                false,
+                |(slot, account_info)| {
+                    assert_eq!(slot, reclaim_slot + 1);
+                    assert_eq!(account_info, account_value + 1);
+                },
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_reclaim_do_not_reclaim_cached_other_slot() {
+        solana_logger::setup();
+        let key = solana_pubkey::new_rand();
+        let index =
+            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
+        let mut gc = Vec::new();
+
+        // Insert an uncached account at slot 0 and an cached account at slot 1
+        index.upsert(
+            0,
+            0,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(false),
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+
+        index.upsert(
+            1,
+            1,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(true),
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+
+        // Now insert a cached account at slot 2
+        index.upsert(
+            2,
+            2,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(true),
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+
+        // Replace the cached account at slot 2 with a uncached account
+        index.upsert(
+            2,
+            2,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(false),
+            &mut gc,
+            UpsertReclaim::ReclaimOldSlots,
+        );
+
+        // Verify that the slot list is length two and consists of the cached account at slot 0
+        // and the uncached account at slot 2
+        let entry = index.get_cloned(&key).unwrap();
+        assert_eq!(entry.slot_list.read().unwrap().len(), 2);
+        assert_eq!(
+            entry.slot_list.read().unwrap()[0],
+            PreAllocatedAccountMapEntry::new(
+                1,
+                CacheableIndexValueTest(true),
+                &index.storage.storage,
+                false
+            )
+            .into()
+        );
+        assert_eq!(
+            entry.slot_list.read().unwrap()[1],
+            PreAllocatedAccountMapEntry::new(
+                2,
+                CacheableIndexValueTest(false),
+                &index.storage.storage,
+                false
+            )
+            .into()
+        );
+        // Verify that the uncached account at slot 1 was reclaimed
+        assert_eq!(gc.len(), 1);
+        assert_eq!(gc[0], (0, CacheableIndexValueTest(false)));
     }
 
     #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -3324,7 +3324,7 @@ pub mod tests {
             UpsertReclaim::ReclaimOldSlots,
         );
 
-        // Verify that the slot list is length two and consists of the cached account at slot 0
+        // Verify that the slot list is length two and consists of the cached account at slot 1
         // and the uncached account at slot 2
         let entry = index.get_cloned(&key).unwrap();
         assert_eq!(entry.slot_list.read().unwrap().len(), 2);
@@ -3348,7 +3348,7 @@ pub mod tests {
             )
             .into()
         );
-        // Verify that the uncached account at slot 1 was reclaimed
+        // Verify that the uncached account at slot 0 was reclaimed
         assert_eq!(gc.len(), 1);
         assert_eq!(gc[0], (0, CacheableIndexValueTest(false)));
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -623,6 +623,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// the new item.
     /// if 'other_slot' is some, then remove any entries in the slot list at 'other_slot' instead
     /// if UpsertReclaim is RemoveOldSlots, remove all uncached slots older than 'slot'
+    /// and add them to reclaims
     /// Note:: This function only supports uncached types `T`.
     fn lock_and_update_slot_list(
         current: &AccountMapEntry<T>,
@@ -664,6 +665,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// - Replaces any entry at `slot` or `other_slot` with `account_info`.
     /// - Appends `account_info` to the slot list if `slot` did not exist previously.
     /// - If UpsertReclaim is ReclaimOldSlots, remove all uncached entries older than `slot`
+    ///   and add them to reclaims
     ///
     /// Returns the reference count change as an `i64`. The reference count change
     /// is the number of entries added (1) - the number of uncached entries removed
@@ -1544,6 +1546,173 @@ mod tests {
     }
 
     #[test]
+    fn test_update_slot_list_other_populate_reclaims() {
+        solana_logger::setup();
+        let reclaim = UpsertReclaim::PopulateReclaims;
+        let new_slot = 5;
+        let info = 1;
+        let other_value = info + 1;
+        let at_new_slot = (new_slot, info);
+        let unique_other_slot = new_slot + 1;
+        for other_slot in [Some(new_slot), Some(unique_other_slot), None] {
+            let mut reclaims = Vec::default();
+            let mut slot_list = Vec::default();
+            // upserting into empty slot_list, so always addref
+            assert_eq!(
+                InMemAccountsIndex::<u64, u64>::update_slot_list(
+                    &mut slot_list,
+                    new_slot,
+                    info,
+                    other_slot,
+                    &mut reclaims,
+                    reclaim
+                ),
+                1,
+                "other_slot: {other_slot:?}"
+            );
+            assert_eq!(slot_list, vec![at_new_slot]);
+            assert!(reclaims.is_empty());
+        }
+
+        // replace other
+        let mut slot_list = vec![(unique_other_slot, other_value)];
+        let expected_reclaims = slot_list.clone();
+        let other_slot = Some(unique_other_slot);
+        let mut reclaims = Vec::default();
+        assert_eq!(
+            // upserting into slot_list that does NOT contain an entry at 'new_slot'
+            // but, it DOES contain an entry at other_slot, so we do NOT add-ref. The assumption is that 'other_slot' is going away
+            // and that the previously held add-ref is now used by 'new_slot'
+            InMemAccountsIndex::<u64, u64>::update_slot_list(
+                &mut slot_list,
+                new_slot,
+                info,
+                other_slot,
+                &mut reclaims,
+                reclaim
+            ),
+            0,
+            "other_slot: {other_slot:?}"
+        );
+        assert_eq!(slot_list, vec![at_new_slot]);
+        assert_eq!(reclaims, expected_reclaims);
+
+        // nothing will exist at this slot
+        let missing_other_slot = unique_other_slot + 1;
+        let ignored_slot = 10; // bigger than is used elsewhere in the test
+        let ignored_value = info + 10;
+
+        // build a list of possible contents in the slot_list prior to calling 'update_slot_list'
+        let possible_initial_slot_list_contents = {
+            let mut possible_initial_slot_list_contents = Vec::new();
+
+            // Add ignored slot account_info entries (slots with larger slot #s than 'new_slot' or 'other_slot')
+            possible_initial_slot_list_contents
+                .extend((0..3).map(|i| (ignored_slot + i, ignored_value + i)));
+
+            // Add account_info for 'new_slot'
+            possible_initial_slot_list_contents.push(at_new_slot);
+            // Add account_info for 'other_slot'
+            possible_initial_slot_list_contents.push((unique_other_slot, other_value));
+            possible_initial_slot_list_contents
+        };
+
+        /*
+         * loop over all possible permutations of 'possible_initial_slot_list_contents'
+         * some examples:
+         * []
+         * [other]
+         * [other, new_slot]
+         * [new_slot, other]
+         * [dummy0, new_slot, dummy1, other] (and all permutation of this order)
+         * [other, dummy1, new_slot] (and all permutation of this order)
+         * ...
+         * [dummy0, new_slot, dummy1, other_slot, dummy2] (and all permutation of this order)
+         */
+        let mut attempts = 0;
+        // loop over each initial size of 'slot_list'
+        for initial_slot_list_len in 0..=possible_initial_slot_list_contents.len() {
+            // loop over every permutation of possible_initial_slot_list_contents within a list of len 'initial_slot_list_len'
+            for content_source_indexes in
+                (0..possible_initial_slot_list_contents.len()).permutations(initial_slot_list_len)
+            {
+                // loop over each possible parameter for 'other_slot'
+                for other_slot in [
+                    Some(new_slot),
+                    Some(unique_other_slot),
+                    Some(missing_other_slot),
+                    None,
+                ] {
+                    if other_slot.is_some()
+                        && new_slot != other_slot.unwrap()
+                        && slot_list.contains(&(new_slot, info))
+                    {
+                        // skip this permutation if 'new_slot' is already in the slot_list, but we are trying to reclaim other slot
+                        // This is an assert case as only one of new_slot and other_slot should be in the slot list
+                        continue;
+                    }
+
+                    attempts += 1;
+                    // initialize slot_list prior to call to 'InMemAccountsIndex::update_slot_list'
+                    // by inserting each possible entry at each possible position
+                    let mut slot_list = content_source_indexes
+                        .iter()
+                        .map(|i| possible_initial_slot_list_contents[*i])
+                        .collect::<Vec<_>>();
+                    let mut expected = slot_list.clone();
+                    let original = slot_list.clone();
+                    let mut reclaims = Vec::default();
+
+                    let result = InMemAccountsIndex::<u64, u64>::update_slot_list(
+                        &mut slot_list,
+                        new_slot,
+                        info,
+                        other_slot,
+                        &mut reclaims,
+                        reclaim,
+                    );
+
+                    // calculate expected reclaims
+                    let mut expected_reclaims = Vec::default();
+                    expected.retain(|(slot, info)| {
+                        let retain = slot != &new_slot && Some(*slot) != other_slot;
+                        if !retain {
+                            expected_reclaims.push((*slot, *info));
+                        }
+                        retain
+                    });
+                    expected.push((new_slot, info));
+
+                    // Calculate the expected ref count change. It is expected to be 1 - the number of reclaims
+                    let expected_result = 1 - expected_reclaims.len() as i64;
+                    assert_eq!(
+                        expected_result, result,
+                        "return value different. other: {other_slot:?}, {expected:?}, \
+                         {slot_list:?}, original: {original:?}"
+                    );
+                    // sort for easy comparison
+                    expected_reclaims.sort_unstable();
+                    reclaims.sort_unstable();
+                    assert_eq!(
+                        expected_reclaims, reclaims,
+                        "reclaims different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
+                    );
+                    // sort for easy comparison
+                    slot_list.sort_unstable();
+                    expected.sort_unstable();
+                    assert_eq!(
+                        slot_list, expected,
+                        "slot_list different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
+                    );
+                }
+            }
+        }
+        assert_eq!(attempts, 652); // complicated permutations, so make sure we ran the right #
+    }
+
+    #[test]
     fn test_should_evict_from_mem_ref_count() {
         for ref_count in [0, 1, 2] {
             let bucket = new_for_test::<u64>();
@@ -1774,7 +1943,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_slot_list_other() {
+    fn test_update_slot_list_other_reclaim_old_slots() {
         solana_logger::setup();
         let reclaim = UpsertReclaim::ReclaimOldSlots;
         let new_slot = 5;
@@ -1830,7 +1999,7 @@ mod tests {
         let ignored_slot = 10; // bigger than is used elsewhere in the test
         let ignored_value = info + 10;
         let reclaimed_slot = 1; // less than is used elsewhere in the test
-        let relcaimed_value = info + 10;
+        let reclaimed_value = info + 10;
 
         // build a list of possible contents in the slot_list prior to calling 'update_slot_list'
         let possible_initial_slot_list_contents = {
@@ -1842,7 +2011,7 @@ mod tests {
 
             // Add reclaimed slot account_info entries (slots with smaller slot #s than 'new_slot' or 'other_slot')
             possible_initial_slot_list_contents
-                .extend((0..3).map(|i| (reclaimed_slot + i, relcaimed_value + i)));
+                .extend((0..3).map(|i| (reclaimed_slot + i, reclaimed_value + i)));
 
             // Add account_info for 'new_slot'
             possible_initial_slot_list_contents.push(at_new_slot);


### PR DESCRIPTION
#### Problem
With obsolete accounts, all older version of accounts can be reclaimed once an updated version is added. Adding this functionality to upsert

#### Summary of Changes
- Added new enum to UpsertReclaim
- Add functionality to update_slot_list
- Add unit tests for new fucntionality


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
