### PR TITLE
cli: allow drift in simulated CUs

### DIFF
--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -43,4 +43,6 @@ pub enum ComputeUnitLimit {
     Static(u32),
     /// Simulate the transaction to find out the compute unit usage
     Simulated,
+    /// Simulate the transaction and add a small percentage to account for potential drift
+    SimulatedWithExtra(u8),
 }

--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -44,5 +44,5 @@ pub enum ComputeUnitLimit {
     /// Simulate the transaction to find out the compute unit usage
     Simulated,
     /// Simulate the transaction and add a small percentage to account for potential drift
-    SimulatedWithExtra(u8),
+    SimulatedWithExtraPercentage(u8),
 }

--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -104,7 +104,9 @@ pub(crate) fn simulate_and_update_compute_unit_limit(
 
             let compute_unit_limit =
                 if let ComputeUnitLimit::SimulatedWithExtra(n) = compute_unit_limit {
-                    (base_compute_unit_limit as u64 * (100 + *n as u64) / 100) as u32
+                    (base_compute_unit_limit as u64)
+                        .saturating_mul(100_u64.saturating_add(*n as u64))
+                        .saturating_div(100) as u32
                 } else {
                     base_compute_unit_limit
                 };

--- a/cli/src/compute_budget.rs
+++ b/cli/src/compute_budget.rs
@@ -98,12 +98,12 @@ pub(crate) fn simulate_and_update_compute_unit_limit(
     };
 
     match compute_unit_limit {
-        ComputeUnitLimit::Simulated | ComputeUnitLimit::SimulatedWithExtra(_) => {
+        ComputeUnitLimit::Simulated | ComputeUnitLimit::SimulatedWithExtraPercentage(_) => {
             let base_compute_unit_limit =
                 simulate_for_compute_unit_limit_unchecked(rpc_client, message)?;
 
             let compute_unit_limit =
-                if let ComputeUnitLimit::SimulatedWithExtra(n) = compute_unit_limit {
+                if let ComputeUnitLimit::SimulatedWithExtraPercentage(n) = compute_unit_limit {
                     (base_compute_unit_limit as u64)
                         .saturating_mul(100_u64.saturating_add(*n as u64))
                         .saturating_div(100) as u32
@@ -147,7 +147,7 @@ impl WithComputeUnitConfig for Vec<Instruction> {
                         compute_unit_limit,
                     ));
                 }
-                ComputeUnitLimit::Simulated | ComputeUnitLimit::SimulatedWithExtra(_) => {
+                ComputeUnitLimit::Simulated | ComputeUnitLimit::SimulatedWithExtraPercentage(_) => {
                     // Default to the max compute unit limit because later transactions will be
                     // simulated to get the exact compute units consumed.
                     self.push(ComputeBudgetInstruction::set_compute_unit_limit(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1712,7 +1712,9 @@ pub fn process_deactivate_stake_account(
     // DeactivateDelinquent parses a VoteState, which may change between simulation and execution
     let compute_unit_limit = match blockhash_query {
         BlockhashQuery::None(_) | BlockhashQuery::FeeCalculator(_, _) => ComputeUnitLimit::Default,
-        BlockhashQuery::All(_) if deactivate_delinquent => ComputeUnitLimit::SimulatedWithExtra(5),
+        BlockhashQuery::All(_) if deactivate_delinquent => {
+            ComputeUnitLimit::SimulatedWithExtraPercentage(5)
+        }
         BlockhashQuery::All(_) => ComputeUnitLimit::Simulated,
     };
     let ixs = vec![if deactivate_delinquent {
@@ -2810,7 +2812,7 @@ pub fn process_delegate_stake(
     // DelegateStake parses a VoteState, which may change between simulation and execution
     let compute_unit_limit = match blockhash_query {
         BlockhashQuery::None(_) | BlockhashQuery::FeeCalculator(_, _) => ComputeUnitLimit::Default,
-        BlockhashQuery::All(_) => ComputeUnitLimit::SimulatedWithExtra(5),
+        BlockhashQuery::All(_) => ComputeUnitLimit::SimulatedWithExtraPercentage(5),
     };
     let ixs = vec![stake_instruction::delegate_stake(
         stake_account_pubkey,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1709,8 +1709,10 @@ pub fn process_deactivate_stake_account(
         *stake_account_pubkey
     };
 
+    // DeactivateDelinquent parses a VoteState, which may change between simulation and execution
     let compute_unit_limit = match blockhash_query {
         BlockhashQuery::None(_) | BlockhashQuery::FeeCalculator(_, _) => ComputeUnitLimit::Default,
+        BlockhashQuery::All(_) if deactivate_delinquent => ComputeUnitLimit::SimulatedWithExtra(5),
         BlockhashQuery::All(_) => ComputeUnitLimit::Simulated,
     };
     let ixs = vec![if deactivate_delinquent {
@@ -2805,9 +2807,10 @@ pub fn process_delegate_stake(
 
     let recent_blockhash = blockhash_query.get_blockhash(rpc_client, config.commitment)?;
 
+    // DelegateStake parses a VoteState, which may change between simulation and execution
     let compute_unit_limit = match blockhash_query {
         BlockhashQuery::None(_) | BlockhashQuery::FeeCalculator(_, _) => ComputeUnitLimit::Default,
-        BlockhashQuery::All(_) => ComputeUnitLimit::Simulated,
+        BlockhashQuery::All(_) => ComputeUnitLimit::SimulatedWithExtra(5),
     };
     let ixs = vec![stake_instruction::delegate_stake(
         stake_account_pubkey,


### PR DESCRIPTION
#### Problem
certain stake program operations may not use exactly the number of CUs on every execution, because the cost to parse `VoteState` can change. this is particularly a concern for new vote accounts, which have not been fully saturated with votes and credits, but it can also happen if the authorized voter is changed

this makes certain operations brittle because the cli uses the exact simulated compute units as a hard limit

#### Summary of Changes
add a generic mechanism to allow overestimating the compute cost, and use it for the two stake program operations that may drift between simulation and execution

i eyeballed 5% from the failing `cli/tests/stake.rs` in #7203, seems like more than enough. i like this mechanism design (the new enum variant) because:
* we dont need to change 30+ callsite in the cli, its basically opt-in
* its tunable so the stake pool clis and whatever other things can choose numbers for their own potentially wobbly commands as they arise