### PR TITLE
docs: fix formatting in SVM specification

### DIFF
--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -277,7 +277,7 @@ Steps of `load_and_execute_sanitized_transactions`
          - `programs_loaded_for_tx_batch` contains a reference to all the `ProgramCacheEntry`s
             necessary for the transaction. It maintains an `Arc` to the programs in the global
             `ProgramCacheEntry` data structure.
-      6. Call `MessageProcessor::process_message` to execute the
+   6. Call `MessageProcessor::process_message` to execute the
       transaction. `MessageProcessor` is contained in
       solana-program-runtime crate. The result of processing message
       is either `ProcessedMessageInfo` which is an i64 wrapped in a


### PR DESCRIPTION
The sixth point has extra spaces, so it becomes another list.

Before:
<img width="820" height="289" alt="image" src="https://github.com/user-attachments/assets/5345fa0a-fe0c-4cb7-81c8-23db1d4c2b29" />

After:
<img width="833" height="301" alt="image" src="https://github.com/user-attachments/assets/b94fc071-8d6d-4034-a870-ad5b3310f233" />

