### PR TITLE
Multihoming: Only swap gossip to valid interfaces

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -3,11 +3,10 @@ use {
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
     },
-    solana_gossip::cluster_info::ClusterInfo,
+    solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_pubkey::Pubkey,
     solana_quic_definitions::NotifyKeyUpdate,
     solana_runtime::bank_forks::BankForks,
-    solana_streamer::atomic_udp_socket::AtomicUdpSocket,
     std::{
         collections::{HashMap, HashSet},
         net::UdpSocket,
@@ -79,5 +78,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub repair_socket: Arc<UdpSocket>,
     pub outstanding_repair_requests: Arc<RwLock<OutstandingRequests<ShredRepairType>>>,
     pub cluster_slots: Arc<ClusterSlots>,
-    pub gossip_socket: Option<AtomicUdpSocket>,
+    pub node: Option<Arc<NodeMultihoming>>,
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -55,7 +55,7 @@ use {
         contact_info::ContactInfo,
         crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
         gossip_service::GossipService,
-        node::Node,
+        node::{Node, NodeMultihoming},
     },
     solana_hard_forks::HardForks,
     solana_hash::Hash,
@@ -834,7 +834,9 @@ impl Validator {
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
+        cluster_info.set_bind_ip_addrs(node.bind_ip_addrs.clone());
         let cluster_info = Arc::new(cluster_info);
+        let node_multihoming = NodeMultihoming::from(&node);
 
         assert!(is_snapshot_config_valid(&config.snapshot_config));
 
@@ -1673,7 +1675,7 @@ impl Validator {
             repair_socket: Arc::new(node.sockets.repair),
             outstanding_repair_requests,
             cluster_slots,
-            gossip_socket: Some(node.sockets.gossip.clone()),
+            node: Some(Arc::new(node_multihoming)),
         });
 
         Ok(Self {

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        cluster_info::{BindIpAddrs, NodeConfig, Sockets},
+        cluster_info::{NodeConfig, Sockets},
         contact_info::{
             ContactInfo,
             Protocol::{QUIC, UDP},
@@ -8,6 +8,7 @@ use {
     },
     solana_net_utils::{
         find_available_ports_in_range,
+        multihomed_sockets::BindIpAddrs,
         sockets::{
             bind_gossip_port_in_range, bind_in_range_with_config, bind_more_with_config,
             bind_two_in_range_with_offset_and_config, localhost_port_range_for_tests,
@@ -22,6 +23,7 @@ use {
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
         num::NonZero,
+        sync::Arc,
     },
 };
 
@@ -29,6 +31,7 @@ use {
 pub struct Node {
     pub info: ContactInfo,
     pub sockets: Sockets,
+    pub bind_ip_addrs: Arc<BindIpAddrs>,
 }
 
 impl Node {
@@ -44,7 +47,7 @@ impl Node {
         let port_range = localhost_port_range_for_tests();
         let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let config = NodeConfig {
-            bind_ip_addrs: BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind"),
+            bind_ip_addrs: Arc::new(BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind")),
             gossip_port: port_range.0,
             port_range,
             advertised_ip: bind_ip_addr,
@@ -73,7 +76,7 @@ impl Node {
         bind_ip_addr: IpAddr,
     ) -> Self {
         let config = NodeConfig {
-            bind_ip_addrs: BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind"),
+            bind_ip_addrs: Arc::new(BindIpAddrs::new(vec![bind_ip_addr]).expect("should bind")),
             gossip_port: gossip_addr.port(),
             port_range,
             advertised_ip: bind_ip_addr,
@@ -107,7 +110,7 @@ impl Node {
             num_quic_endpoints,
             vortexor_receiver_addr,
         } = config;
-        let bind_ip_addr = bind_ip_addrs.primary();
+        let bind_ip_addr = bind_ip_addrs.active();
 
         let gossip_addr = SocketAddr::new(advertised_ip, gossip_port);
         let (gossip_port, (gossip, ip_echo)) =
@@ -284,6 +287,33 @@ impl Node {
             vortexor_receivers,
         };
         info!("Bound all network sockets as follows: {:#?}", &sockets);
-        Node { info, sockets }
+        Node {
+            info,
+            sockets,
+            bind_ip_addrs,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SocketsMultihomed {
+    pub gossip: AtomicUdpSocket,
+    // add tvu, retransmit_sockets, etc below
+}
+
+#[derive(Debug, Clone)]
+pub struct NodeMultihoming {
+    pub sockets: SocketsMultihomed,
+    pub bind_ip_addrs: Arc<BindIpAddrs>,
+}
+
+impl From<&Node> for NodeMultihoming {
+    fn from(node: &Node) -> Self {
+        NodeMultihoming {
+            sockets: SocketsMultihomed {
+                gossip: node.sockets.gossip.clone(),
+            },
+            bind_ip_addrs: node.bind_ip_addrs.clone(),
+        }
     }
 }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod ip_echo_client;
 mod ip_echo_server;
+pub mod multihomed_sockets;
 pub mod sockets;
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/net-utils/src/multihomed_sockets.rs
+++ b/net-utils/src/multihomed_sockets.rs
@@ -1,0 +1,86 @@
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    ops::Deref,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub struct BindIpAddrs {
+    /// The IP addresses this node may bind to
+    /// Index 0 is the primary address
+    /// Index 1+ are secondary addresses
+    addrs: Vec<IpAddr>,
+    active_index: Arc<AtomicUsize>,
+}
+
+impl Default for BindIpAddrs {
+    fn default() -> Self {
+        Self::new(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]).unwrap()
+    }
+}
+
+impl BindIpAddrs {
+    pub fn new(addrs: Vec<IpAddr>) -> Result<Self, String> {
+        if addrs.is_empty() {
+            return Err(
+                "BindIpAddrs requires at least one IP address (--bind-address)".to_string(),
+            );
+        }
+        if addrs.len() > 1 {
+            for ip in &addrs {
+                if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+                    return Err(format!(
+                        "Invalid configuration: {:?} is not allowed with multiple --bind-address values (loopback, unspecified, or multicast)",
+                        ip
+                    ));
+                }
+            }
+        }
+
+        Ok(Self {
+            addrs,
+            active_index: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    #[inline]
+    pub fn active(&self) -> IpAddr {
+        self.addrs[self.active_index.load(Ordering::Acquire)]
+    }
+
+    /// Change active to index (0 = primary)
+    pub fn set_active(&self, index: usize) -> Result<IpAddr, String> {
+        if index >= self.addrs.len() {
+            return Err(format!(
+                "Index {index} out of range, only {} IPs available",
+                self.addrs.len()
+            ));
+        }
+        self.active_index.store(index, Ordering::Release);
+        Ok(self.addrs[index])
+    }
+
+    #[inline]
+    pub fn active_index(&self) -> usize {
+        self.active_index.load(Ordering::Acquire)
+    }
+}
+
+// Makes BindIpAddrs behave like &[IpAddr]
+impl Deref for BindIpAddrs {
+    type Target = [IpAddr];
+
+    fn deref(&self) -> &Self::Target {
+        &self.addrs
+    }
+}
+
+// For generic APIs expecting something like AsRef<[IpAddr]>
+impl AsRef<[IpAddr]> for BindIpAddrs {
+    fn as_ref(&self) -> &[IpAddr] {
+        &self.addrs
+    }
+}

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -25,7 +25,7 @@ use {
         geyser_plugin_manager::GeyserPluginManager, GeyserPluginManagerRequest,
     },
     solana_gossip::{
-        cluster_info::{BindIpAddrs, ClusterInfo, NodeConfig},
+        cluster_info::{ClusterInfo, NodeConfig},
         contact_info::Protocol,
         node::Node,
     },
@@ -39,7 +39,7 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,
     solana_native_token::sol_to_lamports,
-    solana_net_utils::{find_available_ports_in_range, PortRange},
+    solana_net_utils::{find_available_ports_in_range, multihomed_sockets::BindIpAddrs, PortRange},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
@@ -1036,7 +1036,7 @@ impl TestValidator {
         let node = {
             let bind_ip_addr = config.node_config.bind_ip_addr;
             let validator_node_config = NodeConfig {
-                bind_ip_addrs: BindIpAddrs::new(vec![bind_ip_addr])?,
+                bind_ip_addrs: Arc::new(BindIpAddrs::new(vec![bind_ip_addr])?),
                 gossip_port: config.node_config.gossip_addr.port(),
                 port_range: config.node_config.port_range,
                 advertised_ip: bind_ip_addr,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -37,7 +37,7 @@ use {
         },
     },
     solana_gossip::{
-        cluster_info::{BindIpAddrs, NodeConfig, DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS},
+        cluster_info::{NodeConfig, DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS},
         contact_info::ContactInfo,
         node::Node,
     },
@@ -48,6 +48,7 @@ use {
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
     solana_logger::redirect_stderr_to_file,
+    solana_net_utils::multihomed_sockets::BindIpAddrs,
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_pubkey::Pubkey,
@@ -237,7 +238,7 @@ pub fn execute(
     } else if private_rpc {
         solana_net_utils::parse_host("127.0.0.1").unwrap()
     } else {
-        bind_addresses.primary()
+        bind_addresses.active()
     };
 
     let contact_debug_interval = value_t_or_exit!(matches, "contact_debug_interval", u64);
@@ -287,7 +288,7 @@ pub fn execute(
     // version can then be deleted from gossip and get_rpc_node above.
     let expected_shred_version = value_t!(matches, "expected_shred_version", u16)
         .ok()
-        .or_else(|| get_cluster_shred_version(&entrypoint_addrs, bind_addresses.primary()));
+        .or_else(|| get_cluster_shred_version(&entrypoint_addrs, bind_addresses.active()));
 
     let tower_path = value_t!(matches, "tower", PathBuf)
         .ok()
@@ -795,9 +796,8 @@ pub fn execute(
 
     let advertised_ip = if let Some(ip) = gossip_host {
         ip
-    } else if !bind_addresses.primary().is_unspecified() && !bind_addresses.primary().is_loopback()
-    {
-        bind_addresses.primary()
+    } else if !bind_addresses.active().is_unspecified() && !bind_addresses.active().is_loopback() {
+        bind_addresses.active()
     } else if !entrypoint_addrs.is_empty() {
         let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
         order.shuffle(&mut thread_rng());
@@ -812,7 +812,7 @@ pub fn execute(
                 );
                 solana_net_utils::get_public_ip_addr_with_binding(
                     entrypoint_addr,
-                    bind_addresses.primary(),
+                    bind_addresses.active(),
                 )
                 .map_or_else(
                     |err| {
@@ -827,7 +827,7 @@ pub fn execute(
         IpAddr::V4(Ipv4Addr::LOCALHOST)
     };
     let gossip_port = value_t!(matches, "gossip_port", u16).or_else(|_| {
-        solana_net_utils::find_available_port_in_range(bind_addresses.primary(), (0, 1))
+        solana_net_utils::find_available_port_in_range(bind_addresses.active(), (0, 1))
             .map_err(|err| format!("unable to find an available gossip port: {err}"))
     })?;
 
@@ -881,7 +881,7 @@ pub fn execute(
         advertised_ip,
         gossip_port,
         port_range: dynamic_port_range,
-        bind_ip_addrs: bind_addresses,
+        bind_ip_addrs: Arc::new(bind_addresses),
         public_tpu_addr,
         public_tpu_forwards_addr,
         num_tvu_receive_sockets: tvu_receive_threads,


### PR DESCRIPTION
#### Problem
You can rebind gossip to an invalid ip. 

#### Summary of Changes
1) Only allow rebinding of gossip sockets to ips passed in at startup
2) Refactor to support future multihoming for tvu, tpu, etc
2) Move set_gossip_socket AdminRpc Command into a new method called `select_interface_index()`
`select_interface_index()` is where we will control the swapping of interfaces for multihoming. Gossip is currently the only one here so far. In the future, we will add tvu, tpu, etc and they will all get swapped over atomically in this method. This will ensure we don't accidentally run some protocols on one interface and others on another interface.

There will be more PRs that follow
1) Change gossip AtomicUdpSocket to a Vec<UdpSocket>. Bind to all on startup. Then when swapping, read/send from correct already bound gossip socket. No need to rebind
2) Add support for tvu ingress multihoming
3) Add support for tvu egress multihoming 

