### PR TITLE
fix client side binds in TPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Release channels have their own copy of this changelog:
   * `--skip-poh-verify`
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 * Using `--snapshot-interval-slots 0` to disable generating snapshots has been removed. Use `--no-snapshots` instead.
+* Validator will now bind all ports within provided `--dynamic-port-range`, a minimum of 25 ports are required.
 
 #### Changes
 * `--transaction-structure view` is now the default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Release channels have their own copy of this changelog:
   * `--skip-poh-verify`
 * Deprecated snapshot archive formats have been removed and are no longer loadable.
 * Using `--snapshot-interval-slots 0` to disable generating snapshots has been removed. Use `--no-snapshots` instead.
-* Validator will now bind all ports within provided `--dynamic-port-range`, a minimum of 25 ports are required.
+* Validator will now bind all ports within provided `--dynamic-port-range`, including the client ports. A range of at least 25 ports is recommended to avoid failures to bind during startup.
 
 #### Changes
 * `--transaction-structure view` is now the default.

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -10,9 +10,8 @@ use {
         find_available_ports_in_range,
         sockets::{
             bind_gossip_port_in_range, bind_in_range_with_config, bind_more_with_config,
-            bind_to_with_config, bind_two_in_range_with_offset_and_config,
-            localhost_port_range_for_tests, multi_bind_in_range_with_config,
-            SocketConfiguration as SocketConfig,
+            bind_two_in_range_with_offset_and_config, localhost_port_range_for_tests,
+            multi_bind_in_range_with_config, SocketConfiguration as SocketConfig,
         },
         PortRange,
     },
