### PR TITLE
Refactor update reward history for just vote rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2396,24 +2396,15 @@ impl Bank {
         result
     }
 
-    fn update_reward_history(
-        &self,
-        stake_rewards: StakeRewards,
-        vote_rewards: &VoteRewardsAccounts,
-    ) {
-        let additional_reserve = stake_rewards.len() + vote_rewards.accounts_with_rewards.len();
+    fn update_vote_rewards(&self, vote_rewards: &VoteRewardsAccounts) {
         let mut rewards = self.rewards.write().unwrap();
-        rewards.reserve(additional_reserve);
+        rewards.reserve(vote_rewards.accounts_with_rewards.len());
         vote_rewards
             .accounts_with_rewards
             .iter()
             .for_each(|(vote_pubkey, vote_reward, _)| {
                 rewards.push((*vote_pubkey, *vote_reward));
             });
-        stake_rewards
-            .into_iter()
-            .filter(|x| x.get_stake_reward() > 0)
-            .for_each(|x| rewards.push((x.stake_pubkey, x.stake_reward_info)));
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,7 +38,7 @@ use {
         account_saver::collect_accounts_to_store,
         bank::{
             metrics::*,
-            partitioned_epoch_rewards::{EpochRewardStatus, StakeRewards, VoteRewardsAccounts},
+            partitioned_epoch_rewards::{EpochRewardStatus, VoteRewardsAccounts},
         },
         bank_forks::BankForks,
         epoch_stakes::{NodeVoteAccounts, VersionedEpochStakes},

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -146,9 +146,7 @@ impl Bank {
 
         let total_vote_rewards = vote_account_rewards.total_vote_rewards_lamports;
         self.store_vote_accounts_partitioned(vote_account_rewards, metrics);
-
-        // update reward history of JUST vote_rewards, stake_rewards is vec![] here
-        self.update_reward_history(vec![], vote_account_rewards);
+        self.update_vote_rewards(vote_account_rewards);
 
         let StakeRewardCalculation {
             stake_rewards,


### PR DESCRIPTION
#### Problem

The old "update_reward_history()" method is only used once for updating just vote rewards now. We can simplify it to remove stake rewards handling, since stake rewards are handled separately in partitioned epoch rewards.



#### Summary of Changes

This PR refactors the reward history update mechanism to handle only vote rewards, simplifying the code and improving clarity.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
