### PR TITLE
ledger: Remove stale comment about legacy data shreds

### DIFF
--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -23,8 +23,6 @@ use {
 
 #[inline]
 fn get_shred_size(shred: &[u8]) -> Option<usize> {
-    // Legacy data shreds have zero padding at the end which might have been
-    // trimmed. Other variants do not have any trailing zeros.
     match get_shred_variant(shred).ok()? {
         ShredVariant::MerkleCode { .. } => Some(shred::merkle::ShredCode::SIZE_OF_PAYLOAD),
         ShredVariant::MerkleData { .. } => Some(shred::merkle::ShredData::SIZE_OF_PAYLOAD),


### PR DESCRIPTION
#### Problem
Legacy shreds are nomore. The comment mention about it, which only could confuse.

#### Summary of Changes
Remove obsolete comment about legacy shreds in `get_shred_size`
