### PR TITLE
Replaces --accounts-db-clean-threads with --accounts-db-background-threads

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -127,6 +127,15 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
 
     add_arg!(
         // deprecated in v3.0.0
+        Arg::with_name("accounts_db_clean_threads")
+            .long("accounts-db-clean-threads")
+            .takes_value(true)
+            .value_name("NUMBER")
+            .conflicts_with("accounts_db_background_threads"),
+        replaced_by: "accounts-db-background-threads",
+    );
+    add_arg!(
+        // deprecated in v3.0.0
         Arg::with_name("accounts_db_read_cache_limit_mb")
             .long("accounts-db-read-cache-limit-mb")
             .value_name("MAX | LOW,HIGH")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -99,7 +99,7 @@ pub fn execute(
     let run_args = RunArgs::from_clap_arg_match(matches)?;
 
     let cli::thread_args::NumThreadConfig {
-        accounts_db_clean_threads,
+        accounts_db_background_threads,
         accounts_db_foreground_threads,
         accounts_db_hash_threads,
         accounts_index_flush_threads,
@@ -426,7 +426,7 @@ pub fn execute(
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         storage_access,
         scan_filter_for_shrinking,
-        num_background_threads: Some(accounts_db_clean_threads),
+        num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
         ..AccountsDbConfig::default()


### PR DESCRIPTION
#### Problem

AccountsDb thread pools have been renamed to "foreground" and "background" in PR #7499. The (hidden) cli args have not been updated though. 


#### Summary of Changes

For this PR, update the CLI args. Deprecate the old `--accounts-db-clean-threads` and replace it with `--accounts-db-background-threads`.