### PR TITLE
Remove Copy trait implementation for LtHash in tests

### DIFF
--- a/lattice-hash/src/lt_hash.rs
+++ b/lattice-hash/src/lt_hash.rs
@@ -120,8 +120,6 @@ mod tests {
         }
     }
 
-    impl Copy for LtHash {}
-
     // Ensure that if you mix-in or mix-out with the identity, you get the original value
     #[test]
     fn test_identity() {


### PR DESCRIPTION
Remove the problematic `impl Copy for LtHash {}` from tests that contradicted 
the developer's comment "Do not derive Copy because this type is large and 
copying will not be fast/free".

The Copy trait was unnecessary since Add and Sub operators take self by value,
allowing data to be moved between operations without copying. This change
aligns the code with the intended design principles while maintaining all
test functionality.