### PR TITLE
increase min port range in checks for CLI

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -45,7 +45,7 @@ pub struct UdpSocketPair {
 pub type PortRange = (u16, u16);
 
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
-pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 17; // VALIDATOR_PORT_RANGE must be at least this wide
+pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 25; // VALIDATOR_PORT_RANGE must be at least this wide
 
 pub(crate) const HEADER_LENGTH: usize = 4;
 pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;


### PR DESCRIPTION
#### Problem

- Due to alpenglow socket and tpu-clients now using predictable bindings, we need a wider port range
- The old value (17) was not enough for a while now
- Relevant changes were introduced in https://github.com/anza-xyz/agave/pull/7455

#### Summary of Changes

- Update the check in CLI to require a wider port range
