### PR TITLE
Fixes the accounts read cache's entry size

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -27,7 +27,7 @@ use {
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 const CACHE_ENTRY_SIZE: usize =
-    std::mem::size_of::<ReadOnlyAccountCacheEntry>() + 2 * std::mem::size_of::<ReadOnlyCacheKey>();
+    size_of::<ReadOnlyAccountCacheEntry>() + size_of::<ReadOnlyCacheKey>();
 
 type ReadOnlyCacheKey = Pubkey;
 


### PR DESCRIPTION
#### Problem

The read only accounts cache has a metric for how much memory it is using. That metric is based on the size of key-value pair in the hashmap plus the account data. The constant used for the size of the key-value pair is wrong though.

More background: The read cache used to have an LRU list that was used to decide eviction (added https://github.com/solana-labs/solana/pull/22403). In that implementation, each entry in the read cache had a key-value pair for the hashmap itself, plus an additional key (`Pubkey`) entry for the LRU list. Thus, the constant used for an entry's size was the `2 * size_of::<Pubkey>()`.

When the cache's implementation was changed (in https://github.com/anza-xyz/agave/pull/3943), and the LRU list removed, the constant was not updated.


#### Summary of Changes

Fix it.