### PR TITLE
ledger, shred: introduce TestShredBuilder as replacement to make_merkle_shreds_for_tests

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1170,14 +1170,10 @@ mod tests {
         solana_logger::setup();
         let mut rng = rand::thread_rng();
         let slot = 18_291;
-        let shreds = make_merkle_shreds_for_tests(
-            &mut rng,
-            slot,
-            1200 * 5, // data_size
-            true,     // chained
-            is_last_in_slot,
-        )
-        .unwrap();
+        let shreds = TestShredBuilder::new(slot, 1200 * 5, is_last_in_slot)
+            .with_rng(&mut rng)
+            .build()
+            .unwrap();
         let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
 


### PR DESCRIPTION
#### Problem
The `make_merkle_shreds_for_tests` still expects that shreds could be either chained or unchained as well as doesn't provide options for passing test case specific merkle root or parrent offset.

#### Summary of Changes
On the way towards axing the remaining parts of code that still take into account unchained shreds:

- New API `TestShredBuilder` has been introduced
- To prove the implementation and serve as example the `test_should_discard_shred` has been ported
