### PR TITLE
runtime: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -509,10 +509,9 @@ impl AccountsBackgroundService {
                                 Ok(snapshot_slot) => {
                                     assert!(
                                         last_cleaned_slot <= snapshot_slot,
-                                        "last cleaned slot: {last_cleaned_slot}, \
-                                         snapshot request slot: {snapshot_slot}, \
-                                         is startup verification complete: {}, \
-                                         enqueued snapshot requests: {:?}",
+                                        "last cleaned slot: {last_cleaned_slot}, snapshot request \
+                                         slot: {snapshot_slot}, is startup verification complete: \
+                                         {}, enqueued snapshot requests: {:?}",
                                         bank.has_initial_accounts_hash_verification_completed(),
                                         request_handlers
                                             .snapshot_request_handler
@@ -526,8 +525,8 @@ impl AccountsBackgroundService {
                                 }
                                 Err(err) => {
                                     error!(
-                                        "Stopping AccountsBackgroundService! \
-                                         Fatal error while handling snapshot requests: {err}",
+                                        "Stopping AccountsBackgroundService! Fatal error while \
+                                         handling snapshot requests: {err}",
                                     );
                                     exit.store(true, Ordering::Relaxed);
                                     break;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1739,8 +1739,8 @@ impl Bank {
             Some(account)
         })
         .expect(
-            "Stakes cache is inconsistent with accounts-db. This can indicate \
-            a corrupted snapshot or bugs in cached accounts or accounts-db.",
+            "Stakes cache is inconsistent with accounts-db. This can indicate a corrupted \
+             snapshot or bugs in cached accounts or accounts-db.",
         ));
         info!("Loading Stakes took: {stakes_time}");
         let stakes_accounts_load_duration = now.elapsed();
@@ -1845,8 +1845,8 @@ impl Bank {
         // from the passed in genesis_config instead (as new()/new_with_paths() already do)
         assert_eq!(
             bank.genesis_creation_time, genesis_config.creation_time,
-            "Bank snapshot genesis creation time does not match genesis.bin creation time. \
-             The snapshot and genesis.bin might pertain to different clusters"
+            "Bank snapshot genesis creation time does not match genesis.bin creation time. The \
+             snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
         assert_eq!(
@@ -2685,8 +2685,9 @@ impl Bank {
 
         assert!(
             !self.freeze_started(),
-            "Can't change frozen bank by adding not-existing new precompiled program ({program_id}). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+            "Can't change frozen bank by adding not-existing new precompiled program \
+             ({program_id}). Maybe, inconsistent program activation is detected on snapshot \
+             restore?"
         );
 
         // Add a bogus executable account, which will be loaded and ignored.
@@ -3542,7 +3543,8 @@ impl Bank {
     ) -> Vec<TransactionCommitResult> {
         assert!(
             !self.freeze_started(),
-            "commit_transactions() working on a bank that is already frozen or is undergoing freezing!"
+            "commit_transactions() working on a bank that is already frozen or is undergoing \
+             freezing!"
         );
 
         let ProcessedTransactionCounts {
@@ -3985,36 +3987,37 @@ impl Bank {
         pubkey: &Pubkey,
         new_account: &AccountSharedData,
     ) {
-        let old_account_data_size =
-            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
-                match new_account.lamports().cmp(&old_account.lamports()) {
-                    std::cmp::Ordering::Greater => {
-                        let increased = new_account.lamports() - old_account.lamports();
-                        trace!(
-                            "store_account_and_update_capitalization: increased: {pubkey} {increased}"
-                        );
-                        self.capitalization.fetch_add(increased, Relaxed);
-                    }
-                    std::cmp::Ordering::Less => {
-                        let decreased = old_account.lamports() - new_account.lamports();
-                        trace!(
-                            "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
-                        );
-                        self.capitalization.fetch_sub(decreased, Relaxed);
-                    }
-                    std::cmp::Ordering::Equal => {}
+        let old_account_data_size = if let Some(old_account) =
+            self.get_account_with_fixed_root_no_cache(pubkey)
+        {
+            match new_account.lamports().cmp(&old_account.lamports()) {
+                std::cmp::Ordering::Greater => {
+                    let increased = new_account.lamports() - old_account.lamports();
+                    trace!(
+                        "store_account_and_update_capitalization: increased: {pubkey} {increased}"
+                    );
+                    self.capitalization.fetch_add(increased, Relaxed);
                 }
-                old_account.data().len()
-            } else {
-                trace!(
-                    "store_account_and_update_capitalization: created: {} {}",
-                    pubkey,
-                    new_account.lamports()
-                );
-                self.capitalization
-                    .fetch_add(new_account.lamports(), Relaxed);
-                0
-            };
+                std::cmp::Ordering::Less => {
+                    let decreased = old_account.lamports() - new_account.lamports();
+                    trace!(
+                        "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
+                    );
+                    self.capitalization.fetch_sub(decreased, Relaxed);
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+            old_account.data().len()
+        } else {
+            trace!(
+                "store_account_and_update_capitalization: created: {} {}",
+                pubkey,
+                new_account.lamports()
+            );
+            self.capitalization
+                .fetch_add(new_account.lamports(), Relaxed);
+            0
+        };
 
         self.store_account(pubkey, new_account);
         self.calculate_and_update_accounts_data_size_delta_off_chain(
@@ -4156,14 +4159,14 @@ impl Bank {
         let bank_frozen = *lock != Hash::default();
         if new_hard_fork_slot < bank_slot {
             warn!(
-                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is older \
-                than the bank at slot {bank_slot} that attempted to register it."
+                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is older than the \
+                 bank at slot {bank_slot} that attempted to register it."
             );
         } else if (new_hard_fork_slot == bank_slot) && bank_frozen {
             warn!(
-                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is the same \
-                slot as the bank at slot {bank_slot} that attempted to register it, but that \
-                bank is already frozen."
+                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is the same slot \
+                 as the bank at slot {bank_slot} that attempted to register it, but that bank is \
+                 already frozen."
             );
         } else {
             self.hard_forks
@@ -4519,8 +4522,8 @@ impl Bank {
         );
         info!(
             "bank frozen: {slot} hash: {hash} signature_count: {} last_blockhash: {} \
-             capitalization: {}, accounts_lt_hash checksum: {accounts_lt_hash_checksum}, \
-             stats: {bank_hash_stats:?}",
+             capitalization: {}, accounts_lt_hash checksum: {accounts_lt_hash_checksum}, stats: \
+             {bank_hash_stats:?}",
             self.signature_count(),
             self.last_blockhash(),
             self.capitalization(),
@@ -4607,8 +4610,8 @@ impl Bank {
                 let expected = expected_accounts_lt_hash.0.checksum();
                 let calculated = calculated_accounts_lt_hash.0.checksum();
                 error!(
-                    "Verifying accounts failed: accounts lattice hashes do not match, \
-                     expected: {expected}, calculated: {calculated}",
+                    "Verifying accounts failed: accounts lattice hashes do not match, expected: \
+                     {expected}, calculated: {calculated}",
                 );
             }
             is_ok
@@ -5710,8 +5713,9 @@ impl TransactionProcessingCallback for Bank {
 
         assert!(
             !self.freeze_started(),
-            "Can't change frozen bank by adding not-existing new builtin program ({name}, {program_id}). \
-            Maybe, inconsistent program activation is detected on snapshot restore?"
+            "Can't change frozen bank by adding not-existing new builtin program ({name}, \
+             {program_id}). Maybe, inconsistent program activation is detected on snapshot \
+             restore?"
         );
 
         // Add a bogus executable builtin account, which will be loaded and ignored.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3987,37 +3987,36 @@ impl Bank {
         pubkey: &Pubkey,
         new_account: &AccountSharedData,
     ) {
-        let old_account_data_size = if let Some(old_account) =
-            self.get_account_with_fixed_root_no_cache(pubkey)
-        {
-            match new_account.lamports().cmp(&old_account.lamports()) {
-                std::cmp::Ordering::Greater => {
-                    let increased = new_account.lamports() - old_account.lamports();
-                    trace!(
+        let old_account_data_size =
+            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
+                match new_account.lamports().cmp(&old_account.lamports()) {
+                    std::cmp::Ordering::Greater => {
+                        let increased = new_account.lamports() - old_account.lamports();
+                        trace!(
                         "store_account_and_update_capitalization: increased: {pubkey} {increased}"
                     );
-                    self.capitalization.fetch_add(increased, Relaxed);
-                }
-                std::cmp::Ordering::Less => {
-                    let decreased = old_account.lamports() - new_account.lamports();
-                    trace!(
+                        self.capitalization.fetch_add(increased, Relaxed);
+                    }
+                    std::cmp::Ordering::Less => {
+                        let decreased = old_account.lamports() - new_account.lamports();
+                        trace!(
                         "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
                     );
-                    self.capitalization.fetch_sub(decreased, Relaxed);
+                        self.capitalization.fetch_sub(decreased, Relaxed);
+                    }
+                    std::cmp::Ordering::Equal => {}
                 }
-                std::cmp::Ordering::Equal => {}
-            }
-            old_account.data().len()
-        } else {
-            trace!(
-                "store_account_and_update_capitalization: created: {} {}",
-                pubkey,
-                new_account.lamports()
-            );
-            self.capitalization
-                .fetch_add(new_account.lamports(), Relaxed);
-            0
-        };
+                old_account.data().len()
+            } else {
+                trace!(
+                    "store_account_and_update_capitalization: created: {} {}",
+                    pubkey,
+                    new_account.lamports()
+                );
+                self.capitalization
+                    .fetch_add(new_account.lamports(), Relaxed);
+                0
+            };
 
         self.store_account(pubkey, new_account);
         self.calculate_and_update_accounts_data_size_delta_off_chain(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3987,36 +3987,32 @@ impl Bank {
         pubkey: &Pubkey,
         new_account: &AccountSharedData,
     ) {
-        let old_account_data_size =
-            if let Some(old_account) = self.get_account_with_fixed_root_no_cache(pubkey) {
-                match new_account.lamports().cmp(&old_account.lamports()) {
-                    std::cmp::Ordering::Greater => {
-                        let increased = new_account.lamports() - old_account.lamports();
-                        trace!(
-                        "store_account_and_update_capitalization: increased: {pubkey} {increased}"
-                    );
-                        self.capitalization.fetch_add(increased, Relaxed);
-                    }
-                    std::cmp::Ordering::Less => {
-                        let decreased = old_account.lamports() - new_account.lamports();
-                        trace!(
-                        "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
-                    );
-                        self.capitalization.fetch_sub(decreased, Relaxed);
-                    }
-                    std::cmp::Ordering::Equal => {}
+        let old_account_data_size = if let Some(old_account) =
+            self.get_account_with_fixed_root_no_cache(pubkey)
+        {
+            match new_account.lamports().cmp(&old_account.lamports()) {
+                std::cmp::Ordering::Greater => {
+                    let diff = new_account.lamports() - old_account.lamports();
+                    trace!("store_account_and_update_capitalization: increased: {pubkey} {diff}");
+                    self.capitalization.fetch_add(diff, Relaxed);
                 }
-                old_account.data().len()
-            } else {
-                trace!(
-                    "store_account_and_update_capitalization: created: {} {}",
-                    pubkey,
-                    new_account.lamports()
-                );
-                self.capitalization
-                    .fetch_add(new_account.lamports(), Relaxed);
-                0
-            };
+                std::cmp::Ordering::Less => {
+                    let diff = old_account.lamports() - new_account.lamports();
+                    trace!("store_account_and_update_capitalization: decreased: {pubkey} {diff}");
+                    self.capitalization.fetch_sub(diff, Relaxed);
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+            old_account.data().len()
+        } else {
+            trace!(
+                "store_account_and_update_capitalization: created: {pubkey} {}",
+                new_account.lamports()
+            );
+            self.capitalization
+                .fetch_add(new_account.lamports(), Relaxed);
+            0
+        };
 
         self.store_account(pubkey, new_account);
         self.calculate_and_update_accounts_data_size_delta_off_chain(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2376,7 +2376,7 @@ impl Bank {
                 },
             )| {
                 if let Err(err) = vote_account.checked_add_lamports(vote_rewards) {
-                    debug!("reward redemption failed for {}: {:?}", vote_pubkey, err);
+                    debug!("reward redemption failed for {vote_pubkey}: {err:?}");
                     return;
                 }
 
@@ -3132,7 +3132,7 @@ impl Bank {
             },
         );
 
-        debug!("simulate_transaction: {:?}", timings);
+        debug!("simulate_transaction: {timings:?}");
 
         let processing_result = processing_results
             .pop()
@@ -3333,7 +3333,7 @@ impl Bank {
                 }
                 Err(err) => {
                     if err_count.0 == 0 {
-                        debug!("tx error: {:?} {:?}", err, tx);
+                        debug!("tx error: {err:?} {tx:?}");
                     }
                     *err_count += 1;
                 }
@@ -3991,18 +3991,14 @@ impl Bank {
                     std::cmp::Ordering::Greater => {
                         let increased = new_account.lamports() - old_account.lamports();
                         trace!(
-                            "store_account_and_update_capitalization: increased: {} {}",
-                            pubkey,
-                            increased
+                            "store_account_and_update_capitalization: increased: {pubkey} {increased}"
                         );
                         self.capitalization.fetch_add(increased, Relaxed);
                     }
                     std::cmp::Ordering::Less => {
                         let decreased = old_account.lamports() - new_account.lamports();
                         trace!(
-                            "store_account_and_update_capitalization: decreased: {} {}",
-                            pubkey,
-                            decreased
+                            "store_account_and_update_capitalization: decreased: {pubkey} {decreased}"
                         );
                         self.capitalization.fetch_sub(decreased, Relaxed);
                     }
@@ -5205,9 +5201,9 @@ impl Bank {
     }
 
     pub fn add_precompile(&mut self, program_id: &Pubkey) {
-        debug!("Adding precompiled program {}", program_id);
+        debug!("Adding precompiled program {program_id}");
         self.add_precompiled_account(program_id);
-        debug!("Added precompiled program {:?}", program_id);
+        debug!("Added precompiled program {program_id:?}");
     }
 
     // Call AccountsDb::clean_accounts()

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -373,8 +373,7 @@ impl Bank {
                             ) && VoteAccount::try_from(account_from_db.clone()).is_ok()
                             {
                                 panic!(
-                                    "Vote account {} not found in cache, but found in db: {:?}",
-                                    vote_pubkey, account_from_db
+                                    "Vote account {vote_pubkey} not found in cache, but found in db: {account_from_db:?}"
                                 );
                             }
                         }
@@ -423,8 +422,7 @@ impl Bank {
                         });
                     } else {
                         debug!(
-                            "redeem_rewards() failed for {}: {:?}",
-                            stake_pubkey, redeemed
+                            "redeem_rewards() failed for {stake_pubkey}: {redeemed:?}"
                         );
                     }
                     None

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -311,8 +311,12 @@ impl Bank {
 
         // Use `EpochStakes` for vote accounts
         let leader_schedule_epoch = self.epoch_schedule().get_leader_schedule_epoch(self.slot());
-        let cached_vote_accounts = self.epoch_stakes(leader_schedule_epoch)
-            .expect("calculation should always run after Bank::update_epoch_stakes(leader_schedule_epoch)")
+        let cached_vote_accounts = self
+            .epoch_stakes(leader_schedule_epoch)
+            .expect(
+                "calculation should always run after \
+                 Bank::update_epoch_stakes(leader_schedule_epoch)",
+            )
             .stakes()
             .vote_accounts();
 
@@ -373,7 +377,8 @@ impl Bank {
                             ) && VoteAccount::try_from(account_from_db.clone()).is_ok()
                             {
                                 panic!(
-                                    "Vote account {vote_pubkey} not found in cache, but found in db: {account_from_db:?}"
+                                    "Vote account {vote_pubkey} not found in cache, but found in \
+                                     db: {account_from_db:?}"
                                 );
                             }
                         }
@@ -421,9 +426,7 @@ impl Bank {
                             commission,
                         });
                     } else {
-                        debug!(
-                            "redeem_rewards() failed for {stake_pubkey}: {redeemed:?}"
-                        );
+                        debug!("redeem_rewards() failed for {stake_pubkey}: {redeemed:?}");
                     }
                     None
                 })

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -93,7 +93,8 @@ impl Bank {
         else {
             // We should never get here.
             unreachable!(
-                "epoch rewards status is not in distribution phase, but we are trying to distribute rewards"
+                "epoch rewards status is not in distribution phase, but we are trying to \
+                 distribute rewards"
             );
         };
 

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -12,7 +12,7 @@ impl Bank {
         if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
             let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
                 from_account(&account).unwrap();
-            info!("{prefix} epoch_rewards sysvar: {:?}", epoch_rewards);
+            info!("{prefix} epoch_rewards sysvar: {epoch_rewards:?}");
         } else {
             info!("{prefix} epoch_rewards sysvar: none");
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3705,7 +3705,8 @@ fn test_banks_leak() {
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
     error!(
-        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {pid})/$REPLY));done"
+        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= \
+         -p {pid})/$REPLY));done"
     );
     loop {
         num_banks += 1;
@@ -5610,9 +5611,9 @@ fn test_add_builtin_account_squatted_while_not_replacing() {
 
 #[test]
 #[should_panic(
-    expected = "Can't change frozen bank by adding not-existing new builtin \
-                program (mock_program, CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+    expected = "Can't change frozen bank by adding not-existing new builtin program \
+                (mock_program, CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). Maybe, inconsistent \
+                program activation is detected on snapshot restore?"
 )]
 fn test_add_builtin_account_after_frozen() {
     let slot = 123;
@@ -5759,9 +5760,9 @@ fn test_add_precompiled_account_squatted_while_not_replacing() {
 
 #[test]
 #[should_panic(
-    expected = "Can't change frozen bank by adding not-existing new precompiled \
-                program (CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+    expected = "Can't change frozen bank by adding not-existing new precompiled program \
+                (CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). Maybe, inconsistent program \
+                activation is detected on snapshot restore?"
 )]
 fn test_add_precompiled_account_after_frozen() {
     let slot = 123;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3705,7 +3705,7 @@ fn test_banks_leak() {
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
     error!(
-        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {})/$REPLY));done", pid
+        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {pid})/$REPLY));done"
     );
     loop {
         num_banks += 1;
@@ -3729,7 +3729,7 @@ fn test_banks_leak() {
             }
             #[cfg(not(target_os = "linux"))]
             {
-                error!("{} banks, sleeping for 5 sec", num_banks);
+                error!("{num_banks} banks, sleeping for 5 sec");
                 std::thread::sleep(Duration::from_secs(5));
             }
         }
@@ -4178,11 +4178,11 @@ fn test_nonce_authority() {
     let bad_nonce_authority = bad_nonce_authority_keypair.pubkey();
     let custodian_account = bank.get_account(&custodian_pubkey).unwrap();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
-    debug!("cust: {:?}", custodian_account);
+    debug!("cust: {custodian_account:?}");
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
 
     for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {
@@ -4199,7 +4199,7 @@ fn test_nonce_authority() {
         &[&custodian_keypair, &bad_nonce_authority_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
     let initial_custodian_balance = custodian_account.lamports();
     assert_eq!(
         bank.process_transaction(&nonce_tx),
@@ -4237,9 +4237,9 @@ fn test_nonce_payer() {
     let custodian_pubkey = custodian_keypair.pubkey();
     let nonce_pubkey = nonce_keypair.pubkey();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
     debug!("cust: {:?}", bank.get_account(&custodian_pubkey));
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
@@ -4258,7 +4258,7 @@ fn test_nonce_payer() {
         &[&custodian_keypair, &nonce_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
     assert_eq!(
         bank.process_transaction(&nonce_tx),
         Err(TransactionError::InstructionError(
@@ -4303,9 +4303,9 @@ fn test_nonce_payer_tx_wide_cap() {
     let custodian_pubkey = custodian_keypair.pubkey();
     let nonce_pubkey = nonce_keypair.pubkey();
 
-    debug!("alice: {}", alice_pubkey);
-    debug!("custodian: {}", custodian_pubkey);
-    debug!("nonce: {}", nonce_pubkey);
+    debug!("alice: {alice_pubkey}");
+    debug!("custodian: {custodian_pubkey}");
+    debug!("nonce: {nonce_pubkey}");
     debug!("nonce account: {:?}", bank.get_account(&nonce_pubkey));
     debug!("cust: {:?}", bank.get_account(&custodian_pubkey));
     let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
@@ -4324,7 +4324,7 @@ fn test_nonce_payer_tx_wide_cap() {
         &[&custodian_keypair, &nonce_keypair],
         nonce_hash,
     );
-    debug!("{:?}", nonce_tx);
+    debug!("{nonce_tx:?}");
 
     assert_eq!(
         bank.process_transaction(&nonce_tx),
@@ -4794,7 +4794,7 @@ fn test_account_ids_after_program_ids() {
     let result = bank.process_transaction(&tx);
     assert_eq!(result, Ok(()));
     let account = bank.get_account(&solana_vote_program::id()).unwrap();
-    info!("account: {:?}", account);
+    info!("account: {account:?}");
     assert!(account.executable());
 }
 
@@ -5129,11 +5129,11 @@ fn test_fuzz_instructions() {
             assert!(account.executable());
             assert_eq!(account.data(), name);
         }
-        info!("result: {:?}", result);
+        info!("result: {result:?}");
         let result_key = format!("{result:?}");
         *results.entry(result_key).or_insert(0) += 1;
     }
-    info!("results: {:?}", results);
+    info!("results: {results:?}");
 }
 
 // DEVELOPERS: This test is intended to ensure that the bank hash remains
@@ -5268,8 +5268,8 @@ fn test_clean_nonrooted() {
     let pubkey0 = Pubkey::from([0; 32]);
     let pubkey1 = Pubkey::from([1; 32]);
 
-    info!("pubkey0: {}", pubkey0);
-    info!("pubkey1: {}", pubkey1);
+    info!("pubkey0: {pubkey0}");
+    info!("pubkey1: {pubkey1}");
 
     // Set root for bank 0, with caching enabled
     let bank0 = Arc::new(Bank::new_with_config_for_tests(
@@ -6956,7 +6956,7 @@ fn min_rent_exempt_balance_for_sysvars(bank: &Bank, sysvar_ids: &[Pubkey]) -> u6
     sysvar_ids
         .iter()
         .map(|sysvar_id| {
-            trace!("min_rent_excempt_balance_for_sysvars: {}", sysvar_id);
+            trace!("min_rent_excempt_balance_for_sysvars: {sysvar_id}");
             bank.get_minimum_balance_for_rent_exemption(
                 bank.get_account(sysvar_id).unwrap().data().len(),
             )
@@ -11627,7 +11627,7 @@ fn test_deploy_last_epoch_slot() {
     let signers = &[&payer_keypair, &upgrade_authority_keypair];
     let transaction = Transaction::new(signers, message.clone(), bank.last_blockhash());
     let ret = bank.process_transaction(&transaction);
-    assert!(ret.is_ok(), "ret: {:?}", ret);
+    assert!(ret.is_ok(), "ret: {ret:?}");
     goto_end_of_slot(bank.clone());
 
     // go to the first slot in the new epoch
@@ -11944,7 +11944,7 @@ fn test_loader_v3_to_v4_migration(formalize_loaded_transaction_data_size: bool) 
         bank.store_account(&programdata_address, &programdata_account);
         bank.store_account(&payer_keypair.pubkey(), &payer_account);
         let result = bank.process_transaction(&transaction);
-        assert!(result.is_ok(), "result: {:?}", result);
+        assert!(result.is_ok(), "result: {result:?}");
 
         goto_end_of_slot(bank.clone());
         let bank =

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -162,7 +162,11 @@ impl SyncClient for BankClient {
         min_confirmed_blocks: usize,
     ) -> Result<usize> {
         // https://github.com/solana-labs/solana/issues/7199
-        assert_eq!(min_confirmed_blocks, 1, "BankClient cannot observe the passage of multiple blocks, so min_confirmed_blocks must be 1");
+        assert_eq!(
+            min_confirmed_blocks, 1,
+            "BankClient cannot observe the passage of multiple blocks, so min_confirmed_blocks \
+             must be 1"
+        );
         let now = Instant::now();
         let confirmed_blocks;
         loop {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -224,7 +224,7 @@ impl BankForks {
     }
 
     pub fn install_scheduler_pool(&mut self, pool: InstalledSchedulerPoolArc) {
-        info!("Installed new scheduler_pool into bank_forks: {:?}", pool);
+        info!("Installed new scheduler_pool into bank_forks: {pool:?}");
         assert!(
             self.scheduler_pool.replace(pool).is_none(),
             "Reinstalling scheduler pool isn't supported"

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -383,7 +383,8 @@ impl BankForks {
             // Now we have rooted a bank in a new epoch, there are no needs to
             // keep the epoch rewards cache for current epoch any longer.
             info!(
-                "Clearing epoch rewards cache for epoch {old_epoch} after setting root to slot {root}"
+                "Clearing epoch rewards cache for epoch {old_epoch} after setting root to slot \
+                 {root}"
             );
             root_bank.clear_epoch_rewards_cache();
         }

--- a/runtime/src/bank_hash_cache.rs
+++ b/runtime/src/bank_hash_cache.rs
@@ -82,8 +82,8 @@ impl BankHashCache {
         let prev_hash = self.hashes.insert(slot, hash);
         debug_assert!(
             prev_hash.is_none(),
-            "Programmer error, this indicates we have dumped and replayed \
-             a block however the cache was not invalidated"
+            "Programmer error, this indicates we have dumped and replayed a block however the \
+             cache was not invalidated"
         );
         Some(hash)
     }

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -246,8 +246,7 @@ pub fn deactivate_features(
             genesis_config.accounts.remove(deactivate_feature_pk);
         } else {
             warn!(
-                "Feature {:?} set for deactivation is not a known Feature public key",
-                deactivate_feature_pk
+                "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
             );
         }
     }

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -246,7 +246,8 @@ pub fn deactivate_features(
             genesis_config.accounts.remove(deactivate_feature_pk);
         } else {
             warn!(
-                "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature public key"
+                "Feature {deactivate_feature_pk:?} set for deactivation is not a known Feature \
+                 public key"
             );
         }
     }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -614,7 +614,7 @@ impl BankWithSchedulerInner {
                 // unconditional context construction for verification is okay here.
                 let context = SchedulingContext::for_verification(self.bank.clone());
                 let mut scheduler = self.scheduler.write().unwrap();
-                trace!("with_active_scheduler: {:?}", scheduler);
+                trace!("with_active_scheduler: {scheduler:?}");
                 scheduler.transition_from_stale_to_active(|pool, result_with_timings| {
                     let scheduler = pool.take_resumed_scheduler(context, result_with_timings);
                     info!(
@@ -674,7 +674,7 @@ impl BankWithSchedulerInner {
                 );
                 (pool, result_with_timings)
             });
-            trace!("timeout_listener: {:?}", scheduler);
+            trace!("timeout_listener: {scheduler:?}");
         })
     }
 
@@ -746,8 +746,7 @@ impl BankWithSchedulerInner {
             thread::current(),
         );
         trace!(
-            "wait_for_scheduler_termination(result_with_timings: {:?})",
-            result_with_timings,
+            "wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",
         );
 
         result_with_timings

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -618,7 +618,8 @@ impl BankWithSchedulerInner {
                 scheduler.transition_from_stale_to_active(|pool, result_with_timings| {
                     let scheduler = pool.take_resumed_scheduler(context, result_with_timings);
                     info!(
-                        "with_active_scheduler: bank (slot: {}) got active, taking scheduler (id: {})",
+                        "with_active_scheduler: bank (slot: {}) got active, taking scheduler (id: \
+                         {})",
                         self.bank.slot(),
                         scheduler.id(),
                     );
@@ -738,16 +739,15 @@ impl BankWithSchedulerInner {
             SchedulerStatus::Unavailable => (true, None),
         };
         debug!(
-            "wait_for_scheduler_termination(slot: {}, reason: {:?}): noop: {:?}, result: {:?} at {:?}...",
+            "wait_for_scheduler_termination(slot: {}, reason: {:?}): noop: {:?}, result: {:?} at \
+             {:?}...",
             bank.slot(),
             reason,
             was_noop,
             result_with_timings.as_ref().map(|(result, _)| result),
             thread::current(),
         );
-        trace!(
-            "wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",
-        );
+        trace!("wait_for_scheduler_termination(result_with_timings: {result_with_timings:?})",);
 
         result_with_timings
     }
@@ -755,7 +755,8 @@ impl BankWithSchedulerInner {
     fn drop_scheduler(&self) {
         if thread::panicking() {
             error!(
-                "BankWithSchedulerInner::drop_scheduler(): slot: {} skipping due to already panicking...",
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} skipping due to already \
+                 panicking...",
                 self.bank.slot(),
             );
             return;
@@ -767,7 +768,8 @@ impl BankWithSchedulerInner {
             .map(|(result, _timings)| result)
         {
             warn!(
-                "BankWithSchedulerInner::drop_scheduler(): slot: {} discarding error from scheduler: {:?}",
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} discarding error from \
+                 scheduler: {:?}",
                 self.bank.slot(),
                 err,
             );

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -267,8 +267,7 @@ impl PrioritizationFeeCache {
                     })
                     .unwrap_or_else(|err| {
                         warn!(
-                            "prioritization fee cache transaction updates failed: {:?}",
-                            err
+                            "prioritization fee cache transaction updates failed: {err:?}"
                         );
                     });
             }
@@ -285,8 +284,7 @@ impl PrioritizationFeeCache {
             .send(CacheServiceUpdate::BankFinalized { slot, bank_id })
             .unwrap_or_else(|err| {
                 warn!(
-                    "prioritization fee cache signalling bank frozen failed: {:?}",
-                    err
+                    "prioritization fee cache signalling bank frozen failed: {err:?}"
                 )
             });
     }
@@ -351,8 +349,7 @@ impl PrioritizationFeeCache {
             if let Some(prioritization_fee) = &mut prioritization_fee {
                 if let Err(err) = prioritization_fee.mark_block_completed() {
                     error!(
-                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
-                        err
+                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}"
                     );
                 }
                 prioritization_fee.report_metrics(slot);

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -266,9 +266,7 @@ impl PrioritizationFeeCache {
                         writable_accounts,
                     })
                     .unwrap_or_else(|err| {
-                        warn!(
-                            "prioritization fee cache transaction updates failed: {err:?}"
-                        );
+                        warn!("prioritization fee cache transaction updates failed: {err:?}");
                     });
             }
         });
@@ -283,9 +281,7 @@ impl PrioritizationFeeCache {
         self.sender
             .send(CacheServiceUpdate::BankFinalized { slot, bank_id })
             .unwrap_or_else(|err| {
-                warn!(
-                    "prioritization fee cache signalling bank frozen failed: {err:?}"
-                )
+                warn!("prioritization fee cache signalling bank frozen failed: {err:?}")
             });
     }
 
@@ -343,14 +339,15 @@ impl PrioritizationFeeCache {
             // It should be rare that optimistically confirmed bank had no prioritized
             // transactions, but duplicated and unconfirmed bank had.
             if pre_purge_bank_count > 0 && post_purge_bank_count == 0 {
-                warn!("Finalized bank has empty prioritization fee cache. slot {slot} bank id {bank_id}");
+                warn!(
+                    "Finalized bank has empty prioritization fee cache. slot {slot} bank id \
+                     {bank_id}"
+                );
             }
 
             if let Some(prioritization_fee) = &mut prioritization_fee {
                 if let Err(err) = prioritization_fee.mark_block_completed() {
-                    error!(
-                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}"
-                    );
+                    error!("Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {err:?}");
                 }
                 prioritization_fee.report_metrics(slot);
             }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -340,8 +340,14 @@ impl<T> SnapshotAccountsDbFields<T> {
                 // There must not be any overlap in the slots of storages between the full snapshot and the incremental snapshot
                 incremental_snapshot_storages
                     .iter()
-                    .all(|storage_entry| !full_snapshot_storages.contains_key(storage_entry.0)).then_some(()).ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Snapshots are incompatible: There are storages for the same slot in both the full snapshot and the incremental snapshot!")
+                    .all(|storage_entry| !full_snapshot_storages.contains_key(storage_entry.0))
+                    .then_some(())
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Snapshots are incompatible: There are storages for the same slot in \
+                             both the full snapshot and the incremental snapshot!",
+                        )
                     })?;
 
                 let mut combined_storages = full_snapshot_storages;
@@ -435,9 +441,7 @@ where
     let deserializable_bank = deserialize_from::<_, DeserializableVersionedBank>(&mut stream)?;
     if !deserializable_bank.unused_epoch_stakes.is_empty() {
         return Err(Box::new(bincode::ErrorKind::Custom(
-            "Expected deserialized bank's unused_epoch_stakes field \
-             to be empty"
-                .to_string(),
+            "Expected deserialized bank's unused_epoch_stakes field to be empty".to_string(),
         )));
     }
     let mut bank_fields = BankFieldsToDeserialize::from(deserializable_bank);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -688,7 +688,7 @@ mod serde_snapshot_tests {
             reconstruct_accounts_db_via_serialization(&accounts, current_slot, storage_access);
         accounts.clean_accounts_for_tests();
 
-        info!("pubkey: {}", pubkey1);
+        info!("pubkey: {pubkey1}");
         accounts.print_accounts_stats("pre_clean");
         accounts.assert_load_account(current_slot, pubkey1, zero_lamport);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -233,7 +233,7 @@ pub fn bank_from_snapshot_archives(
         exit,
     )?;
     measure_rebuild.stop();
-    info!("{}", measure_rebuild);
+    info!("{measure_rebuild}");
 
     verify_epoch_stakes(&bank)?;
 
@@ -413,7 +413,7 @@ pub fn bank_from_snapshot_dir(
         )?,
         "rebuild storages from snapshot dir"
     );
-    info!("{}", measure_rebuild_storages);
+    info!("{measure_rebuild_storages}");
 
     let next_append_vec_id =
         Arc::try_unwrap(next_append_vec_id).expect("this is the only strong reference");
@@ -441,7 +441,7 @@ pub fn bank_from_snapshot_dir(
         )?,
         "rebuild bank from snapshot"
     );
-    info!("{}", measure_rebuild_bank);
+    info!("{measure_rebuild_bank}");
 
     verify_epoch_stakes(&bank)?;
 

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -118,12 +118,13 @@ impl SnapshotController {
                         request_kind,
                         enqueued: Instant::now(),
                     }) {
-                        warn!(
-                            "Error sending snapshot request for bank: {bank_slot}, err: {e:?}"
-                        );
+                        warn!("Error sending snapshot request for bank: {bank_slot}, err: {e:?}");
                     }
                 } else {
-                    info!("Not sending snapshot request for bank: {bank_slot}, startup verification is incomplete");
+                    info!(
+                        "Not sending snapshot request for bank: {bank_slot}, startup verification \
+                         is incomplete"
+                    );
                 }
                 snapshot_time.stop();
                 total_snapshot_ms += snapshot_time.as_ms();

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -119,12 +119,11 @@ impl SnapshotController {
                         enqueued: Instant::now(),
                     }) {
                         warn!(
-                            "Error sending snapshot request for bank: {}, err: {:?}",
-                            bank_slot, e
+                            "Error sending snapshot request for bank: {bank_slot}, err: {e:?}"
                         );
                     }
                 } else {
-                    info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
+                    info!("Not sending snapshot request for bank: {bank_slot}, startup verification is incomplete");
                 }
                 snapshot_time.stop();
                 total_snapshot_ms += snapshot_time.as_ms();

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -92,7 +92,8 @@ impl<'a> SnapshotMinimizer<'a> {
         let added_accounts = total_accounts_len - initial_accounts_len;
 
         info!(
-            "Added {added_accounts} {name} for total of {total_accounts_len} accounts. get {measure}"
+            "Added {added_accounts} {name} for total of {total_accounts_len} accounts. get \
+             {measure}"
         );
     }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1072,7 +1072,7 @@ fn archive_snapshot(
     // Create the staging directories
     let staging_dir_prefix = TMP_SNAPSHOT_ARCHIVE_PREFIX;
     let staging_dir = tempfile::Builder::new()
-        .prefix(&format!("{}{}-", staging_dir_prefix, snapshot_slot))
+        .prefix(&format!("{staging_dir_prefix}{snapshot_slot}-"))
         .tempdir_in(tar_dir)
         .map_err(|err| E::CreateStagingDir(err, tar_dir.to_path_buf()))?;
     let staging_snapshots_dir = staging_dir.path().join(SNAPSHOTS_DIR);
@@ -1909,7 +1909,7 @@ fn unarchive_snapshot(
                 )?,
                 measure_name
             );
-            info!("{}", measure_untar);
+            info!("{measure_untar}");
             create_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
 
             Ok(UnarchivedSnapshot {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -362,7 +362,10 @@ pub enum SnapshotError {
     #[error("could not parse snapshot archive's file name '{0}'")]
     ParseSnapshotArchiveFileNameError(String),
 
-    #[error("snapshots are incompatible: full snapshot slot ({0}) and incremental snapshot base slot ({1}) do not match")]
+    #[error(
+        "snapshots are incompatible: full snapshot slot ({0}) and incremental snapshot base slot \
+         ({1}) do not match"
+    )]
     MismatchedBaseSlot(Slot, Slot),
 
     #[error("no snapshot archives to load from '{0}'")]
@@ -868,7 +871,8 @@ pub fn serialize_and_archive_snapshot_package(
     write_full_snapshot_slot_file(&bank_snapshot_info.snapshot_dir, full_snapshot_archive_slot)
         .map_err(|err| {
             IoError::other(format!(
-                "failed to serialize snapshot slot {snapshot_slot}, block height {block_height}, kind {snapshot_kind:?}: {err}",
+                "failed to serialize snapshot slot {snapshot_slot}, block height {block_height}, \
+                 kind {snapshot_kind:?}: {err}",
             ))
         })?;
 
@@ -1461,7 +1465,8 @@ fn check_deserialize_file_consumed(
 
     if consumed_size != file_size {
         let error_message = format!(
-            "invalid snapshot data file: '{}' has {} bytes, however consumed {} bytes to deserialize",
+            "invalid snapshot data file: '{}' has {} bytes, however consumed {} bytes to \
+             deserialize",
             file_path.as_ref().display(),
             file_size,
             consumed_size,

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -100,7 +100,8 @@ impl<T: Serialize + Clone> StatusCache<T> {
                             }
                         } else {
                             panic!(
-                                "Map for key must exist if key exists in self.slot_deltas, slot: {slot}"
+                                "Map for key must exist if key exists in self.slot_deltas, slot: \
+                                 {slot}"
                             )
                         }
                     }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -152,7 +152,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         let keys: Vec<_> = self.cache.keys().copied().collect();
 
         for blockhash in keys.iter() {
-            trace!("get_status_any_blockhash: trying {}", blockhash);
+            trace!("get_status_any_blockhash: trying {blockhash}");
             let status = self.get_status(&key, blockhash, ancestors);
             if status.is_some() {
                 return status;


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`