### PR TITLE
Refactor - `last_modification_slot` in `ProgramCache`

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -337,7 +337,7 @@ impl Consumer {
                 &mut error_counters,
                 TransactionProcessingConfig {
                     account_overrides: None,
-                    check_program_modification_slot: bank.check_program_modification_slot(),
+                    check_program_deployment_slot: bank.check_program_deployment_slot(),
                     log_messages_bytes_limit: self.log_messages_bytes_limit,
                     limit_to_load_programs: true,
                     recording_config: ExecutionRecordingConfig::new_single_setting(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1193,6 +1193,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     pub fn merge(
         &mut self,
         program_runtime_environments: &ProgramRuntimeEnvironments,
+        _current_slot: Slot,
         modified_entries: &HashMap<Pubkey, Arc<ProgramCacheEntry>>,
     ) {
         modified_entries.iter().for_each(|(key, entry)| {
@@ -1470,12 +1471,12 @@ mod tests {
     fn set_tombstone<FG: ForkGraph>(
         cache: &mut ProgramCache<FG>,
         key: Pubkey,
-        slot: Slot,
+        current_slot: Slot,
         reason: ProgramCacheEntryType,
     ) -> Arc<ProgramCacheEntry> {
         let envs = get_mock_envs();
         let program = Arc::new(ProgramCacheEntry::new_tombstone(
-            slot,
+            current_slot,
             ProgramCacheEntryOwner::LoaderV2,
             reason,
         ));
@@ -1486,10 +1487,14 @@ mod tests {
     fn insert_unloaded_entry<FG: ForkGraph>(
         cache: &mut ProgramCache<FG>,
         key: Pubkey,
-        slot: Slot,
+        current_slot: Slot,
     ) -> Arc<ProgramCacheEntry> {
         let envs = get_mock_envs();
-        let loaded = new_test_entry_with_usage(slot, slot.saturating_add(1), AtomicU64::default());
+        let loaded = new_test_entry_with_usage(
+            current_slot,
+            current_slot.saturating_add(1),
+            AtomicU64::default(),
+        );
         let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
         cache.assign_program(&envs, key, unloaded.clone());
         unloaded

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1226,7 +1226,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         .filter_map(move |program| match program.program {
                             ProgramCacheEntryType::Loaded(_) => {
                                 if include_program_runtime_v1 {
-                                    Some((*id, program.deployment_slot, program.clone()))
+                                    Some((*id, 0, program.clone()))
                                 } else {
                                     None
                                 }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1155,8 +1155,9 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     pub fn finish_cooperative_loading_task(
         &mut self,
         program_runtime_environments: &ProgramRuntimeEnvironments,
-        slot: Slot,
+        current_slot: Slot,
         key: Pubkey,
+        _last_modification_slot: Slot,
         loaded_program: Arc<ProgramCacheEntry>,
     ) -> bool {
         match &mut self.index {
@@ -1164,7 +1165,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 loading_entries, ..
             } => {
                 let loading_thread = loading_entries.get_mut().unwrap().remove(&key);
-                debug_assert_eq!(loading_thread, Some((slot, thread::current().id())));
+                debug_assert_eq!(loading_thread, Some((current_slot, thread::current().id())));
                 // Check that it will be visible to our own fork once inserted
                 if loaded_program.deployment_slot > self.latest_root_slot
                     && !matches!(
@@ -1175,7 +1176,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             .unwrap()
                             .read()
                             .unwrap()
-                            .relationship(loaded_program.deployment_slot, slot),
+                            .relationship(loaded_program.deployment_slot, current_slot),
                         BlockRelation::Equal | BlockRelation::Ancestor
                     )
                 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1528,7 +1528,7 @@ impl Bank {
             {
                 drop(epoch_boundary_preparation);
                 drop(program_cache);
-                if let Some(recompiled) = load_program_with_pubkey(
+                if let Some((recompiled, _last_modification_slot)) = load_program_with_pubkey(
                     self,
                     &upcoming_environments,
                     &key,
@@ -6093,6 +6093,7 @@ impl Bank {
             &mut ExecuteTimings::default(), // Called by ledger-tool, metrics not accumulated.
             reload,
         )
+        .map(|(loaded_program, _last_modification_slot)| loaded_program)
     }
 
     pub fn withdraw(&self, pubkey: &Pubkey, lamports: u64) -> Result<()> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3726,6 +3726,7 @@ impl Bank {
                             })
                             .merge(
                                 &self.transaction_processor.environments,
+                                self.slot,
                                 programs_modified_by_tx,
                             );
                     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -569,7 +569,7 @@ impl PartialEq for Bank {
             accounts_data_size_delta_off_chain: _,
             epoch_reward_status: _,
             transaction_processor: _,
-            check_program_modification_slot: _,
+            check_program_deployment_slot: _,
             collector_fee_details: _,
             compute_budget: _,
             transaction_account_lock_limit: _,
@@ -878,7 +878,7 @@ pub struct Bank {
 
     transaction_processor: TransactionBatchProcessor<BankForks>,
 
-    check_program_modification_slot: bool,
+    check_program_deployment_slot: bool,
 
     /// Collected fee details
     collector_fee_details: RwLock<CollectorFeeDetails>,
@@ -1117,7 +1117,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
-            check_program_modification_slot: false,
+            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: None,
             transaction_account_lock_limit: None,
@@ -1364,7 +1364,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: parent.epoch_reward_status.clone(),
             transaction_processor,
-            check_program_modification_slot: false,
+            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: parent.compute_budget,
             transaction_account_lock_limit: parent.transaction_account_lock_limit,
@@ -1893,7 +1893,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
-            check_program_modification_slot: false,
+            check_program_deployment_slot: false,
             // collector_fee_details is not serialized to snapshot
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: runtime_config.compute_budget,
@@ -3189,7 +3189,7 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: Some(&account_overrides),
-                check_program_modification_slot: self.check_program_modification_slot,
+                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit: None,
                 limit_to_load_programs: true,
                 recording_config: ExecutionRecordingConfig {
@@ -3931,7 +3931,7 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: None,
-                check_program_modification_slot: self.check_program_modification_slot,
+                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
@@ -5739,12 +5739,12 @@ impl Bank {
         false
     }
 
-    pub fn check_program_modification_slot(&self) -> bool {
-        self.check_program_modification_slot
+    pub fn check_program_deployment_slot(&self) -> bool {
+        self.check_program_deployment_slot
     }
 
-    pub fn set_check_program_modification_slot(&mut self, check: bool) {
-        self.check_program_modification_slot = check;
+    pub fn set_check_program_deployment_slot(&mut self, check: bool) {
+        self.check_program_deployment_slot = check;
     }
 
     pub fn fee_structure(&self) -> &FeeStructure {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1528,7 +1528,7 @@ impl Bank {
             {
                 drop(epoch_boundary_preparation);
                 drop(program_cache);
-                if let Some((recompiled, _last_modification_slot)) = load_program_with_pubkey(
+                if let Some((recompiled, last_modification_slot)) = load_program_with_pubkey(
                     self,
                     &upcoming_environments,
                     &key,
@@ -1547,7 +1547,12 @@ impl Bank {
                         .global_program_cache
                         .write()
                         .unwrap();
-                    program_cache.assign_program(&upcoming_environments, key, recompiled);
+                    program_cache.assign_program(
+                        &upcoming_environments,
+                        key,
+                        last_modification_slot,
+                        recompiled,
+                    );
                 }
             }
         } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1573,7 +1573,10 @@ impl Bank {
             epoch_boundary_preparation.upcoming_epoch = self.epoch.saturating_add(1);
             epoch_boundary_preparation.upcoming_environments = Some(upcoming_environments);
             epoch_boundary_preparation.programs_to_recompile = program_cache
-                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
+                .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2)
+                .into_iter()
+                .map(|(id, _last_modification_slot, entry)| (id, entry))
+                .collect();
             epoch_boundary_preparation
                 .programs_to_recompile
                 .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(self.slot));

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -206,6 +206,7 @@ impl Bank {
             .unwrap()
             .merge(
                 &self.transaction_processor.environments,
+                self.slot,
                 &program_cache_for_tx_batch.drain_modified_entries(),
             );
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -719,8 +719,10 @@ pub(crate) mod tests {
             let entries = program_cache.get_flattened_entries(true, true);
             let target_entry = entries
                 .iter()
-                .find(|(program_id, _)| program_id == &self.target_program_address)
-                .map(|(_, entry)| entry)
+                .find(|(program_id, _last_modification_slot, _entry)| {
+                    program_id == &self.target_program_address
+                })
+                .map(|(_program_id, _last_modification_slot, entry)| entry)
                 .unwrap();
 
             // The target program entry should be updated.

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -2149,6 +2149,7 @@ pub(crate) mod tests {
         program_cache.assign_program(
             &roundtrip_bank.transaction_processor.environments,
             bpf_loader_v2_program_address,
+            upgrade_slot,
             entry,
         );
         // Release the lock on the program cache.

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -285,7 +285,7 @@ impl BankForks {
         mut bank: Bank,
     ) -> BankWithScheduler {
         if self.root.load(Ordering::Relaxed) < self.highest_slot_at_startup {
-            bank.set_check_program_modification_slot(true);
+            bank.set_check_program_deployment_slot(true);
         }
 
         let bank = Arc::new(bank);

--- a/svm-test-harness/instr/src/program_cache.rs
+++ b/svm-test-harness/instr/src/program_cache.rs
@@ -119,14 +119,16 @@ pub fn fill_from_accounts(
                 epoch_schedule: &EpochSchedule,
                 reload: bool,
             ) -> Option<Arc<ProgramCacheEntry>> { */
-            if let Some(loaded_program) = solana_svm::program_loader::load_program_with_pubkey(
-                &FillFromAccountsCallback(accounts),
-                environments,
-                &acc.0,
-                slot,
-                &mut ExecuteTimings::default(),
-                false,
-            ) {
+            if let Some((loaded_program, _last_modification_slot)) =
+                solana_svm::program_loader::load_program_with_pubkey(
+                    &FillFromAccountsCallback(accounts),
+                    environments,
+                    &acc.0,
+                    slot,
+                    &mut ExecuteTimings::default(),
+                    false,
+                )
+            {
                 program_cache.replenish(acc.0, loaded_program);
             }
         }

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -183,8 +183,8 @@ the transaction processor.
 - `account_overrides`: Encapsulates overridden accounts, typically used for
   transaction simulation.
 - `compute_budget`: The compute budget to use for transaction execution.
-- `check_program_modification_slot`: Whether or not to check a program's
-  modification slot when replenishing a program cache instance.
+- `check_program_deployment_slot`: Whether or not to check a program's
+  deployment slot when replenishing a program cache instance.
 - `log_messages_bytes_limit`: The maximum number of bytes that log messages can
   consume.
 - `limit_to_load_programs`: Whether to limit the number of programs loaded for

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -283,17 +283,14 @@ mod tests {
 
     #[derive(Default, Clone)]
     pub(crate) struct MockBankCallback {
-        pub(crate) account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
+        pub(crate) account_shared_data: RefCell<HashMap<Pubkey, (AccountSharedData, Slot)>>,
     }
 
     impl InvokeContextCallback for MockBankCallback {}
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
-            self.account_shared_data
-                .borrow()
-                .get(pubkey)
-                .map(|account| (account.clone(), 0))
+            self.account_shared_data.borrow().get(pubkey).cloned()
         }
     }
 
@@ -314,7 +311,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_accounts(&mock_bank, &key);
         assert!(matches!(
@@ -326,7 +323,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data);
+            .insert(key, (account_data, 0));
 
         let result = load_program_accounts(&mock_bank, &key);
 
@@ -345,7 +342,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_accounts(&mock_bank, &key);
         assert!(matches!(
@@ -357,7 +354,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
         let result = load_program_accounts(&mock_bank, &key);
         assert!(matches!(
             result,
@@ -378,14 +375,14 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 25));
 
         let result = load_program_accounts(&mock_bank, &key);
 
         match result {
-            Some(ProgramAccountLoadResult::ProgramOfLoaderV4(data, slot)) => {
+            Some(ProgramAccountLoadResult::ProgramOfLoaderV4(data, deployment_slot)) => {
                 assert_eq!(data, account_data);
-                assert_eq!(slot, 25);
+                assert_eq!(deployment_slot, 25);
             }
 
             _ => panic!("Invalid result"),
@@ -401,7 +398,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_accounts(&mock_bank, &key);
         match result {
@@ -429,7 +426,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key1, account_data.clone());
+            .insert(key1, (account_data.clone(), 25));
 
         let state = UpgradeableLoaderState::ProgramData {
             slot: 25,
@@ -440,15 +437,15 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, account_data2.clone());
+            .insert(key2, (account_data2.clone(), 25));
 
         let result = load_program_accounts(&mock_bank, &key1);
 
         match result {
-            Some(ProgramAccountLoadResult::ProgramOfLoaderV3(data1, data2, slot)) => {
+            Some(ProgramAccountLoadResult::ProgramOfLoaderV3(data1, data2, deployment_slot)) => {
                 assert_eq!(data1, account_data);
                 assert_eq!(data2, account_data2);
-                assert_eq!(slot, 25);
+                assert_eq!(deployment_slot, 25);
             }
 
             _ => panic!("Invalid result"),
@@ -530,7 +527,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_with_pubkey(
             &mock_bank,
@@ -563,7 +560,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         // This should return an error
         let result = load_program_with_pubkey(
@@ -591,7 +588,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_with_pubkey(
             &mock_bank,
@@ -633,7 +630,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key1, account_data.clone());
+            .insert(key1, (account_data.clone(), 0));
 
         let state = UpgradeableLoaderState::ProgramData {
             slot: 0,
@@ -644,7 +641,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, account_data2.clone());
+            .insert(key2, (account_data2.clone(), 0));
 
         // This should return an error
         let result = load_program_with_pubkey(
@@ -682,7 +679,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, account_data.clone());
+            .insert(key2, (account_data.clone(), 0));
 
         let result = load_program_with_pubkey(
             &mock_bank,
@@ -732,7 +729,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_with_pubkey(
             &mock_bank,
@@ -765,7 +762,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = load_program_with_pubkey(
             &mock_bank,
@@ -781,7 +778,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let environments = ProgramRuntimeEnvironments::default();
         let expected = load_program_from_bytes(
@@ -814,7 +811,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
@@ -856,7 +853,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = get_program_modification_slot(&mock_bank, &key);
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
@@ -868,7 +865,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data.clone());
+            .insert(key, (account_data.clone(), 0));
 
         let result = get_program_modification_slot(&mock_bank, &key);
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
@@ -877,7 +874,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, account_data);
+            .insert(key, (account_data, 0));
 
         let result = get_program_modification_slot(&mock_bank, &key);
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
@@ -901,7 +898,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key1, account_data);
+            .insert(key1, (account_data, 0));
 
         let account_data = AccountSharedData::new_data(
             100,
@@ -915,7 +912,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, account_data);
+            .insert(key2, (account_data, 0));
 
         let result = get_program_modification_slot(&mock_bank, &key1);
         assert_eq!(result.unwrap(), 77);
@@ -935,7 +932,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key1, account_data.clone());
+            .insert(key1, (account_data.clone(), 0));
 
         let result = get_program_modification_slot(&mock_bank, &key1);
         assert_eq!(result.unwrap(), 58);
@@ -944,7 +941,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, account_data);
+            .insert(key2, (account_data, 0));
 
         let result = get_program_modification_slot(&mock_bank, &key2);
         assert_eq!(result.unwrap(), 0);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -472,8 +472,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     true => Err(fees_only_tx.load_error),
                     false => {
                         // Update loaded accounts cache with nonce and fee-payer
-                        account_loader
-                            .update_accounts_for_failed_tx(&fees_only_tx.rollback_accounts);
+                        account_loader.update_accounts_for_failed_tx(
+                            &fees_only_tx.rollback_accounts,
+                            self.slot,
+                        );
 
                         Ok(ProcessedTransaction::FeesOnly(Box::new(fees_only_tx)))
                     }
@@ -541,6 +543,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             account_loader.update_accounts_for_successful_tx(
                                 tx,
                                 &executed_tx.loaded_transaction.accounts,
+                                self.slot,
                             );
                             // Also update local program cache with modifications made by the
                             // transaction, if it executed successfully.
@@ -556,6 +559,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         (Err(_), false) => {
                             account_loader.update_accounts_for_failed_tx(
                                 &executed_tx.loaded_transaction.rollback_accounts,
+                                self.slot,
                             );
 
                             Ok(ProcessedTransaction::Executed(Box::new(executed_tx)))

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -867,7 +867,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
                 let program_to_store = program_to_load.map(|key| {
                     // Load, verify and compile one program.
-                    let program = load_program_with_pubkey(
+                    let (program, _last_modification_slot) = load_program_with_pubkey(
                         account_loader,
                         program_runtime_environments_for_execution,
                         &key,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1163,6 +1163,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.global_program_cache.write().unwrap().assign_program(
             &self.environments,
             program_id,
+            0,
             Arc::new(builtin),
         );
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -8,7 +8,7 @@ use {
         account_overrides::AccountOverrides,
         message_processor::process_message,
         nonce_info::NonceInfo,
-        program_loader::{get_program_modification_slot, load_program_with_pubkey},
+        program_loader::{get_program_deployment_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
         transaction_account_state_info::TransactionAccountStateInfo,
         transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
@@ -838,7 +838,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 .iter()
                 .map(|(pubkey, last_modification_slot)| {
                     let match_criteria = if check_program_modification_slot {
-                        get_program_modification_slot(account_loader, pubkey)
+                        get_program_deployment_slot(account_loader, pubkey)
                             .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                                 ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
                             })

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -112,9 +112,9 @@ pub struct TransactionProcessingConfig<'a> {
     /// Encapsulates overridden accounts, typically used for transaction
     /// simulation.
     pub account_overrides: Option<&'a AccountOverrides>,
-    /// Whether or not to check a program's modification slot when replenishing
+    /// Whether or not to check a program's deployment slot when replenishing
     /// a program cache instance.
-    pub check_program_modification_slot: bool,
+    pub check_program_deployment_slot: bool,
     /// The maximum number of bytes that log messages can consume.
     pub log_messages_bytes_limit: Option<usize>,
     /// Whether to limit the number of programs loaded for the transaction
@@ -416,7 +416,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 &environment.program_runtime_environments_for_execution,
                 &mut program_cache_for_tx_batch,
                 &mut execute_timings,
-                config.check_program_modification_slot,
+                config.check_program_deployment_slot,
                 config.limit_to_load_programs,
                 false, // increment_usage_counter
             );
@@ -505,7 +505,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             &environment.program_runtime_environments_for_execution,
                             &mut program_cache_for_tx_batch,
                             &mut execute_timings,
-                            config.check_program_modification_slot,
+                            config.check_program_deployment_slot,
                             config.limit_to_load_programs,
                             true, // increment_usage_counter
                         );
@@ -829,7 +829,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         program_runtime_environments_for_execution: &ProgramRuntimeEnvironments,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         execute_timings: &mut ExecuteTimings,
-        check_program_modification_slot: bool,
+        check_program_deployment_slot: bool,
         limit_to_load_programs: bool,
         increment_usage_counter: bool,
     ) {
@@ -837,7 +837,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             program_accounts_set
                 .iter()
                 .map(|(pubkey, last_modification_slot)| {
-                    let match_criteria = if check_program_modification_slot {
+                    let match_criteria = if check_program_deployment_slot {
                         get_program_deployment_slot(account_loader, pubkey)
                             .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                                 ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -9,6 +9,7 @@ use {
         thread, Runner,
     },
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+    solana_clock::Slot,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
@@ -28,7 +29,7 @@ use {
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_timings::ExecuteTimings,
     solana_transaction::{sanitized::SanitizedTransaction, Transaction},
-    std::collections::HashSet,
+    std::collections::{HashMap, HashSet},
 };
 
 mod mock_bank;
@@ -47,7 +48,7 @@ fn program_cache_execution(threads: usize) {
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
     ];
 
-    let account_maps: HashSet<Pubkey> = programs.iter().copied().collect();
+    let account_maps: HashMap<Pubkey, Slot> = programs.iter().map(|key| (*key, 0)).collect();
 
     let ths: Vec<_> = (0..threads)
         .map(|_| {

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -327,7 +327,11 @@ impl SvmTestEnvironment<'_> {
                         .global_program_cache
                         .write()
                         .unwrap()
-                        .merge(&self.batch_processor.environments, programs_modified_by_tx);
+                        .merge(
+                            &self.batch_processor.environments,
+                            self.batch_processor.slot,
+                            programs_modified_by_tx,
+                        );
                 }
             }
         }


### PR DESCRIPTION
#### Problem

For `IndexImplementation::V2` of the global program cache we will need a last-modification-slot to be known for every program account.

#### Summary of Changes

Adds `last_modification_slot` to `AccountLoader::loaded_accounts` and `MockCallback::loaded_accounts` so that it can be made available to `ProgramCache::extract()`, `ProgramCache::finish_cooperative_loading_task()` and `ProgramCache::assign_program()` and `ProgramCache::unload_program_entry()`.