### PR TITLE
Configure `cargo-builld-sbf` tests properly with `cargo nextest`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,13 @@
 [store]
 dir = "target/nextest"
 
+[test-groups]
+build-sbf = { max-threads = 1 }
+
+[[profile.default.overides]]
+filter = "package(solana-cargo-build-sbf)"
+test-group = "build-sbf"
+
 [profile.ci]
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }
@@ -31,7 +38,7 @@ threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
 filter = "package(solana-cargo-build-sbf)"
-threads-required = "num-cpus"
+test-group = "build-sbf"
 
 [[profile.ci.overrides]]
 filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_progress$/)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,6 +31,7 @@ threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
 filter = "package(solana-cargo-build-sbf)"
+threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
 filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_progress$/)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.22",
  "semver 1.0.26",
+ "serial_test",
  "solana-file-download",
  "solana-keypair",
  "solana-logger 3.0.0",

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -33,3 +33,4 @@ tar = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
+serial_test = { workspace = true }

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates.rs
@@ -9,6 +9,9 @@ use {
     },
 };
 
+#[macro_use]
+extern crate serial_test;
+
 static SBF_TOOLS_INSTALL: AtomicBool = AtomicBool::new(true);
 fn run_cargo_build(crate_name: &str, extra_args: &[&str], fail: bool) {
     let cwd = env::current_dir().expect("Unable to get current working directory");
@@ -51,11 +54,15 @@ fn clean_target(crate_name: &str) {
     fs::remove_dir_all(target).expect("Failed to remove target dir");
 }
 
+#[test]
+#[serial]
 fn test_build() {
     run_cargo_build("noop", &[], false);
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_dump() {
     // This test requires rustfilt.
     assert_cmd::Command::new("cargo")
@@ -75,6 +82,8 @@ fn test_dump() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_out_dir() {
     run_cargo_build("noop", &["--sbf-out-dir", "tmp_out"], false);
     let cwd = env::current_dir().expect("Unable to get current working directory");
@@ -84,6 +93,8 @@ fn test_out_dir() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_target_dir() {
     let target_dir = "./temp-target-dir";
     run_cargo_build("noop", &["--lto", "--", "--target-dir", target_dir], false);
@@ -98,6 +109,8 @@ fn test_target_dir() {
     fs::remove_dir_all(target_dir).expect("Failed to remove custom target dir");
 }
 
+#[test]
+#[serial]
 fn test_target_and_out_dir() {
     let target_dir = "./temp-target-dir";
     run_cargo_build(
@@ -114,6 +127,8 @@ fn test_target_and_out_dir() {
     fs::remove_dir_all(target_dir).expect("Failed to remove custom target dir");
 }
 
+#[test]
+#[serial]
 fn test_generate_child_script_on_failure() {
     run_cargo_build("fail", &["--generate-child-script-on-failure"], true);
     let cwd = env::current_dir().expect("Unable to get current working directory");
@@ -155,6 +170,8 @@ fn build_noop_and_readelf(arch: &str) -> Assert {
     assert_cmd::Command::new(readelf).args(["-h", bin]).assert()
 }
 
+#[test]
+#[serial]
 fn test_sbpfv0() {
     let assert_v0 = build_noop_and_readelf("v0");
     assert_v0
@@ -165,6 +182,8 @@ fn test_sbpfv0() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_sbpfv1() {
     let assert_v1 = build_noop_and_readelf("v1");
     assert_v1
@@ -175,6 +194,8 @@ fn test_sbpfv1() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_sbpfv2() {
     let assert_v1 = build_noop_and_readelf("v2");
     assert_v1
@@ -185,6 +206,8 @@ fn test_sbpfv2() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_sbpfv3() {
     let assert_v1 = build_noop_and_readelf("v3");
     assert_v1
@@ -195,6 +218,8 @@ fn test_sbpfv3() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_sbpfv4() {
     let assert_v1 = build_noop_and_readelf("v4");
     assert_v1
@@ -205,16 +230,22 @@ fn test_sbpfv4() {
     clean_target("noop");
 }
 
+#[test]
+#[serial]
 fn test_package_metadata_tools_version() {
     run_cargo_build("package-metadata", &[], false);
     clean_target("package-metadata");
 }
 
+#[test]
+#[serial]
 fn test_workspace_metadata_tools_version() {
     run_cargo_build("workspace-metadata", &[], false);
     clean_target("workspace-metadata");
 }
 
+#[test]
+#[serial]
 fn test_corrupted_toolchain() {
     run_cargo_build("noop", &[], false);
 
@@ -274,38 +305,4 @@ fn test_corrupted_toolchain() {
 
     // Revert to the original name, so other tests can run correctly.
     fs::rename(wrong_rust_folder, right_rust_folder).expect("Failed to rename file");
-}
-
-#[test]
-fn cargo_build_sbf_all_tests() {
-    // The cargo-build-sbf tests must download and install the platform tools only once and run
-    // sequentially afterwards.
-    //
-    // The usage of an atomic boolean to prevent multiple tests downloading the tools and the
-    // #[serial] attribute only work when we execute `cargo test`.
-    //
-    // `cargo nextest` used in CI executes each test in a separate process, so the atomic boolean
-    // has no effect, nor does the #[serial] attribute. This causes all tests to download the tools,
-    // locks the toml files, and frequently corrupts the installation. Splitting the repository's
-    // tests in partitions further exacerbates the problem, since the cargo-build-sbf are not even
-    // run in the same machine.
-    //
-    // Creating an omnibus function to execute all tests at once is the simplest solution to that.
-    // It does not use process synchronization to handle the installation, and does not need
-    // any special configuration in nexttest to prevent these tests from being split in partitions.
-
-    test_build();
-    test_dump();
-    test_out_dir();
-    test_target_dir();
-    test_target_and_out_dir();
-    test_generate_child_script_on_failure();
-    test_sbpfv0();
-    test_sbpfv1();
-    test_sbpfv2();
-    test_sbpfv3();
-    test_sbpfv4();
-    test_package_metadata_tools_version();
-    test_workspace_metadata_tools_version();
-    test_corrupted_toolchain();
 }


### PR DESCRIPTION
#### Problem

#7379 introduced a non-stardard way to organize the test in `cargo-build-sbf`, putting together all tests in a single function. That was a stop-gap to solve a race condition in CI that would constantly cause those tests to fail.

#### Summary of Changes

1. Instead of relying on a condition variable to download the platform tools, we'll download them if the archive does not exist or if it is older than 3 minutes. This is to prevent multiple tests from downloading them again in the same CI job.
2. Configure cargo nextest to run the `cargo-build-sbf` tests serially, avoiding race conditions.

PS: I couldn't find a reliable way to force the `cargo-build-sbf` to run in the same partition.