### PR TITLE
turbine: introduce drop channel capacity constant for xdp retransmitter

### DIFF
--- a/turbine/src/xdp.rs
+++ b/turbine/src/xdp.rs
@@ -86,6 +86,7 @@ impl XdpRetransmitter {
             CapSet,
             Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW},
         };
+        const DROP_CHANNEL_CAP: usize = 1_000_000;
 
         // switch to higher caps while we setup XDP. We assume that an error in
         // this function is irrecoverable so we don't try to drop on errors.
@@ -119,7 +120,7 @@ impl XdpRetransmitter {
 
         let mut threads = vec![];
 
-        let (drop_sender, drop_receiver) = crossbeam_channel::bounded(1_000_000);
+        let (drop_sender, drop_receiver) = crossbeam_channel::bounded(DROP_CHANNEL_CAP);
         threads.push(
             Builder::new()
                 .name("solRetransmDrop".to_owned())


### PR DESCRIPTION
#### Problem
There was directly value 1_000_000 in code, which might look less readable.

#### Summary of Changes
- Introduced constant that states it clearly.
