### PR TITLE
add networking team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,6 @@
 /bloom/ @anza-xyz/networking
 /core/src/repair/ @anza-xyz/networking
 /gossip/ @anza-xyz/networking
-/ledger/src/shred/ @anza-xyz/networking
 /net-utils/ @anza-xyz/networking
 /tls-utils/ @anza-xyz/networking
 /turbine/ @anza-xyz/networking

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,11 @@
 /svm-callback/ @anza-xyz/svm
 /transaction-context/ @anza-xyz/svm
 /transaction-view/ @anza-xyz/tx-metadata
+/bloom/ @anza-xyz/networking
+/core/src/repair/ @anza-xyz/networking
+/gossip/ @anza-xyz/networking
+/ledger/src/shred/ @anza-xyz/networking
+/net-utils/ @anza-xyz/networking
+/tls-utils/ @anza-xyz/networking
+/turbine/ @anza-xyz/networking
+/xdp/ @anza-xyz/networking

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,21 @@
-# The SVM team is in the process of migrating these subdirectories to a new
-# repo and would like to avoid introducing dependencies in the meantime.
+# Please keep this file sorted
+/bloom/ @anza-xyz/networking
 /compute-budget-instruction/ @anza-xyz/fees
+/core/src/repair/ @anza-xyz/networking
 /fee/ @anza-xyz/fees
+/gossip/ @anza-xyz/networking
 /log-collector/ @anza-xyz/svm
+/net-utils/ @anza-xyz/networking
 /program-runtime/ @anza-xyz/svm
 /programs/bpf_loader/ @anza-xyz/svm
 /programs/loader-v4/ @anza-xyz/svm
 /runtime-transaction/ @anza-xyz/tx-metadata
+/svm-callback/ @anza-xyz/svm
 /svm-conformance/ @anza-xyz/svm
 /svm-transaction/ @anza-xyz/svm
 /svm/ @anza-xyz/svm
-/svm-callback/ @anza-xyz/svm
+/tls-utils/ @anza-xyz/networking
 /transaction-context/ @anza-xyz/svm
 /transaction-view/ @anza-xyz/tx-metadata
-/bloom/ @anza-xyz/networking
-/core/src/repair/ @anza-xyz/networking
-/gossip/ @anza-xyz/networking
-/net-utils/ @anza-xyz/networking
-/tls-utils/ @anza-xyz/networking
 /turbine/ @anza-xyz/networking
 /xdp/ @anza-xyz/networking


### PR DESCRIPTION
#### Problem

- We could use a well-defined process for reviewer assignment

#### Summary of Changes

 CODEOWNERS config for network team covering:

- gossip
   - bloom (used in gossip)
- turbine (the solana-turbine crate and shred module in solana-ledger)
- core/src/repair
- net-utils
- tls-utils

