### PR TITLE
turbine: remove two redundant filters for discarded shreds/packets in run_shred_sigverify

### DIFF
--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -218,7 +218,6 @@ fn run_shred_sigverify<const K: usize>(
         shred_buffer
             .par_iter_mut()
             .flatten()
-            .filter(|packet| !packet.meta().discard())
             .for_each(|mut packet| {
                 if maybe_verify_and_resign_packet(
                     &mut packet,
@@ -241,7 +240,6 @@ fn run_shred_sigverify<const K: usize>(
     let (shreds, repairs): (Vec<_>, Vec<_>) = shred_buffer
         .iter()
         .flat_map(|batch| batch.iter())
-        .filter(|packet| !packet.meta().discard())
         .filter_map(|packet| {
             let shred = shred::layout::get_shred(packet)?.to_vec();
             Some((shred, packet.meta().repair()))


### PR DESCRIPTION
#### Problem
The [run_shred_sigverify](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L141) delegates packets/shreds to [verify_packets](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L394) which then delegates to [get_slot_leaders](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L418) and the last one does filter out packets which are discarded [here](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L428).

Then after verify_packets return, the caller run_shred_sigverify continues operations on the `shred_buffer` which was previously processed by verify_packets -> get_slot_leaders and gets to the [point](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L221) where it filters out again already discarded shreds/packets and then gets to this [point](https://github.com/anza-xyz/agave/blob/master/turbine/src/sigverify_shreds.rs#L244) where these are filtered out again.

Removing these two filters after verify_packets seem to not affect tests at all.

#### Summary of Changes

- Removed two redundant filters for discarded shreds/packets in run_shred_sigverify.
