### PR TITLE
ci: remove useless nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,10 +4,6 @@ dir = "target/nextest"
 [test-groups]
 build-sbf = { max-threads = 1 }
 
-[[profile.default.overides]]
-filter = "package(solana-cargo-build-sbf)"
-test-group = "build-sbf"
-
 [profile.ci]
 failure-output = "immediate-final"
 slow-timeout = { period = "60s", terminate-after = 1 }


### PR DESCRIPTION
#### Problem

I noticed that we introduced an invalid configuration in https://github.com/anza-xyz/agave/pull/7384. it should be
```diff

- [[profile.default.overides]]
+ [[profile.default.overrides]]
```

also, we always run tests with the ci profile. ideally the default profile should never be used.

#### Summary of Changes

remove it