### PR TITLE
net-utils: clean up deprecated methods and update unit tests

### DIFF
--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -126,18 +126,6 @@ impl SocketConfiguration {
     }
 }
 
-#[allow(deprecated)]
-impl From<crate::SocketConfig> for SocketConfiguration {
-    fn from(value: crate::SocketConfig) -> Self {
-        Self {
-            reuseport: value.reuseport,
-            recv_buffer_size: value.recv_buffer_size,
-            send_buffer_size: value.send_buffer_size,
-            non_blocking: false,
-        }
-    }
-}
-
 #[cfg(any(windows, target_os = "ios"))]
 fn set_reuse_port<T>(_socket: &T) -> io::Result<()> {
     Ok(())
@@ -214,20 +202,6 @@ pub fn bind_in_range_with_config(
     Err(io::Error::other(format!(
         "No available UDP ports in {range:?}"
     )))
-}
-
-#[deprecated(since = "3.0.0", note = "Please bind to specific ports instead")]
-pub fn bind_with_any_port_with_config(
-    ip_addr: IpAddr,
-    config: SocketConfiguration,
-) -> io::Result<UdpSocket> {
-    let sock = udp_socket_with_config(config)?;
-    let addr = SocketAddr::new(ip_addr, 0);
-    let bind = sock.bind(&SockAddr::from(addr));
-    match bind {
-        Ok(_) => Result::Ok(sock.into()),
-        Err(err) => Err(io::Error::other(format!("No available UDP port: {err}"))),
-    }
 }
 
 /// binds num sockets to the same port in a range with config
@@ -362,7 +336,6 @@ pub fn bind_more_with_config(
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use {
         super::*,
@@ -392,18 +365,6 @@ mod tests {
         for sock in &v {
             assert_eq!(port, sock.local_addr().unwrap().port());
         }
-    }
-
-    #[test]
-    fn test_bind_with_any_port() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-        let config = SocketConfiguration::default();
-        let x = bind_with_any_port_with_config(ip_addr, config).unwrap();
-        let y = bind_with_any_port_with_config(ip_addr, config).unwrap();
-        assert_ne!(
-            x.local_addr().unwrap().port(),
-            y.local_addr().unwrap().port()
-        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Several methods in net-utils have been deprecated and replaced by methods in net-utils::sockets. However, the unit tests all still called the deprecated methods. 

#### Summary of Changes
* Remove all deprecated code in net utils that's deprecated as of v2.3.2.
* Update unit tests to use the new net-utils::sockets methods adn structs.
* Fix test_bind() to adapt to re-use port flag no longer being set explicitly and directly in socket config.
* Retire test_multi_bind_in_range_with_config_reuseport_disabled() as it's no longer valid.
* Retire test_bind_with_any_port() as it's no longer valid.


