### PR TITLE
Renames the store() fn in Accounts

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -89,7 +89,7 @@ where
     )
     .collect();
     let storable_accounts: Vec<_> = pubkeys.iter().zip(accounts_data.iter()).collect();
-    accounts.store_accounts_cached((slot, storable_accounts.as_slice()));
+    accounts.store_accounts_par((slot, storable_accounts.as_slice()), None);
     accounts.add_root(slot);
     accounts
         .accounts_db
@@ -116,7 +116,7 @@ where
         // Write to a different slot than the one being read from. Because
         // there's a new account pubkey being written to every time, will
         // compete for the accounts index lock on every store
-        accounts.store_accounts_cached((slot + 1, new_storable_accounts.as_slice()));
+        accounts.store_accounts_par((slot + 1, new_storable_accounts.as_slice()), None);
     });
 }
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -546,8 +546,11 @@ impl Accounts {
         }
     }
 
-    /// Store the accounts into the DB
-    pub fn store_cached<'a>(
+    /// Store `accounts` into the DB
+    ///
+    /// This version updates the accounts index sequentially,
+    /// using the same thread that calls the fn itself.
+    pub fn store_accounts_seq<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
@@ -559,10 +562,18 @@ impl Accounts {
         );
     }
 
-    pub fn store_accounts_cached<'a>(&self, accounts: impl StorableAccounts<'a>) {
+    /// Store `accounts` into the DB
+    ///
+    /// This version updates the accounts index in parallel,
+    /// using the foreground AccountsDb thread pool.
+    pub fn store_accounts_par<'a>(
+        &self,
+        accounts: impl StorableAccounts<'a>,
+        transactions: Option<&'a [&'a SanitizedTransaction]>,
+    ) {
         self.accounts_db.store_accounts_unfrozen(
             accounts,
-            None,
+            transactions,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3595,9 +3595,11 @@ impl Bank {
 
             let to_store = (self.slot(), accounts_to_store.as_slice());
             self.update_bank_hash_stats(&to_store);
+            // See https://github.com/solana-labs/solana/pull/31455 for discussion
+            // on *not* updating the index within a threadpool.
             self.rc
                 .accounts
-                .store_cached(to_store, transactions.as_deref());
+                .store_accounts_seq(to_store, transactions.as_deref());
         });
 
         // Cached vote and stake accounts are synchronized with accounts-db
@@ -3956,7 +3958,7 @@ impl Bank {
             })
         });
         self.update_bank_hash_stats(&accounts);
-        self.rc.accounts.store_accounts_cached(accounts);
+        self.rc.accounts.store_accounts_par(accounts, None);
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -526,10 +526,7 @@ mod tests {
             .unwrap();
 
         // store account 5 into this new bank, unchanged
-        bank.rc.accounts.store_accounts_cached((
-            bank.slot(),
-            [(&keypair5.pubkey(), &prev_account5.clone().unwrap())].as_slice(),
-        ));
+        bank.store_account(&keypair5.pubkey(), prev_account5.as_ref().unwrap());
 
         // freeze the bank to trigger update_accounts_lt_hash() to run
         bank.freeze();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -209,7 +209,7 @@ mod serde_snapshot_tests {
             .collect();
         for (i, pubkey) in pubkeys.iter().enumerate() {
             let account = AccountSharedData::new(i as u64 + 1, 0, &Pubkey::default());
-            accounts.store_accounts_cached((slot, [(pubkey, &account)].as_slice()));
+            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None);
         }
         check_accounts_local(&accounts, &pubkeys, 100);
         accounts.accounts_db.add_root_and_flush_write_cache(slot);


### PR DESCRIPTION
#### Problem

I'm looking through all the various "store" functions we have, as part of doing accounts lt hash updates inline with transaction processing. There's bunch of 'em, and reducing the number will make the inline accounts lt hash updates simpler to implement/reason about/review.

For this PR I'm renaming the store() functions on `Accounts`. Right now they are `store_cached()` and `store_accounts_cached()`. 

From only looking at the names, signature, and the doc comments, it's not clear why there are two different functions. Do they somehow do different things?

In fact they both store accounts to the write cache. Great! The difference is how the accounts index is updated; either with a thread pool in parallel, or sequentially inline in the caller's thread. So let's make that information known.


#### Summary of Changes

Rename the fns.