### PR TITLE
fix: make number formatting in `real_number_string` clearer

### DIFF
--- a/account-decoder-client-types/src/token.rs
+++ b/account-decoder-client-types/src/token.rs
@@ -37,7 +37,7 @@ pub fn real_number_string(amount: u64, decimals: u8) -> String {
     let decimals = decimals as usize;
     if decimals > 0 {
         // Left-pad zeros to decimals + 1, so we at least have an integer zero
-        format!("{:0width$}", amount, width = decimals + 1)
+        format!("{:0width$}", amount, width = decimals + 1);
         // Add the decimal point (Sorry, "," locales!)
         s.insert(s.len() - decimals, '.');
         s

--- a/account-decoder-client-types/src/token.rs
+++ b/account-decoder-client-types/src/token.rs
@@ -37,7 +37,7 @@ pub fn real_number_string(amount: u64, decimals: u8) -> String {
     let decimals = decimals as usize;
     if decimals > 0 {
         // Left-pad zeros to decimals + 1, so we at least have an integer zero
-        let mut s = format!("{:01$}", amount, decimals + 1);
+        format!("{:0width$}", amount, width = decimals + 1)
         // Add the decimal point (Sorry, "," locales!)
         s.insert(s.len() - decimals, '.');
         s


### PR DESCRIPTION
#### Problem


#### Summary of Changes

switched to named width in `format!` for easier reading. no logic changes, just cleaner and more straightforward.
