### PR TITLE
fix port binding for tests in connection cache

### DIFF
--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -514,9 +514,7 @@ mod tests {
         async_trait::async_trait,
         rand::{Rng, SeedableRng},
         rand_chacha::ChaChaRng,
-        solana_net_utils::sockets::{
-            bind_with_any_port_with_config, SocketConfiguration as SocketConfig,
-        },
+        solana_net_utils::sockets::bind_to_localhost_unique,
         solana_transaction_error::TransportResult,
         std::{
             net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -573,13 +571,7 @@ mod tests {
     impl Default for MockUdpConfig {
         fn default() -> Self {
             Self {
-                udp_socket: Arc::new(
-                    bind_with_any_port_with_config(
-                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default(),
-                    )
-                    .expect("Unable to bind to UDP socket"),
-                ),
+                udp_socket: Arc::new(bind_to_localhost_unique().unwrap()),
             }
         }
     }
@@ -588,11 +580,7 @@ mod tests {
         fn new() -> Result<Self, ClientError> {
             Ok(Self {
                 udp_socket: Arc::new(
-                    bind_with_any_port_with_config(
-                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        SocketConfig::default(),
-                    )
-                    .map_err(Into::<ClientError>::into)?,
+                    bind_to_localhost_unique().map_err(Into::<ClientError>::into)?,
                 ),
             })
         }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -44,7 +44,18 @@ pub struct UdpSocketPair {
 
 pub type PortRange = (u16, u16);
 
+#[cfg(not(debug_assertions))]
+/// Port range available to validator by default
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
+
+// Sets the port range outside of the region used by other tests to avoid interference
+// This arrangement is not ideal, but can be removed once ConnectionCache is deprecated
+#[cfg(debug_assertions)]
+pub const VALIDATOR_PORT_RANGE: PortRange = (
+    crate::sockets::UNIQUE_ALLOC_BASE_PORT - 512,
+    crate::sockets::UNIQUE_ALLOC_BASE_PORT,
+);
+
 pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 25; // VALIDATOR_PORT_RANGE must be at least this wide
 
 pub(crate) const HEADER_LENGTH: usize = 4;

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -216,6 +216,7 @@ pub fn bind_in_range_with_config(
     )))
 }
 
+#[deprecated(since = "3.0.0", note = "Please bind to specific ports instead")]
 pub fn bind_with_any_port_with_config(
     ip_addr: IpAddr,
     config: SocketConfiguration,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -12,10 +12,10 @@ use {
     },
 };
 // base port for deconflicted allocations
-const BASE_PORT: u16 = 2000;
+pub(crate) const UNIQUE_ALLOC_BASE_PORT: u16 = 2000;
 // how much to allocate per individual process.
 // we expect to have at most 64 concurrent tests in CI at any moment on a given host.
-const SLICE_PER_PROCESS: u16 = (u16::MAX - BASE_PORT) / 64;
+const SLICE_PER_PROCESS: u16 = (u16::MAX - UNIQUE_ALLOC_BASE_PORT) / 64;
 /// When running under nextest, this will try to provide
 /// a unique slice of port numbers (assuming no other nextest processes
 /// are running on the same host) based on NEXTEST_TEST_GLOBAL_SLOT variable
@@ -36,9 +36,9 @@ pub fn unique_port_range_for_tests(size: u16) -> Range<u16> {
                     "Overrunning into the port range of another test! Consider using fewer ports \
                      per test."
                 );
-                BASE_PORT + slot * SLICE_PER_PROCESS
+                UNIQUE_ALLOC_BASE_PORT + slot * SLICE_PER_PROCESS
             }
-            Err(_) => BASE_PORT,
+            Err(_) => UNIQUE_ALLOC_BASE_PORT,
         };
     assert!(start < u16::MAX - size, "Ran out of port numbers!");
     start..start + size

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -17,10 +17,7 @@ use {
     },
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
-    solana_net_utils::{
-        sockets::{bind_in_range_with_config, SocketConfiguration as SocketConfig},
-        VALIDATOR_PORT_RANGE,
-    },
+    solana_net_utils::sockets,
     solana_quic_definitions::{
         QUIC_CONNECTION_HANDSHAKE_TIMEOUT, QUIC_KEEP_ALIVE, QUIC_MAX_TIMEOUT, QUIC_SEND_FAIRNESS,
     },
@@ -32,7 +29,7 @@ use {
     },
     solana_transaction_error::TransportResult,
     std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
+        net::{SocketAddr, UdpSocket},
         sync::{atomic::Ordering, Arc},
         thread,
     },
@@ -81,11 +78,13 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            let config = SocketConfig::default();
-            let client_socket = bind_in_range_with_config(
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                VALIDATOR_PORT_RANGE,
-                config,
+            #[cfg(debug_assertions)]
+            let client_socket = sockets::bind_to_localhost_unique().unwrap();
+            #[cfg(not(debug_assertions))]
+            let client_socket = sockets::bind_in_range_with_config(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                solana_net_utils::VALIDATOR_PORT_RANGE,
+                sockets::SocketConfiguration::default(),
             )
             .expect("QuicLazyInitializedEndpoint::create_endpoint bind_in_range")
             .1;

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -78,9 +78,8 @@ impl QuicLazyInitializedEndpoint {
         let mut endpoint = if let Some(endpoint) = &self.client_endpoint {
             endpoint.clone()
         } else {
-            #[cfg(debug_assertions)]
-            let client_socket = sockets::bind_to_localhost_unique().unwrap();
-            #[cfg(not(debug_assertions))]
+            // This will bind to random ports, but VALIDATOR_PORT_RANGE is outside
+            // of the range for CI tests when this is running in CI
             let client_socket = sockets::bind_in_range_with_config(
                 std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
                 solana_net_utils::VALIDATOR_PORT_RANGE,


### PR DESCRIPTION
#### Problem

- Port binding in connection cache during tests is non-deterministic and clobbers other tests

Related: https://github.com/anza-xyz/agave/pull/7487 
#### Summary of Changes

- Use deterministic port binding instead where possible
- Adjust VALIDATOR_PORT_RANGE in other cases
