### PR TITLE
replay: do not grab bank forks write lock if no banks to insert

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4200,16 +4200,18 @@ impl ReplayStage {
 
         let mut generate_new_bank_forks_write_lock =
             Measure::start("generate_new_bank_forks_write_lock");
-        let mut forks = bank_forks.write().unwrap();
-        let root = forks.root();
-        for (slot, bank) in new_banks {
-            if slot < root {
-                continue;
+        if !new_banks.is_empty() {
+            let mut forks = bank_forks.write().unwrap();
+            let root = forks.root();
+            for (slot, bank) in new_banks {
+                if slot < root {
+                    continue;
+                }
+                if forks.get(bank.parent_slot()).is_none() {
+                    continue;
+                }
+                forks.insert(bank);
             }
-            if forks.get(bank.parent_slot()).is_none() {
-                continue;
-            }
-            forks.insert(bank);
         }
         generate_new_bank_forks_write_lock.stop();
         replay_timing.generate_new_bank_forks_read_lock_us +=


### PR DESCRIPTION
Upstreaming https://github.com/anza-xyz/alpenglow/pull/226

No need to grab the write locks if there are no banks to insert. Allow for root to change while inserting as well