### PR TITLE
validator: Resolve Rust 1.88 clippy lints and format strings

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -622,9 +622,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         pubkey_str: String,
     ) -> Result<HashMap<RpcAccountIndex, usize>> {
-        debug!(
-            "get_secondary_index_key_size rpc request received: {pubkey_str:?}"
-        );
+        debug!("get_secondary_index_key_size rpc request received: {pubkey_str:?}");
         let index_key = verify_pubkey(&pubkey_str)?;
         meta.with_post_init(|post_init| {
             let bank = post_init.bank_forks.read().unwrap().root_bank();

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -538,8 +538,8 @@ impl AdminRpc for AdminRpcImpl {
         let mut write_staked_nodes = meta.staked_nodes_overrides.write().unwrap();
         write_staked_nodes.clear();
         write_staked_nodes.extend(loaded_config);
-        info!("Staked nodes overrides loaded from {}", path);
-        debug!("overrides map: {:?}", write_staked_nodes);
+        info!("Staked nodes overrides loaded from {path}");
+        debug!("overrides map: {write_staked_nodes:?}");
         Ok(())
     }
 
@@ -548,7 +548,7 @@ impl AdminRpc for AdminRpcImpl {
     }
 
     fn select_active_interface(&self, meta: Self::Metadata, interface: IpAddr) -> Result<()> {
-        debug!("select_active_interface received: {}", interface);
+        debug!("select_active_interface received: {interface}");
         meta.with_post_init(|post_init| {
             let node = post_init.node.as_ref().ok_or_else(|| {
                 jsonrpc_core::Error::invalid_params("`Node` not initialized in post_init")
@@ -557,8 +557,7 @@ impl AdminRpc for AdminRpcImpl {
             node.switch_active_interface(interface, &post_init.cluster_info)
                 .map_err(|e| {
                     jsonrpc_core::Error::invalid_params(format!(
-                        "Switching failed due to error {}",
-                        e
+                        "Switching failed due to error {e}"
                     ))
                 })?;
             info!("Switched primary interface to {interface}");
@@ -624,8 +623,7 @@ impl AdminRpc for AdminRpcImpl {
         pubkey_str: String,
     ) -> Result<HashMap<RpcAccountIndex, usize>> {
         debug!(
-            "get_secondary_index_key_size rpc request received: {:?}",
-            pubkey_str
+            "get_secondary_index_key_size rpc request received: {pubkey_str:?}"
         );
         let index_key = verify_pubkey(&pubkey_str)?;
         meta.with_post_init(|post_init| {
@@ -832,7 +830,7 @@ pub fn run(ledger_path: &Path, metadata: AdminRpcRequestMetadata) {
 
             match server {
                 Err(err) => {
-                    warn!("Unable to start admin rpc service: {:?}", err);
+                    warn!("Unable to start admin rpc service: {err:?}");
                 }
                 Ok(server) => {
                     info!("started admin rpc service!");
@@ -919,7 +917,7 @@ where
 pub fn load_staked_nodes_overrides(
     path: &String,
 ) -> std::result::Result<StakedNodesOverrides, Box<dyn error::Error>> {
-    debug!("Loading staked nodes overrides configuration from {}", path);
+    debug!("Loading staked nodes overrides configuration from {path}");
     if Path::new(&path).exists() {
         let file = std::fs::File::open(path)?;
         Ok(serde_yaml::from_reader(file)?)

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -953,7 +953,7 @@ fn build_known_snapshot_hashes<'a>(
         if is_any_same_slot_and_different_hash(&full_snapshot_hash, known_snapshot_hashes.keys()) {
             warn!(
                 "Ignoring all snapshot hashes from node {node} since we've seen a different full \
-                 snapshot hash with this slot. Full snapshot hash: {full_snapshot_hash:?}"
+                 snapshot hash with this slot. full snapshot hash: {full_snapshot_hash:?}"
             );
             debug!(
                 "known full snapshot hashes: {:#?}",
@@ -979,7 +979,7 @@ fn build_known_snapshot_hashes<'a>(
             ) {
                 warn!(
                     "Ignoring incremental snapshot hash from node {node} since we've seen a \
-                     different incremental snapshot hash with this slot. Full snapshot hash: \
+                     different incremental snapshot hash with this slot. full snapshot hash: \
                      {full_snapshot_hash:?}, incremental snapshot hash: \
                      {incremental_snapshot_hash:?}"
                 );

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -465,8 +465,8 @@ fn get_vetted_rpc_nodes(
             Err(err) => {
                 error!(
                     "Failed to get RPC nodes: {err}. Consider checking system clock, removing \
-                    `--no-port-check`, or adjusting `--known-validator ...` arguments as \
-                    applicable"
+                     `--no-port-check`, or adjusting `--known-validator ...` arguments as \
+                     applicable"
                 );
                 exit(1);
             }
@@ -953,8 +953,7 @@ fn build_known_snapshot_hashes<'a>(
         if is_any_same_slot_and_different_hash(&full_snapshot_hash, known_snapshot_hashes.keys()) {
             warn!(
                 "Ignoring all snapshot hashes from node {node} since we've seen a different full \
-                 snapshot hash with this slot.\
-                 \nfull snapshot hash: {full_snapshot_hash:?}"
+                 snapshot hash with this slot.\nfull snapshot hash: {full_snapshot_hash:?}"
             );
             debug!(
                 "known full snapshot hashes: {:#?}",
@@ -980,9 +979,9 @@ fn build_known_snapshot_hashes<'a>(
             ) {
                 warn!(
                     "Ignoring incremental snapshot hash from node {node} since we've seen a \
-                     different incremental snapshot hash with this slot.\
-                     \nfull snapshot hash: {full_snapshot_hash:?}\
-                     \nincremental snapshot hash: {incremental_snapshot_hash:?}"
+                     different incremental snapshot hash with this slot.\nfull snapshot hash: \
+                     {full_snapshot_hash:?}\nincremental snapshot hash: \
+                     {incremental_snapshot_hash:?}"
                 );
                 debug!(
                     "known incremental snapshot hashes based on this slot: {:#?}",

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -953,7 +953,7 @@ fn build_known_snapshot_hashes<'a>(
         if is_any_same_slot_and_different_hash(&full_snapshot_hash, known_snapshot_hashes.keys()) {
             warn!(
                 "Ignoring all snapshot hashes from node {node} since we've seen a different full \
-                 snapshot hash with this slot.\nfull snapshot hash: {full_snapshot_hash:?}"
+                 snapshot hash with this slot. Full snapshot hash: {full_snapshot_hash:?}"
             );
             debug!(
                 "known full snapshot hashes: {:#?}",
@@ -979,8 +979,8 @@ fn build_known_snapshot_hashes<'a>(
             ) {
                 warn!(
                     "Ignoring incremental snapshot hash from node {node} since we've seen a \
-                     different incremental snapshot hash with this slot.\nfull snapshot hash: \
-                     {full_snapshot_hash:?}\nincremental snapshot hash: \
+                     different incremental snapshot hash with this slot. Full snapshot hash: \
+                     {full_snapshot_hash:?}, incremental snapshot hash: \
                      {incremental_snapshot_hash:?}"
                 );
                 debug!(

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -472,8 +472,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                     [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -484,8 +484,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .help(
                     "Address of the mint account that will receive tokens created at genesis. If \
-                     the ledger already exists then this parameter is silently ignored \
-                     [default: client keypair]",
+                     the ledger already exists then this parameter is silently ignored [default: \
+                     client keypair]",
                 ),
         )
         .arg(
@@ -716,15 +716,15 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                         .parse::<f64>()
                         .map_err(|err| format!("error parsing '{value}': {err}"))
                         .and_then(|rate| match rate.partial_cmp(&0.0) {
-			    Some(Ordering::Greater) | Some(Ordering::Equal) => Ok(()),
-			    Some(Ordering::Less) | None => Err(String::from("value must be >= 0")),
+                            Some(Ordering::Greater) | Some(Ordering::Equal) => Ok(()),
+                            Some(Ordering::Less) | None => Err(String::from("value must be >= 0")),
                         })
                 })
                 .takes_value(true)
                 .allow_hyphen_values(true)
                 .help(
-                    "Override default inflation with fixed rate. If the ledger already exists then \
-                     this parameter is silently ignored",
+                    "Override default inflation with fixed rate. If the ledger already exists \
+                     then this parameter is silently ignored",
                 ),
         )
         .arg(
@@ -749,7 +749,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
                 .default_value("127.0.0.1")
-                .help("IP address to bind the validator ports [default: 127.0.0.1]. Can be repeated to specify multihoming options."),
+                .help(
+                    "IP address to bind the validator ports [default: 127.0.0.1]. Can be repeated \
+                     to specify multihoming options.",
+                ),
         )
         .arg(
             Arg::with_name("clone_account")
@@ -774,9 +777,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .multiple(true)
                 .requires("json_rpc_url")
                 .help(
-                    "Copy an address lookup table and all accounts it references from the cluster referenced by the --url \
-                     argument in the genesis configuration. If the ledger already exists then this \
-                     parameter is silently ignored",
+                    "Copy an address lookup table and all accounts it references from the cluster \
+                     referenced by the --url argument in the genesis configuration. If the ledger \
+                     already exists then this parameter is silently ignored",
                 ),
         )
         .arg(
@@ -917,9 +920,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(false)
                 .requires("json_rpc_url")
                 .help(
-                    "Copy a feature set from the cluster referenced by the --url \
-                     argument in the genesis configuration. If the ledger \
-                     already exists then this parameter is silently ignored",
+                    "Copy a feature set from the cluster referenced by the --url argument in the \
+                     genesis configuration. If the ledger already exists then this parameter is \
+                     silently ignored",
                 ),
         )
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -234,7 +234,7 @@ pub fn warn_for_deprecated_arguments(matches: &ArgMatches) {
                 }
             }
             // this can not rely on logger since it is not initialized at the time of call
-            eprintln!("{}", msg);
+            eprintln!("{msg}");
         }
     }
 }

--- a/validator/src/commands/authorized_voter/mod.rs
+++ b/validator/src/commands/authorized_voter/mod.rs
@@ -42,11 +42,13 @@ pub fn command<'a>() -> App<'a, 'a> {
                         .takes_value(true)
                         .validator(is_keypair)
                         .help(
-                            "Path to keypair of the authorized voter to add [default: read JSON keypair from stdin]",
+                            "Path to keypair of the authorized voter to add [default: read JSON \
+                             keypair from stdin]",
                         ),
                 )
                 .after_help(
-                    "Note: the new authorized voter only applies to the currently running validator instance",
+                    "Note: the new authorized voter only applies to the currently running \
+                     validator instance",
                 ),
         )
         .subcommand(

--- a/validator/src/commands/exit/mod.rs
+++ b/validator/src/commands/exit/mod.rs
@@ -63,7 +63,8 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .long("force")
                 .takes_value(false)
                 .help(
-                    "Request the validator exit immediately instead of waiting for a restart window",
+                    "Request the validator exit immediately instead of waiting for a restart \
+                     window",
                 ),
         )
         .arg(
@@ -86,9 +87,7 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .validator(is_parsable::<usize>)
                 .value_name("MINUTES")
                 .default_value(DEFAULT_MIN_IDLE_TIME)
-                .help(
-                    "Minimum time that the validator should not be leader before restarting",
-                ),
+                .help("Minimum time that the validator should not be leader before restarting"),
         )
         .arg(
             Arg::with_name("max_delinquent_stake")
@@ -134,8 +133,9 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     // Since PostExitAction::Wait case is opt-in (via --wait-for-exit), the
     // result is checked ONLY in that case to provide a friendlier upgrade
     // path for users who are NOT using --wait-for-exit
-    const WAIT_FOR_EXIT_UNSUPPORTED_ERROR: &str =
-        "remote process exit cannot be waited on. `--wait-for-exit` is not supported by the remote process";
+    const WAIT_FOR_EXIT_UNSUPPORTED_ERROR: &str = "remote process exit cannot be waited on. \
+                                                   `--wait-for-exit` is not supported by the \
+                                                   remote process";
     let post_exit_action = exit_args.post_exit_action.clone();
     let validator_pid = admin_rpc_service::runtime().block_on(async move {
         let admin_client = admin_rpc_service::connect(ledger_path).await?;

--- a/validator/src/commands/repair_whitelist/mod.rs
+++ b/validator/src/commands/repair_whitelist/mod.rs
@@ -73,14 +73,16 @@ pub fn command<'a>() -> App<'a, 'a> {
                         .help("Set the validator's repair protocol whitelist"),
                 )
                 .after_help(
-                    "Note: repair protocol whitelist changes only apply to the currently running validator instance",
+                    "Note: repair protocol whitelist changes only apply to the currently running \
+                     validator instance",
                 ),
         )
         .subcommand(
             SubCommand::with_name("remove-all")
                 .about("Clear the validator's repair protocol whitelist")
                 .after_help(
-                    "Note: repair protocol whitelist changes only apply to the currently running validator instance",
+                    "Note: repair protocol whitelist changes only apply to the currently running \
+                     validator instance",
                 ),
         )
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -647,8 +647,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.rocksdb_shred_compaction)
             .help(
                 "Controls how RocksDB compacts shreds. *WARNING*: You will lose your Blockstore \
-                 data when you switch between options. Possible values are: 'level': stores \
-                 shreds using RocksDB's default (level) compaction.",
+                 data when you switch between options.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -109,8 +109,7 @@ impl FromClapArgMatches for RunArgs {
 }
 
 pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 'a> {
-    app
-    .arg(
+    app.arg(
         Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
             .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
             .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
@@ -133,8 +132,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .requires("vote_account")
             .multiple(true)
             .help(
-                "Include an additional authorized voter keypair. May be specified multiple \
-                 times. [default: the --identity keypair]",
+                "Include an additional authorized voter keypair. May be specified multiple times. \
+                 [default: the --identity keypair]",
             ),
     )
     .arg(
@@ -145,9 +144,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_pubkey_or_keypair)
             .requires("identity")
             .help(
-                "Validator vote account public key. If unspecified, voting will be disabled. \
-                 The authorized voter for the account must either be the --identity keypair \
-                 or set by the --authorized-voter argument",
+                "Validator vote account public key. If unspecified, voting will be disabled. The \
+                 authorized voter for the account must either be the --identity keypair or set by \
+                 the --authorized-voter argument",
             ),
     )
     .arg(
@@ -156,8 +155,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("FILE")
             .takes_value(true)
             .help(
-                "Create this file if it doesn't already exist once validator initialization \
-                 is complete",
+                "Create this file if it doesn't already exist once validator initialization is \
+                 complete",
             ),
     )
     .arg(
@@ -185,8 +184,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("no-snapshot-fetch")
             .takes_value(false)
             .help(
-                "Do not attempt to fetch a snapshot from the cluster, start from a local \
-                 snapshot if present",
+                "Do not attempt to fetch a snapshot from the cluster, start from a local snapshot \
+                 if present",
             ),
     )
     .arg(
@@ -218,10 +217,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("restricted-repair-only-mode")
             .takes_value(false)
             .help(
-                "Do not publish the Gossip, TPU, TVU or Repair Service ports. Doing so causes \
-                 the node to operate in a limited capacity that reduces its exposure to the \
-                 rest of the cluster. The --no-voting flag is implicit when this flag is \
-                 enabled",
+                "Do not publish the Gossip, TPU, TVU or Repair Service ports. Doing so causes the \
+                 node to operate in a limited capacity that reduces its exposure to the rest of \
+                 the cluster. The --no-voting flag is implicit when this flag is enabled",
             ),
     )
     .arg(
@@ -302,8 +300,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.rpc_max_multiple_accounts)
             .help(
-                "Override the default maximum accounts accepted by the getMultipleAccounts \
-                 JSON RPC method",
+                "Override the default maximum accounts accepted by the getMultipleAccounts JSON \
+                 RPC method",
             ),
     )
     .arg(
@@ -313,18 +311,16 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.health_check_slot_distance)
             .help(
-                "Report this validator as healthy if its latest replayed optimistically \
-                 confirmed slot is within the specified number of slots from the cluster's \
-                 latest optimistically confirmed slot",
+                "Report this validator as healthy if its latest replayed optimistically confirmed \
+                 slot is within the specified number of slots from the cluster's latest \
+                 optimistically confirmed slot",
             ),
     )
     .arg(
         Arg::with_name("skip_preflight_health_check")
             .long("skip-preflight-health-check")
             .takes_value(false)
-            .help(
-                "Skip health check when running a preflight check",
-            ),
+            .help("Skip health check when running a preflight check"),
     )
     .arg(
         Arg::with_name("rpc_faucet_addr")
@@ -341,9 +337,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .multiple(true)
             .help(
-                "Comma separated persistent accounts location. \
-                May be specified multiple times. \
-                [default: <LEDGER>/accounts]",
+                "Comma separated persistent accounts location. May be specified multiple times. \
+                 [default: <LEDGER>/accounts]",
             ),
     )
     .arg(
@@ -361,14 +356,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .help("Use DIR as the base location for snapshots.")
             .long_help(
-                "Use DIR as the base location for snapshots. \
-                 Snapshot archives will use DIR unless --full-snapshot-archive-path or \
-                 --incremental-snapshot-archive-path is specified. \
-                 Additionally, a subdirectory named \"snapshots\" will be created in DIR. \
-                 This subdirectory holds internal files/data that are used when generating \
-                 snapshot archives. \
-                 [default: --ledger value]",
-             ),
+                "Use DIR as the base location for snapshots. Snapshot archives will use DIR \
+                 unless --full-snapshot-archive-path or --incremental-snapshot-archive-path is \
+                 specified. Additionally, a subdirectory named \"snapshots\" will be created in \
+                 DIR. This subdirectory holds internal files/data that are used when generating \
+                 snapshot archives. [default: --ledger value]",
+            ),
     )
     .arg(
         Arg::with_name(use_snapshot_archives_at_startup::cli::NAME)
@@ -384,10 +377,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("full-snapshot-archive-path")
             .value_name("DIR")
             .takes_value(true)
-            .help(
-                "Use DIR as full snapshot archives location \
-                 [default: --snapshots value]",
-             ),
+            .help("Use DIR as full snapshot archives location [default: --snapshots value]"),
     )
     .arg(
         Arg::with_name("incremental_snapshot_archive_path")
@@ -395,10 +385,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .conflicts_with("no-incremental-snapshots")
             .value_name("DIR")
             .takes_value(true)
-            .help(
-                "Use DIR as incremental snapshot archives location \
-                 [default: --snapshots value]",
-            ),
+            .help("Use DIR as incremental snapshot archives location [default: --snapshots value]"),
     )
     .arg(
         Arg::with_name("tower")
@@ -422,8 +409,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(solana_net_utils::is_host_port)
             .help(
-                "Specify TPU address to advertise in gossip \
-                 [default: ask --entrypoint or localhost when --entrypoint is not provided]",
+                "Specify TPU address to advertise in gossip [default: ask --entrypoint or \
+                 localhost when --entrypoint is not provided]",
             ),
     )
     .arg(
@@ -433,8 +420,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(solana_net_utils::is_host_port)
             .help(
-                "Specify TPU Forwards address to advertise in gossip [default: ask \
-                 --entrypoint or localhostwhen --entrypoint is not provided]",
+                "Specify TPU Forwards address to advertise in gossip [default: ask --entrypoint \
+                 or localhostwhen --entrypoint is not provided]",
             ),
     )
     .arg(
@@ -444,7 +431,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .hidden(hidden_unless_forced())
             .validator(solana_net_utils::is_host_port)
-            .help("TPU Vortexor Receiver address to which verified transaction packet will be forwarded."),
+            .help(
+                "TPU Vortexor Receiver address to which verified transaction packet will be \
+                 forwarded.",
+            ),
     )
     .arg(
         Arg::with_name("public_rpc_addr")
@@ -483,14 +473,18 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("no_snapshots")
             .long("no-snapshots")
             .takes_value(false)
-            .conflicts_with_all(&["no_incremental_snapshots", "snapshot_interval_slots", "full_snapshot_interval_slots"])
-            .help("Disable all snapshot generation")
+            .conflicts_with_all(&[
+                "no_incremental_snapshots",
+                "snapshot_interval_slots",
+                "full_snapshot_interval_slots",
+            ])
+            .help("Disable all snapshot generation"),
     )
     .arg(
         Arg::with_name("no_incremental_snapshots")
             .long("no-incremental-snapshots")
             .takes_value(false)
-            .help("Disable incremental snapshots")
+            .help("Disable incremental snapshots"),
     )
     .arg(
         Arg::with_name("snapshot_interval_slots")
@@ -502,10 +496,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_non_zero)
             .help("Number of slots between generating snapshots")
             .long_help(
-                "Number of slots between generating snapshots. \
-                 If incremental snapshots are enabled, this sets the incremental snapshot interval. \
-                 If incremental snapshots are disabled, this sets the full snapshot interval. \
-                 Must be greater than zero.",
+                "Number of slots between generating snapshots. If incremental snapshots are \
+                 enabled, this sets the incremental snapshot interval. If incremental snapshots \
+                 are disabled, this sets the full snapshot interval. Must be greater than zero.",
             ),
     )
     .arg(
@@ -517,9 +510,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_non_zero)
             .help("Number of slots between generating full snapshots")
             .long_help(
-                "Number of slots between generating full snapshots. \
-                 Only used when incremental snapshots are enabled. \
-                 Must be greater than the incremental snapshot interval. \
+                "Number of slots between generating full snapshots. Only used when incremental \
+                 snapshots are enabled. Must be greater than the incremental snapshot interval. \
                  Must be greater than zero.",
             ),
     )
@@ -532,8 +524,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.maximum_full_snapshot_archives_to_retain)
             .validator(validate_maximum_full_snapshot_archives_to_retain)
             .help(
-                "The maximum number of full snapshot archives to hold on to when purging \
-                 older snapshots.",
+                "The maximum number of full snapshot archives to hold on to when purging older \
+                 snapshots.",
             ),
     )
     .arg(
@@ -544,8 +536,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.maximum_incremental_snapshot_archives_to_retain)
             .validator(validate_maximum_incremental_snapshot_archives_to_retain)
             .help(
-                "The maximum number of incremental snapshot archives to hold on to when \
-                 purging older snapshots.",
+                "The maximum number of incremental snapshot archives to hold on to when purging \
+                 older snapshots.",
             ),
     )
     .arg(
@@ -556,8 +548,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(solana_perf::thread::is_niceness_adjustment_valid)
             .default_value(&default_args.snapshot_packager_niceness_adjustment)
             .help(
-                "Add this value to niceness of snapshot packager thread. Negative value \
-                 increases priority, positive value decreases priority.",
+                "Add this value to niceness of snapshot packager thread. Negative value increases \
+                 priority, positive value decreases priority.",
             ),
     )
     .arg(
@@ -567,9 +559,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.min_snapshot_download_speed)
             .help(
-                "The minimal speed of snapshot downloads measured in bytes/second. If the \
-                 initial download speed falls below this threshold, the system will retry the \
-                 download against a different rpc node.",
+                "The minimal speed of snapshot downloads measured in bytes/second. If the initial \
+                 download speed falls below this threshold, the system will retry the download \
+                 against a different rpc node.",
             ),
     )
     .arg(
@@ -579,8 +571,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .default_value(&default_args.max_snapshot_download_abort)
             .help(
-                "The maximum number of times to abort and retry when encountering a slow \
-                 snapshot download.",
+                "The maximum number of times to abort and retry when encountering a slow snapshot \
+                 download.",
             ),
     )
     .arg(
@@ -654,9 +646,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .possible_values(&["level"])
             .default_value(&default_args.rocksdb_shred_compaction)
             .help(
-                "Controls how RocksDB compacts shreds. *WARNING*: You will lose your \
-                 Blockstore data when you switch between options. Possible values are: \
-                 'level': stores shreds using RocksDB's default (level) compaction.",
+                "Controls how RocksDB compacts shreds. *WARNING*: You will lose your Blockstore \
+                 data when you switch between options. Possible values are: 'level': stores \
+                 shreds using RocksDB's default (level) compaction.",
             ),
     )
     .arg(
@@ -681,8 +673,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<usize>)
             .default_value(&default_args.rocksdb_perf_sample_interval)
             .help(
-                "Controls how often RocksDB read/write performance samples are collected. \
-                 Perf samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate.",
+                "Controls how often RocksDB read/write performance samples are collected. Perf \
+                 samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate.",
             ),
     )
     .arg(
@@ -756,8 +748,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("no-wait-for-vote-to-start-leader")
             .help(
                 "If the validator starts up with no ledger, it will wait to start block \
-                 production until it sees a vote land in a rooted slot. This prevents \
-                 double signing. Turn off to risk double signing a block.",
+                 production until it sees a vote land in a rooted slot. This prevents double \
+                 signing. Turn off to risk double signing a block.",
             ),
     )
     .arg(
@@ -778,9 +770,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .multiple(true)
             .takes_value(true)
             .help(
-                "A snapshot hash must be published in gossip by this validator to be \
-                 accepted. May be specified multiple times. If unspecified any snapshot hash \
-                 will be accepted",
+                "A snapshot hash must be published in gossip by this validator to be accepted. \
+                 May be specified multiple times. If unspecified any snapshot hash will be \
+                 accepted",
             ),
     )
     .arg(
@@ -821,9 +813,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .multiple(true)
             .takes_value(true)
             .help(
-                "A list of validators to prioritize repairs from. If specified, repair \
-                 requests from validators in the list will be prioritized over requests from \
-                 other validators. [default: all validators]",
+                "A list of validators to prioritize repairs from. If specified, repair requests \
+                 from validators in the list will be prioritized over requests from other \
+                 validators. [default: all validators]",
             ),
     )
     .arg(
@@ -834,8 +826,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .multiple(true)
             .takes_value(true)
             .help(
-                "A list of validators to gossip with. If specified, gossip will not \
-                 push/pull from from validators outside this set. [default: all validators]",
+                "A list of validators to gossip with. If specified, gossip will not push/pull \
+                 from from validators outside this set. [default: all validators]",
             ),
     )
     .arg(
@@ -932,9 +924,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.num_quic_endpoints)
             .validator(is_parsable::<usize>)
             .hidden(hidden_unless_forced())
-            .help("The number of QUIC endpoints used for TPU and TPU-Forward. It can be increased to \
-                   increase network ingest throughput, at the expense of higher CPU and general \
-                   validator load."),
+            .help(
+                "The number of QUIC endpoints used for TPU and TPU-Forward. It can be increased \
+                 to increase network ingest throughput, at the expense of higher CPU and general \
+                 validator load.",
+            ),
     )
     .arg(
         Arg::with_name("staked_nodes_overrides")
@@ -943,10 +937,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .help(
                 "Provide path to a yaml file with custom overrides for stakes of specific \
-                 identities. Overriding the amount of stake this validator considers as valid \
-                 for other peers in network. The stake amount is used for calculating the \
-                 number of QUIC streams permitted from the peer and vote packet sender stage. \
-                 Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}",
+                 identities. Overriding the amount of stake this validator considers as valid for \
+                 other peers in network. The stake amount is used for calculating the number of \
+                 QUIC streams permitted from the peer and vote packet sender stage. Format of the \
+                 file: `staked_map_id: {<pubkey>: <SOL stake amount>}",
             ),
     )
     .arg(
@@ -957,8 +951,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(solana_net_utils::is_host)
             .default_value(&default_args.bind_address)
             .multiple(true)
-            .help("Repeatable. IP addresses to bind the validator ports on. First is primary (used on startup), the rest may be switched to during operation."),
-        )
+            .help(
+                "Repeatable. IP addresses to bind the validator ports on. First is primary (used \
+                 on startup), the rest may be switched to during operation.",
+            ),
+    )
     .arg(
         Arg::with_name("rpc_bind_address")
             .long("rpc-bind-address")
@@ -966,8 +963,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(solana_net_utils::is_host)
             .help(
-                "IP address to bind the RPC port [default: 127.0.0.1 if --private-rpc is \
-                 present, otherwise use --bind-address]",
+                "IP address to bind the RPC port [default: 127.0.0.1 if --private-rpc is present, \
+                 otherwise use --bind-address]",
             ),
     )
     .arg(
@@ -998,7 +995,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             })
             .takes_value(true)
             .default_value(&default_args.rpc_blocking_threads)
-            .help("Number of blocking threads to use for servicing CPU bound RPC requests (eg getMultipleAccounts)"),
+            .help(
+                "Number of blocking threads to use for servicing CPU bound RPC requests (eg \
+                 getMultipleAccounts)",
+            ),
     )
     .arg(
         Arg::with_name("rpc_niceness_adj")
@@ -1008,8 +1008,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(solana_perf::thread::is_niceness_adjustment_valid)
             .default_value(&default_args.rpc_niceness_adjustment)
             .help(
-                "Add this value to niceness of RPC threads. Negative value increases \
-                 priority, positive value decreases priority.",
+                "Add this value to niceness of RPC threads. Negative value increases priority, \
+                 positive value decreases priority.",
             ),
     )
     .arg(
@@ -1076,8 +1076,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<usize>)
             .default_value(&default_args.rpc_pubsub_max_active_subscriptions)
             .help(
-                "The maximum number of active subscriptions that RPC PubSub will accept \
-                 across all connections.",
+                "The maximum number of active subscriptions that RPC PubSub will accept across \
+                 all connections.",
             ),
     )
     .arg(
@@ -1100,8 +1100,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<usize>)
             .default_value(&default_args.rpc_pubsub_queue_capacity_bytes)
             .help(
-                "The maximum total size of notifications that RPC PubSub will store across \
-                 all connections.",
+                "The maximum total size of notifications that RPC PubSub will store across all \
+                 connections.",
             ),
     )
     .arg(
@@ -1202,13 +1202,15 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .multiple(true)
             .value_name("HOST:PORT")
             .validator(solana_net_utils::is_host_port)
-            .help("Peer(s) to broadcast transactions to instead of the current leader")
+            .help("Peer(s) to broadcast transactions to instead of the current leader"),
     )
     .arg(
         Arg::with_name("rpc_send_transaction_also_leader")
             .long("rpc-send-transaction-also-leader")
             .requires("rpc_send_transaction_tpu_peer")
-            .help("With `--rpc-send-transaction-tpu-peer HOST:PORT`, also send to the current leader")
+            .help(
+                "With `--rpc-send-transaction-tpu-peer HOST:PORT`, also send to the current leader",
+            ),
     )
     .arg(
         Arg::with_name("rpc_scan_and_fix_roots")
@@ -1260,10 +1262,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .help("The compression level to use when archiving with zstd")
             .long_help(
-                "The compression level to use when archiving with zstd. \
-                 Higher compression levels generally produce higher \
-                 compression ratio at the expense of speed and memory. \
-                 See the zstd manpage for more information."
+                "The compression level to use when archiving with zstd. Higher compression levels \
+                 generally produce higher compression ratio at the expense of speed and memory. \
+                 See the zstd manpage for more information.",
             ),
     )
     .arg(
@@ -1346,16 +1347,16 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .multiple(true)
             .value_name("KEY")
             .help(
-                "When account indexes are enabled, only include specific keys in the index. \
-                 This overrides --account-index-exclude-key.",
+                "When account indexes are enabled, only include specific keys in the index. This \
+                 overrides --account-index-exclude-key.",
             ),
     )
     .arg(
         Arg::with_name("accounts_db_verify_refcounts")
             .long("accounts-db-verify-refcounts")
             .help(
-                "Debug option to scan all append vecs and verify account index refcounts \
-                 prior to clean",
+                "Debug option to scan all append vecs and verify account index refcounts prior to \
+                 clean",
             )
             .hidden(hidden_unless_forced()),
     )
@@ -1366,12 +1367,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .possible_values(&["all", "only-abnormal", "only-abnormal-with-verify"])
             .help(
                 "Debug option to use different type of filtering for accounts index scan in \
-                shrinking. \"all\" will scan both in-memory and on-disk accounts index, which is the default. \
-                \"only-abnormal\" will scan in-memory accounts index only for abnormal entries and \
-                skip scanning on-disk accounts index by assuming that on-disk accounts index contains \
-                only normal accounts index entry. \"only-abnormal-with-verify\" is similar to \
-                \"only-abnormal\", which will scan in-memory index for abnormal entries, but will also \
-                verify that on-disk account entries are indeed normal.",
+                 shrinking. \"all\" will scan both in-memory and on-disk accounts index, which is \
+                 the default. \"only-abnormal\" will scan in-memory accounts index only for \
+                 abnormal entries and skip scanning on-disk accounts index by assuming that \
+                 on-disk accounts index contains only normal accounts index entry. \
+                 \"only-abnormal-with-verify\" is similar to \"only-abnormal\", which will scan \
+                 in-memory index for abnormal entries, but will also verify that on-disk account \
+                 entries are indeed normal.",
             )
             .hidden(hidden_unless_forced()),
     )
@@ -1387,7 +1389,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(&["mmap", "file"])
-            .help("Access account storages using this method")
+            .help("Access account storages using this method"),
     )
     .arg(
         Arg::with_name("accounts_db_ancient_append_vecs")
@@ -1426,8 +1428,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<u64>)
             .takes_value(true)
             .help(
-                "How large the write cache for account data can become. If this is exceeded, \
-                 the cache is flushed more aggressively.",
+                "How large the write cache for account data can become. If this is exceeded, the \
+                 cache is flushed more aggressively.",
             ),
     )
     .arg(
@@ -1441,10 +1443,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .require_delimiter(true)
             .help("How large the read cache for account data can become, in bytes")
             .long_help(
-                "How large the read cache for account data can become, in bytes. \
-                 The values will be the low and high watermarks for the cache. \
-                 When the cache exceeds the high watermark, entries will \
-                 be evicted until the size reaches the low watermark."
+                "How large the read cache for account data can become, in bytes. The values will \
+                 be the low and high watermarks for the cache. When the cache exceeds the high \
+                 watermark, entries will be evicted until the size reaches the low watermark.",
             )
             .hidden(hidden_unless_forced()),
     )
@@ -1455,8 +1456,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .validator(is_parsable::<usize>)
             .takes_value(true)
             .help(
-                "How large accumulated results from an accounts index scan can become. If \
-                 this is exceeded, the scan aborts.",
+                "How large accumulated results from an accounts index scan can become. If this is \
+                 exceeded, the scan aborts.",
             ),
     )
     .arg(
@@ -1474,9 +1475,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .multiple(true)
             .help(
-                "Persistent accounts-index location. \
-                May be specified multiple times. \
-                [default: <LEDGER>/accounts_index]",
+                "Persistent accounts-index location. May be specified multiple times. [default: \
+                 <LEDGER>/accounts_index]",
             ),
     )
     .arg(
@@ -1486,10 +1486,9 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("BOOLEAN")
             .default_value(&default_args.accounts_shrink_optimize_total_space)
             .help(
-                "When this is set to true, the system will shrink the most sparse accounts \
-                 and when the overall shrink ratio is above the specified \
-                 accounts-shrink-ratio, the shrink will stop and it will skip all other less \
-                 sparse accounts.",
+                "When this is set to true, the system will shrink the most sparse accounts and \
+                 when the overall shrink ratio is above the specified accounts-shrink-ratio, the \
+                 shrink will stop and it will skip all other less sparse accounts.",
             ),
     )
     .arg(
@@ -1499,10 +1498,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("RATIO")
             .default_value(&default_args.accounts_shrink_ratio)
             .help(
-                "Specifies the shrink ratio for the accounts to be shrunk. The shrink ratio \
-                 is defined as the ratio of the bytes alive over the  total bytes used. If \
-                 the account's shrink ratio is less than this ratio it becomes a candidate \
-                 for shrinking. The value must between 0. and 1.0 inclusive.",
+                "Specifies the shrink ratio for the accounts to be shrunk. The shrink ratio is \
+                 defined as the ratio of the bytes alive over the  total bytes used. If the \
+                 account's shrink ratio is less than this ratio it becomes a candidate for \
+                 shrinking. The value must between 0. and 1.0 inclusive.",
             ),
     )
     .arg(
@@ -1536,9 +1535,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .default_value(&default_args.banking_trace_dir_byte_limit)
             .help(
                 "Enables the banking trace explicitly, which is enabled by default and writes \
-                 trace files for simulate-leader-blocks, retaining up to the default or \
-                 specified total bytes in the ledger. This flag can be used to override its \
-                 byte limit.",
+                 trace files for simulate-leader-blocks, retaining up to the default or specified \
+                 total bytes in the ledger. This flag can be used to override its byte limit.",
             ),
     )
     .arg(
@@ -1555,11 +1553,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(false)
             .help(
                 "Delay leader block creation while replaying a block which descends from the \
-                current fork and has a lower slot than our next leader slot. If we don't \
-                delay here, our new leader block will be on a different fork from the \
-                block we are replaying and there is a high chance that the cluster will \
-                confirm that block's fork rather than our leader block's fork because it \
-                was created before we started creating ours.",
+                 current fork and has a lower slot than our next leader slot. If we don't delay \
+                 here, our new leader block will be on a different fork from the block we are \
+                 replaying and there is a high chance that the cluster will confirm that block's \
+                 fork rather than our leader block's fork because it was created before we \
+                 started creating ours.",
             ),
     )
     .arg(
@@ -1607,27 +1605,21 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .conflicts_with("wait_for_supermajority")
             .requires("wen_restart_coordinator")
             .help(
-                "Only used during coordinated cluster restarts.\
-                \n\n\
-                Need to also specify the leader's pubkey in --wen-restart-leader.\
-                \n\n\
-                When specified, the validator will enter Wen Restart mode which \
-                pauses normal activity. Validators in this mode will gossip their last \
-                vote to reach consensus on a safe restart slot and repair all blocks \
-                on the selected fork. The safe slot will be a descendant of the latest \
-                optimistically confirmed slot to ensure we do not roll back any \
-                optimistically confirmed slots. \
-                \n\n\
-                The progress in this mode will be saved in the file location provided. \
-                If consensus is reached, the validator will automatically exit with 200 \
-                status code. Then the operators are expected to restart the validator \
-                with --wait_for_supermajority and other arguments (including new shred_version, \
-                supermajority slot, and bankhash) given in the error log before the exit so \
-                the cluster will resume execution. The progress file will be kept around \
-                for future debugging. \
-                \n\n\
-                If wen_restart fails, refer to the progress file (in proto3 format) for \
-                further debugging and watch the discord channel for instructions.",
+                "Only used during coordinated cluster restarts.\n\nNeed to also specify the \
+                 leader's pubkey in --wen-restart-leader.\n\nWhen specified, the validator will \
+                 enter Wen Restart mode which pauses normal activity. Validators in this mode \
+                 will gossip their last vote to reach consensus on a safe restart slot and repair \
+                 all blocks on the selected fork. The safe slot will be a descendant of the \
+                 latest optimistically confirmed slot to ensure we do not roll back any \
+                 optimistically confirmed slots. \n\nThe progress in this mode will be saved in \
+                 the file location provided. If consensus is reached, the validator will \
+                 automatically exit with 200 status code. Then the operators are expected to \
+                 restart the validator with --wait_for_supermajority and other arguments \
+                 (including new shred_version, supermajority slot, and bankhash) given in the \
+                 error log before the exit so the cluster will resume execution. The progress \
+                 file will be kept around for future debugging. \n\nIf wen_restart fails, refer \
+                 to the progress file (in proto3 format) for further debugging and watch the \
+                 discord channel for instructions.",
             ),
     )
     .arg(
@@ -1639,8 +1631,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .required(false)
             .requires("wen_restart")
             .help(
-                "Specifies the pubkey of the leader used in wen restart. \
-                May get stuck if the leader used is different from others.",
+                "Specifies the pubkey of the leader used in wen restart. May get stuck if the \
+                 leader used is different from others.",
             ),
     )
     .arg(
@@ -1676,8 +1668,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("use-connection-cache")
             .takes_value(false)
             .help(
-                "Use connection-cache crate to send transactions over TPU ports. If not set,\
-                tpu-client-next is used by default.",
+                "Use connection-cache crate to send transactions over TPU ports. If not \
+                 set,tpu-client-next is used by default.",
             ),
     )
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1696,8 +1696,7 @@ fn validators_set(
             if validators_set.contains(identity_pubkey) {
                 return Err(crate::commands::Error::Dynamic(
                     Box::<dyn std::error::Error>::from(format!(
-                        "the validator's identity pubkey cannot be a {arg_name}: {}",
-                        identity_pubkey
+                        "the validator's identity pubkey cannot be a {arg_name}: {identity_pubkey}"
                     )),
                 ));
             }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -37,6 +37,25 @@ use {
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
 
+// Declared out of line to allow use of #[rustfmt::skip]
+#[rustfmt::skip]
+const WEN_RESTART_HELP: &str =
+    "Only used during coordinated cluster restarts.\n\n\
+     Need to also specify the leader's pubkey in --wen-restart-leader.\n\n\
+     When specified, the validator will enter Wen Restart mode which pauses normal activity. \
+     Validators in this mode will gossip their last vote to reach consensus on a safe restart \
+     slot and repair all blocks on the selected fork. The safe slot will be a descendant of the \
+     latest optimistically confirmed slot to ensure we do not roll back any optimistically \
+     confirmed slots.\n\n\
+     The progress in this mode will be saved in the file location provided. If consensus is \
+     reached, the validator will automatically exit with 200 status code. Then the operators are \
+     expected to restart the validator with --wait_for_supermajority and other arguments \
+     (including new shred_version, supermajority slot, and bankhash) given in the error log \
+     before the exit so the cluster will resume execution. The progress file will be kept around \
+     for future debugging.\n\n\
+     If wen_restart fails, refer to the progress file (in proto3 format) for further debugging and \
+     watch the discord channel for instructions.";
+
 pub mod account_secondary_indexes;
 pub mod blockstore_options;
 pub mod json_rpc_config;
@@ -1603,23 +1622,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .required(false)
             .conflicts_with("wait_for_supermajority")
             .requires("wen_restart_coordinator")
-            .help(
-                "Only used during coordinated cluster restarts.\n\nNeed to also specify the \
-                 leader's pubkey in --wen-restart-leader.\n\nWhen specified, the validator will \
-                 enter Wen Restart mode which pauses normal activity. Validators in this mode \
-                 will gossip their last vote to reach consensus on a safe restart slot and repair \
-                 all blocks on the selected fork. The safe slot will be a descendant of the \
-                 latest optimistically confirmed slot to ensure we do not roll back any \
-                 optimistically confirmed slots. \n\nThe progress in this mode will be saved in \
-                 the file location provided. If consensus is reached, the validator will \
-                 automatically exit with 200 status code. Then the operators are expected to \
-                 restart the validator with --wait_for_supermajority and other arguments \
-                 (including new shred_version, supermajority slot, and bankhash) given in the \
-                 error log before the exit so the cluster will resume execution. The progress \
-                 file will be kept around for future debugging. \n\nIf wen_restart fails, refer \
-                 to the progress file (in proto3 format) for further debugging and watch the \
-                 discord channel for instructions.",
-            ),
+            .help(WEN_RESTART_HELP),
     )
     .arg(
         Arg::with_name("wen_restart_coordinator")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1288,8 +1288,8 @@ fn new_snapshot_config(
 
     if !is_snapshot_config_valid(&snapshot_config) {
         Err(
-            "invalid snapshot configuration provided: snapshot intervals are incompatible. \n\t- \
-             full snapshot interval MUST be larger than incremental snapshot interval (if enabled)"
+            "invalid snapshot configuration provided: snapshot intervals are incompatible. full \
+             snapshot interval MUST be larger than incremental snapshot interval (if enabled)"
                 .to_string(),
         )?;
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -250,7 +250,10 @@ pub fn execute(
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = !matches.is_present("tpu_disable_quic");
     if !tpu_use_quic {
-        warn!("TPU QUIC was disabled via --tpu_disable_quic, this will prevent validator from receiving transactions!");
+        warn!(
+            "TPU QUIC was disabled via --tpu_disable_quic, this will prevent validator from \
+             receiving transactions!"
+        );
     }
     let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
 
@@ -710,9 +713,9 @@ pub fn execute(
         BlockVerificationMethod::BlockstoreProcessor => {
             warn!(
                 "The value \"blockstore-processor\" for --block-verification-method has been \
-                deprecated. The value \"blockstore-processor\" is still allowed for now, but \
-                is planned for removal in the near future. To update, either set the value \
-                \"unified-scheduler\" or remove the --block-verification-method argument"
+                 deprecated. The value \"blockstore-processor\" is still allowed for now, but is \
+                 planned for removal in the near future. To update, either set the value \
+                 \"unified-scheduler\" or remove the --block-verification-method argument"
             );
         }
         BlockVerificationMethod::UnifiedScheduler => {}
@@ -767,7 +770,10 @@ pub fn execute(
     let gossip_host = matches
         .value_of("gossip_host")
         .map(|gossip_host| {
-            warn!("--gossip-host is deprecated. Use --bind-address or rely on automatic public IP discovery instead.");
+            warn!(
+                "--gossip-host is deprecated. Use --bind-address or rely on automatic public IP \
+                 discovery instead."
+            );
             solana_net_utils::parse_host(gossip_host)
                 .map_err(|err| format!("failed to parse --gossip-host: {err}"))
         })
@@ -1022,7 +1028,10 @@ pub fn execute(
             ) {
                 // 200 is a special error code, see
                 // https://github.com/solana-foundation/solana-improvement-documents/pull/46
-                error!("Please remove --wen_restart and use --wait_for_supermajority as instructed above");
+                error!(
+                    "Please remove --wen_restart and use --wait_for_supermajority as instructed \
+                     above"
+                );
                 exit(200);
             }
             Err(format!("{err:?}"))
@@ -1080,9 +1089,7 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
             Err(err) => eprintln!("get_cluster_shred_version failed: {entrypoint}, {err}"),
             Ok(0) => eprintln!("entrypoint {entrypoint} returned shred-version zero"),
             Ok(shred_version) => {
-                info!(
-                    "obtained shred-version {shred_version} from {entrypoint}"
-                );
+                info!("obtained shred-version {shred_version} from {entrypoint}");
                 return Some(shred_version);
             }
         }
@@ -1135,10 +1142,9 @@ fn new_snapshot_config(
                     if matches.occurrences_of("full_snapshot_interval_slots") > 0 {
                         warn!(
                             "Incremental snapshots are disabled, yet \
-                             --full-snapshot-interval-slots was specified! \
-                             Note that --full-snapshot-interval-slots is *ignored* \
-                             when incremental snapshots are disabled. \
-                             Use --snapshot-interval-slots instead.",
+                             --full-snapshot-interval-slots was specified! Note that \
+                             --full-snapshot-interval-slots is *ignored* when incremental \
+                             snapshots are disabled. Use --snapshot-interval-slots instead.",
                         );
                     }
                     (
@@ -1166,8 +1172,9 @@ fn new_snapshot_config(
         let full_snapshot_interval_slots = full_snapshot_interval_slots.get();
         if full_snapshot_interval_slots > DEFAULT_SLOTS_PER_EPOCH {
             warn!(
-                "The full snapshot interval is excessively large: {full_snapshot_interval_slots}! This will negatively \
-                impact the background cleanup tasks in accounts-db. Consider a smaller value.",
+                "The full snapshot interval is excessively large: {full_snapshot_interval_slots}! \
+                 This will negatively impact the background cleanup tasks in accounts-db. \
+                 Consider a smaller value.",
             );
         }
     }
@@ -1188,8 +1195,8 @@ fn new_snapshot_config(
         .any(|account_path| account_path == &snapshots_dir)
     {
         Err(
-            "the --accounts and --snapshots paths must be unique since they \
-             both create 'snapshots' subdirectories, otherwise there may be collisions"
+            "the --accounts and --snapshots paths must be unique since they both create \
+             'snapshots' subdirectories, otherwise there may be collisions"
                 .to_string(),
         )?;
     }
@@ -1281,9 +1288,8 @@ fn new_snapshot_config(
 
     if !is_snapshot_config_valid(&snapshot_config) {
         Err(
-            "invalid snapshot configuration provided: snapshot intervals are incompatible. \
-             \n\t- full snapshot interval MUST be larger than incremental snapshot interval \
-             (if enabled)"
+            "invalid snapshot configuration provided: snapshot intervals are incompatible. \n\t- \
+             full snapshot interval MUST be larger than incremental snapshot interval (if enabled)"
                 .to_string(),
         )?;
     }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -150,7 +150,7 @@ pub fn execute(
         match &staked_nodes_overrides_path {
             None => StakedNodesOverrides::default(),
             Some(p) => load_staked_nodes_overrides(p).unwrap_or_else(|err| {
-                error!("Failed to load stake-nodes-overrides from {}: {}", p, err);
+                error!("Failed to load stake-nodes-overrides from {p}: {err}");
                 clap::Error::with_description(
                     "Failed to load configuration of stake-nodes-overrides argument",
                     clap::ErrorKind::InvalidValue,
@@ -786,8 +786,7 @@ pub fn execute(
             .find_map(|i| {
                 let entrypoint_addr = &entrypoint_addrs[i];
                 info!(
-                    "Contacting {} to determine the validator's public IP address",
-                    entrypoint_addr
+                    "Contacting {entrypoint_addr} to determine the validator's public IP address"
                 );
                 solana_net_utils::get_public_ip_addr_with_binding(
                     entrypoint_addr,
@@ -1082,8 +1081,7 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
             Ok(0) => eprintln!("entrypoint {entrypoint} returned shred-version zero"),
             Ok(shred_version) => {
                 info!(
-                    "obtained shred-version {} from {}",
-                    shred_version, entrypoint
+                    "obtained shred-version {shred_version} from {entrypoint}"
                 );
                 return Some(shred_version);
             }
@@ -1168,9 +1166,8 @@ fn new_snapshot_config(
         let full_snapshot_interval_slots = full_snapshot_interval_slots.get();
         if full_snapshot_interval_slots > DEFAULT_SLOTS_PER_EPOCH {
             warn!(
-                "The full snapshot interval is excessively large: {}! This will negatively \
+                "The full snapshot interval is excessively large: {full_snapshot_interval_slots}! This will negatively \
                 impact the background cleanup tasks in accounts-db. Consider a smaller value.",
-                full_snapshot_interval_slots,
             );
         }
     }

--- a/validator/src/commands/set_public_address/mod.rs
+++ b/validator/src/commands/set_public_address/mod.rs
@@ -17,21 +17,22 @@ pub struct SetPublicAddressArgs {
 
 impl FromClapArgMatches for SetPublicAddressArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
-        let parse_arg_addr = |arg_name: &str,
-                              arg_long: &str|
-         -> std::result::Result<
-            Option<SocketAddr>,
-            Box<dyn std::error::Error>,
-        > {
-            Ok(matches.value_of(arg_name).map(|host_port| {
-                solana_net_utils::parse_host_port(host_port).map_err(|err| {
-                    format!(
-                        "failed to parse --{arg_long} address. It must be in the HOST:PORT format. {err}"
-                    )
-                })
-            })
-            .transpose()?)
-        };
+        let parse_arg_addr =
+            |arg_name: &str,
+             arg_long: &str|
+             -> std::result::Result<Option<SocketAddr>, Box<dyn std::error::Error>> {
+                Ok(matches
+                    .value_of(arg_name)
+                    .map(|host_port| {
+                        solana_net_utils::parse_host_port(host_port).map_err(|err| {
+                            format!(
+                                "failed to parse --{arg_long} address. It must be in the \
+                                 HOST:PORT format. {err}"
+                            )
+                        })
+                    })
+                    .transpose()?)
+            };
         Ok(SetPublicAddressArgs {
             tpu_addr: parse_arg_addr("tpu_addr", "tpu")?,
             tpu_forwards_addr: parse_arg_addr("tpu_forwards_addr", "tpu-forwards")?,

--- a/validator/src/commands/staked_nodes_overrides/mod.rs
+++ b/validator/src/commands/staked_nodes_overrides/mod.rs
@@ -34,11 +34,13 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .takes_value(true)
                 .required(true)
                 .help(
-                    "Provide path to a file with custom overrides for stakes of specific validator identities.",
+                    "Provide path to a file with custom overrides for stakes of specific \
+                     validator identities.",
                 ),
         )
         .after_help(
-            "Note: the new staked nodes overrides only applies to the currently running validator instance",
+            "Note: the new staked nodes overrides only applies to the currently running validator \
+             instance",
         )
 }
 

--- a/validator/src/commands/wait_for_restart_window/mod.rs
+++ b/validator/src/commands/wait_for_restart_window/mod.rs
@@ -58,9 +58,7 @@ pub(crate) fn command<'a>() -> App<'a, 'a> {
                 .validator(is_parsable::<usize>)
                 .value_name("MINUTES")
                 .default_value(DEFAULT_MIN_IDLE_TIME)
-                .help(
-                    "Minimum time that the validator should not be leader before restarting",
-                ),
+                .help("Minimum time that the validator should not be leader before restarting"),
         )
         .arg(
             Arg::with_name("identity")
@@ -90,7 +88,8 @@ pub(crate) fn command<'a>() -> App<'a, 'a> {
                 .help("Skip health check"),
         )
         .after_help(
-            "Note: If this command exits with a non-zero status then this not a good time for a restart",
+            "Note: If this command exits with a non-zero status then this not a good time for a \
+             restart",
         )
 }
 
@@ -219,7 +218,7 @@ pub fn wait_for_restart_window(
                 if !leader_schedule.is_empty() && upcoming_idle_windows.is_empty() {
                     return Err(format!(
                         "Validator has no idle window of at least {} slots. Largest idle window \
-                       for epoch {} is {} slots",
+                         for epoch {} is {} slots",
                         min_idle_slots, epoch_info.epoch, max_idle_window
                     )
                     .into());
@@ -274,7 +273,7 @@ pub fn wait_for_restart_window(
                                     }
                                     None => format!(
                                         "Validator will be leader soon. Next leader slot is \
-                                       {next_leader_slot}"
+                                         {next_leader_slot}"
                                     ),
                                 })
                             }

--- a/validator/src/commands/wait_for_restart_window/mod.rs
+++ b/validator/src/commands/wait_for_restart_window/mod.rs
@@ -217,9 +217,9 @@ pub fn wait_for_restart_window(
                 }
                 if !leader_schedule.is_empty() && upcoming_idle_windows.is_empty() {
                     return Err(format!(
-                        "Validator has no idle window of at least {} slots. Largest idle window \
-                         for epoch {} is {} slots",
-                        min_idle_slots, epoch_info.epoch, max_idle_window
+                        "Validator has no idle window of at least {min_idle_slots} slots. Largest \
+                         idle window for epoch {} is {max_idle_window} slots",
+                        epoch_info.epoch,
                     )
                     .into());
                 }


### PR DESCRIPTION
#### Problem
Working towards https://github.com/anza-xyz/agave/issues/6850, broken out from https://github.com/anza-xyz/agave/pull/6854

#### Summary of Changes
- Run `cargo clippy --fix --tests` with Rust 1.88.0 set in `rust-toolchain.toml`
    - These should only be instances of `uninlined_format_args`
- Run `cargo fmt` with `format_strings = true` set in `rustfmt.toml`