### PR TITLE
Adds BANK_SNAPSHOTS_DIR constant

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -35,7 +35,7 @@ use {
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_controller::SnapshotController,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
+        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs, BANK_SNAPSHOTS_DIR},
     },
     solana_transaction::versioned::VersionedTransaction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
@@ -130,12 +130,12 @@ pub fn load_and_process_ledger(
     transaction_status_sender: Option<TransactionStatusSender>,
 ) -> Result<LoadAndProcessLedgerOutput, LoadAndProcessLedgerError> {
     let bank_snapshots_dir = if blockstore.is_primary_access() {
-        blockstore.ledger_path().join("snapshot")
+        blockstore.ledger_path().join(BANK_SNAPSHOTS_DIR)
     } else {
         blockstore
             .ledger_path()
             .join(LEDGER_TOOL_DIRECTORY)
-            .join("snapshot")
+            .join(BANK_SNAPSHOTS_DIR)
     };
 
     let mut starting_slot = 0; // default start check with genesis

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -37,6 +37,7 @@ use {
             ValidatorVoteKeypairs,
         },
         snapshot_config::SnapshotConfig,
+        snapshot_utils::BANK_SNAPSHOTS_DIR,
     },
     solana_signer::{signers::Signers, Signer},
     solana_stake_interface::{
@@ -190,7 +191,7 @@ impl LocalCluster {
             snapshot_config.full_snapshot_archives_dir = ledger_path.to_path_buf();
         }
         if snapshot_config.bank_snapshots_dir == dummy {
-            snapshot_config.bank_snapshots_dir = ledger_path.join("snapshot");
+            snapshot_config.bank_snapshots_dir = ledger_path.join(BANK_SNAPSHOTS_DIR);
         }
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -74,7 +74,7 @@ use {
         snapshot_bank_utils,
         snapshot_config::SnapshotConfig,
         snapshot_package::SnapshotKind,
-        snapshot_utils::{self, SnapshotInterval},
+        snapshot_utils::{self, SnapshotInterval, BANK_SNAPSHOTS_DIR},
     },
     solana_signer::Signer,
     solana_stake_interface::{self as stake, state::NEW_WARMUP_COOLDOWN_RATE},
@@ -2321,7 +2321,7 @@ fn test_run_test_load_program_accounts_root() {
 fn create_simple_snapshot_config(ledger_path: &Path) -> SnapshotConfig {
     SnapshotConfig {
         full_snapshot_archives_dir: ledger_path.to_path_buf(),
-        bank_snapshots_dir: ledger_path.join("snapshot"),
+        bank_snapshots_dir: ledger_path.join(BANK_SNAPSHOTS_DIR),
         ..SnapshotConfig::default()
     }
 }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -50,7 +50,7 @@ use {
         genesis_utils::{self, create_genesis_config_with_leader_ex_no_features},
         runtime_config::RuntimeConfig,
         snapshot_config::SnapshotConfig,
-        snapshot_utils::SnapshotInterval,
+        snapshot_utils::{SnapshotInterval, BANK_SNAPSHOTS_DIR},
     },
     solana_sdk_ids::address_lookup_table,
     solana_signer::Signer,
@@ -1125,7 +1125,7 @@ impl TestValidator {
                     NonZeroU64::new(100).unwrap(),
                 ),
                 incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
-                bank_snapshots_dir: ledger_path.join("snapshot"),
+                bank_snapshots_dir: ledger_path.join(BANK_SNAPSHOTS_DIR),
                 full_snapshot_archives_dir: ledger_path.to_path_buf(),
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),
                 ..SnapshotConfig::default()


### PR DESCRIPTION
#### Problem

ledger-tool fails to fastboot. This is because it is looking in the wrong directory for the fastboot state.

Fastboot needs two things:
1. The accounts (aka the account storage files)
2. The bank state (and status cache)

Both the accounts and bank state are correctly _created_ by the validator, but ledger-tool is wrong. ledger-tool has the wrong path for (2), the bank state, which contains the pointers back to (1), the accounts.

So since ledger-tool can't find the bank state, it cannot fastboot.

For this PR specifically, ledger-tool is looking for the bank state in the wrong *bank snapshots dir*. This dir is `snapshots/` in the validator. However, ledger-tool is using `snapshot/` (without the trailing 's').


#### Summary of Changes

Add a constant, `BANK_SNAPSHOTS_DIR`, and use it everywhere.


#### Additional Testing

I ran `agave-validator` for a bit, then `agave-validator exit` to gracefully exit and create the fastboot state. I then used `ledger-tool verify` and confirmed it did successfully fastboot from the validator's local state 🎉 It also successfully can run ledger-tool multiple times from the same local state. Yay!

Note, the code is still a bit broken, as ledger-tool hard codes the bank snapshots dir to be under the ledger directory. The next PR will fix that part. This PR at least fixes the bank snapshots dir to be correct.