### PR TITLE
rpc-client-types: remove deprecated filter method

### DIFF
--- a/rpc-client-types/src/filter.rs
+++ b/rpc-client-types/src/filter.rs
@@ -1,8 +1,6 @@
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     serde::Deserialize,
-    solana_account::{AccountSharedData, ReadableAccount},
-    spl_generic_token::{token::GenericTokenAccount, token_2022::Account},
     std::borrow::Cow,
     thiserror::Error,
 };
@@ -57,18 +55,6 @@ impl RpcFilterType {
                 }
             }
             RpcFilterType::TokenAccountState => Ok(()),
-        }
-    }
-
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use solana_rpc::filter::filter_allows instead"
-    )]
-    pub fn allows(&self, account: &AccountSharedData) -> bool {
-        match self {
-            RpcFilterType::DataSize(size) => account.data().len() as u64 == *size,
-            RpcFilterType::Memcmp(compare) => compare.bytes_match(account.data()),
-            RpcFilterType::TokenAccountState => Account::valid_account_data(account.data()),
         }
     }
 }


### PR DESCRIPTION
#### Problem
* rpc client type filter method has been deprecated since v2.0.

#### Summary of Changes
* remove deprecated method.

