### PR TITLE
BankingStage: add non-vote thread exit signal

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -39,7 +39,7 @@ use {
         num::Saturating,
         ops::Deref,
         sync::{
-            atomic::{AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Arc, RwLock,
         },
         thread::{self, Builder, JoinHandle},
@@ -554,6 +554,7 @@ impl BankingStage {
                         .name("solBnkTxSched".to_string())
                         .spawn(move || {
                             let scheduler_controller = SchedulerController::new(
+                                Arc::new(AtomicBool::new(false)),
                                 decision_maker.clone(),
                                 receive_and_buffer,
                                 bank_forks,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -522,6 +522,7 @@ impl BankingStage {
             let id = (index as u32).saturating_add(NUM_VOTE_PROCESSING_THREADS);
             let consume_worker = ConsumeWorker::new(
                 id,
+                Arc::new(AtomicBool::new(false)),
                 work_receiver,
                 Consumer::new(
                     committer.clone(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -677,7 +677,7 @@ mod tests {
         agave_banking_stage_ingress_types::BankingPacketBatch,
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
-        solana_entry::entry::{self, Entry, EntrySlice},
+        solana_entry::entry::{self, EntrySlice},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
@@ -876,14 +876,9 @@ mod tests {
             &Arc::new(PrioritizationFeeCache::new(0u64)),
         );
 
-        // fund another account so we can send 2 good transactions in a single batch.
-        let keypair = Keypair::new();
-        let fund_tx = system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, start_hash);
-        bank.process_transaction(&fund_tx).unwrap();
-
-        // good tx, but no verify
+        // good tx, and no verify
         let to = solana_pubkey::new_rand();
-        let tx_no_ver = system_transaction::transfer(&keypair, &to, 2, start_hash);
+        let tx_no_ver = system_transaction::transfer(&mint_keypair, &to, 2, start_hash);
 
         // good tx
         let to2 = solana_pubkey::new_rand();
@@ -909,41 +904,44 @@ mod tests {
             .send(BankingPacketBatch::new(packet_batches))
             .unwrap();
 
+        // capture the entry receiver until we've received all our entries.
+        let mut entries = Vec::with_capacity(100);
+        loop {
+            if let Ok((_bank, (entry, _))) = entry_receiver.try_recv() {
+                let tx_entry = !entry.transactions.is_empty();
+                entries.push(entry);
+                if tx_entry {
+                    break; // once we have the entry break. don't expect more than one.
+                }
+            }
+            sleep(Duration::from_millis(10));
+        }
+
         drop(non_vote_sender);
         drop(tpu_vote_sender);
         drop(gossip_vote_sender);
-        // wait until banking_stage to finish up all packets
         banking_stage.join().unwrap();
 
         exit.store(true, Ordering::Relaxed);
         poh_service.join().unwrap();
         drop(poh_recorder);
 
-        let mut blockhash = start_hash;
+        let blockhash = start_hash;
         let (bank, _bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        bank.process_transaction(&fund_tx).unwrap();
-        //receive entries + ticks
-        loop {
-            let entries: Vec<Entry> = entry_receiver
+
+        // receive entries + ticks. The sender has been dropped, so there
+        // are no more entries that will ever come in after the `iter` here.
+        entries.extend(
+            entry_receiver
                 .iter()
-                .map(|(_bank, (entry, _tick_height))| entry)
-                .collect();
+                .map(|(_bank, (entry, _tick_height))| entry),
+        );
 
-            assert!(entries.verify(&blockhash, &entry::thread_pool_for_tests()));
-            if !entries.is_empty() {
-                blockhash = entries.last().unwrap().hash;
-                for entry in entries {
-                    bank.process_entry_transactions(entry.transactions)
-                        .iter()
-                        .for_each(|x| assert_eq!(*x, Ok(())));
-                }
-            }
-
-            if bank.get_balance(&to2) == 1 {
-                break;
-            }
-
-            sleep(Duration::from_millis(200));
+        assert!(entries.verify(&blockhash, &entry::thread_pool_for_tests()));
+        for entry in entries {
+            bank.process_entry_transactions(entry.transactions)
+                .iter()
+                .for_each(|x| assert_eq!(*x, Ok(())));
         }
 
         assert_eq!(bank.get_balance(&to2), 1);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -21,7 +21,10 @@ use {
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     std::{
         num::Saturating,
-        sync::{Arc, RwLock},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
     },
 };
 
@@ -31,6 +34,8 @@ where
     R: ReceiveAndBuffer,
     S: Scheduler<R::Transaction>,
 {
+    /// Exit signal for the scheduler thread.
+    exit: Arc<AtomicBool>,
     /// Decision maker for determining what should be done with transactions.
     decision_maker: DecisionMaker,
     receive_and_buffer: R,
@@ -58,6 +63,7 @@ where
     S: Scheduler<R::Transaction>,
 {
     pub fn new(
+        exit: Arc<AtomicBool>,
         decision_maker: DecisionMaker,
         receive_and_buffer: R,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -65,6 +71,7 @@ where
         worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
     ) -> Self {
         Self {
+            exit,
             decision_maker,
             receive_and_buffer,
             bank_forks,
@@ -78,7 +85,7 @@ where
     }
 
     pub fn run(mut self) -> Result<(), SchedulerError> {
-        loop {
+        while !self.exit.load(Ordering::Relaxed) {
             // BufferedPacketsDecision is shared with legacy BankingStage, which will forward
             // packets. Initially, not renaming these decision variants but the actions taken
             // are different, since new BankingStage will not forward packets.
@@ -435,7 +442,9 @@ mod tests {
             finished_consume_work_receiver,
             PrioGraphSchedulerConfig::default(),
         );
+        let exit = Arc::new(AtomicBool::new(false));
         let scheduler_controller = SchedulerController::new(
+            exit,
             decision_maker,
             receive_and_buffer,
             bank_forks,


### PR DESCRIPTION
#### Problem
- For scheduler-bindings we will want to shutdown the non-vote threads to switch-over to an external scheduler

#### Summary of Changes
- Add exit signal to BankingStage so that non-vote threads can be shutdown
- Set exit signal during join

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
