### PR TITLE
Updating test_slot_list_other in prepration for reclaim old slots

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1767,7 +1767,7 @@ mod tests {
     fn test_update_slot_list_other() {
         solana_logger::setup();
         let reclaim = UpsertReclaim::PopulateReclaims;
-        let new_slot = 0;
+        let new_slot = 5;
         let info = 1;
         let other_value = info + 1;
         let at_new_slot = (new_slot, info);
@@ -1817,21 +1817,23 @@ mod tests {
 
         // nothing will exist at this slot
         let missing_other_slot = unique_other_slot + 1;
-        let ignored_slot = 10; // bigger than is used elsewhere in the test
+        let ignored_slot = 1; // less than is used elsewhere in the test
         let ignored_value = info + 10;
 
-        let mut possible_initial_slot_list_contents;
         // build a list of possible contents in the slot_list prior to calling 'update_slot_list'
-        {
-            // up to 3 ignored slot account_info (ignored means not 'new_slot', not 'other_slot', but different slot #s which could exist in the slot_list initially)
-            possible_initial_slot_list_contents = (0..3)
-                .map(|i| (ignored_slot + i, ignored_value + i))
-                .collect::<Vec<_>>();
-            // account_info that already exists in the slot_list AT 'new_slot'
+        let possible_initial_slot_list_contents = {
+            let mut possible_initial_slot_list_contents = Vec::new();
+
+            // Add ignored slot account_info entries (slots with larger slot #s than 'new_slot' or 'other_slot')
+            possible_initial_slot_list_contents
+                .extend((0..3).map(|i| (ignored_slot + i, ignored_value + i)));
+
+            // Add account_info for 'new_slot'
             possible_initial_slot_list_contents.push(at_new_slot);
             // account_info that already exists in the slot_list AT 'other_slot'
             possible_initial_slot_list_contents.push((unique_other_slot, other_value));
-        }
+            possible_initial_slot_list_contents
+        };
 
         /*
          * loop over all possible permutations of 'possible_initial_slot_list_contents'

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1817,7 +1817,7 @@ mod tests {
 
         // nothing will exist at this slot
         let missing_other_slot = unique_other_slot + 1;
-        let ignored_slot = 1; // less than is used elsewhere in the test
+        let ignored_slot = 10; // less than is used elsewhere in the test
         let ignored_value = info + 10;
 
         // build a list of possible contents in the slot_list prior to calling 'update_slot_list'

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1817,7 +1817,7 @@ mod tests {
 
         // nothing will exist at this slot
         let missing_other_slot = unique_other_slot + 1;
-        let ignored_slot = 10; // less than is used elsewhere in the test
+        let ignored_slot = 10; // bigger than is used elsewhere in the test
         let ignored_value = info + 10;
 
         // build a list of possible contents in the slot_list prior to calling 'update_slot_list'

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1830,7 +1830,7 @@ mod tests {
 
             // Add account_info for 'new_slot'
             possible_initial_slot_list_contents.push(at_new_slot);
-            // account_info that already exists in the slot_list AT 'other_slot'
+            // Add account_info for 'other_slot'
             possible_initial_slot_list_contents.push((unique_other_slot, other_value));
             possible_initial_slot_list_contents
         };


### PR DESCRIPTION
#### Problem
Split from https://github.com/anza-xyz/agave/pull/7333
Reclaim Old Slots refactors test_slot_list_other and updates it functionality. Split out the refactor. 

#### Summary of Changes
- Change list creation to make the changes easier to see in the 
- Modify the slot values so older slots can be added to the list

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
