### PR TITLE
Upsert simple test reclaim old slots support

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5663,6 +5663,14 @@ impl AccountsDb {
         let target_slot = accounts.target_slot();
         let len = std::cmp::min(accounts.len(), infos.len());
 
+        // If reclaiming old slots, ensure the target slot is a root
+        // Having an unrooted slot reclaim a rooted version of a slot
+        // could lead to index corruption if the unrooted version is
+        // discarded
+        if reclaim == UpsertReclaim::ReclaimOldSlots {
+            assert!(self.accounts_index.is_alive_root(target_slot));
+        }
+
         let update = |start, end| {
             let mut reclaims = Vec::with_capacity((end - start) / 2);
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5668,7 +5668,7 @@ impl AccountsDb {
         // could lead to index corruption if the unrooted version is
         // discarded
         if reclaim == UpsertReclaim::ReclaimOldSlots {
-            assert!(self.accounts_index.is_alive_root(target_slot));
+            assert!(target_slot <= self.accounts_index.max_root_inclusive());
         }
 
         let update = |start, end| {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -692,6 +692,8 @@ fn test_flush_slots_with_reclaim_old_slots() {
 
     let storage = accounts.create_and_insert_store(new_slot, 4096, "test_flush_slots");
 
+    accounts.accounts_index.add_root(new_slot);
+
     // Flushing this storage directly using _store_accounts_frozen. This is done to pass in UpsertReclaim::ReclaimOldSlots
     accounts._store_accounts_frozen(
         (new_slot, &accounts_list[..]),

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -3875,6 +3875,15 @@ pub mod tests {
     impl<T: IndexValue> AccountsIndex<T, T> {
         fn upsert_simple_test(&self, key: &Pubkey, slot: Slot, value: T) {
             let mut gc = Vec::new();
+
+            // It is invalid to reclaim older slots if the slot being upserted
+            // is unrooted
+            let reclaim_method = if self.is_alive_root(slot) {
+                UPSERT_RECLAIM_TEST_DEFAULT
+            } else {
+                UpsertReclaim::IgnoreReclaims
+            };
+
             self.upsert(
                 slot,
                 slot,
@@ -3883,7 +3892,7 @@ pub mod tests {
                 &AccountSecondaryIndexes::default(),
                 value,
                 &mut gc,
-                UPSERT_RECLAIM_TEST_DEFAULT,
+                reclaim_method,
             );
             assert!(gc.is_empty());
         }


### PR DESCRIPTION
#### Problem
Reclaiming old slots with an unrooted slot would lead to a corrupted account index

#### Summary of Changes
- Update test to IgnoreReclaims if the slot is unrooted
- Add assert to guarantee reclaims are not collected on an unrooted slot

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
