### PR TITLE
Refactor - Make instructions shareable between program-runtime and programs inside the VM

### DIFF
--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -66,7 +66,7 @@ pub type IndexOfAccount = u16;
 #[derive(Clone, Copy, Debug)]
 pub struct InstructionAccount {
     /// Points to the account and its key in the `TransactionContext`
-    pub index_in_transaction: IndexOfAccount,
+    pub index_in_transaction: u16,
     /// Is this account supposed to sign
     is_signer: u8,
     /// Is this account allowed to become writable
@@ -640,7 +640,7 @@ pub struct TransactionReturnData {
 #[derive(Debug, Clone, Default)]
 pub struct InstructionFrame {
     nesting_level: u16,
-    program_account_index_in_tx: IndexOfAccount,
+    program_account_index_in_tx: u16,
     dedup_map_end: u32,
     instruction_accounts_end: u32,
     instruction_data_end: u32,


### PR DESCRIPTION
#### Problem

Currently in ABI v0 and v1 we have to serialize (and deserialize) every single instruction of a transaction. With these changes it will become possible (in ABI v2) to only serialize the base pointers once per transaction and then have program-runtime and programs in the VM independently derive their own host and guest pointers for each instruction.

#### Summary of Changes

- Moves the backing store of the instructions `Vec`s into `TransactionContext`, with `InstructionFrame` only holding indices to the boundaries of these `Vec`s.
- Stops using type aliases in `repr(C)` structs for maximum clarity.