### PR TITLE
Removes unused update_accounts_bench()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7608,14 +7608,4 @@ pub mod test_utils {
             pubkeys.push(pubkey);
         }
     }
-
-    // Only used by bench, not safe to call otherwise accounts can conflict with the
-    // accounts cache!
-    pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64) {
-        for pubkey in pubkeys {
-            let amount = thread_rng().gen_range(0..10);
-            let account = AccountSharedData::new(amount, 0, AccountSharedData::default().owner());
-            accounts.store_cached((slot, &[(pubkey, &account)][..]), None);
-        }
-    }
 }


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. I found one function that calls `store_cached()` that is not used: `update_accounts_bench()`.


#### Summary of Changes

Remove it.