### PR TITLE
leverage payload.bytes in xdp broadcast

### DIFF
--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -85,7 +85,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
         let shreds = shreds.clone();
         broadcast_shreds(
             socket,
-            shreds,
+            &shreds,
             &cluster_nodes_cache,
             &last_datapoint,
             &mut TransmitShredsStats::default(),

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -468,18 +468,6 @@ pub fn broadcast_shreds(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.root_bank(), bank_forks.working_bank())
     };
-    // Implementation note:
-    // We are gathering the indexes of the shreds in the `shreds` vector rather than the shred
-    // payloads themselves. This is because, in the XDP case, the shred payloads will be sent to
-    // the XDP thread(s) via a channel, and the lifetime of the shred payloads must extend to that
-    // of the XDP thread(s).
-    //
-    // Because the `shreds` vector is behind a shared (`Arc`) reference, we must pass that reference
-    // along to the XDP thread(s) via the Xdp channel message payload. This allows us to extend the
-    // lifetime of the shred payloads to the XDP thread(s) without cloning each payload.
-    //
-    // When `shred::Payload` is refactored to use `Bytes`, this can be adjusted to simply pass the payload
-    // `Bytes` directly to the XDP thread(s).
     let (packets, quic_packets): (Vec<_>, Vec<_>) = shreds
         .iter()
         .group_by(|shred| shred.slot())

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -186,7 +186,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         let (shreds, _) = receiver.recv()?;
         broadcast_shreds(
             sock,
-            shreds,
+            &shreds,
             &self.cluster_nodes_cache,
             &AtomicInterval::default(),
             &mut TransmitShredsStats::default(),

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -392,7 +392,7 @@ impl StandardBroadcastRun {
 
         broadcast_shreds(
             sock,
-            shreds,
+            &shreds,
             &self.cluster_nodes_cache,
             &self.last_datapoint_submit,
             &mut transmit_stats,

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         addr_cache::AddrCache,
         cluster_nodes::{self, ClusterNodes, ClusterNodesCache, Error, MAX_NUM_TURBINE_HOPS},
-        xdp::{XdpSender, XdpShredPayload},
+        xdp::XdpSender,
     },
     bytes::Bytes,
     crossbeam_channel::{Receiver, RecvError, TryRecvError},
@@ -430,11 +430,7 @@ fn retransmit_shred(
             RetransmitSocket::Xdp(sender) => {
                 let mut sent = num_addrs;
                 if num_addrs > 0 {
-                    if let Err(e) = sender.try_send(
-                        key.index() as usize,
-                        addrs.to_vec(),
-                        XdpShredPayload::Owned(shred),
-                    ) {
+                    if let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred) {
                         log::warn!("xdp channel full: {e:?}");
                         stats
                             .num_shreds_dropped_xdp_full


### PR DESCRIPTION
#### Problem

Follow up on #7021. Now that #7049 is merged and shred payloads now use `Bytes`, some of the additional machinery for connecting broadcast to XDP can be simplified. In particular, additional logic was added to prevent unnecessary cloning of shred payloads by passing the entire `Arc<Vec<Shred>>` along with shred indexes. This is no longer necessary with shred payloads being cheaply clonable via `Bytes`.

#### Summary of Changes

This removes the additional logic added in #7021 to avoid shred payload cloning;. This unifies the XDP channel interface to simply accept `shred::Payload`, now that payloads are just a wrapper around `Bytes`.
