### PR TITLE
Fix the usage of old platform tools version

### DIFF
--- a/platform-tools-sdk/cargo-build-sbf/src/main.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/main.rs
@@ -7,9 +7,9 @@ use {
         post_processing::post_process,
         toolchain::{
             corrupted_toolchain, generate_toolchain_name, get_base_rust_version, install_tools,
-            DEFAULT_PLATFORM_TOOLS_VERSION,
+            rust_target_triple, DEFAULT_PLATFORM_TOOLS_VERSION,
         },
-        utils::{rust_target_triple, spawn},
+        utils::spawn,
     },
     cargo_metadata::camino::Utf8PathBuf,
     clap::{crate_description, crate_name, crate_version, Arg},
@@ -118,22 +118,6 @@ fn home_dir() -> PathBuf {
                 exit(1);
             }),
     )
-}
-
-fn semver_version(version: &str) -> String {
-    let starts_with_v = version.starts_with('v');
-    let dots = version.as_bytes().iter().fold(
-        0,
-        |n: u32, c| if *c == b'.' { n.saturating_add(1) } else { n },
-    );
-    match (dots, starts_with_v) {
-        (0, false) => format!("{version}.0.0"),
-        (0, true) => format!("{}.0.0", &version[1..]),
-        (1, false) => format!("{version}.0"),
-        (1, true) => format!("{}.0", &version[1..]),
-        (_, false) => version.to_string(),
-        (_, true) => version[1..].to_string(),
-    }
 }
 
 fn prepare_environment(

--- a/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/post_processing.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{spawn, utils::rust_target_triple, Config},
+    crate::{spawn, toolchain::rust_target_triple, Config},
     log::{debug, error, info, warn},
     regex::Regex,
     solana_keypair::{write_keypair_file, Keypair},

--- a/platform-tools-sdk/cargo-build-sbf/src/utils.rs
+++ b/platform-tools-sdk/cargo-build-sbf/src/utils.rs
@@ -1,5 +1,4 @@
 use {
-    crate::Config,
     itertools::Itertools,
     log::{error, info},
     std::{
@@ -60,12 +59,4 @@ where
         .iter()
         .map(|&c| c as char)
         .collect::<String>()
-}
-
-pub(crate) fn rust_target_triple(config: &Config) -> String {
-    if config.arch == "v0" {
-        "sbpf-solana-solana".to_string()
-    } else {
-        format!("sbpf{}-solana-solana", config.arch)
-    }
 }


### PR DESCRIPTION
#### Problem

Platform tools versions older than v1.44 do not support the sbpf target, so the current version of `cargo-build-sbf` does not work with them.

#### Summary of Changes

Fix the target name generation to branch when the tools version is older than v1.44.
