### PR TITLE
Changing test_delete_dependencies to ignore reclaims

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2576,8 +2576,6 @@ fn test_select_candidates_by_total_usage_all_clean() {
     assert_eq!(0, next_candidates.len());
 }
 
-const UPSERT_POPULATE_RECLAIMS: UpsertReclaim = UpsertReclaim::PopulateReclaims;
-
 #[test]
 fn test_delete_dependencies() {
     solana_logger::setup();
@@ -2598,7 +2596,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info0,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.upsert(
         1,
@@ -2608,7 +2606,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info1,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.upsert(
         1,
@@ -2618,7 +2616,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info1,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.upsert(
         2,
@@ -2628,7 +2626,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info2,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.upsert(
         2,
@@ -2638,7 +2636,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info2,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.upsert(
         3,
@@ -2648,7 +2646,7 @@ fn test_delete_dependencies() {
         &AccountSecondaryIndexes::default(),
         info3,
         &mut reclaims,
-        UPSERT_POPULATE_RECLAIMS,
+        UpsertReclaim::IgnoreReclaims,
     );
     accounts_index.add_root(0);
     accounts_index.add_root(1);


### PR DESCRIPTION
#### Problem
Test is currently using UpsertReclaims when it does not need to. It is only using Upsert to build a slot list.

#### Summary of Changes
- Switch test to use IgnoreReclaims

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
