### PR TITLE
Removes store_cached() and store_cached_inline_update_index() from AccountsDb

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{
             AccountsAddRootTiming, AccountsDb, LoadHint, LoadedAccount, ScanAccountStorageData,
-            ScanStorageResult,
+            ScanStorageResult, UpdateIndexThreadSelection,
         },
         accounts_index::{IndexKey, ScanConfig, ScanError, ScanOrder, ScanResult},
         ancestors::Ancestors,
@@ -552,12 +552,19 @@ impl Accounts {
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
     ) {
-        self.accounts_db
-            .store_cached_inline_update_index(accounts, transactions);
+        self.accounts_db.store_accounts_unfrozen(
+            accounts,
+            transactions,
+            UpdateIndexThreadSelection::Inline,
+        );
     }
 
     pub fn store_accounts_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {
-        self.accounts_db.store_cached(accounts)
+        self.accounts_db.store_accounts_unfrozen(
+            accounts,
+            None,
+            UpdateIndexThreadSelection::PoolWithThreshold,
+        );
     }
 
     /// Add a slot to root.  Root slots cannot be purged

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6091,25 +6091,9 @@ impl AccountsDb {
             .fetch_add(measure.as_us(), Ordering::Relaxed);
     }
 
-    pub fn store_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {
-        self.store_accounts_unfrozen(
-            accounts,
-            None,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        );
-    }
-
-    pub(crate) fn store_cached_inline_update_index<'a>(
-        &self,
-        accounts: impl StorableAccounts<'a>,
-        transactions: Option<&'a [&'a SanitizedTransaction]>,
-    ) {
-        self.store_accounts_unfrozen(accounts, transactions, UpdateIndexThreadSelection::Inline);
-    }
-
     /// Stores accounts in the write cache and updates the index.
     /// This should only be used for accounts that are unrooted (unfrozen)
-    fn store_accounts_unfrozen<'a>(
+    pub(crate) fn store_accounts_unfrozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. There's bunch of 'em, and reducing the number will make the inline accounts lt hash updates simpler to implement/reason about/review.

For this PR it's removing `AccountsDb::store_cached()` and `AccountsDb::store_cached_inline_update_index()`. These functions are just simple wrappers around `AccountsDb::store_accounts_unfrozen()`, and they are only called by one fn in `Accounts`.


#### Summary of Changes

Remove `AccountsDb::store_cached()` and `AccountsDb::store_cached_inline_update_index()`, and update the callers to call `AccountsDb::store_accounts_unfrozen()` directly.