### PR TITLE
chore: typo fixes

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -228,7 +228,7 @@ fn add_stakes(
         .sum::<u64>()
 }
 
-/// Add acounts that should be present in genesis; skip for development clusters
+/// Add accounts that should be present in genesis; skip for development clusters
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lamports: u64) {
     if genesis_config.cluster_type == ClusterType::Development {
         return;

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -537,7 +537,7 @@ pub fn find_available_port_in_range(ip_addr: IpAddr, range: PortRange) -> io::Re
 
 /// Searches for several ports on a given binding ip_addr in the provided range.
 ///
-/// This will start at a random point in the range provided, and search sequencially.
+/// This will start at a random point in the range provided, and search sequentially.
 /// If it can not find anything, an Error is returned.
 pub fn find_available_ports_in_range<const N: usize>(
     ip_addr: IpAddr,

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -23,7 +23,7 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
         let var: &mut T = map(var_addr)?;
     );
 
-    // this clone looks unecessary now, but it exists to zero out trailing alignment bytes
+    // this clone looks unnecessary now, but it exists to zero out trailing alignment bytes
     // it is unclear whether this should ever matter
     // but there are tests using MemoryMapping that expect to see this
     // we preserve the previous behavior out of an abundance of caution

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -410,7 +410,7 @@ fn verify_packets(
     solana_perf::sigverify::mark_disabled(packets, &out);
 }
 
-// Returns pubkey of leaders for shred slots refrenced in the packets.
+// Returns pubkey of leaders for shred slots referenced in the packets.
 // Marks packets as discard if:
 //   - fails to deserialize the shred slot.
 //   - slot leader is unknown.


### PR DESCRIPTION
## Summary
This PR fixes several typos in code comments across different modules to improve code documentation quality.

## Changes
- **genesis/src/genesis_accounts.rs**: Fixed "acounts" → "accounts" in function documentation
- **net-utils/src/lib.rs**: Fixed "sequencially" → "sequentially" in function documentation  
- **syscalls/src/sysvar.rs**: Fixed "unecessary" → "unnecessary" in code comment
- **turbine/src/sigverify_shreds.rs**: Fixed "refrenced" → "referenced" in code comment

