### PR TITLE
Updates AccountsDb::store_for_tests() to use StorableAccounts

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -51,10 +51,10 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         let account = AccountSharedData::new(i + 1, 0, AccountSharedData::default().owner());
         accounts
             .accounts_db
-            .store_for_tests(i, &[(&pubkey, &account)]);
+            .store_for_tests((i, [(&pubkey, &account)].as_slice()));
         accounts
             .accounts_db
-            .store_for_tests(i, &[(&old_pubkey, &zero_account)]);
+            .store_for_tests((i, [(&old_pubkey, &zero_account)].as_slice()));
         old_pubkey = pubkey;
         accounts.accounts_db.add_root_and_flush_write_cache(i);
     }
@@ -268,7 +268,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
         accounts
             .accounts_db
-            .store_for_tests(0, &[(&pubkey, &account)]);
+            .store_for_tests((0, [(&pubkey, &account)].as_slice()));
     }
     accounts.accounts_db.add_root_and_flush_write_cache(0);
     let ancestors = Ancestors::from(vec![0]);

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1120,7 +1120,8 @@ mod tests {
 
     impl Accounts {
         pub fn store_for_tests(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
-            self.accounts_db.store_for_tests(slot, &[(pubkey, account)])
+            self.accounts_db
+                .store_for_tests((slot, [(pubkey, account)].as_slice()))
         }
 
         /// useful to adapt tests written prior to introduction of the write cache
@@ -1225,13 +1226,14 @@ mod tests {
         let pubkey = Pubkey::new_unique();
         let account_data = AccountSharedData::new(1, 0, &Pubkey::default());
         let accounts_db = Arc::new(AccountsDb::new_single_for_tests());
-        accounts_db.store_for_tests(
+        accounts_db.store_for_tests((
             0,
-            &[
+            [
                 (&Pubkey::default(), &account_data),
                 (&pubkey, &account_data),
-            ],
-        );
+            ]
+            .as_slice(),
+        ));
 
         let r_tx = sanitized_tx_from_metas(vec![AccountMeta {
             pubkey,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1432,7 +1432,7 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         let some_data_len = 5;
         let some_slot: Slot = 0;
         let account = AccountSharedData::new(1, some_data_len, &key);
-        accounts_db.store_for_tests(some_slot, &[(&key, &account)]);
+        accounts_db.store_for_tests((some_slot, [(&key, &account)].as_slice()));
         accounts_db.add_root_and_flush_write_cache(0);
         accounts_db
     }
@@ -7486,9 +7486,9 @@ impl AccountsDb {
     }
 
     /// callers used to call store_uncached. But, this is not allowed anymore.
-    pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
+    pub fn store_for_tests<'a>(&self, accounts: impl StorableAccounts<'a>) {
         self.store_accounts_unfrozen(
-            (slot, accounts),
+            accounts,
             None,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
@@ -7502,7 +7502,7 @@ impl AccountsDb {
                 0,
                 AccountSharedData::default().owner(),
             );
-            self.store_for_tests(slot, &[(&pubkeys[idx], &account)]);
+            self.store_for_tests((slot, [(&pubkeys[idx], &account)].as_slice()));
         }
     }
 
@@ -7528,7 +7528,7 @@ impl AccountsDb {
                 AccountSharedData::new((t + 1) as u64, space, AccountSharedData::default().owner());
             pubkeys.push(pubkey);
             assert!(self.load_without_fixed_root(&ancestors, &pubkey).is_none());
-            self.store_for_tests(slot, &[(&pubkey, &account)]);
+            self.store_for_tests((slot, [(&pubkey, &account)].as_slice()));
         }
         for t in 0..num_vote {
             let pubkey = solana_pubkey::new_rand();
@@ -7537,7 +7537,7 @@ impl AccountsDb {
             pubkeys.push(pubkey);
             let ancestors = vec![(slot, 0)].into_iter().collect();
             assert!(self.load_without_fixed_root(&ancestors, &pubkey).is_none());
-            self.store_for_tests(slot, &[(&pubkey, &account)]);
+            self.store_for_tests((slot, [(&pubkey, &account)].as_slice()));
         }
     }
 

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -213,13 +213,13 @@ pub mod tests {
         // Need to add root and flush write cache for each slot to ensure accounts are written
         // to correct slots. Cache flush can skip writes if accounts have already been written to
         // a newer slot
-        accounts.store_for_tests(0, &[(&key1, &account)]);
+        accounts.store_for_tests((0, [(&key1, &account)].as_slice()));
         accounts.add_root_and_flush_write_cache(0);
-        accounts.store_for_tests(1, &[(&key1, &account)]);
+        accounts.store_for_tests((1, [(&key1, &account)].as_slice()));
         accounts.add_root_and_flush_write_cache(1);
 
         // Account with key2 is updated in a single slot, should get notified once
-        accounts.store_for_tests(2, &[(&key2, &account)]);
+        accounts.store_for_tests((2, [(&key2, &account)].as_slice()));
         accounts.add_root_and_flush_write_cache(2);
 
         // Do the notification

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -259,7 +259,7 @@ mod serde_snapshot_tests {
         let db = AccountsDb::new_single_for_tests();
         let key = solana_pubkey::new_rand();
         let account0 = AccountSharedData::new(1, 0, &key);
-        db.store_for_tests(unrooted_slot, &[(&key, &account0)]);
+        db.store_for_tests((unrooted_slot, [(&key, &account0)].as_slice()));
 
         // Purge the slot
         db.remove_unrooted_slots(&[(unrooted_slot, unrooted_bank_id)]);
@@ -267,7 +267,7 @@ mod serde_snapshot_tests {
         // Add a new root
         let key2 = solana_pubkey::new_rand();
         let new_root = unrooted_slot + 1;
-        db.store_for_tests(new_root, &[(&key2, &account0)]);
+        db.store_for_tests((new_root, [(&key2, &account0)].as_slice()));
         db.add_root_and_flush_write_cache(new_root);
 
         // Simulate reconstruction from snapshot
@@ -318,7 +318,7 @@ mod serde_snapshot_tests {
             // Overwrite account 30 from slot 0 with lamports=0 into slot 1.
             // Slot 1 should now have 10 + 1 = 11 accounts
             let account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-            accounts.store_for_tests(latest_slot, &[(&pubkeys[30], &account)]);
+            accounts.store_for_tests((latest_slot, [(&pubkeys[30], &account)].as_slice()));
 
             // Create 10 new accounts in slot 1, should now have 11 + 10 = 21
             // accounts
@@ -337,7 +337,7 @@ mod serde_snapshot_tests {
             // Overwrite account 31 from slot 0 with lamports=0 into slot 2.
             // Slot 2 should now have 20 + 1 = 21 accounts
             let account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-            accounts.store_for_tests(latest_slot, &[(&pubkeys[31], &account)]);
+            accounts.store_for_tests((latest_slot, [(&pubkeys[31], &account)].as_slice()));
 
             // Create 10 new accounts in slot 2. Slot 2 should now have
             // 21 + 10 = 31 accounts
@@ -402,12 +402,12 @@ mod serde_snapshot_tests {
         let accounts = AccountsDb::new_single_for_tests();
 
         let mut current_slot = 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey, &account)]);
+        accounts.store_for_tests((current_slot, [(&pubkey, &account)].as_slice()));
         accounts.add_root(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey, &zero_lamport_account)]);
-        accounts.store_for_tests(current_slot, &[(&pubkey2, &account2)]);
+        accounts.store_for_tests((current_slot, [(&pubkey, &zero_lamport_account)].as_slice()));
+        accounts.store_for_tests((current_slot, [(&pubkey2, &account2)].as_slice()));
 
         accounts.add_root_and_flush_write_cache(current_slot);
 
@@ -452,21 +452,27 @@ mod serde_snapshot_tests {
         let accounts = AccountsDb::new_single_for_tests();
 
         let mut current_slot = 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey, &account)]);
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &account2)]);
+        accounts.store_for_tests((current_slot, [(&pubkey, &account)].as_slice()));
+        accounts.store_for_tests((current_slot, [(&purged_pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &zero_lamport_account)]);
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey2, &account3)]);
+        accounts.store_for_tests((
+            current_slot,
+            [(&purged_pubkey1, &zero_lamport_account)].as_slice(),
+        ));
+        accounts.store_for_tests((current_slot, [(&purged_pubkey2, &account3)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey2, &zero_lamport_account)]);
+        accounts.store_for_tests((
+            current_slot,
+            [(&purged_pubkey2, &zero_lamport_account)].as_slice(),
+        ));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&dummy_pubkey, &dummy_account)]);
+        accounts.store_for_tests((current_slot, [(&dummy_pubkey, &dummy_account)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         accounts.print_accounts_stats("pre_f");
@@ -535,29 +541,35 @@ mod serde_snapshot_tests {
         // create intermediate updates to purged_pubkey1 so that
         // generate_index must add slots as root last at once
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey, &account)]);
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &account2)]);
+        accounts.store_for_tests((current_slot, [(&pubkey, &account)].as_slice()));
+        accounts.store_for_tests((current_slot, [(&purged_pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &account2)]);
+        accounts.store_for_tests((current_slot, [(&purged_pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &account2)]);
+        accounts.store_for_tests((current_slot, [(&purged_pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey1, &zero_lamport_account)]);
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey2, &account3)]);
+        accounts.store_for_tests((
+            current_slot,
+            [(&purged_pubkey1, &zero_lamport_account)].as_slice(),
+        ));
+        accounts.store_for_tests((current_slot, [(&purged_pubkey2, &account3)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&purged_pubkey2, &zero_lamport_account)]);
+        accounts.store_for_tests((
+            current_slot,
+            [(&purged_pubkey2, &zero_lamport_account)].as_slice(),
+        ));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&dummy_pubkey, &dummy_account)]);
+        accounts.store_for_tests((current_slot, [(&dummy_pubkey, &dummy_account)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         accounts.print_count_and_status("before reconstruct");
@@ -597,8 +609,8 @@ mod serde_snapshot_tests {
 
         // A: Initialize AccountsDb with pubkey1 and pubkey2
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey1, &account)]);
-        accounts.store_for_tests(current_slot, &[(&pubkey2, &account)]);
+        accounts.store_for_tests((current_slot, [(&pubkey1, &account)].as_slice()));
+        accounts.store_for_tests((current_slot, [(&pubkey2, &account)].as_slice()));
         accounts.add_root(current_slot);
 
         // B: Test multiple updates to pubkey1 in a single slot/storage
@@ -606,8 +618,8 @@ mod serde_snapshot_tests {
         assert_eq!(0, accounts.alive_account_count_in_slot(current_slot));
         accounts.add_root_and_flush_write_cache(current_slot - 1);
         assert_eq!(1, accounts.ref_count_for_pubkey(&pubkey1));
-        accounts.store_for_tests(current_slot, &[(&pubkey1, &account2)]);
-        accounts.store_for_tests(current_slot, &[(&pubkey1, &account2)]);
+        accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
+        accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
         assert_eq!(1, accounts.alive_account_count_in_slot(current_slot));
         // Stores to same pubkey, same slot only count once towards the
@@ -617,7 +629,7 @@ mod serde_snapshot_tests {
         // C: Yet more update to trigger lazy clean of step A
         current_slot += 1;
         assert_eq!(2, accounts.ref_count_for_pubkey(&pubkey1));
-        accounts.store_for_tests(current_slot, &[(&pubkey1, &account3)]);
+        accounts.store_for_tests((current_slot, [(&pubkey1, &account3)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
         assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
         accounts.add_root_and_flush_write_cache(current_slot);
@@ -625,7 +637,7 @@ mod serde_snapshot_tests {
         // D: Make pubkey1 0-lamport; also triggers clean of step B
         current_slot += 1;
         assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
-        accounts.store_for_tests(current_slot, &[(&pubkey1, &zero_lamport_account)]);
+        accounts.store_for_tests((current_slot, [(&pubkey1, &zero_lamport_account)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
         // had to be a root to flush, but clean won't work as this test expects if it is a root
         // so, remove the root from alive_roots, then restore it after clean
@@ -655,7 +667,7 @@ mod serde_snapshot_tests {
 
         // E: Avoid missing bank hash error
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&dummy_pubkey, &dummy_account)]);
+        accounts.store_for_tests((current_slot, [(&dummy_pubkey, &dummy_account)].as_slice()));
         accounts.add_root(current_slot);
 
         accounts.assert_load_account(current_slot, pubkey1, zero_lamport);
@@ -680,7 +692,7 @@ mod serde_snapshot_tests {
 
         // F: Finally, make Step A cleanable
         current_slot += 1;
-        accounts.store_for_tests(current_slot, &[(&pubkey2, &account)]);
+        accounts.store_for_tests((current_slot, [(&pubkey2, &account)].as_slice()));
         accounts.add_root(current_slot);
 
         // Do clean
@@ -719,7 +731,7 @@ mod serde_snapshot_tests {
 
             current_slot += 1;
             for pubkey in &pubkeys {
-                accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
+                accounts.store_for_tests((current_slot, [(pubkey, &account)].as_slice()));
             }
             let shrink_slot = current_slot;
             accounts.add_root_and_flush_write_cache(current_slot);
@@ -729,7 +741,7 @@ mod serde_snapshot_tests {
             let updated_pubkeys = &pubkeys[0..pubkey_count - pubkey_count_after_shrink];
 
             for pubkey in updated_pubkeys {
-                accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
+                accounts.store_for_tests((current_slot, [(pubkey, &account)].as_slice()));
             }
             accounts.add_root_and_flush_write_cache(current_slot);
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -551,7 +551,7 @@ mod tests {
             current_slot += 1;
 
             for (index, pubkey) in pubkeys.iter().enumerate() {
-                accounts.store_for_tests(current_slot, &[(pubkey, &account)]);
+                accounts.store_for_tests((current_slot, [(pubkey, &account)].as_slice()));
 
                 if current_slot % 2 == 0 && index % 100 == 0 {
                     minimized_account_set.insert(*pubkey);


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. In AccountsDb, there's a bunch of 'em.

For this PR, `store_for_tests()` is the problem.

It was originally added to ease the transition for tests that were written before the write cache. Now, `store_for_tests()` just calls `store_accounts_unfrozen()`. I'd love to remove store_for_tests(), but it'd be a big diff. We can do it in steps to ensure nothing breaks.


#### Summary of Changes

Update `store_for_tests()` to take the accounts as `StorableAccounts`:

Old:
```rust
    pub fn store_for_tests(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
```

New:
```rust
    pub fn store_for_tests<'a>(&self, accounts: impl StorableAccounts<'a>) {
```

Nothing about the impl of `store_for_tests()` will change. We now just make the fn signature the same as `store_accounts_unfrozen()`. This way it is straight forward to see this PR doesn't affect any behavior.