### PR TITLE
chore: fix typos in ledger module comments and messages

### DIFF
--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -53,7 +53,7 @@ fn setup_read_bench(
     );
     blockstore
         .insert_shreds(shreds, None, false)
-        .expect("Expectd successful insertion of shreds into ledger");
+        .expect("Expected successful insertion of shreds into ledger");
 }
 
 // Write small shreds to the ledger

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -22,7 +22,7 @@ bitflags! {
         // 1) S is a rooted slot itself OR
         // 2) S's parent is connected AND S is full (S's complete block present)
         //
-        // 1) is a straightfoward case, roots are finalized blocks on the main fork
+        // 1) is a straightforward case, roots are finalized blocks on the main fork
         // so by definition, they are connected. All roots are connected, but not
         // all connected slots are (or will become) roots.
         //
@@ -40,7 +40,7 @@ bitflags! {
         // CONNECTED is explicitly the first bit to ensure backwards compatibility
         // with the boolean field that ConnectedFlags replaced in SlotMeta.
         const CONNECTED        = 0b0000_0001;
-        // PARENT_CONNECTED IS INTENTIIONALLY UNUSED FOR NOW
+        // PARENT_CONNECTED IS INTENTIONALLY UNUSED FOR NOW
         const PARENT_CONNECTED = 0b1000_0000;
     }
 }
@@ -621,7 +621,7 @@ impl SlotMeta {
 
     /// Mark the meta's parent as connected.
     /// If the meta is also full, the meta is now connected as well. Return a
-    /// boolean indicating whether the meta becamed connected from this call.
+    /// boolean indicating whether the meta became connected from this call.
     pub fn set_parent_connected(&mut self) -> bool {
         // Already connected so nothing to do, bail early
         if self.is_connected() {
@@ -1205,7 +1205,7 @@ mod test {
             bincode::serialize(&with_flags).unwrap()
         );
 
-        // Dserializing WithBool into WithFlags succeeds
+        // Deserializing WithBool into WithFlags succeeds
         assert_eq!(
             with_flags,
             bincode::deserialize::<WithFlags>(&bincode::serialize(&with_bool).unwrap()).unwrap()


### PR DESCRIPTION
Corrected several spelling errors to improve clarity:

- "Expectd" → "Expected" in blockstore.rs
- "straightfoward" → "straightforward" in blockstore_meta.rs
- "INTENTIIONALLY" → "INTENTIONALLY`
- "becamed" → "became`
- "Dserializing" → "Deserializing`