### PR TITLE
PohRecorder - sharable tick heights

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -674,6 +674,14 @@ impl PohRecorder {
         self.tick_height.load()
     }
 
+    pub fn shared_tick_height(&self) -> SharedTickHeight {
+        self.tick_height.clone()
+    }
+
+    pub fn shared_leader_first_tick_height(&self) -> SharedLeaderFirstTickHeight {
+        self.leader_first_tick_height.clone()
+    }
+
     pub fn ticks_per_slot(&self) -> u64 {
         self.ticks_per_slot
     }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1011,11 +1011,17 @@ impl SharedWorkingBank {
         self.0.load_full()
     }
 
-    fn store(&self, bank: Arc<Bank>) {
+    // Mutable access not needed for this function.
+    // However we use it to guarantee only used when PohRecorder is
+    // write locked.
+    fn store(&mut self, bank: Arc<Bank>) {
         self.0.store(Some(bank));
     }
 
-    fn clear(&self) {
+    // Mutable access not needed for this function.
+    // However we use it to guarantee only used when PohRecorder is
+    // write locked.
+    fn clear(&mut self) {
         self.0.store(None);
     }
 
@@ -1038,11 +1044,17 @@ impl SharedTickHeight {
         Self(Arc::new(AtomicU64::new(tick_height)))
     }
 
-    fn store(&self, tick_height: u64) {
+    // Mutable access not needed for this function.
+    // However we use it to guarantee only used when PohRecorder is
+    // write locked.
+    fn store(&mut self, tick_height: u64) {
         self.0.store(tick_height, Ordering::Release);
     }
 
-    fn increment(&self) {
+    // Mutable access not needed for this function.
+    // However we use it to guarantee only used when PohRecorder is
+    // write locked.
+    fn increment(&mut self) {
         self.0.fetch_add(1, Ordering::Release);
     }
 }
@@ -1069,7 +1081,10 @@ impl SharedLeaderFirstTickHeight {
         Self(Arc::new(AtomicU64::new(v)))
     }
 
-    fn store(&self, tick_height: Option<u64>) {
+    // Mutable access not needed for this function.
+    // However we use it to guarantee only used when PohRecorder is
+    // write locked.
+    fn store(&mut self, tick_height: Option<u64>) {
         let v = tick_height.unwrap_or(SHARED_LEADER_FIRST_TICK_HEIGHT_NONE);
         self.0.store(v, Ordering::Release);
     }


### PR DESCRIPTION
#### Problem
- Observing tick height requires locking poh
- For leader decision, we currently want to know how far from leader we are.
    - currently this means we lock poh recorder very often 

#### Summary of Changes
- Make `tick_height` and `leader_first_tick_height` into `Arc<AtomicU64>` (flag for None)
- Wrap both in safe interfaces so that things external to PohRecorder cannot modify them

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
