### PR TITLE
Convert UpsertReclaim::PopulateReclaims specific tests to use define directly

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2817,7 +2817,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         assert!(gc.is_empty());
         index.upsert(
@@ -2828,7 +2828,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         assert!(gc.is_empty());
         index
@@ -2871,7 +2871,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         assert!(gc.is_empty());
         index.upsert(
@@ -2882,7 +2882,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         index.upsert(
             2,
@@ -2892,7 +2892,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         index.upsert(
             3,
@@ -2902,7 +2902,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
         index.add_root(0);
         index.add_root(1);
@@ -2915,7 +2915,7 @@ pub mod tests {
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
-            UPSERT_RECLAIM_TEST_DEFAULT,
+            UpsertReclaim::PopulateReclaims,
         );
 
         // Updating index should not purge older roots, only purges


### PR DESCRIPTION
#### Problem
test_update_new_slot and test_update_gc_purged_slot use UPSERT_RECLAIM_TEST_DEFAULT but are specific to the upsert handling in UpsertReclaim::PopulateReclaims. 

#### Summary of Changes
- Change both tests to use UpsertReclaim::PopulateReclaims directly.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
