### PR TITLE
core: Use `BytesPacket` instead of `Packet` in fetch stage QUIC endpoint

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -190,7 +190,6 @@ impl AncestorHashesService {
                         ancestor_hashes_response_quic_receiver,
                         PacketFlags::REPAIR,
                         response_sender,
-                        Recycler::default(),
                         exit,
                     )
                 })


### PR DESCRIPTION
This is a practically non-functional change, since we are not using QUIC in Turbine on MNB. However,  it's a necessary step to :axe: the legacy `Packet` type.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
