### PR TITLE
Correctly deprecate command-line args

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -203,7 +203,8 @@ pub fn warn_for_deprecated_arguments(matches: &ArgMatches) {
                     msg.push('.');
                 }
             }
-            warn!("{}", msg);
+            // this can not rely on logger since it is not initialized at the time of call
+            eprintln!("{}", msg);
         }
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -142,6 +142,32 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .long("disable-accounts-disk-index")
         .help("Disable the disk-based accounts index if it is enabled by default."));
 
+    add_arg!(
+        // deprecated in v3.0.0
+        Arg::with_name("gossip_host")
+            .long("gossip-host")
+            .value_name("HOST")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host),
+            replaced_by : "bind-address",
+            usage_warning:"Use --bind-address instead",
+    );
+    add_arg!(
+        // deprecated in v3.0.0
+        Arg::with_name("tpu_disable_quic")
+            .long("tpu-disable-quic")
+            .takes_value(false)
+            .help("Do not use QUIC to send transactions."),
+        usage_warning: "UDP support will be dropped"
+    );
+    add_arg!(
+        // deprecated in v3.0.0
+        Arg::with_name("tpu_enable_udp")
+            .long("tpu-enable-udp")
+            .takes_value(false)
+            .help("Enable UDP for receiving/sending transactions."),
+        usage_warning: "UDP support will be dropped"
+    );
     res
 }
 
@@ -678,15 +704,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Gossip port number for the validator"),
         )
         .arg(
-            Arg::with_name("gossip_host")
-                .long("gossip-host")
-                .value_name("HOST")
-                .takes_value(true)
-                .validator(solana_net_utils::is_host)
-                .hidden(hidden_unless_forced())
-                .help("DEPRECATED: Use --bind-address instead."),
-        )
-        .arg(
             Arg::with_name("dynamic_port_range")
                 .long("dynamic-port-range")
                 .value_name("MIN_PORT-MAX_PORT")
@@ -701,7 +718,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
                 .default_value("127.0.0.1")
-                .help("IP address to bind the validator ports [default: 127.0.0.1]"),
+                .help("IP address to bind the validator ports [default: 127.0.0.1]. Can be repeated to specify multihoming options."),
         )
         .arg(
             Arg::with_name("clone_account")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1,7 +1,6 @@
 use {
     crate::commands,
     clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
-    log::warn,
     solana_accounts_db::{
         accounts_db::{
             DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -406,15 +406,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Gossip port number for the validator"),
     )
     .arg(
-        Arg::with_name("gossip_host")
-            .long("gossip-host")
-            .value_name("HOST")
-            .takes_value(true)
-            .validator(solana_net_utils::is_host)
-            .hidden(hidden_unless_forced())
-            .help("DEPRECATED: Use --bind-address instead."),
-    )
-    .arg(
         Arg::with_name("public_tpu_addr")
             .long("public-tpu-address")
             .alias("tpu-host-addr")
@@ -845,20 +836,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(is_parsable::<u64>)
             .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
-    )
-    .arg(
-        Arg::with_name("tpu_disable_quic")
-            .long("tpu-disable-quic")
-            .takes_value(false)
-            .hidden(hidden_unless_forced())
-            .help("DEPRECATED (UDP support will be dropped): Do not use QUIC to send transactions."),
-    )
-    .arg(
-        Arg::with_name("tpu_enable_udp")
-            .long("tpu-enable-udp")
-            .takes_value(false)
-            .hidden(hidden_unless_forced())
-            .help("DEPRECATED (UDP support will be dropped): Enable UDP for receiving/sending transactions."),
     )
     .arg(
         Arg::with_name("tpu_connection_pool_size")


### PR DESCRIPTION
#### Problem

- Some of the CLI args newly deprecated in 3.0 were not correctly implemented
- Deprecated section warning message was broken

#### Summary of Changes

- Move agrs where they belong
- Fix the warning message
