### PR TITLE
Updates the account meta size used by the hashing bench

### DIFF
--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -26,7 +26,7 @@ const DATA_SIZES: [usize; 6] = [
 ///
 /// Ensure this constant stays in sync with the value of `META_SIZE` in
 /// AccountsDb::hash_account_helper().
-const META_SIZE: usize = 81;
+const META_SIZE: usize = 73;
 
 fn bench_hash_account(c: &mut Criterion) {
     let lamports = 123_456_789;


### PR DESCRIPTION
#### Problem

The rent epoch is no longer part of an account's hash. This meta data size is used in the bench for hashing accounts. That size in the bench is wrong, as it still includes the rent epoch.


#### Summary of Changes

Fix the size.