### PR TITLE
test(zk-token-sdk): add RangeProof bytes roundtrip (serialization/deserialization) test

### DIFF
--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -476,5 +476,28 @@ mod tests {
             .is_ok());
     }
 
-    // TODO: write test for serialization/deserialization
+    #[test]
+    fn range_proof_bytes_roundtrip() {
+        let (comm, open) = Pedersen::new(42_u64);
+
+        let mut transcript_create = Transcript::new(b"Test");
+        let mut transcript_verify = Transcript::new(b"Test");
+
+        let bits: usize = 8;
+
+        let proof = RangeProof::new(vec![42], vec![bits], vec![&open], &mut transcript_create)
+            .expect("proof create");
+
+        let enc = proof.to_bytes();
+        assert!(!enc.is_empty());
+
+        let dec = RangeProof::from_bytes(&enc).expect("from_bytes");
+
+        assert_eq!(enc, dec.to_bytes());
+
+        assert!(
+            dec.verify(vec![&comm], vec![bits], &mut transcript_verify)
+                .is_ok()
+        );
+    }
 }


### PR DESCRIPTION
#### Problem
`zk-token-sdk/src/range_proof/mod.rs` contained a TODO to add a serialization/deserialization test for `RangeProof`.  
Without a unit test, regressions in `to_bytes()`/`from_bytes()` (and `InnerProductProof` boundaries) could go unnoticed.

#### Changes
- Add `range_proof_bytes_roundtrip` unit test in `range_proof::tests`.
- Generate a single proof for amount `42` with an `8`-bit range using existing APIs (`Pedersen::new`, `RangeProof::new`).
- Serialize with `to_bytes()`, deserialize with `from_bytes()`.
- Assert byte-level equality and successfully verify the deserialized proof against the original commitment using a consistent transcript label (`b"Test"`).
- Test-only change under `#[cfg(test)]`; no runtime, network, or consensus impact.
