### PR TITLE
Refactor - `TransactionContext::configure_next_instruction()`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -520,13 +520,12 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     invoke_context
         .transaction_context
-        .get_next_instruction_context_mut()
-        .unwrap()
-        .configure_for_tests(
+        .configure_next_instruction_for_tests(
             program_index.saturating_add(1),
             instruction_accounts,
             &instruction_data,
-        );
+        )
+        .unwrap();
     invoke_context.push().unwrap();
     let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
         invoke_context.transaction_context,

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -783,9 +783,12 @@ mod tests {
                 );
                 invoke_context
                     .transaction_context
-                    .get_next_instruction_context_mut()
-                    .unwrap()
-                    .configure_for_tests(0, instruction_accounts, &instruction_data);
+                    .configure_next_instruction_for_tests(
+                        0,
+                        instruction_accounts,
+                        &instruction_data,
+                    )
+                    .unwrap();
                 invoke_context.push().unwrap();
                 let instruction_context = invoke_context
                     .transaction_context
@@ -940,9 +943,12 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(0, instruction_accounts.clone(), &instruction_data);
+                .configure_next_instruction_for_tests(
+                    0,
+                    instruction_accounts.clone(),
+                    &instruction_data,
+                )
+                .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1038,9 +1044,8 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(7, instruction_accounts, &instruction_data);
+                .configure_next_instruction_for_tests(7, instruction_accounts, &instruction_data)
+                .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1203,9 +1208,12 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(0, instruction_accounts.clone(), &instruction_data);
+                .configure_next_instruction_for_tests(
+                    0,
+                    instruction_accounts.clone(),
+                    &instruction_data,
+                )
+                .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1238,9 +1246,8 @@ mod tests {
             // check serialize_parameters_unaligned
             invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(7, instruction_accounts, &instruction_data);
+                .configure_next_instruction_for_tests(7, instruction_accounts, &instruction_data)
+                .unwrap();
             invoke_context.push().unwrap();
             let instruction_context = invoke_context
                 .transaction_context
@@ -1465,9 +1472,8 @@ mod tests {
             deduplicated_instruction_accounts(&transaction_accounts_indexes, |index| index > 0);
         let instruction_data = [];
         transaction_context
-            .get_next_instruction_context_mut()
-            .unwrap()
-            .configure_for_tests(6, instruction_accounts, &instruction_data);
+            .configure_next_instruction_for_tests(6, instruction_accounts, &instruction_data)
+            .unwrap();
         transaction_context.push().unwrap();
         let instruction_context = transaction_context
             .get_current_instruction_context()

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -100,9 +100,8 @@ fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionC
         TransactionContext::new(transaction_accounts, Rent::default(), 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .get_next_instruction_context_mut()
-        .unwrap()
-        .configure_for_tests(0, instruction_accounts, &instruction_data);
+        .configure_next_instruction_for_tests(0, instruction_accounts, &instruction_data)
+        .unwrap();
     transaction_context.push().unwrap();
     transaction_context
 }

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -69,9 +69,8 @@ macro_rules! with_mock_invoke_context {
         );
         $invoke_context
             .transaction_context
-            .get_next_instruction_context_mut()
-            .unwrap()
-            .configure_for_tests(1, instruction_accounts, &[]);
+            .configure_next_instruction_for_tests(1, instruction_accounts, &[])
+            .unwrap();
         $invoke_context.push().unwrap();
     };
 }

