### PR TITLE
Refactor logging placement in partitioned epoch rewards calculation

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -119,17 +119,12 @@ impl Bank {
         let rewards_calculation = epoch_rewards_calculation_cache
             .entry(self.parent_hash)
             .or_insert_with(|| {
-                let calculation = self.calculate_rewards_for_partitioning(
+                Arc::new(self.calculate_rewards_for_partitioning(
                     prev_epoch,
                     reward_calc_tracer,
                     thread_pool,
                     metrics,
-                );
-                info!(
-                    "calculated rewards for epoch: {}, parent_slot: {}, parent_hash: {}",
-                    self.epoch, self.parent_slot, self.parent_hash
-                );
-                Arc::new(calculation)
+                ))
             })
             .clone();
         drop(epoch_rewards_calculation_cache);
@@ -250,6 +245,11 @@ impl Bank {
                 metrics,
             )
             .unwrap_or_default();
+
+        info!(
+            "calculated rewards for epoch: {}, parent_slot: {}, parent_hash: {}",
+            self.epoch, self.parent_slot, self.parent_hash
+        );
 
         PartitionedRewardsCalculation {
             vote_account_rewards,


### PR DESCRIPTION
#### Problem

Refactor logging placement in partitioned epoch rewards calculation for better execution flow and maintainability.


#### Summary of Changes

- Moved logging statement: Relocated the informational log message from inside the rewards calculation cache entry creation to after the actual rewards calculation completes
- Improved code structure: Simplified the cache entry creation by directly wrapping the calculation result with Arc::new() inline, eliminating the intermediate variable

Before:

- Required an intermediate variable assignment before wrapping in Arc
After:

- Log message is now placed after the calculation completes, ensuring it only logs when the calculation actually happens
- Streamlined the Arc creation by inlining it directly in the or_insert_with closure




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
