### PR TITLE
compute-budget: test all migrating builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,6 +7373,7 @@ dependencies = [
  "agave-feature-set",
  "ahash 0.8.11",
  "log",
+ "qualifier_attr",
  "rand 0.8.5",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -19,12 +19,13 @@ name = "solana_builtins_default_costs"
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "solana-vote-program/frozen-abi"]
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:qualifier_attr"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
 log = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 solana-bpf-loader-program = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::field_qualifiers;
 use {
     agave_feature_set::{self as feature_set},
     ahash::AHashMap,
@@ -11,6 +14,10 @@ use {
 };
 
 #[derive(Clone)]
+#[cfg_attr(
+    feature = "dev-context-only-utils",
+    field_qualifiers(core_bpf_migration_feature(pub), position(pub))
+)]
 pub struct MigratingBuiltinCost {
     core_bpf_migration_feature: Pubkey,
     // encoding positional information explicitly for migration feature item,


### PR DESCRIPTION
#### Problem
this test is hardcoded to test the migrating stake program, but the stake program has been migrated. since we are removing it from the list in https://github.com/anza-xyz/agave/pull/7203, we need to make it more generic or delete it

#### Summary of Changes
make it more generic so future migrations are tested by it