### PR TITLE
Remove unnecessary functions from `BorrowedAccount`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1090,7 +1090,7 @@ mod tests {
                     }
                     MockInstruction::Resize { new_len } => instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .set_data(vec![0; new_len as usize])?,
+                        .set_data_from_slice(&vec![0; new_len as usize])?,
                 }
             } else {
                 return Err(InstructionError::InvalidInstructionData);

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1590,7 +1590,7 @@ mod tests {
                 .try_borrow_instruction_account(&transaction_context, index_in_instruction)
                 .unwrap();
             borrowed_account
-                .set_data(vec![0u8; MAX_PERMITTED_DATA_LENGTH as usize])
+                .set_data_from_slice(&vec![0u8; MAX_PERMITTED_DATA_LENGTH as usize])
                 .unwrap();
         }
         assert_eq!(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -8549,7 +8549,7 @@ fn test_transfer_sysvar() {
         let instruction_context = transaction_context.get_current_instruction_context()?;
         instruction_context
             .try_borrow_instruction_account(transaction_context, 1)?
-            .set_data(vec![0; 40])?;
+            .set_data_from_slice(&[0; 40])?;
         Ok(())
     });
 

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -159,7 +159,7 @@ mod tests {
                     MockSystemInstruction::ChangeData { data } => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 1)?
-                            .set_data(vec![data])?;
+                            .set_data_from_slice(&[data])?;
                         Ok(())
                     }
                 }
@@ -394,7 +394,7 @@ mod tests {
                             .try_borrow_instruction_account(transaction_context, 2)?;
                         dup_account.checked_sub_lamports(lamports)?;
                         to_account.checked_add_lamports(lamports)?;
-                        dup_account.set_data(vec![data])?;
+                        dup_account.set_data_from_slice(&[data])?;
                         drop(dup_account);
                         let mut from_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?;

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -890,11 +890,6 @@ pub struct BorrowedAccount<'a> {
 }
 
 impl BorrowedAccount<'_> {
-    /// Returns the transaction context
-    pub fn transaction_context(&self) -> &TransactionContext {
-        self.transaction_context
-    }
-
     /// Returns the index of this account (transaction wide)
     #[inline]
     pub fn get_index_in_transaction(&self) -> IndexOfAccount {
@@ -1006,24 +1001,6 @@ impl BorrowedAccount<'_> {
         self.touch()?;
         self.make_data_mut();
         Ok(self.account.data_as_mut_slice())
-    }
-
-    /// Overwrites the account data and size (transaction wide).
-    ///
-    /// You should always prefer set_data_from_slice(). Calling this method is
-    /// currently safe but requires some special casing during CPI when direct
-    /// account mapping is enabled.
-    #[cfg(all(
-        not(target_os = "solana"),
-        any(test, feature = "dev-context-only-utils")
-    ))]
-    pub fn set_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
-        self.can_data_be_resized(data.len())?;
-        self.touch()?;
-
-        self.update_accounts_resize_delta(data.len())?;
-        self.account.set_data(data);
-        Ok(())
     }
 
     /// Overwrites the account data and size (transaction wide).


### PR DESCRIPTION
#### Problem

`fn transaction_context()` is never used.

`fn set_data` is not recommended for direct mapping and never called outside tests.

#### Summary of Changes

Delete `fn transaction_context()`

Replace call sites of `set_data` by `set_data_from_slice`
