### PR TITLE
Clean up `TransactionContext` and remove `instruction_accounts_lamport_sum`

### DIFF
--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -265,20 +265,6 @@ impl TransactionContext {
     }
 
     /// Searches for an account by its key
-    #[cfg(all(
-        not(target_os = "solana"),
-        any(test, feature = "dev-context-only-utils")
-    ))]
-    pub fn get_account_at_index(
-        &self,
-        index_in_transaction: IndexOfAccount,
-    ) -> Result<&RefCell<AccountSharedData>, InstructionError> {
-        self.accounts
-            .get(index_in_transaction)
-            .ok_or(InstructionError::NotEnoughAccountKeys)
-    }
-
-    /// Searches for an account by its key
     pub fn find_index_of_account(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
         self.account_keys
             .iter()


### PR DESCRIPTION
#### Problem

The management of accounts in `TransactionContext` is amazingly complex. There are multiple ways of accessing them and we pass on references around everywhere. This setting creates a high overhead for the impeding refactors we must do for ABIv2 compatibility.

Furthermore, `instruction_accounts_lamport_sum` isn't really necessary and makes `InstructionContext` incompatible with the ABIv2 layout. 

#### Summary of Changes

1. Delete `get_account_at_index`. It is only used in tests and is an encumbrance because it exposes `AccountSharedData` directly without passing through BorrowedAccount.
2. Unify the usage of `try_borrow_mut` for accounts. It is used in four different places with similar error messages.
3. Instead of summing the lamports for accounts with `instruction_accounts_lamport_sum`, we can have a transaction wide `lamports_delta`, which must be zero at the end of each instruction execution. We only modify it when `set_lamports` is called.
