### PR TITLE
ledger: Remove most uses of BlockstoreOptions::default()

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -511,7 +511,7 @@ pub mod tests {
             blockstore,
             ledger_signal_receiver,
             ..
-        } = Blockstore::open_with_signal(&blockstore_path, BlockstoreOptions::default())
+        } = Blockstore::open_with_signal(&blockstore_path, BlockstoreOptions::default_for_tests())
             .expect("Expected to successfully open ledger");
         let blockstore = Arc::new(blockstore);
         let bank = bank_forks.read().unwrap().working_bank();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -12,7 +12,7 @@ use {
         blockstore_meta::*,
         blockstore_metrics::BlockstoreRpcApiMetrics,
         blockstore_options::{
-            BlockstoreOptions, LedgerColumnOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+            AccessType, BlockstoreOptions, LedgerColumnOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
         },
         blockstore_processor::BlockstoreProcessorError,
         leader_schedule_cache::LeaderScheduleCache,
@@ -72,6 +72,7 @@ use {
         fmt::Write,
         fs::{self, File},
         io::{Error as IoError, ErrorKind},
+        num::NonZeroUsize,
         ops::{Bound, Range},
         path::{Path, PathBuf},
         rc::Rc,
@@ -4845,9 +4846,14 @@ pub fn create_new_ledger(
     let blockstore = Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
+            access_type: AccessType::Primary,
+            recovery_mode: None,
             enforce_ulimit_nofile: false,
             column_options: column_options.clone(),
-            ..BlockstoreOptions::default()
+            // Not much parallelization required to insert a single slot of
+            // shreds so minimal threads will be sufficient
+            num_rocksdb_compaction_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
+            num_rocksdb_flush_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
         },
     )?;
     let ticks_per_slot = genesis_config.ticks_per_slot;
@@ -5906,8 +5912,7 @@ pub mod tests {
     #[test]
     fn test_data_set_completed_on_insert() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let BlockstoreSignals { blockstore, .. } =
-            Blockstore::open_with_signal(ledger_path.path(), BlockstoreOptions::default()).unwrap();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         // Create enough entries to fill 2 shreds, only the later one is data complete
         let slot = 0;
@@ -5944,7 +5949,11 @@ pub mod tests {
             blockstore,
             ledger_signal_receiver: recvr,
             ..
-        } = Blockstore::open_with_signal(ledger_path.path(), BlockstoreOptions::default()).unwrap();
+        } = Blockstore::open_with_signal(
+            ledger_path.path(),
+            BlockstoreOptions::default_for_tests(),
+        )
+        .unwrap();
 
         let entries_per_slot = 50;
         // Create entries for slot 0
@@ -6025,7 +6034,11 @@ pub mod tests {
             blockstore,
             completed_slots_receiver: recvr,
             ..
-        } = Blockstore::open_with_signal(ledger_path.path(), BlockstoreOptions::default()).unwrap();
+        } = Blockstore::open_with_signal(
+            ledger_path.path(),
+            BlockstoreOptions::default_for_tests(),
+        )
+        .unwrap();
 
         let entries_per_slot = 10;
 
@@ -6050,7 +6063,11 @@ pub mod tests {
             blockstore,
             completed_slots_receiver: recvr,
             ..
-        } = Blockstore::open_with_signal(ledger_path.path(), BlockstoreOptions::default()).unwrap();
+        } = Blockstore::open_with_signal(
+            ledger_path.path(),
+            BlockstoreOptions::default_for_tests(),
+        )
+        .unwrap();
 
         let entries_per_slot = 10;
         let slots = [2, 5, 10];
