### PR TITLE
--block-production-num-workers cli arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Release channels have their own copy of this changelog:
 #### Changes
 * `--transaction-structure view` is now the default.
 * The default full snapshot interval is now 100,000 slots.
+* `SOLANA_BANKING_THREADS` environment variable is no longer supported. Use `--block-prouduction-num-workers` instead.
 
 ## 2.3.0
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -323,8 +323,8 @@ fn main() {
         .value_of_t::<TransactionStructure>("transaction_struct")
         .unwrap_or_default();
     let num_banking_threads = matches
-        .value_of_t::<u32>("num_banking_threads")
-        .unwrap_or_else(|_| BankingStage::default_or_env_num_workers());
+        .value_of_t::<usize>("num_banking_threads")
+        .unwrap_or_else(|_| BankingStage::default_num_workers());
     //   a multiple of packet chunk duplicates to avoid races
     let num_chunks = matches.value_of_t::<usize>("num_chunks").unwrap_or(16);
     let packets_per_batch = matches
@@ -333,7 +333,7 @@ fn main() {
     let iterations = matches.value_of_t::<usize>("iterations").unwrap_or(1000);
     let batches_per_iteration = matches
         .value_of_t::<usize>("batches_per_iteration")
-        .unwrap_or(BankingStage::default_or_env_num_workers() as usize);
+        .unwrap_or(BankingStage::default_num_workers());
     let write_lock_contention = matches
         .value_of_t::<WriteLockContention>("write_lock_contention")
         .unwrap_or(WriteLockContention::None);

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -36,6 +36,7 @@ use {
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
     std::{
+        num::NonZeroUsize,
         sync::{atomic::Ordering, Arc, RwLock},
         thread::sleep,
         time::{Duration, Instant},
@@ -321,7 +322,7 @@ fn main() {
         .value_of_t::<BlockProductionMethod>("block_production_method")
         .unwrap_or_default();
     let block_production_num_workers = matches
-        .value_of_t::<usize>("block_production_num_workers")
+        .value_of_t::<NonZeroUsize>("block_production_num_workers")
         .unwrap_or_else(|_| BankingStage::default_num_workers());
     let transaction_struct = matches
         .value_of_t::<TransactionStructure>("transaction_struct")
@@ -334,7 +335,7 @@ fn main() {
     let iterations = matches.value_of_t::<usize>("iterations").unwrap_or(1000);
     let batches_per_iteration = matches
         .value_of_t::<usize>("batches_per_iteration")
-        .unwrap_or(BankingStage::default_num_workers());
+        .unwrap_or(BankingStage::default_num_workers().get());
     let write_lock_contention = matches
         .value_of_t::<WriteLockContention>("write_lock_contention")
         .unwrap_or(WriteLockContention::None);

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -288,18 +288,19 @@ fn main() {
                 .help(BlockProductionMethod::cli_message()),
         )
         .arg(
+            Arg::with_name("block_production_num_workers")
+                .long("block-production-num-workers")
+                .takes_value(true)
+                .value_name("NUMBER")
+                .help("Number of worker threads to use for block production"),
+        )
+        .arg(
             Arg::with_name("transaction_struct")
                 .long("transaction-structure")
                 .value_name("STRUCT")
                 .takes_value(true)
                 .possible_values(TransactionStructure::cli_names())
                 .help(TransactionStructure::cli_message()),
-        )
-        .arg(
-            Arg::new("num_banking_threads")
-                .long("num-banking-threads")
-                .takes_value(true)
-                .help("Number of threads to use in the banking stage"),
         )
         .arg(
             Arg::new("simulate_mint")
@@ -319,12 +320,12 @@ fn main() {
     let block_production_method = matches
         .value_of_t::<BlockProductionMethod>("block_production_method")
         .unwrap_or_default();
+    let block_production_num_workers = matches
+        .value_of_t::<usize>("block_production_num_workers")
+        .unwrap_or_else(|_| BankingStage::default_num_workers());
     let transaction_struct = matches
         .value_of_t::<TransactionStructure>("transaction_struct")
         .unwrap_or_default();
-    let num_banking_threads = matches
-        .value_of_t::<usize>("num_banking_threads")
-        .unwrap_or_else(|_| BankingStage::default_num_workers());
     //   a multiple of packet chunk duplicates to avoid races
     let num_chunks = matches.value_of_t::<usize>("num_chunks").unwrap_or(16);
     let packets_per_batch = matches
@@ -376,8 +377,8 @@ fn main() {
         .map(|packets_for_single_iteration| packets_for_single_iteration.transactions.len() as u64)
         .sum();
     info!(
-        "threads: {} txs: {}",
-        num_banking_threads, total_num_transactions
+        "worker threads: {} txs: {}",
+        block_production_num_workers, total_num_transactions
     );
 
     // fund all the accounts
@@ -462,7 +463,7 @@ fn main() {
         non_vote_receiver,
         tpu_vote_receiver,
         gossip_vote_receiver,
-        num_banking_threads,
+        block_production_num_workers,
         None,
         replay_vote_sender,
         None,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -235,7 +235,7 @@ fn bench_banking(
     let (exit, poh_recorder, transaction_recorder, poh_service, signal_receiver) =
         create_test_recorder(bank.clone(), blockstore, None, None);
     let (s, _r) = unbounded();
-    let _banking_stage = BankingStage::new(
+    let _banking_stage = BankingStage::new_num_threads(
         block_production_method,
         transaction_struct,
         &poh_recorder,
@@ -243,6 +243,7 @@ fn bench_banking(
         non_vote_receiver,
         tpu_vote_receiver,
         gossip_vote_receiver,
+        num_threads,
         None,
         s,
         None,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -144,7 +144,7 @@ fn bench_banking(
     //   a multiple of packet chunk duplicates to avoid races
     const CHUNKS: usize = 8;
     const PACKETS_PER_BATCH: usize = 192;
-    let txes = PACKETS_PER_BATCH * num_threads * CHUNKS;
+    let txes = PACKETS_PER_BATCH * num_threads.get() * CHUNKS;
     let mint_total = 1_000_000_000_000;
     let GenesisConfigInfo {
         mut genesis_config,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -140,7 +140,7 @@ fn bench_banking(
     transaction_struct: TransactionStructure,
 ) {
     solana_logger::setup();
-    let num_threads = BankingStage::default_or_env_num_workers() as usize;
+    let num_threads = BankingStage::default_num_workers();
     //   a multiple of packet chunk duplicates to avoid races
     const CHUNKS: usize = 8;
     const PACKETS_PER_BATCH: usize = 192;

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -828,7 +828,7 @@ impl BankingSimulator {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
-            BankingStage::default_or_env_num_workers(),
+            BankingStage::default_num_workers(),
             None,
             replay_vote_sender,
             None,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -355,38 +355,6 @@ impl LikeClusterInfo for Arc<ClusterInfo> {
 
 impl BankingStage {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        block_production_method: BlockProductionMethod,
-        transaction_struct: TransactionStructure,
-        poh_recorder: &Arc<RwLock<PohRecorder>>,
-        transaction_recorder: TransactionRecorder,
-        non_vote_receiver: BankingPacketReceiver,
-        tpu_vote_receiver: BankingPacketReceiver,
-        gossip_vote_receiver: BankingPacketReceiver,
-        transaction_status_sender: Option<TransactionStatusSender>,
-        replay_vote_sender: ReplayVoteSender,
-        log_messages_bytes_limit: Option<usize>,
-        bank_forks: Arc<RwLock<BankForks>>,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
-    ) -> Self {
-        Self::new_num_threads(
-            block_production_method,
-            transaction_struct,
-            poh_recorder,
-            transaction_recorder,
-            non_vote_receiver,
-            tpu_vote_receiver,
-            gossip_vote_receiver,
-            Self::default_num_workers(),
-            transaction_status_sender,
-            replay_vote_sender,
-            log_messages_bytes_limit,
-            bank_forks,
-            prioritization_fee_cache,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
     pub fn new_num_threads(
         block_production_method: BlockProductionMethod,
         transaction_struct: TransactionStructure,
@@ -725,7 +693,7 @@ mod tests {
             create_test_recorder(bank, blockstore, None, None);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-        let banking_stage = BankingStage::new(
+        let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
             &poh_recorder,
@@ -733,6 +701,7 @@ mod tests {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
+            DEFAULT_NUM_WORKERS,
             None,
             replay_vote_sender,
             None,
@@ -780,7 +749,7 @@ mod tests {
             create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-        let banking_stage = BankingStage::new(
+        let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
             &poh_recorder,
@@ -788,6 +757,7 @@ mod tests {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
+            DEFAULT_NUM_WORKERS,
             None,
             replay_vote_sender,
             None,
@@ -844,7 +814,7 @@ mod tests {
             create_test_recorder(bank.clone(), blockstore, None, None);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-        let banking_stage = BankingStage::new(
+        let banking_stage = BankingStage::new_num_threads(
             block_production_method,
             transaction_struct,
             &poh_recorder,
@@ -852,6 +822,7 @@ mod tests {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
+            DEFAULT_NUM_WORKERS,
             None,
             replay_vote_sender,
             None,
@@ -994,7 +965,7 @@ mod tests {
             let (bank, bank_forks) = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
             let (exit, poh_recorder, transaction_recorder, poh_service, entry_receiver) =
                 create_test_recorder(bank.clone(), blockstore, None, None);
-            let _banking_stage = BankingStage::new(
+            let _banking_stage = BankingStage::new_num_threads(
                 BlockProductionMethod::CentralScheduler,
                 transaction_struct,
                 &poh_recorder,
@@ -1002,6 +973,7 @@ mod tests {
                 non_vote_receiver,
                 tpu_vote_receiver,
                 gossip_vote_receiver,
+                DEFAULT_NUM_WORKERS,
                 None,
                 replay_vote_sender,
                 None,
@@ -1180,7 +1152,7 @@ mod tests {
             create_test_recorder(bank.clone(), blockstore, None, None);
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
-        let banking_stage = BankingStage::new(
+        let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
             &poh_recorder,
@@ -1188,6 +1160,7 @@ mod tests {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
+            DEFAULT_NUM_WORKERS,
             None,
             replay_vote_sender,
             None,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -79,6 +79,10 @@ conditional_vis_mod!(
 );
 conditional_vis_mod!(unified_scheduler, feature = "dev-context-only-utils", pub, pub(crate));
 
+/// The maximum number of worker threads that can be spawned by banking stage.
+/// 64 because `ThreadAwareAccountLocks` uses a `u64` as a bitmask to
+/// track thread placement.
+const MAX_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(64).unwrap();
 const DEFAULT_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(4).unwrap();
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -603,7 +607,6 @@ impl BankingStage {
     }
 
     pub fn max_num_workers() -> NonZeroUsize {
-        const MAX_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(64).unwrap();
         MAX_NUM_WORKERS
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -469,8 +469,10 @@ impl BankingStage {
         // Create an exit signal for the scheduler and workers
         let exit = Arc::new(AtomicBool::new(false));
 
-        // + 1 for scheduler thread
+        assert!(num_workers <= BankingStage::max_num_workers());
         let num_workers = num_workers.get();
+
+        // + 1 for scheduler thread
         let mut thread_hdls = Vec::with_capacity(num_workers + 1);
 
         // Create channels for communication between scheduler and workers
@@ -598,6 +600,11 @@ impl BankingStage {
 
     pub fn default_num_workers() -> NonZeroUsize {
         DEFAULT_NUM_WORKERS
+    }
+
+    pub fn max_num_workers() -> NonZeroUsize {
+        const MAX_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(64).unwrap();
+        MAX_NUM_WORKERS
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -52,7 +52,7 @@ pub(crate) fn ensure_banking_stage_setup(
     channels: &Channels,
     poh_recorder: &Arc<RwLock<PohRecorder>>,
     transaction_recorder: TransactionRecorder,
-    num_threads: u32,
+    num_threads: usize,
 ) {
     let root_bank = bank_forks.read().unwrap().sharable_root_bank();
     let unified_receiver = channels.unified_receiver().clone();
@@ -103,7 +103,7 @@ pub(crate) fn ensure_banking_stage_setup(
     );
 
     pool.register_banking_stage(
-        Some(num_threads.try_into().unwrap()),
+        Some(num_threads),
         unified_receiver,
         banking_packet_handler,
         transaction_recorder,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -39,6 +39,7 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_unified_scheduler_pool::{BankingStageHelper, DefaultSchedulerPool},
     std::{
+        num::NonZeroUsize,
         ops::Deref,
         sync::{Arc, RwLock},
     },
@@ -52,7 +53,7 @@ pub(crate) fn ensure_banking_stage_setup(
     channels: &Channels,
     poh_recorder: &Arc<RwLock<PohRecorder>>,
     transaction_recorder: TransactionRecorder,
-    num_threads: usize,
+    num_threads: NonZeroUsize,
 ) {
     let root_bank = bank_forks.read().unwrap().sharable_root_bank();
     let unified_receiver = channels.unified_receiver().clone();
@@ -103,7 +104,7 @@ pub(crate) fn ensure_banking_stage_setup(
     );
 
     pool.register_banking_stage(
-        Some(num_threads),
+        Some(num_threads.get()),
         unified_receiver,
         banking_packet_handler,
         transaction_recorder,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -150,6 +150,7 @@ impl Tpu {
         vote_quic_server_config: QuicServerParams,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
+        block_production_num_workers: usize,
         transaction_struct: TransactionStructure,
         enable_block_production_forwarding: bool,
         _generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */
@@ -317,7 +318,7 @@ impl Tpu {
             duplicate_confirmed_slot_sender,
         );
 
-        let banking_stage = BankingStage::new(
+        let banking_stage = BankingStage::new_num_threads(
             block_production_method,
             transaction_struct,
             poh_recorder,
@@ -325,6 +326,7 @@ impl Tpu {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_vote_receiver,
+            block_production_num_workers,
             transaction_status_sender,
             replay_vote_sender,
             log_messages_bytes_limit,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -59,6 +59,7 @@ use {
     std::{
         collections::HashMap,
         net::{SocketAddr, UdpSocket},
+        num::NonZeroUsize,
         sync::{atomic::AtomicBool, Arc, RwLock},
         thread::{self, JoinHandle},
         time::Duration,
@@ -150,7 +151,7 @@ impl Tpu {
         vote_quic_server_config: QuicServerParams,
         prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
         block_production_method: BlockProductionMethod,
-        block_production_num_workers: usize,
+        block_production_num_workers: NonZeroUsize,
         transaction_struct: TransactionStructure,
         enable_block_production_forwarding: bool,
         _generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1641,6 +1641,7 @@ impl Validator {
             vote_quic_server_config,
             &prioritization_fee_cache,
             config.block_production_method.clone(),
+            config.block_production_num_workers,
             config.transaction_struct.clone(),
             config.enable_block_production_forwarding,
             config.generator_config.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,6 +4,7 @@ pub use solana_perf::report_target_features;
 use {
     crate::{
         admin_rpc_post_init::{AdminRpcRequestMetadataPostInit, KeyUpdaterType, KeyUpdaters},
+        banking_stage::BankingStage,
         banking_trace::{self, BankingTracer, TraceError},
         cluster_info_vote_listener::VoteTracker,
         completed_data_sets_service::CompletedDataSetsService,
@@ -282,6 +283,7 @@ pub struct ValidatorConfig {
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
     pub block_verification_method: BlockVerificationMethod,
     pub block_production_method: BlockProductionMethod,
+    pub block_production_num_workers: usize,
     pub transaction_struct: TransactionStructure,
     pub enable_block_production_forwarding: bool,
     pub generator_config: Option<GeneratorConfig>,
@@ -360,6 +362,7 @@ impl ValidatorConfig {
             banking_trace_dir_byte_limit: 0,
             block_verification_method: BlockVerificationMethod::default(),
             block_production_method: BlockProductionMethod::default(),
+            block_production_num_workers: BankingStage::default_num_workers(),
             transaction_struct: TransactionStructure::default(),
             // enable forwarding by default for tests
             enable_block_production_forwarding: true,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -283,7 +283,7 @@ pub struct ValidatorConfig {
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
     pub block_verification_method: BlockVerificationMethod,
     pub block_production_method: BlockProductionMethod,
-    pub block_production_num_workers: usize,
+    pub block_production_num_workers: NonZeroUsize,
     pub transaction_struct: TransactionStructure,
     pub enable_block_production_forwarding: bool,
     pub generator_config: Option<GeneratorConfig>,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -242,7 +242,7 @@ fn test_scheduler_producing_blocks() {
         &channels,
         &poh_recorder,
         transaction_recorder,
-        BankingStage::default_or_env_num_workers(),
+        BankingStage::default_num_workers(),
     );
     bank_forks.write().unwrap().install_scheduler_pool(pool);
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -64,6 +64,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
         block_verification_method: config.block_verification_method.clone(),
         block_production_method: config.block_production_method.clone(),
+        block_production_num_workers: config.block_production_num_workers,
         transaction_struct: config.transaction_struct.clone(),
         enable_block_production_forwarding: config.enable_block_production_forwarding,
         generator_config: config.generator_config.clone(),

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -15,6 +15,7 @@ pub struct DefaultThreadArgs {
     pub accounts_db_foreground_threads: String,
     pub accounts_db_hash_threads: String,
     pub accounts_index_flush_threads: String,
+    pub block_production_num_workers: String,
     pub ip_echo_server_threads: String,
     pub rayon_global_threads: String,
     pub replay_forks_threads: String,
@@ -27,7 +28,6 @@ pub struct DefaultThreadArgs {
     pub tvu_receive_threads: String,
     pub tvu_retransmit_threads: String,
     pub tvu_sigverify_threads: String,
-    pub block_production_num_workers: String,
 }
 
 impl Default for DefaultThreadArgs {
@@ -40,6 +40,7 @@ impl Default for DefaultThreadArgs {
             accounts_db_hash_threads: AccountsDbHashThreadsArg::bounded_default().to_string(),
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
+            block_production_num_workers: BankingStage::default_num_workers().to_string(),
             ip_echo_server_threads: IpEchoServerThreadsArg::bounded_default().to_string(),
             rayon_global_threads: RayonGlobalThreadsArg::bounded_default().to_string(),
             replay_forks_threads: ReplayForksThreadsArg::bounded_default().to_string(),
@@ -56,7 +57,6 @@ impl Default for DefaultThreadArgs {
             tvu_receive_threads: TvuReceiveThreadsArg::bounded_default().to_string(),
             tvu_retransmit_threads: TvuRetransmitThreadsArg::bounded_default().to_string(),
             tvu_sigverify_threads: TvuShredSigverifyThreadsArg::bounded_default().to_string(),
-            block_production_num_workers: BankingStage::default_num_workers().to_string(),
         }
     }
 }
@@ -67,6 +67,7 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
         new_thread_arg::<AccountsDbForegroundThreadsArg>(&defaults.accounts_db_foreground_threads),
         new_thread_arg::<AccountsDbHashThreadsArg>(&defaults.accounts_db_hash_threads),
         new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_index_flush_threads),
+        new_thread_arg::<BlockProductionNumWorkersArg>(&defaults.block_production_num_workers),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
         new_thread_arg::<RayonGlobalThreadsArg>(&defaults.rayon_global_threads),
         new_thread_arg::<ReplayForksThreadsArg>(&defaults.replay_forks_threads),
@@ -83,7 +84,6 @@ pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
         new_thread_arg::<TvuReceiveThreadsArg>(&defaults.tvu_receive_threads),
         new_thread_arg::<TvuRetransmitThreadsArg>(&defaults.tvu_retransmit_threads),
         new_thread_arg::<TvuShredSigverifyThreadsArg>(&defaults.tvu_sigverify_threads),
-        new_thread_arg::<BlockProductionNumWorkersArg>(&defaults.block_production_num_workers),
     ]
 }
 
@@ -103,6 +103,7 @@ pub struct NumThreadConfig {
     pub accounts_db_foreground_threads: NonZeroUsize,
     pub accounts_db_hash_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
+    pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
     pub rayon_global_threads: NonZeroUsize,
     pub replay_forks_threads: NonZeroUsize,
@@ -113,7 +114,6 @@ pub struct NumThreadConfig {
     pub tvu_receive_threads: NonZeroUsize,
     pub tvu_retransmit_threads: NonZeroUsize,
     pub tvu_sigverify_threads: NonZeroUsize,
-    pub block_production_num_workers: NonZeroUsize,
 }
 
 pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
@@ -139,6 +139,11 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         accounts_index_flush_threads: value_t_or_exit!(
             matches,
             AccountsIndexFlushThreadsArg::NAME,
+            NonZeroUsize
+        ),
+        block_production_num_workers: value_t_or_exit!(
+            matches,
+            BlockProductionNumWorkersArg::NAME,
             NonZeroUsize
         ),
         ip_echo_server_threads: value_t_or_exit!(
@@ -177,11 +182,6 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         tvu_sigverify_threads: value_t_or_exit!(
             matches,
             TvuShredSigverifyThreadsArg::NAME,
-            NonZeroUsize
-        ),
-        block_production_num_workers: value_t_or_exit!(
-            matches,
-            BlockProductionNumWorkersArg::NAME,
             NonZeroUsize
         ),
     }
@@ -261,6 +261,25 @@ impl ThreadArg for AccountsIndexFlushThreadsArg {
 
     fn default() -> usize {
         accounts_index::default_num_flush_threads().get()
+    }
+}
+
+struct BlockProductionNumWorkersArg;
+impl ThreadArg for BlockProductionNumWorkersArg {
+    const NAME: &'static str = "block_production_num_workers";
+    const LONG_NAME: &'static str = "block-production-num-workers";
+    const HELP: &'static str = "Number of worker threads to use for block production";
+
+    fn default() -> usize {
+        BankingStage::default_num_workers()
+    }
+
+    fn min() -> usize {
+        1
+    }
+
+    fn max() -> usize {
+        64
     }
 }
 
@@ -414,24 +433,5 @@ impl ThreadArg for TvuShredSigverifyThreadsArg {
 
     fn default() -> usize {
         get_thread_count()
-    }
-}
-
-struct BlockProductionNumWorkersArg;
-impl ThreadArg for BlockProductionNumWorkersArg {
-    const NAME: &'static str = "block_production_num_workers";
-    const LONG_NAME: &'static str = "block-production-num-workers";
-    const HELP: &'static str = "Number of worker threads to use for block production";
-
-    fn default() -> usize {
-        BankingStage::default_num_workers()
-    }
-
-    fn min() -> usize {
-        1
-    }
-
-    fn max() -> usize {
-        64
     }
 }

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -279,7 +279,7 @@ impl ThreadArg for BlockProductionNumWorkersArg {
     }
 
     fn max() -> usize {
-        64
+        BankingStage::max_num_workers().get()
     }
 }
 

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -271,7 +271,7 @@ impl ThreadArg for BlockProductionNumWorkersArg {
     const HELP: &'static str = "Number of worker threads to use for block production";
 
     fn default() -> usize {
-        BankingStage::default_num_workers()
+        BankingStage::default_num_workers().get()
     }
 
     fn min() -> usize {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -681,7 +681,7 @@ pub fn execute(
             "block_production_method",
             BlockProductionMethod
         ),
-        block_production_num_workers: block_production_num_workers.get(),
+        block_production_num_workers,
         transaction_struct: value_t_or_exit!(matches, "transaction_struct", TransactionStructure),
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
         banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -103,6 +103,7 @@ pub fn execute(
         accounts_db_foreground_threads,
         accounts_db_hash_threads,
         accounts_index_flush_threads,
+        block_production_num_workers,
         ip_echo_server_threads,
         rayon_global_threads,
         replay_forks_threads,
@@ -113,7 +114,6 @@ pub fn execute(
         tvu_receive_threads,
         tvu_retransmit_threads,
         tvu_sigverify_threads,
-        block_production_num_workers,
     } = cli::thread_args::parse_num_threads_args(matches);
 
     let identity_keypair = Arc::new(run_args.identity_keypair);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -113,6 +113,7 @@ pub fn execute(
         tvu_receive_threads,
         tvu_retransmit_threads,
         tvu_sigverify_threads,
+        block_production_num_workers,
     } = cli::thread_args::parse_num_threads_args(matches);
 
     let identity_keypair = Arc::new(run_args.identity_keypair);
@@ -680,6 +681,7 @@ pub fn execute(
             "block_production_method",
             BlockProductionMethod
         ),
+        block_production_num_workers: block_production_num_workers.get(),
         transaction_struct: value_t_or_exit!(matches, "transaction_struct", TransactionStructure),
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
         banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),


### PR DESCRIPTION
#### Problem
- want to add admin-rpc to respawn banking threads with different configurations
- weird if we allow respawning with different worker counts through admin-rpc but not via cli

#### Summary of Changes
- Add validator cli to spawn different numbers of worker threads
- Update changelog to reflect removal of the env-var

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
