### PR TITLE
chore(ci): fix typos in audit and sanity scripts

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -36,7 +36,7 @@ cargo_audit_ignores=(
   # ID:        RUSTSEC-2024-0421
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0421
   # Solution:  Upgrade to >=1.0.0
-  # need to solve this depentant tree:
+  # need to solve this dependant tree:
   # jsonrpc-core-client v18.0.0 -> jsonrpc-client-transports v18.0.0 -> url v1.7.2 -> idna v0.1.5
   --ignore RUSTSEC-2024-0421
 

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 source multinode-demo/common.sh
 
 if [[ -z $CI ]]; then
-  # Build eargerly if needed for local development. Otherwise, odd timing error occurs...
+  # Build eagerly if needed for local development. Otherwise, odd timing error occurs...
   $solana_keygen --version
   $solana_genesis --version
   $solana_faucet --version


### PR DESCRIPTION
- "depentant" → "dependant" in `ci/do-audit.sh`
- "eargerly" → "eagerly" in `ci/run-sanity.sh`