### PR TITLE
Replaces --accounts-db-read-cache-limit-mb with --accounts-db-read-cache-limit

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -128,6 +128,28 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
 
     add_arg!(
         // deprecated in v3.0.0
+        Arg::with_name("accounts_db_read_cache_limit_mb")
+            .long("accounts-db-read-cache-limit-mb")
+            .value_name("MAX | LOW,HIGH")
+            .takes_value(true)
+            .min_values(1)
+            .max_values(2)
+            .multiple(false)
+            .require_delimiter(true)
+            .help("How large the read cache for account data can become, in mebibytes")
+            .long_help(
+                "How large the read cache for account data can become, in mebibytes. \
+                 If given a single value, it will be the maximum size for the cache. \
+                 If given a pair of values, they will be the low and high watermarks \
+                 for the cache. When the cache exceeds the high watermark, entries will \
+                 be evicted until the size reaches the low watermark."
+            )
+            .hidden(hidden_unless_forced())
+            .conflicts_with("accounts_db_read_cache_limit"),
+            replaced_by: "accounts-db-read-cache-limit",
+    );
+    add_arg!(
+        // deprecated in v3.0.0
         Arg::with_name("accounts_hash_cache_path")
             .long("accounts-hash-cache-path")
             .value_name("PATH")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1445,20 +1445,19 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("accounts_db_read_cache_limit_mb")
-            .long("accounts-db-read-cache-limit-mb")
-            .value_name("MAX | LOW,HIGH")
+        Arg::with_name("accounts_db_read_cache_limit")
+            .long("accounts-db-read-cache-limit")
+            .value_name("LOW,HIGH")
             .takes_value(true)
-            .min_values(1)
+            .min_values(2)
             .max_values(2)
             .multiple(false)
             .require_delimiter(true)
-            .help("How large the read cache for account data can become, in mebibytes")
+            .help("How large the read cache for account data can become, in bytes")
             .long_help(
-                "How large the read cache for account data can become, in mebibytes. \
-                 If given a single value, it will be the maximum size for the cache. \
-                 If given a pair of values, they will be the low and high watermarks \
-                 for the cache. When the cache exceeds the high watermark, entries will \
+                "How large the read cache for account data can become, in bytes. \
+                 The values will be the low and high watermarks for the cache. \
+                 When the cache exceeds the high watermark, entries will \
                  be evicted until the size reaches the low watermark."
             )
             .hidden(hidden_unless_forced()),


### PR DESCRIPTION
#### Problem

There is a hidden cli arg for setting the accounts read-only cache size. It allows passing in either a single value or a pair of values. The pair of values is used to set the high and low watermarks for the cache, which triggers when to start and stop the eviction process. If only a single value is provided, it is used as both high and low watermarks.

Using the same value for both high and low watermarks is discouraged as it results in worse performance (more time doing evictions), but still possible. We can't really remove that from the existing cli arg though.

Additionally, the size is specified in mebibytes. This is another slightly odd/inconsistent value type.


#### Summary of Changes

Deprecate the existing `--accounts-db-read-cache-limit-mb` cli arg, and add `--accounts-db-read-cache-limit`. This new cli arg requires passing a pair of values (for both high and low watermarks), and uses bytes instead of mebibytes. It is still hidden.

Note: Since the existing cli arg is hidden, in theory we could likely just remove it entirely. Deprecating was straight forward for this case though, so I decided to go that route for (potentially) better UX.


#### Additional Testing

I ran `agave-validator` with these cli combos to check everything works as expected:
* `--accounts-db-read-cache-limit-mb`: ✅ validator starts successfully, and there is a log indicating this cli arg is deprecated
* both `--accounts-db-read-cache-limit-mb` and `--accounts-db-read-cache-limit`: ✅ validator does not start, which is the desired behavior, due to conflicting cli args
* `--accounts-db-read-cache-limit` with 1 value: ✅ fails as expected
* `--accounts-db-read-cache-limit` with 2 values: ✅ succeeds as expected
* `--accounts-db-read-cache-limit` with 3 values: ✅ fails as expected