@@ -6095,7 +6112,11 @@ pub mod tests {
             blockstore,
             completed_slots_receiver: recvr,
             ..
-        } = Blockstore::open_with_signal(ledger_path.path(), BlockstoreOptions::default()).unwrap();
+        } = Blockstore::open_with_signal(
+            ledger_path.path(),
+            BlockstoreOptions::default_for_tests(),
+        )
+        .unwrap();
 
         let entries_per_slot = 10;
         let mut slots = vec![2, 5, 10];

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1301,7 +1301,7 @@ pub mod tests {
     #[test]
     fn test_cf_names_and_descriptors_equal_length() {
         let path = PathBuf::default();
-        let options = BlockstoreOptions::default();
+        let options = BlockstoreOptions::default_for_tests();
         let oldest_slot = OldestSlot::default();
         // The names and descriptors don't need to be in the same order for our use cases;
         // however, there should be the same number of each. For example, adding a new column
@@ -1342,11 +1342,7 @@ pub mod tests {
 
         // Open with Primary to create the new database
         {
-            let options = BlockstoreOptions {
-                access_type: AccessType::Primary,
-                enforce_ulimit_nofile: false,
-                ..BlockstoreOptions::default()
-            };
+            let options = BlockstoreOptions::default_for_tests();
             let mut rocks = Rocks::open(db_path.to_path_buf(), options).unwrap();
 
             // Introduce a new column that will not be known
@@ -1361,17 +1357,12 @@ pub mod tests {
         {
             let options = BlockstoreOptions {
                 access_type: AccessType::Secondary,
-                enforce_ulimit_nofile: false,
-                ..BlockstoreOptions::default()
+                ..BlockstoreOptions::default_for_tests()
             };
             let _ = Rocks::open(db_path.to_path_buf(), options).unwrap();
         }
         {
-            let options = BlockstoreOptions {
-                access_type: AccessType::Primary,
-                enforce_ulimit_nofile: false,
-                ..BlockstoreOptions::default()
-            };
+            let options = BlockstoreOptions::default_for_tests();
             let _ = Rocks::open(db_path.to_path_buf(), options).unwrap();
         }
     }
@@ -1389,12 +1380,7 @@ pub mod tests {
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path();
-
-        let options = BlockstoreOptions {
-            access_type: AccessType::Primary,
-            enforce_ulimit_nofile: false,
-            ..BlockstoreOptions::default()
-        };
+        let options = BlockstoreOptions::default_for_tests();
 
         // Create a new database
         {

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -37,12 +37,17 @@ impl Default for BlockstoreOptions {
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 impl BlockstoreOptions {
     pub fn default_for_tests() -> Self {
         Self {
+            access_type: AccessType::Primary,
+            recovery_mode: None,
             // No need to enforce the limit in tests
             enforce_ulimit_nofile: false,
-            ..BlockstoreOptions::default()
+            column_options: LedgerColumnOptions::default(),
+            num_rocksdb_compaction_threads: default_num_compaction_threads(),
+            num_rocksdb_flush_threads: default_num_flush_threads(),
         }
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2425,7 +2425,7 @@ pub mod tests {
                     blockstore.ledger_path(),
                     BlockstoreOptions {
                         access_type,
-                        ..BlockstoreOptions::default()
+                        ..BlockstoreOptions::default_for_tests()
                     },
                 )
                 .expect("Unable to open access to blockstore");

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -103,10 +103,8 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
     Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
-            access_type: AccessType::Primary,
-            recovery_mode: None,
             enforce_ulimit_nofile: true,
-            ..BlockstoreOptions::default()
+            ..BlockstoreOptions::default_for_tests()
         },
     )
     // Fall back on Secondary if Primary fails; Primary will fail if
@@ -116,9 +114,8 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
             ledger_path,
             BlockstoreOptions {
                 access_type: AccessType::Secondary,
-                recovery_mode: None,
                 enforce_ulimit_nofile: true,
-                ..BlockstoreOptions::default()
+                ..BlockstoreOptions::default_for_tests()
             },
         )
         .unwrap_or_else(|e| {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1728,7 +1728,7 @@ mod tests {
                 known_validators,
                 socket_addr_space: SocketAddrSpace::Global,
                 rpc_bootstrap_config: RpcBootstrapConfig::default(),
-                blockstore_options: BlockstoreOptions::default(),
+                blockstore_options: BlockstoreOptions::default_for_tests(),
                 json_rpc_config: JsonRpcConfig {
                     health_check_slot_distance: 128,
                     max_multiple_accounts: Some(100),


### PR DESCRIPTION
#### Summary of Changes
The end goal is to kill the Default trait implementation; this change makes use of a default_for_tests() function and then applies some reasonable default values on a per-case basis for non tests