### PR TITLE
fix: correct typos in genesis and watchtower modules

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -228,7 +228,7 @@ fn add_stakes(
         .sum::<u64>()
 }
 
-/// Add acounts that should be present in genesis; skip for development clusters
+/// Add accounts that should be present in genesis; skip for development clusters
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lamports: u64) {
     if genesis_config.cluster_type == ClusterType::Development {
         return;

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -422,7 +422,7 @@ fn validate_endpoints(
         if let Some(common_genesis_hash) = opt_common_genesis_hash {
             if common_genesis_hash != genesis_hash {
                 return Err(
-                    "Endpoints don't aggree on genesis hash, have you mixed up clusters?".into(),
+                    "Endpoints don't agree on genesis hash, have you mixed up clusters?".into(),
                 );
             }
         } else {


### PR DESCRIPTION
"acounts" → "accounts" in genesis_accounts.rs

"aggree" → "agree" in main.rs