### PR TITLE
Renames solBgHashVerify thread

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4605,7 +4605,7 @@ impl Bank {
             let accounts_db_ = Arc::clone(accounts_db);
             accounts_db.verify_accounts_hash_in_bg.start(|| {
                 Builder::new()
-                    .name("solBgHashVerify".into())
+                    .name("solBgVerfyAccts".into())
                     .spawn(move || {
                         info!("Verifying accounts in background...");
                         let start = Instant::now();


### PR DESCRIPTION
#### Problem

I'm working towards unifying all bits of accounts verification to be consistently named something related to "verify accounts" (e.g. the function, the thread, the thread pool, the logs, and the metrics).

For this PR, the thread that is spun up to verify accounts in the background is currently named "solBgHashVerify". I'd like to rename it to be more consistent with "verify accounts".


#### Summary of Changes

Rename it.