### PR TITLE
Fix typos in user-facing help and logs

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -304,7 +304,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .action(ArgAction::Append)
                         .multiple_values(true)
                         .value_parser(grind_parser(GrindType::Starts))
-                        .help("Saves specified number of keypairs whos public key starts with the indicated prefix\nExample: --starts-with sol:4\nPREFIX type is Base58\nCOUNT type is u64"),
+                        .help("Saves specified number of keypairs whose public key starts with the indicated prefix\nExample: --starts-with sol:4\nPREFIX type is Base58\nCOUNT type is u64"),
                 )
                 .arg(
                     Arg::new("ends_with")
@@ -315,7 +315,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .action(ArgAction::Append)
                         .multiple_values(true)
                         .value_parser(grind_parser(GrindType::Ends))
-                        .help("Saves specified number of keypairs whos public key ends with the indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is Base58\nCOUNT type is u64"),
+                        .help("Saves specified number of keypairs whose public key ends with the indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is Base58\nCOUNT type is u64"),
                 )
                 .arg(
                     Arg::new("starts_and_ends_with")
@@ -326,7 +326,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .action(ArgAction::Append)
                         .multiple_values(true)
                         .value_parser(grind_parser(GrindType::StartsAndEnds))
-                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated prefix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
+                        .help("Saves specified number of keypairs whose public key starts and ends with the indicated prefix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
                 )
                 .arg(
                     Arg::new("num_threads")

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -173,7 +173,7 @@ and the following fields are required
                             "Mode of execution, where 'interpreter' runs \
                              the program in the virtual machine's interpreter, 'debugger' is the same as 'interpreter' \
                              but hosts a GDB interface, and 'jit' precompiles the program to native machine code \
-                             before execting it in the virtual machine.",
+                             before executing it in the virtual machine.",
                         )
                         .short("e")
                         .long("mode")

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -396,7 +396,7 @@ impl QuicClient {
                         .prepare_connection_us
                         .fetch_add(measure_prepare_connection.as_us(), Ordering::Relaxed);
                     trace!(
-                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, send_packet_us: {} prepare_connection_us: {}",
+                        "Successfully sent to {} with id {}, thread: {:?}, data len: {}, send_packet_us: {} prepare_connection_us: {}",
                         self.addr,
                         connection.stable_id(),
                         thread::current().id(),

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -329,7 +329,7 @@ impl ThreadArg for TpuTransactionForwardReceiveThreadArgs {
     const NAME: &'static str = "tpu_transaction_forward_receive_threads";
     const LONG_NAME: &'static str = "tpu-transaction-forward-receive-threads";
     const HELP: &'static str =
-        "Number of threads to use for receiving transactions on the TPU fowards port";
+        "Number of threads to use for receiving transactions on the TPU forward port";
 
     fn default() -> usize {
         solana_streamer::quic::default_num_tpu_transaction_forward_receive_threads()

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -686,7 +686,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("skip_startup_ledger_verification")
             .long("skip-startup-ledger-verification")
             .takes_value(false)
-            .help("Skip ledger verification at validator bootup."),
+            .help("Skip ledger verification at validator startup."),
     )
     .arg(
         Arg::with_name("cuda")


### PR DESCRIPTION
#### Problem
User-facing CLI help and log messages contain typos that degrade UX, searchability, and professionalism.

#### Summary of Changes
- validator/src/commands/run/args.rs: “bootup” → “startup” (help text)
- keygen/src/keygen.rs: “whos” → “whose” in three help messages
- quic-client/src/nonblocking/quic_client.rs: “Succcessfully” → “Successfully” (trace log)
- validator/src/cli/thread_args.rs: “fowards port” → “forward port” (help text)
- ledger-tool/src/program.rs: “execting” → “executing” (help text)

#### Notes
- No functional or API changes; string fixes only
- No serialization or protocol impact
- Tests unaffected
