### PR TITLE
Renames verify_accounts_hash() fn

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1020,7 +1020,7 @@ fn test_purge_empty_accounts() {
 
         if pass == 0 {
             add_root_and_flush_write_cache(&bank0);
-            assert!(bank0.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank0.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
             continue;
         }
 
@@ -1029,14 +1029,14 @@ fn test_purge_empty_accounts() {
         bank0.squash();
         add_root_and_flush_write_cache(&bank0);
         if pass == 1 {
-            assert!(bank0.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank0.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
             continue;
         }
 
         bank1.freeze();
         bank1.squash();
         add_root_and_flush_write_cache(&bank1);
-        assert!(bank1.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+        assert!(bank1.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
 
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
@@ -1044,7 +1044,7 @@ fn test_purge_empty_accounts() {
 
         bank1.clean_accounts_for_tests();
 
-        assert!(bank1.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+        assert!(bank1.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
     }
 }
 
@@ -2180,7 +2180,7 @@ fn test_bank_hash_internal_state() {
     bank2.transfer(amount, &mint_keypair, &pubkey2).unwrap();
     bank2.squash();
     bank2.force_flush_accounts_cache();
-    assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+    assert!(bank2.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
 }
 
 #[test]
@@ -2214,7 +2214,7 @@ fn test_bank_hash_internal_state_verify() {
             // we later modify bank 2, so this flush is destructive to the test
             bank2.freeze();
             add_root_and_flush_write_cache(&bank2);
-            assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank2.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
         }
         let bank3 = new_bank_from_parent_with_bank_forks(
             &bank_forks,
@@ -2225,7 +2225,7 @@ fn test_bank_hash_internal_state_verify() {
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set bank2's accounts hash in the pass==0 if above
-            assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank2.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
             continue;
         }
         if pass == 1 {
@@ -2234,7 +2234,7 @@ fn test_bank_hash_internal_state_verify() {
             // Doing so throws an assert. So, we can't flush 3 until 2 is flushed.
             bank3.freeze();
             add_root_and_flush_write_cache(&bank3);
-            assert!(bank3.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank3.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
             continue;
         }
 
@@ -2243,7 +2243,7 @@ fn test_bank_hash_internal_state_verify() {
         bank2.freeze(); // <-- keep freeze() *outside* `if pass == 2 {}`
         if pass == 2 {
             add_root_and_flush_write_cache(&bank2);
-            assert!(bank2.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+            assert!(bank2.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
 
             // Verifying the accounts lt hash is only intended to be called at startup, and
             // normally in the background.  Since here we're *not* at startup, and doing it
@@ -2258,7 +2258,7 @@ fn test_bank_hash_internal_state_verify() {
 
         bank3.freeze();
         add_root_and_flush_write_cache(&bank3);
-        assert!(bank3.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+        assert!(bank3.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
     }
 }
 
@@ -10911,7 +10911,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
 }
 
 #[test]
-fn test_verify_accounts_hash() {
+fn test_verify_accounts() {
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair: mint,
@@ -10962,8 +10962,8 @@ fn test_verify_accounts_hash() {
     bank.squash();
     bank.force_flush_accounts_cache();
 
-    // ensure the accounts hash verifies
-    assert!(bank.verify_accounts_hash(VerifyAccountsHashConfig::default_for_test(), None));
+    // ensure the accounts verify successfully
+    assert!(bank.verify_accounts(VerifyAccountsHashConfig::default_for_test(), None));
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

I'm working towards unifying all bits of accounts verification to be consistently named something related to "verify accounts" (e.g. the function, the thread, the thread pool, the logs, and the metrics).

For this PR, I'm targeting the fn itself, `verify_accounts_hash()`.


#### Summary of Changes

Rename it.