### PR TITLE
Removing unnecessary clone found 

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5912,7 +5912,7 @@ impl AccountsDb {
         dead_slots_iter: impl Iterator<Item = &'a Slot> + Clone,
     ) {
         let mut measure = Measure::start("remove_dead_slots_metadata-ms");
-        self.clean_dead_slots_from_accounts_index(dead_slots_iter.clone());
+        self.clean_dead_slots_from_accounts_index(dead_slots_iter);
         measure.stop();
         inc_new_counter_info!("remove_dead_slots_metadata-ms", measure.as_ms() as usize);
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5907,10 +5907,7 @@ impl AccountsDb {
         (dead_slots, reclaimed_offsets)
     }
 
-    fn remove_dead_slots_metadata<'a>(
-        &'a self,
-        dead_slots_iter: impl Iterator<Item = &'a Slot> + Clone,
-    ) {
+    fn remove_dead_slots_metadata<'a>(&'a self, dead_slots_iter: impl Iterator<Item = &'a Slot>) {
         let mut measure = Measure::start("remove_dead_slots_metadata-ms");
         self.clean_dead_slots_from_accounts_index(dead_slots_iter);
         measure.stop();
@@ -5989,7 +5986,7 @@ impl AccountsDb {
 
     fn clean_dead_slots_from_accounts_index<'a>(
         &'a self,
-        dead_slots_iter: impl Iterator<Item = &'a Slot> + Clone,
+        dead_slots_iter: impl Iterator<Item = &'a Slot>,
     ) {
         let mut accounts_index_root_stats = AccountsIndexRootsStats::default();
         let mut measure = Measure::start("clean_dead_slot");


### PR DESCRIPTION
#### Problem
Unnecessary clones waste CPU cycles and makes code less readable. 
This one is minor, but after this the clippy lint can be run on accounts-db

#### Summary of Changes
- remove unnecessary clone

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
