### PR TITLE
Resolve race condition in wait_for_idle

### DIFF
--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -140,13 +140,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             return;
         }
 
-        // when age has incremented twice, we know that we have made it through scanning all bins since we started waiting,
-        //  so we are then 'idle'
-        let end_age = self.current_age().wrapping_add(2);
+        let start_age = self.current_age();
         loop {
             self.wait_dirty_or_aged
                 .wait_timeout(Duration::from_millis(self.age_interval_ms()));
-            if end_age == self.current_age() {
+            // when age has incremented twice or more from the starting age, we know that we have
+            // made it through scanning all bins since we started waiting, so we are then 'idle'
+            if self.current_age().wrapping_sub(start_age) > 1 {
                 break;
             }
         }


### PR DESCRIPTION
#### Problem
wait_for_idle sometimes misses the termination condition under testing, leading to a 512s wait. 

#### Summary of Changes
Modify the logic to wait at least 2 ages rather than exactly 2 ages, and handling wrapping properly. 

Fixes #
[2025-08-18T19:47:19.593627000Z ERROR solana_accounts_db::bucket_map_holder] wait_for_idle: current_age: 3, end_age: 2
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
