### PR TITLE
xdp: optimize tx_loop

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -133,30 +133,6 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
     // packets.
     let mut batched_packets = 0;
 
-    // With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver
-    // once we want the NIC to do something.
-    let kick = |ring: &TxRing<SliceUmemFrame<'_>>| {
-        if !ring.needs_wakeup() {
-            return;
-        }
-
-        if let Err(e) = ring.wake() {
-            match e.raw_os_error() {
-                // these are non-fatal errors
-                Some(libc::EBUSY | libc::ENOBUFS | libc::EAGAIN) => {}
-                // this can temporarily happen with some drivers when changing
-                // settings (eg with ethtool)
-                Some(libc::ENETDOWN) => {
-                    log::warn!("network interface is down")
-                }
-                // we should never get here, hopefully the driver recovers?
-                _ => {
-                    log::error!("network interface driver error: {e:?}");
-                }
-            }
-        }
-    };
-
     let mut timeouts = 0;
     loop {
         match receiver.try_recv() {
@@ -323,5 +299,35 @@ pub fn tx_loop<T: AsRef<[u8]>, A: AsRef<[SocketAddr]>>(
 
         ring.sync(false);
         kick(&ring);
+    }
+}
+
+// With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver once
+// we want the NIC to do something.
+#[inline(always)]
+fn kick(ring: &TxRing<SliceUmemFrame<'_>>) {
+    if !ring.needs_wakeup() {
+        return;
+    }
+
+    if let Err(e) = ring.wake() {
+        kick_error(e);
+    }
+}
+
+#[inline(never)]
+fn kick_error(e: std::io::Error) {
+    match e.raw_os_error() {
+        // these are non-fatal errors
+        Some(libc::EBUSY | libc::ENOBUFS | libc::EAGAIN) => {}
+        // this can temporarily happen with some drivers when changing
+        // settings (eg with ethtool)
+        Some(libc::ENETDOWN) => {
+            log::warn!("network interface is down")
+        }
+        // we should never get here, hopefully the driver recovers?
+        _ => {
+            log::error!("network interface driver error: {e:?}");
+        }
     }
 }


### PR DESCRIPTION
Couple of optimizations for things that showed up in profiles while benching a mlx5 card. We now batch more atomic ops to reduce loads from remote caches, and manually inline a closure that for whatever reason llvm wasn't inlining.