### PR TITLE
Adding runtime switch for obsolete account marking

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1503,6 +1503,18 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("accounts_db_mark_obsolete_accounts")
+            .long("accounts_db_mark_obsolete_accounts")
+            .help(
+                "Flag to indicate if the experimental obsolete account tracking feature is enabled.
+                This feature tracks obsolete accounts in the account storage entry allowing
+                for earlier cleaning of obsolete accounts in the storages and index.
+                Enabling this feature will disable fast-boot as they are not compatible at this
+                time"
+            )
+            .hidden(hidden_unless_forced()),
+    )
+    .arg(
         Arg::with_name("allow_private_addr")
             .long("allow-private-addr")
             .takes_value(false)

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1450,11 +1450,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("accounts-db-mark-obsolete-accounts")
             .help("Enables experimental obsolete account tracking")
             .long_help(
-                "Enables experimental obsolete account tracking \
+                "Enables experimental obsolete account tracking. \
                  This feature tracks obsolete accounts in the account storage entry allowing \
                  for earlier cleaning of obsolete accounts in the storages and index. \
                  At this time this feature is not compatible with booting from local \
-                 snapshot state and must unpack from archives"
+                 snapshot state and must unpack from archives."
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1505,13 +1505,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     .arg(
         Arg::with_name("accounts_db_mark_obsolete_accounts")
             .long("accounts-db-mark-obsolete-accounts")
-            .help("Enables experimental obsolete account tracking.")
+            .help("Enables experimental obsolete account tracking")
             .long_help(
-                "Enables experimental obsolete account tracking.
-                This feature tracks obsolete accounts in the account storage entry allowing
-                for earlier cleaning of obsolete accounts in the storages and index.
-                At this time this feature is not compatible with booting from local
-                snapshot state and must unpack from archives"
+                "Enables experimental obsolete account tracking \
+                 This feature tracks obsolete accounts in the account storage entry allowing \
+                 for earlier cleaning of obsolete accounts in the storages and index. \
+                 At this time this feature is not compatible with booting from local \
+                 snapshot state and must unpack from archives"
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1446,6 +1446,19 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
+        Arg::with_name("accounts_db_mark_obsolete_accounts")
+            .long("accounts-db-mark-obsolete-accounts")
+            .help("Enables experimental obsolete account tracking")
+            .long_help(
+                "Enables experimental obsolete account tracking \
+                 This feature tracks obsolete accounts in the account storage entry allowing \
+                 for earlier cleaning of obsolete accounts in the storages and index. \
+                 At this time this feature is not compatible with booting from local \
+                 snapshot state and must unpack from archives"
+            )
+            .hidden(hidden_unless_forced()),
+    )
+    .arg(
         Arg::with_name("accounts_index_scan_results_limit_mb")
             .long("accounts-index-scan-results-limit-mb")
             .value_name("MEGABYTES")
@@ -1501,19 +1514,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                  the account's shrink ratio is less than this ratio it becomes a candidate \
                  for shrinking. The value must between 0. and 1.0 inclusive.",
             ),
-    )
-    .arg(
-        Arg::with_name("accounts_db_mark_obsolete_accounts")
-            .long("accounts-db-mark-obsolete-accounts")
-            .help("Enables experimental obsolete account tracking")
-            .long_help(
-                "Enables experimental obsolete account tracking \
-                 This feature tracks obsolete accounts in the account storage entry allowing \
-                 for earlier cleaning of obsolete accounts in the storages and index. \
-                 At this time this feature is not compatible with booting from local \
-                 snapshot state and must unpack from archives"
-            )
-            .hidden(hidden_unless_forced()),
     )
     .arg(
         Arg::with_name("allow_private_addr")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1504,13 +1504,14 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
     )
     .arg(
         Arg::with_name("accounts_db_mark_obsolete_accounts")
-            .long("accounts_db_mark_obsolete_accounts")
-            .help(
-                "Flag to indicate if the experimental obsolete account tracking feature is enabled.
+            .long("accounts-db-mark-obsolete-accounts")
+            .help("Enables experimental obsolete account tracking.")
+            .long_help(
+                "Enables experimental obsolete account tracking.
                 This feature tracks obsolete accounts in the account storage entry allowing
                 for earlier cleaning of obsolete accounts in the storages and index.
-                Enabling this feature will disable fast-boot as they are not compatible at this
-                time"
+                At this time this feature is not compatible with booting from local
+                snapshot state and must unpack from archives"
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -551,8 +551,8 @@ pub fn execute(
             "The --accounts-db-mark-obsolete-accounts option requires \
              the --use-snapshot-archives-at-startup option to be set to {}. \
              Current value: {}",
-             UseSnapshotArchivesAtStartup::Always,
-             use_snapshot_archives_at_startup
+            UseSnapshotArchivesAtStartup::Always,
+            use_snapshot_archives_at_startup
         ))?;
     }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -549,8 +549,8 @@ pub fn execute(
     {
         Err(format!(
             "The --accounts-db-mark-obsolete-accounts option requires \
-                 the --use-snapshot-archives-at-startup option to be set to 'Always'. \
-                 Current value: {use_snapshot_archives_at_startup:?}"
+             the --use-snapshot-archives-at-startup option to be set to 'Always'. \
+             Current value: {use_snapshot_archives_at_startup:?}"
         ))?;
     }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -405,6 +405,8 @@ pub fn execute(
         })
         .unwrap_or_default();
 
+    let mark_obsolete_accounts = matches.is_present("accounts_db_mark_obsolete_accounts");
+
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         account_indexes: Some(account_indexes.clone()),
@@ -429,7 +431,7 @@ pub fn execute(
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
         num_hash_threads: Some(accounts_db_hash_threads),
-        mark_obsolete_accounts: matches.is_present("accounts_db_mark_obsolete_accounts"),
+        mark_obsolete_accounts,
         ..AccountsDbConfig::default()
     };
 
@@ -542,9 +544,7 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
-    if accounts_db_config
-        .as_ref()
-        .is_some_and(|config| config.mark_obsolete_accounts)
+    if mark_obsolete_accounts
         && use_snapshot_archives_at_startup != UseSnapshotArchivesAtStartup::Always
     {
         Err(format!(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -549,10 +549,10 @@ pub fn execute(
     {
         Err(format!(
             "The --accounts-db-mark-obsolete-accounts option requires \
-                 the --use-snapshot-archives-at-startup option to be set to {}. \
-                 Current value: {}",
-            UseSnapshotArchivesAtStartup::Always,
-            use_snapshot_archives_at_startup
+             the --use-snapshot-archives-at-startup option to be set to {}. \
+             Current value: {}",
+             UseSnapshotArchivesAtStartup::Always,
+             use_snapshot_archives_at_startup
         ))?;
     }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -549,8 +549,10 @@ pub fn execute(
     {
         Err(format!(
             "The --accounts-db-mark-obsolete-accounts option requires \
-             the --use-snapshot-archives-at-startup option to be set to 'Always'. \
-             Current value: {use_snapshot_archives_at_startup:?}"
+                 the --use-snapshot-archives-at-startup option to be set to {}. \
+                 Current value: {}",
+            UseSnapshotArchivesAtStartup::Always,
+            use_snapshot_archives_at_startup
         ))?;
     }
 


### PR DESCRIPTION
#### Problem
Marking obsolete accounts can only be enabled through a build change

#### Summary of Changes
- Add a hidden configuration for obsolete accounts through CLI
- Disable fast-boot if obsolete accounts are enabled. 

Notes: First time adding a configuration switch. I assume this is how we do it...

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
