### PR TITLE
Mark Accounts Obsolete during flush if reclaiming old slots

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6192,7 +6192,7 @@ impl AccountsDb {
                 None,
                 &HashSet::default(),
                 HandleReclaims::ProcessDeadSlots(&purge_stats),
-                MarkAccountsObsolete::No,
+                MarkAccountsObsolete::Yes(slot),
             );
             handle_reclaims_time.stop();
             handle_reclaims_elapsed = handle_reclaims_time.as_us();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -707,6 +707,13 @@ fn test_flush_slots_with_reclaim_old_slots() {
     assert!(accounts.storage.get_slot_storage_entry(0).is_none());
     for slot in 1..5 {
         assert!(accounts.storage.get_slot_storage_entry(slot).is_some());
+
+        // Verify that the obsolete accounts for the remaining slots are correct
+        let storage = accounts.storage.get_slot_storage_entry(slot).unwrap();
+        assert_eq!(
+            storage.get_obsolete_accounts(Some(new_slot)).len() as u64,
+            5 - slot
+        );
     }
     assert!(accounts.storage.get_slot_storage_entry(new_slot).is_some());
 }


### PR DESCRIPTION
#### Problem
If old slots are being reclaimed, then obsolete accounts should be marked

#### Summary of Changes
- Mark obsolete accounts during flush 
- Update test to verify obsolete accounts are marked

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
