### PR TITLE
replay: handle set-root happening at anytime

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2993,17 +2993,17 @@ impl ReplayStage {
             debug!("bank_slot {bank_slot:?} is marked dead");
             replay_result.is_slot_dead = true;
         } else {
-            let bank = bank_forks
-                .read()
-                .unwrap()
-                .get_with_scheduler(bank_slot)
-                .unwrap();
+            let Some(bank) = bank_forks.read().unwrap().get_with_scheduler(bank_slot) else {
+                info!("Abandoning replay of unrooted slot {bank_slot}");
+                return replay_result;
+            };
             let parent_slot = bank.parent_slot();
             let prev_leader_slot = progress.get_bank_prev_leader_slot(&bank);
             let (num_blocks_on_fork, num_dropped_blocks_on_fork) = {
-                let stats = progress
-                    .get(&parent_slot)
-                    .expect("parent of active bank must exist in progress map");
+                let Some(stats) = progress.get(&parent_slot) else {
+                    info!("Abandoning replay of unrooted slot {bank_slot}");
+                    return replay_result;
+                };
                 let num_blocks_on_fork = stats.num_blocks_on_fork + 1;
                 let new_dropped_blocks = bank.slot() - parent_slot - 1;
                 let num_dropped_blocks_on_fork =
@@ -3079,11 +3079,10 @@ impl ReplayStage {
             }
 
             let bank_slot = replay_result.bank_slot;
-            let bank = &bank_forks
-                .read()
-                .unwrap()
-                .get_with_scheduler(bank_slot)
-                .unwrap();
+            let Some(bank) = &bank_forks.read().unwrap().get_with_scheduler(bank_slot) else {
+                info!("Abandoning replay of unrooted slot {bank_slot}");
+                continue;
+            };
             if let Some(replay_result) = &replay_result.replay_result {
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
@@ -4219,7 +4218,14 @@ impl ReplayStage {
         let mut generate_new_bank_forks_write_lock =
             Measure::start("generate_new_bank_forks_write_lock");
         let mut forks = bank_forks.write().unwrap();
-        for (_, bank) in new_banks {
+        let root = forks.root();
+        for (slot, bank) in new_banks {
+            if slot < root {
+                continue;
+            }
+            if forks.get(bank.parent_slot()).is_none() {
+                continue;
+            }
             forks.insert(bank);
         }
         generate_new_bank_forks_write_lock.stop();


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/153

Setting root can happen at any time as replay will no longer be responsible for it if the feature flag is active, we need to be able to support this.