### PR TITLE
Add CacheableIndexValueTest struct for accounts index tests 

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2944,9 +2944,10 @@ pub mod tests {
     }
 
     #[test]
-    fn test_upsert_reclaims( ) {
+    fn test_upsert_reclaims() {
         let key = solana_pubkey::new_rand();
-        let index = AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
+        let index =
+            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
         let mut reclaims = Vec::new();
         index.upsert(
             0,
@@ -3000,8 +3001,6 @@ pub mod tests {
         let entry = index.get_cloned(&key).unwrap();
         let slot_list = entry.slot_list.read().unwrap();
         assert_eq!(slot_list.len(), 1);
-
-
     }
 
     fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T, T>) -> usize {
@@ -3574,14 +3573,15 @@ pub mod tests {
         }
     }
 
-    /// Type that supports caching for tests. Can be used to test the caching
-    /// behaviour of update slot list
+    /// Type that supports caching for tests. Used to test upsert behaviour
+    /// when the slot list has mixed cached and uncached items.
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     struct CacheableIndexValueTest(bool);
     impl IndexValue for CacheableIndexValueTest {}
     impl DiskIndexValue for CacheableIndexValueTest {}
     impl IsCached for CacheableIndexValueTest {
         fn is_cached(&self) -> bool {
+            // Return self value as whether the item is cached or not
             self.0
         }
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2943,6 +2943,67 @@ pub mod tests {
         assert!(found_key);
     }
 
+    #[test]
+    fn test_upsert_reclaims( ) {
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
+        let mut reclaims = Vec::new();
+        index.upsert(
+            0,
+            0,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(true),
+            &mut reclaims,
+            UPSERT_RECLAIM_TEST_DEFAULT,
+        );
+        // No reclaims should be returned on the first item
+        assert!(reclaims.is_empty());
+
+        index.upsert(
+            0,
+            0,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(false),
+            &mut reclaims,
+            UPSERT_RECLAIM_TEST_DEFAULT,
+        );
+        // Cached item should not be reclaimed
+        assert!(reclaims.is_empty());
+
+        // Slot list should only have a single entry
+        // Using brackets to limit scope of read lock
+        {
+            let entry = index.get_cloned(&key).unwrap();
+            let slot_list = entry.slot_list.read().unwrap();
+            assert_eq!(slot_list.len(), 1);
+        }
+
+        index.upsert(
+            0,
+            0,
+            &key,
+            &AccountSharedData::default(),
+            &AccountSecondaryIndexes::default(),
+            CacheableIndexValueTest(false),
+            &mut reclaims,
+            UPSERT_RECLAIM_TEST_DEFAULT,
+        );
+
+        // Uncached item should be returned as reclaim
+        assert!(!reclaims.is_empty());
+
+        // Slot list should only have a single entry
+        let entry = index.get_cloned(&key).unwrap();
+        let slot_list = entry.slot_list.read().unwrap();
+        assert_eq!(slot_list.len(), 1);
+
+
+    }
+
     fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T, T>) -> usize {
         index.storage.storage.stats.total_count()
     }
@@ -3508,6 +3569,23 @@ pub mod tests {
     }
 
     impl IsZeroLamport for u64 {
+        fn is_zero_lamport(&self) -> bool {
+            false
+        }
+    }
+
+    /// Type that supports caching for tests. Can be used to test the caching
+    /// behaviour of update slot list
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+    struct CacheableIndexValueTest(bool);
+    impl IndexValue for CacheableIndexValueTest {}
+    impl DiskIndexValue for CacheableIndexValueTest {}
+    impl IsCached for CacheableIndexValueTest {
+        fn is_cached(&self) -> bool {
+            self.0
+        }
+    }
+    impl IsZeroLamport for CacheableIndexValueTest {
         fn is_zero_lamport(&self) -> bool {
             false
         }


### PR DESCRIPTION
#### Problem
Currently there is no test type in accounts index that supports being both cached and uncached

#### Summary of Changes
- Added new type where the value is whether it is cached or not
- Added basic test to verify behaviour

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
