### PR TITLE
Fix SBF dep crate test

### DIFF
--- a/programs/sbf/rust/dep_crate/src/lib.rs
+++ b/programs/sbf/rust/dep_crate/src/lib.rs
@@ -9,10 +9,12 @@ use {
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     let mut buf = [0; 4];
     LittleEndian::write_u32(&mut buf, 1_000_000);
+    std::hint::black_box(&mut buf);
     assert_eq!(1_000_000, LittleEndian::read_u32(&buf));
 
     let mut buf = [0; 2];
     LittleEndian::write_i16(&mut buf, -5_000);
+    std::hint::black_box(&mut buf);
     assert_eq!(-5_000, LittleEndian::read_i16(&buf));
 
     SUCCESS

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1446,7 +1446,7 @@ fn assert_instruction_count() {
             ("solana_sbf_rust_128bit", 801),
             ("solana_sbf_rust_alloc", 4983),
             ("solana_sbf_rust_custom_heap", 303),
-            ("solana_sbf_rust_dep_crate", 3),
+            ("solana_sbf_rust_dep_crate", 22),
             ("solana_sbf_rust_iter", 1414),
             ("solana_sbf_rust_many_args", 1287),
             ("solana_sbf_rust_mem", 1298),


### PR DESCRIPTION
#### Problem

The `dep_crate` program writes to a buffer and then read from it afterwards, asserting the value is correct. The compiler is smart enough to detect the read value will be the same as the written value, so it optimizes away all that code. Consequently, the function we were testing is simply `mov64 r0, 0`, and `exit`, which is obviously not testing anything.

#### Summary of Changes

Use a black box to prevent the optimization.