### PR TITLE
validator: Use BANK_SNAPSHOTS_DIR constant

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -61,7 +61,9 @@ use {
     solana_runtime::{
         runtime_config::RuntimeConfig,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
-        snapshot_utils::{self, ArchiveFormat, SnapshotInterval, SnapshotVersion},
+        snapshot_utils::{
+            self, ArchiveFormat, SnapshotInterval, SnapshotVersion, BANK_SNAPSHOTS_DIR,
+        },
     },
     solana_send_transaction_service::send_transaction_service,
     solana_signer::Signer,
@@ -1261,7 +1263,7 @@ fn new_snapshot_config(
         )?;
     }
 
-    let bank_snapshots_dir = snapshots_dir.join("snapshots");
+    let bank_snapshots_dir = snapshots_dir.join(BANK_SNAPSHOTS_DIR);
     fs::create_dir_all(&bank_snapshots_dir).map_err(|err| {
         format!(
             "failed to create bank snapshots directory '{}': {err}",


### PR DESCRIPTION
#### Summary of Changes
This single sources and replaces the hard-coded "snapshots" value

Follow-on to https://github.com/anza-xyz/agave/pull/7453, noticed while reviewing https://github.com/anza-xyz/agave/pull/7457