### PR TITLE
Remove BankStart

### DIFF
--- a/core/benches/receive_and_buffer_utils.rs
+++ b/core/benches/receive_and_buffer_utils.rs
@@ -23,16 +23,12 @@ use {
     solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
     solana_message::{Message, VersionedMessage},
     solana_perf::packet::{to_packet_batches, PacketBatch, NUM_PACKETS},
-    solana_poh::poh_recorder::BankStart,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk_ids::system_program,
     solana_signer::Signer,
     solana_transaction::versioned::VersionedTransaction,
-    std::{
-        sync::{Arc, RwLock},
-        time::Instant,
-    },
+    std::sync::{Arc, RwLock},
 };
 
 // the max number of instructions of given type that we can put into packet.
@@ -191,16 +187,12 @@ pub fn setup_receive_and_buffer<T: ReceiveAndBuffer + ReceiveAndBufferCreator>(
 
     let (bank, bank_forks) =
         Bank::new_for_benches(&genesis_config).wrap_with_bank_forks_for_tests();
-    let bank_start = BankStart {
-        working_bank: bank.clone(),
-        bank_creation_time: Arc::new(Instant::now()),
-    };
 
     let (sender, receiver) = unbounded();
 
     let receive_and_buffer = T::create(receiver, bank_forks);
 
-    let decision = BufferedPacketsDecision::Consume(bank_start);
+    let decision = BufferedPacketsDecision::Consume(bank.clone());
 
     let txs = generate_transactions(
         num_txs,

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -63,7 +63,7 @@ impl Committer {
         batch: &TransactionBatch<impl TransactionWithMeta>,
         processing_results: Vec<TransactionProcessingResult>,
         starting_transaction_index: Option<usize>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         balance_collector: Option<BalanceCollector>,
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
         processed_counts: &ProcessedTransactionCounts,
@@ -122,7 +122,7 @@ impl Committer {
     fn collect_balances_and_send_status_batch(
         &self,
         commit_results: Vec<TransactionCommitResult>,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         batch: &TransactionBatch<impl TransactionWithMeta>,
         balance_collector: Option<BalanceCollector>,
         starting_transaction_index: Option<usize>,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -28,7 +28,7 @@ use {
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     solana_transaction_error::TransactionError,
-    std::{num::Saturating, sync::Arc},
+    std::num::Saturating,
 };
 
 /// Consumer will create chunks of transactions from buffer with up to this size.
@@ -94,7 +94,7 @@ impl Consumer {
 
     pub fn process_and_record_transactions(
         &self,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         txs: &[impl TransactionWithMeta],
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
@@ -124,7 +124,7 @@ impl Consumer {
 
     pub fn process_and_record_aged_transactions(
         &self,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         txs: &[impl TransactionWithMeta],
         max_ages: &[MaxAge],
     ) -> ProcessTransactionBatchOutput {
@@ -159,7 +159,7 @@ impl Consumer {
 
     fn process_and_record_transactions_with_pre_results(
         &self,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         txs: &[impl TransactionWithMeta],
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
     ) -> ProcessTransactionBatchOutput {
@@ -227,7 +227,7 @@ impl Consumer {
 
     fn execute_and_commit_transactions_locked(
         &self,
-        bank: &Arc<Bank>,
+        bank: &Bank,
         batch: &TransactionBatch<impl TransactionWithMeta>,
     ) -> ExecuteAndCommitTransactionsOutput {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
@@ -532,7 +532,7 @@ mod tests {
             borrow::Cow,
             sync::{
                 atomic::{AtomicBool, AtomicU64, Ordering},
-                RwLock,
+                Arc, RwLock,
             },
             thread::{Builder, JoinHandle},
             time::Duration,

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -6,9 +6,9 @@ use {
         vote_storage::VoteBatchInsertionMetrics,
     },
     solana_clock::Slot,
-    solana_poh::poh_recorder::BankStart,
+    solana_runtime::bank::Bank,
     solana_svm::transaction_error_metrics::*,
-    std::num::Saturating,
+    std::{num::Saturating, sync::Arc},
 };
 
 /// A summary of what happened to transactions passed to the processing pipeline.
@@ -476,9 +476,9 @@ impl LeaderSlotMetricsTracker {
     // Check leader slot, return MetricsTrackerAction to be applied by apply_action()
     pub(crate) fn check_leader_slot_boundary(
         &mut self,
-        bank_start: Option<&BankStart>,
+        bank: Option<&Arc<Bank>>,
     ) -> MetricsTrackerAction {
-        match (self.leader_slot_metrics.as_mut(), bank_start) {
+        match (self.leader_slot_metrics.as_mut(), bank) {
             (None, None) => MetricsTrackerAction::Noop,
 
             (Some(leader_slot_metrics), None) => {
@@ -487,16 +487,16 @@ impl LeaderSlotMetricsTracker {
             }
 
             // Our leader slot has begain, time to create a new slot tracker
-            (None, Some(bank_start)) => MetricsTrackerAction::NewTracker(Some(
-                LeaderSlotMetrics::new(bank_start.working_bank.slot()),
-            )),
+            (None, Some(bank)) => {
+                MetricsTrackerAction::NewTracker(Some(LeaderSlotMetrics::new(bank.slot())))
+            }
 
-            (Some(leader_slot_metrics), Some(bank_start)) => {
-                if leader_slot_metrics.slot != bank_start.working_bank.slot() {
+            (Some(leader_slot_metrics), Some(bank)) => {
+                if leader_slot_metrics.slot != bank.slot() {
                     // Last slot has ended, new slot has began
                     leader_slot_metrics.mark_slot_end_detected();
                     MetricsTrackerAction::ReportAndNewTracker(Some(LeaderSlotMetrics::new(
-                        bank_start.working_bank.slot(),
+                        bank.slot(),
                     )))
                 } else {
                     MetricsTrackerAction::Noop
@@ -801,24 +801,18 @@ mod tests {
         super::*,
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
-        std::{mem, sync::Arc, time::Instant},
+        std::{mem, sync::Arc},
     };
 
     struct TestSlotBoundaryComponents {
         first_bank: Arc<Bank>,
-        first_poh_recorder_bank: BankStart,
         next_bank: Arc<Bank>,
-        next_poh_recorder_bank: BankStart,
         leader_slot_metrics_tracker: LeaderSlotMetricsTracker,
     }
 
     fn setup_test_slot_boundary_banks() -> TestSlotBoundaryComponents {
         let genesis = create_genesis_config(10);
         let first_bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
-        let first_poh_recorder_bank = BankStart {
-            working_bank: first_bank.clone(),
-            bank_creation_time: Arc::new(Instant::now()),
-        };
 
         // Create a child descended from the first bank
         let next_bank = Arc::new(Bank::new_from_parent(
@@ -826,18 +820,12 @@ mod tests {
             &Pubkey::new_unique(),
             first_bank.slot() + 1,
         ));
-        let next_poh_recorder_bank = BankStart {
-            working_bank: next_bank.clone(),
-            bank_creation_time: Arc::new(Instant::now()),
-        };
 
         let leader_slot_metrics_tracker = LeaderSlotMetricsTracker::default();
 
         TestSlotBoundaryComponents {
             first_bank,
-            first_poh_recorder_bank,
             next_bank,
-            next_poh_recorder_bank,
             leader_slot_metrics_tracker,
         }
     }
@@ -861,7 +849,7 @@ mod tests {
     #[test]
     pub fn test_update_on_leader_slot_boundary_not_leader_to_leader() {
         let TestSlotBoundaryComponents {
-            first_poh_recorder_bank,
+            first_bank,
             mut leader_slot_metrics_tracker,
             ..
         } = setup_test_slot_boundary_banks();
@@ -869,8 +857,7 @@ mod tests {
         // Test case where the thread has not detected a leader bank, and now sees a leader bank.
         // Metrics should not be reported because leader slot has not ended
         assert!(leader_slot_metrics_tracker.leader_slot_metrics.is_none());
-        let action =
-            leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+        let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
         assert_eq!(
             mem::discriminant(&MetricsTrackerAction::NewTracker(None)),
             mem::discriminant(&action)
@@ -883,7 +870,6 @@ mod tests {
     pub fn test_update_on_leader_slot_boundary_leader_to_not_leader() {
         let TestSlotBoundaryComponents {
             first_bank,
-            first_poh_recorder_bank,
             mut leader_slot_metrics_tracker,
             ..
         } = setup_test_slot_boundary_banks();
@@ -893,8 +879,7 @@ mod tests {
         // because that leader slot has just ended.
         {
             // Setup first_bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
             assert!(leader_slot_metrics_tracker.apply_action(action).is_none());
         }
         {
@@ -924,7 +909,6 @@ mod tests {
     pub fn test_update_on_leader_slot_boundary_leader_to_leader_same_slot() {
         let TestSlotBoundaryComponents {
             first_bank,
-            first_poh_recorder_bank,
             mut leader_slot_metrics_tracker,
             ..
         } = setup_test_slot_boundary_banks();
@@ -933,14 +917,12 @@ mod tests {
         // implying the slot is still running. Metrics should not be reported
         {
             // Setup with first_bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
             assert!(leader_slot_metrics_tracker.apply_action(action).is_none());
         }
         {
             // Assert nop-op if same bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
             assert_eq!(
                 mem::discriminant(&MetricsTrackerAction::Noop),
                 mem::discriminant(&action)
@@ -966,9 +948,7 @@ mod tests {
     pub fn test_update_on_leader_slot_boundary_leader_to_leader_bigger_slot() {
         let TestSlotBoundaryComponents {
             first_bank,
-            first_poh_recorder_bank,
             next_bank,
-            next_poh_recorder_bank,
             mut leader_slot_metrics_tracker,
         } = setup_test_slot_boundary_banks();
 
@@ -977,14 +957,12 @@ mod tests {
         // smaller slot
         {
             // Setup with first_bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
             assert!(leader_slot_metrics_tracker.apply_action(action).is_none());
         }
         {
             // Assert reporting if new bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&next_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&next_bank));
             assert_eq!(
                 mem::discriminant(&MetricsTrackerAction::ReportAndNewTracker(None)),
                 mem::discriminant(&action)
@@ -1014,9 +992,7 @@ mod tests {
     pub fn test_update_on_leader_slot_boundary_leader_to_leader_smaller_slot() {
         let TestSlotBoundaryComponents {
             first_bank,
-            first_poh_recorder_bank,
             next_bank,
-            next_poh_recorder_bank,
             mut leader_slot_metrics_tracker,
         } = setup_test_slot_boundary_banks();
         // Test case where the thread has a leader bank, and now detects there's a new leader bank
@@ -1024,14 +1000,12 @@ mod tests {
         // bigger slot
         {
             // Setup with next_bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&next_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&next_bank));
             assert!(leader_slot_metrics_tracker.apply_action(action).is_none());
         }
         {
             // Assert reporting if new bank
-            let action = leader_slot_metrics_tracker
-                .check_leader_slot_boundary(Some(&first_poh_recorder_bank));
+            let action = leader_slot_metrics_tracker.check_leader_slot_boundary(Some(&first_bank));
             assert_eq!(
                 mem::discriminant(&MetricsTrackerAction::ReportAndNewTracker(None)),
                 mem::discriminant(&action)

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -77,9 +77,9 @@ pub(crate) struct LeaderSlotTimingMetrics {
 }
 
 impl LeaderSlotTimingMetrics {
-    pub(crate) fn new(bank_creation_time: &Instant) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            outer_loop_timings: OuterLoopTimings::new(bank_creation_time),
+            outer_loop_timings: OuterLoopTimings::new(),
             process_buffered_packets_timings: ProcessBufferedPacketsTimings::default(),
             consume_buffered_packets_timings: ConsumeBufferedPacketsTimings::default(),
             process_packets_timings: ProcessPacketsTimings::default(),
@@ -104,9 +104,6 @@ impl LeaderSlotTimingMetrics {
 pub(crate) struct OuterLoopTimings {
     pub bank_detected_time: Instant,
 
-    // Delay from when the bank was created to when this thread detected it
-    pub bank_detected_delay_us: u64,
-
     // Time spent processing buffered packets
     pub process_buffered_packets_us: u64,
 
@@ -122,10 +119,9 @@ pub(crate) struct OuterLoopTimings {
 }
 
 impl OuterLoopTimings {
-    fn new(bank_creation_time: &Instant) -> Self {
+    fn new() -> Self {
         Self {
             bank_detected_time: Instant::now(),
-            bank_detected_delay_us: bank_creation_time.elapsed().as_micros() as u64,
             process_buffered_packets_us: 0,
             receive_and_buffer_packets_us: 0,
             receive_and_buffer_packets_invoked_count: 0,
@@ -148,12 +144,6 @@ impl OuterLoopTimings {
                 self.bank_detected_to_slot_end_detected_us,
                 i64
             ),
-            (
-                "bank_creation_to_slot_end_detected_us",
-                self.bank_detected_to_slot_end_detected_us + self.bank_detected_delay_us,
-                i64
-            ),
-            ("bank_detected_delay_us", self.bank_detected_delay_us, i64),
             (
                 "process_buffered_packets_us",
                 self.process_buffered_packets_us,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -94,7 +94,7 @@ where
             self.timing_metrics.update(|timing_metrics| {
                 timing_metrics.decision_time_us += decision_time_us;
             });
-            let new_leader_slot = decision.bank_start().map(|b| b.working_bank.slot());
+            let new_leader_slot = decision.bank().map(|b| b.slot());
             self.count_metrics
                 .maybe_report_and_reset_slot(new_leader_slot);
             self.timing_metrics
@@ -131,16 +131,11 @@ where
         decision: &BufferedPacketsDecision,
     ) -> Result<(), SchedulerError> {
         match decision {
-            BufferedPacketsDecision::Consume(bank_start) => {
+            BufferedPacketsDecision::Consume(bank) => {
                 let (scheduling_summary, schedule_time_us) = measure_us!(self.scheduler.schedule(
                     &mut self.container,
                     |txs, results| {
-                        Self::pre_graph_filter(
-                            txs,
-                            results,
-                            &bank_start.working_bank,
-                            MAX_PROCESSING_AGE,
-                        )
+                        Self::pre_graph_filter(txs, results, bank, MAX_PROCESSING_AGE)
                     },
                     |_| PreLockFilterAction::AttemptToSchedule // no pre-lock filter for now
                 )?);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -6,10 +6,7 @@ use {
         receive_and_buffer::{DisconnectedError, ReceiveAndBuffer},
         scheduler::{PreLockFilterAction, Scheduler},
         scheduler_error::SchedulerError,
-        scheduler_metrics::{
-            SchedulerCountMetrics, SchedulerLeaderDetectionMetrics, SchedulerTimingMetrics,
-            SchedulingDetails,
-        },
+        scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics, SchedulingDetails},
     },
     crate::banking_stage::{
         consume_worker::ConsumeWorkerMetrics,
@@ -43,8 +40,6 @@ where
     container: R::Container,
     /// State for scheduling and communicating with worker threads.
     scheduler: S,
-    /// Metrics tracking time for leader bank detection.
-    leader_detection_metrics: SchedulerLeaderDetectionMetrics,
     /// Metrics tracking counts on transactions in different states
     /// over an interval and during a leader slot.
     count_metrics: SchedulerCountMetrics,
@@ -75,7 +70,6 @@ where
             bank_forks,
             container: R::Container::with_capacity(TOTAL_BUFFERED_PACKETS),
             scheduler,
-            leader_detection_metrics: SchedulerLeaderDetectionMetrics::default(),
             count_metrics: SchedulerCountMetrics::default(),
             timing_metrics: SchedulerTimingMetrics::default(),
             worker_metrics,
@@ -101,8 +95,6 @@ where
                 timing_metrics.decision_time_us += decision_time_us;
             });
             let new_leader_slot = decision.bank_start().map(|b| b.working_bank.slot());
-            self.leader_detection_metrics
-                .update_and_maybe_report(decision.bank_start());
             self.count_metrics
                 .maybe_report_and_reset_slot(new_leader_slot);
             self.timing_metrics

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -2,7 +2,6 @@ use {
     super::scheduler::SchedulingSummary,
     itertools::MinMaxResult,
     solana_clock::Slot,
-    solana_poh::poh_recorder::BankStart,
     solana_time_utils::AtomicInterval,
     std::{
         num::Saturating,
@@ -371,69 +370,6 @@ impl SchedulerTimingMetricsInner {
         self.clear_time_us = Saturating(0);
         self.clean_time_us = Saturating(0);
         self.receive_completed_time_us = Saturating(0);
-    }
-}
-
-#[derive(Default)]
-pub struct SchedulerLeaderDetectionMetrics {
-    inner: Option<SchedulerLeaderDetectionMetricsInner>,
-}
-
-struct SchedulerLeaderDetectionMetricsInner {
-    slot: Slot,
-    bank_creation_time: Instant,
-    bank_detected_time: Instant,
-}
-
-impl SchedulerLeaderDetectionMetrics {
-    pub fn update_and_maybe_report(&mut self, bank_start: Option<&BankStart>) {
-        match (&self.inner, bank_start) {
-            (None, Some(bank_start)) => self.initialize_inner(bank_start),
-            (Some(_inner), None) => self.report_and_reset(),
-            (Some(inner), Some(bank_start)) if inner.slot != bank_start.working_bank.slot() => {
-                self.report_and_reset();
-                self.initialize_inner(bank_start);
-            }
-            _ => {}
-        }
-    }
-
-    fn initialize_inner(&mut self, bank_start: &BankStart) {
-        let bank_detected_time = Instant::now();
-        self.inner = Some(SchedulerLeaderDetectionMetricsInner {
-            slot: bank_start.working_bank.slot(),
-            bank_creation_time: *bank_start.bank_creation_time,
-            bank_detected_time,
-        });
-    }
-
-    fn report_and_reset(&mut self) {
-        let SchedulerLeaderDetectionMetricsInner {
-            slot,
-            bank_creation_time,
-            bank_detected_time,
-        } = self.inner.take().expect("inner must be present");
-
-        let bank_detected_delay_us = bank_detected_time
-            .duration_since(bank_creation_time)
-            .as_micros()
-            .try_into()
-            .unwrap_or(i64::MAX);
-        let bank_detected_to_slot_end_detected_us = bank_detected_time
-            .elapsed()
-            .as_micros()
-            .try_into()
-            .unwrap_or(i64::MAX);
-        datapoint_info!(
-            "banking_stage_scheduler_leader_detection",
-            ("slot", slot, i64),
-            ("bank_detected_delay_us", bank_detected_delay_us, i64),
-            (
-                "bank_detected_to_slot_end_detected_us",
-                bank_detected_to_slot_end_detected_us,
-                i64
-            ),
-        );
     }
 }
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -19,7 +19,7 @@ use {
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
     solana_measure::{measure::Measure, measure_us},
-    solana_poh::poh_recorder::{BankStart, PohRecorderError},
+    solana_poh::poh_recorder::PohRecorderError,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -121,7 +121,7 @@ impl VoteWorker {
     ) {
         let (decision, make_decision_us) =
             measure_us!(self.decision_maker.make_consume_or_forward_decision());
-        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank_start());
+        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank());
         slot_metrics_tracker.increment_make_decision_us(make_decision_us);
 
         // Take metrics action before processing packets (potentially resetting the
@@ -131,9 +131,9 @@ impl VoteWorker {
         slot_metrics_tracker.apply_action(metrics_action);
 
         match decision {
-            BufferedPacketsDecision::Consume(bank_start) => {
+            BufferedPacketsDecision::Consume(bank) => {
                 let (_, consume_buffered_packets_us) = measure_us!(self.consume_buffered_packets(
-                    &bank_start,
+                    &bank,
                     banking_stage_stats,
                     slot_metrics_tracker,
                 ));
@@ -159,7 +159,7 @@ impl VoteWorker {
 
     fn consume_buffered_packets(
         &mut self,
-        bank_start: &BankStart,
+        bank: &Bank,
         banking_stage_stats: &BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) {
@@ -173,7 +173,7 @@ impl VoteWorker {
         let num_packets_to_process = self.storage.len();
 
         let reached_end_of_slot = self.process_packets(
-            bank_start,
+            bank,
             &mut consumed_buffered_packets_count,
             &mut rebuffered_packet_count,
             banking_stage_stats,
@@ -208,7 +208,7 @@ impl VoteWorker {
     // returns `true` if the end of slot is reached
     fn process_packets(
         &mut self,
-        bank_start: &BankStart,
+        bank: &Bank,
         consumed_buffered_packets_count: &mut usize,
         rebuffered_packet_count: &mut usize,
         banking_stage_stats: &BankingStageStats,
@@ -217,7 +217,7 @@ impl VoteWorker {
         // Based on the stake distribution present in the supplied bank, drain the unprocessed votes
         // from each validator using a weighted random ordering. Votes from validators with
         // 0 stake are ignored.
-        let all_vote_packets = self.storage.drain_unprocessed(&bank_start.working_bank);
+        let all_vote_packets = self.storage.drain_unprocessed(bank);
 
         let mut reached_end_of_slot = false;
         let mut sanitized_transactions = Vec::with_capacity(UNPROCESSED_BUFFER_STEP_SIZE);
@@ -228,7 +228,7 @@ impl VoteWorker {
             vote_packets.clear();
             chunk.iter().for_each(|packet| {
                 if consume_scan_should_process_packet(
-                    &bank_start.working_bank,
+                    bank,
                     banking_stage_stats,
                     packet,
                     reached_end_of_slot,
@@ -241,7 +241,7 @@ impl VoteWorker {
             });
 
             if let Some(retryable_vote_indices) = self.do_process_packets(
-                bank_start,
+                bank,
                 &mut reached_end_of_slot,
                 &mut sanitized_transactions,
                 banking_stage_stats,
@@ -265,7 +265,7 @@ impl VoteWorker {
 
     fn do_process_packets(
         &self,
-        bank_start: &BankStart,
+        bank: &Bank,
         reached_end_of_slot: &mut bool,
         sanitized_transactions: &mut Vec<RuntimeTransaction<SanitizedTransaction>>,
         banking_stage_stats: &BankingStageStats,
@@ -280,8 +280,7 @@ impl VoteWorker {
 
         let (process_transactions_summary, process_packets_transactions_us) = measure_us!(self
             .process_packets_transactions(
-                &bank_start.working_bank,
-                &bank_start.bank_creation_time,
+                bank,
                 sanitized_transactions,
                 banking_stage_stats,
                 slot_metrics_tracker,
@@ -299,7 +298,7 @@ impl VoteWorker {
             ..
         } = process_transactions_summary;
 
-        if reached_max_poh_height || !bank_start.should_working_bank_still_be_processing_txs() {
+        if reached_max_poh_height || !bank.is_complete() {
             *reached_end_of_slot = true;
         }
 
@@ -325,15 +324,13 @@ impl VoteWorker {
 
     fn process_packets_transactions(
         &self,
-        bank: &Arc<Bank>,
-        bank_creation_time: &Instant,
+        bank: &Bank,
         sanitized_transactions: &[impl TransactionWithMeta],
         banking_stage_stats: &BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) -> ProcessTransactionsSummary {
-        let (mut process_transactions_summary, process_transactions_us) = measure_us!(
-            self.process_transactions(bank, bank_creation_time, sanitized_transactions)
-        );
+        let (mut process_transactions_summary, process_transactions_us) =
+            measure_us!(self.process_transactions(bank, sanitized_transactions));
         slot_metrics_tracker.increment_process_transactions_us(process_transactions_us);
         banking_stage_stats
             .transaction_processing_elapsed
@@ -381,8 +378,7 @@ impl VoteWorker {
     /// than the total number if max PoH height was reached and the bank halted
     fn process_transactions(
         &self,
-        bank: &Arc<Bank>,
-        bank_creation_time: &Instant,
+        bank: &Bank,
         transactions: &[impl TransactionWithMeta],
     ) -> ProcessTransactionsSummary {
         let process_transaction_batch_output = self
@@ -408,8 +404,7 @@ impl VoteWorker {
         total_transaction_counts
             .accumulate(&transaction_counts, commit_transactions_result.is_ok());
 
-        let should_bank_still_be_processing_txs =
-            Bank::should_bank_still_be_processing_txs(bank_creation_time, bank.ns_per_slot);
+        let should_bank_still_be_processing_txs = bank.is_complete();
         let reached_max_poh_height = match (
             commit_transactions_result,
             should_bank_still_be_processing_txs,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -56,21 +56,6 @@ pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;
 
 pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));
 
-#[derive(Debug, Clone)]
-pub struct BankStart {
-    pub working_bank: Arc<Bank>,
-    pub bank_creation_time: Arc<Instant>,
-}
-
-impl BankStart {
-    pub fn should_working_bank_still_be_processing_txs(&self) -> bool {
-        Bank::should_bank_still_be_processing_txs(
-            &self.bank_creation_time,
-            self.working_bank.ns_per_slot,
-        )
-    }
-}
-
 // Sends the Result of the record operation, including the index in the slot of the first
 // transaction, if being tracked by WorkingBank
 type RecordResultSender = Sender<Result<Option<usize>>>;
@@ -647,13 +632,6 @@ impl PohRecorder {
 
     pub fn bank(&self) -> Option<Arc<Bank>> {
         self.working_bank.as_ref().map(|w| w.bank.clone())
-    }
-
-    pub fn bank_start(&self) -> Option<BankStart> {
-        self.working_bank.as_ref().map(|w| BankStart {
-            working_bank: w.bank.clone(),
-            bank_creation_time: w.start.clone(),
-        })
     }
 
     pub fn has_bank(&self) -> bool {


### PR DESCRIPTION
#### Problem
- BankStart is currently returned in BufferedPacketDecision
    - this forces us to take a lock on the poh_recorder to make decision
    - we want to get leader-bank w/o any locking

#### Summary of Changes
- Remove BankStart
    - this causes the removal several metrics related to leader bank detection time 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
