### PR TITLE
Add zero lamport accounts during flush

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -28,6 +28,8 @@ pub struct AccountsStats {
     pub purge_exact_count: AtomicU64,
     pub num_obsolete_slots_removed: AtomicUsize,
     pub num_obsolete_bytes_removed: AtomicU64,
+    pub add_zero_lamport_accounts_us: AtomicU64,
+    pub num_zero_lamport_accounts_added: AtomicU64,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
#### Problem
With reclaimOldSlots is used during store_accounts_frozen, zero lamport accounts are always single_ref. 

#### Summary of Changes
- Loop through zero lamport single ref accounts and add them as zero_lamport_single_ref during flush 
- Add the storage to the shrink list if it is eligible for shrink
- Stats


Notes: 

- Marking zero lamport accounts could be done during write_accounts_to_storage or update_index which also loop through info, but perf impact is negligible of doing it separately and the code is cleaner this way
- I did not add any new testing in this PR. The code is relatively simple, and will be tested once obsolete accounts is fully implemented. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
