### PR TITLE
Simplify transaction context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11384,6 +11384,7 @@ name = "solana-transaction-context"
 version = "3.0.0"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_derive",
  "solana-account",

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1349,10 +1349,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(
-            invoke_context
-                .transaction_context
-                .accounts_resize_delta()
-                .unwrap(),
+            invoke_context.transaction_context.accounts_resize_delta(),
             resize_delta
         );
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -366,7 +366,7 @@ impl<'a> InvokeContext<'a> {
                         instruction_account.set_is_writable(
                             instruction_account.is_writable() || account_meta.is_writable,
                         );
-                        instruction_account.clone()
+                        *instruction_account
                     };
                     instruction_accounts.push(cloned_account);
                 } else {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -538,18 +538,15 @@ impl<'a> InvokeContext<'a> {
         let process_executable_chain_time = Measure::start("process_executable_chain_time");
 
         let builtin_id = {
-            let borrowed_root_account = instruction_context
-                .try_borrow_program_account(self.transaction_context)
-                .map_err(|_| InstructionError::UnsupportedProgramId)?;
-            let owner_id = borrowed_root_account.get_owner();
-            if native_loader::check_id(owner_id) {
-                *borrowed_root_account.get_key()
-            } else if bpf_loader_deprecated::check_id(owner_id)
-                || bpf_loader::check_id(owner_id)
-                || bpf_loader_upgradeable::check_id(owner_id)
-                || loader_v4::check_id(owner_id)
+            let owner_id = instruction_context.get_program_owner(self.transaction_context)?;
+            if native_loader::check_id(&owner_id) {
+                *instruction_context.get_program_key(self.transaction_context)?
+            } else if bpf_loader_deprecated::check_id(&owner_id)
+                || bpf_loader::check_id(&owner_id)
+                || bpf_loader_upgradeable::check_id(&owner_id)
+                || loader_v4::check_id(&owner_id)
             {
-                *owner_id
+                owner_id
             } else {
                 return Err(InstructionError::UnsupportedProgramId);
             }
@@ -709,12 +706,11 @@ impl<'a> InvokeContext<'a> {
         self.transaction_context
             .get_current_instruction_context()
             .and_then(|instruction_context| {
-                let program_account =
-                    instruction_context.try_borrow_program_account(self.transaction_context);
-                debug_assert!(program_account.is_ok());
-                program_account
+                let owner_id = instruction_context.get_program_owner(self.transaction_context);
+                debug_assert!(owner_id.is_ok());
+                owner_id
             })
-            .map(|program_account| *program_account.get_owner() != bpf_loader_deprecated::id())
+            .map(|owner_key| owner_key != bpf_loader_deprecated::id())
             .unwrap_or(true)
     }
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -238,14 +238,9 @@ pub fn serialize_parameters(
         return Err(InstructionError::MaxAccountsExceeded);
     }
 
-    let (program_id, is_loader_deprecated) = {
-        let program_account =
-            instruction_context.try_borrow_program_account(transaction_context)?;
-        (
-            *program_account.get_key(),
-            *program_account.get_owner() == bpf_loader_deprecated::id(),
-        )
-    };
+    let program_id = *instruction_context.get_program_key(transaction_context)?;
+    let is_loader_deprecated =
+        instruction_context.get_program_owner(transaction_context)? == bpf_loader_deprecated::id();
 
     let accounts = (0..instruction_context.get_number_of_instruction_accounts())
         .map(|instruction_account_index| {
@@ -296,10 +291,8 @@ pub fn deserialize_parameters(
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
-    let is_loader_deprecated = *instruction_context
-        .try_borrow_program_account(transaction_context)?
-        .get_owner()
-        == bpf_loader_deprecated::id();
+    let is_loader_deprecated =
+        instruction_context.get_program_owner(transaction_context)? == bpf_loader_deprecated::id();
     let account_lengths = accounts_metadata.iter().map(|a| a.original_data_len);
     if is_loader_deprecated {
         deserialize_parameters_unaligned(

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1605,7 +1605,7 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(
-            transaction_context.accounts_resize_delta().unwrap(),
+            transaction_context.accounts_resize_delta(),
             MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION
                 - remaining_allowed_growth as i64,
         );

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9619,6 +9619,7 @@ name = "solana-transaction-context"
 version = "3.0.0"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_derive",
  "solana-account",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5203,9 +5203,10 @@ fn test_same_program_id_uses_unique_executable_accounts() {
     declare_process_instruction!(MockBuiltin, 1, |invoke_context| {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        instruction_context
-            .try_borrow_program_account(transaction_context)?
-            .set_data_length(2)
+        let program_idx = instruction_context.get_index_of_program_account_in_transaction()?;
+        let mut acc = transaction_context.accounts().try_borrow_mut(program_idx)?;
+        acc.set_data(vec![1, 2]);
+        Ok(())
     });
 
     let (genesis_config, mint_keypair) = create_genesis_config(50000);

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -411,7 +411,6 @@ pub fn validate_fee_payer(
         &payer_pre_rent_state,
         &payer_post_rent_state,
         payer_address,
-        payer_account,
         payer_index,
     )
 }

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -48,10 +48,6 @@ pub fn check_rent_state(
             transaction_context
                 .get_key_of_account_at_index(index)
                 .expect(expect_msg),
-            &transaction_context
-                .accounts()
-                .try_borrow(index)
-                .expect(expect_msg),
             index,
         )?;
     }
@@ -67,7 +63,6 @@ pub fn check_rent_state_with_account(
     pre_rent_state: &RentState,
     post_rent_state: &RentState,
     address: &Pubkey,
-    _account_state: &AccountSharedData,
     account_index: IndexOfAccount,
 ) -> TransactionResult<()> {
     if !solana_sdk_ids::incinerator::check_id(address)

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,10 +16,11 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils"]
+dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
+qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-account = { workspace = true }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -745,7 +745,7 @@ impl InstructionContext {
         &'a self,
         transaction_context: &'b TransactionContext,
         index_in_transaction: IndexOfAccount,
-        index_in_instruction: Option<IndexOfAccount>,
+        index_in_instruction: IndexOfAccount,
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
         let account = transaction_context
             .accounts
@@ -770,7 +770,7 @@ impl InstructionContext {
         self.try_borrow_account(
             transaction_context,
             index_in_transaction,
-            Some(instruction_account_index),
+            instruction_account_index,
         )
     }
 
@@ -836,7 +836,7 @@ pub struct BorrowedAccount<'a> {
     instruction_context: &'a InstructionContext,
     index_in_transaction: IndexOfAccount,
     // Program accounts are not part of the instruction_accounts vector, and thus None
-    index_in_instruction_accounts: Option<IndexOfAccount>,
+    index_in_instruction_accounts: IndexOfAccount,
     account: RefMut<'a, AccountSharedData>,
 }
 
@@ -1107,24 +1107,16 @@ impl BorrowedAccount<'_> {
 
     /// Returns whether this account is a signer (instruction wide)
     pub fn is_signer(&self) -> bool {
-        if let Some(index_in_instruction_accounts) = self.index_in_instruction_accounts {
-            self.instruction_context
-                .is_instruction_account_signer(index_in_instruction_accounts)
-                .unwrap_or_default()
-        } else {
-            false
-        }
+        self.instruction_context
+            .is_instruction_account_signer(self.index_in_instruction_accounts)
+            .unwrap_or_default()
     }
 
     /// Returns whether this account is writable (instruction wide)
     pub fn is_writable(&self) -> bool {
-        if let Some(index_in_instruction_accounts) = self.index_in_instruction_accounts {
-            self.instruction_context
-                .is_instruction_account_writable(index_in_instruction_accounts)
-                .unwrap_or_default()
-        } else {
-            false
-        }
+        self.instruction_context
+            .is_instruction_account_writable(self.index_in_instruction_accounts)
+            .unwrap_or_default()
     }
 
     /// Returns true if the owner of this account is the current `InstructionContext`s last program (instruction wide)

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -63,7 +63,7 @@ pub type IndexOfAccount = u16;
 /// This data structure is supposed to be shared with programs in ABIv2, so do not modify it
 /// without consulting SIMD-0177.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 pub struct InstructionAccount {
     /// Points to the account and its key in the `TransactionContext`
     pub index_in_transaction: IndexOfAccount,
@@ -106,7 +106,7 @@ impl InstructionAccount {
 /// An account key and the matching account
 pub type TransactionAccount = (Pubkey, AccountSharedData);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TransactionAccounts {
     accounts: Vec<RefCell<AccountSharedData>>,
     touched_flags: RefCell<Box<[bool]>>,
@@ -208,7 +208,7 @@ impl TransactionAccounts {
 /// Loaded transaction shared between runtime and programs.
 ///
 /// This context is valid for the entire duration of a transaction being processed.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct TransactionContext {
     account_keys: Pin<Box<[Pubkey]>>,
     accounts: Rc<TransactionAccounts>,
@@ -583,7 +583,7 @@ pub struct TransactionReturnData {
 /// Loaded instruction shared between runtime and programs.
 ///
 /// This context is valid for the entire duration of a (possibly cross program) instruction being processed.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default)]
 pub struct InstructionContext {
     nesting_level: usize,
     program_account_index_in_tx: IndexOfAccount,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -534,10 +534,9 @@ impl TransactionContext {
                     return;
                 }
 
-                let remaining_allowed_growth =
-                    MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION
-                        .saturating_sub(accounts.resize_delta.get())
-                        .max(0) as usize;
+                let remaining_allowed_growth = MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION
+                    .saturating_sub(accounts.resize_delta.get())
+                    .max(0) as usize;
 
                 if requested_length > region.len as usize {
                     // Realloc immediately here to fit the requested access,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -746,7 +746,7 @@ impl InstructionContext {
             transaction_context,
             instruction_account,
             account,
-            ix_program_account_idx: self.program_account_index_in_tx,
+            index_in_transaction_of_instruction_program: self.program_account_index_in_tx,
         })
     }
 
@@ -811,7 +811,7 @@ pub struct BorrowedAccount<'a> {
     transaction_context: &'a TransactionContext,
     account: RefMut<'a, AccountSharedData>,
     instruction_account: InstructionAccount,
-    ix_program_account_idx: IndexOfAccount,
+    index_in_transaction_of_instruction_program: IndexOfAccount,
 }
 
 impl BorrowedAccount<'_> {
@@ -1092,7 +1092,7 @@ impl BorrowedAccount<'_> {
     /// Returns true if the owner of this account is the current `InstructionContext`s last program (instruction wide)
     pub fn is_owned_by_current_program(&self) -> bool {
         self.transaction_context
-            .get_key_of_account_at_index(self.ix_program_account_idx)
+            .get_key_of_account_at_index(self.index_in_transaction_of_instruction_program)
             .map(|program_key| program_key == self.get_owner())
             .unwrap_or_default()
     }


### PR DESCRIPTION
#### Problem

This PR removes more complexity around transaction context, removing unnecessary functions, unused arguments and simplifying `BorrowedAccount` to make refactors for a new account structure easier.

#### Summary of Changes

1. Delete `try_borrow_program_account` in favor of `get_program_onwer`.
2. Remove the special case handling in `BorrowedAccount`.
3. Remove unused argument of `check_rent_state_with_account`.
4. Switch from `RefCell` to `Cell` for `resize_delta` and `lamports_delta`, since integers can be copied cheaply and we don't need borrows.
5. Simplify fields of `BorrowedAccount`.
6. Remove unnecessary derives that are incompatible with unsafe cell.

PS: This is the last cleanup before introducing a new account layout for program-runtime.