### PR TITLE
DecisionMaker - lock-free

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -516,7 +516,7 @@ impl BankingStage {
         let (finished_work_sender, finished_work_receiver) = unbounded();
 
         // Spawn the worker threads
-        let decision_maker = DecisionMaker::new(poh_recorder.clone());
+        let decision_maker = DecisionMaker::from(poh_recorder.read().unwrap().deref());
         let mut worker_metrics = Vec::with_capacity(num_workers as usize);
         for (index, work_receiver) in work_receivers.into_iter().enumerate() {
             let id = (index as u32).saturating_add(NUM_VOTE_PROCESSING_THREADS);
@@ -612,7 +612,7 @@ impl BankingStage {
             QosService::new(0),
             log_messages_bytes_limit,
         );
-        let decision_maker = DecisionMaker::new(poh_recorder);
+        let decision_maker = DecisionMaker::from(poh_recorder.read().unwrap().deref());
 
         Builder::new()
             .name("solBanknStgVote".to_string())

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -992,6 +992,7 @@ impl SharedWorkingBank {
     // Mutable access not needed for this function.
     // However we use it to guarantee only used when PohRecorder is
     // write locked.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn store(&mut self, bank: Arc<Bank>) {
         self.0.store(Some(bank));
     }
@@ -999,10 +1000,12 @@ impl SharedWorkingBank {
     // Mutable access not needed for this function.
     // However we use it to guarantee only used when PohRecorder is
     // write locked.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn clear(&mut self) {
         self.0.store(None);
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn empty() -> Self {
         Self(Arc::new(ArcSwapOption::empty()))
     }
@@ -1018,6 +1021,7 @@ impl SharedTickHeight {
         self.0.load(Ordering::Acquire)
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn new(tick_height: u64) -> Self {
         Self(Arc::new(AtomicU64::new(tick_height)))
     }
@@ -1025,6 +1029,7 @@ impl SharedTickHeight {
     // Mutable access not needed for this function.
     // However we use it to guarantee only used when PohRecorder is
     // write locked.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn store(&mut self, tick_height: u64) {
         self.0.store(tick_height, Ordering::Release);
     }
@@ -1032,6 +1037,7 @@ impl SharedTickHeight {
     // Mutable access not needed for this function.
     // However we use it to guarantee only used when PohRecorder is
     // write locked.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn increment(&mut self) {
         self.0.fetch_add(1, Ordering::Release);
     }
@@ -1054,6 +1060,7 @@ impl SharedLeaderFirstTickHeight {
         }
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn new(tick_height: Option<u64>) -> Self {
         let v = tick_height.unwrap_or(SHARED_LEADER_FIRST_TICK_HEIGHT_NONE);
         Self(Arc::new(AtomicU64::new(v)))
@@ -1062,6 +1069,7 @@ impl SharedLeaderFirstTickHeight {
     // Mutable access not needed for this function.
     // However we use it to guarantee only used when PohRecorder is
     // write locked.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn store(&mut self, tick_height: Option<u64>) {
         let v = tick_height.unwrap_or(SHARED_LEADER_FIRST_TICK_HEIGHT_NONE);
         self.0.store(v, Ordering::Release);


### PR DESCRIPTION
#### Problem
- DecisionMaker takes locks on poh_recorder every few ms (cached decision)
- We can make it lock free with #7351, #7355 merged

#### Summary of Changes
- Make `DecisionMaker` lock-free (and `PohRecorder` free!)
- Allow mutation of shared working bank, tick, leader_first_tick for tests
    - allows us to remove PohRecorder from few tests completely. which also means no more blockstore, or temporary directory. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
