### PR TITLE
fix: update broken documentation redirects in publish-docs.sh

### DIFF
--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -106,7 +106,7 @@ cat > "$CONFIG_FILE" <<EOF
     { "destination": "https://solana.com/docs/core/cpi", "source": "/developing/programming-model/calling-between-programs" },
     { "destination": "https://solana.com/docs/core/runtime", "source": "/developing/programming-model/runtime" },
     { "destination": "https://solana.com/docs/core/transactions", "source": "/developing/programming-model/transactions" },
-    { "destination": "https://solana.com/docs/core/transactions/fees", "source": "/developing/intro/transaction_fees" },
+    { "destination": "https://solana.com/docs/core/fees", "source": "/developing/intro/transaction_fees" },
     { "destination": "https://solana.com/docs/core/transactions/confirmation", "source": "/developing/transaction_confirmation" },
     { "destination": "https://solana.com/docs/core/transactions/versions", "source": "/developing/versioned-transactions" },
     { "destination": "https://solana.com/docs/core/transactions/retry", "source": "/integrations/retrying-transactions" },
@@ -121,7 +121,7 @@ cat > "$CONFIG_FILE" <<EOF
     { "destination": "https://solana.com/docs/programs/examples", "source": "/developing/on-chain-programs/examples" },
     { "destination": "https://solana.com/docs/programs/faq", "source": "/developing/on-chain-programs/faq" },
     { "destination": "https://solana.com/docs/programs/limitations", "source": "/developing/on-chain-programs/limitations" },
-    { "destination": "https://solana.com/docs/programs/lang-rust", "source": "/developing/on-chain-programs/developing-rust" },
+    { "destination": "https://solana.com/docs/programs/rust", "source": "/developing/on-chain-programs/developing-rust" },
     { "destination": "https://solana.com/docs/programs/lang-c", "source": "/developing/on-chain-programs/developing-c" },
     { "destination": "https://solana.com/docs/clients/javascript-reference", "source": "/developing/clients/javascript-reference" },
     { "destination": "https://solana.com/docs/clients/javascript", "source": "/developing/clients/javascript-api" },
@@ -141,7 +141,7 @@ cat > "$CONFIG_FILE" <<EOF
     { "destination": "https://solana.com/docs/intro/history", "source": "/history" },
     { "destination": "https://solana.com/docs/intro/wallets", "source": "/wallet-guide/support" },
     { "destination": "https://solana.com/docs/intro/wallets", "source": "/wallet-guide" },
-    { "destination": "https://solana.com/docs/intro", "source": "/introduction" }
+    { "destination": "https://solana.com/docs", "source": "/introduction" }
   ]
 }
 EOF


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Update redirect URLs to fix broken links found in documentation:
- Fix transaction fees redirect: docs/core/transactions/fees → docs/core/fees
- Fix Rust programs redirect: docs/programs/lang-rust → docs/programs/rust
- Fix introduction page redirect: docs/intro → docs (main documentation page)

