### PR TITLE
feat: support vote state v4 in VoteStateView

### DIFF
--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -1,7 +1,8 @@
 use {
     self::{
         field_frames::{
-            AuthorizedVotersListFrame, EpochCreditsItem, EpochCreditsListFrame, RootSlotFrame,
+            AuthorizedVotersListFrame, BlsPubkeyCompressedFrame, BlsPubkeyCompressedView,
+            EpochCreditsItem, EpochCreditsListFrame, PendingDelegatorRewardsView, RootSlotFrame,
             RootSlotView, VotesFrame,
         },
         frame_v1_14_11::VoteStateFrameV1_14_11,
@@ -9,9 +10,11 @@ use {
         list_view::ListView,
     },
     core::fmt::Debug,
+    field_frames::{CommissionBpsView, CommissionFrame, CommissionView},
+    frame_v4::VoteStateFrameV4,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    solana_vote_interface::state::{BlockTimestamp, Lockout},
+    solana_vote_interface::state::{BlockTimestamp, Lockout, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     std::sync::Arc,
 };
 #[cfg(feature = "dev-context-only-utils")]
@@ -23,6 +26,7 @@ use {
 mod field_frames;
 mod frame_v1_14_11;
 mod frame_v3;
+mod frame_v4;
 mod list_view;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -30,6 +34,7 @@ pub enum VoteStateViewError {
     AccountDataTooSmall,
     InvalidVotesLength,
     InvalidRootSlotOption,
+    InvalidBlsPubkeyCompressedOption,
     InvalidAuthorizedVotersLength,
     InvalidEpochCreditsLength,
     OldVersion,
@@ -46,6 +51,14 @@ enum Field {
     AuthorizedVoters,
     EpochCredits,
     LastTimestamp,
+}
+
+enum Simd185Field {
+    InflationRewardsCollector,
+    BlockRevenueCollector,
+    BlockRevenueCommission,
+    PendingDelegatorRewards,
+    BlsPubkeyCompressed,
 }
 
 /// A view into a serialized VoteState.
@@ -73,9 +86,45 @@ impl VoteStateView {
     }
 
     pub fn commission(&self) -> u8 {
-        let offset = self.frame.offset(Field::Commission);
+        self.inflation_rewards_commission_view()
+            .commission_percent()
+    }
+
+    pub fn block_revenue_collector(&self) -> Option<&Pubkey> {
+        let offset = self
+            .frame
+            .simd185_field_offset(Simd185Field::BlockRevenueCollector)?;
         // SAFETY: `frame` was created from `data`.
-        self.data[offset]
+        unsafe { Some(&*(self.data.as_ptr().add(offset) as *const Pubkey)) }
+    }
+
+    pub fn inflation_rewards_collector(&self) -> Option<&Pubkey> {
+        let offset = self
+            .frame
+            .simd185_field_offset(Simd185Field::InflationRewardsCollector)?;
+        // SAFETY: `frame` was created from `data`.
+        unsafe { Some(&*(self.data.as_ptr().add(offset) as *const Pubkey)) }
+    }
+
+    pub fn inflation_rewards_commission(&self) -> u16 {
+        self.inflation_rewards_commission_view().commission_bps()
+    }
+
+    pub fn block_revenue_commission(&self) -> u16 {
+        self.block_revenue_commission_view()
+            .map(|view| view.commission_bps())
+            .unwrap_or(10_000)
+    }
+
+    pub fn pending_delegator_rewards(&self) -> u64 {
+        self.pending_delegator_rewards_view()
+            .map(|view| view.value())
+            .unwrap_or(0)
+    }
+
+    pub fn bls_pubkey_compressed(&self) -> Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]> {
+        self.bls_pubkey_compressed_view()
+            .and_then(|view| view.pubkey())
     }
 
     pub fn votes_iter(&self) -> impl Iterator<Item = Lockout> + '_ {
@@ -128,6 +177,37 @@ impl VoteStateView {
         }
     }
 
+    fn inflation_rewards_commission_view(&self) -> CommissionView {
+        let offset = self.frame.offset(Field::Commission);
+        // SAFETY: `frame` was created from `data`.
+        CommissionView::new(self.frame.commission_frame(), &self.data[offset..])
+    }
+
+    fn block_revenue_commission_view(&self) -> Option<CommissionBpsView> {
+        let offset = self
+            .frame
+            .simd185_field_offset(Simd185Field::BlockRevenueCommission)?;
+        // SAFETY: `frame` was created from `data`.
+        Some(CommissionBpsView::new(&self.data[offset..]))
+    }
+
+    fn pending_delegator_rewards_view(&self) -> Option<PendingDelegatorRewardsView> {
+        let offset = self
+            .frame
+            .simd185_field_offset(Simd185Field::PendingDelegatorRewards)?;
+        // SAFETY: `frame` was created from `data`.
+        Some(PendingDelegatorRewardsView::new(&self.data[offset..]))
+    }
+
+    fn bls_pubkey_compressed_view(&self) -> Option<BlsPubkeyCompressedView> {
+        let offset = self
+            .frame
+            .simd185_field_offset(Simd185Field::BlsPubkeyCompressed)?;
+        let frame = self.frame.bls_pubkey_compressed_frame()?;
+        // SAFETY: `frame` was created from `data`.
+        Some(BlsPubkeyCompressedView::new(frame, &self.data[offset..]))
+    }
+
     fn votes_view(&self) -> ListView<VotesFrame> {
         let offset = self.frame.offset(Field::Votes);
         // SAFETY: `frame` was created from `data`.
@@ -166,6 +246,7 @@ impl From<VoteStateV3> for VoteStateView {
 enum VoteStateFrame {
     V1_14_11(VoteStateFrameV1_14_11),
     V3(VoteStateFrameV3),
+    V4(VoteStateFrameV4),
 }
 
 impl VoteStateFrame {
@@ -181,6 +262,7 @@ impl VoteStateFrame {
             0 => return Err(VoteStateViewError::OldVersion),
             1 => Self::V1_14_11(VoteStateFrameV1_14_11::try_new(bytes)?),
             2 => Self::V3(VoteStateFrameV3::try_new(bytes)?),
+            3 => Self::V4(VoteStateFrameV4::try_new(bytes)?),
             _ => return Err(VoteStateViewError::UnsupportedVersion),
         })
     }
@@ -189,6 +271,30 @@ impl VoteStateFrame {
         match &self {
             Self::V1_14_11(frame) => frame.field_offset(field),
             Self::V3(frame) => frame.field_offset(field),
+            Self::V4(frame) => frame.field_offset(field),
+        }
+    }
+
+    fn simd185_field_offset(&self, field: Simd185Field) -> Option<usize> {
+        match &self {
+            Self::V1_14_11(_frame) => None,
+            Self::V3(_frame) => None,
+            Self::V4(frame) => Some(frame.simd185_field_offset(field)),
+        }
+    }
+
+    fn commission_frame(&self) -> CommissionFrame {
+        match &self {
+            Self::V1_14_11(_) => CommissionFrame::new_percent(),
+            Self::V3(_) => CommissionFrame::new_percent(),
+            Self::V4(_) => CommissionFrame::new_bps(),
+        }
+    }
+
+    fn bls_pubkey_compressed_frame(&self) -> Option<BlsPubkeyCompressedFrame> {
+        match &self {
+            Self::V1_14_11 { .. } | Self::V3 { .. } => None,
+            Self::V4(frame) => Some(frame.bls_pubkey_compressed_frame),
         }
     }
 
@@ -196,6 +302,7 @@ impl VoteStateFrame {
         match &self {
             Self::V1_14_11(frame) => VotesFrame::Lockout(frame.votes_frame),
             Self::V3(frame) => VotesFrame::Landed(frame.votes_frame),
+            Self::V4(frame) => VotesFrame::Landed(frame.votes_frame),
         }
     }
 
@@ -203,6 +310,7 @@ impl VoteStateFrame {
         match &self {
             Self::V1_14_11(vote_frame) => vote_frame.root_slot_frame,
             Self::V3(vote_frame) => vote_frame.root_slot_frame,
+            Self::V4(vote_frame) => vote_frame.root_slot_frame,
         }
     }
 
@@ -210,6 +318,7 @@ impl VoteStateFrame {
         match &self {
             Self::V1_14_11(frame) => frame.authorized_voters_frame,
             Self::V3(frame) => frame.authorized_voters_frame,
+            Self::V4(frame) => frame.authorized_voters_frame,
         }
     }
 
@@ -217,6 +326,7 @@ impl VoteStateFrame {
         match &self {
             Self::V1_14_11(frame) => frame.epoch_credits_frame,
             Self::V3(frame) => frame.epoch_credits_frame,
+            Self::V4(frame) => frame.epoch_credits_frame,
         }
     }
 }
@@ -230,14 +340,50 @@ mod tests {
         solana_vote_interface::{
             authorized_voters::AuthorizedVoters,
             state::{
-                vote_state_1_14_11::VoteState1_14_11, LandedVote, VoteInit, VoteStateV3,
+                LandedVote, VoteInit, VoteState1_14_11, VoteStateV3, VoteStateV4,
                 VoteStateVersions, MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY,
             },
         },
         std::collections::VecDeque,
     };
 
-    fn new_test_vote_state() -> VoteStateV3 {
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    enum TestVoteStateVersions {
+        V0_23_5,
+        V1_14_11,
+        V3,
+        V4(Box<VoteStateV4>),
+    }
+
+    fn new_test_vote_state_v4() -> VoteStateV4 {
+        let votes = (0..MAX_LOCKOUT_HISTORY)
+            .map(|i| LandedVote {
+                latency: i as u8,
+                lockout: Lockout::new_with_confirmation_count(i as u64, i as u32),
+            })
+            .collect();
+
+        VoteStateV4 {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            inflation_rewards_collector: Pubkey::new_unique(),
+            block_revenue_collector: Pubkey::new_unique(),
+            inflation_rewards_commission_bps: 42,
+            block_revenue_commission_bps: 42,
+            pending_delegator_rewards: 42,
+            bls_pubkey_compressed: Some([42; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
+            votes,
+            root_slot: Some(42),
+            authorized_voters: AuthorizedVoters::new(42, Pubkey::new_unique()),
+            epoch_credits: vec![(42, 42, 42)],
+            last_timestamp: BlockTimestamp {
+                slot: 42,
+                timestamp: 42,
+            },
+        }
+    }
+
+    fn new_test_vote_state_v3() -> VoteStateV3 {
         let mut target_vote_state = VoteStateV3::new(
             &VoteInit {
                 node_pubkey: Pubkey::new_unique(),
@@ -274,8 +420,53 @@ mod tests {
     }
 
     #[test]
+    fn test_vote_state_view_v4() {
+        let target_vote_state = new_test_vote_state_v4();
+        let target_vote_state_versions =
+            TestVoteStateVersions::V4(Box::new(target_vote_state.clone()));
+        let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
+        let vote_state_view = VoteStateView::try_new(Arc::new(vote_state_buf)).unwrap();
+        assert_eq_vote_state_v4(&vote_state_view, &target_vote_state);
+    }
+
+    #[test]
+    fn test_vote_state_view_v4_default() {
+        let target_vote_state = VoteStateV4::default();
+        let target_vote_state_versions =
+            TestVoteStateVersions::V4(Box::new(target_vote_state.clone()));
+        let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
+        let vote_state_view = VoteStateView::try_new(Arc::new(vote_state_buf)).unwrap();
+        assert_eq_vote_state_v4(&vote_state_view, &target_vote_state);
+    }
+
+    #[test]
+    fn test_vote_state_view_v4_arbitrary() {
+        // variant
+        // provide 4x the minimum struct size in bytes to ensure we typically touch every field
+        let struct_bytes_x4 = VoteStateV3::size_of() * 4;
+        for _ in 0..100 {
+            let raw_data: Vec<u8> = (0..struct_bytes_x4).map(|_| rand::random::<u8>()).collect();
+            let mut unstructured = Unstructured::new(&raw_data);
+
+            let mut target_vote_state = VoteStateV4::arbitrary(&mut unstructured).unwrap();
+            target_vote_state.votes.truncate(MAX_LOCKOUT_HISTORY);
+            target_vote_state
+                .epoch_credits
+                .truncate(MAX_EPOCH_CREDITS_HISTORY);
+            if target_vote_state.authorized_voters.len() >= u8::MAX as usize {
+                continue;
+            }
+
+            let target_vote_state_versions =
+                TestVoteStateVersions::V4(Box::new(target_vote_state.clone()));
+            let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
+            let vote_state_view = VoteStateView::try_new(Arc::new(vote_state_buf)).unwrap();
+            assert_eq_vote_state_v4(&vote_state_view, &target_vote_state);
+        }
+    }
+    #[test]
     fn test_vote_state_view_v3() {
-        let target_vote_state = new_test_vote_state();
+        let target_vote_state = new_test_vote_state_v3();
         let target_vote_state_versions = VoteStateVersions::V3(Box::new(target_vote_state.clone()));
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
         let vote_state_view = VoteStateView::try_new(Arc::new(vote_state_buf)).unwrap();
@@ -319,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_vote_state_view_1_14_11() {
-        let target_vote_state: VoteState1_14_11 = new_test_vote_state().into();
+        let target_vote_state: VoteState1_14_11 = new_test_vote_state_v3().into();
         let target_vote_state_versions =
             VoteStateVersions::V1_14_11(Box::new(target_vote_state.clone()));
         let vote_state_buf = bincode::serialize(&target_vote_state_versions).unwrap();
@@ -366,6 +557,77 @@ mod tests {
             let vote_state_view = VoteStateView::try_new(Arc::new(vote_state_buf)).unwrap();
             assert_eq_vote_state_1_14_11(&vote_state_view, &target_vote_state);
         }
+    }
+
+    fn assert_eq_vote_state_v4(vote_state_view: &VoteStateView, vote_state: &VoteStateV4) {
+        assert_eq!(vote_state_view.node_pubkey(), &vote_state.node_pubkey);
+        assert_eq!(
+            vote_state_view.inflation_rewards_collector(),
+            Some(&vote_state.inflation_rewards_collector)
+        );
+        assert_eq!(
+            vote_state_view.block_revenue_collector(),
+            Some(&vote_state.block_revenue_collector)
+        );
+        assert_eq!(
+            vote_state_view.inflation_rewards_commission(),
+            vote_state.inflation_rewards_commission_bps
+        );
+        assert_eq!(
+            vote_state_view.block_revenue_commission(),
+            vote_state.block_revenue_commission_bps
+        );
+        assert_eq!(
+            vote_state_view.pending_delegator_rewards(),
+            vote_state.pending_delegator_rewards
+        );
+        assert_eq!(
+            vote_state_view.bls_pubkey_compressed(),
+            vote_state.bls_pubkey_compressed
+        );
+        let view_votes = vote_state_view.votes_iter().collect::<Vec<_>>();
+        let state_votes = vote_state
+            .votes
+            .iter()
+            .map(|vote| vote.lockout)
+            .collect::<Vec<_>>();
+        assert_eq!(view_votes, state_votes);
+        assert_eq!(vote_state_view.root_slot(), vote_state.root_slot);
+
+        if let Some((first_voter_epoch, first_voter)) = vote_state.authorized_voters.first() {
+            assert_eq!(
+                vote_state_view.get_authorized_voter(*first_voter_epoch),
+                Some(first_voter)
+            );
+
+            let (last_voter_epoch, last_voter) = vote_state.authorized_voters.last().unwrap();
+            assert_eq!(
+                vote_state_view.get_authorized_voter(*last_voter_epoch),
+                Some(last_voter)
+            );
+            assert_eq!(
+                vote_state_view.get_authorized_voter(u64::MAX),
+                Some(last_voter)
+            );
+        } else {
+            assert_eq!(vote_state_view.get_authorized_voter(u64::MAX), None);
+        }
+
+        assert_eq!(
+            vote_state_view.num_epoch_credits(),
+            vote_state.epoch_credits.len()
+        );
+        let view_credits: Vec<(Epoch, u64, u64)> = vote_state_view
+            .epoch_credits_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>();
+        assert_eq!(view_credits, vote_state.epoch_credits);
+
+        assert_eq!(
+            vote_state_view.credits(),
+            vote_state.epoch_credits.last().map(|x| x.1).unwrap_or(0)
+        );
+        assert_eq!(vote_state_view.last_timestamp(), vote_state.last_timestamp);
     }
 
     fn assert_eq_vote_state_v3(vote_state_view: &VoteStateView, vote_state: &VoteStateV3) {

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -758,7 +758,7 @@ mod tests {
 
     #[test]
     fn test_vote_state_view_unsupported_version() {
-        let vote_data = Arc::new(3u32.to_le_bytes().to_vec());
+        let vote_data = Arc::new(4u32.to_le_bytes().to_vec());
         let vote_state_view_err = VoteStateView::try_new(vote_data).unwrap_err();
         assert_eq!(vote_state_view_err, VoteStateViewError::UnsupportedVersion);
     }

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -10,7 +10,7 @@ use {
         list_view::ListView,
     },
     core::fmt::Debug,
-    field_frames::{CommissionBpsView, CommissionFrame, CommissionView},
+    field_frames::{CommissionFrame, CommissionView},
     frame_v4::VoteStateFrameV4,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
@@ -183,12 +183,15 @@ impl VoteStateView {
         CommissionView::new(self.frame.commission_frame(), &self.data[offset..])
     }
 
-    fn block_revenue_commission_view(&self) -> Option<CommissionBpsView> {
+    fn block_revenue_commission_view(&self) -> Option<CommissionView> {
         let offset = self
             .frame
             .simd185_field_offset(Simd185Field::BlockRevenueCommission)?;
         // SAFETY: `frame` was created from `data`.
-        Some(CommissionBpsView::new(&self.data[offset..]))
+        Some(CommissionView::new(
+            CommissionFrame::new_bps(),
+            &self.data[offset..],
+        ))
     }
 
     fn pending_delegator_rewards_view(&self) -> Option<PendingDelegatorRewardsView> {

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -331,23 +331,6 @@ impl From<&EpochCreditsItem> for (Epoch, u64, u64) {
         (item.epoch(), item.credits(), item.prev_credits())
     }
 }
-pub(super) struct CommissionBpsView<'a> {
-    buffer: &'a [u8],
-}
-
-impl<'a> CommissionBpsView<'a> {
-    pub(super) fn new(buffer: &'a [u8]) -> Self {
-        Self { buffer }
-    }
-}
-
-impl CommissionBpsView<'_> {
-    pub(super) fn commission_bps(&self) -> u16 {
-        let data = unsafe { *(self.buffer.as_ptr() as *const [u8; 2]) };
-        u16::from_le_bytes(data)
-    }
-}
-
 pub(super) struct CommissionView<'a> {
     frame: CommissionFrame,
     buffer: &'a [u8],

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -2,7 +2,8 @@ use {
     super::{list_view::ListView, Result, VoteStateViewError},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    std::io::BufRead,
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+    std::io::{BufRead, Read},
 };
 
 pub(super) trait ListFrame {
@@ -116,6 +117,65 @@ impl ListFrame for LockoutListFrame {
 
     fn len(&self) -> usize {
         self.len as usize
+    }
+}
+
+pub(super) struct BlsPubkeyCompressedView<'a> {
+    frame: BlsPubkeyCompressedFrame,
+    buffer: &'a [u8],
+}
+
+impl<'a> BlsPubkeyCompressedView<'a> {
+    pub(super) fn new(frame: BlsPubkeyCompressedFrame, buffer: &'a [u8]) -> Self {
+        Self { frame, buffer }
+    }
+}
+
+impl BlsPubkeyCompressedView<'_> {
+    pub(super) fn pubkey(&self) -> Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]> {
+        if !self.frame.has_pubkey {
+            None
+        } else {
+            let mut cursor = std::io::Cursor::new(self.buffer);
+            cursor.consume(1);
+            let mut buf = [0; BLS_PUBLIC_KEY_COMPRESSED_SIZE];
+            cursor.read_exact(&mut buf).unwrap();
+            Some(buf)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+pub(super) struct BlsPubkeyCompressedFrame {
+    pub(super) has_pubkey: bool,
+}
+
+impl BlsPubkeyCompressedFrame {
+    pub(super) fn total_size(&self) -> usize {
+        1 + self.size()
+    }
+
+    pub(super) fn size(&self) -> usize {
+        if self.has_pubkey {
+            BLS_PUBLIC_KEY_COMPRESSED_SIZE
+        } else {
+            0
+        }
+    }
+
+    pub(super) fn read(cursor: &mut std::io::Cursor<&[u8]>) -> Result<Self> {
+        let byte = solana_serialize_utils::cursor::read_u8(cursor)
+            .map_err(|_err| VoteStateViewError::AccountDataTooSmall)?;
+        let has_pubkey = match byte {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(VoteStateViewError::InvalidBlsPubkeyCompressedOption),
+        }?;
+
+        let frame = Self { has_pubkey };
+        cursor.consume(frame.size());
+        Ok(frame)
     }
 }
 
@@ -271,6 +331,85 @@ impl From<&EpochCreditsItem> for (Epoch, u64, u64) {
         (item.epoch(), item.credits(), item.prev_credits())
     }
 }
+pub(super) struct CommissionBpsView<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> CommissionBpsView<'a> {
+    pub(super) fn new(buffer: &'a [u8]) -> Self {
+        Self { buffer }
+    }
+}
+
+impl CommissionBpsView<'_> {
+    pub(super) fn commission_bps(&self) -> u16 {
+        let data = unsafe { *(self.buffer.as_ptr() as *const [u8; 2]) };
+        u16::from_le_bytes(data)
+    }
+}
+
+pub(super) struct CommissionView<'a> {
+    frame: CommissionFrame,
+    buffer: &'a [u8],
+}
+
+impl<'a> CommissionView<'a> {
+    pub(super) fn new(frame: CommissionFrame, buffer: &'a [u8]) -> Self {
+        Self { frame, buffer }
+    }
+}
+
+impl CommissionView<'_> {
+    pub(super) fn commission_percent(&self) -> u8 {
+        if !self.frame.use_bps {
+            self.buffer[0]
+        } else {
+            let data = unsafe { *(self.buffer.as_ptr() as *const [u8; 2]) };
+            let bps = u16::from_le_bytes(data);
+            let percent = (bps / 100).min(u8::MAX as u16);
+            percent as u8
+        }
+    }
+
+    pub(super) fn commission_bps(&self) -> u16 {
+        if !self.frame.use_bps {
+            100 * self.buffer[0] as u16
+        } else {
+            let data = unsafe { *(self.buffer.as_ptr() as *const [u8; 2]) };
+            u16::from_le_bytes(data)
+        }
+    }
+}
+
+pub(super) struct CommissionFrame {
+    use_bps: bool,
+}
+
+impl CommissionFrame {
+    pub(super) const fn new_percent() -> Self {
+        Self { use_bps: false }
+    }
+    pub(super) const fn new_bps() -> Self {
+        Self { use_bps: true }
+    }
+}
+
+pub(super) struct PendingDelegatorRewardsView<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> PendingDelegatorRewardsView<'a> {
+    pub(super) fn new(buffer: &'a [u8]) -> Self {
+        Self { buffer }
+    }
+}
+
+impl PendingDelegatorRewardsView<'_> {
+    pub(super) fn value(&self) -> u64 {
+        let data = unsafe { *(self.buffer.as_ptr() as *const [u8; 8]) };
+        u64::from_le_bytes(data)
+    }
+}
 
 pub(super) struct RootSlotView<'a> {
     frame: RootSlotFrame,
@@ -348,6 +487,19 @@ mod tests {
     use {super::*, solana_vote_interface::state::CircBuf};
 
     #[test]
+    fn test_bls_pubkey_view() {
+        let frame = BlsPubkeyCompressedFrame { has_pubkey: true };
+        let buffer = [1; 49]; // 1 byte for has_pubkey + 48 bytes for the pubkey
+        let view = BlsPubkeyCompressedView::new(frame, &buffer);
+        assert!(view.pubkey().is_some());
+
+        let frame = BlsPubkeyCompressedFrame { has_pubkey: false };
+        let buffer = [0; 1];
+        let view = BlsPubkeyCompressedView::new(frame, &buffer);
+        assert!(view.pubkey().is_none());
+    }
+
+    #[test]
     fn test_prior_voters_total_size() {
         #[repr(C)]
         pub(super) struct PriorVotersItem {
@@ -361,5 +513,37 @@ mod tests {
             core::mem::size_of::<u64>() /* idx */ +
             core::mem::size_of::<bool>() /* is_empty */;
         assert_eq!(PriorVotersFrame::total_size(), expected_total_size);
+    }
+
+    #[test]
+    fn test_commission_view() {
+        let frame = CommissionFrame::new_percent();
+        let buffer = [0; 1];
+        let commission_view = CommissionView::new(frame, &buffer);
+        assert_eq!(commission_view.commission_percent(), 0);
+
+        // base case
+        let frame = CommissionFrame::new_bps();
+        let buffer = [0, 0];
+        let commission_view = CommissionView::new(frame, &buffer);
+        assert_eq!(commission_view.commission_percent(), 0);
+
+        // 1% commission
+        let frame = CommissionFrame::new_bps();
+        let buffer = 100u16.to_le_bytes();
+        let commission_view = CommissionView::new(frame, &buffer);
+        assert_eq!(commission_view.commission_percent(), 1);
+
+        // round down to 1%
+        let frame = CommissionFrame::new_bps();
+        let buffer = 101u16.to_le_bytes();
+        let commission_view = CommissionView::new(frame, &buffer);
+        assert_eq!(commission_view.commission_percent(), 1);
+
+        // over u8 max
+        let frame = CommissionFrame::new_bps();
+        let buffer = u16::MAX.to_le_bytes();
+        let commission_view = CommissionView::new(frame, &buffer);
+        assert_eq!(commission_view.commission_percent(), u8::MAX);
     }
 }

--- a/vote/src/vote_state_view/frame_v4.rs
+++ b/vote/src/vote_state_view/frame_v4.rs
@@ -1,0 +1,280 @@
+use {
+    super::{
+        field_frames::{BlsPubkeyCompressedFrame, LandedVotesListFrame, ListFrame},
+        AuthorizedVotersListFrame, EpochCreditsListFrame, Field, Result, RootSlotFrame,
+        Simd185Field, VoteStateViewError,
+    },
+    solana_pubkey::Pubkey,
+    solana_vote_interface::state::BlockTimestamp,
+    std::io::BufRead,
+};
+
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+pub(crate) struct VoteStateFrameV4 {
+    pub(super) bls_pubkey_compressed_frame: BlsPubkeyCompressedFrame,
+    pub(super) votes_frame: LandedVotesListFrame,
+    pub(super) root_slot_frame: RootSlotFrame,
+    pub(super) authorized_voters_frame: AuthorizedVotersListFrame,
+    pub(super) epoch_credits_frame: EpochCreditsListFrame,
+}
+
+impl VoteStateFrameV4 {
+    pub(crate) fn try_new(bytes: &[u8]) -> Result<Self> {
+        let bls_pubkey_offset = Self::bls_pubkey_compressed_offset();
+        let mut cursor = std::io::Cursor::new(bytes);
+        cursor.set_position(bls_pubkey_offset as u64);
+
+        let bls_pubkey_compressed_frame = BlsPubkeyCompressedFrame::read(&mut cursor)?;
+        let votes_frame = LandedVotesListFrame::read(&mut cursor)?;
+        let root_slot_frame = RootSlotFrame::read(&mut cursor)?;
+        let authorized_voters_frame = AuthorizedVotersListFrame::read(&mut cursor)?;
+        let epoch_credits_frame = EpochCreditsListFrame::read(&mut cursor)?;
+        cursor.consume(core::mem::size_of::<BlockTimestamp>());
+        if cursor.position() as usize <= bytes.len() {
+            Ok(Self {
+                bls_pubkey_compressed_frame,
+                votes_frame,
+                root_slot_frame,
+                authorized_voters_frame,
+                epoch_credits_frame,
+            })
+        } else {
+            Err(VoteStateViewError::AccountDataTooSmall)
+        }
+    }
+
+    pub(super) fn field_offset(&self, field: Field) -> usize {
+        match field {
+            Field::NodePubkey => Self::node_pubkey_offset(),
+            Field::Commission => Self::inflation_rewards_commission_offset(),
+            Field::Votes => self.votes_offset(),
+            Field::RootSlot => self.root_slot_offset(),
+            Field::AuthorizedVoters => self.authorized_voters_offset(),
+            Field::EpochCredits => self.epoch_credits_offset(),
+            Field::LastTimestamp => self.last_timestamp_offset(),
+        }
+    }
+
+    pub(super) fn simd185_field_offset(&self, field: Simd185Field) -> usize {
+        match field {
+            Simd185Field::InflationRewardsCollector => Self::inflation_rewards_collector_offset(),
+            Simd185Field::BlockRevenueCollector => Self::block_revenue_collector_offset(),
+            Simd185Field::BlockRevenueCommission => Self::block_revenue_commission_offset(),
+            Simd185Field::PendingDelegatorRewards => Self::pending_delegator_rewards_offset(),
+            Simd185Field::BlsPubkeyCompressed => Self::bls_pubkey_compressed_offset(),
+        }
+    }
+
+    const fn node_pubkey_offset() -> usize {
+        core::mem::size_of::<u32>() // version
+    }
+
+    const fn authorized_withdrawer_offset() -> usize {
+        Self::node_pubkey_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn inflation_rewards_collector_offset() -> usize {
+        Self::authorized_withdrawer_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn block_revenue_collector_offset() -> usize {
+        Self::inflation_rewards_collector_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn inflation_rewards_commission_offset() -> usize {
+        Self::block_revenue_collector_offset() + core::mem::size_of::<Pubkey>()
+    }
+
+    const fn block_revenue_commission_offset() -> usize {
+        Self::inflation_rewards_commission_offset() + core::mem::size_of::<u16>()
+    }
+
+    const fn pending_delegator_rewards_offset() -> usize {
+        Self::block_revenue_commission_offset() + core::mem::size_of::<u16>()
+    }
+
+    const fn bls_pubkey_compressed_offset() -> usize {
+        Self::pending_delegator_rewards_offset() + core::mem::size_of::<u64>()
+    }
+
+    fn votes_offset(&self) -> usize {
+        Self::bls_pubkey_compressed_offset() + self.bls_pubkey_compressed_frame.total_size()
+    }
+
+    fn root_slot_offset(&self) -> usize {
+        self.votes_offset() + self.votes_frame.total_size()
+    }
+
+    fn authorized_voters_offset(&self) -> usize {
+        self.root_slot_offset() + self.root_slot_frame.total_size()
+    }
+
+    fn epoch_credits_offset(&self) -> usize {
+        self.authorized_voters_offset() + self.authorized_voters_frame.total_size()
+    }
+
+    fn last_timestamp_offset(&self) -> usize {
+        self.epoch_credits_offset() + self.epoch_credits_frame.total_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_vote_interface::{
+            authorized_voters::AuthorizedVoters,
+            state::{LandedVote, Lockout, VoteStateV4, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
+        },
+        std::collections::VecDeque,
+    };
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    enum TestVoteStateVersions {
+        V0_23_5,
+        V1_14_11,
+        V3,
+        V4(VoteStateV4),
+    }
+
+    #[test]
+    fn test_try_new_zeroed() {
+        let target_vote_state = VoteStateV4::default();
+        let target_vote_state_versions = TestVoteStateVersions::V4(target_vote_state);
+        let mut bytes = bincode::serialize(&target_vote_state_versions).unwrap();
+
+        for i in 0..bytes.len() {
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes[..i]);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::AccountDataTooSmall)
+            );
+        }
+
+        for has_trailing_bytes in [false, true] {
+            if has_trailing_bytes {
+                bytes.extend_from_slice(&[0; 42]);
+            }
+            assert_eq!(
+                VoteStateFrameV4::try_new(&bytes),
+                Ok(VoteStateFrameV4 {
+                    bls_pubkey_compressed_frame: BlsPubkeyCompressedFrame { has_pubkey: false },
+                    votes_frame: LandedVotesListFrame { len: 0 },
+                    root_slot_frame: RootSlotFrame {
+                        has_root_slot: false,
+                    },
+                    authorized_voters_frame: AuthorizedVotersListFrame { len: 0 },
+                    epoch_credits_frame: EpochCreditsListFrame { len: 0 },
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_try_new_simple() {
+        let target_vote_state = VoteStateV4 {
+            authorized_voters: AuthorizedVoters::new(0, Pubkey::default()),
+            epoch_credits: vec![(1, 2, 3)],
+            bls_pubkey_compressed: Some([42; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
+            votes: VecDeque::from([LandedVote {
+                latency: 0,
+                lockout: Lockout::default(),
+            }]),
+            root_slot: Some(42),
+            ..VoteStateV4::default()
+        };
+
+        let target_vote_state_versions = TestVoteStateVersions::V4(target_vote_state);
+        let mut bytes = bincode::serialize(&target_vote_state_versions).unwrap();
+
+        for i in 0..bytes.len() {
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes[..i]);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::AccountDataTooSmall)
+            );
+        }
+
+        for has_trailing_bytes in [false, true] {
+            if has_trailing_bytes {
+                bytes.extend_from_slice(&[0; 42]);
+            }
+            assert_eq!(
+                VoteStateFrameV4::try_new(&bytes),
+                Ok(VoteStateFrameV4 {
+                    bls_pubkey_compressed_frame: BlsPubkeyCompressedFrame { has_pubkey: true },
+                    votes_frame: LandedVotesListFrame { len: 1 },
+                    root_slot_frame: RootSlotFrame {
+                        has_root_slot: true,
+                    },
+                    authorized_voters_frame: AuthorizedVotersListFrame { len: 1 },
+                    epoch_credits_frame: EpochCreditsListFrame { len: 1 },
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_try_new_invalid_values() {
+        let mut bytes = vec![0; VoteStateFrameV4::bls_pubkey_compressed_offset()];
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(2u8.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidBlsPubkeyCompressedOption)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; 1]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidVotesLength)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; core::mem::size_of::<u64>()]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(2u8.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidRootSlotOption)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; 1]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidAuthorizedVotersLength)
+            );
+        }
+
+        bytes.extend_from_slice(&[0; core::mem::size_of::<u64>()]);
+
+        {
+            let mut bytes = bytes.clone();
+            bytes.extend_from_slice(&(256u64.to_le_bytes()));
+            let vote_state_frame = VoteStateFrameV4::try_new(&bytes);
+            assert_eq!(
+                vote_state_frame,
+                Err(VoteStateViewError::InvalidEpochCreditsLength)
+            );
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
Need support for vote state v4 in the runtime via `VoteStateView`

#### Summary of Changes
Add support for v4 in `VoteStateView` by adding new frame types and new simd185 field accessors. This change assumes that vote state v4 cannot be created unless the simd185 feature gate is activated, so no feature gating needed here.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
