### PR TITLE
Support priority ordering for bp unified scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11667,6 +11667,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
+ "test-case",
  "unwrap_none",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -160,6 +160,7 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true, features = ["agave-unstable-api"] }
+solana-unified-scheduler-logic = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }
 solana-validator-exit = { workspace = true }
 solana-version = { workspace = true }
@@ -206,7 +207,6 @@ solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }
-solana-unified-scheduler-logic = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true, features = [
     "dev-context-only-utils",
 ] }

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -43,7 +43,7 @@ pub enum DeserializedPacketError {
 
 // Make a dummy feature_set with all features enabled to
 // fetch compute_unit_price and compute_unit_limit for legacy leader.
-pub(crate) static FEATURE_SET: std::sync::LazyLock<FeatureSet> =
+static FEATURE_SET: std::sync::LazyLock<FeatureSet> =
     std::sync::LazyLock::new(FeatureSet::all_enabled);
 
 #[derive(Debug)]

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -43,7 +43,7 @@ pub enum DeserializedPacketError {
 
 // Make a dummy feature_set with all features enabled to
 // fetch compute_unit_price and compute_unit_limit for legacy leader.
-static FEATURE_SET: std::sync::LazyLock<FeatureSet> =
+pub(crate) static FEATURE_SET: std::sync::LazyLock<FeatureSet> =
     std::sync::LazyLock::new(FeatureSet::all_enabled);
 
 #[derive(Debug)]

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -742,7 +742,7 @@ impl TransactionViewReceiveAndBuffer {
 /// from user input. They should never be zero.
 /// Any difference in the prioritization is negligible for
 /// the current transaction costs.
-fn calculate_priority_and_cost(
+pub(crate) fn calculate_priority_and_cost(
     transaction: &impl TransactionWithMeta,
     fee_budget_limits: &FeeBudgetLimits,
     bank: &Bank,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -36,10 +36,9 @@ use {
     },
     crate::banking_trace::Channels,
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::bank_forks::BankForks,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_runtime_transaction::transaction_meta::StaticMeta,
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::{
         num::NonZeroUsize,
@@ -97,10 +96,10 @@ pub(crate) fn ensure_banking_stage_setup(
                         continue;
                     };
 
-                    let Some(compute_budget_limits) = process_compute_budget_instructions(
-                        SVMMessage::program_instructions_iter(transaction.message()),
-                        &bank.feature_set,
-                    ).ok() else {
+                    let Ok(compute_budget_limits) = transaction
+                        .compute_budget_instruction_details()
+                        .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
+                    else {
                         continue;
                     };
 

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -40,7 +40,6 @@ use {
     solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::bank_forks::BankForks,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_unified_scheduler_logic::OrderedTaskId,
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::{
         num::NonZeroUsize,
@@ -110,12 +109,7 @@ pub(crate) fn ensure_banking_stage_setup(
                         &compute_budget_limits.into(),
                         &bank,
                     );
-
-                    let task_id = {
-                        let reversed_priority = (u64::MAX - priority) as OrderedTaskId;
-                        let task_id = (task_id_base + packet_index) as OrderedTaskId;
-                        reversed_priority << const { OrderedTaskId::BITS / 2 } | task_id
-                    };
+                    let task_id = BankingStageHelper::new_task_id(task_id_base + packet_index, priority);
 
                     let task = helper.create_new_task(transaction, task_id, packet_size);
                     helper.send_new_task(task);

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -40,7 +40,7 @@ use {
     solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::bank_forks::BankForks,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_unified_scheduler_logic::Index,
+    solana_unified_scheduler_logic::OrderedTaskId,
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::{
         num::NonZeroUsize,
@@ -111,13 +111,13 @@ pub(crate) fn ensure_banking_stage_setup(
                         &bank,
                     );
 
-                    let index = {
-                        let reversed_priority = (u64::MAX - priority) as Index;
-                        let task_id = (task_id_base + packet_index) as Index;
-                        reversed_priority << const { Index::BITS / 2 } | task_id
+                    let task_id = {
+                        let reversed_priority = (u64::MAX - priority) as OrderedTaskId;
+                        let task_id = (task_id_base + packet_index) as OrderedTaskId;
+                        reversed_priority << const { OrderedTaskId::BITS / 2 } | task_id
                     };
 
-                    let task = helper.create_new_task(transaction, index, packet_size);
+                    let task = helper.create_new_task(transaction, task_id, packet_size);
                     helper.send_new_task(task);
                 }
             }

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -31,7 +31,6 @@ use qualifier_attr::qualifiers;
 use {
     super::{
         decision_maker::{BufferedPacketsDecision, DecisionMaker, DecisionMakerWrapper},
-        immutable_deserialized_packet::FEATURE_SET,
         packet_deserializer::PacketDeserializer,
         transaction_scheduler::receive_and_buffer::calculate_priority_and_cost,
     },
@@ -101,7 +100,7 @@ pub(crate) fn ensure_banking_stage_setup(
 
                     let Some(compute_budget_limits) = process_compute_budget_instructions(
                         SVMMessage::program_instructions_iter(transaction.message()),
-                        &FEATURE_SET,
+                        &bank.feature_set,
                     ).ok() else {
                         continue;
                     };

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -525,6 +525,8 @@ fn schedule_batches_for_execution(
         // to unlock.
         // scheduling is skipped if we have already detected an error in this loop
         let indexes = starting_index..starting_index + transactions.len();
+        // Widening usize index to Index (= u128) won't ever fail.
+        let indexes = indexes.map(|i| i.try_into().unwrap());
         first_err = first_err.and_then(|()| {
             bank.schedule_transaction_executions(transactions.into_iter().zip_eq(indexes))
         });

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -525,10 +525,10 @@ fn schedule_batches_for_execution(
         // to unlock.
         // scheduling is skipped if we have already detected an error in this loop
         let indexes = starting_index..starting_index + transactions.len();
-        // Widening usize index to Index (= u128) won't ever fail.
-        let indexes = indexes.map(|i| i.try_into().unwrap());
+        // Widening usize index to OrderedTaskId (= u128) won't ever fail.
+        let task_ids = indexes.map(|i| i.try_into().unwrap());
         first_err = first_err.and_then(|()| {
-            bank.schedule_transaction_executions(transactions.into_iter().zip_eq(indexes))
+            bank.schedule_transaction_executions(transactions.into_iter().zip_eq(task_ids))
         });
     }
     first_err

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6526,6 +6526,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "solana-turbine",
+ "solana-unified-scheduler-logic",
  "solana-unified-scheduler-pool",
  "solana-validator-exit",
  "solana-version",

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -30,7 +30,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    solana_unified_scheduler_logic::{Index, SchedulingMode},
+    solana_unified_scheduler_logic::{OrderedTaskId, SchedulingMode},
     std::{
         fmt::{self, Debug},
         mem,
@@ -177,7 +177,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn schedule_execution(
         &self,
         transaction: RuntimeTransaction<SanitizedTransaction>,
-        index: Index,
+        task_id: OrderedTaskId,
     ) -> ScheduleResult;
 
     /// Return the error which caused the scheduler to abort.
@@ -513,18 +513,18 @@ impl BankWithScheduler {
     /// wait_for_termination()-ed or the unified scheduler is disabled in the first place).
     pub fn schedule_transaction_executions(
         &self,
-        transactions_with_indexes: impl ExactSizeIterator<
-            Item = (RuntimeTransaction<SanitizedTransaction>, Index),
+        transaction_with_task_ids: impl ExactSizeIterator<
+            Item = (RuntimeTransaction<SanitizedTransaction>, OrderedTaskId),
         >,
     ) -> Result<()> {
         trace!(
             "schedule_transaction_executions(): {} txs",
-            transactions_with_indexes.len()
+            transaction_with_task_ids.len()
         );
 
         let schedule_result: ScheduleResult = self.inner.with_active_scheduler(|scheduler| {
-            for (sanitized_transaction, index) in transactions_with_indexes {
-                scheduler.schedule_execution(sanitized_transaction, index)?;
+            for (sanitized_transaction, task_id) in transaction_with_task_ids {
+                scheduler.schedule_execution(sanitized_transaction, task_id)?;
             }
             Ok(())
         });

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -30,7 +30,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    solana_unified_scheduler_logic::SchedulingMode,
+    solana_unified_scheduler_logic::{Index, SchedulingMode},
     std::{
         fmt::{self, Debug},
         mem,
@@ -177,7 +177,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn schedule_execution(
         &self,
         transaction: RuntimeTransaction<SanitizedTransaction>,
-        index: usize,
+        index: Index,
     ) -> ScheduleResult;
 
     /// Return the error which caused the scheduler to abort.
@@ -514,7 +514,7 @@ impl BankWithScheduler {
     pub fn schedule_transaction_executions(
         &self,
         transactions_with_indexes: impl ExactSizeIterator<
-            Item = (RuntimeTransaction<SanitizedTransaction>, usize),
+            Item = (RuntimeTransaction<SanitizedTransaction>, Index),
         >,
     ) -> Result<()> {
         trace!(

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -23,3 +23,4 @@ solana-message = { workspace = true }
 solana-runtime-transaction = { workspace = true, features = [
     "dev-context-only-utils",
 ] }
+test-case = { workspace = true }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -613,14 +613,14 @@ impl PriorityUsage {
 
     fn take_readable(maybe_usage: &mut Option<Self>) {
         let Some(Self::Readonly(tasks)) = maybe_usage.take() else {
-            unreachable!();
+            panic!();
         };
         assert!(tasks.is_empty());
     }
 
     fn take_writable(maybe_usage: &mut Option<Self>) -> Task {
         let Some(Self::Writable(task)) = maybe_usage.take() else {
-            unreachable!();
+            panic!();
         };
         task
     }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -929,10 +929,9 @@ impl UsageQueueInner {
                         Ok(())
                     }
                     (Some(PriorityUsage::Writable(current_task)), _) => {
-                        if !new_task.is_higher_priority(current_task) {
-                            return Err(());
-                        }
-                        if !current_task.try_reblock(token) {
+                        if !new_task.is_higher_priority(current_task)
+                            || !current_task.try_reblock(token)
+                        {
                             return Err(());
                         }
                         let reblocked_task = Usage::take_writable(current_and_requested_usage.0);

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -696,6 +696,11 @@ impl UsageQueueInner {
     fn with_priority() -> Self {
         Self::Priority {
             current_usage: None,
+            // PriorityUsageQueue (i.e. BTreeMap) doesn't support capacity provisioning unlike
+            // VecDeque above. For efficient key-based lookup, BTreeMap can't usually be backed by
+            // some continuous provisioning-friendly collection (i.e. Vec). And, due to the need of
+            // those lookups by the current implementation, we can't use BinaryHeap and its family
+            // _for now_.
             blocked_usages_from_tasks: PriorityUsageQueue::new(),
         }
     }


### PR DESCRIPTION
#### Problem

Currently, block production unified scheduler doesn't support transaction's priority fee based task reordering while it's scheduling.

#### Summary of Changes

Support it. For that, also change `Task::index` field type to `u128` from `usize` (effectively, `u64`).

block verification code path shouldn't be affected other than addition enum dispatching...

extracted from #2325 