### PR TITLE
Add sub function to store_accounts_frozen

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6238,7 +6238,7 @@ impl AccountsDb {
         storage: &Arc<AccountStorageEntry>,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) -> StoreAccountsTiming {
-        self.store_accounts_to_storage(
+        self._store_accounts_frozen(
             accounts,
             storage,
             UpsertReclaim::IgnoreReclaims,
@@ -6249,7 +6249,7 @@ impl AccountsDb {
     /// Stores accounts in the storage and updates the index.
     /// This function is intended for accounts that are rooted (frozen).
     /// - `UpsertReclaims` must be set to `IgnoreReclaims` at this time
-    fn store_accounts_to_storage<'a>(
+    fn _store_accounts_frozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
         storage: &Arc<AccountStorageEntry>,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6231,7 +6231,7 @@ impl AccountsDb {
     /// This function is intended for accounts that are rooted (frozen).
     /// - `UpsertReclaims` is set to `IgnoreReclaims`. If the slot in `accounts` differs from the new slot,
     ///   accounts may be removed from the account index. In such cases, the caller must ensure that alive
-    ///   accounts are decremented for the older storage or that the old storage is freed entirely
+    ///   accounts are decremented for the older storage or that the old storage is removed entirely
     pub fn store_accounts_frozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6248,8 +6248,7 @@ impl AccountsDb {
 
     /// Stores accounts in the storage and updates the index.
     /// This function is intended for accounts that are rooted (frozen).
-    /// - `UpsertReclaims` should be set to `IgnoreReclaims` at this time.
-    ///   Other values are experimental and may not work as expected.
+    /// - `UpsertReclaims` must be set to `IgnoreReclaims` at this time
     fn store_accounts_to_storage<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
@@ -6259,6 +6258,9 @@ impl AccountsDb {
     ) -> StoreAccountsTiming {
         let slot = accounts.target_slot();
         let mut store_accounts_time = Measure::start("store_accounts");
+
+        // Other values for UpsertReclaim are not supported yet
+        assert_eq!(reclaim_handling, UpsertReclaim::IgnoreReclaims);
 
         // Flush the read cache if necessary. This will occur during shrink or clean
         if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {


### PR DESCRIPTION
#### Problem
Obsolete Accounts will need to call store_accounts_frozen with a configurable UpsertReclaim value

#### Summary of Changes
- Create sub function store_accounts_to_storage that takes a parameter for UpsertReclaims
- Call sub function from store_accounts_frozen

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
