### PR TITLE
ledger-tool: Separates --snapshots and --full-snapshot-archive-path

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -157,18 +157,23 @@ pub fn snapshot_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .help("Do not start from a local snapshot if present"),
         Arg::with_name("snapshots")
             .long("snapshots")
-            .alias("snapshot-archive-path")
-            .alias("full-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
             .help("Use DIR for snapshot location [default: --ledger value]"),
+        Arg::with_name("full_snapshot_archive_path")
+            .long("full-snapshot-archive-path")
+            .alias("snapshot-archive-path")
+            .value_name("DIR")
+            .takes_value(true)
+            .global(true)
+            .help("Use DIR as full snapshot archives location [default: --snapshots value]"),
         Arg::with_name("incremental_snapshot_archive_path")
             .long("incremental-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
             .global(true)
-            .help("Use DIR for separate incremental snapshot location"),
+            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]"),
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
             .takes_value(true)

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -143,12 +143,16 @@ pub fn load_and_process_ledger(
                 .join(LEDGER_TOOL_DIRECTORY)
                 .join(BANK_SNAPSHOTS_DIR)
         };
-        let full_snapshot_archives_dir = snapshots_dir.clone();
+        let full_snapshot_archives_dir =
+            value_t!(arg_matches, "full_snapshot_archive_path", String)
+                .ok()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| snapshots_dir.clone());
         let incremental_snapshot_archives_dir =
             value_t!(arg_matches, "incremental_snapshot_archive_path", String)
                 .ok()
                 .map(PathBuf::from)
-                .unwrap_or_else(|| full_snapshot_archives_dir.clone());
+                .unwrap_or_else(|| snapshots_dir.clone());
         if let Some(full_snapshot_slot) =
             snapshot_utils::get_highest_full_snapshot_archive_slot(&full_snapshot_archives_dir)
         {


### PR DESCRIPTION
#### Problem

ledger-tool fastboot may fail if the validator previously running on this machine had custom paths for both `--snapshots` and `--full-snapshot-archive-path`.

This is because ledger-tool does not have a way to differentiate between where snapshot *archives* are and where *bank snapshots* are.


#### Summary of Changes

Split ledger-tool's `--snapshots` into both `--snapshots` and `--full-snapshot-archive-path`. This now mimics what agave-validator does, so an operator can now use the same cli args for both validator and ledger-tool.