--- a/programs/system/src/system_instruction.rs
+++ b/programs/system/src/system_instruction.rs
@@ -267,9 +267,8 @@ mod test {
         ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
             $invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(2, $instruction_accounts, &[]);
+                .configure_next_instruction_for_tests(2, $instruction_accounts, &[])
+                .unwrap();
             $invoke_context.push().unwrap();
             let $transaction_context = &$invoke_context.transaction_context;
             let $instruction_context = $transaction_context

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1160,18 +1160,20 @@ mod tests {
         // Create a fake TransactionContext with a fake InstructionContext with a single account which is the
         // vote account that was just created
         let processor_account = AccountSharedData::new(0, 0, &solana_sdk_ids::native_loader::id());
-        let transaction_context = TransactionContext::new(
+        let mut transaction_context = TransactionContext::new(
             vec![(id(), processor_account), (node_pubkey, vote_account)],
             rent.clone(),
             0,
             0,
         );
-        let mut instruction_context = InstructionContext::default();
-        instruction_context.configure_for_tests(
-            0,
-            vec![InstructionAccount::new(1, false, true)],
-            &[],
-        );
+        transaction_context
+            .configure_next_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, true)],
+                &[],
+            )
+            .unwrap();
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state
@@ -1309,18 +1311,20 @@ mod tests {
         // Create a fake TransactionContext with a fake InstructionContext with a single account which is the
         // vote account that was just created
         let processor_account = AccountSharedData::new(0, 0, &solana_sdk_ids::native_loader::id());
-        let transaction_context = TransactionContext::new(
+        let mut transaction_context = TransactionContext::new(
             vec![(id(), processor_account), (node_pubkey, vote_account)],
             rent,
             0,
             0,
         );
-        let mut instruction_context = InstructionContext::default();
-        instruction_context.configure_for_tests(
-            0,
-            vec![InstructionAccount::new(1, false, true)],
-            &[],
-        );
+        transaction_context
+            .configure_next_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, true)],
+                &[],
+            )
+            .unwrap();
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
 
         // Get the BorrowedAccount from the InstructionContext which is what is used to manipulate and inspect account
         // state

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1281,9 +1281,8 @@ mod tests {
             }
             if stack_height > transaction_context.get_instruction_context_stack_height() {
                 transaction_context
-                    .get_next_instruction_context_mut()
-                    .unwrap()
-                    .configure_for_tests(0, vec![], &[index_in_trace as u8]);
+                    .configure_next_instruction_for_tests(0, vec![], &[index_in_trace as u8])
+                    .unwrap();
                 transaction_context.push().unwrap();
             }
         }

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1345,9 +1345,12 @@ mod tests {
             );
             $invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests($program_account, instruction_accounts, instruction_data);
+                .configure_next_instruction_for_tests(
+                    $program_account,
+                    instruction_accounts,
+                    instruction_data,
+                )
+                .unwrap();
             $invoke_context.push().unwrap();
         };
     }
@@ -1907,16 +1910,15 @@ mod tests {
 
         invoke_context
             .transaction_context
-            .get_next_instruction_context_mut()
-            .unwrap()
-            .configure_for_tests(
+            .configure_next_instruction_for_tests(
                 0,
                 vec![
                     InstructionAccount::new(1, false, true),
                     InstructionAccount::new(1, false, true),
                 ],
                 &[],
-            );
+            )
+            .unwrap();
         let accounts = SyscallInvokeSignedRust::translate_accounts(
             vm_addr,
             1,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2220,9 +2220,8 @@ mod tests {
             with_mock_invoke_context!($invoke_context, transaction_context, transaction_accounts);
             $invoke_context
                 .transaction_context
-                .get_next_instruction_context_mut()
-                .unwrap()
-                .configure_for_tests(1, vec![], &[]);
+                .configure_next_instruction_for_tests(1, vec![], &[])
+                .unwrap();
             $invoke_context.push().unwrap();
         };
     }
@@ -4452,9 +4451,12 @@ mod tests {
                 )];
                 invoke_context
                     .transaction_context
-                    .get_next_instruction_context_mut()
-                    .unwrap()
-                    .configure_for_tests(0, instruction_accounts, &[index_in_trace as u8]);
+                    .configure_next_instruction_for_tests(
+                        0,
+                        instruction_accounts,
+                        &[index_in_trace as u8],
+                    )
+                    .unwrap();
                 invoke_context.transaction_context.push().unwrap();
             }
         }


### PR DESCRIPTION
#### Problem

Currently `InstructionContext::configure()` and `InstructionContext::configure_for_tests()` are the only methods which require a mutable reference of an `InstructionContext`. By moving these into the `TransactionContext`, which is useful anyway because they are always used in combination with `TransactionContext::get_next_instruction_context_mut()`, we can make sure that there only exist `&InstructionContext` immutable references through out the program runtime. That in turn will allow us to have immutable back-references inside `InstructionContext` back to Vectors backed by the `TransactionContext` and then have one heap allocation for all instructions which replaces host pointers by indices and makes the instruction structure sharable with programs inside the VM.

#### Summary of Changes

Unifies `TransactionContext::get_next_instruction_context_mut()` and `InstructionContext::configure()` into `TransactionContext::configure_next_instruction()`. Also, unifies `TransactionContext::get_next_instruction_context_mut()` and `InstructionContext::configure_for_tests()` into `TransactionContext::configure_next_instruction_for_tests()`.