### PR TITLE
chore: reduce waste in port allocations of some tests

### DIFF
--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -183,7 +183,7 @@ mod tests {
     use {
         crate::{packet::PACKET_DATA_SIZE, recvmmsg::*},
         solana_net_utils::sockets::{
-            bind_in_range_with_config, localhost_port_range_for_tests,
+            bind_in_range_with_config, localhost_port_range_for_tests, unique_port_range_for_tests,
             SocketConfiguration as SocketConfig,
         },
         std::{
@@ -195,10 +195,20 @@ mod tests {
     type TestConfig = (UdpSocket, SocketAddr, UdpSocket, SocketAddr);
 
     fn test_setup_reader_sender(ip: IpAddr) -> io::Result<TestConfig> {
-        let port_range = localhost_port_range_for_tests();
-        let reader = bind_in_range_with_config(ip, port_range, SocketConfig::default())?.1;
+        let port_range = unique_port_range_for_tests(2);
+        let reader = bind_in_range_with_config(
+            ip,
+            (port_range.start, port_range.end),
+            SocketConfig::default(),
+        )?
+        .1;
         let reader_addr = reader.local_addr()?;
-        let sender = bind_in_range_with_config(ip, port_range, SocketConfig::default())?.1;
+        let sender = bind_in_range_with_config(
+            ip,
+            (port_range.start, port_range.end),
+            SocketConfig::default(),
+        )?
+        .1;
         let sender_addr = sender.local_addr()?;
         Ok((reader, reader_addr, sender, sender_addr))
     }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -327,10 +327,10 @@ mod tests {
             SendTransactionStats,
         },
         quinn::Endpoint,
-        solana_net_utils::{bind_in_range, sockets::localhost_port_range_for_tests},
+        solana_net_utils::sockets::{bind_to_localhost_unique, unique_port_range_for_tests},
         solana_tls_utils::QuicClientCertificate,
         std::{
-            net::{IpAddr, Ipv4Addr, SocketAddr},
+            net::{Ipv4Addr, SocketAddr},
             sync::Arc,
             time::Duration,
         },
@@ -342,10 +342,7 @@ mod tests {
     const TEST_MAX_TIME: Duration = Duration::from_secs(5);
 
     fn create_test_endpoint() -> Endpoint {
-        let port_range = localhost_port_range_for_tests();
-        let socket = bind_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range)
-            .unwrap()
-            .1;
+        let socket = bind_to_localhost_unique().unwrap();
         let client_config = create_client_config(&QuicClientCertificate::new(None));
         create_client_endpoint(BindTarget::Socket(socket), client_config).unwrap()
     }
@@ -354,8 +351,8 @@ mod tests {
     async fn test_worker_stopped_after_failed_connect() {
         let endpoint = create_test_endpoint();
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let port_range = unique_port_range_for_tests(2);
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
 
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -388,8 +385,8 @@ mod tests {
     async fn test_worker_shutdown() {
         let endpoint = create_test_endpoint();
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let port_range = unique_port_range_for_tests(2);
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
 
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
@@ -421,8 +418,8 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut cache = WorkersCache::new(10, cancel.clone());
 
-        let port_range = localhost_port_range_for_tests();
-        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.0);
+        let port_range = unique_port_range_for_tests(2);
+        let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
         let worker_channel_size = 1;
         let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;


### PR DESCRIPTION
#### Problem

Certain test use too many ports so we can get out-of-ports issues in CI.
This is especially a problem since we want to allocate more ports for main validator allocations as in https://github.com/anza-xyz/agave/pull/7455

#### Summary of Changes

Tame their appetite for ports a bit
This does not change any logic.