### PR TITLE
Uses store_accounts_cached() in test_update_accounts_lt_hash()

### DIFF
--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -523,13 +523,10 @@ mod tests {
             .unwrap();
 
         // store account 5 into this new bank, unchanged
-        bank.rc.accounts.store_cached(
-            (
-                bank.slot(),
-                [(&keypair5.pubkey(), &prev_account5.clone().unwrap())].as_slice(),
-            ),
-            None,
-        );
+        bank.rc.accounts.store_accounts_cached((
+            bank.slot(),
+            [(&keypair5.pubkey(), &prev_account5.clone().unwrap())].as_slice(),
+        ));
 
         // freeze the bank to trigger update_accounts_lt_hash() to run
         bank.freeze();


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. There's bunch of 'em, and reducing the number will make the inline accounts lt hash updates simpler to implement/reason about/review.

For this PR it's `test_update_accounts_lt_hash()`.

This test calls `Accounts::store_cached()`, which I'm trying to remove. It can call `Accounts::store_accounts_cached()` instead.


#### Summary of Changes

Call `store_accounts_cached()` instead.