### PR TITLE
Refactor - TransactionContext limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11346,6 +11346,7 @@ dependencies = [
  "solana-account-info",
  "solana-instruction",
  "solana-instructions-sysvar",
+ "solana-program-entrypoint",
  "solana-pubkey",
  "solana-rent",
  "solana-sbpf",

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -14,13 +14,10 @@ use {
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
         BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
+        MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
 };
-
-/// Maximum number of instruction accounts that can be serialized into the
-/// SBF VM.
-const MAX_INSTRUCTION_ACCOUNTS: u8 = NON_DUP_MARKER;
 
 /// Modifies the memory mapping in serialization and CPI return for stricter_abi_and_runtime_constraints
 pub fn modify_memory_region_of_account(
@@ -237,7 +234,7 @@ pub fn serialize_parameters(
     InstructionError,
 > {
     let num_ix_accounts = instruction_context.get_number_of_instruction_accounts();
-    if num_ix_accounts > MAX_INSTRUCTION_ACCOUNTS as IndexOfAccount {
+    if num_ix_accounts > MAX_ACCOUNTS_PER_INSTRUCTION as IndexOfAccount {
         return Err(InstructionError::MaxAccountsExceeded);
     }
 
@@ -726,19 +723,19 @@ mod tests {
             } in [
                 TestCase {
                     name: "serialize max accounts with cap",
-                    num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
+                    num_ix_accounts: MAX_ACCOUNTS_PER_INSTRUCTION,
                     append_dup_account: false,
                     expected_err: None,
                 },
                 TestCase {
                     name: "serialize too many accounts with cap",
-                    num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS) + 1,
+                    num_ix_accounts: MAX_ACCOUNTS_PER_INSTRUCTION + 1,
                     append_dup_account: false,
                     expected_err: Some(InstructionError::MaxAccountsExceeded),
                 },
                 TestCase {
                     name: "serialize too many accounts and append dup with cap",
-                    num_ix_accounts: usize::from(MAX_INSTRUCTION_ACCOUNTS),
+                    num_ix_accounts: MAX_ACCOUNTS_PER_INSTRUCTION,
                     append_dup_account: true,
                     expected_err: Some(InstructionError::MaxAccountsExceeded),
                 },

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -36,6 +36,7 @@ solana-signature = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-account-info = { workspace = true }
+solana-program-entrypoint = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction-context = { path = ".", features = [
     "dev-context-only-utils",


### PR DESCRIPTION
#### Problem

Some constants such as `MAX_CPI_INSTRUCTION_DATA_LEN`, `MAX_CPI_INSTRUCTION_ACCOUNTS` and `MAX_INSTRUCTION_ACCOUNTS` are spread over the code base but belong in transaction_context.rs

Additionally, we currently mix up `MAX_ACCOUNTS_PER_TRANSACTION` and `MAX_ACCOUNTS_PER_INSTRUCTION` in some tests. Eventually, we should deprecate these other definition sites in favor of transaction_context.rs

#### Summary of Changes

- Moves `MAX_CPI_INSTRUCTION_ACCOUNTS` and `MAX_CPI_INSTRUCTION_DATA_LEN` from cpi.rs into transaction_context.rs renaming them to `MAX_ACCOUNTS_PER_INSTRUCTION` and `MAX_INSTRUCTION_DATA_LEN`.
- Renames `MAX_PERMITTED_DATA_LENGTH` => `MAX_ACCOUNT_DATA_LEN`.
- Renames `MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION` => `MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION`.
- `MAX_PERMITTED_DATA_INCREASE` => `MAX_ACCOUNT_DATA_GROWTH_PER_INSTRUCTION`.
