### PR TITLE
replay: refactor set-root to enable alpenglow to take over

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-votor"
+version = "3.0.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bs58",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
+ "itertools 0.12.1",
+ "log",
+ "parking_lot 0.12.3",
+ "qualifier_attr",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-accounts-db",
+ "solana-bloom",
+ "solana-clock",
+ "solana-entry",
+ "solana-epoch-schedule",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro 3.0.0",
+ "solana-gossip",
+ "solana-hash",
+ "solana-keypair",
+ "solana-ledger",
+ "solana-logger 3.0.0",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubkey",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
+ "test-case",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "agave-watchtower"
 version = "3.0.0"
 dependencies = [
@@ -7903,6 +7946,7 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-transaction-view",
  "agave-verified-packet-receiver",
+ "agave-votor",
  "ahash 0.8.11",
  "anyhow",
  "arrayvec",
@@ -8030,7 +8074,6 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
- "solana-votor",
  "solana-wen-restart",
  "spl-memo-interface",
  "static_assertions",
@@ -11807,49 +11850,6 @@ dependencies = [
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.14",
-]
-
-[[package]]
-name = "solana-votor"
-version = "3.0.0"
-dependencies = [
- "anyhow",
- "bincode",
- "bs58",
- "crossbeam-channel",
- "dashmap",
- "etcd-client",
- "itertools 0.12.1",
- "log",
- "parking_lot 0.12.3",
- "qualifier_attr",
- "rayon",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-accounts-db",
- "solana-bloom",
- "solana-clock",
- "solana-entry",
- "solana-epoch-schedule",
- "solana-frozen-abi",
- "solana-frozen-abi-macro 3.0.0",
- "solana-gossip",
- "solana-hash",
- "solana-keypair",
- "solana-ledger",
- "solana-logger 3.0.0",
- "solana-measure",
- "solana-metrics",
- "solana-pubkey",
- "solana-rpc",
- "solana-runtime",
- "solana-signature",
- "solana-signer",
- "solana-time-utils",
- "solana-transaction",
- "test-case",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8030,6 +8030,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "solana-votor",
  "solana-wen-restart",
  "spl-memo-interface",
  "static_assertions",
@@ -11806,6 +11807,49 @@ dependencies = [
  "solana-vote-interface",
  "test-case",
  "thiserror 2.0.14",
+]
+
+[[package]]
+name = "solana-votor"
+version = "3.0.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bs58",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
+ "itertools 0.12.1",
+ "log",
+ "parking_lot 0.12.3",
+ "qualifier_attr",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-accounts-db",
+ "solana-bloom",
+ "solana-clock",
+ "solana-entry",
+ "solana-epoch-schedule",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro 3.0.0",
+ "solana-gossip",
+ "solana-hash",
+ "solana-keypair",
+ "solana-ledger",
+ "solana-logger 3.0.0",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubkey",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
+ "test-case",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
  "solana-time-utils",
  "solana-transaction",
  "test-case",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ members = [
     "version",
     "vortexor",
     "vote",
+    "votor",
     "watchtower",
     "wen-restart",
     "xdp",
@@ -556,6 +557,7 @@ solana-version = { path = "version", version = "=3.0.0" }
 solana-vote = { path = "vote", version = "=3.0.0" }
 solana-vote-interface = "2.2.6"
 solana-vote-program = { path = "programs/vote", version = "=3.0.0", default-features = false }
+solana-votor = { path = "votor", version = "=3.0.0" }
 solana-wen-restart = { path = "wen-restart", version = "=3.0.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.0.0" }
 solana-zk-keygen = { path = "zk-keygen", version = "=3.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ agave-syscalls = { path = "syscalls", version = "=3.0.0" }
 agave-thread-manager = { path = "thread-manager", version = "=3.0.0" }
 agave-transaction-view = { path = "transaction-view", version = "=3.0.0" }
 agave-verified-packet-receiver = { path = "verified-packet-receiver", version = "=3.0.0" }
+agave-votor = { path = "votor", version = "=3.0.0" }
 agave-xdp = { path = "xdp", version = "=3.0.0" }
 ahash = "0.8.11"
 anyhow = "1.0.98"
@@ -557,7 +558,6 @@ solana-version = { path = "version", version = "=3.0.0" }
 solana-vote = { path = "vote", version = "=3.0.0" }
 solana-vote-interface = "2.2.6"
 solana-vote-program = { path = "programs/vote", version = "=3.0.0", default-features = false }
-solana-votor = { path = "votor", version = "=3.0.0" }
 solana-wen-restart = { path = "wen-restart", version = "=3.0.0" }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=3.0.0" }
 solana-zk-keygen = { path = "zk-keygen", version = "=3.0.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -164,6 +164,7 @@ solana-validator-exit = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
+solana-votor = { workspace = true }
 solana-wen-restart = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,7 @@ agave-banking-stage-ingress-types = { workspace = true }
 agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
 agave-verified-packet-receiver = { workspace = true }
+agave-votor = { workspace = true, features = ["agave-unstable-api"] }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 arrayvec = { workspace = true }
@@ -164,7 +165,6 @@ solana-validator-exit = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
-solana-votor = { workspace = true }
 solana-wen-restart = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -32,6 +32,7 @@ use {
         voting_service::VoteOp,
         window_service::DuplicateSlotReceiver,
     },
+    agave_votor::root_utils,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     rayon::{prelude::*, ThreadPool},
     solana_accounts_db::contains::Contains,
@@ -75,7 +76,6 @@ use {
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
     solana_vote::vote_transaction::VoteTransaction,
-    solana_votor::root_utils,
     std::{
         collections::{HashMap, HashSet},
         num::{NonZeroUsize, Saturating},

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -75,6 +75,7 @@ use {
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
     solana_vote::vote_transaction::VoteTransaction,
+    solana_votor::root_utils,
     std::{
         collections::{HashMap, HashSet},
         num::{NonZeroUsize, Saturating},
@@ -2400,8 +2401,15 @@ impl ReplayStage {
         let new_root = tower.record_bank_vote(bank);
 
         if let Some(new_root) = new_root {
+            let highest_super_majority_root = Some(
+                block_commitment_cache
+                    .read()
+                    .unwrap()
+                    .highest_super_majority_root(),
+            );
             Self::check_and_handle_new_root(
-                bank,
+                &identity_keypair.pubkey(),
+                bank.parent_slot(),
                 new_root,
                 bank_forks,
                 progress,
@@ -2409,7 +2417,7 @@ impl ReplayStage {
                 leader_schedule_cache,
                 snapshot_controller,
                 rpc_subscriptions,
-                block_commitment_cache,
+                highest_super_majority_root,
                 bank_notification_sender,
                 has_new_vote_been_rooted,
                 tracked_vote_transactions,
@@ -3967,8 +3975,12 @@ impl ReplayStage {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// A wrapper around `root_utils::check_and_handle_new_root` which:
+    /// - calls into `root_utils::set_bank_forks_root`
+    /// - Executes `set_progress_and_tower_bft_root` to cleanup tower bft structs and the progress map
     fn check_and_handle_new_root(
-        vote_bank: &Bank,
+        my_pubkey: &Pubkey,
+        parent_slot: Slot,
         new_root: Slot,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
@@ -3976,110 +3988,49 @@ impl ReplayStage {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         snapshot_controller: Option<&SnapshotController>,
         rpc_subscriptions: Option<&RpcSubscriptions>,
-        block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
+        highest_super_majority_root: Option<Slot>,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         has_new_vote_been_rooted: &mut bool,
         tracked_vote_transactions: &mut Vec<TrackedVoteTransaction>,
         drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
         tbft_structs: &mut TowerBFTStructures,
     ) -> Result<(), SetRootError> {
-        // get the root bank before squash
-        let root_bank = bank_forks
-            .read()
-            .unwrap()
-            .get(new_root)
-            .expect("Root bank doesn't exist");
-        let mut rooted_banks = root_bank.parents();
-        let oldest_parent = rooted_banks.last().map(|last| last.parent_slot());
-        rooted_banks.push(root_bank.clone());
-        let rooted_slots: Vec<_> = rooted_banks.iter().map(|bank| bank.slot()).collect();
-        // The following differs from rooted_slots by including the parent slot of the oldest parent bank.
-        let rooted_slots_with_parents = bank_notification_sender
-            .as_ref()
-            .is_some_and(|sender| sender.should_send_parents)
-            .then(|| {
-                let mut new_chain = rooted_slots.clone();
-                new_chain.push(oldest_parent.unwrap_or_else(|| vote_bank.parent_slot()));
-                new_chain
-            });
-
-        // Call leader schedule_cache.set_root() before blockstore.set_root() because
-        // bank_forks.root is consumed by repair_service to update gossip, so we don't want to
-        // get shreds for repair on gossip before we update leader schedule, otherwise they may
-        // get dropped.
-        leader_schedule_cache.set_root(rooted_banks.last().unwrap());
-        blockstore
-            .set_roots(rooted_slots.iter())
-            .expect("Ledger set roots failed");
-        let highest_super_majority_root = Some(
-            block_commitment_cache
-                .read()
-                .unwrap()
-                .highest_super_majority_root(),
-        );
-        Self::handle_new_root(
+        root_utils::check_and_handle_new_root(
+            parent_slot,
             new_root,
-            bank_forks,
-            progress,
             snapshot_controller,
             highest_super_majority_root,
-            has_new_vote_been_rooted,
-            tracked_vote_transactions,
+            bank_notification_sender,
             drop_bank_sender,
-            tbft_structs,
-        )?;
-        blockstore.slots_stats.mark_rooted(new_root);
-        if let Some(rpc_subscriptions) = rpc_subscriptions {
-            rpc_subscriptions.notify_roots(rooted_slots);
-        }
-        if let Some(sender) = bank_notification_sender {
-            let dependency_work = sender
-                .dependency_tracker
-                .as_ref()
-                .map(|s| s.get_current_declared_work());
-            sender
-                .sender
-                .send((BankNotification::NewRootBank(root_bank), dependency_work))
-                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
-
-            if let Some(new_chain) = rooted_slots_with_parents {
-                sender
-                    .sender
-                    .send((BankNotification::NewRootedChain(new_chain), dependency_work))
-                    .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
-            }
-        }
-        info!("new root {new_root}");
-        Ok(())
+            blockstore,
+            leader_schedule_cache,
+            bank_forks,
+            rpc_subscriptions,
+            my_pubkey,
+            move |bank_forks| {
+                Self::set_progress_and_tower_bft_root(
+                    new_root,
+                    bank_forks,
+                    progress,
+                    has_new_vote_been_rooted,
+                    tracked_vote_transactions,
+                    tbft_structs,
+                )
+            },
+        )
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn handle_new_root(
+    // To avoid code duplication and keep compatibility with alpenglow, we add this
+    // extra callback in the rooting path. This happens immediately after setting the bank forks root
+    fn set_progress_and_tower_bft_root(
         new_root: Slot,
-        bank_forks: &RwLock<BankForks>,
+        bank_forks: &BankForks,
         progress: &mut ProgressMap,
-        snapshot_controller: Option<&SnapshotController>,
-        highest_super_majority_root: Option<Slot>,
         has_new_vote_been_rooted: &mut bool,
         tracked_vote_transactions: &mut Vec<TrackedVoteTransaction>,
-        drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
         tbft_structs: &mut TowerBFTStructures,
-    ) -> Result<(), SetRootError> {
-        bank_forks.read().unwrap().prune_program_cache(new_root);
-        let removed_banks = bank_forks.write().unwrap().set_root(
-            new_root,
-            snapshot_controller,
-            highest_super_majority_root,
-        )?;
-
-        drop_bank_sender
-            .send(removed_banks)
-            .unwrap_or_else(|err| warn!("bank drop failed: {err:?}"));
-
-        // Dropping the bank_forks write lock and reacquiring as a read lock is
-        // safe because updates to bank_forks are only made by a single thread.
-        let r_bank_forks = bank_forks.read().unwrap();
-        let new_root_bank = &r_bank_forks[new_root];
+    ) {
+        let new_root_bank = &bank_forks[new_root];
         if !*has_new_vote_been_rooted {
             for TrackedVoteTransaction {
                 message_hash,
@@ -4098,15 +4049,17 @@ impl ReplayStage {
                 std::mem::take(tracked_vote_transactions);
             }
         }
-        progress.handle_new_root(&r_bank_forks);
+
+        progress.handle_new_root(bank_forks);
         let TowerBFTStructures {
             heaviest_subtree_fork_choice,
             duplicate_slots_tracker,
             duplicate_confirmed_slots,
-            epoch_slots_frozen_slots,
             unfrozen_gossip_verified_vote_hashes,
+            epoch_slots_frozen_slots,
+            ..
         } = tbft_structs;
-        heaviest_subtree_fork_choice.set_tree_root((new_root, r_bank_forks.root_bank().hash()));
+        heaviest_subtree_fork_choice.set_tree_root((new_root, bank_forks.root_bank().hash()));
         *duplicate_slots_tracker = duplicate_slots_tracker.split_off(&new_root);
         // duplicate_slots_tracker now only contains entries >= `new_root`
 
@@ -4115,8 +4068,39 @@ impl ReplayStage {
 
         unfrozen_gossip_verified_vote_hashes.set_root(new_root);
         *epoch_slots_frozen_slots = epoch_slots_frozen_slots.split_off(&new_root);
-        Ok(())
         // epoch_slots_frozen_slots now only contains entries >= `new_root`
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn handle_new_root(
+        new_root: Slot,
+        bank_forks: &RwLock<BankForks>,
+        progress: &mut ProgressMap,
+        snapshot_controller: Option<&SnapshotController>,
+        highest_super_majority_root: Option<Slot>,
+        has_new_vote_been_rooted: &mut bool,
+        tracked_vote_transactions: &mut Vec<TrackedVoteTransaction>,
+        drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+        tbft_structs: &mut TowerBFTStructures,
+    ) -> Result<(), SetRootError> {
+        root_utils::set_bank_forks_root(
+            new_root,
+            bank_forks,
+            snapshot_controller,
+            highest_super_majority_root,
+            drop_bank_sender,
+            move |bank_forks| {
+                Self::set_progress_and_tower_bft_root(
+                    new_root,
+                    bank_forks,
+                    progress,
+                    has_new_vote_been_rooted,
+                    tracked_vote_transactions,
+                    tbft_structs,
+                )
+            },
+        )?;
+        Ok(())
     }
 
     fn generate_new_bank_forks(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -279,6 +279,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-votor"
+version = "3.0.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bs58",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
+ "itertools 0.12.1",
+ "log",
+ "parking_lot 0.12.2",
+ "qualifier_attr",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-accounts-db",
+ "solana-bloom",
+ "solana-clock",
+ "solana-entry",
+ "solana-epoch-schedule",
+ "solana-gossip",
+ "solana-hash",
+ "solana-keypair",
+ "solana-ledger",
+ "solana-logger 3.0.0",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubkey",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "agave-xdp"
 version = "3.0.0"
 dependencies = [
@@ -6189,6 +6229,7 @@ dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
  "agave-verified-packet-receiver",
+ "agave-votor",
  "ahash 0.8.11",
  "anyhow",
  "arrayvec",
@@ -6302,7 +6343,6 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
- "solana-votor",
  "solana-wen-restart",
  "static_assertions",
  "strum",
@@ -9893,46 +9933,6 @@ dependencies = [
  "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.14",
-]
-
-[[package]]
-name = "solana-votor"
-version = "3.0.0"
-dependencies = [
- "anyhow",
- "bincode",
- "bs58",
- "crossbeam-channel",
- "dashmap",
- "etcd-client",
- "itertools 0.12.1",
- "log",
- "parking_lot 0.12.2",
- "qualifier_attr",
- "rayon",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-accounts-db",
- "solana-bloom",
- "solana-clock",
- "solana-entry",
- "solana-epoch-schedule",
- "solana-gossip",
- "solana-hash",
- "solana-keypair",
- "solana-ledger",
- "solana-logger 3.0.0",
- "solana-measure",
- "solana-metrics",
- "solana-pubkey",
- "solana-rpc",
- "solana-runtime",
- "solana-signature",
- "solana-signer",
- "solana-time-utils",
- "solana-transaction",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "solana-signer",
  "solana-time-utils",
  "solana-transaction",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6302,6 +6302,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "solana-votor",
  "solana-wen-restart",
  "static_assertions",
  "strum",
@@ -9892,6 +9893,46 @@ dependencies = [
  "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.14",
+]
+
+[[package]]
+name = "solana-votor"
+version = "3.0.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bs58",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
+ "itertools 0.12.1",
+ "log",
+ "parking_lot 0.12.2",
+ "qualifier_attr",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-accounts-db",
+ "solana-bloom",
+ "solana-clock",
+ "solana-entry",
+ "solana-epoch-schedule",
+ "solana-gossip",
+ "solana-hash",
+ "solana-keypair",
+ "solana-ledger",
+ "solana-logger 3.0.0",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubkey",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
+agave-unstable-api = []
 dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "solana-votor"
+name = "agave-votor"
 description = "Blockchain, Rebuilt for Scale"
-documentation = "https://docs.rs/solana-votor"
+documentation = "https://docs.rs/agave-votor"
 readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "solana-votor"
+description = "Blockchain, Rebuilt for Scale"
+documentation = "https://docs.rs/solana-votor"
+readme = "../README.md"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[features]
+dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-accounts-db/frozen-abi",
+    "solana-bloom/frozen-abi",
+    "solana-ledger/frozen-abi",
+    "solana-runtime/frozen-abi",
+]
+
+[dependencies]
+anyhow = { workspace = true }
+bincode = { workspace = true }
+bs58 = { workspace = true }
+crossbeam-channel = { workspace = true }
+dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+etcd-client = { workspace = true, features = ["tls"] }
+itertools = { workspace = true }
+log = { workspace = true }
+parking_lot = { workspace = true }
+qualifier_attr = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_derive = { workspace = true }
+solana-accounts-db = { workspace = true }
+solana-bloom = { workspace = true }
+solana-clock = { workspace = true }
+solana-entry = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
+solana-gossip = { workspace = true }
+solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
+solana-ledger = { workspace = true }
+solana-logger = { workspace = true }
+solana-measure = { workspace = true }
+solana-metrics = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rpc = { workspace = true }
+solana-runtime = { workspace = true }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+solana-time-utils = { workspace = true }
+solana-transaction = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
+pub mod root_utils;
+
+#[macro_use]
+extern crate log;

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -1,6 +1,3 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-
+#[cfg(feature = "agave-unstable-api")]
 pub mod root_utils;
-
-#[macro_use]
-extern crate log;

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -1,0 +1,142 @@
+use {
+    crossbeam_channel::Sender,
+    solana_clock::Slot,
+    solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
+    solana_pubkey::Pubkey,
+    solana_rpc::{
+        optimistically_confirmed_bank_tracker::{BankNotification, BankNotificationSenderConfig},
+        rpc_subscriptions::RpcSubscriptions,
+    },
+    solana_runtime::{
+        bank_forks::{BankForks, SetRootError},
+        installed_scheduler_pool::BankWithScheduler,
+        snapshot_controller::SnapshotController,
+    },
+    std::sync::{Arc, RwLock},
+};
+
+/// Sets the new root, additionally performs the callback after setting the bank forks root
+/// During this transition period where both replay stage and votor can root depending on the feature flag we
+/// have a callback that cleans up progress map and other tower bft structures. Then the callgraph is
+///
+/// ReplayStage::check_and_handle_new_root -> root_utils::check_and_handle_new_root(callback)
+///                                                             |
+///                                                             v
+/// ReplayStage::handle_new_root           -> root_utils::set_bank_forks_root(callback) -> callback()
+///
+/// Votor does not need the progress map or other tower bft structures, so it will not use the callback.
+#[allow(clippy::too_many_arguments)]
+pub fn check_and_handle_new_root<CB>(
+    parent_slot: Slot,
+    new_root: Slot,
+    snapshot_controller: Option<&SnapshotController>,
+    highest_super_majority_root: Option<Slot>,
+    bank_notification_sender: &Option<BankNotificationSenderConfig>,
+    drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+    blockstore: &Blockstore,
+    leader_schedule_cache: &Arc<LeaderScheduleCache>,
+    bank_forks: &RwLock<BankForks>,
+    rpc_subscriptions: Option<&RpcSubscriptions>,
+    my_pubkey: &Pubkey,
+    callback: CB,
+) -> Result<(), SetRootError>
+where
+    CB: FnOnce(&BankForks),
+{
+    // get the root bank before squash
+    let root_bank = bank_forks
+        .read()
+        .unwrap()
+        .get(new_root)
+        .expect("Root bank doesn't exist");
+    let mut rooted_banks = root_bank.parents();
+    let oldest_parent = rooted_banks.last().map(|last| last.parent_slot());
+    rooted_banks.push(root_bank.clone());
+    let rooted_slots: Vec<_> = rooted_banks.iter().map(|bank| bank.slot()).collect();
+    // The following differs from rooted_slots by including the parent slot of the oldest parent bank.
+    let rooted_slots_with_parents = bank_notification_sender
+        .as_ref()
+        .is_some_and(|sender| sender.should_send_parents)
+        .then(|| {
+            let mut new_chain = rooted_slots.clone();
+            new_chain.push(oldest_parent.unwrap_or(parent_slot));
+            new_chain
+        });
+
+    // Call leader schedule_cache.set_root() before blockstore.set_root() because
+    // bank_forks.root is consumed by repair_service to update gossip, so we don't want to
+    // get shreds for repair on gossip before we update leader schedule, otherwise they may
+    // get dropped.
+    leader_schedule_cache.set_root(rooted_banks.last().unwrap());
+    blockstore
+        .set_roots(rooted_slots.iter())
+        .expect("Ledger set roots failed");
+    set_bank_forks_root(
+        new_root,
+        bank_forks,
+        snapshot_controller,
+        highest_super_majority_root,
+        drop_bank_sender,
+        callback,
+    )?;
+    blockstore.slots_stats.mark_rooted(new_root);
+    if let Some(rpc_subscriptions) = rpc_subscriptions {
+        rpc_subscriptions.notify_roots(rooted_slots);
+    }
+    if let Some(sender) = bank_notification_sender {
+        let dependency_work = sender
+            .dependency_tracker
+            .as_ref()
+            .map(|s| s.get_current_declared_work());
+        sender
+            .sender
+            .send((BankNotification::NewRootBank(root_bank), dependency_work))
+            .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
+
+        if let Some(new_chain) = rooted_slots_with_parents {
+            let dependency_work = sender
+                .dependency_tracker
+                .as_ref()
+                .map(|s| s.get_current_declared_work());
+            sender
+                .sender
+                .send((BankNotification::NewRootedChain(new_chain), dependency_work))
+                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
+        }
+    }
+    info!("{} new root {}", my_pubkey, new_root);
+    Ok(())
+}
+
+/// Sets the bank forks root:
+/// - Prune the program cache
+/// - Prune bank forks and drop the removed banks
+/// - Calls the callback for use in replay stage and tests
+pub fn set_bank_forks_root<CB>(
+    new_root: Slot,
+    bank_forks: &RwLock<BankForks>,
+    snapshot_controller: Option<&SnapshotController>,
+    highest_super_majority_root: Option<Slot>,
+    drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+    callback: CB,
+) -> Result<(), SetRootError>
+where
+    CB: FnOnce(&BankForks),
+{
+    bank_forks.read().unwrap().prune_program_cache(new_root);
+    let removed_banks = bank_forks.write().unwrap().set_root(
+        new_root,
+        snapshot_controller,
+        highest_super_majority_root,
+    )?;
+
+    drop_bank_sender
+        .send(removed_banks)
+        .unwrap_or_else(|err| warn!("bank drop failed: {:?}", err));
+
+    // Dropping the bank_forks write lock and reacquiring as a read lock is
+    // safe because updates to bank_forks are only made by a single thread.
+    let r_bank_forks = bank_forks.read().unwrap();
+    callback(&r_bank_forks);
+    Ok(())
+}

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -134,8 +134,6 @@ where
         .send(removed_banks)
         .unwrap_or_else(|err| warn!("bank drop failed: {err:?}"));
 
-    // Dropping the bank_forks write lock and reacquiring as a read lock is
-    // safe because updates to bank_forks are only made by a single thread.
     let r_bank_forks = bank_forks.read().unwrap();
     callback(&r_bank_forks);
     Ok(())

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -1,5 +1,6 @@
 use {
     crossbeam_channel::Sender,
+    log::{info, warn},
     solana_clock::Slot,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_pubkey::Pubkey,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -91,7 +91,7 @@ where
         sender
             .sender
             .send((BankNotification::NewRootBank(root_bank), dependency_work))
-            .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
+            .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
 
         if let Some(new_chain) = rooted_slots_with_parents {
             let dependency_work = sender
@@ -101,7 +101,7 @@ where
             sender
                 .sender
                 .send((BankNotification::NewRootedChain(new_chain), dependency_work))
-                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
+                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
         }
     }
     info!("{} new root {}", my_pubkey, new_root);
@@ -132,7 +132,7 @@ where
 
     drop_bank_sender
         .send(removed_banks)
-        .unwrap_or_else(|err| warn!("bank drop failed: {:?}", err));
+        .unwrap_or_else(|err| warn!("bank drop failed: {err:?}"));
 
     // Dropping the bank_forks write lock and reacquiring as a read lock is
     // safe because updates to bank_forks are only made by a single thread.

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -104,7 +104,7 @@ where
                 .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
         }
     }
-    info!("{} new root {}", my_pubkey, new_root);
+    info!("{my_pubkey}: new root {new_root}");
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem
In alpenglow, replay will no longer be the thread setting root. To prepare for this we refactor the set root to the votor crate.

#### Summary of Changes
This pulls in the votor crate from the Alpenglow repo but only for the `root_utils` file. The full upstreaming of this crate will take place after VoteStateV4 has landed in sdk master (bunch of dependencies to resolve that need this 😅 ).

The callgraph is
```
///
/// ReplayStage::check_and_handle_new_root -> root_utils::check_and_handle_new_root(callback)
///                                                             |
///                                                             v
/// ReplayStage::handle_new_root           -> root_utils::set_bank_forks_root(callback) -> callback()
```

This extra `callback` will take care of rooting the TowerBFT specific structures to maintain compatibility. In the future Alpenglow will call the root_utils function without the callback