### PR TITLE
banking_stage/ Saturating -> Wrapping

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -36,7 +36,7 @@ use {
     solana_time_utils::AtomicInterval,
     std::{
         cmp, env,
-        num::Saturating,
+        num::Wrapping,
         ops::Deref,
         sync::{
             atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -326,20 +326,20 @@ pub struct BatchedTransactionDetails {
 
 #[derive(Debug, Default)]
 pub struct BatchedTransactionCostDetails {
-    pub batched_signature_cost: Saturating<u64>,
-    pub batched_write_lock_cost: Saturating<u64>,
-    pub batched_data_bytes_cost: Saturating<u64>,
-    pub batched_loaded_accounts_data_size_cost: Saturating<u64>,
-    pub batched_programs_execute_cost: Saturating<u64>,
+    pub batched_signature_cost: Wrapping<u64>,
+    pub batched_write_lock_cost: Wrapping<u64>,
+    pub batched_data_bytes_cost: Wrapping<u64>,
+    pub batched_loaded_accounts_data_size_cost: Wrapping<u64>,
+    pub batched_programs_execute_cost: Wrapping<u64>,
 }
 
 #[derive(Debug, Default)]
 pub struct BatchedTransactionErrorDetails {
-    pub batched_retried_txs_per_block_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_vote_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_account_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_account_data_block_limit_count: Saturating<u64>,
-    pub batched_dropped_txs_per_account_data_total_limit_count: Saturating<u64>,
+    pub batched_retried_txs_per_block_limit_count: Wrapping<u64>,
+    pub batched_retried_txs_per_vote_limit_count: Wrapping<u64>,
+    pub batched_retried_txs_per_account_limit_count: Wrapping<u64>,
+    pub batched_retried_txs_per_account_data_block_limit_count: Wrapping<u64>,
+    pub batched_dropped_txs_per_account_data_total_limit_count: Wrapping<u64>,
 }
 
 pub struct BankingStage {

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -21,7 +21,7 @@ use {
         transaction_processing_result::TransactionProcessingResult,
     },
     solana_transaction_error::TransactionError,
-    std::{num::Saturating, sync::Arc},
+    std::{num::Wrapping, sync::Arc},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -136,13 +136,13 @@ impl Committer {
                 .iter()
                 .map(|tx| tx.as_sanitized_transaction().into_owned())
                 .collect_vec();
-            let mut transaction_index = Saturating(starting_transaction_index.unwrap_or_default());
+            let mut transaction_index = Wrapping(starting_transaction_index.unwrap_or_default());
             let (batch_transaction_indexes, tx_costs): (Vec<_>, Vec<_>) = commit_results
                 .iter()
                 .zip(sanitized_transactions.iter())
                 .map(|(commit_result, tx)| {
                     if let Ok(committed_tx) = commit_result {
-                        let Saturating(this_transaction_index) = transaction_index;
+                        let Wrapping(this_transaction_index) = transaction_index;
                         transaction_index += 1;
 
                         let tx_cost = Some(

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -28,7 +28,7 @@ use {
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     solana_transaction_error::TransactionError,
-    std::num::Saturating,
+    std::num::Wrapping,
 };
 
 /// Consumer will create chunks of transactions from buffer with up to this size.
@@ -361,9 +361,7 @@ impl Consumer {
             starting_transaction_index,
         } = record_transactions_summary;
         execute_and_commit_timings.record_transactions_timings = RecordTransactionsTimings {
-            processing_results_to_transactions_us: Saturating(
-                processing_results_to_transactions_us,
-            ),
+            processing_results_to_transactions_us: Wrapping(processing_results_to_transactions_us),
             ..record_transactions_timings
         };
 

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -8,7 +8,7 @@ use {
     solana_clock::Slot,
     solana_runtime::bank::Bank,
     solana_svm::transaction_error_metrics::*,
-    std::{num::Saturating, sync::Arc},
+    std::{num::Wrapping, sync::Arc},
 };
 
 /// A summary of what happened to transactions passed to the processing pipeline.
@@ -50,15 +50,15 @@ pub(crate) struct ProcessTransactionsSummary {
 #[derive(Debug, Default, PartialEq)]
 pub struct CommittedTransactionsCounts {
     /// Total number of transactions that were passed as candidates for processing
-    pub attempted_processing_count: Saturating<u64>,
+    pub attempted_processing_count: Wrapping<u64>,
     /// Total number of transactions that made it into the block
-    pub committed_transactions_count: Saturating<u64>,
+    pub committed_transactions_count: Wrapping<u64>,
     /// Total number of transactions that made it into the block where the transactions
     /// output from processing was success/no error.
-    pub committed_transactions_with_successful_result_count: Saturating<u64>,
+    pub committed_transactions_with_successful_result_count: Wrapping<u64>,
     /// All transactions that were processed but then failed record because the
     /// slot ended
-    pub processed_but_failed_commit: Saturating<u64>,
+    pub processed_but_failed_commit: Wrapping<u64>,
 }
 
 impl CommittedTransactionsCounts {
@@ -110,19 +110,19 @@ struct LeaderSlotPacketCountMetrics {
     // total number of transactions that attempted processing in this slot. Should equal the sum
     // of `committed_transactions_count`, `retryable_errored_transaction_count`, and
     // `nonretryable_errored_transactions_count`.
-    transactions_attempted_processing_count: Saturating<u64>,
+    transactions_attempted_processing_count: Wrapping<u64>,
 
     // total number of transactions that were executed and committed into the block
     // on this thread
-    committed_transactions_count: Saturating<u64>,
+    committed_transactions_count: Wrapping<u64>,
 
     // total number of transactions that were executed, got a successful execution output/no error,
     // and were then committed into the block
-    committed_transactions_with_successful_result_count: Saturating<u64>,
+    committed_transactions_with_successful_result_count: Wrapping<u64>,
 
     // total number of transactions that were not executed or failed commit, BUT were added back to the buffered
     // queue because they were retryable errors
-    retryable_errored_transaction_count: Saturating<u64>,
+    retryable_errored_transaction_count: Wrapping<u64>,
 
     // The size of the unprocessed buffer at the end of the slot
     end_of_slot_unprocessed_buffer_len: u64,
@@ -133,27 +133,27 @@ struct LeaderSlotPacketCountMetrics {
 
     // total number of transactions that attempted execution due to some fatal error (too old, duplicate signature, etc.)
     // AND were dropped from the buffered queue
-    nonretryable_errored_transactions_count: Saturating<u64>,
+    nonretryable_errored_transactions_count: Wrapping<u64>,
 
     // total number of transactions that were executed, but failed to be committed into the Poh stream because
     // the block ended. Some of these may be already counted in `nonretryable_errored_transactions_count` if they
     // then hit the age limit after failing to be committed.
-    executed_transactions_failed_commit_count: Saturating<u64>,
+    executed_transactions_failed_commit_count: Wrapping<u64>,
 
     // total number of transactions that were excluded from the block because there were concurrent write locks active.
     // These transactions are added back to the buffered queue and are already counted in
     // `self.retrayble_errored_transaction_count`.
-    account_lock_throttled_transactions_count: Saturating<u64>,
+    account_lock_throttled_transactions_count: Wrapping<u64>,
 
     // total number of transactions that were excluded from the block because their write
     // account locks exceed the limit.
     // These transactions are not retried.
-    account_locks_limit_throttled_transactions_count: Saturating<u64>,
+    account_locks_limit_throttled_transactions_count: Wrapping<u64>,
 
     // total number of transactions that were excluded from the block because they were too expensive
     // according to the cost model. These transactions are added back to the buffered queue and are
     // already counted in `self.retrayble_errored_transaction_count`.
-    cost_model_throttled_transactions_count: Saturating<u64>,
+    cost_model_throttled_transactions_count: Wrapping<u64>,
 }
 
 impl LeaderSlotPacketCountMetrics {
@@ -172,22 +172,22 @@ impl LeaderSlotPacketCountMetrics {
             newly_buffered_packets_count,
             retryable_packets_filtered_count,
             transactions_attempted_processing_count:
-                Saturating(transactions_attempted_processing_count),
-            committed_transactions_count: Saturating(committed_transactions_count),
+                Wrapping(transactions_attempted_processing_count),
+            committed_transactions_count: Wrapping(committed_transactions_count),
             committed_transactions_with_successful_result_count:
-                Saturating(committed_transactions_with_successful_result_count),
-            retryable_errored_transaction_count: Saturating(retryable_errored_transaction_count),
+                Wrapping(committed_transactions_with_successful_result_count),
+            retryable_errored_transaction_count: Wrapping(retryable_errored_transaction_count),
             retryable_packets_count,
             nonretryable_errored_transactions_count:
-                Saturating(nonretryable_errored_transactions_count),
+                Wrapping(nonretryable_errored_transactions_count),
             executed_transactions_failed_commit_count:
-                Saturating(executed_transactions_failed_commit_count),
+                Wrapping(executed_transactions_failed_commit_count),
             account_lock_throttled_transactions_count:
-                Saturating(account_lock_throttled_transactions_count),
+                Wrapping(account_lock_throttled_transactions_count),
             account_locks_limit_throttled_transactions_count:
-                Saturating(account_locks_limit_throttled_transactions_count),
+                Wrapping(account_locks_limit_throttled_transactions_count),
             cost_model_throttled_transactions_count:
-                Saturating(cost_model_throttled_transactions_count),
+                Wrapping(cost_model_throttled_transactions_count),
             end_of_slot_unprocessed_buffer_len,
         } = self;
         datapoint_info!(
@@ -541,11 +541,11 @@ impl LeaderSlotMetricsTracker {
             let &ProcessTransactionsSummary {
                 transaction_counts:
                     CommittedTransactionsCounts {
-                        attempted_processing_count: Saturating(attempted_processing_count),
-                        committed_transactions_count: Saturating(committed_transactions_count),
+                        attempted_processing_count: Wrapping(attempted_processing_count),
+                        committed_transactions_count: Wrapping(committed_transactions_count),
                         committed_transactions_with_successful_result_count:
-                            Saturating(committed_transactions_with_successful_result_count),
-                        processed_but_failed_commit: Saturating(processed_but_failed_commit),
+                            Wrapping(committed_transactions_with_successful_result_count),
+                        processed_but_failed_commit: Wrapping(processed_but_failed_commit),
                     },
                 ref retryable_transaction_indexes,
                 cost_model_throttled_transactions_count,
@@ -643,11 +643,11 @@ impl LeaderSlotMetricsTracker {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             let metrics = &mut leader_slot_metrics.packet_count_metrics;
             let PacketReceiverStats {
-                passed_sigverify_count: Saturating(passed_sigverify_count),
-                failed_sigverify_count: Saturating(failed_sigverify_count),
-                invalid_vote_count: Saturating(invalid_vote_count),
-                failed_prioritization_count: Saturating(failed_prioritization_count),
-                failed_sanitization_count: Saturating(failed_sanitization_count),
+                passed_sigverify_count: Wrapping(passed_sigverify_count),
+                failed_sigverify_count: Wrapping(failed_sigverify_count),
+                invalid_vote_count: Wrapping(invalid_vote_count),
+                failed_prioritization_count: Wrapping(failed_prioritization_count),
+                failed_sanitization_count: Wrapping(failed_sanitization_count),
             } = stats;
 
             metrics.total_new_valid_packets += passed_sigverify_count;

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -6,7 +6,7 @@ use {
     crossbeam_channel::RecvTimeoutError,
     solana_perf::packet::PacketBatch,
     std::{
-        num::Saturating,
+        num::Wrapping,
         time::{Duration, Instant},
     },
 };
@@ -28,15 +28,15 @@ pub struct PacketDeserializer {
 #[derive(Default, Debug, PartialEq)]
 pub struct PacketReceiverStats {
     /// Number of packets passing sigverify
-    pub passed_sigverify_count: Saturating<u64>,
+    pub passed_sigverify_count: Wrapping<u64>,
     /// Number of packets failing sigverify
-    pub failed_sigverify_count: Saturating<u64>,
+    pub failed_sigverify_count: Wrapping<u64>,
     /// Number of packets dropped due to sanitization error
-    pub failed_sanitization_count: Saturating<u64>,
+    pub failed_sanitization_count: Wrapping<u64>,
     /// Number of packets dropped due to prioritization error
-    pub failed_prioritization_count: Saturating<u64>,
+    pub failed_prioritization_count: Wrapping<u64>,
     /// Number of vote packets dropped
-    pub invalid_vote_count: Saturating<u64>,
+    pub invalid_vote_count: Wrapping<u64>,
 }
 
 impl PacketReceiverStats {
@@ -86,7 +86,7 @@ impl PacketDeserializer {
         banking_batches: &[BankingPacketBatch],
     ) -> ReceivePacketResults {
         let mut packet_stats = PacketReceiverStats::default();
-        let mut errors = Saturating::<usize>(0);
+        let mut errors = Wrapping::<usize>(0);
         let deserialized_packets: Vec<_> = banking_batches
             .iter()
             .flat_map(|banking_batch| banking_batch.iter())
@@ -101,7 +101,7 @@ impl PacketDeserializer {
                 }
             })
             .collect();
-        let Saturating(errors) = errors;
+        let Wrapping(errors) = errors;
         packet_stats.passed_sigverify_count +=
             errors.saturating_add(deserialized_packets.len()) as u64;
         packet_stats.failed_sigverify_count += packet_count
@@ -176,8 +176,8 @@ mod tests {
     fn test_deserialize_and_collect_packets_empty() {
         let results = PacketDeserializer::deserialize_and_collect_packets(0, &[]);
         assert_eq!(results.deserialized_packets.len(), 0);
-        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(0));
-        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(0));
+        assert_eq!(results.packet_stats.passed_sigverify_count, Wrapping(0));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Wrapping(0));
     }
 
     #[test]
@@ -192,8 +192,8 @@ mod tests {
             &[BankingPacketBatch::new(packet_batches)],
         );
         assert_eq!(results.deserialized_packets.len(), 2);
-        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(2));
-        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(0));
+        assert_eq!(results.packet_stats.passed_sigverify_count, Wrapping(2));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Wrapping(0));
     }
 
     #[test]
@@ -213,7 +213,7 @@ mod tests {
             &[BankingPacketBatch::new(packet_batches)],
         );
         assert_eq!(results.deserialized_packets.len(), 1);
-        assert_eq!(results.packet_stats.passed_sigverify_count, Saturating(1));
-        assert_eq!(results.packet_stats.failed_sigverify_count, Saturating(1));
+        assert_eq!(results.packet_stats.passed_sigverify_count, Wrapping(1));
+        assert_eq!(results.packet_stats.failed_sigverify_count, Wrapping(1));
     }
 }

--- a/core/src/banking_stage/packet_receiver.rs
+++ b/core/src/banking_stage/packet_receiver.rs
@@ -10,7 +10,7 @@ use {
     agave_banking_stage_ingress_types::BankingPacketReceiver,
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
-    std::{num::Saturating, sync::atomic::Ordering, time::Duration},
+    std::{num::Wrapping, sync::atomic::Ordering, time::Duration},
 };
 
 pub struct PacketReceiver {
@@ -88,7 +88,7 @@ impl PacketReceiver {
 
         slot_metrics_tracker.increment_received_packet_counts(packet_stats);
 
-        let mut dropped_packets_count = Saturating(0);
+        let mut dropped_packets_count = Wrapping(0);
         let mut newly_buffered_packets_count = 0;
         let mut newly_buffered_forwarded_packets_count = 0;
         Self::push_unprocessed(
@@ -111,7 +111,7 @@ impl PacketReceiver {
             .receive_and_buffer_packets_count
             .fetch_add(packet_count, Ordering::Relaxed);
         {
-            let Saturating(dropped_packets_count) = dropped_packets_count;
+            let Wrapping(dropped_packets_count) = dropped_packets_count;
             vote_source_counts
                 .dropped_packets_count
                 .fetch_add(dropped_packets_count, Ordering::Relaxed);
@@ -128,7 +128,7 @@ impl PacketReceiver {
         vote_storage: &mut VoteStorage,
         vote_source: VoteSource,
         deserialized_packets: Vec<ImmutableDeserializedPacket>,
-        dropped_packets_count: &mut Saturating<usize>,
+        dropped_packets_count: &mut Wrapping<usize>,
         newly_buffered_packets_count: &mut usize,
         newly_buffered_forwarded_packets_count: &mut usize,
         banking_stage_stats: &mut BankingStageStats,

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -18,7 +18,7 @@ use {
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_transaction_error::TransactionError,
     std::{
-        num::Saturating,
+        num::Wrapping,
         sync::atomic::{AtomicU64, Ordering},
     },
 };
@@ -247,25 +247,25 @@ impl QosService {
         let &BatchedTransactionDetails {
             costs:
                 BatchedTransactionCostDetails {
-                    batched_signature_cost: Saturating(batched_signature_cost),
-                    batched_write_lock_cost: Saturating(batched_write_lock_cost),
-                    batched_data_bytes_cost: Saturating(batched_data_bytes_cost),
+                    batched_signature_cost: Wrapping(batched_signature_cost),
+                    batched_write_lock_cost: Wrapping(batched_write_lock_cost),
+                    batched_data_bytes_cost: Wrapping(batched_data_bytes_cost),
                     batched_loaded_accounts_data_size_cost:
-                        Saturating(batched_loaded_accounts_data_size_cost),
-                    batched_programs_execute_cost: Saturating(batched_programs_execute_cost),
+                        Wrapping(batched_loaded_accounts_data_size_cost),
+                    batched_programs_execute_cost: Wrapping(batched_programs_execute_cost),
                 },
             errors:
                 BatchedTransactionErrorDetails {
                     batched_retried_txs_per_block_limit_count:
-                        Saturating(batched_retried_txs_per_block_limit_count),
+                        Wrapping(batched_retried_txs_per_block_limit_count),
                     batched_retried_txs_per_vote_limit_count:
-                        Saturating(batched_retried_txs_per_vote_limit_count),
+                        Wrapping(batched_retried_txs_per_vote_limit_count),
                     batched_retried_txs_per_account_limit_count:
-                        Saturating(batched_retried_txs_per_account_limit_count),
+                        Wrapping(batched_retried_txs_per_account_limit_count),
                     batched_retried_txs_per_account_data_block_limit_count:
-                        Saturating(batched_retried_txs_per_account_data_block_limit_count),
+                        Wrapping(batched_retried_txs_per_account_data_block_limit_count),
                     batched_dropped_txs_per_account_data_total_limit_count:
-                        Saturating(batched_dropped_txs_per_account_data_total_limit_count),
+                        Wrapping(batched_dropped_txs_per_account_data_total_limit_count),
                 },
         } = batched_transaction_details;
         self.metrics
@@ -950,19 +950,19 @@ mod tests {
         let batched_transaction_details =
             QosService::accumulate_batched_transaction_costs(tx_cost_results.iter());
         assert_eq!(
-            Saturating(expected_signatures),
+            Wrapping(expected_signatures),
             batched_transaction_details.costs.batched_signature_cost
         );
         assert_eq!(
-            Saturating(expected_write_locks),
+            Wrapping(expected_write_locks),
             batched_transaction_details.costs.batched_write_lock_cost
         );
         assert_eq!(
-            Saturating(expected_data_bytes),
+            Wrapping(expected_data_bytes),
             batched_transaction_details.costs.batched_data_bytes_cost
         );
         assert_eq!(
-            Saturating(expected_programs_execution_costs),
+            Wrapping(expected_programs_execution_costs),
             batched_transaction_details
                 .costs
                 .batched_programs_execute_cost

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -20,7 +20,7 @@ use {
     crossbeam_channel::{Receiver, Sender},
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    std::num::Saturating,
+    std::num::Wrapping,
 };
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -107,7 +107,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
 
         // Track metrics on filter.
         let mut num_scanned: usize = 0;
-        let mut num_scheduled = Saturating::<usize>(0);
+        let mut num_scheduled = Wrapping::<usize>(0);
         let mut num_sent: usize = 0;
         let mut num_unschedulable_conflicts: usize = 0;
         let mut num_unschedulable_threads: usize = 0;
@@ -206,7 +206,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
 
         self.working_account_set.clear();
         num_sent += self.common.send_batches()?;
-        let Saturating(num_scheduled) = num_scheduled;
+        let Wrapping(num_scheduled) = num_scheduled;
         assert_eq!(
             num_scheduled, num_sent,
             "number of scheduled and sent transactions must match"

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -25,7 +25,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm_transaction::svm_message::SVMMessage,
-    std::num::Saturating,
+    std::num::Wrapping,
 };
 
 #[inline(always)]
@@ -141,8 +141,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         let mut blocking_locks = ReadWriteAccountSet::default();
 
         // Track metrics on filter.
-        let mut num_filtered_out = Saturating::<usize>(0);
-        let mut total_filter_time_us = Saturating::<u64>(0);
+        let mut num_filtered_out = Wrapping::<usize>(0);
+        let mut total_filter_time_us = Wrapping::<u64>(0);
 
         let mut window_budget = self.config.look_ahead_window_size;
         let mut chunked_pops = |container: &mut S,
@@ -205,8 +205,8 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             self.common.consume_work_senders.len() * self.config.target_transactions_per_batch,
         );
         let mut num_scanned: usize = 0;
-        let mut num_scheduled = Saturating::<usize>(0);
-        let mut num_sent = Saturating::<usize>(0);
+        let mut num_scheduled = Wrapping::<usize>(0);
+        let mut num_sent = Wrapping::<usize>(0);
         let mut num_unschedulable_conflicts: usize = 0;
         let mut num_unschedulable_threads: usize = 0;
         while num_scanned < self.config.max_scanned_transactions_per_scheduling_pass {
@@ -326,9 +326,9 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
             "number of scheduled and sent transactions must match"
         );
 
-        let Saturating(num_scheduled) = num_scheduled;
-        let Saturating(num_filtered_out) = num_filtered_out;
-        let Saturating(total_filter_time_us) = total_filter_time_us;
+        let Wrapping(num_scheduled) = num_scheduled;
+        let Wrapping(num_filtered_out) = num_filtered_out;
+        let Wrapping(total_filter_time_us) = total_filter_time_us;
 
         Ok(SchedulingSummary {
             starting_queue_size,

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -39,7 +39,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::{MessageHash, SanitizedTransaction},
     std::{
-        num::Saturating,
+        num::Wrapping,
         sync::{Arc, RwLock},
         time::Instant,
     },
@@ -178,7 +178,7 @@ impl SanitizedTransactionReceiveAndBuffer {
 
         let mut error_counts = TransactionErrorMetrics::default();
         for chunk in packets.chunks(CHUNK_SIZE) {
-            let mut post_sanitization_count = Saturating::<usize>(0);
+            let mut post_sanitization_count = Wrapping::<usize>(0);
             chunk
                 .iter()
                 .filter_map(|packet| {
@@ -220,9 +220,9 @@ impl SanitizedTransactionReceiveAndBuffer {
             );
             let post_lock_validation_count = transactions.len();
 
-            let mut post_transaction_check_count = Saturating::<usize>(0);
-            let mut num_dropped_on_capacity = Saturating::<usize>(0);
-            let mut num_buffered = Saturating::<usize>(0);
+            let mut post_transaction_check_count = Wrapping::<usize>(0);
+            let mut num_dropped_on_capacity = Wrapping::<usize>(0);
+            let mut num_buffered = Wrapping::<usize>(0);
             for (((transaction, max_age), fee_budget_limits), _check_result) in transactions
                 .drain(..)
                 .zip(max_ages.drain(..))
@@ -244,10 +244,10 @@ impl SanitizedTransactionReceiveAndBuffer {
                 num_buffered += 1;
             }
 
-            let Saturating(post_sanitization_count) = post_sanitization_count;
-            let Saturating(post_transaction_check_count) = post_transaction_check_count;
-            let Saturating(num_dropped_on_capacity) = num_dropped_on_capacity;
-            let Saturating(num_buffered) = num_buffered;
+            let Wrapping(post_sanitization_count) = post_sanitization_count;
+            let Wrapping(post_transaction_check_count) = post_transaction_check_count;
+            let Wrapping(num_dropped_on_capacity) = num_dropped_on_capacity;
+            let Wrapping(num_buffered) = num_buffered;
 
             // Update metrics for transactions that were dropped.
             let num_dropped_on_sanitization = chunk.len().saturating_sub(post_sanitization_count);

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -6,7 +6,7 @@ use {
         transaction_state::TransactionState, transaction_state_container::StateContainer,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    std::num::Saturating,
+    std::num::Wrapping,
 };
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -27,8 +27,8 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut impl StateContainer<Tx>,
     ) -> Result<(usize, usize), SchedulerError> {
-        let mut total_num_transactions = Saturating::<usize>(0);
-        let mut total_num_retryable = Saturating::<usize>(0);
+        let mut total_num_transactions = Wrapping::<usize>(0);
+        let mut total_num_retryable = Wrapping::<usize>(0);
         loop {
             let (num_transactions, num_retryable) = self
                 .scheduling_common_mut()
@@ -39,8 +39,8 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
             total_num_transactions += num_transactions;
             total_num_retryable += num_retryable;
         }
-        let Saturating(total_num_transactions) = total_num_transactions;
-        let Saturating(total_num_retryable) = total_num_retryable;
+        let Wrapping(total_num_transactions) = total_num_transactions;
+        let Wrapping(total_num_retryable) = total_num_retryable;
         Ok((total_num_transactions, total_num_retryable))
     }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -20,7 +20,7 @@ use {
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     std::{
-        num::Saturating,
+        num::Wrapping,
         sync::{Arc, RwLock},
     },
 };
@@ -202,7 +202,7 @@ where
     /// Clears the transaction state container.
     /// This only clears pending transactions, and does **not** clear in-flight transactions.
     fn clear_container(&mut self) {
-        let mut num_dropped_on_clear = Saturating::<usize>(0);
+        let mut num_dropped_on_clear = Wrapping::<usize>(0);
         while let Some(id) = self.container.pop() {
             self.container.remove_by_id(id.id);
             num_dropped_on_clear += 1;
@@ -233,7 +233,7 @@ where
 
         const CHUNK_SIZE: usize = 128;
         let mut error_counters = TransactionErrorMetrics::default();
-        let mut num_dropped_on_clean = Saturating::<usize>(0);
+        let mut num_dropped_on_clean = Wrapping::<usize>(0);
         for chunk in transaction_ids.chunks(CHUNK_SIZE) {
             let lock_results = vec![Ok(()); chunk.len()];
             let sanitized_txs: Vec<_> = chunk

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -4,7 +4,7 @@ use {
     solana_clock::Slot,
     solana_time_utils::AtomicInterval,
     std::{
-        num::Saturating,
+        num::Wrapping,
         time::{Duration, Instant},
     },
 };
@@ -49,37 +49,37 @@ struct SlotSchedulerCountMetrics {
 #[derive(Default)]
 pub struct SchedulerCountMetricsInner {
     /// Number of packets received.
-    pub num_received: Saturating<usize>,
+    pub num_received: Wrapping<usize>,
     /// Number of packets buffered.
-    pub num_buffered: Saturating<usize>,
+    pub num_buffered: Wrapping<usize>,
     /// Number of transactions scheduled.
-    pub num_scheduled: Saturating<usize>,
+    pub num_scheduled: Wrapping<usize>,
     /// Number of transactions that were unschedulable due to multiple conflicts.
-    pub num_unschedulable_conflicts: Saturating<usize>,
+    pub num_unschedulable_conflicts: Wrapping<usize>,
     /// Number of transactions that were unschedulable due to thread capacity.
-    pub num_unschedulable_threads: Saturating<usize>,
+    pub num_unschedulable_threads: Wrapping<usize>,
     /// Number of transactions that were filtered out during scheduling.
-    pub num_schedule_filtered_out: Saturating<usize>,
+    pub num_schedule_filtered_out: Wrapping<usize>,
     /// Number of completed transactions received from workers.
-    pub num_finished: Saturating<usize>,
+    pub num_finished: Wrapping<usize>,
     /// Number of transactions that were retryable.
-    pub num_retryable: Saturating<usize>,
+    pub num_retryable: Wrapping<usize>,
 
     /// Number of transactions that were immediately dropped on receive.
-    pub num_dropped_on_receive: Saturating<usize>,
+    pub num_dropped_on_receive: Wrapping<usize>,
     /// Number of transactions that were dropped due to sanitization failure.
-    pub num_dropped_on_sanitization: Saturating<usize>,
+    pub num_dropped_on_sanitization: Wrapping<usize>,
     /// Number of transactions that were dropped due to failed lock validation.
-    pub num_dropped_on_validate_locks: Saturating<usize>,
+    pub num_dropped_on_validate_locks: Wrapping<usize>,
     /// Number of transactions that were dropped due to failed transaction
     /// checks during receive.
-    pub num_dropped_on_receive_transaction_checks: Saturating<usize>,
+    pub num_dropped_on_receive_transaction_checks: Wrapping<usize>,
     /// Number of transactions that were dropped due to clearing.
-    pub num_dropped_on_clear: Saturating<usize>,
+    pub num_dropped_on_clear: Wrapping<usize>,
     /// Number of transactions that were dropped during cleaning.
-    pub num_dropped_on_clean: Saturating<usize>,
+    pub num_dropped_on_clean: Wrapping<usize>,
     /// Number of transactions that were dropped due to exceeded capacity.
-    pub num_dropped_on_capacity: Saturating<usize>,
+    pub num_dropped_on_capacity: Wrapping<usize>,
     /// Min prioritization fees in the transaction container
     pub min_prioritization_fees: u64,
     /// Max prioritization fees in the transaction container
@@ -115,22 +115,22 @@ impl SlotSchedulerCountMetrics {
 impl SchedulerCountMetricsInner {
     fn report(&self, name: &'static str, slot: Option<Slot>) {
         let &Self {
-            num_received: Saturating(num_received),
-            num_buffered: Saturating(num_buffered),
-            num_scheduled: Saturating(num_scheduled),
-            num_unschedulable_conflicts: Saturating(num_unschedulable_conflicts),
-            num_unschedulable_threads: Saturating(num_unschedulable_threads),
-            num_schedule_filtered_out: Saturating(num_schedule_filtered_out),
-            num_finished: Saturating(num_finished),
-            num_retryable: Saturating(num_retryable),
-            num_dropped_on_receive: Saturating(num_dropped_on_receive),
-            num_dropped_on_sanitization: Saturating(num_dropped_on_sanitization),
-            num_dropped_on_validate_locks: Saturating(num_dropped_on_validate_locks),
+            num_received: Wrapping(num_received),
+            num_buffered: Wrapping(num_buffered),
+            num_scheduled: Wrapping(num_scheduled),
+            num_unschedulable_conflicts: Wrapping(num_unschedulable_conflicts),
+            num_unschedulable_threads: Wrapping(num_unschedulable_threads),
+            num_schedule_filtered_out: Wrapping(num_schedule_filtered_out),
+            num_finished: Wrapping(num_finished),
+            num_retryable: Wrapping(num_retryable),
+            num_dropped_on_receive: Wrapping(num_dropped_on_receive),
+            num_dropped_on_sanitization: Wrapping(num_dropped_on_sanitization),
+            num_dropped_on_validate_locks: Wrapping(num_dropped_on_validate_locks),
             num_dropped_on_receive_transaction_checks:
-                Saturating(num_dropped_on_receive_transaction_checks),
-            num_dropped_on_clear: Saturating(num_dropped_on_clear),
-            num_dropped_on_clean: Saturating(num_dropped_on_clean),
-            num_dropped_on_capacity: Saturating(num_dropped_on_capacity),
+                Wrapping(num_dropped_on_receive_transaction_checks),
+            num_dropped_on_clear: Wrapping(num_dropped_on_clear),
+            num_dropped_on_clean: Wrapping(num_dropped_on_clean),
+            num_dropped_on_capacity: Wrapping(num_dropped_on_capacity),
             min_prioritization_fees: _min_prioritization_fees,
             max_prioritization_fees: _max_prioritization_fees,
         } = self;
@@ -181,39 +181,39 @@ impl SchedulerCountMetricsInner {
     }
 
     fn has_data(&self) -> bool {
-        self.num_received != Saturating(0)
-            || self.num_buffered != Saturating(0)
-            || self.num_scheduled != Saturating(0)
-            || self.num_unschedulable_conflicts != Saturating(0)
-            || self.num_unschedulable_threads != Saturating(0)
-            || self.num_schedule_filtered_out != Saturating(0)
-            || self.num_finished != Saturating(0)
-            || self.num_retryable != Saturating(0)
-            || self.num_dropped_on_receive != Saturating(0)
-            || self.num_dropped_on_sanitization != Saturating(0)
-            || self.num_dropped_on_validate_locks != Saturating(0)
-            || self.num_dropped_on_receive_transaction_checks != Saturating(0)
-            || self.num_dropped_on_clear != Saturating(0)
-            || self.num_dropped_on_clean != Saturating(0)
-            || self.num_dropped_on_capacity != Saturating(0)
+        self.num_received != Wrapping(0)
+            || self.num_buffered != Wrapping(0)
+            || self.num_scheduled != Wrapping(0)
+            || self.num_unschedulable_conflicts != Wrapping(0)
+            || self.num_unschedulable_threads != Wrapping(0)
+            || self.num_schedule_filtered_out != Wrapping(0)
+            || self.num_finished != Wrapping(0)
+            || self.num_retryable != Wrapping(0)
+            || self.num_dropped_on_receive != Wrapping(0)
+            || self.num_dropped_on_sanitization != Wrapping(0)
+            || self.num_dropped_on_validate_locks != Wrapping(0)
+            || self.num_dropped_on_receive_transaction_checks != Wrapping(0)
+            || self.num_dropped_on_clear != Wrapping(0)
+            || self.num_dropped_on_clean != Wrapping(0)
+            || self.num_dropped_on_capacity != Wrapping(0)
     }
 
     fn reset(&mut self) {
-        self.num_received = Saturating(0);
-        self.num_buffered = Saturating(0);
-        self.num_scheduled = Saturating(0);
-        self.num_unschedulable_conflicts = Saturating(0);
-        self.num_unschedulable_threads = Saturating(0);
-        self.num_schedule_filtered_out = Saturating(0);
-        self.num_finished = Saturating(0);
-        self.num_retryable = Saturating(0);
-        self.num_dropped_on_receive = Saturating(0);
-        self.num_dropped_on_sanitization = Saturating(0);
-        self.num_dropped_on_validate_locks = Saturating(0);
-        self.num_dropped_on_receive_transaction_checks = Saturating(0);
-        self.num_dropped_on_clear = Saturating(0);
-        self.num_dropped_on_clean = Saturating(0);
-        self.num_dropped_on_capacity = Saturating(0);
+        self.num_received = Wrapping(0);
+        self.num_buffered = Wrapping(0);
+        self.num_scheduled = Wrapping(0);
+        self.num_unschedulable_conflicts = Wrapping(0);
+        self.num_unschedulable_threads = Wrapping(0);
+        self.num_schedule_filtered_out = Wrapping(0);
+        self.num_finished = Wrapping(0);
+        self.num_retryable = Wrapping(0);
+        self.num_dropped_on_receive = Wrapping(0);
+        self.num_dropped_on_sanitization = Wrapping(0);
+        self.num_dropped_on_validate_locks = Wrapping(0);
+        self.num_dropped_on_receive_transaction_checks = Wrapping(0);
+        self.num_dropped_on_clear = Wrapping(0);
+        self.num_dropped_on_clean = Wrapping(0);
+        self.num_dropped_on_capacity = Wrapping(0);
         self.min_prioritization_fees = u64::MAX;
         self.max_prioritization_fees = 0;
     }
@@ -285,21 +285,21 @@ struct SlotSchedulerTimingMetrics {
 #[derive(Default)]
 pub struct SchedulerTimingMetricsInner {
     /// Time spent making processing decisions.
-    pub decision_time_us: Saturating<u64>,
+    pub decision_time_us: Wrapping<u64>,
     /// Time spent receiving packets.
-    pub receive_time_us: Saturating<u64>,
+    pub receive_time_us: Wrapping<u64>,
     /// Time spent buffering packets.
-    pub buffer_time_us: Saturating<u64>,
+    pub buffer_time_us: Wrapping<u64>,
     /// Time spent filtering transactions during scheduling.
-    pub schedule_filter_time_us: Saturating<u64>,
+    pub schedule_filter_time_us: Wrapping<u64>,
     /// Time spent scheduling transactions.
-    pub schedule_time_us: Saturating<u64>,
+    pub schedule_time_us: Wrapping<u64>,
     /// Time spent clearing transactions from the container.
-    pub clear_time_us: Saturating<u64>,
+    pub clear_time_us: Wrapping<u64>,
     /// Time spent cleaning expired or processed transactions from the container.
-    pub clean_time_us: Saturating<u64>,
+    pub clean_time_us: Wrapping<u64>,
     /// Time spent receiving completed transactions.
-    pub receive_completed_time_us: Saturating<u64>,
+    pub receive_completed_time_us: Wrapping<u64>,
 }
 
 impl IntervalSchedulerTimingMetrics {
@@ -331,14 +331,14 @@ impl SlotSchedulerTimingMetrics {
 impl SchedulerTimingMetricsInner {
     fn report(&self, name: &'static str, slot: Option<Slot>) {
         let &Self {
-            decision_time_us: Saturating(decision_time_us),
-            receive_time_us: Saturating(receive_time_us),
-            buffer_time_us: Saturating(buffer_time_us),
-            schedule_filter_time_us: Saturating(schedule_filter_time_us),
-            schedule_time_us: Saturating(schedule_time_us),
-            clear_time_us: Saturating(clear_time_us),
-            clean_time_us: Saturating(clean_time_us),
-            receive_completed_time_us: Saturating(receive_completed_time_us),
+            decision_time_us: Wrapping(decision_time_us),
+            receive_time_us: Wrapping(receive_time_us),
+            buffer_time_us: Wrapping(buffer_time_us),
+            schedule_filter_time_us: Wrapping(schedule_filter_time_us),
+            schedule_time_us: Wrapping(schedule_time_us),
+            clear_time_us: Wrapping(clear_time_us),
+            clean_time_us: Wrapping(clean_time_us),
+            receive_completed_time_us: Wrapping(receive_completed_time_us),
         } = self;
         let mut datapoint = create_datapoint!(
             @point name,
@@ -362,14 +362,14 @@ impl SchedulerTimingMetricsInner {
     }
 
     fn reset(&mut self) {
-        self.decision_time_us = Saturating(0);
-        self.receive_time_us = Saturating(0);
-        self.buffer_time_us = Saturating(0);
-        self.schedule_filter_time_us = Saturating(0);
-        self.schedule_time_us = Saturating(0);
-        self.clear_time_us = Saturating(0);
-        self.clean_time_us = Saturating(0);
-        self.receive_completed_time_us = Saturating(0);
+        self.decision_time_us = Wrapping(0);
+        self.receive_time_us = Wrapping(0);
+        self.buffer_time_us = Wrapping(0);
+        self.schedule_filter_time_us = Wrapping(0);
+        self.schedule_time_us = Wrapping(0);
+        self.clear_time_us = Wrapping(0);
+        self.clean_time_us = Wrapping(0);
+        self.receive_completed_time_us = Wrapping(0);
     }
 }
 

--- a/poh/src/transaction_recorder.rs
+++ b/poh/src/transaction_recorder.rs
@@ -7,7 +7,7 @@ use {
     solana_measure::measure_us,
     solana_transaction::versioned::VersionedTransaction,
     std::{
-        num::Saturating,
+        num::{Saturating, Wrapping},
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
@@ -18,7 +18,7 @@ use {
 
 #[derive(Default, Debug)]
 pub struct RecordTransactionsTimings {
-    pub processing_results_to_transactions_us: Saturating<u64>,
+    pub processing_results_to_transactions_us: Wrapping<u64>,
     pub hash_us: Saturating<u64>,
     pub poh_record_us: Saturating<u64>,
 }


### PR DESCRIPTION
#### Problem
- Saturating u64s isn't gonna happen for counts or microsecond timers
- We're hiding the addition of all these `if`s in our code to handle something that will not ever happen

#### Summary of Changes
- Just use "wrapping" that is guaranteed to not wrap by using basic mathematics:
    - if you are counting at 10GHz, 1 increment per cycle it would still take you 58 years to overflow
    - if you're tracking microseconds, it'd require 584 THOUSAND years
- branch-prediction probably means there's very little cost to doing this, but logically seeing Saturating has been driving me crazy for a long while

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
