### PR TITLE
chore(core): fix typos in comments and test messages

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -486,7 +486,7 @@ impl LeaderSlotMetricsTracker {
                 MetricsTrackerAction::ReportAndResetTracker
             }
 
-            // Our leader slot has begain, time to create a new slot tracker
+            // Our leader slot has begun, time to create a new slot tracker
             (None, Some(bank_start)) => {
                 MetricsTrackerAction::NewTracker(Some(LeaderSlotMetrics::new(
                     bank_start.working_bank.slot(),
@@ -496,7 +496,7 @@ impl LeaderSlotMetricsTracker {
 
             (Some(leader_slot_metrics), Some(bank_start)) => {
                 if leader_slot_metrics.slot != bank_start.working_bank.slot() {
-                    // Last slot has ended, new slot has began
+                    // Last slot has ended, new slot has begun
                     leader_slot_metrics.mark_slot_end_detected();
                     MetricsTrackerAction::ReportAndNewTracker(Some(LeaderSlotMetrics::new(
                         bank_start.working_bank.slot(),

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -539,7 +539,7 @@ mod test {
         let pubkey2 = Pubkey::new_unique();
         let pubkey3 = Pubkey::new_unique();
 
-        // Dependecy graph:
+        // Dependency graph:
         // 3 --
         //     \
         //       -> 1 -> 0

--- a/core/src/cluster_slots_service/cluster_slots.rs
+++ b/core/src/cluster_slots_service/cluster_slots.rs
@@ -776,7 +776,7 @@ mod tests {
         assert_eq!(
             cs.lookup(1).unwrap().get_support_by_pubkey(&pk).unwrap(),
             42,
-            "the stake of the node should be commited to the slot"
+            "the stake of the node should be committed to the slot"
         );
     }
 }


### PR DESCRIPTION
Corrected spelling mistakes across core modules:
- "begain" → "begun" in `leader_slot_metrics.rs`
- "Dependecy" → "Dependency" in `greedy_scheduler.rs`
- "commited" → "committed" in `cluster_slots.rs`