### PR TITLE
Renames verify_accounts_lt_hash_us metric

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4638,7 +4638,7 @@ impl Bank {
                             "startup_verify_accounts",
                             ("total_us", total_time.as_micros(), i64),
                             (
-                                "verify_accounts_lt_hash_us",
+                                "calculate_accounts_lt_hash_us",
                                 lattice_verify_time.as_micros(),
                                 i64
                             ),


### PR DESCRIPTION
#### Problem

The `verify_accounts_lt_hash_us` metric name was to disambiguate it from the merkle-based accounts hash verification. Now that merkle-based accounts hashing is gone, we don't need that disambiguation anymore.

To be more clear, this metric is *calculating* the accounts lt hash. The verification happens after the calculation. So the name of the metric is *slightly* incorrect and could be made clearer.


#### Summary of Changes

Rename it.