### PR TITLE
Removes accounts_db::test_utils::create_test_accounts()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7623,29 +7623,3 @@ impl AccountsDb {
         &self.uncleaned_pubkeys
     }
 }
-
-/// A set of utility functions used for testing and benchmarking
-#[cfg(feature = "dev-context-only-utils")]
-pub mod test_utils {
-    use {super::*, crate::accounts::Accounts};
-
-    pub fn create_test_accounts(
-        accounts: &Accounts,
-        pubkeys: &mut Vec<Pubkey>,
-        num: usize,
-        slot: Slot,
-    ) {
-        let data_size = 0;
-
-        for t in 0..num {
-            let pubkey = solana_pubkey::new_rand();
-            let account = AccountSharedData::new(
-                (t + 1) as u64,
-                data_size,
-                AccountSharedData::default().owner(),
-            );
-            accounts.store_cached((slot, &[(&pubkey, &account)][..]), None);
-            pubkeys.push(pubkey);
-        }
-    }
-}

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -18,8 +18,7 @@ mod serde_snapshot_tests {
             account_storage_reader::AccountStorageReader,
             accounts::Accounts,
             accounts_db::{
-                get_temp_accounts_paths, test_utils::create_test_accounts, AccountStorageEntry,
-                AccountsDb, AtomicAccountsFileId,
+                get_temp_accounts_paths, AccountStorageEntry, AccountsDb, AtomicAccountsFileId,
             },
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
             ancestors::Ancestors,
@@ -205,8 +204,13 @@ mod serde_snapshot_tests {
         let accounts = Accounts::new(Arc::new(accounts_db));
 
         let slot = 0;
-        let mut pubkeys: Vec<Pubkey> = vec![];
-        create_test_accounts(&accounts, &mut pubkeys, 100, slot);
+        let pubkeys: Vec<_> = std::iter::repeat_with(solana_pubkey::new_rand)
+            .take(100)
+            .collect();
+        for (i, pubkey) in pubkeys.iter().enumerate() {
+            let account = AccountSharedData::new(i as u64 + 1, 0, &Pubkey::default());
+            accounts.store_accounts_cached((slot, [(pubkey, &account)].as_slice()));
+        }
         check_accounts_local(&accounts, &pubkeys, 100);
         accounts.accounts_db.add_root_and_flush_write_cache(slot);
         let accounts_hash = accounts


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. There's bunch of 'em, and reducing the number will make the inline accounts lt hash updates simpler to implement/reason about/review.

For this PR it's `accounts_db::test_utils::create_test_accounts()`.

This function is within `accounts_db.rs`, but it takes an `Accounts` not `AccountsDb`, and it's only called by one test in `runtime/src/serde_snapshot/tests.rs`...


#### Summary of Changes

Inline the fn into the test.