### PR TITLE
BankingStage: add owned context for spawning non-vote threads

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -459,7 +459,7 @@ fn main() {
     let banking_stage = BankingStage::new_num_threads(
         block_production_method,
         transaction_struct,
-        &poh_recorder,
+        poh_recorder.clone(),
         transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,
@@ -469,7 +469,7 @@ fn main() {
         replay_vote_sender,
         None,
         bank_forks.clone(),
-        &prioritization_fee_cache,
+        prioritization_fee_cache,
     );
 
     // This is so that the signal_receiver does not go out of scope after the closure.

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -238,7 +238,7 @@ fn bench_banking(
     let _banking_stage = BankingStage::new_num_threads(
         block_production_method,
         transaction_struct,
-        &poh_recorder,
+        poh_recorder.clone(),
         transaction_recorder,
         non_vote_receiver,
         tpu_vote_receiver,
@@ -248,7 +248,7 @@ fn bench_banking(
         s,
         None,
         bank_forks,
-        &Arc::new(PrioritizationFeeCache::new(0u64)),
+        Arc::new(PrioritizationFeeCache::new(0u64)),
     );
 
     let chunk_len = verified.len() / CHUNKS;

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -823,7 +823,7 @@ impl BankingSimulator {
         let banking_stage = BankingStage::new_num_threads(
             block_production_method.clone(),
             transaction_struct.clone(),
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -833,7 +833,7 @@ impl BankingSimulator {
             replay_vote_sender,
             None,
             bank_forks.clone(),
-            prioritization_fee_cache,
+            prioritization_fee_cache.clone(),
         );
 
         let (&_slot, &raw_base_event_time) = freeze_time_by_slot

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -785,6 +785,7 @@ mod tests {
         exit.store(true, Ordering::Relaxed);
         poh_service.join().unwrap();
         drop(poh_recorder);
+        banking_stage.join().unwrap();
 
         trace!("getting entries");
         let entries: Vec<_> = entry_receiver
@@ -795,7 +796,6 @@ mod tests {
         assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
         assert!(entries.verify(&start_hash, &entry::thread_pool_for_tests()));
         assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
-        banking_stage.join().unwrap();
     }
 
     fn test_banking_stage_entries_only(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -337,7 +337,8 @@ pub struct BatchedTransactionErrorDetails {
 
 pub struct BankingStage {
     vote_thread_hdl: JoinHandle<()>,
-    non_vote_exit_signal: Arc<AtomicBool>,
+    // Only None during final join of BankingStage.
+    non_vote_context: Option<BankingStageNonVoteContext>,
     non_vote_thread_hdls: Vec<JoinHandle<()>>,
 }
 
@@ -362,7 +363,7 @@ impl BankingStage {
     pub fn new_num_threads(
         block_production_method: BlockProductionMethod,
         transaction_struct: TransactionStructure,
-        poh_recorder: &Arc<RwLock<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         transaction_recorder: TransactionRecorder,
         non_vote_receiver: BankingPacketReceiver,
         tpu_vote_receiver: BankingPacketReceiver,
@@ -372,12 +373,12 @@ impl BankingStage {
         replay_vote_sender: ReplayVoteSender,
         log_messages_bytes_limit: Option<usize>,
         bank_forks: Arc<RwLock<BankForks>>,
-        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
     ) -> Self {
         let committer = Committer::new(
-            transaction_status_sender.clone(),
-            replay_vote_sender.clone(),
-            prioritization_fee_cache.clone(),
+            transaction_status_sender,
+            replay_vote_sender,
+            prioritization_fee_cache,
         );
         let vote_thread_hdl = Self::spawn_vote_worker(
             tpu_vote_receiver,
@@ -394,21 +395,25 @@ impl BankingStage {
             block_production_method,
             BlockProductionMethod::CentralSchedulerGreedy
         );
-        let (non_vote_exit_signal, non_vote_thread_hdls) = Self::new_central_scheduler(
+        let non_vote_context = BankingStageNonVoteContext {
+            non_vote_exit_signal: Arc::new(AtomicBool::new(false)),
+            non_vote_receiver,
+            transaction_recorder,
+            poh_recorder,
+            bank_forks,
+            committer,
+            log_messages_bytes_limit,
+        };
+        let non_vote_thread_hdls = Self::new_central_scheduler(
             transaction_struct,
             use_greedy_scheduler,
             num_workers,
-            non_vote_receiver,
-            transaction_recorder.clone(),
-            poh_recorder.clone(),
-            bank_forks.clone(),
-            committer.clone(),
-            log_messages_bytes_limit,
+            non_vote_context.clone(),
         );
 
         Self {
             vote_thread_hdl,
-            non_vote_exit_signal,
+            non_vote_context: Some(non_vote_context),
             non_vote_thread_hdls,
         }
     }
@@ -417,44 +422,31 @@ impl BankingStage {
         transaction_struct: TransactionStructure,
         use_greedy_scheduler: bool,
         num_workers: NonZeroUsize,
-        non_vote_receiver: BankingPacketReceiver,
-        transaction_recorder: TransactionRecorder,
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        bank_forks: Arc<RwLock<BankForks>>,
-        committer: Committer,
-        log_messages_bytes_limit: Option<usize>,
-    ) -> (Arc<AtomicBool>, Vec<JoinHandle<()>>) {
+        context: BankingStageNonVoteContext,
+    ) -> Vec<JoinHandle<()>> {
         match transaction_struct {
             TransactionStructure::Sdk => {
                 let receive_and_buffer = SanitizedTransactionReceiveAndBuffer::new(
-                    PacketDeserializer::new(non_vote_receiver),
-                    bank_forks.clone(),
+                    PacketDeserializer::new(context.non_vote_receiver.clone()),
+                    context.bank_forks.clone(),
                 );
                 Self::spawn_scheduler_and_workers(
                     receive_and_buffer,
                     use_greedy_scheduler,
                     num_workers,
-                    transaction_recorder,
-                    poh_recorder,
-                    bank_forks,
-                    committer,
-                    log_messages_bytes_limit,
+                    context,
                 )
             }
             TransactionStructure::View => {
                 let receive_and_buffer = TransactionViewReceiveAndBuffer {
-                    receiver: non_vote_receiver,
-                    bank_forks: bank_forks.clone(),
+                    receiver: context.non_vote_receiver.clone(),
+                    bank_forks: context.bank_forks.clone(),
                 };
                 Self::spawn_scheduler_and_workers(
                     receive_and_buffer,
                     use_greedy_scheduler,
                     num_workers,
-                    transaction_recorder,
-                    poh_recorder,
-                    bank_forks,
-                    committer,
-                    log_messages_bytes_limit,
+                    context,
                 )
             }
         }
@@ -464,17 +456,12 @@ impl BankingStage {
         receive_and_buffer: R,
         use_greedy_scheduler: bool,
         num_workers: NonZeroUsize,
-        transaction_recorder: TransactionRecorder,
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        bank_forks: Arc<RwLock<BankForks>>,
-        committer: Committer,
-        log_messages_bytes_limit: Option<usize>,
-    ) -> (Arc<AtomicBool>, Vec<JoinHandle<()>>) {
-        // Create an exit signal for the scheduler and workers
-        let exit = Arc::new(AtomicBool::new(false));
-
+        context: BankingStageNonVoteContext,
+    ) -> Vec<JoinHandle<()>> {
         assert!(num_workers <= BankingStage::max_num_workers());
         let num_workers = num_workers.get();
+
+        let exit = context.non_vote_exit_signal.clone();
 
         // + 1 for scheduler thread
         let mut thread_hdls = Vec::with_capacity(num_workers + 1);
@@ -485,7 +472,7 @@ impl BankingStage {
         let (finished_work_sender, finished_work_receiver) = unbounded();
 
         // Spawn the worker threads
-        let decision_maker = DecisionMaker::from(poh_recorder.read().unwrap().deref());
+        let decision_maker = DecisionMaker::from(context.poh_recorder.read().unwrap().deref());
         let mut worker_metrics = Vec::with_capacity(num_workers);
         for (index, work_receiver) in work_receivers.into_iter().enumerate() {
             let id = index as u32;
@@ -494,13 +481,13 @@ impl BankingStage {
                 exit.clone(),
                 work_receiver,
                 Consumer::new(
-                    committer.clone(),
-                    transaction_recorder.clone(),
+                    context.committer.clone(),
+                    context.transaction_recorder.clone(),
                     QosService::new(id),
-                    log_messages_bytes_limit,
+                    context.log_messages_bytes_limit,
                 ),
                 finished_work_sender.clone(),
-                poh_recorder.read().unwrap().shared_working_bank(),
+                context.poh_recorder.read().unwrap().shared_working_bank(),
             );
 
             worker_metrics.push(consume_worker.metrics_handle());
@@ -528,7 +515,7 @@ impl BankingStage {
                                 exit,
                                 decision_maker,
                                 receive_and_buffer,
-                                bank_forks,
+                                context.bank_forks.clone(),
                                 $scheduler,
                                 worker_metrics,
                             );
@@ -563,7 +550,7 @@ impl BankingStage {
             spawn_scheduler!(scheduler);
         }
 
-        (exit, thread_hdls)
+        thread_hdls
     }
 
     fn spawn_vote_worker(
@@ -610,15 +597,31 @@ impl BankingStage {
         MAX_NUM_WORKERS
     }
 
-    pub fn join(self) -> thread::Result<()> {
+    pub fn join(mut self) -> thread::Result<()> {
         self.vote_thread_hdl.join()?;
 
-        self.non_vote_exit_signal.store(true, Ordering::Relaxed);
+        self.non_vote_context
+            .take()
+            .expect("non-vote context must be Some")
+            .non_vote_exit_signal
+            .store(true, Ordering::Relaxed);
         for bank_thread_hdl in self.non_vote_thread_hdls {
             bank_thread_hdl.join()?;
         }
         Ok(())
     }
+}
+
+// Context for spawning non-vote threads in the banking stage.
+#[derive(Clone)]
+struct BankingStageNonVoteContext {
+    non_vote_exit_signal: Arc<AtomicBool>,
+    non_vote_receiver: BankingPacketReceiver,
+    transaction_recorder: TransactionRecorder,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    committer: Committer,
+    log_messages_bytes_limit: Option<usize>,
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -707,7 +710,7 @@ mod tests {
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -717,7 +720,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::new(PrioritizationFeeCache::new(0u64)),
         );
         drop(non_vote_sender);
         drop(tpu_vote_sender);
@@ -763,7 +766,7 @@ mod tests {
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -773,7 +776,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::new(PrioritizationFeeCache::new(0u64)),
         );
         trace!("sending bank");
         drop(non_vote_sender);
@@ -828,7 +831,7 @@ mod tests {
         let banking_stage = BankingStage::new_num_threads(
             block_production_method,
             transaction_struct,
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -838,7 +841,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks.clone(), // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
-            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::new(PrioritizationFeeCache::new(0u64)),
         );
 
         // good tx, and no verify
@@ -979,7 +982,7 @@ mod tests {
             let _banking_stage = BankingStage::new_num_threads(
                 BlockProductionMethod::CentralScheduler,
                 transaction_struct,
-                &poh_recorder,
+                poh_recorder.clone(),
                 transaction_recorder,
                 non_vote_receiver,
                 tpu_vote_receiver,
@@ -989,7 +992,7 @@ mod tests {
                 replay_vote_sender,
                 None,
                 bank_forks,
-                &Arc::new(PrioritizationFeeCache::new(0u64)),
+                Arc::new(PrioritizationFeeCache::new(0u64)),
             );
 
             // wait for banking_stage to eat the packets
@@ -1166,7 +1169,7 @@ mod tests {
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralScheduler,
             transaction_struct,
-            &poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -1176,7 +1179,7 @@ mod tests {
             replay_vote_sender,
             None,
             bank_forks,
-            &Arc::new(PrioritizationFeeCache::new(0u64)),
+            Arc::new(PrioritizationFeeCache::new(0u64)),
         );
 
         let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -322,7 +322,7 @@ impl Tpu {
         let banking_stage = BankingStage::new_num_threads(
             block_production_method,
             transaction_struct,
-            poh_recorder,
+            poh_recorder.clone(),
             transaction_recorder,
             non_vote_receiver,
             tpu_vote_receiver,
@@ -332,7 +332,7 @@ impl Tpu {
             replay_vote_sender,
             log_messages_bytes_limit,
             bank_forks.clone(),
-            prioritization_fee_cache,
+            prioritization_fee_cache.clone(),
         );
 
         let SpawnForwardingStageResult {


### PR DESCRIPTION
#### Problem
- Once the banking stage threads are spawned we lose the things that we used to create them
- In the next PR I plan to introduce admin-rpc commands to change block-production method without restarting the validator

#### Summary of Changes
- New struct `BankingStageNonVoteContext`:
    - holds the unchanging things that we need to spawn non-vote banking stage threads
- BankingStage owns a context which is dropped on `join` so that we do not hold the channels for longer than previously   

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