@@ -203,12 +202,15 @@ impl Node {
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("Alpenglow port bind should succeed");
         // These are client sockets, so the port is set to be 0 because it must be ephimeral.
-        let tpu_vote_forwarding_client =
-            bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
-        let tpu_transaction_forwarding_client =
-            bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
-        let quic_vote_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
-        let rpc_sts_client = bind_to_with_config(bind_ip_addr, 0, socket_config).unwrap();
+        let (_, tpu_vote_forwarding_client) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+        let (_, tpu_transaction_forwarding_client) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+        let (_, quic_vote_client) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
+
+        let (_, rpc_sts_client) =
+            bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
 
         let mut info = ContactInfo::new(
             *pubkey,

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -201,7 +201,8 @@ impl Node {
         let (alpenglow_port, alpenglow) =
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config)
                 .expect("Alpenglow port bind should succeed");
-        // These are client sockets, so the port is set to be 0 because it must be ephimeral.
+        // These are "client" sockets, so they could use ephemeral ports, but we
+        // force them into the provided port_range to simplify the operations.
         let (_, tpu_vote_forwarding_client) =
             bind_in_range_with_config(bind_ip_addr, port_range, socket_config).unwrap();
         let (_, tpu_transaction_forwarding_client) =

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -603,7 +603,6 @@ pub fn bind_more_with_config(
 mod tests {
     use {
         super::*,
-        crate::sockets::unique_port_range_for_tests,
         ip_echo_server::IpEchoServerResponse,
         itertools::Itertools,
         std::{net::Ipv4Addr, time::Duration},
@@ -749,16 +748,14 @@ mod tests {
     #[test]
     fn test_bind_in_range_nil() {
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let range = sockets::unique_port_range_for_tests(2);
-        bind_in_range(ip_addr, (range.end, range.end)).unwrap_err();
-        bind_in_range(ip_addr, (range.end, range.start)).unwrap_err();
+        bind_in_range(ip_addr, (2000, 2000)).unwrap_err();
+        bind_in_range(ip_addr, (2000, 1999)).unwrap_err();
     }
 
     #[test]
     fn test_find_available_port_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let range = sockets::unique_port_range_for_tests(4);
-        let (pr_s, pr_e) = (range.start, range.end);
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         assert_eq!(
             find_available_port_in_range(ip_addr, (pr_s, pr_s + 1)).unwrap(),
             pr_s
@@ -787,11 +784,12 @@ mod tests {
     #[test]
     fn test_bind_common_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let range = sockets::unique_port_range_for_tests(5);
+        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
         let config = SocketConfig::default();
         let (port, _sockets) =
-            bind_common_in_range_with_config(ip_addr, (range.start, range.end), config).unwrap();
-        assert!(range.contains(&port));
+            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
+        assert!((pr_s..pr_e).contains(&port));
+
         bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
     }
 
@@ -919,16 +917,13 @@ mod tests {
         let mut tcp_listeners = vec![];
         let mut udp_sockets = vec![];
 
-        let port_range = unique_port_range_for_tests(1);
         let (_server_port, (_, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (port_range.start, port_range.end), config)
-                .unwrap();
+            bind_common_in_range_with_config(ip_addr, (2200, 2300), config).unwrap();
         for _ in 0..MAX_PORT_VERIFY_THREADS * 2 {
-            let port_range = unique_port_range_for_tests(1);
             let (_client_port, (client_udp_socket, client_tcp_listener)) =
                 bind_common_in_range_with_config(
                     ip_addr,
-                    (port_range.start, port_range.end),
+                    (2300, 2300 + (MAX_PORT_VERIFY_THREADS * 3) as u16),
                     config,
                 )
                 .unwrap();
@@ -966,24 +961,18 @@ mod tests {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let offset = 6;
-        let port_range = unique_port_range_for_tests(10);
         if let Ok(((port1, _), (port2, _))) =
-            bind_two_in_range_with_offset(ip_addr, (port_range.start, port_range.end), offset)
+            bind_two_in_range_with_offset(ip_addr, (1024, 65535), offset)
         {
             assert!(port2 == port1 + offset);
         }
-        let offset = 7;
+        let offset = 42;
         if let Ok(((port1, _), (port2, _))) =
-            bind_two_in_range_with_offset(ip_addr, (port_range.start, port_range.end), offset)
+            bind_two_in_range_with_offset(ip_addr, (1024, 65535), offset)
         {
             assert!(port2 == port1 + offset);
         }
-        assert!(bind_two_in_range_with_offset(
-            ip_addr,
-            (port_range.start, port_range.start + 5),
-            offset
-        )
-        .is_err());
+        assert!(bind_two_in_range_with_offset(ip_addr, (1024, 1044), offset).is_err());
     }
 
     #[test]
@@ -991,9 +980,7 @@ mod tests {
         let ip_addr: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfig::default(); //reuseport is false by default
 
-        let port_range = unique_port_range_for_tests(3);
-        let result =
-            multi_bind_in_range_with_config(ip_addr, (port_range.start, port_range.end), config, 2);
+        let result = multi_bind_in_range_with_config(ip_addr, (2010, 2110), config, 2);
 
         assert!(
             result.is_err(),
@@ -1008,10 +995,9 @@ mod tests {
         let ip_a = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let ip_b = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let port_range = sockets::localhost_port_range_for_tests();
-
+        let server_ports = sockets::localhost_port_range_for_tests();
         let (_srv_udp_port, (srv_udp_sock, srv_tcp_listener)) =
-            bind_common_in_range_with_config(ip_a, port_range, config).unwrap();
+            bind_common_in_range_with_config(ip_a, server_ports, config).unwrap();
 
         let ip_echo_server_addr = srv_udp_sock.local_addr().unwrap();
         let _runtime = ip_echo_server(
@@ -1021,10 +1007,18 @@ mod tests {
         );
 
         let mut udp_sockets = Vec::new();
-        let (_p1, (sock_a, _tl_a)) =
-            bind_common_in_range_with_config(ip_a, port_range, config).unwrap();
-        let (_p2, (sock_b, _tl_b)) =
-            bind_common_in_range_with_config(ip_b, port_range, config).unwrap();
+        let (_p1, (sock_a, _tl_a)) = bind_common_in_range_with_config(
+            ip_a,
+            sockets::localhost_port_range_for_tests(),
+            config,
+        )
+        .unwrap();
+        let (_p2, (sock_b, _tl_b)) = bind_common_in_range_with_config(
+            ip_b,
+            sockets::localhost_port_range_for_tests(),
+            config,
+        )
+        .unwrap();
 
         udp_sockets.push(sock_a);
         udp_sockets.push(sock_b);

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -603,6 +603,7 @@ pub fn bind_more_with_config(
 mod tests {
     use {
         super::*,
+        crate::sockets::unique_port_range_for_tests,
         ip_echo_server::IpEchoServerResponse,
         itertools::Itertools,
         std::{net::Ipv4Addr, time::Duration},
@@ -748,14 +749,16 @@ mod tests {
     #[test]
     fn test_bind_in_range_nil() {
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        bind_in_range(ip_addr, (2000, 2000)).unwrap_err();
-        bind_in_range(ip_addr, (2000, 1999)).unwrap_err();
+        let range = sockets::unique_port_range_for_tests(2);
+        bind_in_range(ip_addr, (range.end, range.end)).unwrap_err();
+        bind_in_range(ip_addr, (range.end, range.start)).unwrap_err();
     }
 
     #[test]
     fn test_find_available_port_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
+        let range = sockets::unique_port_range_for_tests(4);
+        let (pr_s, pr_e) = (range.start, range.end);
         assert_eq!(
             find_available_port_in_range(ip_addr, (pr_s, pr_s + 1)).unwrap(),
             pr_s
@@ -784,12 +787,11 @@ mod tests {
     #[test]
     fn test_bind_common_in_range() {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let (pr_s, pr_e) = sockets::localhost_port_range_for_tests();
+        let range = sockets::unique_port_range_for_tests(5);
         let config = SocketConfig::default();
         let (port, _sockets) =
-            bind_common_in_range_with_config(ip_addr, (pr_s, pr_e), config).unwrap();
-        assert!((pr_s..pr_e).contains(&port));
-
+            bind_common_in_range_with_config(ip_addr, (range.start, range.end), config).unwrap();
+        assert!(range.contains(&port));
         bind_common_in_range_with_config(ip_addr, (port, port + 1), config).unwrap_err();
     }
 
@@ -917,13 +919,16 @@ mod tests {
         let mut tcp_listeners = vec![];
         let mut udp_sockets = vec![];
 
+        let port_range = unique_port_range_for_tests(1);
         let (_server_port, (_, server_tcp_listener)) =
-            bind_common_in_range_with_config(ip_addr, (2200, 2300), config).unwrap();
+            bind_common_in_range_with_config(ip_addr, (port_range.start, port_range.end), config)
+                .unwrap();
         for _ in 0..MAX_PORT_VERIFY_THREADS * 2 {
+            let port_range = unique_port_range_for_tests(1);
             let (_client_port, (client_udp_socket, client_tcp_listener)) =
                 bind_common_in_range_with_config(
                     ip_addr,
-                    (2300, 2300 + (MAX_PORT_VERIFY_THREADS * 3) as u16),
+                    (port_range.start, port_range.end),
                     config,
                 )
                 .unwrap();
@@ -961,18 +966,24 @@ mod tests {
         solana_logger::setup();
         let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let offset = 6;
+        let port_range = unique_port_range_for_tests(10);
         if let Ok(((port1, _), (port2, _))) =
-            bind_two_in_range_with_offset(ip_addr, (1024, 65535), offset)
+            bind_two_in_range_with_offset(ip_addr, (port_range.start, port_range.end), offset)
         {
             assert!(port2 == port1 + offset);
         }
-        let offset = 42;
+        let offset = 7;
         if let Ok(((port1, _), (port2, _))) =
-            bind_two_in_range_with_offset(ip_addr, (1024, 65535), offset)
+            bind_two_in_range_with_offset(ip_addr, (port_range.start, port_range.end), offset)
         {
             assert!(port2 == port1 + offset);
         }
-        assert!(bind_two_in_range_with_offset(ip_addr, (1024, 1044), offset).is_err());
+        assert!(bind_two_in_range_with_offset(
+            ip_addr,
+            (port_range.start, port_range.start + 5),
+            offset
+        )
+        .is_err());
     }
 
     #[test]
@@ -980,7 +991,9 @@ mod tests {
         let ip_addr: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = SocketConfig::default(); //reuseport is false by default
 
-        let result = multi_bind_in_range_with_config(ip_addr, (2010, 2110), config, 2);
+        let port_range = unique_port_range_for_tests(3);
+        let result =
+            multi_bind_in_range_with_config(ip_addr, (port_range.start, port_range.end), config, 2);
 
         assert!(
             result.is_err(),
@@ -995,9 +1008,10 @@ mod tests {
         let ip_a = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let ip_b = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let server_ports = sockets::localhost_port_range_for_tests();
+        let port_range = sockets::localhost_port_range_for_tests();
+
         let (_srv_udp_port, (srv_udp_sock, srv_tcp_listener)) =
-            bind_common_in_range_with_config(ip_a, server_ports, config).unwrap();
+            bind_common_in_range_with_config(ip_a, port_range, config).unwrap();
 
         let ip_echo_server_addr = srv_udp_sock.local_addr().unwrap();
         let _runtime = ip_echo_server(
@@ -1007,18 +1021,10 @@ mod tests {
         );
 
         let mut udp_sockets = Vec::new();
-        let (_p1, (sock_a, _tl_a)) = bind_common_in_range_with_config(
-            ip_a,
-            sockets::localhost_port_range_for_tests(),
-            config,
-        )
-        .unwrap();
-        let (_p2, (sock_b, _tl_b)) = bind_common_in_range_with_config(
-            ip_b,
-            sockets::localhost_port_range_for_tests(),
-            config,
-        )
-        .unwrap();
+        let (_p1, (sock_a, _tl_a)) =
+            bind_common_in_range_with_config(ip_a, port_range, config).unwrap();
+        let (_p2, (sock_b, _tl_b)) =
+            bind_common_in_range_with_config(ip_b, port_range, config).unwrap();
 
         udp_sockets.push(sock_a);
         udp_sockets.push(sock_b);

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -12,7 +12,7 @@ use {
     },
 };
 // base port for deconflicted allocations
-const BASE_PORT: u16 = 5000;
+const BASE_PORT: u16 = 2000;
 // how much to allocate per individual process.
 // we expect to have at most 64 concurrent tests in CI at any moment on a given host.
 const SLICE_PER_PROCESS: u16 = (u16::MAX - BASE_PORT) / 64;
@@ -26,7 +26,7 @@ const SLICE_PER_PROCESS: u16 = (u16::MAX - BASE_PORT) / 64;
 #[allow(clippy::arithmetic_side_effects)]
 pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
     static SLICE: AtomicU16 = AtomicU16::new(0);
-    let offset = SLICE.fetch_add(size, Ordering::Relaxed);
+    let offset = SLICE.fetch_add(size, Ordering::SeqCst);
     let start = offset
         + match std::env::var("NEXTEST_TEST_GLOBAL_SLOT") {
             Ok(slot) => {
@@ -44,7 +44,7 @@ pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
     start..start + size
 }
 
-/// Retrieve a free 20-port slice for unit tests
+/// Retrieve a free 25-port slice for unit tests
 ///
 /// When running under nextest, this will try to provide
 /// a unique slice of port numbers (assuming no other nextest processes
@@ -54,7 +54,7 @@ pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
 /// When running without nextest, this will only bump an atomic and eventually
 /// panic when it runs out of port numbers to assign.
 pub fn localhost_port_range_for_tests() -> (u16, u16) {
-    let pr = unique_port_range_for_tests(20);
+    let pr = unique_port_range_for_tests(25);
     (pr.start, pr.end)
 }
 


### PR DESCRIPTION
#### Problem

CI is flaking due to "bug" in port assignment in `fn new_with_external_ip`

This should go in together with https://github.com/anza-xyz/agave/pull/7456 else we can randomly run out of ports in some CI runs.

#### Summary of Changes

- Bind TPU client ports inside given port-range too
- bump localhost-port-range-for-tests allocation to 25 ports from 20
