### PR TITLE
fix: correct typos and improve comments in accounts-db module

### DIFF
--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -38,7 +38,7 @@ fn create_test_transactions(lock_count: usize, read_conflicts: bool) -> Vec<Sani
         #[allow(clippy::needless_range_loop)]
         for i in 0..lock_count {
             // `lock_accounts()` distinguishes writable from readonly, so give transactions an even split
-            // signer doesnt matter for locking but `sanitize()` expects to see at least one
+            // signer doesn't matter for locking but `sanitize()` expects to see at least one
             let account_meta = if i == 0 {
                 AccountMeta::new(Pubkey::new_unique(), true)
             } else if i % 2 == 0 {

--- a/accounts-db/src/io_uring/file_creator.rs
+++ b/accounts-db/src/io_uring/file_creator.rs
@@ -154,7 +154,7 @@ impl<B> FileCreator for IoUringFileCreator<'_, B> {
 }
 
 impl<B> IoUringFileCreator<'_, B> {
-    /// Schedule opening file at `path` with `mode` permissons.
+    /// Schedule opening file at `path` with `mode` permissions.
     ///
     /// Returns key that can be used for scheduling writes for it.
     fn open(

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1226,12 +1226,12 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "would exceed accounts blocks offset boundary")]
-    fn test_get_acount_meta_from_offset_out_of_bounds() {
+    fn test_get_account_meta_from_offset_out_of_bounds() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir
             .path()
-            .join("test_get_acount_meta_from_offset_out_of_bounds");
+            .join("test_get_account_meta_from_offset_out_of_bounds");
 
         let footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -27,7 +27,7 @@ const _: () = assert!(std::mem::size_of::<AccountMetaFlags>() == 4);
 /// A trait that allows different implementations of the account meta that
 /// support different tiers of the accounts storage.
 pub trait TieredAccountMeta: Sized {
-    /// Constructs a TieredAcountMeta instance.
+    /// Constructs a TieredAccountMeta instance.
     fn new() -> Self;
 
     /// A builder function that initializes lamports.


### PR DESCRIPTION
Fixed typos in comments across multiple files:

acount → account

permissons → permissions

signer doesnt → signer doesn't