### PR TITLE
Process dead slots when handling reclaims during flush

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2681,23 +2681,20 @@ impl AccountsDb {
                 mark_accounts_obsolete,
             );
             reclaim_result.1 = reclaimed_offsets;
-
-            if !dead_slots.is_empty() {
-                let HandleReclaims::ProcessDeadSlots(purge_stats) = handle_reclaims;
-                if let Some(expected_single_dead_slot) = expected_single_dead_slot {
-                    assert!(dead_slots.len() <= 1);
-                    if dead_slots.len() == 1 {
-                        assert!(dead_slots.contains(&expected_single_dead_slot));
-                    }
+            let HandleReclaims::ProcessDeadSlots(purge_stats) = handle_reclaims;
+            if let Some(expected_single_dead_slot) = expected_single_dead_slot {
+                assert!(dead_slots.len() <= 1);
+                if dead_slots.len() == 1 {
+                    assert!(dead_slots.contains(&expected_single_dead_slot));
                 }
-
-                self.process_dead_slots(
-                    &dead_slots,
-                    Some(&mut reclaim_result.0),
-                    purge_stats,
-                    pubkeys_removed_from_accounts_index,
-                );
             }
+
+            self.process_dead_slots(
+                &dead_slots,
+                Some(&mut reclaim_result.0),
+                purge_stats,
+                pubkeys_removed_from_accounts_index,
+            );
         }
         reclaim_result
     }
@@ -6216,7 +6213,7 @@ impl AccountsDb {
             .store_num_accounts
             .fetch_add(accounts.len() as u64, Ordering::Relaxed);
 
-        // If there are any reclaims then they should be handled. Reclaims effect
+        // If there are any reclaims then they should be handled. Reclaims affect
         // all storages, and may result in the removal of dead storages.
         let mut handle_reclaims_elapsed = 0;
         if !reclaims.is_empty() {

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -30,6 +30,8 @@ pub struct AccountsStats {
     pub handle_dead_keys_us: AtomicU64,
     pub purge_exact_us: AtomicU64,
     pub purge_exact_count: AtomicU64,
+    pub num_obsolete_slots_removed: AtomicUsize,
+    pub num_obsolete_bytes_removed: AtomicU64,
 }
 
 #[derive(Debug, Default)]

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -646,6 +646,69 @@ define_accounts_db_test!(test_accounts_unsquashed, |db0| {
     );
 });
 
+/// Test to verify that reclaiming old storages during flush works correctly.
+/// Creates multiple storages with accounts, flushes them, and then creates a new storage
+/// that invalidates some of the old accounts. The test checks that one of the old storages
+/// is reclaimed as is fully invalidated
+#[test]
+fn test_flush_slots_with_reclaim_old_slots() {
+    let accounts = AccountsDb::new_single_for_tests();
+    let mut pubkeys = vec![];
+
+    // Create and flush 5 slots with 5 accounts each
+    for slot in 0..5 {
+        let mut slot_pubkeys = vec![];
+        for _ in 0..5 {
+            let pubkey = solana_pubkey::new_rand();
+            let account = AccountSharedData::new(slot + 1, 0, &pubkey);
+            accounts.store_for_tests((slot, [(&pubkey, &account)].as_slice()));
+            slot_pubkeys.push(pubkey);
+        }
+        pubkeys.push(slot_pubkeys);
+        accounts.add_root_and_flush_write_cache(slot);
+    }
+
+    // Create another slot which invalidates 5 accounts from the first slot,
+    // 4 accounts from the second slot, etc.
+    let new_slot = 5;
+    for (slot, slot_pubkeys) in pubkeys.iter().enumerate() {
+        for pubkey in slot_pubkeys.iter().take(5 - slot) {
+            let account = AccountSharedData::new(new_slot + 1, 0, pubkey);
+            accounts.store_for_tests((new_slot, [(pubkey, &account)].as_slice()));
+        }
+    }
+
+    // Get the accounts from the write cache slot
+    let accounts_list: Vec<(Pubkey, AccountSharedData)> = accounts
+        .accounts_cache
+        .slot_cache(new_slot)
+        .unwrap()
+        .iter()
+        .map(|iter_item| {
+            let key = *iter_item.key();
+            let account = iter_item.value().account.clone();
+            (key, account)
+        })
+        .collect();
+
+    let storage = accounts.create_and_insert_store(new_slot, 4096, "test_flush_slots");
+
+    // Flushing this storage directly using _store_accounts_frozen. This is done to pass in UpsertReclaim::ReclaimOldSlots
+    accounts._store_accounts_frozen(
+        (new_slot, &accounts_list[..]),
+        &storage,
+        UpsertReclaim::ReclaimOldSlots,
+        UpdateIndexThreadSelection::PoolWithThreshold,
+    );
+
+    // Verify that the storage for the first slot has been removed
+    assert!(accounts.storage.get_slot_storage_entry(0).is_none());
+    for slot in 1..5 {
+        assert!(accounts.storage.get_slot_storage_entry(slot).is_some());
+    }
+    assert!(accounts.storage.get_slot_storage_entry(new_slot).is_some());
+}
+
 fn run_test_remove_unrooted_slot(is_cached: bool, db: AccountsDb) {
     let unrooted_slot = 9;
     let unrooted_bank_id = 9;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -679,15 +679,15 @@ fn test_flush_slots_with_reclaim_old_slots() {
     }
 
     // Get the accounts from the write cache slot
-    let accounts_list: Vec<(Pubkey, AccountSharedData)> = accounts
+    let accounts_list: Vec<(_, _)> = accounts
         .accounts_cache
         .slot_cache(new_slot)
         .unwrap()
         .iter()
         .map(|iter_item| {
-            let key = *iter_item.key();
+            let pubkey = *iter_item.key();
             let account = iter_item.value().account.clone();
-            (key, account)
+            (pubkey, account)
         })
         .collect();
 
@@ -698,7 +698,7 @@ fn test_flush_slots_with_reclaim_old_slots() {
         (new_slot, &accounts_list[..]),
         &storage,
         UpsertReclaim::ReclaimOldSlots,
-        UpdateIndexThreadSelection::PoolWithThreshold,
+        UpdateIndexThreadSelection::Inline,
     );
 
     // Verify that the storage for the first slot has been removed

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -649,7 +649,7 @@ define_accounts_db_test!(test_accounts_unsquashed, |db0| {
 /// Test to verify that reclaiming old storages during flush works correctly.
 /// Creates multiple storages with accounts, flushes them, and then creates a new storage
 /// that invalidates some of the old accounts. The test checks that one of the old storages
-/// is reclaimed as is fully invalidated
+/// is reclaimed as the storage is fully invalidated
 #[test]
 fn test_flush_slots_with_reclaim_old_slots() {
     let accounts = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -701,6 +701,9 @@ fn test_flush_slots_with_reclaim_old_slots() {
         UpdateIndexThreadSelection::Inline,
     );
 
+    // Remove the flushed slot from the cache
+    assert!(accounts.accounts_cache.remove_slot(new_slot).is_some());
+
     // Verify that the storage for the first slot has been removed
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
     for slot in 1..5 {


### PR DESCRIPTION
#### Problem
With ReclaimOldSlots it is possible to have dead storages during cache flush. This is because an entire older storage could be marked obsolete. Multiple storages may even be marked obsolete. 

#### Summary of Changes
- Process dead slots when calling handle_reclaims in store_accounts_frozen
- Remove type that does not process dead slots as it is no longer used
- Log stats

Note::
This is non functional at this time, as store_accounts_frozen is always called with PopulateReclaims::IgnoreReclaims. This causes the code path to never be exercised. 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
