### PR TITLE
svm repo split: decouple dev deps: reserved-account-keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10870,7 +10870,6 @@ name = "solana-svm"
 version = "3.0.0"
 dependencies = [
  "agave-feature-set",
- "agave-reserved-account-keys",
  "agave-syscalls",
  "ahash 0.8.11",
  "assert_matches",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -82,7 +82,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
-agave-reserved-account-keys = { workspace = true }
 agave-syscalls = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -808,7 +808,6 @@ mod tests {
     use {
         super::*,
         crate::transaction_account_state_info::TransactionAccountStateInfo,
-        agave_reserved_account_keys::ReservedAccountKeys,
         rand0_7::prelude::*,
         solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         solana_hash::Hash,
@@ -838,7 +837,13 @@ mod tests {
         solana_transaction::{sanitized::SanitizedTransaction, Transaction},
         solana_transaction_context::{TransactionAccount, TransactionContext},
         solana_transaction_error::{TransactionError, TransactionResult as Result},
-        std::{borrow::Cow, cell::RefCell, collections::HashMap, fs::File, io::Read},
+        std::{
+            borrow::Cow,
+            cell::RefCell,
+            collections::{HashMap, HashSet},
+            fs::File,
+            io::Read,
+        },
         test_case::test_case,
     };
 
@@ -934,10 +939,7 @@ mod tests {
     }
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::Legacy(LegacyMessage::new(
-            message,
-            &ReservedAccountKeys::empty_key_set(),
-        ))
+        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
     }
 
     #[test_case(false; "informal_loaded_size")]

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -76,7 +76,6 @@ pub(crate) fn process_message(
 mod tests {
     use {
         super::*,
-        agave_reserved_account_keys::ReservedAccountKeys,
         ed25519_dalek::ed25519::signature::Signer,
         openssl::{
             ec::{EcGroup, EcKey},
@@ -109,7 +108,7 @@ mod tests {
         solana_svm_callback::InvokeContextCallback,
         solana_svm_feature_set::SVMFeatureSet,
         solana_transaction_context::TransactionContext,
-        std::sync::Arc,
+        std::{collections::HashSet, sync::Arc},
     };
 
     struct MockCallback {}
@@ -127,8 +126,7 @@ mod tests {
     }
 
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty_key_set())
-            .unwrap()
+        SanitizedMessage::try_from_legacy_message(message, &HashSet::new()).unwrap()
     }
 
     #[test]

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -70,7 +70,6 @@ impl TransactionAccountStateInfo {
 mod test {
     use {
         super::*,
-        agave_reserved_account_keys::ReservedAccountKeys,
         solana_account::AccountSharedData,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -82,6 +81,7 @@ mod test {
         solana_signer::Signer,
         solana_transaction_context::TransactionContext,
         solana_transaction_error::TransactionError,
+        std::collections::HashSet,
     };
 
     #[test]
@@ -110,10 +110,8 @@ mod test {
             recent_blockhash: Hash::default(),
         };
 
-        let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(
-            message,
-            &ReservedAccountKeys::empty_key_set(),
-        ));
+        let sanitized_message =
+            SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
@@ -164,10 +162,8 @@ mod test {
             recent_blockhash: Hash::default(),
         };
 
-        let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(
-            message,
-            &ReservedAccountKeys::empty_key_set(),
-        ));
+        let sanitized_message =
+            SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1089,7 +1089,6 @@ mod tests {
             nonce_info::NonceInfo,
             rollback_accounts::RollbackAccounts,
         },
-        agave_reserved_account_keys::ReservedAccountKeys,
         solana_account::{create_account_shared_data_for_test, WritableAccount},
         solana_clock::Clock,
         solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -1119,10 +1118,7 @@ mod tests {
     };
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::Legacy(LegacyMessage::new(
-            message,
-            &ReservedAccountKeys::empty_key_set(),
-        ))
+        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
     }
 
     struct TestForkGraph {}


### PR DESCRIPTION
#### Problem
We have to decouple any uses of `agave-` crates in the dev-dependencies of the crates slated to move to the new SVM repo.

#### Summary of Changes
Simply uses `HashSet` directly instead of bringing in the `agave-reserved-account-keys` dev-dependency only to use `empty_key_set`.

Part of #7317 