### PR TITLE
bench-tps: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -229,7 +229,8 @@ where
         let bsps = (tx_count) as f64 / ns as f64;
         let nsps = ns as f64 / (tx_count) as f64;
         info!(
-            "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total time, {:?}",
+            "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total \
+             time, {:?}",
             bsps * 1_000_000_f64,
             nsps / 1_000_f64,
             duration.as_millis(),
@@ -266,9 +267,7 @@ where
     T: 'static + TpsClient + Send + Sync + ?Sized,
 {
     if target_slots_per_epoch != 0 {
-        info!(
-            "Waiting until epochs are {target_slots_per_epoch} slots long.."
-        );
+        info!("Waiting until epochs are {target_slots_per_epoch} slots long..");
         loop {
             if let Ok(epoch_info) = client.get_epoch_info() {
                 if epoch_info.slots_in_epoch >= target_slots_per_epoch {
@@ -999,7 +998,10 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
                     sent_at: Utc::now(),
                     compute_unit_prices,
                 }) {
-                    error!("Receiver has been dropped with error `{error}`, stop sending transactions.");
+                    error!(
+                        "Receiver has been dropped with error `{error}`, stop sending \
+                         transactions."
+                    );
                     break 'thread_loop;
                 }
             }
@@ -1083,9 +1085,7 @@ fn compute_and_report_stats(
     if total_maxes > 0.0 {
         let num_nodes_with_tps = maxes.read().unwrap().len() - nodes_with_zero_tps;
         let average_max = total_maxes / num_nodes_with_tps as f32;
-        info!(
-            "\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS"
-        );
+        info!("\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS");
     }
 
     let total_tx_send_count = total_tx_send_count as u64;
@@ -1095,7 +1095,8 @@ fn compute_and_report_stats(
         0.0
     };
     info!(
-        "\nHighest TPS: {:.2} sampling period {}s max transactions: {} clients: {} drop rate: {:.2}",
+        "\nHighest TPS: {:.2} sampling period {}s max transactions: {} clients: {} drop rate: \
+         {:.2}",
         max_of_maxes,
         sample_period,
         max_tx_count,
@@ -1179,7 +1180,8 @@ pub fn fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>(
 
         let funding_key_balance = client.get_balance(&funding_key.pubkey()).unwrap_or(0);
         info!(
-            "Funding keypair balance: {funding_key_balance} max_fee: {max_fee} lamports_per_account: {lamports_per_account} extra: {extra} total: {total}"
+            "Funding keypair balance: {funding_key_balance} max_fee: {max_fee} \
+             lamports_per_account: {lamports_per_account} extra: {extra} total: {total}"
         );
 
         if funding_key_balance < total + rent {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -267,13 +267,12 @@ where
 {
     if target_slots_per_epoch != 0 {
         info!(
-            "Waiting until epochs are {} slots long..",
-            target_slots_per_epoch
+            "Waiting until epochs are {target_slots_per_epoch} slots long.."
         );
         loop {
             if let Ok(epoch_info) = client.get_epoch_info() {
                 if epoch_info.slots_in_epoch >= target_slots_per_epoch {
-                    info!("Done epoch_info: {:?}", epoch_info);
+                    info!("Done epoch_info: {epoch_info:?}");
                     break;
                 }
                 info!(
@@ -295,7 +294,7 @@ fn create_sampler_thread<T>(
 where
     T: 'static + TpsClient + Send + Sync + ?Sized,
 {
-    info!("Sampling TPS every {} second...", sample_period);
+    info!("Sampling TPS every {sample_period} second...");
     let maxes = maxes.clone();
     let client = client.clone();
     Builder::new()
@@ -440,12 +439,12 @@ where
         match client.get_transaction_count() {
             Ok(count) => break count,
             Err(err) => {
-                info!("Couldn't get transaction count: {:?}", err);
+                info!("Couldn't get transaction count: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         }
     };
-    info!("Initial transaction count {}", first_tx_count);
+    info!("Initial transaction count {first_tx_count}");
 
     let exit_signal = Arc::new(AtomicBool::new(false));
 
@@ -516,28 +515,28 @@ where
 
     info!("Waiting for sampler threads...");
     if let Err(err) = sample_thread.join() {
-        info!("  join() failed with: {:?}", err);
+        info!("  join() failed with: {err:?}");
     }
 
     // join the tx send threads
     info!("Waiting for transmit threads...");
     for t in sender_threads {
         if let Err(err) = t.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
     if let Some(blockhash_thread) = blockhash_thread {
         info!("Waiting for blockhash thread...");
         if let Err(err) = blockhash_thread.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
     if let Some(log_transaction_service) = log_transaction_service {
         info!("Waiting for log_transaction_service thread...");
         if let Err(err) = log_transaction_service.join() {
-            info!("  join() failed with: {:?}", err);
+            info!("  join() failed with: {err:?}");
         }
     }
 
@@ -560,7 +559,7 @@ where
 }
 
 fn metrics_submit_lamport_balance(lamport_balance: u64) {
-    info!("Token balance: {}", lamport_balance);
+    info!("Token balance: {lamport_balance}");
     datapoint_info!(
         "bench-tps-lamport_balance",
         ("balance", lamport_balance, i64)
@@ -700,7 +699,7 @@ fn get_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?Sized>(
                 return nonce_accounts;
             }
             Err(err) => {
-                info!("Couldn't get durable nonce account: {:?}", err);
+                info!("Couldn't get durable nonce account: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         }
@@ -883,7 +882,7 @@ fn get_new_latest_blockhash<T: TpsClient + ?Sized>(
                 return Some(new_blockhash);
             }
         }
-        debug!("Got same blockhash ({:?}), will retry...", blockhash);
+        debug!("Got same blockhash ({blockhash:?}), will retry...");
 
         // Retry ~twice during a slot
         sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2));
@@ -962,7 +961,7 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
         if let Some(txs) = txs {
             shared_tx_thread_count.fetch_add(1, Ordering::Relaxed);
             let num_txs = txs.len();
-            info!("Transferring 1 unit {} times...", num_txs);
+            info!("Transferring 1 unit {num_txs} times...");
             let transfer_start = Instant::now();
             let mut old_transactions = false;
             let mut min_timestamp = u64::MAX;
@@ -1006,7 +1005,7 @@ fn do_tx_transfers<T: TpsClient + ?Sized>(
             }
 
             if let Err(error) = client.send_batch(transactions) {
-                warn!("send_batch_sync in do_tx_transfers failed: {}", error);
+                warn!("send_batch_sync in do_tx_transfers failed: {error}");
             }
 
             datapoint_info!(
@@ -1085,8 +1084,7 @@ fn compute_and_report_stats(
         let num_nodes_with_tps = maxes.read().unwrap().len() - nodes_with_zero_tps;
         let average_max = total_maxes / num_nodes_with_tps as f32;
         info!(
-            "\nAverage max TPS: {:.2}, {} nodes had 0 TPS",
-            average_max, nodes_with_zero_tps
+            "\nAverage max TPS: {average_max:.2}, {nodes_with_zero_tps} nodes had 0 TPS"
         );
     }
 
@@ -1121,7 +1119,7 @@ pub fn generate_and_fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>
     let rent = client.get_minimum_balance_for_rent_exemption(0)?;
     let lamports_per_account = lamports_per_account + rent;
 
-    info!("Creating {} keypairs...", keypair_count);
+    info!("Creating {keypair_count} keypairs...");
     let (mut keypairs, extra) = generate_keypairs(funding_key, keypair_count as u64);
     fund_keypairs(
         client,
@@ -1181,8 +1179,7 @@ pub fn fund_keypairs<T: 'static + TpsClient + Send + Sync + ?Sized>(
 
         let funding_key_balance = client.get_balance(&funding_key.pubkey()).unwrap_or(0);
         info!(
-            "Funding keypair balance: {} max_fee: {} lamports_per_account: {} extra: {} total: {}",
-            funding_key_balance, max_fee, lamports_per_account, extra, total
+            "Funding keypair balance: {funding_key_balance} max_fee: {max_fee} lamports_per_account: {lamports_per_account} extra: {extra} total: {total}"
         );
 
         if funding_key_balance < total + rent {

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -121,7 +121,8 @@ impl Default for Config {
 
 /// Defines and builds the CLI args for a run of the benchmark
 pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
-    App::new(crate_name!()).about(crate_description!())
+    App::new(crate_name!())
+        .about(crate_description!())
         .version(version)
         .arg({
             let arg = Arg::with_name("config_file")
@@ -146,8 +147,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -176,7 +177,6 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .hidden(hidden_unless_forced())
                 .help("Deprecated. Use --authority instead"),
-
         )
         .arg(
             Arg::with_name("authority")
@@ -184,7 +184,9 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("authority")
                 .value_name("PATH")
                 .takes_value(true)
-                .help("File containing a client authority (keypair) to fund participating accounts"),
+                .help(
+                    "File containing a client authority (keypair) to fund participating accounts",
+                ),
         )
         .arg(
             Arg::with_name("threads")
@@ -201,25 +203,24 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .help("Seconds to run benchmark, then exit; default is forever"),
         )
-        .arg(
-            Arg::with_name("sustained")
-                .long("sustained")
-                .help("Use sustained performance mode vs. peak mode. This overlaps the tx generation with transfers."),
-        )
+        .arg(Arg::with_name("sustained").long("sustained").help(
+            "Use sustained performance mode vs. peak mode. This overlaps the tx generation with \
+             transfers.",
+        ))
         .arg(
             Arg::with_name("tx_count")
                 .long("tx-count")
                 .alias("tx_count")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Number of transactions to send per batch")
+                .help("Number of transactions to send per batch"),
         )
         .arg(
             Arg::with_name("keypair_multiplier")
                 .long("keypair-multiplier")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Multiply by transaction count to determine number of keypairs to create")
+                .help("Multiply by transaction count to determine number of keypairs to create"),
         )
         .arg(
             Arg::with_name("thread-batch-sleep-ms")
@@ -249,8 +250,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .value_name("LAMPORTS")
                 .takes_value(true)
                 .help(
-                    "The cost in lamports that the cluster will charge for signature \
-                     verification when the cluster is operating at target-signatures-per-slot",
+                    "The cost in lamports that the cluster will charge for signature verification \
+                     when the cluster is operating at target-signatures-per-slot",
                 ),
         )
         .arg(
@@ -258,51 +259,53 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("num-lamports-per-account")
                 .value_name("LAMPORTS")
                 .takes_value(true)
-                .help(
-                    "Number of lamports per account.",
-                ),
+                .help("Number of lamports per account."),
         )
         .arg(
             Arg::with_name("target_slots_per_epoch")
                 .long("target-slots-per-epoch")
                 .value_name("SLOTS")
                 .takes_value(true)
-                .help(
-                    "Wait until epochs are this many slots long.",
-                ),
+                .help("Wait until epochs are this many slots long."),
         )
         .arg(
             Arg::with_name("rpc_client")
                 .long("use-rpc-client")
                 .conflicts_with("tpu_client")
                 .takes_value(false)
-                .help("Submit transactions with a RpcClient")
+                .help("Submit transactions with a RpcClient"),
         )
         .arg(
             Arg::with_name("tpu_client")
                 .long("use-tpu-client")
                 .conflicts_with("rpc_client")
                 .takes_value(false)
-                .help("Submit transactions with a TpuClient")
+                .help("Submit transactions with a TpuClient"),
         )
         .arg(
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("DEPRECATED: Do not submit transactions via QUIC; only affects TpuClient (default) sends"),
+                .help(
+                    "DEPRECATED: Do not submit transactions via QUIC; only affects TpuClient \
+                     (default) sends",
+                ),
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)
-                .help("Controls the connection pool size per remote address; only affects TpuClient (default) sends"),
+                .help(
+                    "Controls the connection pool size per remote address; only affects TpuClient \
+                     (default) sends",
+                ),
         )
         .arg(
             Arg::with_name("compute_unit_price")
-            .long("compute-unit-price")
-            .takes_value(true)
-            .validator(|s| is_within_range(s, 0..))
-            .help("Sets constant compute-unit-price to transfer transactions"),
+                .long("compute-unit-price")
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 0..))
+                .help("Sets constant compute-unit-price to transfer transactions"),
         )
         .arg(
             Arg::with_name("use_randomized_compute_unit_price")
@@ -329,20 +332,29 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .requires("instruction_padding_data_size")
                 .takes_value(true)
                 .value_name("PUBKEY")
-                .help("If instruction data is padded, optionally specify the padding program id to target"),
+                .help(
+                    "If instruction data is padded, optionally specify the padding program id to \
+                     target",
+                ),
         )
         .arg(
             Arg::with_name("instruction_padding_data_size")
                 .long("instruction-padding-data-size")
                 .takes_value(true)
-                .help("If set, wraps all instructions in the instruction padding program, with the given amount of padding bytes in instruction data."),
+                .help(
+                    "If set, wraps all instructions in the instruction padding program, with the \
+                     given amount of padding bytes in instruction data.",
+                ),
         )
         .arg(
             Arg::with_name("num_conflict_groups")
                 .long("num-conflict-groups")
                 .takes_value(true)
                 .validator(|arg| is_within_range(arg, 1..))
-                .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
+                .help(
+                    "The number of unique destination accounts per transactions 'chunk'. Lower \
+                     values will result in more transaction conflicts.",
+                ),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -360,7 +372,10 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .requires("json_rpc_url")
                 .validator(is_keypair)
-                .help("File containing the node identity (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
+                .help(
+                    "File containing the node identity (keypair) of a validator with active \
+                     stake. This allows communicating with network using staked connection",
+                ),
         )
         .arg(
             Arg::with_name("commitment_config")
@@ -383,8 +398,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .value_name("FILENAME")
                 .takes_value(true)
                 .help(
-                    "File to save details about all the submitted transactions.\
-                    This option is useful for debug purposes."
+                    "File to save details about all the submitted transactions.This option is \
+                     useful for debug purposes.",
                 ),
         )
 }

--- a/bench-tps/src/keypairs.rs
+++ b/bench-tps/src/keypairs.rs
@@ -25,7 +25,7 @@ where
         let path = Path::new(client_ids_and_stake_file);
         let file = File::open(path).unwrap();
 
-        info!("Reading {}", client_ids_and_stake_file);
+        info!("Reading {client_ids_and_stake_file}");
         let accounts: HashMap<String, Base64Account> = serde_yaml::from_reader(file).unwrap();
         let mut keypairs = vec![];
         let mut last_balance = 0;

--- a/bench-tps/src/log_transaction_service.rs
+++ b/bench-tps/src/log_transaction_service.rs
@@ -89,7 +89,10 @@ impl LogTransactionService {
         Client: 'static + TpsClient + Send + Sync + ?Sized,
     {
         if !data_file_provided(block_data_file, transaction_data_file) {
-            panic!("Expect block-data-file or transaction-data-file is specified, must have been verified by callee.");
+            panic!(
+                "Expect block-data-file or transaction-data-file is specified, must have been \
+                 verified by callee."
+            );
         }
 
         let client = client.clone();
@@ -123,8 +126,10 @@ impl LogTransactionService {
         };
         let block_processing_timer_receiver = tick(Duration::from_millis(PROCESS_BLOCKS_EVERY_MS));
 
-        let mut start_slot = get_slot_with_retry(&client, commitment)
-            .expect("get_slot_with_retry should have succeed, cannot proceed without having slot. Must be a problem with RPC.");
+        let mut start_slot = get_slot_with_retry(&client, commitment).expect(
+            "get_slot_with_retry should have succeed, cannot proceed without having slot. Must be \
+             a problem with RPC.",
+        );
 
         let mut sender_stopped = false;
         let mut signature_to_tx_info = MapSignatureToTxInfo::new();

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -259,7 +259,12 @@ fn main() {
         );
         client
             .get_account(&instruction_padding_config.program_id)
-            .expect("Instruction padding program must be deployed to this cluster. Deploy the program using `solana program deploy ./bench-tps/tests/fixtures/spl_instruction_padding.so` and pass the resulting program id with `--instruction-padding-program-id`");
+            .expect(
+                "Instruction padding program must be deployed to this cluster. Deploy the program \
+                 using `solana program deploy \
+                 ./bench-tps/tests/fixtures/spl_instruction_padding.so` and pass the resulting \
+                 program id with `--instruction-padding-program-id`",
+            );
     }
     let keypairs = get_keypairs(
         client.clone(),

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -47,7 +47,7 @@ fn find_node_activated_stake(
 ) -> Result<(u64, u64), ()> {
     let vote_accounts = rpc_client.get_vote_accounts();
     if let Err(error) = vote_accounts {
-        error!("Failed to get vote accounts, error: {}", error);
+        error!("Failed to get vote accounts, error: {error}");
         return Err(());
     }
 
@@ -207,7 +207,7 @@ fn main() {
 
     let keypair_count = *tx_count * keypair_multiplier;
     if *write_to_client_file {
-        info!("Generating {} keypairs", keypair_count);
+        info!("Generating {keypair_count} keypairs");
         let (keypairs, _) = generate_keypairs(id, keypair_count as u64);
         let num_accounts = keypairs.len() as u64;
         let max_fee = FeeRateGovernor::new(*target_lamports_per_signature, 0)
@@ -228,7 +228,7 @@ fn main() {
             );
         });
 
-        info!("Writing {}", client_ids_and_stake_file);
+        info!("Writing {client_ids_and_stake_file}");
         let serialized = serde_yaml::to_string(&accounts).unwrap();
         let path = Path::new(&client_ids_and_stake_file);
         let mut file = File::create(path).unwrap();

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -45,7 +45,7 @@ pub fn sample_txs<T>(
         let mut txs =
             match client.get_transaction_count_with_commitment(CommitmentConfig::processed()) {
                 Err(e) => {
-                    info!("Couldn't get transaction count {:?}", e);
+                    info!("Couldn't get transaction count {e:?}");
                     sleep(Duration::from_secs(sample_period));
                     continue;
                 }
@@ -53,7 +53,7 @@ pub fn sample_txs<T>(
             };
 
         if txs < last_txs {
-            info!("Expected txs({}) >= last_txs({})", txs, last_txs);
+            info!("Expected txs({txs}) >= last_txs({last_txs})");
             txs = last_txs;
         }
         total_txs = txs - initial_txs;

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -295,14 +295,16 @@ where
                     if failed_verify > 100 && failed_verify > verified_txs {
                         too_many_failures.store(true, Ordering::Relaxed);
                         warn!(
-                            "Too many failed transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
+                            "Too many failed transfers... {remaining_count} remaining, \
+                             {verified_txs} verified, {failed_verify} failures"
                         );
                     }
                     if remaining_count > 0 {
                         let mut time_l = time.lock().unwrap();
                         if time_l.elapsed().as_secs() > 2 {
                             info!(
-                                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
+                                "Verifying transfers... {remaining_count} remaining, \
+                                 {verified_txs} verified, {failed_verify} failures"
                             );
                             *time_l = Instant::now();
                         }
@@ -322,7 +324,8 @@ where
             let failed_verify = failed_verify.load(Ordering::Relaxed);
             let remaining_count = starting_txs.saturating_sub(verified_txs + failed_verify);
             info!(
-                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
+                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, \
+                 {failed_verify} failures"
             );
             sleep(Duration::from_millis(100));
         }

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -31,7 +31,7 @@ pub fn get_latest_blockhash<T: TpsClient + ?Sized>(client: &T) -> Hash {
         match client.get_latest_blockhash() {
             Ok(blockhash) => return blockhash,
             Err(err) => {
-                info!("Couldn't get last blockhash: {:?}", err);
+                info!("Couldn't get last blockhash: {err:?}");
                 sleep(Duration::from_secs(1));
             }
         };
@@ -110,7 +110,7 @@ pub fn generate_durable_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?S
     let (mut nonce_keypairs, _extra) = generate_keypairs(seed_keypair, count as u64);
     nonce_keypairs.truncate(count);
 
-    info!("Creating {} nonce accounts...", count);
+    info!("Creating {count} nonce accounts...");
     let to_fund: Vec<NonceCreateSigners> = authority_keypairs
         .iter()
         .zip(nonce_keypairs.iter())
@@ -155,7 +155,7 @@ fn verify_funding_transfer<T: TpsClient + ?Sized>(
     for a in &tx.message().account_keys[1..] {
         match client.get_balance_with_commitment(a, CommitmentConfig::processed()) {
             Ok(balance) => return balance >= amount,
-            Err(err) => error!("failed to get balance {:?}", err),
+            Err(err) => error!("failed to get balance {err:?}"),
         }
     }
     false
@@ -231,7 +231,7 @@ where
             //  retry
             tries += 1;
         }
-        info!("transactions sent in {} tries", tries);
+        info!("transactions sent in {tries} tries");
     }
 
     fn sign(&mut self, blockhash: Hash) {
@@ -295,16 +295,14 @@ where
                     if failed_verify > 100 && failed_verify > verified_txs {
                         too_many_failures.store(true, Ordering::Relaxed);
                         warn!(
-                            "Too many failed transfers... {} remaining, {} verified, {} failures",
-                            remaining_count, verified_txs, failed_verify
+                            "Too many failed transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
                         );
                     }
                     if remaining_count > 0 {
                         let mut time_l = time.lock().unwrap();
                         if time_l.elapsed().as_secs() > 2 {
                             info!(
-                                "Verifying transfers... {} remaining, {} verified, {} failures",
-                                remaining_count, verified_txs, failed_verify
+                                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
                             );
                             *time_l = Instant::now();
                         }
@@ -324,8 +322,7 @@ where
             let failed_verify = failed_verify.load(Ordering::Relaxed);
             let remaining_count = starting_txs.saturating_sub(verified_txs + failed_verify);
             info!(
-                "Verifying transfers... {} remaining, {} verified, {} failures",
-                remaining_count, verified_txs, failed_verify
+                "Verifying transfers... {remaining_count} remaining, {verified_txs} verified, {failed_verify} failures"
             );
             sleep(Duration::from_millis(100));
         }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`