### PR TITLE
Remove expected_single_dead_slot from store_accounts_frozen

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6271,10 +6271,6 @@ impl AccountsDb {
             .fetch_add(store_accounts_time.as_us(), Ordering::Relaxed);
         let mut update_index_time = Measure::start("update_index");
 
-        // if we are squashing a single slot, then we can expect a single dead slot
-        let expected_single_dead_slot =
-            (!accounts.contains_multiple_slots()).then(|| accounts.target_slot());
-
         // If the cache was flushed, then because `update_index` occurs
         // after the account are stored by the above `store_accounts_to`
         // call and all the accounts are stored, all reads after this point
@@ -6309,7 +6305,7 @@ impl AccountsDb {
             let mut handle_reclaims_time = Measure::start("handle_reclaims");
             self.handle_reclaims(
                 (!reclaims.is_empty()).then(|| reclaims.iter()),
-                expected_single_dead_slot,
+                None,
                 &HashSet::default(),
                 // this callsite does NOT process dead slots
                 HandleReclaims::DoNotProcessDeadSlots,


### PR DESCRIPTION
#### Problem
Store accounts frozen calculates and passes in a single dead slot to reclaims. This is broken, as the it also passes in DoNotReclaim, which will assert if a dead slot is found


#### Summary of Changes
- Removes expected_single_dead_slot from store_accounts_frozen

Note: This is also forward looking to obsolete accounts as obsolete accounts may reclaim multiple slots. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
