### PR TITLE
Fixes test_remove_unrooted_slot() when not cached

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -656,8 +656,16 @@ fn run_test_remove_unrooted_slot(is_cached: bool, db: AccountsDb) {
     if is_cached {
         db.store_cached((unrooted_slot, &[(&key, &account0)][..]));
     } else {
-        db.store_for_tests((unrooted_slot, [(&key, &account0)].as_slice()));
+        let file_size = 4096; // value doesn't need to be exact, just big enough to hold account0
+        let storage = db.create_and_insert_store(unrooted_slot, file_size, "");
+        db.store_accounts_frozen(
+            (unrooted_slot, [(&key, &account0)].as_slice()),
+            &storage,
+            UpdateIndexThreadSelection::Inline,
+        );
+        assert!(db.storage.get_slot_storage_entry(unrooted_slot).is_some());
     }
+    assert!(!db.accounts_index.is_alive_root(unrooted_slot));
     assert!(db.accounts_index.contains(&key));
     db.assert_load_account(unrooted_slot, key, 1);
 


### PR DESCRIPTION
#### Problem

When `test_remove_unrooted_slot()` is testing `is_cached == false`, it still writes to the cache... It should write to a storage instead.

Looks like we broke this test back in: https://github.com/solana-labs/solana/pull/29083. Oops! The test broke because a few lines above the change to use `db.store_for_tests()` we had enabled the write cache, which meant that `store_for_tests()` also wrote to the cache.
https://github.com/solana-labs/solana/blob/1b49c52d9896172f2ccc18a896b9c7c7b784cfbd/runtime/src/accounts_db.rs#L11213


#### Summary of Changes

Write to a storage.