### PR TITLE
svm repo split: decouple dev deps: feature-set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10835,7 +10835,6 @@ dependencies = [
 name = "solana-svm"
 version = "3.0.0"
 dependencies = [
- "agave-feature-set",
  "agave-syscalls",
  "ahash 0.8.11",
  "assert_matches",
@@ -10853,7 +10852,7 @@ dependencies = [
  "solana-account",
  "solana-bpf-loader-program",
  "solana-clock",
- "solana-compute-budget-instruction",
+ "solana-compute-budget",
  "solana-compute-budget-interface",
  "solana-compute-budget-program",
  "solana-ed25519-program",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -80,7 +80,6 @@ spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-agave-feature-set = { workspace = true }
 agave-syscalls = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
@@ -91,7 +90,7 @@ rand0-7 = { workspace = true }
 shuttle = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-clock = { workspace = true }
-solana-compute-budget-instruction = { workspace = true }
+solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { workspace = true }
 solana-ed25519-program = { workspace = true }


### PR DESCRIPTION
#### Problem
We have to decouple any uses of `agave-` crates in the dev-dependencies of the crates slated to move to the new SVM repo.

This is a re-attempt at #7461, where instead I've reimplemented the compute budget instruction processing locally.

#### Summary of Changes
Simply uses `SVMFeatureSet` instead of the runtime-level `FeatureSet` for SVM integration testing. This is actually more accurate, since no features outside of `SVMFeatureSet` should ever be required to test functionality within SVM.

Additionally, reimplement `process_compute_budget_instructions` locally, without the `FeatureSet` parameter, and keying only on the `SetLoadedAccountsDataSizeLimit` instruction, which is the only one we care about in these tests.

Part of #7317 