### PR TITLE
Remove unnecessary usages of `try_borrow_account`

### DIFF
--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -487,18 +487,16 @@ fn process_instruction_inner(
         }
         .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     } else {
-        let program = instruction_context.try_borrow_program_account(transaction_context)?;
         let mut get_or_create_executor_time = Measure::start("get_or_create_executor_time");
         let loaded_program = invoke_context
             .program_cache_for_tx_batch
-            .find(program.get_key())
+            .find(program_id)
             .ok_or_else(|| {
                 ic_logger_msg!(log_collector, "Program is not cached");
                 InstructionError::UnsupportedProgramId
             })?;
         get_or_create_executor_time.stop();
         invoke_context.timings.get_or_create_executor_us += get_or_create_executor_time.as_us();
-        drop(program);
         match &loaded_program.program {
             ProgramCacheEntryType::FailedVerification(_)
             | ProgramCacheEntryType::Closed

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -131,21 +131,17 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
     let instruction_context = transaction_context.get_current_instruction_context()?;
 
     let owner_pubkey = {
-        let owner_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 2)?;
-
-        if !owner_account.is_signer() {
+        if !instruction_context.is_instruction_account_signer(2)? {
             return Err(InstructionError::MissingRequiredSignature);
         }
-        *owner_account.get_key()
-    }; // done with `owner_account`, so drop it to prevent a potential double borrow
 
-    let proof_context_account_pubkey = *instruction_context
-        .try_borrow_instruction_account(transaction_context, 0)?
-        .get_key();
-    let destination_account_pubkey = *instruction_context
-        .try_borrow_instruction_account(transaction_context, 1)?
-        .get_key();
+        *instruction_context.get_key_of_instruction_account(2, transaction_context)?
+    };
+
+    let proof_context_account_pubkey =
+        *instruction_context.get_key_of_instruction_account(0, transaction_context)?;
+    let destination_account_pubkey =
+        *instruction_context.get_key_of_instruction_account(1, transaction_context)?;
     if proof_context_account_pubkey == destination_account_pubkey {
         return Err(InstructionError::InvalidInstructionData);
     }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -817,6 +817,15 @@ impl InstructionContext {
     pub fn instruction_accounts(&self) -> &[InstructionAccount] {
         &self.instruction_accounts
     }
+
+    pub fn get_key_of_instruction_account<'a>(
+        &self,
+        index_in_instruction: IndexOfAccount,
+        transaction_context: &'a TransactionContext,
+    ) -> Result<&'a Pubkey, InstructionError> {
+        self.get_index_of_instruction_account_in_transaction(index_in_instruction)
+            .and_then(|idx| transaction_context.get_key_of_account_at_index(idx))
+    }
 }
 
 /// Shared account borrowed from the TransactionContext and an InstructionContext.


### PR DESCRIPTION
#### Problem

In some places, we only use `BorrowedAccount` to retrieve the key, the singer and the writable flags. These items are not part of `AccountSharedData`, so we don't need to borrow from the accounts array.

#### Summary of Changes

Replace `try_borrow_account` by similar functions from `InstructionContext`.
